### PR TITLE
Data bindings

### DIFF
--- a/crates/catalog/src/capture.rs
+++ b/crates/catalog/src/capture.rs
@@ -1,0 +1,66 @@
+use crate::{specs, Collection, Endpoint, Error, Resource, Result, Scope, DB};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Capture {
+    id: i64,
+    resource: Resource,
+}
+
+impl Capture {
+    pub fn register(scope: Scope, spec: &specs::Capture) -> Result<Capture> {
+        let (endpoint_id, source_entity): (Option<i64>, &str) = match &spec.source {
+            specs::CaptureSource::External { endpoint, target } => {
+                let resolved = scope
+                    .push_prop("endpoint")
+                    .then(|scope| Endpoint::get_by_name(scope, endpoint.as_str()))?;
+                (Some(resolved.id), target.as_str())
+            }
+            specs::CaptureSource::Builtin(builtin_source) => (None, builtin_source.type_name()),
+        };
+
+        let collection = scope
+            .push_prop("target")
+            .then(|scope| Collection::get_imported_by_name(scope, spec.target.name.as_ref()))?;
+        let resource = scope.resource();
+
+        let mut stmt = scope.db.prepare_cached("INSERT INTO captures
+                                               (resource_id, endpoint_id, source_entity, target_collection_id)
+                                               VALUES (?, ?, ?, ?);")?;
+
+        stmt.execute(rusqlite::params![
+            resource.id,
+            endpoint_id,
+            source_entity,
+            collection.id
+        ])?;
+        let id = scope.db.last_insert_rowid();
+
+        Ok(Capture { id, resource })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{dump_tables, test_register};
+
+    #[test]
+    fn capture_is_registered_for_flow_ingester() {
+        let yaml = r##"
+            collections:
+              - name: foo
+                key: [/id]
+                schema:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                  required: [id]
+
+            captures:
+              - source: flow-ingester
+                target: { name: foo }
+            "##;
+        let db = test_register(yaml).expect("failed to register");
+        let results = dump_tables(&db, &["endpoints", "captures"]).unwrap();
+        insta::assert_yaml_snapshot!(results);
+    }
+}

--- a/crates/catalog/src/catalog_test_golden.out
+++ b/crates/catalog/src/catalog_test_golden.out
@@ -455,10 +455,11 @@ INSERT INTO projections (
 VALUES (1, 'field_1', '/key/0', TRUE),
     (1, 'field_2', '/key/1', FALSE),
     (1, 'field/3', '/path/3', FALSE),
+    (1, 'flow_document', '', FALSE),
     -- Repeat field name with different collection.
     (2, 'field_1', '', FALSE),
     (2, 'field_a', '/a', TRUE);
-changes:   5   total_changes: XYZ
+changes:   6   total_changes: XYZ
 
 -- Invalid projection (no such collection).
 Error: near line (XYZ): FOREIGN KEY constraint failed
@@ -978,6 +979,17 @@ VALUES (
     ),
     (
         'file:///path/to/a/schema.yaml#anchor',
+        '',
+        '["object"]',
+        TRUE,
+        'flow_document title',
+        'flow_document description',
+        NULL,
+        NULL,
+        NULL
+    ),
+    (
+        'file:///path/to/a/schema.yaml#anchor',
         '/path/3',
         '["string", "null"]',
         TRUE,
@@ -987,7 +999,7 @@ VALUES (
         FALSE,
         98
     );
-changes:   3   total_changes: XYZ
+changes:   4   total_changes: XYZ
 
 INSERT INTO inferences (schema_uri, location_ptr, types_json, must_exist)
 VALUES -- Will show up in collection_keys as error due to invalid type "number"
@@ -1049,6 +1061,7 @@ collection_id|schema_uri|collection_name|field|location_ptr|user_provided|types_
 1|file:///path/to/a/schema.yaml#anchor|col/src|field_1|/key/0|1|["string"]|1|the title of /key/0|the description of /key/0|text/plain|0||96|0|1
 1|file:///path/to/a/schema.yaml#anchor|col/src|field_2|/key/1|0|["string", "null"]|1|the title of /key/1|the description of /key/1|text/plain|1||97|1|1
 1|file:///path/to/a/schema.yaml#anchor|col/src|field/3|/path/3|0|["string", "null"]|1|the title of /path/3|the description of /path/3|text/plain|0||98|0|0
+1|file:///path/to/a/schema.yaml#anchor|col/src|flow_document||0|["object"]|1|flow_document title|flow_document description|||||0|0
 2|https://canonical/schema/uri#/$defs/path|col/derived|field_1||0|||||||||0|0
 2|https://canonical/schema/uri#/$defs/path|col/derived|field_a|/a|1|||||||||1|0
 changes:   0   total_changes: XYZ
@@ -1056,14 +1069,14 @@ changes:   0   total_changes: XYZ
 SELECT *
 FROM projected_fields_json;
 collection_id|projections_json|partition_fields_json
-1|[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}}]|["field_2"]
+1|[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}},{"field":"flow_document","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["object"],"must_exist":true}}]|["field_2"]
 2|[{"field":"field_1","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false},{"field":"field_a","ptr":"/a","user_provided":true,"is_partition_key":true,"is_primary_key":false}]|["field_a"]
 changes:   0   total_changes: XYZ
 
 SELECT *
 FROM collections_json;
 collection_id|collection_name|is_derivation|spec_json
-1|col/src|0|{"name":"col/src","schema_uri":"file:///path/to/a/schema.yaml#anchor","key_ptrs":["/key/0","/key/1"],"partition_fields":["field_2"],"projections":[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}}]}
+1|col/src|0|{"name":"col/src","schema_uri":"file:///path/to/a/schema.yaml#anchor","key_ptrs":["/key/0","/key/1"],"partition_fields":["field_2"],"projections":[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}},{"field":"flow_document","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["object"],"must_exist":true}}]}
 2|col/derived|1|{"name":"col/derived","schema_uri":"https://canonical/schema/uri#/$defs/path","key_ptrs":["/foo"],"partition_fields":["field_a"],"projections":[{"field":"field_1","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false},{"field":"field_a","ptr":"/a","user_provided":true,"is_partition_key":true,"is_primary_key":false}]}
 changes:   0   total_changes: XYZ
 
@@ -1096,7 +1109,7 @@ changes:   0   total_changes: XYZ
 SELECT *
 FROM collection_details;
 collection_id|collection_name|schema_uri|key_json|resource_id|partition_fields_json|projections_json|alt_schemas_json|is_derivation|register_schema_uri|register_initial_json
-1|col/src|file:///path/to/a/schema.yaml#anchor|["/key/0","/key/1"]|3|["field_2"]|[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}}]|["https://alt/source/schema#anchor"]|0||
+1|col/src|file:///path/to/a/schema.yaml#anchor|["/key/0","/key/1"]|3|["field_2"]|[{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}},{"field":"flow_document","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["object"],"must_exist":true}}]|["https://alt/source/schema#anchor"]|0||
 2|col/derived|https://canonical/schema/uri#/$defs/path|["/foo"]|2|["field_a"]|[{"field":"field_1","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false},{"field":"field_a","ptr":"/a","user_provided":true,"is_partition_key":true,"is_primary_key":false}]|[]|1|file:///path/to/a/schema.yaml#register|{}
 3|col/der.iv-e_d|https://canonical/schema/uri#/$defs/path|["/foo"]|1|[]|{}|[]|1|file:///path/to/a/schema.yaml#other-register|[]
 4|col/srcs/other|file:///path/to/a/schema.yaml|["/key"]|6|[]|{}|[]|0||
@@ -1179,3 +1192,83 @@ test_case_id|test_case_name|steps_json
 420|my test|[{"verify":{"collection":"col/der.iv-e_d","documents":[111,222],"partitions":null}},{"ingest":{"collection":"col/der.iv-e_d","documents":[true,false]}}]
 860|another test|[{"ingest":{"collection":"col/derived","documents":["a","b"]}},{"verify":{"collection":"col/src","documents":[333,444],"partitions":{"include":{"field_2":[null]},"exclude":{"field_2":[456,"789"]}}}}]
 changes:   0   total_changes: XYZ
+
+-- Insert valid endpoints
+INSERT INTO endpoints (endpoint_id, resource_id, endpoint_name, endpoint_type, endpoint_uri)
+VALUES
+    (1, 1, 'testSqlite', 'sqlite', './example-sqlite.db'),
+    (2, 1, 'testPostgres', 'postgres', 'postgres://foo:bar@testpg:5432/testdb');
+changes:   2   total_changes: XYZ
+
+-- Invalid (endpoint name differs only by case)
+Error: near line (XYZ): UNIQUE constraint failed: endpoints.endpoint_name
+INSERT INTO endpoints (endpoint_id, resource_id, endpoint_name, endpoint_type, endpoint_uri)
+VALUES
+    (88, 1, 'TESTsQLITE', 'sqlite', './any-old-thing');
+
+-- Invalid (invalid type)
+Error: near line (XYZ): CHECK constraint failed: endpoint_type must be a recognized type
+INSERT INTO endpoints (endpoint_id, resource_id, endpoint_name, endpoint_type, endpoint_uri)
+VALUES
+    (99, 1, 'invalidType', 'aintright', './any-old-thing');
+
+SELECT * FROM endpoints;
+endpoint_id|resource_id|endpoint_name|endpoint_type|endpoint_uri
+1|1|testSqlite|sqlite|./example-sqlite.db
+2|1|testPostgres|postgres|postgres://foo:bar@testpg:5432/testdb
+changes:   0   total_changes: XYZ
+
+-- Insert valid materializations.
+INSERT INTO materializations
+    (materialization_id, resource_id, endpoint_id, target_entity, source_collection_id, fields_json)
+VALUES
+    -- Valid materialization fields_json
+    (1, 1, 1, 'test_table', 1, '["field_1", "field_2", "field/3", "flow_document"]'),
+    -- Invalid fields_json (not all collection keys projected)
+    (2, 1, 2, 'test_table', 1, '["field_1", "flow_document"]'),
+    -- Invalid fields_json (missing projection of the root document)
+    (3, 1, 2, 'different_table', 1, '["field_1", "field_2"]');
+changes:   3   total_changes: XYZ
+
+-- Invalid (same endpoint, source, and target)
+Error: near line (XYZ): UNIQUE constraint failed: materializations.endpoint_id, materializations.target_entity, materializations.source_collection_id
+INSERT INTO materializations
+    (materialization_id, resource_id, endpoint_id, target_entity, source_collection_id, fields_json)
+VALUES
+    (55, 1, 1, 'test_table', 1, '["field_1", "field_2"]');
+
+-- Invalid (target_entity differs only by case)
+Error: near line (XYZ): UNIQUE constraint failed: materializations.endpoint_id, materializations.target_entity, materializations.source_collection_id
+INSERT INTO materializations
+    (materialization_id, resource_id, endpoint_id, target_entity, source_collection_id, fields_json)
+VALUES
+    (55, 1, 1, 'TEST_TABLE', 1, '["field_1", "field_2"]');
+
+-- Invalid (references a field that is not a projection)
+Error: near line (XYZ): One or more materialization fields is not a projection of the collection
+INSERT INTO materializations
+    (materialization_id, resource_id, endpoint_id, target_entity, source_collection_id, fields_json)
+VALUES
+    (66, 1, 1, 'a_unique_table', 1, '["field_three", "field_2"]');
+
+
+SELECT * FROM materializations;
+materialization_id|resource_id|endpoint_id|target_entity|source_collection_id|fields_json
+1|1|1|test_table|1|["field_1", "field_2", "field/3", "flow_document"]
+2|1|2|test_table|1|["field_1", "flow_document"]
+3|1|2|different_table|1|["field_1", "field_2"]
+changes:   0   total_changes: XYZ
+
+SELECT * FROM materializations_json;
+materialization_id|collection_id|endpoint_name|endpoint_type|endpoint_uri|target_entity|spec_json
+1|1|testSqlite|sqlite|./example-sqlite.db|test_table|{"name":"col/src","schema_uri":"file:///path/to/a/schema.yaml#anchor","key_ptrs":["/key/0","/key/1"],"partition_fields":["field_2"],"projections":[{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}},{"field":"field/3","ptr":"/path/3","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":98}}},{"field":"flow_document","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["object"],"must_exist":true}}]}
+2|1|testPostgres|postgres|postgres://foo:bar@testpg:5432/testdb|test_table|{"name":"col/src","schema_uri":"file:///path/to/a/schema.yaml#anchor","key_ptrs":["/key/0","/key/1"],"partition_fields":["field_2"],"projections":[{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"flow_document","ptr":"","user_provided":false,"is_partition_key":false,"is_primary_key":false,"inference":{"types":["object"],"must_exist":true}}]}
+3|1|testPostgres|postgres|postgres://foo:bar@testpg:5432/testdb|different_table|{"name":"col/src","schema_uri":"file:///path/to/a/schema.yaml#anchor","key_ptrs":["/key/0","/key/1"],"partition_fields":["field_2"],"projections":[{"field":"field_1","ptr":"/key/0","user_provided":true,"is_partition_key":false,"is_primary_key":true,"inference":{"types":["string"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":false,"max_length":96}}},{"field":"field_2","ptr":"/key/1","user_provided":false,"is_partition_key":true,"is_primary_key":true,"inference":{"types":["string","null"],"must_exist":true,"string":{"content_type":"text/plain","is_base64":true,"max_length":97}}}]}
+changes:   0   total_changes: XYZ
+
+SELECT * FROM materialization_invalid_projections;
+materialization_id|error
+2|Collection key "/key/1" is not included in the materialized projections
+3|Materialization must include a projection of the root document (location pointer of an empty string)
+changes:   0   total_changes: XYZ
+

--- a/crates/catalog/src/endpoint.rs
+++ b/crates/catalog/src/endpoint.rs
@@ -1,0 +1,76 @@
+use crate::{specs, Resource, Result, Scope};
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Endpoint {
+    pub id: i64,
+    pub resource: Resource,
+}
+
+impl Endpoint {
+    pub fn register(scope: Scope, endpoint_name: &str, spec: &specs::Endpoint) -> Result<Endpoint> {
+        let endpoint_type = spec.type_name();
+        let uri = spec.uri();
+        let resource = scope.resource();
+        let mut stmt = scope.db.prepare_cached(
+            "INSERT INTO endpoints (resource_id, endpoint_name, endpoint_type, endpoint_uri) VALUES (?, ?, ?, ?);",
+        )?;
+        stmt.execute(rusqlite::params![
+            resource.id,
+            endpoint_name,
+            endpoint_type,
+            uri
+        ])?;
+        let id = scope.db.last_insert_rowid();
+        Ok(Endpoint { id, resource })
+    }
+
+    pub fn get_by_name(scope: Scope, endpoint_name: &str) -> Result<Endpoint> {
+        scope
+            .db
+            .query_row(
+                "select endpoint_id, resource_id from endpoints where endpoint_name = ?;",
+                rusqlite::params![endpoint_name],
+                |row| {
+                    Ok(Endpoint {
+                        id: row.get(0)?,
+                        resource: Resource { id: row.get(1)? },
+                    })
+                },
+            )
+            .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{create, dump_table, ContentType, Resource};
+    use url::Url;
+
+    #[test]
+    fn endpoint_is_registered() {
+        let db = create(":memory:").unwrap();
+        let resource_url = Url::parse("test://foo.bar/flow.yaml").unwrap();
+        let resource = Resource::register_content(
+            &db,
+            ContentType::CatalogSpec,
+            &resource_url,
+            b"bogus content",
+        )
+        .unwrap();
+
+        let scope = Scope::for_test(&db, resource.id);
+
+        let uri = specs::Endpoint::Postgres(specs::EndpointUri::new(
+            "postgres://foo:bar@baz.test:5432/flow",
+        ));
+        let endpoint =
+            Endpoint::register(scope, "testName", &uri).expect("failed to register endpoint");
+        let endpoints = dump_table(&db, "endpoints").unwrap();
+        insta::assert_yaml_snapshot!(endpoints);
+
+        let result =
+            Endpoint::get_by_name(scope, "testName").expect("failed to get endpoint by name");
+        assert_eq!(endpoint, result);
+    }
+}

--- a/crates/catalog/src/lib.rs
+++ b/crates/catalog/src/lib.rs
@@ -1,3 +1,4 @@
+mod capture;
 mod collection;
 mod content_type;
 mod db;
@@ -25,6 +26,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use url::Url;
 
+pub use capture::Capture;
 pub use collection::Collection;
 pub use content_type::ContentType;
 pub use derivation::Derivation;

--- a/crates/catalog/src/materialization.rs
+++ b/crates/catalog/src/materialization.rs
@@ -1,5 +1,205 @@
-use crate::{specs, Scope, DB};
+use crate::{specs, Collection, Endpoint, Error, Resource, Result, Scope, DB};
+use itertools::Itertools;
+use json::schema::types;
+use std::collections::{HashMap, HashSet};
 
+pub struct Materialization {
+    pub id: i64,
+    pub resource: Resource,
+}
+
+impl Materialization {
+    pub fn register(scope: Scope, spec: &specs::Materialization) -> Result<Materialization> {
+        let endpoint = scope
+            .push_prop("endpoint")
+            .then(|s| Endpoint::get_by_name(s, &spec.endpoint))?;
+        let collection = scope
+            .push_prop("source")
+            .then(|s| Collection::get_imported_by_name(s, spec.source.name.as_ref()))?;
+
+        let fields = scope.push_prop("fields").then(|scope| match &spec.fields {
+            specs::MaterializationFields::Include(include) => {
+                resolve_projections_including(scope, collection.id, include.as_slice())
+            }
+            specs::MaterializationFields::Exclude(exclude) => {
+                resolve_projections_excluding(scope, collection.id, exclude.as_slice())
+            }
+        })?;
+        let fields_json = serde_json::to_string(&fields)?;
+
+        let mut stmt = scope.db.prepare_cached(
+            "INSERT INTO materializations
+                (resource_id, endpoint_id, target_entity, source_collection_id, fields_json)
+            VALUES (?, ?, ?, ?, ?);",
+        )?;
+
+        let resource = scope.resource();
+        stmt.execute(rusqlite::params![
+            resource.id,
+            endpoint.id,
+            spec.target.as_str(),
+            collection.id,
+            fields_json
+        ])?;
+        let id = scope.db.last_insert_rowid();
+
+        validate_materialization_fields(scope.db, id)?;
+        Ok(Materialization { id, resource })
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("{}", .0.iter().join("\n"))]
+pub struct MaterializationFieldsError(Vec<String>);
+
+// Queries the materialization_invalid_projections view and returns any errors found there.
+// This must only be called after the materialization has been inserted.
+fn validate_materialization_fields(db: &DB, materialization_id: i64) -> Result<()> {
+    use rusqlite::OptionalExtension;
+    let mut stmt = db.prepare_cached(
+        "select error from materialization_invalid_projections where materialization_id = ?;",
+    )?;
+
+    let mut errors = Vec::new();
+    if let Some(mut rows) = stmt
+        .query(rusqlite::params![materialization_id])
+        .optional()?
+    {
+        while let Some(row) = rows.next()? {
+            let err: String = row.get(0)?;
+            errors.push(err);
+        }
+    }
+
+    if !errors.is_empty() {
+        Err(MaterializationFieldsError(errors).into())
+    } else {
+        Ok(())
+    }
+}
+
+fn resolve_projections_including(
+    scope: Scope,
+    collection_id: i64,
+    include: &[String],
+) -> Result<Vec<String>> {
+    // We only need to validate that each field actually has a valid projection. Technically, the
+    // database schema already enforces this invariant, but we'll do up front explicitly so that we
+    // can produce good error messages with suggestions for the nearest match.
+    for field in include {
+        // TODO: another place for using a multi-error
+        scope.push_prop(field).then(|scope| {
+            let (nearest, osa_distance) =
+                get_closest_match_projection(scope.db, collection_id, field.as_str())?;
+            if field != &nearest {
+                Err(Error::missing_projection(
+                    field.clone(),
+                    Some((nearest, osa_distance)),
+                ))
+            } else {
+                Ok(())
+            }
+        })?;
+    }
+    Ok(include.to_owned())
+}
+
+fn include_default_projection(
+    current_by_location: &HashMap<String, (String, bool)>,
+    types: types::Set,
+    location_ptr: &str,
+) -> bool {
+    !current_by_location.contains_key(location_ptr)
+        && (types.is_single_scalar_type() || location_ptr.is_empty())
+}
+
+fn resolve_projections_excluding(
+    scope: Scope,
+    collection_id: i64,
+    exclude: &[String],
+) -> Result<Vec<String>> {
+    let mut by_location = HashMap::new();
+    let mut stmt = scope.db.prepare_cached("SELECT field, location_ptr, user_provided, types_json, is_primary_key FROM projected_fields WHERE collection_id = ?;")?;
+    let mut rows = stmt.query(rusqlite::params![collection_id])?;
+
+    // We'll remove the excluded fields from this set as they're encountered, and return
+    // an error if there are any fields left here after iterating all the projections. If there are
+    // any remaining, then it's because no projection exists with that field name.
+    let mut excluded_fields = exclude.iter().cloned().collect::<HashSet<_>>();
+
+    while let Some(row) = rows.next()? {
+        let field: String = row.get(0)?;
+        let location_ptr: String = row.get(1)?;
+        let user_provided: bool = row.get(2)?;
+        let types_json: String = row.get(3)?;
+        let is_primary_key: bool = row.get(4)?;
+
+        let types: types::Set = serde_json::from_str(&types_json)?;
+        if !excluded_fields.remove(&field) {
+            if user_provided || include_default_projection(&by_location, types, &location_ptr) {
+                by_location.insert(location_ptr, (field, is_primary_key));
+            }
+        }
+    }
+
+    // TODO: (phil) consider creating a multi-error variant and using that here
+    // User has provided at least one field name to exclude, but no projection exists with that name.
+    if let Some(unmatched_field) = excluded_fields.into_iter().next() {
+        let closest_match =
+            get_closest_match_projection(scope.db, collection_id, &unmatched_field)?;
+        return Err(Error::missing_projection(
+            unmatched_field.to_string(),
+            Some(closest_match),
+        ));
+    }
+
+    // Sort the projections in a reasonable order. The most important thing is that this ordering
+    // is deterministic and consistent across subsequent catalog builds. But we try to also make
+    // the ordering reasonable by sorting by whether the field is part of the key and then by
+    // location, except for the empty location pointer, which always goes last. This is to match
+    // the convention of putting primary key columns first in SQL DDL.
+    let sorted_results = by_location
+        .into_iter()
+        .sorted_by(|(a_loc, (_, a_is_key)), (b_loc, (_, b_is_key))| {
+            let mut loc_ordering = a_loc.cmp(b_loc);
+            // Is either location the root pointer? If so, then reverse so that the root pointer is
+            // always sorted last.
+            if a_loc.is_empty() || b_loc.is_empty() {
+                loc_ordering = loc_ordering.reverse();
+            }
+            a_is_key.cmp(&b_is_key).reverse().then(loc_ordering)
+        })
+        .map(|(_, v)| v.0)
+        .collect::<Vec<_>>();
+    Ok(sorted_results)
+}
+
+fn get_flow_document_projection(db: &DB, collection_id: i64) -> Result<String> {
+    let query = "SELECT field
+        FROM projections
+        WHERE collection_id = ? AND location_ptr = ''
+        ORDER BY user_provided, field DESC
+        LIMIT 1;";
+    db.query_row(query, rusqlite::params![collection_id], |r| r.get(0))
+        .map_err(Into::into)
+}
+
+fn get_closest_match_projection(
+    db: &DB,
+    collection_id: i64,
+    field: &str,
+) -> rusqlite::Result<(String, i64)> {
+    let query = "SELECT field, osa_distance(field, ?) AS osa_dist
+        FROM projections
+        WHERE collection_id = ?
+        ORDER BY osa_dist ASC
+        LIMIT 1;";
+    db.query_row(query, rusqlite::params![field, collection_id], |row| {
+        Ok((row.get(0)?, row.get(1)?))
+    })
+}
+
+#[deprecated = "transitioning to Materialization"]
 #[derive(Debug, Copy, Clone)]
 pub struct MaterializationTarget {
     pub id: i64,
@@ -57,7 +257,141 @@ impl MaterializationTarget {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{create, Error};
+    use crate::{create, dump_tables, test_register, Error};
+
+    #[test]
+    fn register_returns_error_when_materialization_fields_are_missing_root_document() {
+        let yaml = r##"
+            collections:
+              - name: foo
+                key: [/id]
+                schema:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                    wee: { type: string }
+                    woo: { type: number }
+                  required: [id, wee]
+            endpoints:
+              testDB:
+                postgres: 'postgres://flow:flow@flow.test:5432/flow'
+            materializations:
+              - source:
+                  name: foo
+                endpoint: testDB
+                target: test_table
+                fields:
+                  include:
+                    - id
+                    - wee
+            "##;
+        let err = test_register(yaml)
+            .expect_err("expected an error")
+            .unlocate();
+
+        let expected_err = "Materialization must include a projection of the root document (location pointer of an empty string)";
+        match err {
+            Error::InvalidMaterialization(MaterializationFieldsError(messages)) => {
+                assert_eq!(vec![expected_err.to_string()], messages);
+            }
+            other => panic!("expected invalidMaterialization error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn materialization_is_registered_with_exclude_fields() {
+        let yaml = r##"
+            collections:
+              - name: foo
+                key: [/id]
+                schema:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                    wee: { type: string }
+                    woo: { type: number }
+                  required: [id, wee]
+                projections:
+                  wat: /woo
+            endpoints:
+              testDB:
+                postgres: 'postgres://flow:flow@flow.test:5432/flow'
+            materializations:
+              - source:
+                  name: foo
+                endpoint: testDB
+                target: test_table
+                fields:
+                  exclude:
+                    - wee
+            "##;
+        let db = test_register(yaml).expect("failed to register");
+        let results = dump_tables(&db, &["materializations", "materializations_json"]).unwrap();
+        insta::assert_yaml_snapshot!(results);
+    }
+
+    #[test]
+    fn materialization_is_registered_with_include_fields() {
+        let yaml = r##"
+            collections:
+              - name: foo
+                key: [/id]
+                schema:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                    wee: { type: string }
+                    woo: { type: number }
+                  required: [id, wee]
+                projections:
+                  wat: /woo
+            endpoints:
+              testDB:
+                postgres: 'postgres://flow:flow@flow.test:5432/flow'
+            materializations:
+              - source:
+                  name: foo
+                endpoint: testDB
+                target: test_table
+                fields:
+                  include:
+                    - id
+                    - flow_document
+                    - wat
+            "##;
+        let db = test_register(yaml).expect("failed to register");
+        let results = dump_tables(&db, &["materializations", "materializations_json"]).unwrap();
+        insta::assert_yaml_snapshot!(results);
+    }
+
+    #[test]
+    fn materialization_is_registered_with_default_fields() {
+        let yaml = r##"
+            collections:
+              - name: foo
+                key: [/id]
+                schema:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                    wee: { type: string }
+                    woo: { type: number }
+                  required: [id, wee]
+                projections:
+                  wat: /woo
+            endpoints:
+              testDB:
+                postgres: 'postgres://flow:flow@flow.test:5432/flow'
+            materializations:
+              - source:
+                  name: foo
+                endpoint: testDB
+                target: test_table
+            "##;
+        let db = test_register(yaml).expect("failed to register");
+        let results = dump_tables(&db, &["materializations", "materializations_json"]).unwrap();
+        insta::assert_yaml_snapshot!(results);
+    }
 
     #[test]
     fn get_by_name_returns_extant_target() {

--- a/crates/catalog/src/snapshots/catalog__capture__test__capture_is_registered_for_flow_ingester.snap
+++ b/crates/catalog/src/snapshots/catalog__capture__test__capture_is_registered_for_flow_ingester.snap
@@ -1,0 +1,11 @@
+---
+source: crates/catalog/src/capture.rs
+expression: results
+---
+captures:
+  - - 1
+    - 1
+    - ~
+    - flow-ingester
+    - 1
+endpoints: []

--- a/crates/catalog/src/snapshots/catalog__collection__test__register.snap
+++ b/crates/catalog/src/snapshots/catalog__collection__test__register.snap
@@ -29,6 +29,10 @@ projections:
     - b/b
     - /b/b
     - false
+  - - 1
+    - flow_document
+    - ""
+    - false
 resource_imports:
   - - 1
     - 10

--- a/crates/catalog/src/snapshots/catalog__endpoint__test__endpoint_is_registered.snap
+++ b/crates/catalog/src/snapshots/catalog__endpoint__test__endpoint_is_registered.snap
@@ -1,0 +1,9 @@
+---
+source: crates/catalog/src/endpoint.rs
+expression: endpoints
+---
+- - 1
+  - 1
+  - testName
+  - postgres
+  - "postgres://foo:bar@baz.test:5432/flow"

--- a/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_default_fields.snap
+++ b/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_default_fields.snap
@@ -1,0 +1,65 @@
+---
+source: crates/catalog/src/materialization.rs
+expression: results
+---
+materializations:
+  - - 1
+    - 1
+    - 1
+    - test_table
+    - 1
+    - - id
+      - wee
+      - wat
+      - flow_document
+materializations_json:
+  - - 1
+    - 1
+    - testDB
+    - postgres
+    - "postgres://flow:flow@flow.test:5432/flow"
+    - test_table
+    - key_ptrs:
+        - /id
+      name: foo
+      partition_fields: []
+      projections:
+        - field: id
+          inference:
+            must_exist: true
+            types:
+              - integer
+          is_partition_key: false
+          is_primary_key: true
+          ptr: /id
+          user_provided: false
+        - field: wee
+          inference:
+            must_exist: true
+            string:
+              is_base64: false
+            types:
+              - string
+          is_partition_key: false
+          is_primary_key: false
+          ptr: /wee
+          user_provided: false
+        - field: wat
+          inference:
+            must_exist: false
+            types:
+              - number
+          is_partition_key: false
+          is_primary_key: false
+          ptr: /woo
+          user_provided: true
+        - field: flow_document
+          inference:
+            must_exist: true
+            types:
+              - object
+          is_partition_key: false
+          is_primary_key: false
+          ptr: ""
+          user_provided: false
+      schema_uri: "test://flow-catalog-test-register/flow.yaml?ptr=/collections/0/schema"

--- a/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_exclude_fields.snap
+++ b/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_exclude_fields.snap
@@ -1,0 +1,53 @@
+---
+source: crates/catalog/src/materialization.rs
+expression: results
+---
+materializations:
+  - - 1
+    - 1
+    - 1
+    - test_table
+    - 1
+    - - id
+      - wat
+      - flow_document
+materializations_json:
+  - - 1
+    - 1
+    - testDB
+    - postgres
+    - "postgres://flow:flow@flow.test:5432/flow"
+    - test_table
+    - key_ptrs:
+        - /id
+      name: foo
+      partition_fields: []
+      projections:
+        - field: id
+          inference:
+            must_exist: true
+            types:
+              - integer
+          is_partition_key: false
+          is_primary_key: true
+          ptr: /id
+          user_provided: false
+        - field: wat
+          inference:
+            must_exist: false
+            types:
+              - number
+          is_partition_key: false
+          is_primary_key: false
+          ptr: /woo
+          user_provided: true
+        - field: flow_document
+          inference:
+            must_exist: true
+            types:
+              - object
+          is_partition_key: false
+          is_primary_key: false
+          ptr: ""
+          user_provided: false
+      schema_uri: "test://flow-catalog-test-register/flow.yaml?ptr=/collections/0/schema"

--- a/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_include_fields.snap
+++ b/crates/catalog/src/snapshots/catalog__materialization__test__materialization_is_registered_with_include_fields.snap
@@ -1,0 +1,53 @@
+---
+source: crates/catalog/src/materialization.rs
+expression: results
+---
+materializations:
+  - - 1
+    - 1
+    - 1
+    - test_table
+    - 1
+    - - id
+      - flow_document
+      - wat
+materializations_json:
+  - - 1
+    - 1
+    - testDB
+    - postgres
+    - "postgres://flow:flow@flow.test:5432/flow"
+    - test_table
+    - key_ptrs:
+        - /id
+      name: foo
+      partition_fields: []
+      projections:
+        - field: id
+          inference:
+            must_exist: true
+            types:
+              - integer
+          is_partition_key: false
+          is_primary_key: true
+          ptr: /id
+          user_provided: false
+        - field: flow_document
+          inference:
+            must_exist: true
+            types:
+              - object
+          is_partition_key: false
+          is_primary_key: false
+          ptr: ""
+          user_provided: false
+        - field: wat
+          inference:
+            must_exist: false
+            types:
+              - number
+          is_partition_key: false
+          is_primary_key: false
+          ptr: /woo
+          user_provided: true
+      schema_uri: "test://flow-catalog-test-register/flow.yaml?ptr=/collections/0/schema"

--- a/crates/catalog/src/snapshots/catalog__projections__test__default_projections_and_inferences_are_registered.snap
+++ b/crates/catalog/src/snapshots/catalog__projections__test__default_projections_and_inferences_are_registered.snap
@@ -1,5 +1,5 @@
 ---
-source: src/catalog/projections.rs
+source: crates/catalog/src/projections.rs
 expression: actual
 ---
 {
@@ -758,6 +758,12 @@ expression: actual
       1,
       "twoFoo/fooObj/d",
       "/twoFoo/fooObj/d",
+      false
+    ],
+    [
+      1,
+      "flow_document",
+      "",
       false
     ]
   ]

--- a/crates/catalog/src/source.rs
+++ b/crates/catalog/src/source.rs
@@ -1,6 +1,6 @@
 use super::{
-    specs, sql_params, Collection, ContentType, Endpoint, Materialization, MaterializationTarget,
-    Resource, Result, Scope, TestCase,
+    specs, sql_params, Capture, Collection, ContentType, Endpoint, Materialization,
+    MaterializationTarget, Resource, Result, Scope, TestCase,
 };
 use url::Url;
 
@@ -74,6 +74,13 @@ impl Source {
                 .push_prop("materializationTargets")
                 .push_prop(name)
                 .then(|scope| MaterializationTarget::register(&scope, name, materialization))?;
+        }
+
+        for (i, capture) in spec.captures.iter().enumerate() {
+            scope
+                .push_prop("captures")
+                .push_item(i)
+                .then(|scope| Capture::register(scope, capture))?;
         }
 
         for (i, materialization) in spec.materializations.iter().enumerate() {

--- a/go/flow/catalog_test.go
+++ b/go/flow/catalog_test.go
@@ -31,6 +31,16 @@ func TestLoadDerivedCollection(t *testing.T) {
 				},
 			},
 			{
+				Field:        "flow_document",
+				Ptr:          "",
+				UserProvided: false,
+				IsPrimaryKey: false,
+				Inference: &pf.Inference{
+					Types:     []string{"object"},
+					MustExist: true,
+				},
+			},
+			{
 				Field:        "i",
 				Ptr:          "/i",
 				UserProvided: false,
@@ -63,6 +73,16 @@ func TestLoadCapturedCollections(t *testing.T) {
 		KeyPtrs:         []string{"/i"},
 		PartitionFields: []string{},
 		Projections: []*pf.Projection{
+			{
+				Field:        "flow_document",
+				Ptr:          "",
+				UserProvided: false,
+				IsPrimaryKey: false,
+				Inference: &pf.Inference{
+					Types:     []string{"object"},
+					MustExist: true,
+				},
+			},
 			{
 				Field:        "i",
 				IsPrimaryKey: true,


### PR DESCRIPTION
WIP on catalog-specs-redux

This is a work in progress on #68 that implements the YAML specification. The `materializations` and `captures` here are non-functional, so the old materialization machinery was left in place for now. The idea is for the two to live side-by-side until the new materialization and captures are fully functional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/78)
<!-- Reviewable:end -->
