### PR TITLE
Implement Materializations in flow-consumer

### DIFF
--- a/examples/stock-stats/catalog.yaml
+++ b/examples/stock-stats/catalog.yaml
@@ -79,7 +79,7 @@ materializations:
   dailyStatsPostgres:
     collection: stock/daily-stats
     postgres:
-      uri: postgres://127.0.0.1:5432/my-db
+      uri: postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable
       table: daily_stats
 
 tests:

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.5
 	github.com/google/uuid v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/jgraettinger/cockroach-encoding v1.1.0
+	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.5.0

--- a/go/flow/transaction.go
+++ b/go/flow/transaction.go
@@ -239,7 +239,7 @@ func queueContinue(from pf.IndexedShuffleResponse, into *pf.DeriveRequest_Contin
 	into.UuidParts = append(into.UuidParts, from.UuidParts[from.Index])
 	into.PackedKey = append(into.PackedKey, into.Arena.Add(
 		from.Arena.Bytes(from.PackedKey[from.Index])))
-	into.TransformId = append(into.TransformId, from.Transform.CatalogDbId)
+	into.TransformId = append(into.TransformId, from.Transform.ReaderCatalogDbId)
 }
 
 func unwrapContinue(resp deriveResponseOrError) (*pf.DeriveResponse_Continue, error) {

--- a/go/flow/transaction_test.go
+++ b/go/flow/transaction_test.go
@@ -56,7 +56,7 @@ func TestTransactionLifeCycle(t *testing.T) {
 				Message: pf.IndexedShuffleResponse{
 					ShuffleResponse: &shuffleResponse,
 					Index:           index,
-					Transform:       &pf.TransformSpec{CatalogDbId: int32(index)},
+					Transform:       &pf.ReadSpec{ReaderCatalogDbId: int32(index)},
 				},
 			}
 		}

