### PR TITLE
bindings: add crate and Go module with Service inter-op mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ name = "bindings"
 version = "0.0.0"
 dependencies = [
  "cbindgen",
+ "derive",
  "protocol",
 ]
 
@@ -1194,22 +1195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
-dependencies = [
- "bytes",
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "tokio",
- "tokio-rustls",
- "webpki",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,41 +2225,25 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "serde",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2342,19 +2311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,16 +2367,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -2617,12 +2563,6 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -2858,18 +2798,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
-dependencies = [
- "futures-core",
- "rustls",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -3281,12 +3209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,25 +3403,6 @@ checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindings"
+version = "0.0.0"
+dependencies = [
+ "cbindgen",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +258,25 @@ dependencies = [
  "unicode-normalization",
  "url",
  "yaml-merge-keys",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df6a11bba1d7cab86c166cecf4cf8acd7d02b7b65924d81b33d27197f22ee35"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -2880,6 +2906,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ name = "bindings"
 version = "0.0.0"
 dependencies = [
  "cbindgen",
+ "protocol",
 ]
 
 [[package]]

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bindings"
+version = "0.0.0"
+authors = ["Estuary Technologies, Inc"]
+edition = "2018"
+
+[lib]
+crate_type = ["staticlib"]
+
+[dependencies]
+
+[build-dependencies]
+cbindgen = "*"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -9,6 +9,7 @@ crate_type = ["staticlib"]
 
 [dependencies]
 protocol = { path = "../protocol", version = "0.0.0" }
+derive = { path = "../derive", version = "0.0.0" }
 
 [build-dependencies]
 cbindgen = "*"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crate_type = ["staticlib"]
 
 [dependencies]
+protocol = { path = "../protocol", version = "0.0.0" }
 
 [build-dependencies]
 cbindgen = "*"

--- a/crates/bindings/build.rs
+++ b/crates/bindings/build.rs
@@ -1,0 +1,18 @@
+extern crate cbindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let config = cbindgen::Config::from_file(PathBuf::from(&crate_dir).join("cbindgen.toml"))
+        .expect("failed to parse cbindgen config");
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file("flow_bindings.h");
+}

--- a/crates/bindings/cbindgen.toml
+++ b/crates/bindings/cbindgen.toml
@@ -1,0 +1,1 @@
+language = "C"

--- a/crates/bindings/cbindgen.toml
+++ b/crates/bindings/cbindgen.toml
@@ -1,1 +1,7 @@
 language = "C"
+
+[parse]
+# Parse dependencies, but only the white-listed "protocol" crate.
+# We're required to generate bindings for the protocol::cgo::Out type.
+parse_deps = true
+include = ["protocol"]

--- a/crates/bindings/flow_bindings.h
+++ b/crates/bindings/flow_bindings.h
@@ -1,0 +1,97 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Opaque pointer for a Service instance in the ABI.
+ */
+typedef struct {
+  uint8_t _private[0];
+} ServiceImpl;
+
+/**
+ * Output frame produced by a Service.
+ */
+typedef struct {
+  /**
+   * Service-defined response code.
+   */
+  uint32_t code;
+  /**
+   * Begin data offset into the Channel arena.
+   */
+  uint32_t begin;
+  /**
+   * End data offset into the Channel arena.
+   */
+  uint32_t end;
+} Out;
+
+/**
+ * Channel is shared between CGO and Rust, and holds details
+ * about the language interconnect.
+ */
+typedef struct {
+  ServiceImpl *svc_impl;
+  uint8_t *arena_ptr;
+  uintptr_t arena_len;
+  uintptr_t arena_cap;
+  Out *out_ptr;
+  uintptr_t out_len;
+  uintptr_t out_cap;
+  uint8_t *err_ptr;
+  uintptr_t err_len;
+  uintptr_t err_cap;
+} Channel;
+
+/**
+ * Input frame produced from CGO, which is a single service invocation.
+ * 16 bytes, or 1/4 of a typical cache line.
+ */
+typedef struct {
+  const uint8_t *data_ptr;
+  uint32_t data_len;
+  uint32_t code;
+} In1;
+
+/**
+ * Four invocations, composed into one struct.
+ * 64 bytes, or one typical cache line.
+ */
+typedef struct {
+  In1 in0;
+  In1 in1;
+  In1 in2;
+  In1 in3;
+} In4;
+
+/**
+ * Sixteen invocations, composed into one struct.
+ * 256 bytes, or four typical cache lines.
+ */
+typedef struct {
+  In4 in0;
+  In4 in1;
+  In4 in2;
+  In4 in3;
+} In16;
+
+Channel *upper_case_create(void);
+
+void upper_case_invoke1(Channel *ch, In1 i);
+
+void upper_case_invoke4(Channel *ch, In4 i);
+
+void upper_case_invoke16(Channel *ch, In16 i);
+
+void upper_case_drop(Channel *ch);
+
+ServiceImpl *create_upper_case_naive(void);
+
+uint32_t upper_case_naive(ServiceImpl *svc,
+                          uint32_t _code,
+                          const uint8_t *in_ptr,
+                          uint32_t in_len,
+                          const uint8_t **out_ptr,
+                          uint32_t *out_len);

--- a/crates/bindings/flow_bindings.h
+++ b/crates/bindings/flow_bindings.h
@@ -77,6 +77,16 @@ typedef struct {
   In4 in3;
 } In16;
 
+Channel *extractor_create(void);
+
+void extractor_invoke1(Channel *ch, In1 i);
+
+void extractor_invoke4(Channel *ch, In4 i);
+
+void extractor_invoke16(Channel *ch, In16 i);
+
+void extractor_drop(Channel *ch);
+
 Channel *upper_case_create(void);
 
 void upper_case_invoke1(Channel *ch, In1 i);

--- a/crates/bindings/flow_bindings.h
+++ b/crates/bindings/flow_bindings.h
@@ -19,11 +19,11 @@ typedef struct {
    */
   uint32_t code;
   /**
-   * Begin data offset into the Channel arena.
+   * Begin data offset within the arena.
    */
   uint32_t begin;
   /**
-   * End data offset into the Channel arena.
+   * End data offset within the arena.
    */
   uint32_t end;
 } Out;

--- a/crates/bindings/src/extract.rs
+++ b/crates/bindings/src/extract.rs
@@ -1,0 +1,23 @@
+use crate::service::{self, Channel};
+use derive::extract_api::Extractor;
+
+#[no_mangle]
+pub extern "C" fn extractor_create() -> *mut Channel {
+    service::create::<Extractor>()
+}
+#[no_mangle]
+pub extern "C" fn extractor_invoke1(ch: *mut Channel, i: service::In1) {
+    service::invoke::<Extractor, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn extractor_invoke4(ch: *mut Channel, i: service::In4) {
+    service::invoke::<Extractor, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn extractor_invoke16(ch: *mut Channel, i: service::In16) {
+    service::invoke::<Extractor, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn extractor_drop(ch: *mut Channel) {
+    service::drop::<Extractor>(ch)
+}

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod service;
+mod upper_case;

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1,2 +1,3 @@
+mod extract;
 pub mod service;
 mod upper_case;

--- a/crates/bindings/src/service.rs
+++ b/crates/bindings/src/service.rs
@@ -1,30 +1,4 @@
-/// Service is a trait implemented by services which may be called from Go.
-pub trait Service {
-    /// Error type returned by Service invocations.
-    type Error: std::error::Error;
-    /// Create a new instance of the Service.
-    fn create() -> Self;
-    /// Invoke with the given op-code & |data| payload.
-    /// It extends |arena| with any returned []byte data, and pushes output messages onto |out|.
-    fn invoke(
-        &mut self,
-        code: u32,
-        data: &[u8],
-        arena: &mut Vec<u8>,
-        out: &mut Vec<Out>,
-    ) -> Result<(), Self::Error>;
-}
-
-/// Output frame produced by a Service.
-#[repr(C)]
-pub struct Out {
-    /// Service-defined response code.
-    pub code: u32,
-    /// Begin data offset into the Channel arena.
-    pub begin: u32,
-    /// End data offset into the Channel arena.
-    pub end: u32,
-}
+pub use protocol::cgo::{Out, Service};
 
 /// InN is a variadic input which invokes itself against a Service.
 pub trait InN {

--- a/crates/bindings/src/service.rs
+++ b/crates/bindings/src/service.rs
@@ -1,0 +1,233 @@
+/// Service is a trait implemented by services which may be called from Go.
+pub trait Service {
+    /// Error type returned by Service invocations.
+    type Error: std::error::Error;
+    /// Create a new instance of the Service.
+    fn create() -> Self;
+    /// Invoke with the given op-code & |data| payload.
+    /// It extends |arena| with any returned []byte data, and pushes output messages onto |out|.
+    fn invoke(
+        &mut self,
+        code: u32,
+        data: &[u8],
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Output frame produced by a Service.
+#[repr(C)]
+pub struct Out {
+    /// Service-defined response code.
+    pub code: u32,
+    /// Begin data offset into the Channel arena.
+    pub begin: u32,
+    /// End data offset into the Channel arena.
+    pub end: u32,
+}
+
+/// InN is a variadic input which invokes itself against a Service.
+pub trait InN {
+    fn invoke<S: Service>(
+        self: &Self,
+        svc: &mut S,
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), S::Error>;
+}
+
+/// Input frame produced from CGO, which is a single service invocation.
+/// 16 bytes, or 1/4 of a typical cache line.
+#[repr(C)]
+pub struct In1 {
+    data_ptr: *const u8,
+    data_len: u32,
+    code: u32,
+}
+
+impl InN for In1 {
+    #[inline]
+    fn invoke<S: Service>(
+        self: &Self,
+        svc: &mut S,
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), S::Error> {
+        svc.invoke(
+            self.code,
+            unsafe { std::slice::from_raw_parts(self.data_ptr, self.data_len as usize) },
+            arena,
+            out,
+        )
+    }
+}
+
+/// Four invocations, composed into one struct.
+/// 64 bytes, or one typical cache line.
+#[repr(C)]
+pub struct In4 {
+    in0: In1,
+    in1: In1,
+    in2: In1,
+    in3: In1,
+}
+
+impl InN for In4 {
+    #[inline]
+    fn invoke<S: Service>(
+        self: &Self,
+        svc: &mut S,
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), S::Error> {
+        self.in0.invoke(svc, arena, out)?;
+        self.in1.invoke(svc, arena, out)?;
+        self.in2.invoke(svc, arena, out)?;
+        self.in3.invoke(svc, arena, out)
+    }
+}
+
+/// Sixteen invocations, composed into one struct.
+/// 256 bytes, or four typical cache lines.
+#[repr(C)]
+pub struct In16 {
+    in0: In4,
+    in1: In4,
+    in2: In4,
+    in3: In4,
+}
+
+impl InN for In16 {
+    #[inline]
+    fn invoke<S: Service>(
+        self: &Self,
+        svc: &mut S,
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), S::Error> {
+        self.in0.invoke(svc, arena, out)?;
+        self.in1.invoke(svc, arena, out)?;
+        self.in2.invoke(svc, arena, out)?;
+        self.in3.invoke(svc, arena, out)
+    }
+}
+
+/// Opaque pointer for a Service instance in the ABI.
+#[repr(C)]
+pub struct ServiceImpl {
+    _private: [u8; 0],
+}
+
+/// Channel is shared between CGO and Rust, and holds details
+/// about the language interconnect.
+#[repr(C)]
+pub struct Channel {
+    // Opaque service pointer.
+    svc_impl: *mut ServiceImpl,
+
+    // Output memory arena, exposed to CGO.
+    arena_ptr: *mut u8,
+    arena_len: usize,
+    arena_cap: usize,
+
+    // Output frame codes & arena offsets, exposed to CGO.
+    out_ptr: *mut Out,
+    out_len: usize,
+    out_cap: usize,
+
+    // Final error returned by the Service.
+    err_ptr: *mut u8,
+    err_len: usize,
+    err_cap: usize,
+}
+
+/// Create a new Service instance, wrapped in an owning Channel.
+/// This is intended to be monomorphized by each Service implementation,
+/// and exposed via cbindgen.  See the UpperCase service for an example.
+#[inline]
+pub fn create<S: Service>() -> *mut Channel {
+    let svc_impl = Box::new(S::create());
+    let svc_impl = Box::leak(svc_impl) as *mut S as *mut ServiceImpl;
+
+    let ch = Box::new(Channel {
+        svc_impl,
+        arena_ptr: 0 as *mut u8,
+        arena_len: 0,
+        arena_cap: 0,
+        out_ptr: 0 as *mut Out,
+        out_len: 0,
+        out_cap: 0,
+        err_ptr: 0 as *mut u8,
+        err_len: 0,
+        err_cap: 0,
+    });
+    Box::leak(ch)
+}
+
+/// Invoke a Service with one input.
+/// This is intended to be monomorphized by each Service implementation,
+/// and exposed via cbindgen.  See the UpperCase service for an example.
+#[inline]
+pub fn invoke<S: Service, I: InN>(ch: *mut Channel, i: I) {
+    let ch = unsafe { &mut *ch };
+
+    if ch.err_cap != 0 {
+        return; // If an error has been set, further invocations are no-ops.
+    }
+
+    let mut arena = unsafe { Vec::<u8>::from_raw_parts(ch.arena_ptr, ch.arena_len, ch.arena_cap) };
+    let mut out = unsafe { Vec::<Out>::from_raw_parts(ch.out_ptr, ch.out_len, ch.out_cap) };
+    let mut err_str = unsafe { String::from_raw_parts(ch.err_ptr, ch.err_len, ch.err_cap) };
+    let svc_impl = unsafe { &mut *(ch.svc_impl as *mut S) };
+
+    let r = i.invoke(svc_impl, &mut arena, &mut out);
+    if let Err(err) = r {
+        // Set terminal error string.
+        err_str = format!("{:?}", err);
+    }
+
+    ch.arena_ptr = arena.as_mut_ptr();
+    ch.arena_cap = arena.capacity();
+    ch.arena_len = arena.len();
+    std::mem::forget(arena);
+
+    ch.out_ptr = out.as_mut_ptr();
+    ch.out_cap = out.capacity();
+    ch.out_len = out.len();
+    std::mem::forget(out);
+
+    ch.err_ptr = err_str.as_mut_ptr();
+    ch.err_cap = err_str.capacity();
+    ch.err_len = err_str.len();
+    std::mem::forget(err_str);
+}
+
+/// Drop a Service and its Channel.
+/// This is intended to be monomorphized by each Service implementation,
+/// and exposed via cbindgen.  See the UpperCase service for an example.
+#[inline]
+pub fn drop<S: Service>(ch: *mut Channel) {
+    let Channel {
+        // Opaque service pointer.
+        svc_impl,
+
+        // Output frame codes & arena offsets, exposed to CGO.
+        arena_ptr,
+        arena_len,
+        arena_cap,
+
+        out_ptr,
+        out_len,
+        out_cap,
+
+        err_ptr,
+        err_len,
+        err_cap,
+    } = *unsafe { Box::from_raw(ch) };
+
+    // Drop svc_impl, arena, and out.
+    unsafe { Box::from_raw(svc_impl as *mut S) };
+    unsafe { Vec::<u8>::from_raw_parts(arena_ptr, arena_len, arena_cap) };
+    unsafe { Vec::<Out>::from_raw_parts(out_ptr, out_len, out_cap) };
+    unsafe { String::from_raw_parts(err_ptr, err_len, err_cap) };
+}

--- a/crates/bindings/src/upper_case.rs
+++ b/crates/bindings/src/upper_case.rs
@@ -1,0 +1,109 @@
+use crate::service::{self, Channel, Service, ServiceImpl};
+use std::io::Write;
+
+/// UpperCase is an example Service that returns its inputs as upper-case
+/// ASCII, along with a running sum of the number of bytes upper-cased
+/// (returned with each response code).
+pub struct UpperCase {
+    sum_length: u32,
+}
+
+impl Service for UpperCase {
+    type Error = std::io::Error;
+
+    fn create() -> Self {
+        Self { sum_length: 0 }
+    }
+
+    fn invoke(
+        &mut self,
+        _code: u32,
+        data: &[u8],
+        arena: &mut Vec<u8>,
+        out: &mut Vec<service::Out>,
+    ) -> Result<(), Self::Error> {
+        if data == b"whoops!" {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, "whoops!"));
+        }
+
+        let begin = arena.len() as u32;
+        arena.extend(data.iter().map(u8::to_ascii_uppercase));
+        self.sum_length += data.len() as u32;
+
+        out.push(service::Out {
+            code: self.sum_length,
+            begin,
+            end: arena.len() as u32,
+        });
+
+        Ok(())
+    }
+}
+
+// Define cbindgen <=> CGO hooks for driving the UpperCase service.
+
+#[no_mangle]
+pub extern "C" fn upper_case_create() -> *mut Channel {
+    service::create::<UpperCase>()
+}
+#[no_mangle]
+pub extern "C" fn upper_case_invoke1(ch: *mut Channel, i: service::In1) {
+    service::invoke::<UpperCase, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn upper_case_invoke4(ch: *mut Channel, i: service::In4) {
+    service::invoke::<UpperCase, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn upper_case_invoke16(ch: *mut Channel, i: service::In16) {
+    service::invoke::<UpperCase, _>(ch, i)
+}
+#[no_mangle]
+pub extern "C" fn upper_case_drop(ch: *mut Channel) {
+    service::drop::<UpperCase>(ch)
+}
+
+/// UpperCaseNaive is not part of UpperCase's service interface.
+/// It's here for comparative benchmarking with a more traditional CGO call style.
+
+struct UpperCaseNaive {
+    sum_length: u32,
+    arena: Vec<u8>,
+}
+
+#[no_mangle]
+pub extern "C" fn create_upper_case_naive() -> *mut ServiceImpl {
+    Box::leak(Box::new(UpperCaseNaive {
+        sum_length: 0,
+        arena: Vec::new(),
+    })) as *mut UpperCaseNaive as *mut ServiceImpl
+}
+
+#[no_mangle]
+pub extern "C" fn upper_case_naive(
+    svc: *mut ServiceImpl,
+    _code: u32,
+    in_ptr: *const u8,
+    in_len: u32,
+    out_ptr: &mut *const u8,
+    out_len: &mut u32,
+) -> u32 {
+    let svc = unsafe { &mut *(svc as *mut UpperCaseNaive) };
+    let in_ = unsafe { std::slice::from_raw_parts(in_ptr, in_len as usize) };
+
+    svc.arena.clear();
+
+    let code = if in_ == b"whoops!" {
+        let err = std::io::Error::new(std::io::ErrorKind::Other, "whoops!");
+        write!(svc.arena, "{:?}", err).unwrap();
+        std::u32::MAX
+    } else {
+        svc.arena.extend(in_.iter().map(u8::to_ascii_uppercase));
+        svc.sum_length += in_.len() as u32;
+        svc.sum_length
+    };
+
+    *out_ptr = svc.arena.as_ptr();
+    *out_len = svc.arena.len() as u32;
+    code
+}

--- a/crates/catalog/Cargo.toml
+++ b/crates/catalog/Cargo.toml
@@ -14,7 +14,7 @@ include_dir = { version = "*", default-features = false }
 itertools = "*"
 log = "*"
 regex = "*"
-reqwest = { version = "*", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "*", default-features = false, features = ["blocking", "native-tls"] }
 rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
 schemars = "*"
 serde = { version = "*", features = ["derive"] }

--- a/crates/derive/src/snapshots/derive__extract_api__test__extractor_service.snap
+++ b/crates/derive/src/snapshots/derive__extract_api__test__extractor_service.snap
@@ -1,0 +1,29 @@
+---
+source: crates/derive/src/extract_api.rs
+expression: "(String::from_utf8_lossy(&arena), out)"
+---
+(
+    "prefix\t\u{2}\u{0}\t\u{3}\u{5}\u{7}\u{6}\u{8}\u{11}2/��9j�\u{1e}\u{8}\u{5}\u{10}*a-string\u{8}\u{4}*\u{4}\u{8}\u{1c}\u{10}$",
+    [
+        Out {
+            code: 999,
+            begin: 0,
+            end: 0,
+        },
+        Out {
+            code: 0,
+            begin: 6,
+            end: 24,
+        },
+        Out {
+            code: 1,
+            begin: 24,
+            end: 28,
+        },
+        Out {
+            code: 2,
+            begin: 36,
+            end: 44,
+        },
+    ],
+)

--- a/crates/protocol/src/cgo.rs
+++ b/crates/protocol/src/cgo.rs
@@ -1,0 +1,40 @@
+/// Service is a trait implemented by Rust services which may be called from Go.
+pub trait Service {
+    /// Error type returned by Service invocations.
+    type Error: std::error::Error;
+
+    /// Create a new instance of the Service.
+    fn create() -> Self;
+
+    /// Invoke the Service with the given code & data payload.
+    ///
+    /// Both codes & payloads are used defined -- a service and its callers must
+    /// establish a shared protocol for interaction, in terms of codes and/or
+    /// []byte payloads.
+    ///
+    /// Invoke may return []byte data to the caller by writing it at the end of
+    /// |arena|. Existing content of the arena must not be modified.
+    ///
+    /// Invoke may also return Out frames to the caller by appending into |out|.
+    /// Out frames can return []byte data by writing to |arena| first, and then
+    /// appending an Out frame which references the written offsets.
+    /// As with |arena|, existing |out| frames must not be modified.
+    fn invoke(
+        &mut self,
+        code: u32,
+        data: &[u8],
+        arena: &mut Vec<u8>,
+        out: &mut Vec<Out>,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Output frame produced by a Service.
+#[repr(C)]
+pub struct Out {
+    /// Service-defined response code.
+    pub code: u32,
+    /// Begin data offset within the arena.
+    pub begin: u32,
+    /// End data offset within the arena.
+    pub end: u32,
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -4,6 +4,7 @@ pub mod protocol {
 }
 */
 
+pub mod cgo;
 pub mod consumer;
 pub mod flow;
 pub mod protocol;

--- a/go/bindings/extract.go
+++ b/go/bindings/extract.go
@@ -1,0 +1,75 @@
+package bindings
+
+// #include "../../crates/bindings/flow_bindings.h"
+import "C"
+import (
+	pf "github.com/estuary/flow/go/protocol"
+)
+
+type Extractor struct {
+	svc    *Service
+	uuids  []pf.UUIDParts
+	fields []pf.Field
+}
+
+// NewExtractor returns an instance of the Extractor service.
+func NewExtractor(uuidPtr string, fieldPtrs []string) (*Extractor, error) {
+	var svc = newService(
+		func() *C.Channel { return C.extractor_create() },
+		func(ch *C.Channel, in C.In1) { C.extractor_invoke1(ch, in) },
+		func(ch *C.Channel, in C.In4) { C.extractor_invoke4(ch, in) },
+		func(ch *C.Channel, in C.In16) { C.extractor_invoke16(ch, in) },
+		func(ch *C.Channel) { C.extractor_drop(ch) },
+	)
+
+	var err = svc.SendMessage(0, &pf.ExtractRequest{UuidPtr: uuidPtr, FieldPtrs: fieldPtrs})
+	if err != nil {
+		return nil, err
+	} else if _, _, err = svc.Poll(); err != nil {
+		return nil, err
+	}
+
+	var fields = make([]pf.Field, len(fieldPtrs))
+
+	return &Extractor{
+		svc:    svc,
+		uuids:  make([]pf.UUIDParts, 8),
+		fields: fields,
+	}, nil
+}
+
+// SendDocument sends the document to the Extractor.
+func (e *Extractor) SendDocument(doc []byte) { e.svc.SendBytes(1, doc) }
+
+// Poll the extractor for extracted UUIDs and Fields of all documents
+// sent since the last Poll. The returned Arena, UUIDParts, and Fields
+// are valid only until the next call to Poll.
+func (e *Extractor) Poll() (pf.Arena, []pf.UUIDParts, []pf.Field, error) {
+	var arena, frames, err = e.svc.Poll()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	e.uuids = e.uuids[:0]
+	for f := range e.fields {
+		e.fields[f].Values = e.fields[f].Values[:0]
+	}
+
+	// One frame for each UUID & field of every document.
+	for len(frames) > len(e.fields) {
+
+		var uuid pf.UUIDParts
+		frames[0].MustDecode(&uuid)
+		e.uuids = append(e.uuids, uuid)
+
+		for f := 0; f != len(e.fields); f++ {
+			var val pf.Field_Value
+			frames[f+1].MustDecode(&val)
+			e.fields[f].Values = append(e.fields[f].Values, val)
+		}
+
+		frames = frames[len(e.fields)+1:]
+	}
+
+	return arena, e.uuids, e.fields, nil
+}

--- a/go/bindings/extract_test.go
+++ b/go/bindings/extract_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestExtractor(t *testing.T) {
-	var e, err = NewExtractor("/0", []string{"/1", "/2"})
+	var ex, err = NewExtractor("/0", []string{"/1", "/2"})
 	assert.NoError(t, err)
 
-	e.SendDocument([]byte(`["9f2952f3-c6a3-11ea-8802-080607050309", 42, "a-string"]`))
-	e.SendDocument([]byte(`["9f2952f3-c6a3-12fb-8802-080607050309", 52, "other-string"]`))
+	ex.Document([]byte(`["9f2952f3-c6a3-11ea-8802-080607050309", 42, "a-string"]`))
+	ex.Document([]byte(`["9f2952f3-c6a3-12fb-8802-080607050309", 52, "other-string"]`))
 
-	arena, uuids, fields, err := e.Poll()
+	arena, uuids, fields, err := ex.Extract()
 	assert.NoError(t, err)
 
 	assert.Equal(t, []pf.UUIDParts{

--- a/go/bindings/extract_test.go
+++ b/go/bindings/extract_test.go
@@ -1,0 +1,63 @@
+package bindings
+
+import (
+	"testing"
+
+	pf "github.com/estuary/flow/go/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractor(t *testing.T) {
+	var e, err = NewExtractor("/0", []string{"/1", "/2"})
+	assert.NoError(t, err)
+
+	e.SendDocument([]byte(`["9f2952f3-c6a3-11ea-8802-080607050309", 42, "a-string"]`))
+	e.SendDocument([]byte(`["9f2952f3-c6a3-12fb-8802-080607050309", 52, "other-string"]`))
+
+	arena, uuids, fields, err := e.Poll()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []pf.UUIDParts{
+		{
+			ProducerAndFlags: 0x0806070503090000 + 0x02,
+			Clock:            0x1eac6a39f2952f32,
+		},
+		{
+			ProducerAndFlags: 0x0806070503090000 + 0x02,
+			Clock:            0x2fbc6a39f2952f32,
+		},
+	}, uuids)
+
+	var s1 = pf.Slice{Begin: 0x16, End: 0x1e}
+	var s2 = pf.Slice{Begin: 0x3c, End: 0x48}
+
+	assert.Equal(t, []pf.Field{
+		{Values: []pf.Field_Value{
+			{
+
+				Kind:     pf.Field_Value_UNSIGNED,
+				Unsigned: 42,
+			},
+			{
+
+				Kind:     pf.Field_Value_UNSIGNED,
+				Unsigned: 52,
+			},
+		}},
+		{Values: []pf.Field_Value{
+			{
+
+				Kind:  pf.Field_Value_STRING,
+				Bytes: s1,
+			},
+			{
+
+				Kind:  pf.Field_Value_STRING,
+				Bytes: s2,
+			},
+		}},
+	}, fields)
+
+	assert.Equal(t, string(arena.Bytes(s1)), "a-string")
+	assert.Equal(t, string(arena.Bytes(s2)), "other-string")
+}

--- a/go/bindings/service.go
+++ b/go/bindings/service.go
@@ -1,0 +1,240 @@
+package bindings
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/../../target/release -lbindings -ldl
+#include "../../crates/bindings/flow_bindings.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"unsafe"
+)
+
+// Service is a Go handle to an instantiated service binding.
+type Service struct {
+	ch       *C.Channel
+	frameIn  []C.In1
+	frameOut []Frame
+	frameBuf []byte
+
+	invoke1  func(*C.Channel, C.In1)
+	invoke4  func(*C.Channel, C.In4)
+	invoke16 func(*C.Channel, C.In16)
+}
+
+// Build a new Service instance. This is to be wrapped by concrete, exported
+// Service constructors of this package -- constructors which also handle
+// bootstrap and configuration of the Service, map to returned errors, and may
+// provide friendlier interfaces than those of Service.
+func newService(
+	create func() *C.Channel,
+	invoke1 func(*C.Channel, C.In1),
+	invoke4 func(*C.Channel, C.In4),
+	invoke16 func(*C.Channel, C.In16),
+	drop func(*C.Channel),
+) *Service {
+	var ch = create()
+
+	var svc = &Service{
+		ch:       ch,
+		frameIn:  make([]C.In1, 0, 16),
+		frameOut: make([]Frame, 0, 16),
+		frameBuf: make([]byte, 0, 256),
+		invoke1:  invoke1,
+		invoke4:  invoke4,
+		invoke16: invoke16,
+	}
+	runtime.SetFinalizer(svc, func(svc *Service) {
+		drop(svc.ch)
+	})
+
+	return svc
+}
+
+// Frame is a payload which may be passed to and from a Service.
+type Frame struct {
+	// User-defined Code of the Frame.
+	Code uint32
+	// Data payload of the frame.
+	Data []byte
+}
+
+// Frameable is the interface provided by messages that know how to frame
+// themselves, notably Protobuf messages.
+type Frameable interface {
+	ProtoSize() int
+	MarshalToSizedBuffer(dAtA []byte) (int, error)
+}
+
+// SendBytes to the Service.
+// The sent |data| must not be changed until the next Service Poll().
+func (s *Service) SendBytes(code uint32, data []byte) {
+	var h = (*reflect.SliceHeader)(unsafe.Pointer(&data))
+
+	s.frameIn = append(s.frameIn, C.In1{
+		code:     C.uint32_t(code),
+		data_len: C.uint32_t(h.Len),
+		data_ptr: (*C.uint8_t)(unsafe.Pointer(h.Data)),
+	})
+}
+
+// SendMessage sends the serialization of a Frameable message to the Service.
+func (s *Service) SendMessage(code uint32, m Frameable) error {
+	var n, err = m.MarshalToSizedBuffer(s.ReserveBytes(code, m.ProtoSize()))
+	if err != nil {
+		return err
+	} else if n != 0 {
+		return fmt.Errorf("MarshalToSizedBuffer left unexpected remainder: %d", n)
+	}
+	return nil
+}
+
+// ReserveBytes reserves a length-sized []byte slice which will be
+// sent with the next Service Poll(). Until then, the caller may
+// write into the returned bytes, e.x. in order to serialize a
+// message of prior known size.
+func (s *Service) ReserveBytes(code uint32, length int) []byte {
+	var l = len(s.frameBuf)
+	var c = cap(s.frameBuf)
+
+	if c-l < length {
+		// Grow frameBuf, but don't bother to copy (prior buffers are
+		// still pinned by their current Frames).
+		for c < length {
+			c = c << 1
+		}
+		s.frameBuf, l = make([]byte, 0, c), 0
+	}
+
+	var next = s.frameBuf[0 : l+length]
+	s.SendBytes(code, next[l:])
+	s.frameBuf = next
+
+	return next[l:]
+}
+
+// Poll the Service. On return, all frames sent since the last Poll have been
+// processed, and any response Frames are returned. Poll also returns a memory
+// arena which individual Frames may reference (e.x., by encoding offsets into
+// the returned arena).
+// NOTE: The []byte arena and returned Frame Data is owned by the Service, not Go,
+// and is *ONLY* valid until the next call to Poll(). At that point, it may be
+// over-written or freed, and attempts to access it may crash the program.
+func (s *Service) Poll() ([]byte, []Frame, error) {
+	// Reset output storage cursors.
+	// SAFETY: the channel arena and output frames hold only integer types
+	// (u8 bytes and u32 offsets, respectively), having trivial impl Drops.
+	s.ch.arena_len = 0
+	s.ch.out_len = 0
+
+	var input = s.frameIn
+
+	// Invoke in strides of 16.
+	// The compiler is smart enough to omit bounds checks here.
+	for len(input) >= 16 {
+		s.invoke16(s.ch, C.In16{
+			in0: C.In4{
+				in0: input[0],
+				in1: input[1],
+				in2: input[2],
+				in3: input[3],
+			},
+			in1: C.In4{
+				in0: input[4],
+				in1: input[5],
+				in2: input[6],
+				in3: input[7],
+			},
+			in2: C.In4{
+				in0: input[8],
+				in1: input[9],
+				in2: input[10],
+				in3: input[11],
+			},
+			in3: C.In4{
+				in0: input[12],
+				in1: input[13],
+				in2: input[14],
+				in3: input[15],
+			},
+		})
+		input = input[16:]
+	}
+	// Invoke in strides of 4.
+	for len(input) >= 4 {
+		s.invoke4(s.ch, C.In4{
+			in0: input[0],
+			in1: input[1],
+			in2: input[2],
+			in3: input[3],
+		})
+		input = input[4:]
+	}
+	// Invoke in strides of 1.
+	for _, in := range input {
+		s.invoke1(s.ch, in)
+	}
+	// All inputs are consumed. Reset.
+	s.frameIn = s.frameIn[:0]
+	s.frameBuf = s.frameBuf[:0]
+
+	// During invocations, ch.arena_*, ch.out_*, and ch.err_* slices were updated.
+	// Obtain zero-copy access to each of them.
+	var arena []byte
+	var chOut []C.Out
+	var chErr []byte
+
+	var arenaHeader = (*reflect.SliceHeader)(unsafe.Pointer(&arena))
+	var chOutHeader = (*reflect.SliceHeader)(unsafe.Pointer(&chOut))
+	var chErrHeader = (*reflect.SliceHeader)(unsafe.Pointer(&chErr))
+
+	arenaHeader.Cap = int(s.ch.arena_cap)
+	arenaHeader.Len = int(s.ch.arena_len)
+	arenaHeader.Data = uintptr(unsafe.Pointer(s.ch.arena_ptr))
+
+	chOutHeader.Cap = int(s.ch.out_cap)
+	chOutHeader.Len = int(s.ch.out_len)
+	chOutHeader.Data = uintptr(unsafe.Pointer(s.ch.out_ptr))
+
+	chErrHeader.Cap = int(s.ch.err_cap)
+	chErrHeader.Len = int(s.ch.err_len)
+	chErrHeader.Data = uintptr(unsafe.Pointer(s.ch.err_ptr))
+
+	// We must copy raw C.Out instances to our Go-side |frameOut|.
+
+	// First grow it, if required.
+	if c := cap(s.frameOut); c < len(chOut) {
+		for c < len(chOut) {
+			c = c << 1
+		}
+		s.frameOut = make([]Frame, len(chOut), c)
+	} else {
+		s.frameOut = s.frameOut[:len(chOut)]
+	}
+
+	for i, o := range chOut {
+		// This avoids the bounds check into |arena| which would otherwise be done,
+		// if Go slicing were used. Equivalent to `arena[o.begin:o.end]`.
+		var data []byte
+		var dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&data))
+		dataHeader.Cap = int(o.end - o.begin)
+		dataHeader.Len = int(o.end - o.begin)
+		dataHeader.Data = uintptr(unsafe.Pointer(s.ch.arena_ptr)) + uintptr(o.begin)
+
+		s.frameOut[i] = Frame{
+			Code: uint32(o.code),
+			Data: data,
+		}
+	}
+
+	var err error
+	if len(chErr) != 0 {
+		err = errors.New(string(chErr))
+	}
+
+	return arena, s.frameOut, err
+}

--- a/go/bindings/service_test.go
+++ b/go/bindings/service_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	pf "github.com/estuary/flow/go/protocol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +28,7 @@ func TestUpperServiceFunctional(t *testing.T) {
 	svc.SendMessage(2, frameableString("world"))
 	var arena, responses, err = svc.Poll()
 
-	assert.Equal(t, []byte("HELLOWORLD"), arena)
+	assert.Equal(t, pf.Arena("HELLOWORLD"), arena)
 	assert.Equal(t, []Frame{
 		{Data: []byte("HELLO"), Code: 5},
 		{Data: []byte("WORLD"), Code: 10},
@@ -37,7 +38,7 @@ func TestUpperServiceFunctional(t *testing.T) {
 	svc.SendMessage(3, frameableString("bye"))
 	arena, responses, err = svc.Poll()
 
-	assert.Equal(t, []byte("BYE"), arena)
+	assert.Equal(t, pf.Arena("BYE"), arena)
 	assert.Equal(t, []Frame{
 		{Data: []byte("BYE"), Code: 13},
 	}, responses)

--- a/go/bindings/service_test.go
+++ b/go/bindings/service_test.go
@@ -1,0 +1,200 @@
+package bindings
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// frameableString implements the Frameable interface.
+type frameableString string
+
+func (m frameableString) ProtoSize() int { return len(m) }
+func (m frameableString) MarshalToSizedBuffer(b []byte) (int, error) {
+	copy(b, m)
+	return 0, nil
+}
+
+func TestUpperServiceFunctional(t *testing.T) {
+	var svc = newUpperCase()
+
+	// Cover frameBuf growing.
+	svc.frameBuf = make([]byte, 0, 1)
+
+	svc.SendBytes(1, []byte("hello"))
+	svc.SendMessage(2, frameableString("world"))
+	var arena, responses, err = svc.Poll()
+
+	assert.Equal(t, []byte("HELLOWORLD"), arena)
+	assert.Equal(t, []Frame{
+		{Data: []byte("HELLO"), Code: 5},
+		{Data: []byte("WORLD"), Code: 10},
+	}, responses)
+	assert.NoError(t, err)
+
+	svc.SendMessage(3, frameableString("bye"))
+	arena, responses, err = svc.Poll()
+
+	assert.Equal(t, []byte("BYE"), arena)
+	assert.Equal(t, []Frame{
+		{Data: []byte("BYE"), Code: 13},
+	}, responses)
+	assert.NoError(t, err)
+
+	// Trigger an error, and expect it's plumbed through.
+	svc.SendBytes(6, []byte("whoops!"))
+	_, _, err = svc.Poll()
+	assert.EqualError(t, err, "Custom { kind: Other, error: \"whoops!\" }")
+}
+
+func TestNoOpServiceFunctional(t *testing.T) {
+	var svc = newNoOpService()
+
+	svc.SendBytes(1, []byte("hello"))
+	svc.SendBytes(2, []byte("world"))
+
+	var arena, responses, err = svc.Poll()
+	assert.Empty(t, arena)
+	assert.Equal(t, []Frame{{}, {}}, responses)
+	assert.NoError(t, err)
+
+	svc.SendBytes(3, []byte("bye"))
+
+	arena, responses, err = svc.Poll()
+	assert.Empty(t, arena)
+	assert.Equal(t, []Frame{{}}, responses)
+	assert.NoError(t, err)
+}
+
+func TestUpperServiceWithStrides(t *testing.T) {
+	var svc = newUpperCase()
+
+	for i := 0; i != 4; i++ {
+		var given = []byte("abcd0123efghijklm456nopqrstuvwxyz789")
+		var expect = bytes.Repeat([]byte("ABCD0123EFGHIJKLM456NOPQRSTUVWXYZ789"), 2)
+
+		svc.SendBytes(1, nil)
+		for b := 0; b != len(given); b += 2 {
+			svc.SendBytes(2, given[b:b+2])
+		}
+		svc.SendBytes(3, nil)
+
+		for b := 0; b != len(given); b += 1 {
+			svc.SendBytes(4, given[b:b+1])
+		}
+		svc.SendBytes(5, nil)
+
+		var got []byte
+		var _, responses, err = svc.Poll()
+		assert.NoError(t, err)
+
+		for _, r := range responses {
+			got = append(got, r.Data...)
+		}
+		assert.Equal(t, expect, got)
+		assert.Equal(t, len(given)*2*(i+1), int(responses[len(responses)-1].Code))
+	}
+}
+
+func TestUpperServiceNaive(t *testing.T) {
+	var svc = newUpperCaseNaive()
+
+	var code, data, err = svc.invoke(123, []byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, int(code))
+	assert.Equal(t, data, []byte("HELLO"))
+
+	var given = []byte("abcd0123efghijklm456nopqrstuvwxyz789")
+	var expect = []byte("ABCD0123EFGHIJKLM456NOPQRSTUVWXYZ789")
+
+	code, data, err = svc.invoke(456, given)
+	assert.NoError(t, err)
+	assert.Equal(t, 5+len(given), int(code))
+	assert.Equal(t, expect, data)
+
+	_, _, err = svc.invoke(789, []byte("whoops!"))
+	assert.EqualError(t, err, "Custom { kind: Other, error: \"whoops!\" }")
+}
+
+func TestUpperServiceGo(t *testing.T) {
+	var svc = newUpperCaseGo()
+
+	var code, data, err = svc.invoke(123, []byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, int(code))
+	assert.Equal(t, data, []byte("HELLO"))
+
+	var given = []byte("abcd0123efghijklm456nopqrstuvwxyz789")
+	var expect = []byte("ABCD0123EFGHIJKLM456NOPQRSTUVWXYZ789")
+
+	code, data, err = svc.invoke(456, given)
+	assert.NoError(t, err)
+	assert.Equal(t, 5+len(given), int(code))
+	assert.Equal(t, expect, data)
+
+	_, _, err = svc.invoke(789, []byte("whoops!"))
+	assert.EqualError(t, err, "whoops!")
+}
+
+func BenchmarkUpperService(b *testing.B) {
+	var strides = []int{
+		1,  // Worst case.
+		3,  // Almost worst case: 3 separate invocations.
+		4,  // Single 4-stride invocation.
+		11, // 4 + 4 + 1 + 1 + 1
+		15, // 4 + 4 + 4 + 1 + 1 + 1
+		17, // 16 + 1
+		31, // 16 + 4 + 4 + 4 + 1 + 1 + 1
+		32, // 16 + 16
+		63, // 16 + 16 + 16 + 4 + 4 + 4 + 1 + 1 + 1
+		137,
+		426,
+	}
+	var input = []byte("hello world")
+
+	for _, stride := range strides {
+		b.Run("cgo-"+strconv.Itoa(stride), func(b *testing.B) {
+			var svc = newUpperCase()
+
+			for i := 0; i != b.N; i++ {
+				if i%stride == 0 && i > 0 {
+					svc.Poll()
+				}
+				svc.SendBytes(0, input)
+			}
+			var _, _, _ = svc.Poll()
+		})
+
+		b.Run("noop-"+strconv.Itoa(stride), func(b *testing.B) {
+			var svc = newNoOpService()
+
+			for i := 0; i != b.N; i++ {
+				if i%stride == 0 && i > 0 {
+					svc.Poll()
+				}
+				svc.SendBytes(0, input)
+			}
+			var _, _, _ = svc.Poll()
+		})
+	}
+}
+
+func BenchmarkUpperServiceNaive(b *testing.B) {
+	var svc = newUpperCaseNaive()
+	var input = []byte("hello world")
+
+	for i := 0; i != b.N; i++ {
+		_, _, _ = svc.invoke(123, input)
+	}
+}
+
+func BenchmarkUpperServiceGo(b *testing.B) {
+	var svc = newUpperCaseGo()
+	var input = []byte("hello world")
+
+	for i := 0; i != b.N; i++ {
+		_, _, _ = svc.invoke(123, input)
+	}
+}

--- a/go/bindings/upper_case.go
+++ b/go/bindings/upper_case.go
@@ -1,0 +1,118 @@
+package bindings
+
+// #include "../../crates/bindings/flow_bindings.h"
+import "C"
+import (
+	"bytes"
+	"errors"
+	"math"
+	"reflect"
+	"unsafe"
+)
+
+// newUpperCase is a testing Service that upper-cases each input Frame,
+// and returns the running sum length of its inputs via its response
+// Frame Code.
+func newUpperCase() *Service {
+	return newService(
+		func() *C.Channel { return C.upper_case_create() },
+		func(ch *C.Channel, in C.In1) { C.upper_case_invoke1(ch, in) },
+		func(ch *C.Channel, in C.In4) { C.upper_case_invoke4(ch, in) },
+		func(ch *C.Channel, in C.In16) { C.upper_case_invoke16(ch, in) },
+		func(ch *C.Channel) { C.upper_case_drop(ch) },
+	)
+}
+
+// newNoOpService is a testing Service that doesn't invoke into CGO,
+// but still produces an (empty) output Frame for each input.
+func newNoOpService() *Service {
+	return newService(
+		func() *C.Channel {
+			var ch = (*C.Channel)(C.calloc(C.sizeof_Channel, 1))
+			ch.out_ptr = (*C.Out)(C.calloc(C.sizeof_Out, 512))
+
+			ch.out_cap = 512
+			ch.out_len = 0
+
+			return ch
+		},
+		// Increment output cursors, so that we build Frames for each input,
+		// but don't actually invoke CGO.
+		func(ch *C.Channel, in C.In1) { ch.out_len += 1 },
+		func(ch *C.Channel, in C.In4) { ch.out_len += 4 },
+		func(ch *C.Channel, in C.In16) { ch.out_len += 16 },
+		func(ch *C.Channel) {
+			C.free(unsafe.Pointer(ch.out_ptr))
+			C.free(unsafe.Pointer(ch))
+		},
+	)
+}
+
+// upperCaseNaive is an alternative, non-Service implementation which
+// does the same task using a more typical CGO invocation pattern.
+// It too avoids copies and returned Rust-owned memory after each call.
+// It's here for comparative benchmarking.
+type upperCaseNaive struct {
+	svc *C.ServiceImpl
+}
+
+func newUpperCaseNaive() upperCaseNaive {
+	return upperCaseNaive{
+		svc: C.create_upper_case_naive(),
+	}
+}
+
+func (s *upperCaseNaive) invoke(codeIn uint32, input []byte) (uint32, []byte, error) {
+	var h = (*reflect.SliceHeader)(unsafe.Pointer(&input))
+	var out_len C.uint32_t
+	var out_ptr *C.uint8_t
+
+	var codeOut = C.upper_case_naive(
+		s.svc,
+		C.uint32_t(codeIn),
+		(*C.uint8_t)(unsafe.Pointer(h.Data)),
+		C.uint32_t(h.Len),
+		&out_ptr,
+		&out_len)
+
+	var output []byte
+	h = (*reflect.SliceHeader)(unsafe.Pointer(&output))
+	h.Cap = int(out_len)
+	h.Len = int(out_len)
+	h.Data = uintptr(unsafe.Pointer(out_ptr))
+
+	var err error
+	if codeOut == math.MaxUint32 {
+		err = errors.New(string(output))
+	}
+	return uint32(codeOut), output, err
+}
+
+// upperCaseGo is yet another pure-Go implementation, for comparative benchmarking.
+type upperCaseGo struct {
+	invoke func(uint32, []byte) (uint32, []byte, error)
+}
+
+func newUpperCaseGo() upperCaseGo {
+	var sumLength uint32
+	var arena []byte
+
+	// Use a closure to force dynamic dispatch / prevent inlining.
+	var fn = func(codeIn uint32, input []byte) (uint32, []byte, error) {
+		if bytes.Equal(input, []byte("whoops!")) {
+			return 0, nil, errors.New("whoops!")
+		}
+
+		arena = append(arena[:0], input...)
+		sumLength += uint32(len(input))
+
+		for i, b := range arena {
+			if b >= 'a' && b <= 'z' {
+				arena[i] = b - 'a' + 'A'
+			}
+		}
+		return sumLength, arena, nil
+	}
+
+	return upperCaseGo{invoke: fn}
+}

--- a/go/bindings/upper_case.go
+++ b/go/bindings/upper_case.go
@@ -13,7 +13,7 @@ import (
 // newUpperCase is a testing Service that upper-cases each input Frame,
 // and returns the running sum length of its inputs via its response
 // Frame Code.
-func newUpperCase() *Service {
+func newUpperCase() *service {
 	return newService(
 		func() *C.Channel { return C.upper_case_create() },
 		func(ch *C.Channel, in C.In1) { C.upper_case_invoke1(ch, in) },
@@ -25,7 +25,7 @@ func newUpperCase() *Service {
 
 // newNoOpService is a testing Service that doesn't invoke into CGO,
 // but still produces an (empty) output Frame for each input.
-func newNoOpService() *Service {
+func newNoOpService() *service {
 	return newService(
 		func() *C.Channel {
 			var ch = (*C.Channel)(C.calloc(C.sizeof_Channel, 1))


### PR DESCRIPTION
A Service looks like a bidirectional channel, but is one which is
synchronously polled to send and receive framed message code and data
payloads. It's intended as a fundamental building block for building
bidirectional in-process streaming services that interoperate between
Go and Rust -- an interface which is a heck of a lot faster than gRPC.

It achieves zero-copy semantics by pushing Go []byte buffers down
into CGO invocations, and surfacing Rust-owned []byte arenas and
Frame payloads. There are some rules callers need to adhere to,
such as not scribbling "sent" memory until Poll() is called, and
not referencing Rust-owned memory returned by Poll() after _another_
Poll() call is made.

It amortizes the CGO overhead by vectorizing dispatch. On the Rust
side, some common functions are provided to monomorphize appropriate
bindings for an implementation of a Service trait.

Lies, damn lies, and benchmarks:

This shows a variety of stride patterns (number of sent messages
per Poll() call), some of which are deliberately worst case.
A comparative benchmark with a "naieve" CGO service is included,
which is also zero-copy (via some unsafe hacks) and approximates an
optimized non-Service implementation.

    $ go test ./go/bindings/ -v -bench='.' -benchtime 3s
    === RUN   TestUpperService
    --- PASS: TestUpperService (0.00s)
    === RUN   TestUpperServiceNaieve
    --- PASS: TestUpperServiceNaieve (0.00s)
    goos: linux
    goarch: amd64
    pkg: github.com/estuary/flow/go/bindings
    BenchmarkUpperService
    BenchmarkUpperService/1
    BenchmarkUpperService/1-24              43287075                81.8
    ns/op
    BenchmarkUpperService/3
    BenchmarkUpperService/3-24              48669957                71.3
    ns/op
    BenchmarkUpperService/4
    BenchmarkUpperService/4-24              100000000               33.1
    ns/op
    BenchmarkUpperService/11
    BenchmarkUpperService/11-24             82098810                43.3
    ns/op
    BenchmarkUpperService/15
    BenchmarkUpperService/15-24             88228374                40.6
    ns/op
    BenchmarkUpperService/17
    BenchmarkUpperService/17-24             126318896               28.7
    ns/op
    BenchmarkUpperService/31
    BenchmarkUpperService/31-24             100000000               33.5
    ns/op
    BenchmarkUpperService/32
    BenchmarkUpperService/32-24             149790940               24.0
    ns/op
    BenchmarkUpperService/63
    BenchmarkUpperService/63-24             127205176               28.3
    ns/op
    BenchmarkUpperService/137
    BenchmarkUpperService/137-24            150098632               24.1
    ns/op
    BenchmarkUpperService/426
    BenchmarkUpperService/426-24            157566507               22.9
    ns/op
    BenchmarkUpperServiceNaieve
    BenchmarkUpperServiceNaieve-24          38690248                91.2
    ns/op
    PASS
    ok      github.com/estuary/flow/go/bindings     55.728s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/76)
<!-- Reviewable:end -->
