### PR TITLE
Add an ingestion endpoint for a single document

### DIFF
--- a/go/ingest/apis.go
+++ b/go/ingest/apis.go
@@ -22,11 +22,24 @@ func RegisterAPIs(srv *server.Server, ingester *flow.Ingester, journals *keyspac
 	var router = mux.NewRouter()
 	srv.HTTPMux.Handle("/", router)
 
+	// Allows transactional ingestion of multiple documents across multiple collections.
+	// Expects a JSON object body where the keys are collection names and the values are arrays of
+	// documents to ingest.
 	router.
 		Path("/ingest").
 		Methods("POST", "PUT").
 		Headers("Content-Type", "application/json").
-		HandlerFunc(func(w http.ResponseWriter, r *http.Request) { serveHTTPJSON(args, w, r) })
+		HandlerFunc(func(w http.ResponseWriter, r *http.Request) { serveHTTPTransactionJSON(args, w, r) })
+
+		// Ingests a single document to a collection named in the URL path (e.g. /ingest/my-collection).
+		// The request body is a JSON document that will be appended to the collection.
+	router.
+		PathPrefix("/ingest/").
+		Methods("POST", "PUT").
+		Headers("Content-Type", "application/json").
+		HandlerFunc(func(w http.ResponseWriter, r *http.Request) { serveHTTPDocumentJSON(args, w, r) })
+
+		// These allow ingestion of multiple documents to a single collection over a websocket.
 	router.
 		PathPrefix("/ingest/").
 		Methods("GET").

--- a/go/ingest/apis_test.go
+++ b/go/ingest/apis_test.go
@@ -61,9 +61,12 @@ func TestAPIs(t *testing.T) {
 	tasks.GoRun()
 
 	// Actual sub-tests all go here:
-	t.Run("httpSimple", func(t *testing.T) { testHTTPSimple(t, addr) })
-	t.Run("httpNotFound", func(t *testing.T) { testHTTPNotFound(t, addr) })
-	t.Run("httpMalformed", func(t *testing.T) { testHTTPMalformed(t, addr) })
+	t.Run("httpSingleSimple", func(t *testing.T) { testHTTPSingleSimple(t, addr) })
+	t.Run("httpSingleNotFound", func(t *testing.T) { testHTTPSingleNotFound(t, addr) })
+	t.Run("httpSingleMalformed", func(t *testing.T) { testHTTPSingleMalformed(t, addr) })
+	t.Run("httpMultiSimple", func(t *testing.T) { testHTTPMultiSimple(t, addr) })
+	t.Run("httpMultiNotFound", func(t *testing.T) { testHTTPMultiNotFound(t, addr) })
+	t.Run("httpMultiMalformed", func(t *testing.T) { testHTTPMultiMalformed(t, addr) })
 	t.Run("csvSimple", func(t *testing.T) { testCSVSimple(t, addr) })
 	t.Run("csvCollectionNotFound", func(t *testing.T) { testCSVCollectionNotFound(t, addr) })
 	t.Run("csvMalformed", func(t *testing.T) { testCSVMalformed(t, addr) })


### PR DESCRIPTION
Adds an ingestion endpoint for ingesting a single document into a single collection from a single http request. This endpoint is meant to simplify "webhook" integrations by allowing a client to simply POST to a collection's endpoint, as long as the data validates against the collection's schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/90)
<!-- Reviewable:end -->