--- a/go/labels/labels.go
+++ b/go/labels/labels.go
@@ -34,6 +34,9 @@ const (
 	// Derivation is the name of the Estuary collection to be derived.
 	// Once set on a ShardSpec, it cannot change.
 	Derivation = "estuary.dev/derivation"
+	// Materialization is the name of the materialization (within a collection).
+	// Once set on a ShardSpec, it cannot change.
+	Materialization = "estuary.dev/materialization"
 	// RClockBegin is a uint64 in big-endian 16-char hexadecimal notation,
 	// which is the beginning rotated clock range (inclusive) managed by this shard.
 	RClockBegin = "estuary.dev/rclock-begin"

--- a/go/materialize/config.go
+++ b/go/materialize/config.go
@@ -1,0 +1,261 @@
+package materialize
+
+import (
+	"fmt"
+	"strings"
+
+	"database/sql"
+	"encoding/json"
+	log "github.com/sirupsen/logrus"
+	"go.gazette.dev/core/consumer"
+
+	// Below are imports needed by the go sql package. These are not used directly, but they are
+	// required in order to connect to the databases.
+	// The sqlite driver
+	_ "github.com/mattn/go-sqlite3"
+
+	// The postgresql driver
+	_ "github.com/lib/pq"
+)
+
+const (
+	TargetTypePostgres string = "postgres"
+	TargetTypeSqlite   string = "sqlite"
+
+	MaterializationsTableName  string = "flow_materializations"
+	OriginalDocumentColumnName string = "flow_document"
+)
+
+var PostgresSqlConfig SqlConfig = SqlConfig{
+	IdentifierQuotes: TokenPair{
+		Left:  "\"",
+		Right: "\"",
+	},
+	DriverName: "postgres",
+	GetSqlPlaceholder: func(i int) string {
+		// The +1 here is because the i that's passed to this function is 0-indexed, but
+		// postgres argument numbers start at 1.
+		return fmt.Sprintf("$%d", i+1)
+	},
+}
+var SqliteSqlConfig SqlConfig = SqlConfig{
+	IdentifierQuotes: TokenPair{
+		Left:  "\"",
+		Right: "\"",
+	},
+	DriverName: "sqlite3",
+	GetSqlPlaceholder: func(_ int) string {
+		return "?"
+	},
+}
+
+/*
+* We expect the table:
+*
+* CREATE TABLE IF NOT EXISTS flow_materializations
+* (
+*     table_name PRIMARY KEY TEXT NOT NULL,
+*     config_json TEXT NOT NULL
+* );
+*
+* Where config_json is a json representation of a MaterializationRuntimeConfig.
+* This json holds information about the fields that will be materialized.
+ */
+
+// Holds SQL statements and related information about the target schema. This struct is created
+// on initialization using data stored in the `flow_materializations` table in target database
+type MaterializationSql struct {
+	InsertStatement        string
+	FullDocumentQuery      string
+	RuntimeConfig          *MaterializationRuntimeConfig
+	ProjectionPointers     []string
+	PrimaryKeyFieldIndexes []int
+}
+
+type TokenPair struct {
+	Left  string `json:"left"`
+	Right string `json:"right"`
+}
+
+type SqlConfig struct {
+	IdentifierQuotes  TokenPair
+	DriverName        string
+	GetSqlPlaceholder func(int) string
+}
+
+func (self *SqlConfig) quoted(inner interface{}) quoted {
+	return quoted{
+		inner:  inner,
+		quotes: &self.IdentifierQuotes,
+	}
+}
+
+type Projection struct {
+	Field           string `json:"field"`
+	LocationPointer string `json:"locationPtr"`
+	PrimaryKey      bool   `json:"primaryKey"`
+}
+
+type MaterializationRuntimeConfig struct {
+	Projections []Projection `json:"fields"`
+}
+
+func (self *MaterializationRuntimeConfig) getProjectionPointers() []string {
+	var pointers []string
+	for _, field := range self.Projections {
+		pointers = append(pointers, field.LocationPointer)
+	}
+	return pointers
+}
+
+// Loaded from Catalog database
+type Materialization struct {
+	CatalogDbId         int32
+	MaterializationName string
+	TargetUri           string
+	TableName           string
+	TargetType          string
+}
+
+func (self *Materialization) sqlConfig() (*SqlConfig, error) {
+	switch self.TargetType {
+	case TargetTypePostgres:
+		return &PostgresSqlConfig, nil
+	case TargetTypeSqlite:
+		return &SqliteSqlConfig, nil
+	default:
+		return nil, fmt.Errorf("unsupported materialization target uri scheme: '%s'", self.TargetType)
+	}
+}
+
+type quoted struct {
+	quotes *TokenPair
+	inner  interface{}
+}
+
+func (self *quoted) String() string {
+	return fmt.Sprintf("%s%s%s", self.quotes.Left, self.inner, self.quotes.Right)
+}
+
+func NewMaterializationTarget(materialization *Materialization) (Target, error) {
+	var sqlConfig, err = materialization.sqlConfig()
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open(sqlConfig.DriverName, materialization.TargetUri)
+	if err != nil {
+		return nil, err
+	}
+	runtimeConfig, err := loadRuntimeConfig(sqlConfig, db, materialization.TableName)
+	if err != nil {
+		return nil, err
+	}
+
+	var insertStatement = generateInsertStatement(materialization, runtimeConfig, sqlConfig)
+	var documentQuery = generateFlowDocumentQuery(materialization, runtimeConfig, sqlConfig)
+
+	var projectionPointers []string
+	var primaryKeyFieldIndexes []int
+	for i, projection := range runtimeConfig.Projections {
+		projectionPointers = append(projectionPointers, projection.LocationPointer)
+		if projection.PrimaryKey {
+			primaryKeyFieldIndexes = append(primaryKeyFieldIndexes, i)
+		}
+	}
+
+	var sql = &MaterializationSql{
+		RuntimeConfig:          runtimeConfig,
+		InsertStatement:        insertStatement,
+		FullDocumentQuery:      documentQuery,
+		ProjectionPointers:     projectionPointers,
+		PrimaryKeyFieldIndexes: primaryKeyFieldIndexes,
+	}
+	var store = consumer.NewSQLStore(db)
+	return &MaterializationStore{
+		sqlConfig: sql,
+		delegate:  store,
+	}, nil
+}
+
+func loadRuntimeConfig(sqlConfig *SqlConfig, db *sql.DB, tableName string) (*MaterializationRuntimeConfig, error) {
+	var sql = fmt.Sprintf("SELECT config_json FROM flow_materializations WHERE table_name = %s;", sqlConfig.GetSqlPlaceholder(0))
+	log.WithFields(log.Fields{
+		"tableName": tableName,
+		"query":     sql,
+	}).Debug("Loading materialization for table")
+	var rows = db.QueryRow(sql, tableName)
+	var runtimeConfigJson string
+	var err = rows.Scan(&runtimeConfigJson)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to query the materialization runtime configuration from the target database: %v", err)
+	}
+	var runtimeConf = new(MaterializationRuntimeConfig)
+	err = json.Unmarshal([]byte(runtimeConfigJson), runtimeConf)
+	if err != nil {
+		log.WithField("rawRuntimeConfiguration", runtimeConfigJson).
+			WithField("tableName", tableName).
+			Error("Failed to unmarshal materialization runtime configuration")
+		return nil, fmt.Errorf("Materialization runtime configuration appears corrupted: %v", err)
+	}
+	return runtimeConf, nil
+}
+
+func generateFlowDocumentQuery(materialization *Materialization, runtimeConfig *MaterializationRuntimeConfig, sqlConfig *SqlConfig) string {
+	var tableName = sqlConfig.quoted(materialization.TableName)
+	var conditions []string
+	for i, field := range runtimeConfig.Projections {
+		if field.PrimaryKey {
+			var col = sqlConfig.quoted(field.Field)
+			var condition = fmt.Sprintf("%s = %s", col.String(), sqlConfig.GetSqlPlaceholder(i))
+			conditions = append(conditions, condition)
+		}
+	}
+
+	var columnName = sqlConfig.quoted(OriginalDocumentColumnName)
+	return fmt.Sprintf("SELECT %s from %v WHERE %s;", columnName.String(), tableName.String(), strings.Join(conditions, " AND "))
+}
+
+func generateInsertStatement(materialization *Materialization, runtimeConfig *MaterializationRuntimeConfig, sqlConfig *SqlConfig) string {
+	var tableName = sqlConfig.quoted(materialization.TableName)
+
+	var primaryKeyColumns []string
+	quotedColumnNames := make([]string, len(runtimeConfig.Projections))
+	var updateColumns []string
+	for i, field := range runtimeConfig.Projections {
+		// I don't know why, but go won't let you call String unless this is first
+		// assigned to a variable. Perhaps some rules about the receiver being a pointer?
+		var quotedCol = sqlConfig.quoted(field.Field)
+		var quotedColumnName = quotedCol.String()
+		quotedColumnNames[i] = quotedColumnName
+		if field.PrimaryKey {
+			primaryKeyColumns = append(primaryKeyColumns, quotedColumnName)
+		} else {
+			updateColumns = append(updateColumns, quotedColumnName)
+		}
+	}
+	// Populate the placeholders for the query. These may be different depending on the driver.
+	// +1 to i for the full document column
+	var questionMarks = make([]string, len(runtimeConfig.Projections)+1)
+	for i := 0; i < len(runtimeConfig.Projections)+1; i++ {
+		questionMarks[i] = sqlConfig.GetSqlPlaceholder(i)
+	}
+
+	// We always add the column that holds the full document at the very end. This column needs to
+	// be included in both the complete list and the list of columns that will be updated on a
+	// unique constraint violation
+	var fullDocumentColumn = sqlConfig.quoted(OriginalDocumentColumnName)
+	var quotedFullDocColumn = fullDocumentColumn.String()
+	quotedColumnNames = append(quotedColumnNames, quotedFullDocColumn)
+	updateColumns = append(updateColumns, quotedFullDocColumn)
+
+	var updates = make([]string, len(updateColumns))
+	for i, uc := range updateColumns {
+		updates[i] = fmt.Sprintf("%s = EXCLUDED.%s", uc, uc)
+	}
+
+	var onConflictDo = fmt.Sprintf("DO UPDATE SET %s", strings.Join(updates, ", "))
+
+	var sql = fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) %s;", tableName.String(), strings.Join(quotedColumnNames, ", "), strings.Join(questionMarks, ", "), strings.Join(primaryKeyColumns, ", "), onConflictDo)
+	log.WithField("sql", sql).WithField("materialization", materialization.MaterializationName).Info("Generated SQL insert statement for materialization")
+	return sql
+}

