### PR TITLE
Validate that test verify step docs are ordered

### DIFF
--- a/crates/catalog/src/error.rs
+++ b/crates/catalog/src/error.rs
@@ -1,5 +1,6 @@
 use super::ContentType;
 use crate::extraction::KeyError;
+use crate::test_case::TestVerifyOutOfOrder;
 use doc::{self, inference};
 use itertools::Itertools;
 use json::schema;
@@ -108,6 +109,9 @@ pub enum Error {
 
     #[error("The --catalog was not built by this version of flowctl. Catalog version: '{0}'")]
     CatalogVersionMismatch(String),
+
+    #[error(transparent)]
+    TestInvalid(#[from] TestVerifyOutOfOrder),
 }
 
 impl Error {

--- a/crates/catalog/src/snapshots/catalog__collection__test__register.snap
+++ b/crates/catalog/src/snapshots/catalog__collection__test__register.snap
@@ -1,0 +1,34 @@
+---
+source: crates/catalog/src/collection.rs
+expression: dump
+---
+collections:
+  - - 1
+    - test/collection
+    - "test://example/schema.json#foobar"
+    - - /key/1
+      - /key/0
+    - 1
+partitions:
+  - - 1
+    - field_a
+projections:
+  - - 1
+    - field_a
+    - /a/a
+    - true
+  - - 1
+    - field_b
+    - /b/b
+    - true
+  - - 1
+    - a/a
+    - /a/a
+    - false
+  - - 1
+    - b/b
+    - /b/b
+    - false
+resource_imports:
+  - - 1
+    - 10

--- a/crates/catalog/src/specs.rs
+++ b/crates/catalog/src/specs.rs
@@ -11,6 +11,14 @@ use std::time::Duration;
 #[schemars(example = "CollectionName::example")]
 pub struct CollectionName(#[schemars(schema_with = "CollectionName::schema")] String);
 
+impl CollectionName {
+    /// Test only since this does not check the collection name against the validation regex
+    #[cfg(test)]
+    pub fn new(name: impl Into<String>) -> CollectionName {
+        CollectionName(name.into())
+    }
+}
+
 impl AsRef<str> for CollectionName {
     fn as_ref(&self) -> &str {
         &self.0


### PR DESCRIPTION
The documents in a test verify step must be in lexicographical order,
according to the collection's key. This commit adds a verification
during catalog builds to verify that the documents are in the proper
order, so that we can fail fast when the user provides them out of
order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/62)
<!-- Reviewable:end -->
