### PR TITLE
crates/models: factored crate focusing on catalog domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "models"
+version = "0.0.0"
+dependencies = [
+ "caseless",
+ "doc",
+ "futures",
+ "humantime-serde",
+ "include_dir",
+ "insta",
+ "itertools 0.9.0",
+ "json",
+ "log",
+ "pretty_env_logger",
+ "protocol",
+ "regex",
+ "reqwest",
+ "rusqlite",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strsim 0.10.0",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "yaml-merge-keys",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "models"
+version = "0.0.0"
+authors = ["Estuary Technologies, Inc"]
+edition = "2018"
+
+[dependencies]
+json = { path = "../json", version = "0.0.0" }
+doc = { path = "../doc", version = "0.0.0" }
+protocol = { path = "../protocol", version = "0.0.0" }
+
+futures = "*"
+caseless = "*"
+humantime-serde = "*"
+include_dir = { version = "*", default-features = false }
+itertools = "*"
+log = "*"
+regex = "*"
+reqwest = { version = "*", default-features = false, features = ["blocking", "native-tls"] }
+rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
+schemars = "*"
+serde = { version = "*", features = ["derive"] }
+serde_json = { version =  "*", features = ["raw_value"] }
+serde_yaml = "*"
+strsim = "*"
+tempfile = "*"
+thiserror = "*"
+unicode-normalization = "*"
+url = "*"
+yaml-merge-keys = { version = "*", features = ["serde_yaml"] }
+tracing = "*"
+
+[dev-dependencies]
+protocol = { path = "../protocol", version = "0.0.0" }
+
+insta = "*"
+pretty_env_logger = "*"

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod source;

--- a/crates/models/src/source/loader.rs
+++ b/crates/models/src/source/loader.rs
@@ -1,0 +1,870 @@
+use super::wrappers::{
+    CaptureName, CollectionName, ContentType, EndpointName, EndpointType, JsonPointer,
+    MaterializationName, ShuffleHash, TestName, TransformName,
+};
+use super::{specs, Scope};
+
+use doc::Schema as CompiledSchema;
+use futures::future::{FutureExt, LocalBoxFuture};
+use futures::TryFutureExt;
+use json::schema::{build::build_schema, Application, Keyword};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::future::Future;
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LoadError {
+    #[error("failed to parse URL")]
+    URLParse(#[from] url::ParseError),
+    #[error("failed to fetch resource {uri}")]
+    Fetch {
+        uri: String,
+        #[source]
+        detail: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("failed to parse YAML (location {:?})", .0.location())]
+    YAMLErr(#[from] serde_yaml::Error),
+    #[error("failed to merge YAML alias nodes")]
+    YAMLMergeErr(#[from] yaml_merge_keys::MergeKeyError),
+    #[error("failed to build JSON schema")]
+    SchemaBuild(#[from] json::schema::BuildError),
+    #[error("failed to index JSON schema")]
+    SchemaIndex(#[from] json::schema::index::Error),
+}
+
+pub trait Visitor {
+    type Error: std::error::Error + 'static;
+
+    /// Notification that a resource fetch has begun.
+    fn visit_fetch<'a>(&mut self, scope: Scope<'a>, resource: &Url) -> Result<(), Self::Error>;
+
+    /// Notification that a resource of the given content-type and content has been loaded.
+    /// visit_resource is called immediately before entities of the resource are visited,
+    /// so Visitor implementations may want to clear out any retained prior entries from a
+    /// previous visitation of this resource.
+    fn visit_resource<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        resource: &Url,
+        content_type: ContentType,
+        content: &[u8],
+    ) -> Result<(), Self::Error>;
+
+    fn visit_import<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        parent_uri: &Url,
+        child_uri: &Url,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_nodejs_dependency<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        package: &str,
+        version: &str,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_collection<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        collection: &CollectionName,
+        schema: &Url,
+        key: &specs::CompositeKey,
+        store: &EndpointName,
+        patch_config: &serde_json::Value,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_projection<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        collection: &CollectionName,
+        field: &str,
+        location: &JsonPointer,
+        partition: bool,
+        user_provided: bool,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_derivation<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        derivation: &CollectionName,
+        register_schema: &Url,
+        register_initial: &serde_json::Value,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_transform<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        transform: &TransformName,
+        derivation: &CollectionName,
+        source: &CollectionName,
+        source_partitions: Option<&specs::PartitionSelector>,
+        source_schema: Option<&Url>,
+        shuffle_key: Option<&specs::CompositeKey>,
+        shuffle_lambda: Option<&specs::Lambda>,
+        shuffle_hash: ShuffleHash,
+        read_delay: Option<std::time::Duration>,
+        update: Option<&specs::Lambda>,
+        publish: Option<&specs::Lambda>,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_endpoint<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        endpoint: &EndpointName,
+        endpoint_type: EndpointType,
+        base_config: &serde_json::Value,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_materialization<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        materialization: &MaterializationName,
+        source: &CollectionName,
+        source_schema: Option<&Url>,
+        endpoint: &EndpointName,
+        patch_config: &serde_json::Value,
+        fields: &specs::FieldSelector,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_capture<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        capture: &CaptureName,
+        target: &CollectionName,
+        allow_push: bool,
+        endpoint: Option<&EndpointName>,
+        patch_config: Option<&serde_json::Value>,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_test<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        total_steps: usize,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_test_step_ingest<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        step_index: usize,
+        collection: &CollectionName,
+        documents: &[serde_json::Value],
+    ) -> Result<(), Self::Error>;
+
+    fn visit_test_step_verify<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        step_index: usize,
+        collection: &CollectionName,
+        documents: &[serde_json::Value],
+        partitions: Option<&specs::PartitionSelector>,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_schema_document<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        dom: &serde_json::Value,
+    ) -> Result<(), Self::Error>;
+
+    fn visit_catalog<'a>(&mut self, scope: Scope<'a>) -> Result<(), Self::Error>;
+
+    fn visit_error<'a>(&mut self, scope: Scope<'a>, err: LoadError) -> Result<(), Self::Error>;
+}
+
+pub type FetchResult = Result<Box<[u8]>, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Loader provides a stack-based driver for traversing catalog source
+/// models, with dispatch to a Visitor trait and having fine-grained
+/// tracking of location context.
+pub struct Loader<V, F, FF>
+where
+    V: Visitor,
+    F: FnMut(&Url) -> FF,
+    FF: Future<Output = FetchResult>,
+{
+    /// The database connection to use during the build process.
+    visitor: RefCell<V>,
+    /// Dynamic fetch function for retrieving discovered, unvisited resources.
+    fetch: RefCell<F>,
+    // Marked resources which are currently being loaded with senders
+    // for each waiting task (if Some), or have completed loaded (None).
+    visited: RefCell<HashSet<Url>>,
+}
+
+impl<V, F, FF> Loader<V, F, FF>
+where
+    V: Visitor,
+    F: FnMut(&Url) -> FF,
+    FF: Future<Output = FetchResult>,
+{
+    /// Build and return a new Loader.
+    pub fn new(visitor: V, fetch: F) -> Loader<V, F, FF> {
+        Loader {
+            visitor: RefCell::new(visitor),
+            fetch: RefCell::new(fetch),
+            visited: RefCell::new(HashSet::new()),
+        }
+    }
+
+    /// Consume this Loader, returning its wrapped Visitor.
+    pub fn into_visitor(self) -> V {
+        let Loader { visitor, .. } = self;
+        visitor.into_inner()
+    }
+
+    /// Load (or re-load) a resource of the given ContentType.
+    pub async fn load_resource<'a>(
+        &'a self,
+        scope: Scope<'a>,
+        resource: &'a Url,
+        content_type: ContentType,
+    ) -> Result<(), V::Error> {
+        // Mark as visited, so that recursively-loaded imports don't re-visit.
+        self.visited.borrow_mut().insert(resource.clone());
+        self.visitor.borrow_mut().visit_fetch(scope, resource)?;
+
+        let content = (self.fetch.borrow_mut())(&resource);
+        let content = content.await.map_err(|e| LoadError::Fetch {
+            uri: resource.to_string(),
+            detail: e,
+        });
+
+        if let Some(content) = opt_err_to_ok(self.fallible(scope, content))? {
+            self.load_resource_content(scope, resource, &content, content_type)
+                .await?;
+        }
+        Ok(())
+    }
+
+    // Resources are loaded recursively, and Rust requires that recursive
+    // async calls be made through a boxed future. Otherwise, the generated
+    // state machine would have infinite size!
+    fn load_resource_content<'a>(
+        &'a self,
+        scope: Scope<'a>,
+        resource: &'a Url,
+        content: &'a [u8],
+        content_type: ContentType,
+    ) -> LocalBoxFuture<'a, Result<(), V::Error>> {
+        async move {
+            self.visitor
+                .borrow_mut()
+                .visit_resource(scope, &resource, content_type, &content)?;
+
+            let scope = scope.push_resource(&resource);
+
+            match content_type {
+                ContentType::CatalogSpec => self.load_catalog(scope, content).await?,
+                ContentType::JsonSchema => self.load_schema_document(scope, content).await?,
+                _ => (),
+            }
+
+            Ok(())
+        }
+        .map(|r| r.or_else(ok_if_none))
+        .boxed_local()
+    }
+
+    async fn load_schema_document<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        content: &[u8],
+    ) -> Result<(), Option<V::Error>> {
+        let dom: serde_json::Value = self.fallible(scope, serde_yaml::from_slice(&content))?;
+        let root: CompiledSchema =
+            self.fallible(scope, build_schema(scope.resource().clone(), &dom))?;
+
+        let mut index = doc::SchemaIndex::new();
+        self.fallible(scope, index.add(&root))?;
+
+        self.load_schema_node(scope, &index, &root).await?;
+
+        self.visitor
+            .borrow_mut()
+            .visit_schema_document(scope, &dom)?;
+
+        Ok(())
+    }
+
+    fn load_schema_node<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        index: &'s doc::SchemaIndex<'s>,
+        schema: &'s CompiledSchema,
+    ) -> LocalBoxFuture<'s, Result<(), V::Error>> {
+        // Build an iterator that returns a Future for each Application keyword.
+        // That future in turn:
+        // * Builds a recursive future A from it's contained schema, and
+        // * Builds a future B which fetches a referenced external resource, if present.
+        // Then futures A & B are concurrently joined.
+        let it = schema.kw.iter().filter_map(move |kw| match kw {
+            Keyword::Application(app, child) => Some(async move {
+                // Add Application keywords to the Scope's Location.
+                let location = app.push_keyword(&scope.location);
+                let scope = Scope {
+                    location: app.push_keyword_target(&location),
+                    ..scope
+                };
+
+                // Map to an external URL that's not contained by this CompiledSchema.
+                let uri = match app {
+                    Application::Ref(uri) => {
+                        // $ref applications often use #fragment suffixes which indicate
+                        // a sub-schema of the base schema document to use.
+                        let mut uri = uri.clone();
+                        uri.set_fragment(None);
+
+                        if index.fetch(&uri).is_none() {
+                            Some(uri)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+
+                // Recursive call to walk the schema.
+                let recurse = self.load_schema_node(scope, index, child);
+
+                if let Some(uri) = uri {
+                    // Concurrently fetch |uri| while continuing to walk the schema.
+                    let ((), ()) = futures::try_join!(
+                        recurse,
+                        self.load_import(scope, &uri, ContentType::JsonSchema)
+                    )?;
+                } else {
+                    let () = recurse.await?;
+                }
+
+                Ok(())
+            }),
+            _ => None,
+        });
+
+        // Join all futures of the iterator.
+        futures::future::try_join_all(it)
+            .map_ok(|_: Vec<()>| ())
+            .boxed_local()
+    }
+
+    /// Load a schema reference, which may be an inline schema.
+    async fn load_schema_reference<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        schema: specs::Schema,
+    ) -> Result<Url, Option<V::Error>> {
+        // If schema is a relative URL, then import it.
+        if let specs::Schema::Url(import) = schema {
+            let mut import = self.fallible(scope, scope.resource().join(import.as_ref()))?;
+
+            // Temporarily strip schema fragment to import base document.
+            let fragment = import.fragment().map(str::to_string);
+            import.set_fragment(None);
+
+            self.load_import(scope, &import, ContentType::JsonSchema)
+                .await?;
+
+            import.set_fragment(fragment.as_deref());
+            Ok(import)
+        } else {
+            // Schema is in-line. Create a synthetic resource URL by extending the parent
+            // with a `ptr` query parameter, encoding the json pointer path of the schema.
+            let mut import = scope.resource().clone();
+            import.set_query(Some(&format!("ptr={}", scope.location.url_escaped())));
+
+            self.load_resource_content(
+                scope,
+                &import,
+                &serde_json::to_vec(&schema).unwrap(),
+                ContentType::JsonSchema,
+            )
+            .await?;
+
+            self.visitor
+                .borrow_mut()
+                .visit_import(scope, scope.resource(), &import)?;
+            Ok(import)
+        }
+    }
+
+    // Load an import to another resource, recursively fetching if not yet visited.
+    async fn load_import<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        import: &'s Url,
+        content_type: ContentType,
+    ) -> Result<(), V::Error> {
+        // Recursively process the import if it's not already visited.
+        if !self.visited.borrow().contains(&import) {
+            self.load_resource(scope, &import, content_type).await?;
+        }
+
+        self.visitor
+            .borrow_mut()
+            .visit_import(scope, scope.resource(), &import)?;
+
+        Ok(())
+    }
+
+    // Load a top-level catalog specification.
+    async fn load_catalog<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        content: &[u8],
+    ) -> Result<(), Option<V::Error>> {
+        let dom: serde_yaml::Value = self.fallible(scope, serde_yaml::from_slice(&content))?;
+        let dom: serde_yaml::Value =
+            self.fallible(scope, yaml_merge_keys::merge_keys_serde(dom))?;
+
+        let specs::Catalog {
+            _schema,
+            import,
+            node_dependencies,
+            collections,
+            endpoints,
+            materializations,
+            captures,
+            tests,
+        } = self.fallible(scope, serde_yaml::from_value(dom))?;
+
+        // Visit NPM dependencies.
+        for (package, version) in node_dependencies.iter() {
+            self.visitor.borrow_mut().visit_nodejs_dependency(
+                scope.push_prop("nodeDependencies").push_prop(package),
+                package,
+                version,
+            )?;
+        }
+
+        // Task which loads all imports.
+        let import = import.into_iter().enumerate().map(|(index, import)| {
+            async move {
+                let scope = scope.push_prop("import");
+                let scope = scope.push_item(index);
+
+                // Map from relative to absolute URL.
+                let import = self.fallible(scope, scope.resource().join(import.as_ref()))?;
+
+                self.load_import(scope, &import, ContentType::CatalogSpec)
+                    .await?;
+                Ok(())
+            }
+            .map(|r| r.or_else(ok_if_none))
+        });
+        let import = futures::future::try_join_all(import);
+
+        // Task which loads all collections.
+        let collections = collections
+            .into_iter()
+            .map(|(name, collection)| async move {
+                self.load_collection(
+                    scope.push_prop("collections").push_prop(name.as_ref()),
+                    &name,
+                    collection,
+                )
+                .await
+            });
+        let collections = futures::future::try_join_all(collections);
+
+        // Visit endpoints.
+        for (name, endpoint) in endpoints {
+            self.visitor.borrow_mut().visit_endpoint(
+                scope.push_prop("endpoints").push_prop(name.as_ref()),
+                &name,
+                endpoint.endpoint_type(),
+                &endpoint.base_config(),
+            )?;
+        }
+
+        // Visit captures.
+        for (name, capture) in captures {
+            self.load_capture(
+                scope.push_prop("captures").push_prop(name.as_ref()),
+                &name,
+                capture,
+            )?;
+        }
+
+        // Task which loads all materializations.
+        let materializations =
+            materializations
+                .into_iter()
+                .map(|(name, materialization)| async move {
+                    self.load_materialization(
+                        scope.push_prop("materializations").push_prop(name.as_ref()),
+                        &name,
+                        materialization,
+                    )
+                    .await
+                });
+        let materializations = futures::future::try_join_all(materializations);
+
+        // Visit tests.
+        for (name, steps) in tests {
+            self.load_test_case(
+                scope.push_prop("tests").push_prop(name.as_ref()),
+                &name,
+                steps,
+            )?;
+        }
+
+        let (_, _, _): (Vec<()>, Vec<()>, Vec<()>) =
+            futures::try_join!(import, collections, materializations)?;
+
+        self.visitor.borrow_mut().visit_catalog(scope)?;
+        Ok(())
+    }
+
+    async fn load_collection<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        collection_name: &'s CollectionName,
+        collection: specs::Collection,
+    ) -> Result<(), V::Error> {
+        let specs::Collection {
+            schema,
+            key,
+            store:
+                specs::EndpointRef {
+                    name: store,
+                    config: patch_config,
+                },
+            projections,
+            derivation,
+        } = collection;
+
+        // Visit all collection projections.
+        for (field, projection) in projections.iter() {
+            match projection {
+                specs::Projection::Pointer(location) => {
+                    self.visitor.borrow_mut().visit_projection(
+                        scope.push_prop("projections").push_prop(field),
+                        collection_name,
+                        field,
+                        &location,
+                        false,
+                        true,
+                    )?;
+                }
+                specs::Projection::Object {
+                    location,
+                    partition,
+                } => {
+                    self.visitor.borrow_mut().visit_projection(
+                        scope.push_prop("projections").push_prop(field),
+                        collection_name,
+                        field,
+                        &location,
+                        *partition,
+                        true,
+                    )?;
+                }
+            }
+        }
+
+        // Task which loads & maps collection schema => URL.
+        // Recoverable failures project to Ok(None).
+        let schema = self
+            .load_schema_reference(scope.push_prop("schema"), schema)
+            .map(opt_err_to_ok);
+
+        // If this collection is a derivation, concurrently
+        // load the collection's schema and its derivation.
+        let schema = match derivation {
+            Some(derivation) => {
+                let derivation = self.load_derivation(
+                    scope.push_prop("derivation"),
+                    collection_name,
+                    derivation,
+                );
+
+                let (schema, ()) = futures::try_join!(schema, derivation)?;
+                schema
+            }
+            None => schema.await?,
+        };
+
+        if let Some(schema) = schema {
+            self.visitor.borrow_mut().visit_collection(
+                scope,
+                collection_name,
+                &schema,
+                &key,
+                &store,
+                &patch_config,
+            )?;
+        }
+        Ok(())
+    }
+
+    async fn load_derivation<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        derivation_name: &'s CollectionName,
+        derivation: specs::Derivation,
+    ) -> Result<(), V::Error> {
+        let specs::Derivation {
+            register:
+                specs::Register {
+                    schema: register_schema,
+                    initial: register_initial,
+                },
+            transform,
+        } = derivation;
+
+        // Task which loads & maps register schema => URL.
+        // Recoverable failures project to Ok(None).
+        let register_schema = async move {
+            self.load_schema_reference(
+                scope.push_prop("register").push_prop("schema"),
+                register_schema,
+            )
+            .await
+        }
+        .map(opt_err_to_ok);
+
+        // Task which loads each derivation transform.
+        let transforms = transform.into_iter().map(|(name, transform)| async move {
+            self.load_transform(
+                scope.push_prop("transform").push_prop(name.as_ref()),
+                &name,
+                derivation_name,
+                transform,
+            )
+            .await
+        });
+        let transforms = futures::future::try_join_all(transforms);
+
+        let (register_schema, _): (_, Vec<()>) = futures::try_join!(register_schema, transforms)?;
+
+        if let Some(register_schema) = register_schema {
+            self.visitor.borrow_mut().visit_derivation(
+                scope,
+                derivation_name,
+                &register_schema,
+                &register_initial,
+            )?;
+        }
+        Ok(())
+    }
+
+    async fn load_transform<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        transform_name: &'s TransformName,
+        derivation: &'s CollectionName,
+        transform: specs::Transform,
+    ) -> Result<(), V::Error> {
+        let specs::Transform {
+            source:
+                specs::TransformSource {
+                    name: source,
+                    schema: source_schema,
+                    partitions: source_partitions,
+                },
+            read_delay,
+            shuffle,
+            update,
+            publish,
+        } = transform;
+
+        let (shuffle_key, shuffle_lambda, shuffle_hash) = match shuffle {
+            Some(specs::Shuffle::Key(key)) => (Some(key), None, ShuffleHash::None),
+            Some(specs::Shuffle::MD5(key)) => (Some(key), None, ShuffleHash::Md5),
+            Some(specs::Shuffle::Lambda(lambda)) => (None, Some(lambda), ShuffleHash::None),
+            None => (None, None, ShuffleHash::None),
+        };
+
+        // Map optional source schema => URL.
+        let source_schema = match source_schema {
+            Some(url) => match self
+                .load_schema_reference(scope.push_prop("source").push_prop("schema"), url)
+                .map(opt_err_to_ok)
+                .await?
+            {
+                Some(url) => Some(url),
+                None => return Ok(()), // Error while loading.
+            },
+            None => None,
+        };
+
+        self.visitor.borrow_mut().visit_transform(
+            scope,
+            transform_name,
+            derivation,
+            &source,
+            source_partitions.as_ref(),
+            source_schema.as_ref(),
+            shuffle_key.as_ref(),
+            shuffle_lambda.as_ref(),
+            shuffle_hash,
+            read_delay,
+            update.as_ref(),
+            publish.as_ref(),
+        )?;
+
+        Ok(())
+    }
+
+    async fn load_materialization<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        materialization_name: &'s MaterializationName,
+        materialization: specs::Materialization,
+    ) -> Result<(), V::Error> {
+        let specs::Materialization {
+            source:
+                specs::MaterializationSource {
+                    name: source,
+                    schema: source_schema,
+                },
+            endpoint:
+                specs::EndpointRef {
+                    name: endpoint,
+                    config: patch_config,
+                },
+            fields,
+        } = materialization;
+
+        // Map optional source schema => URL.
+        let source_schema = match source_schema {
+            Some(url) => match self
+                .load_schema_reference(scope.push_prop("source").push_prop("schema"), url)
+                .map(opt_err_to_ok)
+                .await?
+            {
+                Some(url) => Some(url),
+                None => return Ok(()), // Error while loading.
+            },
+            None => None,
+        };
+
+        self.visitor.borrow_mut().visit_materialization(
+            scope,
+            materialization_name,
+            &source,
+            source_schema.as_ref(),
+            &endpoint,
+            &patch_config,
+            &fields,
+        )?;
+
+        Ok(())
+    }
+
+    fn load_capture<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        name: &'s CaptureName,
+        capture: specs::Capture,
+    ) -> Result<(), V::Error> {
+        let (allow_push, endpoint, patch_config) = match capture.inner {
+            specs::CaptureType::PushAPI => (true, None, None),
+            specs::CaptureType::Endpoint(specs::EndpointRef { name, config }) => {
+                (false, Some(name), Some(config))
+            }
+        };
+        self.visitor.borrow_mut().visit_capture(
+            scope,
+            &name,
+            &capture.target.name,
+            allow_push,
+            endpoint.as_ref(),
+            patch_config.as_ref(),
+        )?;
+        Ok(())
+    }
+
+    fn load_test_case<'s>(
+        &'s self,
+        scope: Scope<'s>,
+        name: &'s TestName,
+        steps: Vec<specs::TestStep>,
+    ) -> Result<(), V::Error> {
+        let total_steps = steps.len();
+
+        for (index, step) in steps.into_iter().enumerate() {
+            let scope = scope.push_item(index);
+
+            match step {
+                specs::TestStep::Ingest(specs::TestStepIngest {
+                    collection,
+                    documents,
+                }) => {
+                    self.visitor.borrow_mut().visit_test_step_ingest(
+                        scope,
+                        &name,
+                        index,
+                        &collection,
+                        &documents,
+                    )?;
+                }
+                specs::TestStep::Verify(specs::TestStepVerify {
+                    collection,
+                    documents,
+                    partitions,
+                }) => {
+                    self.visitor.borrow_mut().visit_test_step_verify(
+                        scope,
+                        &name,
+                        index,
+                        &collection,
+                        &documents,
+                        partitions.as_ref(),
+                    )?;
+                }
+            }
+        }
+
+        self.visitor
+            .borrow_mut()
+            .visit_test(scope, &name, total_steps)?;
+
+        Ok(())
+    }
+
+    // Consume a result capable of producing a LoadError, reporting any error to the visitor.
+    // * If the input Result is Ok, its value is returned directly.
+    // * If the input Result is Err and the visitor consumed it without error,
+    //   Err(None) is returned. This provides an opportunity to abort out of local
+    //   control flows which require this result to succeed. Macro control-flow
+    //   can recover and continue from a local error by using the
+    //   Result.or_else(ok_if_none) combinator.
+    // * If the input Result is Err and the visitor produced on error on consumption,
+    //   Err(Some(V::Error)) is returned.
+    fn fallible<'s, T, E>(&self, scope: Scope<'s>, r: Result<T, E>) -> Result<T, Option<V::Error>>
+    where
+        E: Into<LoadError>,
+    {
+        match r {
+            Ok(t) => Ok(t),
+            Err(err) => match self.visitor.borrow_mut().visit_error(scope, err.into()) {
+                Ok(()) => Err(None),
+                Err(err) => Err(Some(err)),
+            },
+        }
+    }
+}
+
+// ok_if_none maps a None option of the Error to Ok,
+// and a Some(err) to an Err(Some(err)).
+// Use with Result.or_else() to "hoist" a None error into
+// an Ok(()).
+fn ok_if_none<E>(e: Option<E>) -> Result<(), E> {
+    match e {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+fn opt_err_to_ok<T, E>(r: Result<T, Option<E>>) -> Result<Option<T>, E> {
+    match r {
+        Ok(t) => Ok(Some(t)),
+        Err(None) => Ok(None),
+        Err(Some(e)) => Err(e),
+    }
+}

--- a/crates/models/src/source/mod.rs
+++ b/crates/models/src/source/mod.rs
@@ -1,0 +1,9 @@
+mod loader;
+pub mod scenarios;
+mod scope;
+pub mod specs;
+mod wrappers;
+
+pub use loader::{FetchResult, LoadError, Loader, Visitor};
+pub use scope::Scope;
+pub use wrappers::*;

--- a/crates/models/src/source/scenarios/mod.rs
+++ b/crates/models/src/source/scenarios/mod.rs
@@ -1,0 +1,405 @@
+use super::{
+    specs, CaptureName, CollectionName, ContentType, EndpointName, EndpointType, FetchResult,
+    JsonPointer, LoadError, Loader, MaterializationName, Scope, ShuffleHash, TestName,
+    TransformName, Visitor,
+};
+
+use futures::channel::oneshot;
+use futures::future::FutureExt;
+use serde_json::{json, Value};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::task::Poll;
+use url::Url;
+
+macro_rules! file_tests {
+    ($($name:ident,)*) => {
+    $(
+        #[test]
+        fn $name() {
+			let fixture = include_bytes!(concat!(stringify!($name), ".yaml"));
+			let output = evaluate_fixtures(VecVisitor(Vec::new()), fixture);
+			insta::assert_yaml_snapshot!(output.unwrap().0);
+        }
+    )*
+    }
+}
+
+file_tests! {
+    test_catalog_import_cycles,
+    test_collections,
+    test_derivations,
+    test_schema_with_inline,
+    test_schema_with_nested_ids,
+    test_schema_with_references,
+    test_simple_catalog,
+    test_test_case,
+    test_endpoints_captures_materializations,
+}
+
+pub fn evaluate_fixtures<V: Visitor>(visitor: V, fixtures: &[u8]) -> Result<V, V::Error> {
+    let fixtures: serde_json::Map<String, Value> =
+        serde_yaml::from_slice(fixtures).expect("fixtures must be a valid YAML object");
+
+    // Fetches holds started fetches since the last future poll.
+    // Use an ordered map so that we signal one-shots in a stable order,
+    // making snapshots reliable.
+    let fetches: RefCell<BTreeMap<String, oneshot::Sender<FetchResult>>> =
+        RefCell::new(BTreeMap::new());
+
+    // Fetch function which queues oneshot futures for started fetches.
+    let fetch = |url: &Url| {
+        let (tx, rx) = oneshot::channel();
+        if let Some(_) = fetches.borrow_mut().insert(url.to_string(), tx) {
+            panic!("url {} has already been fetched", url);
+        }
+        rx.map(|r| r.unwrap())
+    };
+
+    let loader = Loader::new(visitor, fetch);
+
+    let root = Url::parse("test://root").unwrap();
+    let mut fut = loader
+        .load_resource(Scope::new(&root), &root, ContentType::CatalogSpec)
+        .boxed_local();
+
+    let waker = futures::task::noop_waker();
+    let mut ctx = std::task::Context::from_waker(&waker);
+
+    loop {
+        match fut.poll_unpin(&mut ctx) {
+            Poll::Ready(Ok(())) => {
+                std::mem::forget(fut);
+                return Ok(loader.into_visitor());
+            }
+            Poll::Ready(Err(err)) => return Err(err),
+            Poll::Pending if fetches.borrow().is_empty() => {
+                panic!("future is pending, but started no fetches")
+            }
+            Poll::Pending => {
+                for (url, tx) in fetches.borrow_mut().split_off("") {
+                    match fixtures.get(&url) {
+                        Some(value) => tx.send(Ok(value.to_string().as_bytes().into())),
+                        None => tx.send(Err("fixture not found".into())),
+                    }
+                    .unwrap();
+                }
+            }
+        }
+    }
+}
+
+pub struct VecVisitor(Vec<Value>);
+
+impl Visitor for VecVisitor {
+    type Error = std::convert::Infallible;
+
+    fn visit_fetch<'a>(&mut self, scope: Scope<'a>, resource: &Url) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "fetch": {
+                "scope": scope.flatten().as_str(),
+                "resource": resource.as_str(),
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_catalog<'a>(&mut self, scope: Scope<'a>) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "catalog": {
+                "scope": scope.flatten().as_str(),
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_schema_document<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        _dom: &serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "schema": {
+                "scope": scope.flatten().as_str(),
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_import<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        parent_uri: &Url,
+        child_uri: &Url,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "import": {
+                "scope": scope.flatten().as_str(),
+                "parent_uri": parent_uri.as_str(),
+                "child_uri": child_uri.as_str(),
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_resource<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        resource: &Url,
+        content_type: ContentType,
+        _content: &[u8],
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "resource": {
+                "scope": scope.flatten().as_str(),
+                "resource": resource.as_str(),
+                "content_type": content_type.as_str(),
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_nodejs_dependency<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        package: &str,
+        version: &str,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "nodejs_dependency": {
+                "scope": scope.flatten().as_str(),
+                "package": package,
+                "version": version,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_collection<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        name: &CollectionName,
+        schema: &Url,
+        key: &specs::CompositeKey,
+        store: &EndpointName,
+        patch_config: &serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "collection": {
+                "scope": scope.flatten().as_str(),
+                "name": name,
+                "schema": schema.as_str(),
+                "key": key,
+                "store": store,
+                "patch_config": patch_config,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_projection<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        collection: &CollectionName,
+        field: &str,
+        location: &JsonPointer,
+        partition: bool,
+        user_provided: bool,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "projection": {
+                "scope": scope.flatten().as_str(),
+                "collection": collection,
+                "field": field,
+                "location": location,
+                "partition": partition,
+                "user_provided": user_provided,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_derivation<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        derivation: &CollectionName,
+        register_schema: &Url,
+        register_initial: &serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "derivation": {
+                "scope": scope.flatten().as_str(),
+                "derivation": derivation,
+                "register_schema": register_schema.as_str(),
+                "register_initial": register_initial,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_transform<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        transform: &TransformName,
+        derivation: &CollectionName,
+        source: &CollectionName,
+        source_partitions: Option<&specs::PartitionSelector>,
+        source_schema: Option<&Url>,
+        shuffle_key: Option<&specs::CompositeKey>,
+        shuffle_lambda: Option<&specs::Lambda>,
+        shuffle_hash: ShuffleHash,
+        read_delay: Option<std::time::Duration>,
+        update: Option<&specs::Lambda>,
+        publish: Option<&specs::Lambda>,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "transform": {
+                "scope": scope.flatten().as_str(),
+                "transform": transform,
+                "derivation": derivation,
+                "source": source,
+                "source_partitions": source_partitions,
+                "source_schema": source_schema.map(|u| u.as_str()),
+                "shuffle_key": shuffle_key,
+                "shuffle_lambda": shuffle_lambda,
+                "shuffle_hash": shuffle_hash as i32,
+                "read_delay": read_delay.map(|d| d.as_secs()),
+                "update": update,
+                "publish": publish,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_endpoint<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        endpoint: &EndpointName,
+        endpoint_type: EndpointType,
+        base_config: &serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "endpoint": {
+                "scope": scope.flatten().as_str(),
+                "endpoint": endpoint,
+                "endpoint_type": endpoint_type.as_str(),
+                "base_config": base_config,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_materialization<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        materialization: &MaterializationName,
+        source: &CollectionName,
+        source_schema: Option<&Url>,
+        endpoint: &EndpointName,
+        patch_config: &serde_json::Value,
+        fields: &specs::FieldSelector,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "materialization": {
+                "scope": scope.flatten().as_str(),
+                "materialization": materialization,
+                "source": source,
+                "source_schema": source_schema.map(|u| u.as_str()),
+                "endpoint": endpoint,
+                "patch_config": patch_config,
+                "fields": fields,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_capture<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        capture: &CaptureName,
+        target: &CollectionName,
+        allow_push: bool,
+        endpoint: Option<&EndpointName>,
+        patch_config: Option<&serde_json::Value>,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "capture": {
+                "scope": scope.flatten().as_str(),
+                "capture": capture,
+                "target": target,
+                "allow_push": allow_push,
+                "endpoint": endpoint,
+                "patch_config": patch_config,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_test_step_ingest<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        step_index: usize,
+        collection: &CollectionName,
+        documents: &[serde_json::Value],
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "test_step_ingest": {
+                "scope": scope.flatten().as_str(),
+                "test": test,
+                "step_index": step_index,
+                "collection": collection,
+                "documents": documents,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_test_step_verify<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        step_index: usize,
+        collection: &CollectionName,
+        documents: &[serde_json::Value],
+        partitions: Option<&specs::PartitionSelector>,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "test_step_verify": {
+                "scope": scope.flatten().as_str(),
+                "test": test,
+                "step_index": step_index,
+                "collection": collection,
+                "documents": documents,
+                "partitions": partitions,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_test<'a>(
+        &mut self,
+        scope: Scope<'a>,
+        test: &TestName,
+        total_steps: usize,
+    ) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "test": {
+                "scope": scope.flatten().as_str(),
+                "test": test,
+                "total_steps": total_steps,
+            }
+        }));
+        Ok(())
+    }
+
+    fn visit_error<'a>(&mut self, scope: Scope<'a>, err: LoadError) -> Result<(), Self::Error> {
+        self.0.push(json!({
+            "error": {
+                "scope": scope.flatten().as_str(),
+                "message": format!("{:?}", err),
+            }
+        }));
+        Ok(())
+    }
+}

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__catalog_import_cycles.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__catalog_import_cycles.snap
@@ -1,0 +1,72 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- fetch:
+    resource: "test://root/A"
+    scope: "test://root#/import/0"
+- fetch:
+    resource: "test://root/B"
+    scope: "test://root#/import/1"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root/A"
+    scope: "test://root#/import/0"
+- fetch:
+    resource: "test://root/C"
+    scope: "test://root/A#/import/0"
+- import:
+    child_uri: "test://root/B"
+    parent_uri: "test://root/A"
+    scope: "test://root/A#/import/1"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root/B"
+    scope: "test://root#/import/1"
+- import:
+    child_uri: "test://root/C"
+    parent_uri: "test://root/B"
+    scope: "test://root/B#/import/0"
+- import:
+    child_uri: "test://root/A"
+    parent_uri: "test://root/B"
+    scope: "test://root/B#/import/1"
+- catalog:
+    scope: "test://root/B"
+- import:
+    child_uri: "test://root/B"
+    parent_uri: "test://root"
+    scope: "test://root#/import/1"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root/C"
+    scope: "test://root/A#/import/0"
+- import:
+    child_uri: "test://root"
+    parent_uri: "test://root/C"
+    scope: "test://root/C#/import/0"
+- import:
+    child_uri: "test://root/B"
+    parent_uri: "test://root/C"
+    scope: "test://root/C#/import/1"
+- catalog:
+    scope: "test://root/C"
+- import:
+    child_uri: "test://root/C"
+    parent_uri: "test://root/A"
+    scope: "test://root/A#/import/0"
+- catalog:
+    scope: "test://root/A"
+- import:
+    child_uri: "test://root/A"
+    parent_uri: "test://root"
+    scope: "test://root#/import/0"
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__collections.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__collections.snap
@@ -1,0 +1,49 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- projection:
+    collection: test/collection
+    field: field_a
+    location: /a/a
+    partition: true
+    scope: "test://root#/collections/test~1collection/projections/field_a"
+    user_provided: true
+- projection:
+    collection: test/collection
+    field: field_b
+    location: /b/b
+    partition: false
+    scope: "test://root#/collections/test~1collection/projections/field_b"
+    user_provided: true
+- fetch:
+    resource: "test://root/schema.json"
+    scope: "test://root#/collections/test~1collection/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root/schema.json"
+    scope: "test://root#/collections/test~1collection/schema"
+- schema:
+    scope: "test://root/schema.json"
+- import:
+    child_uri: "test://root/schema.json"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/test~1collection/schema"
+- collection:
+    key:
+      - /key/1
+      - /key/0
+    name: test/collection
+    patch_config: ~
+    schema: "test://root/schema.json#foobar"
+    scope: "test://root#/collections/test~1collection"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__derivations.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__derivations.snap
@@ -1,0 +1,133 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- fetch:
+    resource: "test://root/a-schema.json"
+    scope: "test://root#/collections/d1~1collection/schema"
+- fetch:
+    resource: "test://root/reg-schema.json"
+    scope: "test://root#/collections/d1~1collection/derivation/register/schema"
+- fetch:
+    resource: "test://root/alt-schema.json"
+    scope: "test://root#/collections/d1~1collection/derivation/transform/some-name/source/schema"
+- import:
+    child_uri: "test://root/a-schema.json"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/d2~1collection/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root?ptr=/collections/d2~1collection/derivation/register/schema"
+    scope: "test://root#/collections/d2~1collection/derivation/register/schema"
+- schema:
+    scope: "test://root?ptr=/collections/d2~1collection/derivation/register/schema"
+- import:
+    child_uri: "test://root?ptr=/collections/d2~1collection/derivation/register/schema"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/d2~1collection/derivation/register/schema"
+- transform:
+    derivation: d2/collection
+    publish:
+      nodeJS: publish two
+    read_delay: ~
+    scope: "test://root#/collections/d2~1collection/derivation/transform/do-the-thing"
+    shuffle_hash: 0
+    shuffle_key: ~
+    shuffle_lambda: ~
+    source: src/collection
+    source_partitions: ~
+    source_schema: ~
+    transform: do-the-thing
+    update: ~
+- derivation:
+    derivation: d2/collection
+    register_initial: ~
+    register_schema: "test://root?ptr=/collections/d2~1collection/derivation/register/schema"
+    scope: "test://root#/collections/d2~1collection/derivation"
+- collection:
+    key:
+      - /d2-key
+    name: d2/collection
+    patch_config: ~
+    schema: "test://root/a-schema.json"
+    scope: "test://root#/collections/d2~1collection"
+    store: endpoint
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root/a-schema.json"
+    scope: "test://root#/collections/d1~1collection/schema"
+- schema:
+    scope: "test://root/a-schema.json"
+- import:
+    child_uri: "test://root/a-schema.json"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/d1~1collection/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root/reg-schema.json"
+    scope: "test://root#/collections/d1~1collection/derivation/register/schema"
+- schema:
+    scope: "test://root/reg-schema.json"
+- import:
+    child_uri: "test://root/reg-schema.json"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/d1~1collection/derivation/register/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root/alt-schema.json"
+    scope: "test://root#/collections/d1~1collection/derivation/transform/some-name/source/schema"
+- schema:
+    scope: "test://root/alt-schema.json"
+- import:
+    child_uri: "test://root/alt-schema.json"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/d1~1collection/derivation/transform/some-name/source/schema"
+- transform:
+    derivation: d1/collection
+    publish:
+      nodeJS: publish one
+    read_delay: 3600
+    scope: "test://root#/collections/d1~1collection/derivation/transform/some-name"
+    shuffle_hash: 0
+    shuffle_key:
+      - /shuffle
+      - /key
+    shuffle_lambda: ~
+    source: src/collection
+    source_partitions:
+      exclude:
+        other_field:
+          - false
+      include:
+        a_field:
+          - foo
+          - 42
+    source_schema: "test://root/alt-schema.json#foobar"
+    transform: some-name
+    update:
+      nodeJS: update one
+- derivation:
+    derivation: d1/collection
+    register_initial:
+      initial:
+        - value
+        - 32
+    register_schema: "test://root/reg-schema.json#/$defs/qib"
+    scope: "test://root#/collections/d1~1collection/derivation"
+- collection:
+    key:
+      - /d1-key
+    name: d1/collection
+    patch_config: ~
+    schema: "test://root/a-schema.json"
+    scope: "test://root#/collections/d1~1collection"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__endpoints_captures_materializations.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__endpoints_captures_materializations.snap
@@ -1,0 +1,69 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- endpoint:
+    base_config:
+      dbname: ~
+      host: localhost
+      password: whoops
+      port: ~
+      user: somebody
+    endpoint: my DB
+    endpoint_type: postgres
+    scope: "test://root#/endpoints/my%20DB"
+- endpoint:
+    base_config:
+      bucket: foobar
+      prefix: path/prefix
+    endpoint: my bucket
+    endpoint_type: s3
+    scope: "test://root#/endpoints/my%20bucket"
+- capture:
+    allow_push: false
+    capture: my bucket capture
+    endpoint: my bucket
+    patch_config: ~
+    scope: "test://root#/captures/my%20bucket%20capture"
+    target: a/collection
+- capture:
+    allow_push: false
+    capture: my table capture
+    endpoint: my DB
+    patch_config:
+      extra: stuff
+    scope: "test://root#/captures/my%20table%20capture"
+    target: other/collection
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root?ptr=/materializations/my%20materialization/source/schema"
+    scope: "test://root#/materializations/my%20materialization/source/schema"
+- schema:
+    scope: "test://root?ptr=/materializations/my%20materialization/source/schema"
+- import:
+    child_uri: "test://root?ptr=/materializations/my%20materialization/source/schema"
+    parent_uri: "test://root"
+    scope: "test://root#/materializations/my%20materialization/source/schema"
+- materialization:
+    endpoint: my DB
+    fields:
+      exclude:
+        - del
+      include:
+        - add
+      recommended: true
+    materialization: my materialization
+    patch_config:
+      table: foobar
+    scope: "test://root#/materializations/my%20materialization"
+    source: source/collection
+    source_schema: "test://root?ptr=/materializations/my%20materialization/source/schema"
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_inline.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_inline.snap
@@ -1,0 +1,31 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://root?ptr=/collections/test/schema"
+    scope: "test://root#/collections/test/schema"
+- schema:
+    scope: "test://root?ptr=/collections/test/schema"
+- import:
+    child_uri: "test://root?ptr=/collections/test/schema"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/test/schema"
+- collection:
+    key:
+      - /some-key
+    name: test
+    patch_config: ~
+    schema: "test://root?ptr=/collections/test/schema"
+    scope: "test://root#/collections/test"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_nested_ids.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_nested_ids.snap
@@ -1,0 +1,34 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- fetch:
+    resource: "test://actual"
+    scope: "test://root#/collections/a~1collection/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://actual"
+    scope: "test://root#/collections/a~1collection/schema"
+- schema:
+    scope: "test://actual"
+- import:
+    child_uri: "test://actual"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/a~1collection/schema"
+- collection:
+    key:
+      - /key
+    name: a/collection
+    patch_config: ~
+    schema: "test://actual"
+    scope: "test://root#/collections/a~1collection"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_references.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__schema_with_references.snap
@@ -1,0 +1,60 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- fetch:
+    resource: "test://external/a"
+    scope: "test://root#/collections/test/schema"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://external/a"
+    scope: "test://root#/collections/test/schema"
+- fetch:
+    resource: "test://external/b"
+    scope: "test://external/a#/$defs/a/$ref"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://external/b"
+    scope: "test://external/a#/$defs/a/$ref"
+- fetch:
+    resource: "test://external/c"
+    scope: "test://external/b#/$defs/c/$ref"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://external/c"
+    scope: "test://external/b#/$defs/c/$ref"
+- schema:
+    scope: "test://external/c"
+- import:
+    child_uri: "test://external/c"
+    parent_uri: "test://external/b"
+    scope: "test://external/b#/$defs/c/$ref"
+- schema:
+    scope: "test://external/b"
+- import:
+    child_uri: "test://external/b"
+    parent_uri: "test://external/a"
+    scope: "test://external/a#/$defs/a/$ref"
+- schema:
+    scope: "test://external/a"
+- import:
+    child_uri: "test://external/a"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/test/schema"
+- collection:
+    key:
+      - /a
+    name: test
+    patch_config: ~
+    schema: "test://external/a#/$defs/a"
+    scope: "test://root#/collections/test"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__simple_catalog.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__simple_catalog.snap
@@ -1,0 +1,79 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- nodejs_dependency:
+    package: package-one
+    scope: "test://root#/nodeDependencies/package-one"
+    version: v0.1.2
+- nodejs_dependency:
+    package: pkg-2
+    scope: "test://root#/nodeDependencies/pkg-2"
+    version: ~v2
+- fetch:
+    resource: "test://root/sibling"
+    scope: "test://root#/import/0"
+- fetch:
+    resource: "test://not/found"
+    scope: "test://root#/import/1"
+- projection:
+    collection: a/collection
+    field: baz
+    location: /bing
+    partition: true
+    scope: "test://root#/collections/a~1collection/projections/baz"
+    user_provided: true
+- projection:
+    collection: a/collection
+    field: foo
+    location: /bar
+    partition: false
+    scope: "test://root#/collections/a~1collection/projections/foo"
+    user_provided: true
+- fetch:
+    resource: "test://example/schema"
+    scope: "test://root#/collections/a~1collection/schema"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root/sibling"
+    scope: "test://root#/import/0"
+- catalog:
+    scope: "test://root/sibling"
+- import:
+    child_uri: "test://root/sibling"
+    parent_uri: "test://root"
+    scope: "test://root#/import/0"
+- error:
+    message: "Fetch { uri: \"test://not/found\", detail: \"fixture not found\" }"
+    scope: "test://root#/import/1"
+- import:
+    child_uri: "test://not/found"
+    parent_uri: "test://root"
+    scope: "test://root#/import/1"
+- resource:
+    content_type: application/schema+yaml
+    resource: "test://example/schema"
+    scope: "test://root#/collections/a~1collection/schema"
+- schema:
+    scope: "test://example/schema"
+- import:
+    child_uri: "test://example/schema"
+    parent_uri: "test://root"
+    scope: "test://root#/collections/a~1collection/schema"
+- collection:
+    key:
+      - /key
+    name: a/collection
+    patch_config: ~
+    schema: "test://example/schema"
+    scope: "test://root#/collections/a~1collection"
+    store: endpoint
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/snapshots/models__source__scenarios__test_case.snap
+++ b/crates/models/src/source/scenarios/snapshots/models__source__scenarios__test_case.snap
@@ -1,0 +1,47 @@
+---
+source: crates/models/src/source/scenarios/mod.rs
+expression: output.unwrap().0
+---
+- fetch:
+    resource: "test://root"
+    scope: "test://root"
+- resource:
+    content_type: application/vnd.estuary.dev-catalog-spec+yaml
+    resource: "test://root"
+    scope: "test://root"
+- test_step_ingest:
+    collection: test/collection
+    documents:
+      - ingest: 1
+      - true
+    scope: "test://root#/tests/A%20test%20case/0"
+    step_index: 0
+    test: A test case
+- test_step_verify:
+    collection: test/collection
+    documents:
+      - verify: 2
+      - false
+    partitions: ~
+    scope: "test://root#/tests/A%20test%20case/1"
+    step_index: 1
+    test: A test case
+- test_step_verify:
+    collection: test/collection
+    documents:
+      - verify: 3
+      - fin
+    partitions:
+      exclude: {}
+      include:
+        a_field:
+          - some-val
+    scope: "test://root#/tests/A%20test%20case/2"
+    step_index: 2
+    test: A test case
+- test:
+    scope: "test://root#/tests/A%20test%20case"
+    test: A test case
+    total_steps: 3
+- catalog:
+    scope: "test://root"

--- a/crates/models/src/source/scenarios/test_catalog_import_cycles.yaml
+++ b/crates/models/src/source/scenarios/test_catalog_import_cycles.yaml
@@ -1,0 +1,11 @@
+test://root:
+    import: [ A, B ]
+
+test://root/A:
+    import: [ C, B ]
+
+test://root/B: 
+    import: [ C, A ]
+
+test://root/C: 
+    import: [ test://root, B ]

--- a/crates/models/src/source/scenarios/test_collections.yaml
+++ b/crates/models/src/source/scenarios/test_collections.yaml
@@ -1,0 +1,26 @@
+test://root:
+  collections:
+    test/collection:
+      schema: schema.json#foobar
+      key: [/key/1, /key/0]
+      store: {name: endpoint}
+      projections:
+        field_a: { location: /a/a, partition: true }
+        field_b: { location: /b/b, partition: false }
+
+test://root/schema.json:
+  $anchor: foobar
+  type: object
+  properties:
+    a:
+      type: object
+      properties:
+        a: { type: string }
+    b:
+      type: object
+      properties:
+        b: { type: string }
+    key:
+      type: array
+      items: { type: string }
+      minItems: 2

--- a/crates/models/src/source/scenarios/test_derivations.yaml
+++ b/crates/models/src/source/scenarios/test_derivations.yaml
@@ -1,0 +1,51 @@
+test://root/a-schema.json: true
+
+test://root/alt-schema.json:
+  $anchor: foobar
+  type: object
+  properties:
+    d1-key: { type: string }
+    shuffle: { type: integer }
+    key:
+      type: integer
+      title: "the key title"
+      description: "the key description"
+    moar: { type: number }
+
+test://root/reg-schema.json:
+  $defs: { qib: true }
+
+test://root:
+  collections:
+    d1/collection:
+      schema: a-schema.json
+      key: [/d1-key]
+      store: {name: endpoint}
+      derivation:
+        register:
+          schema: reg-schema.json#/$defs/qib
+          initial: { "initial": ["value", 32] }
+        transform:
+          some-name:
+            source:
+              name: src/collection
+              partitions:
+                include: { "a_field": ["foo", 42] }
+                exclude: { "other_field": [false] }
+              schema: alt-schema.json#foobar
+            readDelay: "1 hour"
+            shuffle:
+              key: ["/shuffle", "/key"]
+            update: { nodeJS: "update one" }
+            publish: { nodeJS: "publish one" }
+
+    d2/collection:
+      schema: a-schema.json
+      key: [/d2-key]
+      store: {name: endpoint}
+      derivation:
+        transform:
+          do-the-thing:
+            source:
+              name: src/collection
+            publish: { nodeJS: "publish two" }

--- a/crates/models/src/source/scenarios/test_endpoints_captures_materializations.yaml
+++ b/crates/models/src/source/scenarios/test_endpoints_captures_materializations.yaml
@@ -1,0 +1,37 @@
+test://root:
+  endpoints:
+    "my bucket":
+      s3:
+        bucket: foobar
+        prefix: path/prefix
+
+    "my DB":
+      postgres:
+        host: localhost
+        user: somebody
+        password: whoops
+
+  captures:
+    "my bucket capture":
+      target:
+        name: a/collection
+      endpoint: { name: my bucket }
+    "my table capture":
+      target:
+        name: other/collection
+      endpoint:
+        name: my DB
+        config: { extra: "stuff" }
+
+  materializations:
+    "my materialization":
+      source:
+        name: source/collection
+        schema: true
+      endpoint:
+        name: my DB
+        config: { table: "foobar" }
+      fields:
+        include: [add]
+        exclude: [del]
+        recommended: true

--- a/crates/models/src/source/scenarios/test_schema_with_inline.yaml
+++ b/crates/models/src/source/scenarios/test_schema_with_inline.yaml
@@ -1,0 +1,8 @@
+test://root:
+  collections:
+    test:
+      schema:
+        type: object
+        additionalProperties: true
+      key: [/some-key]
+      store: { name: endpoint }

--- a/crates/models/src/source/scenarios/test_schema_with_nested_ids.yaml
+++ b/crates/models/src/source/scenarios/test_schema_with_nested_ids.yaml
@@ -1,0 +1,29 @@
+test://actual:
+  $defs:
+    wrapper:
+      $id: test://fake/root
+      $defs:
+        a:
+          {
+            $id: test://fake/other/a-doc,
+            items: [true, { $ref: "b-doc#/items/1" }],
+          }
+        b:
+          {
+            $id: test://fake/other/b-doc,
+            items: [{ $ref: "a-doc#/items/0" }, true],
+          }
+        c: true
+      allOf:
+        - $ref: other/a-doc#/items/1
+        - $ref: test://fake/other/b-doc#/items/0
+        - $ref: "#/$defs/c"
+        - $ref: test://fake/root#/$defs/c
+  $ref: test://fake/root
+
+test://root:
+  collections:
+    a/collection:
+      schema: test://actual
+      key: [/key]
+      store: {name: endpoint}

--- a/crates/models/src/source/scenarios/test_schema_with_references.yaml
+++ b/crates/models/src/source/scenarios/test_schema_with_references.yaml
@@ -1,0 +1,16 @@
+test://external/a:
+  $defs: { a: { $ref: "b#/$defs/c" } }
+
+test://external/b:
+  $defs: { c: { $ref: "c" } }
+
+test://external/c: true
+
+test://external/d: false
+
+test://root:
+  collections:
+    test:
+      schema: test://external/a#/$defs/a
+      key: [/a]
+      store: {name: endpoint}

--- a/crates/models/src/source/scenarios/test_simple_catalog.yaml
+++ b/crates/models/src/source/scenarios/test_simple_catalog.yaml
@@ -1,0 +1,20 @@
+test://root:
+    import:
+        - sibling
+        - test://not/found
+    nodeDependencies:
+        package-one: "v0.1.2"
+        pkg-2: "~v2"
+    collections:
+        a/collection:
+            schema: "test://example/schema"
+            key: [/key]
+            store: { name: endpoint }
+            projections:
+                foo: "/bar"
+                baz:
+                    location: "/bing"
+                    partition: true
+
+test://root/sibling: {}
+test://example/schema: true

--- a/crates/models/src/source/scenarios/test_test_case.yaml
+++ b/crates/models/src/source/scenarios/test_test_case.yaml
@@ -1,0 +1,17 @@
+test://root:
+  tests:
+    "A test case":
+      - ingest:
+          collection: test/collection
+          documents: [{ "ingest": 1 }, true]
+      # No selector.
+      - verify:
+          collection: test/collection
+          documents: [{ "verify": 2 }, false]
+      # With selector.
+      - verify:
+          collection: test/collection
+          partitions:
+            include: { "a_field": ["some-val"] }
+            exclude: {}
+          documents: [{ "verify": 3 }, "fin"]

--- a/crates/models/src/source/scope.rs
+++ b/crates/models/src/source/scope.rs
@@ -1,0 +1,93 @@
+use json::Location;
+use url::Url;
+
+/// Scope is a stack-based mechanism for tracking fine-grained location
+/// context of a resource currently being processed.
+#[derive(Copy, Clone)]
+pub struct Scope<'a> {
+    /// Parent of this Scope, or None if this is the Context root.
+    pub parent: Option<&'a Scope<'a>>,
+    /// Resource of this Context, which is !None if and only if this Scope roots
+    /// processing of a new resource (as opposed to being scoped to a path therein).
+    pub resource: Option<&'a Url>,
+    /// Location within the current resource.
+    pub location: Location<'a>,
+}
+
+impl<'a> Scope<'a> {
+    /// Create a new scope rooted at the given resource.
+    pub fn new(resource: &'a Url) -> Scope {
+        Scope {
+            parent: None,
+            resource: Some(resource),
+            location: Location::Root,
+        }
+    }
+    /// Push a resource onto the current Scope, returning a new Scope.
+    pub fn push_resource(&'a self, resource: &'a Url) -> Scope {
+        if resource.fragment().is_some() {
+            panic!("resource cannot have fragment");
+        }
+        Scope {
+            parent: Some(self),
+            resource: Some(resource),
+            location: Location::Root,
+        }
+    }
+    /// Push a property onto the current Scope, returning a new Scope.
+    pub fn push_prop(&'a self, name: &'a str) -> Scope {
+        Scope {
+            parent: Some(self),
+            resource: None,
+            location: self.location.push_prop(name),
+        }
+    }
+    /// Push an item index onto the current Scope, returning a new Scope.
+    pub fn push_item(&'a self, index: usize) -> Scope {
+        Scope {
+            parent: Some(self),
+            resource: None,
+            location: self.location.push_item(index),
+        }
+    }
+
+    /// Returns the resource being processed by this Scope.
+    pub fn resource(self) -> &'a url::Url {
+        match self.resource {
+            Some(r) => r,
+            None => self.parent.unwrap().resource(),
+        }
+    }
+
+    /// Flatten the scope into its current resource URI, extended with a
+    /// URL fragment-encoded JSON pointer of the current location.
+    pub fn flatten(&'a self) -> Url {
+        let mut f = self.resource().clone();
+
+        if !matches!(self.location, Location::Root) {
+            f.set_fragment(Some(&self.location.pointer_str().to_string()))
+        }
+        f
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Scope, Url};
+
+    #[test]
+    fn test_scope_errors() {
+        let ra = Url::parse("http://example/A").unwrap();
+        let rb = Url::parse("http://example/B").unwrap();
+
+        let s1 = Scope::new(&ra);
+        let s2 = s1.push_prop("foo");
+        let s3 = s2.push_item(32);
+        let s4 = s3.push_resource(&rb);
+        let s5 = s4.push_prop("something");
+
+        assert_eq!(s1.flatten().as_str(), "http://example/A");
+        assert_eq!(s3.flatten().as_str(), "http://example/A#/foo/32");
+        assert_eq!(s5.flatten().as_str(), "http://example/B#/something");
+    }
+}

--- a/crates/models/src/source/specs.rs
+++ b/crates/models/src/source/specs.rs
@@ -1,0 +1,806 @@
+use super::wrappers::*;
+
+use schemars::{schema, JsonSchema};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value as from_json_value, json, Value};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Ordered JSON-Pointers which define how a composite key may be extracted from
+/// a collection document.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[schemars(example = "CompositeKey::example")]
+pub struct CompositeKey(Vec<JsonPointer>);
+
+impl CompositeKey {
+    pub fn example() -> Self {
+        CompositeKey(vec![JsonPointer::example()])
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(AsRef::as_ref)
+    }
+}
+
+/// Each catalog source defines a portion of a Flow Catalog, by defining
+/// collections, derivations, tests, and materializations of the Catalog.
+/// Catalog sources may reference and import other sources, in order to
+/// collections and other entities that source defines.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Catalog {
+    /// # JSON-Schema against which the Catalog is validated.
+    #[serde(default, rename = "$schema")]
+    pub _schema: Option<String>,
+    /// # Import other Flow catalog sources.
+    /// By importing another Flow catalog source, the collections, schemas, and derivations
+    /// it defines become usable within this Catalog source. Each import is an absolute URI,
+    /// or a URI which is relative to this source location.
+    #[serde(default)]
+    #[schemars(example = "Catalog::example_import")]
+    pub import: Vec<RelativeUrl>,
+    /// # NPM package dependencies of the Catalog.
+    /// Dependencies are included when building the catalog's build NodeJS
+    /// package, as {"package-name": "version"}. I.e. {"moment": "^2.24"}.
+    ///
+    /// Version strings can take any form understood by NPM.
+    /// See https://docs.npmjs.com/files/package.json#dependencies
+    #[serde(default)]
+    #[schemars(default = "Catalog::default_node_dependencies")]
+    pub node_dependencies: BTreeMap<String, String>,
+    /// # Collections defined by this Catalog.
+    #[serde(default)]
+    #[schemars(example = "Catalog::example_collections")]
+    pub collections: BTreeMap<CollectionName, Collection>,
+    /// # Named Endpoints of this Catalog.
+    #[serde(default)]
+    pub endpoints: BTreeMap<EndpointName, Endpoint>,
+    /// # Materializations of this Catalog.
+    #[serde(default)]
+    pub materializations: BTreeMap<MaterializationName, Materialization>,
+    /// # Captures of this Catalog.
+    #[serde(default)]
+    pub captures: BTreeMap<CaptureName, Capture>,
+    // Tests of the catalog, indexed by name.
+    #[serde(default)]
+    #[schemars(default = "Catalog::default_test")]
+    #[schemars(example = "Catalog::example_test")]
+    pub tests: BTreeMap<TestName, Vec<TestStep>>,
+}
+
+impl Catalog {
+    fn default_node_dependencies() -> BTreeMap<String, String> {
+        from_json_value(json!({"a-npm-package": "^1.2.3"})).unwrap()
+    }
+    fn default_test() -> Value {
+        json!({"Test that fob quips ipsum": []})
+    }
+    fn example_import() -> Vec<RelativeUrl> {
+        vec![
+            RelativeUrl::example_relative(),
+            RelativeUrl::example_absolute(),
+        ]
+    }
+    fn example_collections() -> Vec<Collection> {
+        vec![Collection::example()]
+    }
+    fn example_test() -> Value {
+        json!({
+            "Test that fob quips ipsum": [
+                TestStep::example_ingest(),
+                TestStep::example_verify(),
+            ]
+        })
+    }
+}
+
+/// Collection describes a set of related documents, where each adheres to a
+/// common schema and grouping key. Collections are append-only: once a document
+/// is added to a collection, it is never removed. However, it may be replaced
+/// or updated (either in whole, or in part) by a future document sharing its
+/// key. Each new document of a given key is "reduced" into existing documents
+/// of the key. By default, this reduction is achieved by completely replacing
+/// the previous document, but much richer reduction behaviors can be specified
+/// through the use of annotated reduction strategies of the collection schema.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Collection::example")]
+pub struct Collection {
+    /// # Schema against which collection documents are validated and reduced.
+    #[schemars(example = "Schema::example_relative")]
+    pub schema: Schema,
+    /// # Composite key of this collection.
+    pub key: CompositeKey,
+    /// # Fragment storage endpoint of this collection.
+    /// This must be a compatible file storage endpoint, such as S3 or GCS.
+    pub store: EndpointRef,
+    /// # Projections and logical partitions of this collection.
+    #[serde(default)]
+    #[schemars(default = "Projections::example")]
+    pub projections: Projections,
+    /// # Derivation which builds this collection from others.
+    pub derivation: Option<Derivation>,
+}
+
+impl Collection {
+    fn example() -> Self {
+        from_json_value(json!({
+            "name": CollectionName::example(),
+            "schema": RelativeUrl::example_relative(),
+            "key": CompositeKey::example(),
+        }))
+        .unwrap()
+    }
+}
+
+/// Projections are named locations within a collection document which
+/// may be used for logical partitioning or directly exposed to databases
+/// into which collections are materialized.
+#[derive(Serialize, Deserialize, Debug, Default, JsonSchema)]
+#[schemars(example = "Projections::example")]
+pub struct Projections(BTreeMap<String, Projection>);
+
+impl Projections {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Projection)> {
+        self.0.iter()
+    }
+
+    fn example() -> Self {
+        from_json_value(json!({
+            "a_field": JsonPointer::example(),
+            "a_partition": {
+                "location": JsonPointer::example(),
+                "partition": true,
+            }
+        }))
+        .unwrap()
+    }
+}
+
+/// A projection representation that allows projections to be specified either as a simple JSON Pointer,
+/// or as an object with separate properties for `loction` and `partition`.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(untagged, deny_unknown_fields, rename_all = "camelCase")]
+pub enum Projection {
+    Pointer(JsonPointer),
+    Object {
+        /// # Location of this projection.
+        location: JsonPointer,
+        /// # Is this projection a logical partition?
+        #[serde(default)]
+        partition: bool,
+    },
+}
+impl Projection {
+    /// Location of the projected field within the document.
+    pub fn location(&self) -> &JsonPointer {
+        match self {
+            Projection::Pointer(location) => location,
+            Projection::Object { location, .. } => location,
+        }
+    }
+
+    /// Is this projection a logical partition?
+    pub fn is_partition(&self) -> bool {
+        match self {
+            Projection::Pointer(_) => false,
+            Projection::Object { partition, .. } => *partition,
+        }
+    }
+}
+
+/// Registers are the internal states of a derivation, which can be read and
+/// updated by all of its transformations. They're an important building
+/// block for joins, aggregations, and other complex stateful workflows.
+///
+/// Registers are implemented using JSON-Schemas, often ones with reduction
+/// annotations. When reading source documents, every distinct shuffle key
+/// by which the source collection is read is mapped to a corresponding
+/// register value (or, if no shuffle key is defined, the source collection's
+/// key is used instead).
+///
+/// Then, an "update" lambda of the transformation produces updates which
+/// are reduced into the register, and a "publish" lambda reads the current
+/// (and previous, if updated) register value.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Register {
+    /// # Schema which validates and reduces register documents.
+    pub schema: Schema,
+    /// # Initial value of a keyed register which has never been updated.
+    /// If not specified, the default is "null".
+    #[serde(default = "value_null")]
+    pub initial: Value,
+}
+
+fn value_null() -> Value {
+    Value::Null
+}
+
+impl Default for Register {
+    fn default() -> Self {
+        Register {
+            schema: Schema::Bool(true),
+            initial: Value::Null,
+        }
+    }
+}
+
+/// A derivation specifies how a collection is derived from other
+/// collections. A collection without a derivation is a "captured"
+/// collection, into which documents are directly ingested.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Derivation::example")]
+pub struct Derivation {
+    /// # Register configuration of this derivation.
+    #[serde(default)]
+    pub register: Register,
+    /// # Transforms which make up this derivation.
+    #[schemars(default = "Derivation::default_transform")]
+    pub transform: BTreeMap<TransformName, Transform>,
+}
+
+impl Derivation {
+    fn example() -> Self {
+        from_json_value(json!({
+            "transform": {
+                "nameOfTransform": Transform::example(),
+            }
+        }))
+        .unwrap()
+    }
+    fn default_transform() -> Value {
+        json!({"nameOfTransform": {"source": {"name": "a/source/collection"}}})
+    }
+}
+
+/// Lambdas are user functions which are invoked by the Flow runtime to
+/// process and transform source collection documents into derived collections.
+/// Flow supports multiple lambda run-times, with a current focus on TypeScript
+/// and remote HTTP APIs.
+///
+/// TypeScript lambdas are invoked within on-demand run-times, which are
+/// automatically started and scaled by Flow's task distribution in order
+/// to best co-locate data and processing, as well as to manage fail-over.
+///
+/// Remote lambdas may be called from many Flow tasks, and are up to the
+/// API provider to provision and scale.
+///
+/// (Note that Sqlite lambdas are not implemented yet).
+///
+/// Lambdas are invoked from a few contexts:
+///
+/// "Update" lambdas take a source document and transform it into one or more
+/// register updates, which are then reduced into the associated register by
+/// the runtime. For example these register updates might update counters,
+/// or update the state of a "join" window.
+///
+/// "Publish" lambdas take a source document, a current register and
+/// (if there is also an "update" lambda) a previous register, and transform
+/// them into one or more documents to be published into a derived collection.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Lambda::example_nodejs_publish")]
+#[schemars(example = "Lambda::example_nodejs_update")]
+#[schemars(example = "Lambda::example_remote")]
+pub enum Lambda {
+    NodeJS(String),
+    Sqlite(String),
+    SqliteFile(RelativeUrl),
+    Remote(String),
+}
+
+impl Lambda {
+    fn example_nodejs_publish() -> Self {
+        from_json_value(json!({
+            "nodeJS": "return doPublish(source, register);"
+        }))
+        .unwrap()
+    }
+    fn example_nodejs_update() -> Self {
+        from_json_value(json!({
+            "nodeJS": "return doUpdate(source);"
+        }))
+        .unwrap()
+    }
+    fn example_remote() -> Self {
+        from_json_value(json!({
+            "remote": "http://example/api"
+        }))
+        .unwrap()
+    }
+}
+
+/// A Shuffle specifies how a shuffling key is to be extracted from
+/// collection documents.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Transform::example")]
+pub enum Shuffle {
+    /// Shuffle by extracting the given fields.
+    Key(CompositeKey),
+    /// Shuffle by taking the MD5 hash of the given fields.
+    /// Note this is **not** a cryptographicly strong hash,
+    /// but is well suited for mapping large keys into shorter ones,
+    /// or for better distributing hot-spots in a key space.
+    MD5(CompositeKey),
+    /// Invoke the lambda for each source document,
+    /// and shuffle on its returned key.
+    Lambda(Lambda),
+}
+
+/// A Transform reads and shuffles documents of a source collection,
+/// and processes each document through either one or both of a register
+/// "update" lambda and a derived document "publish" lambda.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Transform::example")]
+pub struct Transform {
+    /// # Source collection read by this transform.
+    pub source: TransformSource,
+    /// # Delay applied to documents read by this transform.
+    /// Delays are applied as an adjustment to the UUID clock encoded within each
+    /// document, which is then used to impose a relative ordering of all documents
+    /// read by this derivation. This means that read delays are applied in a
+    /// consistent way, even when back-filling over historical documents. When caught
+    /// up and tailing the source collection, delays also "gate" documents such that
+    /// they aren't processed until the current wall-time reflects the delay.
+    #[serde(default, with = "humantime_serde")]
+    #[schemars(schema_with = "duration_schema")]
+    pub read_delay: Option<Duration>,
+    /// # Shuffle by which source documents are mapped to registers.
+    /// If empty, the key of the source collection is used.
+    #[serde(default)]
+    #[schemars(default = "CompositeKey::example")]
+    pub shuffle: Option<Shuffle>,
+    /// # Update lambda that produces register updates from source documents.
+    #[serde(default)]
+    #[schemars(default = "Lambda::example_nodejs_update")]
+    pub update: Option<Lambda>,
+    /// # Publish lambda that produces documents to publish into the collection.
+    #[serde(default)]
+    #[schemars(default = "Lambda::example_nodejs_publish")]
+    pub publish: Option<Lambda>,
+}
+
+impl Transform {
+    fn example() -> Self {
+        from_json_value(json!({
+            "source": TransformSource::example(),
+            "publish": Lambda::example_nodejs_publish(),
+            "update": Lambda::example_nodejs_update(),
+        }))
+        .unwrap()
+    }
+}
+
+/// SourcePartitions is optional partitions of a read source collection.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "TransformSource::example")]
+pub struct TransformSource {
+    /// # Name of the collection to be materialized.
+    pub name: CollectionName,
+    /// # Optional JSON-Schema to validate against the source collection.
+    /// All data in the source collection is already validated against the
+    /// schema of that collection, so providing a source schema is only used
+    /// for _additional_ validation beyond that.
+    ///
+    /// This is useful in building "Extract Load Transform" patterns,
+    /// where a collection is captured with minimal schema applied (perhaps
+    /// because it comes from an uncontrolled third party), and is then
+    /// progressively verified as collections are derived.
+    /// If None, the principal schema of the collection is used instead.
+    #[serde(default)]
+    #[schemars(default = "Schema::example_relative")]
+    pub schema: Option<Schema>,
+    /// # Selector over partition of the source collection to read.
+    #[serde(default)]
+    #[schemars(default = "PartitionSelector::example")]
+    pub partitions: Option<PartitionSelector>,
+}
+
+impl TransformSource {
+    fn example() -> Self {
+        Self {
+            name: CollectionName::new("source/collection"),
+            schema: None,
+            partitions: None,
+        }
+    }
+}
+
+/// Partition selectors identify a desired subset of the
+/// available logical partitions of a collection.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "PartitionSelector::example")]
+pub struct PartitionSelector {
+    /// Partition field names and corresponding values which must be matched
+    /// from the Source collection. Only documents having one of the specified
+    /// values across all specified partition names will be matched. For example,
+    ///   source: [App, Web]
+    ///   region: [APAC]
+    /// would mean only documents of 'App' or 'Web' source and also occurring
+    /// in the 'APAC' region will be processed.
+    #[serde(default)]
+    pub include: BTreeMap<String, Vec<Value>>,
+    /// Partition field names and values which are excluded from the source
+    /// collection. Any documents matching *any one* of the partition values
+    /// will be excluded.
+    #[serde(default)]
+    pub exclude: BTreeMap<String, Vec<Value>>,
+}
+
+impl PartitionSelector {
+    fn example() -> Self {
+        from_json_value(json!({
+            "include": {
+                "a_partition": ["A", "B"],
+            },
+            "exclude": {
+                "other_partition": [32, 64],
+            }
+        }))
+        .unwrap()
+    }
+}
+
+/// A schema is a draft 2019-09 JSON Schema which validates Flow documents.
+/// Schemas also provide annotations at document locations, such as reduction
+/// strategies for combining one document into another.
+///
+/// Schemas may be defined inline to the catalog, or given as a relative
+/// or absolute URI. URIs may optionally include a JSON fragment pointer that
+/// locates a specific sub-schema therein.
+///
+/// I.e, "schemas/marketing.yaml#/$defs/campaign" would reference the schema
+/// at location {"$defs": {"campaign": ...}} within ./schemas/marketing.yaml.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(untagged)]
+#[schemars(example = "Schema::example_absolute")]
+#[schemars(example = "Schema::example_relative")]
+#[schemars(example = "Schema::example_inline_basic")]
+#[schemars(example = "Schema::example_inline_counter")]
+pub enum Schema {
+    Url(RelativeUrl),
+    Object(BTreeMap<String, Value>),
+    Bool(bool),
+}
+
+impl Schema {
+    fn example_absolute() -> Self {
+        from_json_value(json!("http://example/schema#/$defs/subPath")).unwrap()
+    }
+    fn example_relative() -> Self {
+        from_json_value(json!("../path/to/schema#/$defs/subPath")).unwrap()
+    }
+    fn example_inline_basic() -> Self {
+        from_json_value(json!({
+            "type": "object",
+            "properties": {
+                "foo": { "type": "integer" },
+                "bar": { "const": 42 }
+            }
+        }))
+        .unwrap()
+    }
+    fn example_inline_counter() -> Self {
+        from_json_value(json!({
+            "type": "object",
+            "reduce": {"strategy": "merge"},
+            "properties": {
+                "foo_count": {
+                    "type": "integer",
+                    "reduce": {"strategy": "sum"},
+                }
+            }
+        }))
+        .unwrap()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(example = "TestStep::example_ingest")]
+#[schemars(example = "TestStep::example_verify")]
+pub enum TestStep {
+    /// Ingest document fixtures into a collection.
+    Ingest(TestStepIngest),
+    /// Verify the contents of a collection match a set of document fixtures.
+    Verify(TestStepVerify),
+}
+
+impl TestStep {
+    fn example_ingest() -> Self {
+        TestStep::Ingest(TestStepIngest::example())
+    }
+    fn example_verify() -> Self {
+        TestStep::Verify(TestStepVerify::example())
+    }
+}
+
+/// An ingestion test step ingests document fixtures into the named
+/// collection.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(example = "TestStepIngest::example")]
+pub struct TestStepIngest {
+    /// # Name of the collection into which the test will ingest.
+    pub collection: CollectionName,
+    /// # Documents to ingest.
+    /// Each document must conform to the collection's schema.
+    pub documents: Vec<Value>,
+}
+
+impl TestStepIngest {
+    fn example() -> Self {
+        from_json_value(json!({
+            "collection": CollectionName::example(),
+            "documents": [
+                {"example": "document"},
+                {"another": "document"},
+            ]
+        }))
+        .unwrap()
+    }
+}
+
+/// A verification test step verifies that the contents of the named
+/// collection match the expected fixtures, after fully processing all
+/// preceding ingestion test steps.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(example = "TestStepVerify::example")]
+pub struct TestStepVerify {
+    /// # Collection into which the test will ingest.
+    pub collection: CollectionName,
+    /// # Documents to verify.
+    /// Each document may contain only a portion of the matched document's
+    /// properties, and any properties present in the actual document but
+    /// not in this document fixture are ignored. All other values must
+    /// match or the test will fail.
+    pub documents: Vec<Value>,
+    /// # Selector over partitions to verify.
+    #[serde(default)]
+    #[schemars(default = "PartitionSelector::example")]
+    pub partitions: Option<PartitionSelector>,
+}
+
+impl TestStepVerify {
+    fn example() -> Self {
+        from_json_value(json!({
+            "collection": CollectionName::example(),
+            "documents": [
+                {"expected": "document"},
+            ],
+        }))
+        .unwrap()
+    }
+}
+
+/// Connection configuration that's used for connecting to a variety of sql databases.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+pub struct SqlTargetConnection {
+    /// # The connection URI for the target database
+    pub uri: String,
+}
+
+/// An Endpoint is an external system from which a Flow collection may be captured,
+/// or to which a Flow collection may be materialized.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub enum Endpoint {
+    /// # A PostgreSQL database.
+    Postgres(PostgresConfig),
+    /// # A SQLite database.
+    Sqlite(SqliteConfig),
+    /// # An S3 bucket and prefix.
+    S3(BucketConfig),
+}
+
+impl Endpoint {
+    pub fn endpoint_type(&self) -> EndpointType {
+        match self {
+            Endpoint::Postgres(_) => EndpointType::Postgres,
+            Endpoint::Sqlite(_) => EndpointType::Sqlite,
+            Endpoint::S3(_) => EndpointType::S3,
+        }
+    }
+
+    pub fn base_config(&self) -> Value {
+        match self {
+            Endpoint::Postgres(cfg) => serde_json::to_value(cfg),
+            Endpoint::Sqlite(cfg) => serde_json::to_value(cfg),
+            Endpoint::S3(cfg) => serde_json::to_value(cfg),
+        }
+        .unwrap()
+    }
+}
+
+/// PostgreSQL endpoint configuration.
+/// Compare to https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+pub struct PostgresConfig {
+    /// Preserve and pass-through all configuration.
+    /// Some fields are explicit below, to benefit from JSON-Schema generation.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, Value>,
+
+    /// # Host address of the database.
+    pub host: String,
+    /// # Port of the database (default: 5432).
+    pub port: Option<u16>,
+    /// # Connection user.
+    pub user: String,
+    /// # Connection password.
+    pub password: String,
+    /// # Logical database (default: $user).
+    pub dbname: Option<String>,
+}
+
+/// Sqlite endpoint configuration.
+/// Compare to https://github.com/mattn/go-sqlite3#connection-string
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+pub struct SqliteConfig {
+    /// Preserve and pass-through all configuration.
+    /// Some fields are explicit below, to benefit from JSON-Schema generation.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, Value>,
+
+    /// # Filesystem path of the database.
+    pub path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+pub struct BucketConfig {
+    /// Preserve and pass-through all configuration.
+    /// Some fields are explicit below, to benefit from JSON-Schema generation.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, Value>,
+    /// # S3 bucket to use.
+    pub bucket: String,
+    /// # S3 path prefix.
+    #[serde(default)]
+    pub prefix: String,
+}
+
+/// A Materialization binds a Flow collection with an external system & target
+/// (e.x, a SQL table) into which the collection is to be continuously materialized.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Materialization {
+    /// # Source collection to materialize.
+    pub source: MaterializationSource,
+    /// # Endpoint to materialize into.
+    pub endpoint: EndpointRef,
+    /// # Projections for this materialization.
+    #[serde(default)]
+    pub fields: FieldSelector,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(example = "MaterializationSource::example")]
+pub struct MaterializationSource {
+    /// # Name of the collection to be materialized.
+    pub name: CollectionName,
+    /// # Optional JSON-Schema to validate against the source collection.
+    #[serde(default)]
+    #[schemars(default = "Schema::example_relative")]
+    pub schema: Option<Schema>,
+}
+
+impl MaterializationSource {
+    fn example() -> Self {
+        Self {
+            name: CollectionName::new("source/collection"),
+            schema: None,
+        }
+    }
+}
+
+/// A reference to an endpoint, with optional additional configuration.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(example = "EndpointRef::example")]
+pub struct EndpointRef {
+    /// # Name of the endpoint to use.
+    pub name: EndpointName,
+    /// # Additional endpoint configuration.
+    /// Configuration is merged into that of the endpoint.
+    #[serde(default = "value_null")]
+    pub config: Value,
+}
+
+impl EndpointRef {
+    fn example() -> Self {
+        Self {
+            name: EndpointName::example(),
+            config: json!({"table": "a_sql_table"}),
+        }
+    }
+}
+
+/// FieldSelector defines a selection of fields.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "FieldSelector::example")]
+pub struct FieldSelector {
+    /// # Fields to include.
+    /// This supplements any recommended fields, where enabled.
+    include: Vec<String>,
+    /// # Fields to exclude.
+    /// This removes from recommended fields, where enabled.
+    exclude: Vec<String>,
+    /// # Should recommended projections for the endpoint be used?
+    recommended: bool,
+}
+
+impl Default for FieldSelector {
+    fn default() -> Self {
+        FieldSelector {
+            include: Vec::new(),
+            exclude: Vec::new(),
+            recommended: true,
+        }
+    }
+}
+
+impl FieldSelector {
+    fn example() -> Self {
+        FieldSelector {
+            include: vec!["added".to_string()],
+            exclude: vec!["removed".to_string()],
+            recommended: true,
+        }
+    }
+}
+
+/// List of Captures, each binding a source in an external system (e.g. cloud storage prefix)
+/// to a captured collection. Captures may provided for any collection defined either within
+/// the current file, or a file that's imported by it. Multiple Captures may be defined per
+/// collection, and may be defined in different files.
+/// A Capture binds a source of data to a target collection. The result of this binding
+/// is a process that will continuously add data to the collection as it becomes available from the
+/// source.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Capture {
+    /// # Target collection to capture into.
+    pub target: CaptureTarget,
+    #[serde(flatten)]
+    pub inner: CaptureType,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(example = "CaptureTarget::example")]
+pub struct CaptureTarget {
+    /// # Name of the collection to be read.
+    pub name: CollectionName,
+}
+
+impl CaptureTarget {
+    fn example() -> Self {
+        Self {
+            name: CollectionName::new("target/collection"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub enum CaptureType {
+    Endpoint(EndpointRef),
+    PushAPI,
+}
+
+fn duration_schema(_: &mut schemars::gen::SchemaGenerator) -> schema::Schema {
+    from_json_value(json!({
+        "type": ["string", "null"],
+        "pattern": "^\\d+(s|m|h)$"
+    }))
+    .unwrap()
+}

--- a/crates/models/src/source/wrappers.rs
+++ b/crates/models/src/source/wrappers.rs
@@ -1,0 +1,248 @@
+use schemars::{schema, JsonSchema};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value as from_json_value, json};
+
+pub use protocol::flow::shuffle::Hash as ShuffleHash;
+
+/// EndpointType enumerates the endpoint types understood by Flow.
+#[derive(Copy, Debug, Clone)]
+pub enum EndpointType {
+    Postgres,
+    Sqlite,
+    S3,
+}
+
+impl EndpointType {
+    pub const POSTGRES: &'static str = "postgres";
+    pub const SQLITE: &'static str = "sqlite";
+    pub const S3S: &'static str = "s3";
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Postgres => Self::POSTGRES,
+            Self::Sqlite => Self::SQLITE,
+            Self::S3 => Self::S3S,
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            Self::POSTGRES => Some(Self::Postgres),
+            Self::SQLITE => Some(Self::Sqlite),
+            Self::S3S => Some(Self::S3),
+            _ => None,
+        }
+    }
+}
+
+/// ContentType enumerates resource content types understood by Flow.
+#[derive(Copy, Debug, Clone)]
+pub enum ContentType {
+    CatalogSpec,
+    JsonSchema,
+    NpmPack,
+}
+
+impl ContentType {
+    pub const CATALOG_SPEC: &'static str = "application/vnd.estuary.dev-catalog-spec+yaml";
+    pub const JSON_SCHEMA: &'static str = "application/schema+yaml";
+    pub const NPM_PACK: &'static str = "application/vnd.estuary.dev-catalog-npm-pack";
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::CatalogSpec => Self::CATALOG_SPEC,
+            Self::JsonSchema => Self::JSON_SCHEMA,
+            Self::NpmPack => Self::NPM_PACK,
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            Self::CATALOG_SPEC => Some(Self::CatalogSpec),
+            Self::JSON_SCHEMA => Some(Self::JsonSchema),
+            Self::NPM_PACK => Some(Self::NpmPack),
+            _ => None,
+        }
+    }
+}
+
+/// Names consist of Unicode letters, numbers, and symbols: - _ . /
+///
+/// Spaces and other special characters are disallowed.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "CollectionName::example")]
+pub struct CollectionName(#[schemars(schema_with = "CollectionName::schema")] String);
+
+impl CollectionName {
+    pub fn new(name: impl Into<String>) -> CollectionName {
+        CollectionName(name.into())
+    }
+    pub fn example() -> Self {
+        Self("a/collection".to_owned())
+    }
+    fn schema(_: &mut schemars::gen::SchemaGenerator) -> schema::Schema {
+        from_json_value(json!({
+            "type": "string",
+            "pattern": "^[^ \t\n\\!@#$%^&*()+=\\<\\>?;:'\"\\[\\]\\|~`]+$",
+        }))
+        .unwrap()
+    }
+}
+
+impl AsRef<str> for CollectionName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "TransformName::example")]
+pub struct TransformName(String);
+
+impl TransformName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn example() -> Self {
+        Self("a transform".to_owned())
+    }
+}
+
+impl AsRef<str> for TransformName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// EndpointName names a Flow endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "TransformName::example")]
+pub struct EndpointName(String);
+
+impl EndpointName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn example() -> Self {
+        Self("an endpoint".to_owned())
+    }
+}
+
+impl AsRef<str> for EndpointName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// MaterializationName names a Flow materialization.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "TransformName::example")]
+pub struct MaterializationName(String);
+
+impl MaterializationName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn example() -> Self {
+        Self("a materialization".to_owned())
+    }
+}
+
+impl AsRef<str> for MaterializationName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// CaptureName names a Flow capture.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "TransformName::example")]
+pub struct CaptureName(String);
+
+impl CaptureName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn example() -> Self {
+        Self("a capture".to_owned())
+    }
+}
+
+impl AsRef<str> for CaptureName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// TestName names a Flow catalog test.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialOrd, PartialEq, Ord, Eq)]
+#[schemars(example = "TransformName::example")]
+pub struct TestName(String);
+
+impl TestName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn example() -> Self {
+        Self("a capture".to_owned())
+    }
+}
+
+impl AsRef<str> for TestName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A URL identifying a resource, which may be a relative local path
+/// with respect to the current resource (i.e, ../path/to/flow.yaml),
+/// or may be an external absolute URL (i.e., http://example/flow.yaml).
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[schemars(example = "RelativeUrl::example_relative")]
+#[schemars(example = "RelativeUrl::example_absolute")]
+pub struct RelativeUrl(String);
+
+impl AsRef<str> for RelativeUrl {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for RelativeUrl {
+    fn from(s: &str) -> Self {
+        RelativeUrl(s.to_owned())
+    }
+}
+
+impl RelativeUrl {
+    pub fn example_relative() -> Self {
+        Self("../path/to/local.yaml".to_owned())
+    }
+    pub fn example_absolute() -> Self {
+        Self("https://example/resource".to_owned())
+    }
+}
+
+/// JSON Pointer which identifies a location in a document.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[schemars(example = "JsonPointer::example")]
+pub struct JsonPointer(#[schemars(schema_with = "JsonPointer::schema")] String);
+
+impl AsRef<str> for JsonPointer {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl JsonPointer {
+    pub fn example() -> Self {
+        Self("/json/ptr".to_owned())
+    }
+    fn schema(_: &mut schemars::gen::SchemaGenerator) -> schema::Schema {
+        from_json_value(json!({
+            "type": "string",
+            "pattern": "^/.+",
+        }))
+        .unwrap()
+    }
+}


### PR DESCRIPTION
This packs a whole bunch of planned catalog changes into a parallel
implementing crate, leaving `catalog` in place for now.

It also introduces a new "visitor" pattern for traversing catalog
entities and sources, de-emphasizing the SQLite database as a primary
state store during catalog building steps.

Future PRs will introduce specialized visitors which perform validation
and catalog build tasks.

Issue #68

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/87)
<!-- Reviewable:end -->