--- a/go/materialize/interface.go
+++ b/go/materialize/interface.go
@@ -1,0 +1,30 @@
+package materialize
+
+import (
+	"context"
+	"encoding/json"
+	"go.gazette.dev/core/consumer"
+)
+
+// TargetTransaction represents the remote store's view of the transaction.
+type TargetTransaction interface {
+	// Retrieves the current document from the remote store, or nil if it doesn't exist.
+	FetchExistingDocument(primaryKey []interface{}) (json.RawMessage, error)
+	// Stores the materialized document and all extractedFields.
+	Store(extractedFields []interface{}, fullDocument json.RawMessage) error
+}
+
+// Target represents an external system that may hold a materialized view. This
+// interface attempts to abstract over the details of any such system, whether it's a sql database
+// or key-value store, or anything else.
+type Target interface {
+	consumer.Store
+	// Starts a new transaction
+	BeginTxn(_ context.Context) (TargetTransaction, error)
+	// Returns a slice of all the location pointers to all projected fields. This slice must not
+	// change over the lifetime of a running shard.
+	ProjectionPointers() []string
+	// Represents the primary keys of the collection as a slice of indexes into `ProjectionPointers`.
+	// This also must not change over the lifetime of a running shard.
+	PrimaryKeyFieldIndexes() []int
+}

