### PR TITLE
flowctl-apply: various tweaks and fixes from kubernetes testing

### DIFF
--- a/crates/build/src/nodejs/mod.rs
+++ b/crates/build/src/nodejs/mod.rs
@@ -212,11 +212,11 @@ pub fn compile_package(package_dir: &path::Path) -> Result<(), anyhow::Error> {
         npm_cmd(package_dir, &["install", "--no-audit", "--no-fund"])?;
     }
     npm_cmd(package_dir, &["run", "compile"])?;
+    npm_cmd(package_dir, &["run", "lint"])?;
     Ok(())
 }
 
 pub fn pack_package(package_dir: &path::Path) -> Result<tables::Resources, anyhow::Error> {
-    npm_cmd(package_dir, &["run", "lint"])?;
     npm_cmd(package_dir, &["pack"])?;
 
     let pack = package_dir.join("catalog-js-transformer-0.0.0.tgz");

--- a/examples/acmeBank.flow.ts
+++ b/examples/acmeBank.flow.ts
@@ -9,8 +9,8 @@ export class AcmeBankBalances implements interfaces.AcmeBankBalances {
     ): collections.AcmeBankBalances[] {
         return [
             // A transfer removes from the sender and adds to the receiver.
-            {account: source.from, amount: -source.amount},
-            {account: source.to, amount: source.amount},
+            { account: source.from, amount: -source.amount },
+            { account: source.to, amount: source.amount },
         ];
     }
 }

--- a/examples/common.flow.yaml
+++ b/examples/common.flow.yaml
@@ -32,5 +32,9 @@ journalRules:
     template:
       fragment:
         compression_codec: GZIP
-        stores: [file:///]
+        stores:
+          # Default is to persist to the local file system as a stand-in for cloud storage.
+          - file:///
+          # Uncomment me instead, when testing against a local kubernetes environment.
+          # - s3://examples/fragments/?profile=minio&endpoint=http%3A%2F%2Fflow-minio%3A9000
         flush_interval: 5m

--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,4 @@ require (
 	google.golang.org/grpc v1.28.0
 )
 
-replace go.gazette.dev/core => github.com/jgraettinger/gazette v0.0.0-20210323182341-afd20bd8a2fe
+replace go.gazette.dev/core => github.com/jgraettinger/gazette v0.0.0-20210328171803-5197badabb37

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/jgraettinger/cockroach-encoding v1.1.0 h1:TRSWxnWdjgT1hcfn3aFa3dwhzNa
 github.com/jgraettinger/cockroach-encoding v1.1.0/go.mod h1:gcht+UqiTiDC6NEF7DLHUXQStSlWjogvhlkAttXVtmE=
 github.com/jgraettinger/gazette v0.0.0-20210323182341-afd20bd8a2fe h1:OOI2QZgGwcg7A0Pq3o4P0+gY+rm69pdctOqSz+D7aWk=
 github.com/jgraettinger/gazette v0.0.0-20210323182341-afd20bd8a2fe/go.mod h1:29BmfOIru2l+dcO5GiD7r9sFvtJVPbF2eXZ1AYn7VdI=
+github.com/jgraettinger/gazette v0.0.0-20210328171803-5197badabb37 h1:uGrLtbngH19mpk289cFhqZsMg+SXLkLeCjZpE/lPB08=
+github.com/jgraettinger/gazette v0.0.0-20210328171803-5197badabb37/go.mod h1:29BmfOIru2l+dcO5GiD7r9sFvtJVPbF2eXZ1AYn7VdI=
 github.com/jgraettinger/urkel v0.1.2/go.mod h1:PQ2/GQdeAtepWvfbEczTdzYM+bmB0qgB0L23qeUaKbA=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go/bindings/build_load.go
+++ b/go/bindings/build_load.go
@@ -106,9 +106,9 @@ func loadBuiltCatalog(config pf.BuildAPI_Config) (*BuiltCatalog, error) {
 	}
 
 	if err := loadRows(db,
-		`SELECT content FROM resources WHERE content_type = "NpmPackage";`,
-		func() []interface{} { return []interface{}{[]byte(nil)} },
-		func(l []interface{}) { out.NPMPackage = l[0].([]byte) },
+		`SELECT content FROM resources WHERE content_type = '"NpmPackage"';`,
+		func() []interface{} { return []interface{}{&out.NPMPackage} },
+		func(_ []interface{}) {},
 	); err != nil {
 		return nil, fmt.Errorf("loading NPM package: %w", err)
 	}

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -24,7 +24,7 @@ import (
 
 type FlowConfig struct {
 	CatalogRoot string `long:"catalog-root" env:"CATALOG_ROOT" default:"/flow/catalog" description:"Flow Catalog Etcd base prefix"`
-	BrokerRoot  string `long:"broker-root" env:"BROKER_ROOT" default:"/gazette/cluster" description:"Broker Etcd base prefix"`
+	BrokerRoot  string `long:"broker-root" env:"BROKER_ROOT" default:"/gazette/cluster/flow" description:"Broker Etcd base prefix"`
 }
 
 // FlowConsumerConfig configures the flow-consumer application.


### PR DESCRIPTION
* 🐛 It's '"NpmPackage"', not "NpmPackage" (it's a JSON-encoded enum).
  `flowctly apply` now panics if an NPM package fails to be built.

* We can't rely on Etcd being sync-able in `flowctl apply`, as it's
  often behind a `kubectl port-forward`.

* Code format acmeBank.flow.ts

* Add commented-out store URL for kubernetes test clusters.

* Update broker root.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/134)
<!-- Reviewable:end -->
