### PR TITLE
change base docker image to node lts

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -1,5 +1,12 @@
 FROM node:lts-buster
 
+# The node image provides an optional (non-default) "node" user, which has a UID:GID of 1000.
+# Deleting this user allows the flow user to take the UID 1000. The reason that's helpful is that it
+# matches the default UID of linux users, so if you mount a directory in this container, any files
+# written by the flow user within the container will actually be owned by the default user on the
+# host.
+RUN userdel -r node
+
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh
 # mappings to directly query AWS/Azure/GCP metadata APIs.

--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM node:lts-buster
 
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh


### PR DESCRIPTION
Changes the flow docker image so that it's based on [node:lts-buster](https://hub.docker.com/layers/node/library/node/lts-buster/images/sha256-3729fcdfd2ae17fa75ae927289aa687cbdea1a2f392ba4fd341bee69da894ca0?context=explore). This is the latest LTS node release, based on debian 10. The main goal here was to ensure that nodejs is available inside the flow image. Technically, we could get away with much less than what's included in this image, at least at runtime. But this seems like a reasonable place to leave it for now.

There's corresponding changes in the flow-template repo to create a simplified dev container based on this. One of the features there (and the reason for the deletion of the `node` user) is that the devcontainer now runs as the (non-root) flow user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/124)
<!-- Reviewable:end -->