--- a/go/materialize/sqlite_test.go
+++ b/go/materialize/sqlite_test.go
@@ -1,0 +1,109 @@
+package materialize
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSqliteMaterialization(t *testing.T) {
+	dbfile := tempFilename("sqlitetest")
+	defer os.Remove(dbfile)
+
+	db, err := sql.Open("sqlite3", dbfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execSql(db, t, createFlowMaterializationsTable)
+
+	execSql(db, t, `
+        INSERT INTO flow_materializations (table_name, config_json)
+        VALUES ('good_table', '{
+            "fields": [
+                { "field": "a", "locationPtr": "/a", "primaryKey": true },
+                { "field": "b", "locationPtr": "/b", "primaryKey": true },
+                { "field": "x", "locationPtr": "/x", "primaryKey": false },
+                { "field": "y", "locationPtr": "/y", "primaryKey": false },
+                { "field": "z", "locationPtr": "/z", "primaryKey": false }
+            ]
+        }');
+    `)
+	execSql(db, t, `CREATE TABLE good_table (a, b, x, y, z, flow_document, PRIMARY KEY (a, b));`)
+	// close the database, since we're done with setup
+	require.Nil(t, db.Close(), "db error on close")
+
+	materialization := Materialization{
+		CatalogDbId:         1,
+		MaterializationName: "testSqlite",
+		TargetUri:           dbfile,
+		TableName:           "good_table",
+		TargetType:          "sqlite",
+	}
+	target, err := NewMaterializationTarget(&materialization)
+	if err != nil {
+		t.Fatalf("Failed to initialize materialization target: %v", err)
+	}
+
+	expectedPointers := []string{"/a", "/b", "/x", "/y", "/z"}
+	require.Equal(t, expectedPointers, target.ProjectionPointers(), "invalid field pointers")
+
+	expectedPKIndexes := []int{0, 1}
+	require.Equal(t, expectedPKIndexes, target.PrimaryKeyFieldIndexes(), "invalid PK indexes")
+
+	transaction, err := target.BeginTxn(context.Background())
+
+	shouldBeNil, err := transaction.FetchExistingDocument([]interface{}{"foo", "bar"})
+	require.Nil(t, err, "error fetching missing document")
+	require.Nil(t, shouldBeNil, "expected nil document")
+
+	fullDoc := json.RawMessage("testDocument")
+	err = transaction.Store([]interface{}{"someA", "someB", "someX", "someY", "someZ"}, fullDoc)
+	require.Nil(t, err, "error storing document")
+
+	returnedDoc, err := transaction.FetchExistingDocument([]interface{}{"someA", "someB"})
+	require.Nil(t, err, "failed to fetch existing document")
+	require.Equal(t, fullDoc, returnedDoc, json.RawMessage("invalid flow_document"))
+
+	err = transaction.Store([]interface{}{"someA", "someB", "diffX", "diffY", "diffZ"}, json.RawMessage("differentDoc"))
+	require.Nil(t, err, "error updating document")
+
+	updated, err := transaction.FetchExistingDocument([]interface{}{"someA", "someB"})
+	require.Nil(t, err, "failed to fetch updated doc")
+	require.Equal(t, json.RawMessage("differentDoc"), updated, "invalid updated flow_document")
+}
+
+func assertEq(t *testing.T, expected interface{}, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+const createFlowMaterializationsTable = `
+CREATE TABLE IF NOT EXISTS flow_materializations
+(
+    table_name TEXT NOT NULL PRIMARY KEY,
+    config_json TEXT NOT NULL
+);`
+
+func execSql(db *sql.DB, t *testing.T, sql string, args ...interface{}) {
+	_, err := db.Exec(sql, args...)
+	if err != nil {
+		t.Fatalf("Failed to execute sql: %q, err: %v", sql, err)
+	}
+}
+
+func tempFilename(name string) string {
+	ts := time.Now().UnixNano()
+	filename := fmt.Sprintf("%s-%s", name, strconv.FormatInt(ts, 10)[:6])
+	return path.Join(os.TempDir(), filename)
+}

--- a/go/materialize/store.go
+++ b/go/materialize/store.go
@@ -1,0 +1,97 @@
+package materialize
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"go.gazette.dev/core/consumer"
+	pc "go.gazette.dev/core/consumer/protocol"
+)
+
+type SqlTransaction struct {
+	delegate *sql.Tx
+	sql      *MaterializationSql
+}
+
+var _ TargetTransaction = (*SqlTransaction)(nil)
+
+func (self *SqlTransaction) FetchExistingDocument(primaryKey []interface{}) (json.RawMessage, error) {
+	var documentJson json.RawMessage
+	stmt, err := self.delegate.Prepare(self.sql.FullDocumentQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	row := stmt.QueryRow(primaryKey...)
+	err = row.Scan(&documentJson)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("Failed to query existing docuement: %w", err)
+	} else if err == sql.ErrNoRows {
+		return nil, nil
+	} else {
+		return documentJson, nil
+	}
+}
+
+func (self *SqlTransaction) Store(extractedFields []interface{}, fullDocument json.RawMessage) error {
+	stmt, err := self.delegate.Prepare(self.sql.InsertStatement)
+	if err != nil {
+		return err
+	}
+	// We always put the full document as the last field
+	allFields := append(extractedFields, fullDocument)
+	_, err = stmt.Exec(allFields...)
+	stmt.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to execute insert statement: %w", err)
+	}
+	return nil
+}
+
+type MaterializationStore struct {
+	sqlConfig *MaterializationSql
+	delegate  *consumer.SQLStore
+}
+
+var _ Target = (*MaterializationStore)(nil)
+
+func (self *MaterializationStore) ProjectionPointers() []string {
+	return self.sqlConfig.ProjectionPointers
+}
+
+func (self *MaterializationStore) PrimaryKeyFieldIndexes() []int {
+	return self.sqlConfig.PrimaryKeyFieldIndexes
+}
+
+func (self *MaterializationStore) BeginTxn(ctx context.Context) (TargetTransaction, error) {
+	txOpts := sql.TxOptions{
+		// TODO: see if we need to set an explicit value for Isolation
+		Isolation: 0,
+		ReadOnly:  false,
+	}
+	tx, err := self.delegate.Transaction(ctx, &txOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlT := &SqlTransaction{
+		delegate: tx,
+		sql:      self.sqlConfig,
+	}
+	return sqlT, nil
+}
+
+func (self *MaterializationStore) StartCommit(shard consumer.Shard, checkpoint pc.Checkpoint, waitFor consumer.OpFutures) consumer.OpFuture {
+	return self.delegate.StartCommit(shard, checkpoint, waitFor)
+}
+
+func (self *MaterializationStore) RestoreCheckpoint(shard consumer.Shard) (pc.Checkpoint, error) {
+	return self.delegate.RestoreCheckpoint(shard)
+}
+
+func (self *MaterializationStore) Destroy() {
+	if self != nil {
+		self.delegate.Destroy()
+	}
+}

--- a/go/protocol/document_extensions.go
+++ b/go/protocol/document_extensions.go
@@ -68,13 +68,29 @@ func (parts *UUIDParts) Pack() message.UUID {
 	)
 }
 
