### PR TITLE
avoid lint error when there are no derivations

### DIFF
--- a/crates/build/src/nodejs/generators.rs
+++ b/crates/build/src/nodejs/generators.rs
@@ -348,6 +348,8 @@ export type Document = unknown;
 // Lambda is a relaxed signature implemented by all Flow transformation lambdas.
 export type Lambda = (source: Document, register?: Document, previous?: Document) => Document[];
 
+// "Use" imported modules, even if they're empty, to satisfy compiler and linting.
+export type __interfaces_module = interfaces.__module;
 "#;
 
 const STUBS_HEADER: &str = "import { collections, interfaces, registers } from 'flow/modules';\n";

--- a/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
+++ b/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
@@ -195,6 +195,8 @@ expression: intents
     // Lambda is a relaxed signature implemented by all Flow transformation lambdas.
     export type Lambda = (source: Document, register?: Document, previous?: Document) => Document[];
     
+    // "Use" imported modules, even if they're empty, to satisfy compiler and linting.
+    export type __interfaces_module = interfaces.__module;
     // Import derivation classes from their implementation modules.
     import {
         LocalDerivation,

--- a/flow_generated/flow/routes.ts
+++ b/flow_generated/flow/routes.ts
@@ -5,6 +5,8 @@ export type Document = unknown;
 // Lambda is a relaxed signature implemented by all Flow transformation lambdas.
 export type Lambda = (source: Document, register?: Document, previous?: Document) => Document[];
 
+// "Use" imported modules, even if they're empty, to satisfy compiler and linting.
+export type __interfaces_module = interfaces.__module;
 // Import derivation classes from their implementation modules.
 import {
     TestingIntStrings,


### PR DESCRIPTION
When building a catalog that has no derivations, the build fails due to the TS linter complaining about an unused variable. This replicates the same solution used in other generated TS files to allow builds to succeed even when there are no derivations.