### PR TITLE
docker: slim down build, and update README with alias guidance

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -1,24 +1,18 @@
-FROM node:lts-buster
-
-# The node image provides an optional (non-default) "node" user, which has a UID:GID of 1000.
-# Deleting this user allows the flow user to take the UID 1000. The reason that's helpful is that it
-# matches the default UID of linux users, so if you mount a directory in this container, any files
-# written by the flow user within the container will actually be owned by the default user on the
-# host.
-RUN userdel -r node
+FROM debian:bullseye-slim
 
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh
 # mappings to directly query AWS/Azure/GCP metadata APIs.
 RUN apt-get update -y \
- && apt-get upgrade -y \
  && apt-get install --no-install-recommends -y \
       ca-certificates \
       curl \
+      libjemalloc2 \
       liblz4-1 \
-      libreadline7 \
       libsnappy1v5 \
       libzstd1 \
+      nodejs \
+      npm \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy binaries & libraries to the image.
@@ -30,4 +24,4 @@ RUN ldconfig
 # Run as non-privileged "flow" user.
 RUN useradd flow --create-home --shell /usr/sbin/nologin
 USER flow
-WORKDIR /home/flow
+WORKDIR /home/flow/project

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -69,6 +69,9 @@ jobs:
       - run: make rust-test
       - run: make go-test-ci
       - run: make catalog-test
+      # catalog-test dirties the branch by creating examples/examples.db.
+      # Tidy up before further invocations using `git describe --dirty`
+      - run: git clean -f -d && git status && git diff
       - run: make package
       - run: make docker-image
       - run: make docker-push-to-quay

--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,17 @@ target/
 
 # Outputs from catalog build & test that we don't version.
 /dist
-/examples/examples.db*
-/flowctl-develop
 /node_modules
+
+# We'd like to not ignore flowctl-develop at all, to make it clear when
+# the working directory is dirty, but node_modules has so many files that
+# VSCode can't track it.
+/flowctl-develop/node_modules
 
 # Ordinarily one *would* version package-lock.json.
 # In our case, though, we want early warning if dependencies of the
 # vanilla package.json produce broken builds.
-package-lock.json
+/package-lock.json
 
 # Typical IDE stuff.
 .vim

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ endpoints:
   acmeBank/database:
     postgres:
       # docker run --rm -e POSTGRES_PASSWORD=password -p 5432:5432 postgres -c log_statement=all
+      # Use host: host.docker.internal when running Docker for Windows / Mac.
       host: localhost
       password: password
       dbname: postgres
@@ -191,7 +192,20 @@ to jump off from. If you have early access to
 you can try it right from your browser.
 
 A Docker image of the development branch is also available as `quay.io/estuary/flow:dev`.
-We'll start more regular releases soon, but not quite yet.
+We'll start more regular releases soon, but not quite yet. We recommend using an alias to run the image:
+
+```console
+$ alias flowctl='docker run --rm -it --mount type=bind,source="$(pwd)",target=/home/flow/project --port 8080:8080 quay.io/estuary/flow:dev flowctl'
+
+# Test all examples from the Flow repository.
+$ git clone https://github.com/estuary/flow.git && cd flow
+$ flowctl test --source examples/all.flow.yaml
+
+# Or you can test & develop from a remote catalog without cloning.
+# flowctl will create necessary TypeScript project scaffolding:
+$ mkdir ~/tmp && cd ~/tmp
+$ flowctl test --source https://raw.githubusercontent.com/estuary/flow/master/examples/all.flow.yaml
+```
 
 You interact with Flow through the `flowctl` CLI tool:
 

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,7 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -352,6 +353,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e h1:S+/ptYdZtpK/MDstwCyt+ZHdXEpz86RJZ5gyZU4txJY=
 github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Switch to 20.04 as the official builder, and debian bullseye
(from which 20.04 is drawn) as the published docker runtime.

Use it's NodeJS version, 12, as it's recent enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/131)
<!-- Reviewable:end -->