+// A generic label that describes a reader.
+type ReaderLabel struct {
+	Key   string
+	Value string
+}
+
+// A Generic descriptor of a thing that will perform a shuffled read
+type ReadSpec struct {
+	SourceName        string
+	SourcePartitions  pb.LabelSelector
+	Shuffle           Shuffle
+	ReaderType        string
+	ReaderNames       []string
+	ReaderCatalogDbId int32
+}
+
 // IndexedShuffleResponse is an implementation of message.Message which
 // indexes a specific document within a ShuffleResponse.
 type IndexedShuffleResponse struct {
 	*ShuffleResponse
 	Index int
 	// Transform on whose behalf this document was read.
-	Transform *TransformSpec
+	Transform *ReadSpec
 }
 
 var _ message.Message = IndexedShuffleResponse{}

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -68,7 +68,7 @@ func NewDeriveApp(
 	if err != nil {
 		return nil, fmt.Errorf("loading transform specs: %w", err)
 	}
-	readBuilder, err := shuffle.NewReadBuilder(service, journals, shard, transforms)
+	readBuilder, err := shuffle.NewReadBuilder(service, journals, shard, shuffle.ReadSpecsFromTransforms(transforms))
 	if err != nil {
 		return nil, fmt.Errorf("NewReadBuilder: %w", err)
 	}

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -1,0 +1,437 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/labels"
+	"github.com/estuary/flow/go/materialize"
+	pf "github.com/estuary/flow/go/protocol"
+	"github.com/estuary/flow/go/shuffle"
+	cache "github.com/hashicorp/golang-lru"
+	log "github.com/sirupsen/logrus"
+
+	pb "go.gazette.dev/core/broker/protocol"
+	"go.gazette.dev/core/consumer"
+	pc "go.gazette.dev/core/consumer/protocol"
+	"go.gazette.dev/core/consumer/recoverylog"
+	"go.gazette.dev/core/keyspace"
+	"go.gazette.dev/core/message"
+)
+
+// Wraps the transaction from the target system and also holds the Combine stream
+// and the set of keys that have been observed in this transaction.
+type MaterializeTransaction struct {
+	storeTransaction           materialize.TargetTransaction
+	combine                    *flow.Combine
+	observedDocumentPackedKeys map[string]int
+}
+
+// An Application implementation that materializes a view of a collection into a target database.
+// The name of the collection and materialization are taken from labels on the Shard.
+// This delegates to a MaterializationTarget, which implements the consumer.Store interface, for
+// all of the communication with the remote system.
+type Materialize struct {
+	materializationName string
+	delegate            *flow.WorkerHost
+	readBuilder         *shuffle.ReadBuilder
+	coordinator         *shuffle.Coordinator
+	collectionSpec      *pf.CollectionSpec
+	documentCache       *cache.Cache
+	targetStore         materialize.Target
+	transacton          *MaterializeTransaction
+}
+
+func NewMaterializeApp(
+	service *consumer.Service,
+	journals *keyspace.KeySpace,
+	extractor *flow.WorkerHost,
+	shard consumer.Shard,
+	_ *recoverylog.Recorder,
+) (*Materialize, error) {
+	log.Infof("Initializing Materialization for %v", shard.Spec().Labels)
+	var catalogURL, err = shardLabel(shard, labels.CatalogURL)
+	if err != nil {
+		return nil, err
+	}
+	collectionName, err := shardLabel(shard, labels.Collection)
+	if err != nil {
+		return nil, err
+	}
+	materializationName, err := shardLabel(shard, labels.Materialization)
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't use a recovery log for materializations, since their checkpoints are stored in the
+	// target system. Passing the empty string here has the effect of just using a temp file for the
+	// catalog. Note that we only read basic information from the catalog like the connection info
+	// for the target system and the table name. Specifics about the set of projections will come
+	// from the target system itself.
+	catalog, err := flow.NewCatalog(catalogURL, "")
+	if err != nil {
+		return nil, fmt.Errorf("opening catalog: %w", err)
+	}
+
+	collectionSpec, err := catalog.LoadCollection(collectionName)
+	if err != nil {
+		return nil, fmt.Errorf("loading collection spec: %w", err)
+	}
+	materializationSpec, err := catalog.LoadMaterialization(collectionName, materializationName)
+	if err != nil {
+		return nil, fmt.Errorf("loading materialization spec: %w", err)
+	}
+	err = catalog.Close()
+	if err != nil {
+		return nil, fmt.Errorf("closing catalog database: %w", err)
+	}
+
+	// Initialize the Store implementation for the target system. This will actually connect to the
+	// target system and initialize the set of projected fields from data stored there.
+	targetStore, err := materialize.NewMaterializationTarget(materializationSpec)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialize matarialization from target database: %w", err)
+	}
+
+	readerSpec := pf.ReadSpec{
+		SourceName: collectionName,
+		Shuffle: pf.Shuffle{
+			ShuffleKeyPtr: collectionSpec.KeyPtrs,
+			UsesSourceKey: true,
+		},
+		ReaderType:        "materialization",
+		ReaderNames:       []string{collectionName, materializationName},
+		ReaderCatalogDbId: materializationSpec.CatalogDbId,
+	}
+	readBuilder, err := shuffle.NewReadBuilder(service, journals, shard, []pf.ReadSpec{readerSpec})
+	if err != nil {
+		return nil, fmt.Errorf("NewReadBuilder: %w", err)
+	}
+
+	delegate, err := flow.NewWorkerHost(
+		"combine",
+		"--catalog",
+		catalogURL,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("starting materialization flow-worker: %w", err)
+	}
+
+	var coordinator = shuffle.NewCoordinator(shard.Context(), shard.JournalClient(),
+		pf.NewExtractClient(extractor.Conn))
+
+	// There's lots of room to optimize the size/characteristics of the cache, but we're ignoring all
+	// that for now and just using a reasonable limit on the total number of entries.
+	cache, err := cache.New(1024)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialize materialization document cache: %w", err)
+	}
+	log.WithFields(log.Fields{
+		"collection":      collectionName,
+		"materialization": materializationName,
+	}).Info("Successfully initialized materialization")
+
+	return &Materialize{
+		delegate:       delegate,
+		readBuilder:    readBuilder,
+		coordinator:    coordinator,
+		collectionSpec: &collectionSpec,
+		documentCache:  cache,
+		targetStore:    targetStore,
+		transacton:     nil,
+	}, nil
+}
+
+// Implementing consumer.Store for Materialize
+var _ consumer.Store = (*Materialize)(nil)
+
+// These functions just get delegated to the Store implementation for the target system
+func (self *Materialize) StartCommit(shard consumer.Shard, checkpoint pc.Checkpoint, waitFor consumer.OpFutures) consumer.OpFuture {
+	return self.targetStore.StartCommit(shard, checkpoint, waitFor)
+}
+
+func (self *Materialize) RestoreCheckpoint(shard consumer.Shard) (pc.Checkpoint, error) {
+	return self.targetStore.RestoreCheckpoint(shard)
+}
+
+func (self *Materialize) Destroy() {
+	// `self` will be null if the initialization returned an error, so we check here to avoid
+	// polluting the logs.
+	if self != nil {
+		self.targetStore.Destroy()
+	}
+}
+
+// Implementing shuffle.Store for Materialize
+var _ shuffle.Store = (*Materialize)(nil)
+
+func (self *Materialize) Coordinator() *shuffle.Coordinator {
+	return self.coordinator
+}
+
+// Implementing runtime.Application for Materialize
+var _ Application = (*Materialize)(nil)
+
+func (self *Materialize) BuildHints() (recoverylog.FSMHints, error) {
+	// This is a no-op since we aren't using a recover log
+	return recoverylog.FSMHints{}, nil
+}
+
+func (self *Materialize) BeginTxn(shard consumer.Shard) error {
+	if self.transacton != nil {
+		return fmt.Errorf("BeginTxn called while a transaction was already in progress")
+	}
+	log.WithFields(log.Fields{
+		"collection":      self.collectionSpec.Name.String(),
+		"materialization": self.materializationName,
+	}).Debug("Starting new transaction")
+	tx, err := self.targetStore.BeginTxn(shard.Context())
+	if err != nil {
+		return err
+	}
+
+	combine, err := flow.NewCombine(shard.Context(), self.delegate.Conn, self.collectionSpec)
+	if err != nil {
+		return err
+	}
+	err = combine.Open(self.targetStore.ProjectionPointers())
+	if err != nil {
+		return err
+	}
+	self.transacton = &MaterializeTransaction{
+		storeTransaction:           tx,
+		combine:                    combine,
+		observedDocumentPackedKeys: make(map[string]int),
+	}
+	return nil
+}
+
+func (self *Materialize) ConsumeMessage(shard consumer.Shard, envelope message.Envelope, pub *message.Publisher) error {
+	if self.transacton == nil {
+		return fmt.Errorf("ConsumeMessage called without any transaction in progress")
+	}
+
+	shuffleResponse := envelope.Message.(pf.IndexedShuffleResponse)
+	if len(shuffleResponse.TerminalError) > 0 {
+		return fmt.Errorf("Terminal Error on shuffled read: %s", shuffleResponse.TerminalError)
+	}
+
+	var flags = message.GetFlags(shuffleResponse.GetUUID())
+	if flags == message.Flag_ACK_TXN {
+		return nil // We just ignore the ACK documents.
+	}
+
+	log.WithFields(log.Fields{
+		"collection":      self.collectionSpec.Name.String(),
+		"materialization": self.materializationName,
+		"messageUuid":     envelope.GetUUID(),
+	}).Debug("on ConsumeMessage")
+
+	packedShuffleKey := extractPackedKey(shuffleResponse)
+
+	// We need to check if we've added the existing document to the Combine already. If not,
+	// then we'll fetch the existing document (either from cache or the materialization
+	// database) and add that to the Combine. The "packed" shuffle key, represented as a string,
+	// is used as the key for the cache and the hashmap of ovserved document ids. This is
+	// because go doesn't allow `[]interface{}` to be used as a map key.
+	if _, isPresent := self.transacton.observedDocumentPackedKeys[packedShuffleKey]; !isPresent {
+		primaryKeys, err := unsafeExtractFields(shuffleResponse.Index, shuffleResponse.ShuffleKey, shuffleResponse.Arena)
+		if err != nil {
+			return fmt.Errorf("Failed to extract primary keys from document: %w", err)
+		}
+		existingDocument, err := self.fetchExistingDocument(packedShuffleKey, primaryKeys)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch existing document for keys: %v: %w", primaryKeys, err)
+		}
+		if len(existingDocument) > 0 {
+			err = self.transacton.combine.Add(existingDocument)
+			if err != nil {
+				return fmt.Errorf("Failed to add existing document to combine RPC: %w", err)
+			}
+		}
+	}
+	self.transacton.observedDocumentPackedKeys[packedShuffleKey] += 1
+
+	sliceRange := shuffleResponse.DocsJson[shuffleResponse.Index]
+	bytes := shuffleResponse.Arena.Bytes(sliceRange)
+	err := self.transacton.combine.Add(json.RawMessage(bytes))
+	if err != nil {
+		return fmt.Errorf("Failed to add new document to combine RPC: %w", err)
+	}
+
+	return nil
+}
+
+func (self *Materialize) FinalizeTxn(shard consumer.Shard, pub *message.Publisher) error {
+	if self.transacton == nil {
+		return fmt.Errorf("FinalizeTxn called without any transaction in progress")
+	}
+	var totalKeys int
+	var totalDocuments int
+	for _, v := range self.transacton.observedDocumentPackedKeys {
+		totalKeys += 1
+		totalDocuments += v
+	}
+	log.WithFields(log.Fields{
+		"shard":             shard.Spec().Labels,
+		"observedKeys":      totalKeys,
+		"observedDocuments": totalDocuments,
+	}).Debug("on FinalizeTxn")
+
+	err := self.transacton.combine.Flush()
+	if err != nil {
+		return fmt.Errorf("Failed to flush Combine RPC: %w", err)
+	}
+	err = self.transacton.combine.Finish(self.updateDatabase)
+	return err
+}
+
+func (self *Materialize) FinishedTxn(shard consumer.Shard, _ consumer.OpFuture) {
+	log.WithFields(log.Fields{
+		"shard": shard.Spec().Labels,
+	}).Debug("on FinishedTxn")
+	self.transacton = nil
+}
+
+func (self *Materialize) StartReadingMessages(shard consumer.Shard, checkpoint pc.Checkpoint, channel chan<- consumer.EnvelopeOrError) {
+	log.WithFields(log.Fields{
+		"shard":      shard.Spec().Labels,
+		"checkpoint": checkpoint,
+	}).Debug("Starting to Read Messages")
+	shuffle.StartReadingMessages(shard.Context(), self.readBuilder, checkpoint, channel)
+}
+
+// ReadThrough delegates to shuffle.ReadThrough
+func (self *Materialize) ReadThrough(offsets pb.Offsets) (pb.Offsets, error) {
+	return self.readBuilder.ReadThrough(offsets)
+}
+
+// ReplayRange delegates to shuffle's StartReplayRead.
+func (self *Materialize) ReplayRange(shard consumer.Shard, journal pb.Journal, begin pb.Offset, end pb.Offset) message.Iterator {
+	return self.readBuilder.StartReplayRead(shard.Context(), journal, begin, end)
+}
+
+// Called for each document in the Combine RPC response, after all documents have been added for
+// this transaction.
+func (self *Materialize) updateDatabase(icr pf.IndexedCombineResponse) error {
+	docIndex := icr.Index
+	log.WithFields(log.Fields{
+		"collection":      self.collectionSpec.Name.String(),
+		"materialization": self.materializationName,
+		"docIndex":        icr.Index,
+	}).Debug("Updating database")
+	extractedFields, err := unsafeExtractFields(docIndex, icr.Fields, icr.Arena)
+	if err != nil {
+		return err
+	}
+
+	// The full document json is always the last column, so we add that to the fields that were
+	// extracted. This is all dependent on the order
+	var documentJson = icr.Arena.Bytes(icr.DocsJson[docIndex])
+
+	err = self.transacton.storeTransaction.Store(extractedFields, documentJson)
+	if err != nil {
+		return fmt.Errorf("Failed to store document: %w", err)
+	}
+	log.Debugf("Successfully updated database for document %d", docIndex)
+
+	packedKey := self.getPackedKey(icr)
+	self.documentCache.Add(packedKey, json.RawMessage(documentJson))
+	return nil
+}
+
+func (self *Materialize) fetchExistingDocument(packedPrimaryKey string, primaryKeys []interface{}) (json.RawMessage, error) {
+	var documentJson json.RawMessage
+	var rawDocument, exists = self.documentCache.Get(packedPrimaryKey)
+	if exists {
+		documentJson = rawDocument.(json.RawMessage)
+	} else {
+		var fetched, err = self.transacton.storeTransaction.FetchExistingDocument(primaryKeys)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve existing document: %w", err)
+		}
+		documentJson = fetched
+	}
+	return documentJson, nil
+}
+
+func (self *Materialize) getPackedKey(icr pf.IndexedCombineResponse) string {
+	var packedBytes []byte
+	for _, i := range self.targetStore.PrimaryKeyFieldIndexes() {
+		icr.Fields[i].Values[icr.Index].EncodePacked(packedBytes, icr.Arena)
+	}
+	return string(packedBytes)
+}
+
+func extractPackedKey(shuffleResponse pf.IndexedShuffleResponse) string {
+	byteRange := shuffleResponse.PackedKey[shuffleResponse.Index]
+	keyBytes := shuffleResponse.Arena[byteRange.Begin:byteRange.End]
+	return string(keyBytes)
+}
+
+func unsafeExtractFields(documentIndex int, fields []pf.Field, arena pf.Arena) ([]interface{}, error) {
+	extractedFields := make([]interface{}, len(fields))
+	for i, field := range fields {
+		extractedValue, err := unsafeGetValue(field.Values[documentIndex], arena)
+		if err != nil {
+			return nil, err
+		}
+		extractedFields[i] = extractedValue
+	}
+	return extractedFields, nil
+}
+
+// Safe version that returns the value of a field. Copies contents out of the arena, if necessary.
+func getValue(field pf.Field_Value, arena pf.Arena) (interface{}, error) {
+	switch field.Kind {
+	case pf.Field_Value_NULL:
+		return nil, nil
+	case pf.Field_Value_TRUE:
+		return true, nil
+	case pf.Field_Value_FALSE:
+		return false, nil
+	case pf.Field_Value_UNSIGNED:
+		return field.Unsigned, nil
+	case pf.Field_Value_SIGNED:
+		return field.Signed, nil
+	case pf.Field_Value_DOUBLE:
+		return field.Double, nil
+	case pf.Field_Value_OBJECT, pf.Field_Value_ARRAY, pf.Field_Value_STRING:
+		bytes := arena[field.Bytes.Begin:field.Bytes.End]
+		return string(bytes), nil
+	default:
+		return nil, fmt.Errorf("invalid field value: %#v", field)
+	}
+}
+
+// Returns the field value, which may still contain a pointer into the arena.
+func unsafeGetValue(field pf.Field_Value, arena pf.Arena) (interface{}, error) {
+	switch field.Kind {
+	case pf.Field_Value_NULL:
+		return nil, nil
+	case pf.Field_Value_TRUE:
+		return true, nil
+	case pf.Field_Value_FALSE:
+		return false, nil
+	case pf.Field_Value_UNSIGNED:
+		return field.Unsigned, nil
+	case pf.Field_Value_SIGNED:
+		return field.Signed, nil
+	case pf.Field_Value_DOUBLE:
+		return field.Double, nil
+	case pf.Field_Value_OBJECT, pf.Field_Value_ARRAY, pf.Field_Value_STRING:
+		return unsafeGetString(field.Bytes, arena), nil
+	default:
+		return nil, fmt.Errorf("invalid field value: %#v", field)
+	}
+}
+
+func unsafeGetString(slice pf.Slice, arena pf.Arena) string {
+	bytes := arena[slice.Begin:slice.End]
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&bytes))
+	sh := reflect.StringHeader{Data: bh.Data, Len: bh.Len}
+	return *(*string)(unsafe.Pointer(&sh))
+}

