### PR TITLE
models: add `names` and updated `tables`

### DIFF
--- a/crates/models/src/names.rs
+++ b/crates/models/src/names.rs
@@ -1,0 +1,279 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+// This module holds project-wide, type-safe wrappers, enums, and *very* simple
+// structures which identify or name Flow concepts, and must be referenced from
+// multiple different crates.
+
+/// Collection names consist of Unicode letters, numbers, and symbols: - _ . /
+///
+/// Spaces and other special characters are disallowed.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[schemars(example = "Collection::example")]
+pub struct Collection(#[schemars(schema_with = "Collection::schema")] String);
+
+impl Collection {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Collection {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Transform::example")]
+pub struct Transform(String);
+
+impl Transform {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Transform {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Endpoint names a Flow endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Endpoint::example")]
+pub struct Endpoint(String);
+
+impl Endpoint {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for Endpoint {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Materialization names a Flow materialization.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Materialization::example")]
+pub struct Materialization(String);
+
+impl Materialization {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for Materialization {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Capture names a Flow capture.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Capture::example")]
+pub struct Capture(String);
+
+impl Capture {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for Capture {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Test names a Flow catalog test.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Test::example")]
+pub struct Test(String);
+
+impl Test {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for Test {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Rule names a specification rule.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "Rule::example")]
+pub struct Rule(String);
+
+impl Rule {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for Rule {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// JSON Pointer which identifies a location in a document.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[schemars(example = "JsonPointer::example")]
+pub struct JsonPointer(#[schemars(schema_with = "JsonPointer::schema")] String);
+
+impl JsonPointer {
+    pub fn new(ptr: impl Into<String>) -> Self {
+        Self(ptr.into())
+    }
+}
+
+impl std::ops::Deref for JsonPointer {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for JsonPointer {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Ordered JSON-Pointers which define how a composite key may be extracted from
+/// a collection document.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[schemars(example = "CompositeKey::example")]
+pub struct CompositeKey(Vec<JsonPointer>);
+
+impl CompositeKey {
+    pub fn new(parts: impl Into<Vec<JsonPointer>>) -> Self {
+        Self(parts.into())
+    }
+    pub fn example() -> Self {
+        CompositeKey(vec![JsonPointer::example()])
+    }
+}
+
+impl std::ops::Deref for CompositeKey {
+    type Target = Vec<JsonPointer>;
+
+    fn deref(&self) -> &Vec<JsonPointer> {
+        &self.0
+    }
+}
+
+/// EndpointType enumerates the endpoint types understood by Flow.
+#[derive(Copy, Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+pub enum EndpointType {
+    Postgres,
+    Sqlite,
+    S3,
+    GS,
+    Remote,
+}
+
+impl EndpointType {
+    pub fn as_scheme(&self) -> &str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::Sqlite => "sqlite",
+            Self::S3 => "s3",
+            Self::GS => "gs",
+            Self::Remote => "remote",
+        }
+    }
+}
+
+/// ContentType enumerates resource content types understood by Flow.
+#[derive(Copy, Debug, Clone, Serialize, Deserialize)]
+pub enum ContentType {
+    CatalogSpec,
+    JsonSchema,
+    NpmPack,
+    TypescriptModule,
+}
+
+/// Object is an alias for a JSON object.
+pub type Object = serde_json::Map<String, Value>;
+
+/// Lambdas are user functions which are invoked by the Flow runtime to
+/// process and transform source collection documents into derived collections.
+/// Flow supports multiple lambda run-times, with a current focus on TypeScript
+/// and remote HTTP APIs.
+///
+/// TypeScript lambdas are invoked within on-demand run-times, which are
+/// automatically started and scaled by Flow's task distribution in order
+/// to best co-locate data and processing, as well as to manage fail-over.
+///
+/// Remote lambdas may be called from many Flow tasks, and are up to the
+/// API provider to provision and scale.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "Lambda::example_typescript")]
+#[schemars(example = "Lambda::example_remote")]
+pub enum Lambda {
+    Typescript,
+    Remote(String),
+}
+
+/// Partition selectors identify a desired subset of the
+/// available logical partitions of a collection.
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[schemars(example = "PartitionSelector::example")]
+pub struct PartitionSelector {
+    /// Partition field names and corresponding values which must be matched
+    /// from the Source collection. Only documents having one of the specified
+    /// values across all specified partition names will be matched. For example,
+    ///   source: [App, Web]
+    ///   region: [APAC]
+    /// would mean only documents of 'App' or 'Web' source and also occurring
+    /// in the 'APAC' region will be processed.
+    #[serde(default)]
+    pub include: BTreeMap<String, Vec<Value>>,
+    /// Partition field names and values which are excluded from the source
+    /// collection. Any documents matching *any one* of the partition values
+    /// will be excluded.
+    #[serde(default)]
+    pub exclude: BTreeMap<String, Vec<Value>>,
+}
+
+/// TestStepType enumerates the types of test steps understood by Flow.
+#[derive(Copy, Debug, Clone, Serialize, Deserialize)]
+pub enum TestStepType {
+    Ingest,
+    Verify,
+}

--- a/crates/models/src/tables/behaviors.rs
+++ b/crates/models/src/tables/behaviors.rs
@@ -1,0 +1,52 @@
+use doc::{Schema as CompiledSchema, SchemaIndex};
+
+impl super::Collection {
+    /// UUID pointer of this collection.
+    pub fn uuid_ptr(&self) -> String {
+        return "/_meta/uuid".to_string();
+    }
+}
+
+impl super::Transform {
+    /// Group name of this transform, used to group shards & shuffled reads
+    /// which collectively process the transformation.
+    pub fn group_name(&self) -> String {
+        format!(
+            "derive/{}/{}",
+            self.derivation.as_str(),
+            self.transform.as_str()
+        )
+    }
+}
+
+impl super::SchemaDoc {
+    pub fn compile(&self) -> Result<CompiledSchema, json::schema::build::Error> {
+        json::schema::build::build_schema(self.schema.clone(), &self.dom)
+    }
+
+    pub fn compile_all(slice: &[Self]) -> Result<Vec<CompiledSchema>, json::schema::build::Error> {
+        slice
+            .iter()
+            .map(|d| d.compile())
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Compile and index all schemas, and leak a 'static index over all built schemas.
+    pub fn leak_index(slice: &[Self]) -> Result<&'static doc::SchemaIndex<'static>, anyhow::Error> {
+        // Compile the bundle of catalog schemas. Then, deliberately "leak" the
+        // immutable Schema bundle for the remainder of program in order to achieve
+        // a 'static lifetime, which is required for use in spawned tokio Tasks (and
+        // therefore in TxnCtx).
+        let schemas = Self::compile_all(&slice)?;
+        let schemas = Box::leak(Box::new(schemas));
+
+        let mut schema_index = SchemaIndex::<'static>::new();
+        for schema in schemas.iter() {
+            schema_index.add(schema)?;
+        }
+        schema_index.verify_references()?;
+
+        // Also leak a &'static SchemaIndex.
+        Ok(Box::leak(Box::new(schema_index)))
+    }
+}


### PR DESCRIPTION
"names" module, along with "tables", are now the *only* places for
cross-project domain models.

Specifications from source loading will be made private in a future
commit.

Protobuf models are now encoded using proto-encoding, rather than JSON.
Update debug views to reflect this (and make identifying intra-model
changes easier).

Table changes:
- Add JournalRules
- Rework Transforms, flattening some formerly hoisted spec fields.
- Rework Materializations, again flattening fields.
- Rework TestSteps, flattening fields.
- Add NamedSchemas, which identifies `$anchor: Named` schemas of the catalog.
- Add BuiltTransforms & BuiltDerivations.

Also added a module for additional table behaviors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/94)
<!-- Reviewable:end -->
