### PR TITLE
bindings: combiner passes packed rather than unpacked fields

### DIFF
--- a/go/bindings/combine_test.go
+++ b/go/bindings/combine_test.go
@@ -46,7 +46,7 @@ func TestCombineBindings(t *testing.T) {
 	builder.Release(combiner)
 }
 
-type callback = func(raw json.RawMessage, key []byte, fields tuple.Tuple) error
+type callback = func(doc json.RawMessage, packedKey, packedFields []byte) error
 
 func expectCombineFixture(t *testing.T, finish func(callback) error) {
 	var expect = []struct {
@@ -57,8 +57,8 @@ func expectCombineFixture(t *testing.T, finish func(callback) error) {
 		{42, []string{"two", "three"}},
 	}
 
-	require.NoError(t, finish(func(raw json.RawMessage, key []byte, fields tuple.Tuple) error {
-		t.Log("doc", string(raw), "fields", fields)
+	require.NoError(t, finish(func(raw json.RawMessage, packedKey, packedFields []byte) error {
+		t.Log("doc", string(raw))
 
 		var doc struct {
 			I    int64
@@ -73,8 +73,8 @@ func expectCombineFixture(t *testing.T, finish func(callback) error) {
 		require.Equal(t, expect[0].s, doc.S)
 		require.Equal(t, string(pf.DocumentUUIDPlaceholder), doc.Meta.UUID)
 
-		require.Equal(t, tuple.Tuple{doc.I}.Pack(), key)
-		require.Equal(t, tuple.Tuple{doc.S[1], doc.I}, fields)
+		require.Equal(t, tuple.Tuple{doc.I}.Pack(), packedKey)
+		require.Equal(t, tuple.Tuple{doc.S[1], doc.I}.Pack(), packedFields)
 
 		expect = expect[1:]
 		return nil

--- a/go/bindings/derive.go
+++ b/go/bindings/derive.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"unsafe"
 
-	"github.com/estuary/flow/go/fdb/tuple"
 	"github.com/estuary/flow/go/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/tecbot/gorocksdb"
@@ -119,7 +118,7 @@ func (d *Derive) Flush() error {
 }
 
 // Finish deriving documents, invoking the callback for derived document.
-func (d *Derive) Finish(cb func(json.RawMessage, []byte, tuple.Tuple) error) error {
+func (d *Derive) Finish(cb func(doc json.RawMessage, packedKey, packedPartitions []byte) error) error {
 	d.svc.sendBytes(5, nil)
 
 	var _, out, err = d.svc.poll()

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/estuary/flow/go/bindings"
-	"github.com/estuary/flow/go/fdb/tuple"
 	flowLabels "github.com/estuary/flow/go/labels"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/nsf/jsondiff"
@@ -210,7 +209,7 @@ func (c *Cluster) Verify(test *pf.TestSpec, testStep int, from, to *Clock) error
 
 	// Drain actual documents from the combiner.
 	var actual [][]byte
-	err = combiner.Finish(func(doc json.RawMessage, _ []byte, _fields tuple.Tuple) error {
+	err = combiner.Finish(func(doc json.RawMessage, _, _ []byte) error {
 		actual = append(actual, doc)
 		return nil
 	})


### PR DESCRIPTION
Materialization wants to work with them in packed form, so let the
client unpack if that's what they want to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/108)
<!-- Reviewable:end -->