--- a/go/shuffle/reader_test.go
+++ b/go/shuffle/reader_test.go
@@ -222,7 +222,7 @@ func (a testApp) NewStore(shard consumer.Shard, recorder *recoverylog.Recorder) 
 		return nil, err
 	}
 
-	readBuilder, err := NewReadBuilder(a.service, a.journals, shard, a.transforms)
+	readBuilder, err := NewReadBuilder(a.service, a.journals, shard, ReadSpecsFromTransforms(a.transforms))
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (a testApp) ConsumeMessage(shard consumer.Shard, store consumer.Store, env 
 	var key = msg.Arena.Bytes(msg.PackedKey[msg.Index])
 	state[string(key)]++
 
-	if msg.Transform.Name != "highAndLow" {
+	if msg.Transform.ReaderNames[1] != "highAndLow" {
 		return fmt.Errorf("expected TransformSpec fixture to be passed-through")
 	}
 	return nil


### PR DESCRIPTION
First pass at materialization for both sqlite and postgres. There's nothing creating shard specs for these at the moment, so we have to do that part manually for the short term.

Run the consumer:
`PATH=$PATH:~/projects/flow/target/debug ./.build-ci/go-path/bin/flow-consumer serve --consumer.host=localhost --log.level=debug --consumer.port 9020`

The following shard spec can be applied to test the materialization for stock/daily-stats:

```
common:
  max_txn_duration: 1s
  labels:
  - name: app.gazette.dev/managed-by
    value: estuary.dev/flow
  - name: estuary.dev/catalog-url
    value: catalog.db
  - name: estuary.dev/key-begin
    value: "00"
  - name: estuary.dev/key-end
    value: ffffffffffffffffffffffff
  - name: estuary.dev/rclock-begin
    value: "0000000000000000"
  - name: estuary.dev/rclock-end
    value: ffffffffffffffff
shards:
- id: materializations/stock/daily-stats/dailyStatsPostgres
  labels:
  - name: estuary.dev/collection
    value: stock/daily-stats
  - name: estuary.dev/materialization
    value: dailyStatsPostgres
```