### PR TITLE
Add basic prometheus metrics and trace lambdas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/snowflakedb/gosnowflake v1.4.2-0.20210318070613-b0c023e3afd7
 	github.com/stretchr/testify v1.5.1

--- a/go/bindings/combine_test.go
+++ b/go/bindings/combine_test.go
@@ -27,6 +27,7 @@ func TestCombineBindings(t *testing.T) {
 	require.NoError(t, err)
 
 	combiner, err := NewCombine(
+		"test/combineBindings",
 		schemaIndex,
 		collection.SchemaUri,
 		collection.KeyPtrs,

--- a/go/bindings/derive_test.go
+++ b/go/bindings/derive_test.go
@@ -57,6 +57,7 @@ func TestDeriveWithIntStrings(t *testing.T) {
 	}
 
 	derive, err := NewDerive(
+		"test/derive/withIntStrings",
 		schemaIndex,
 		derivation,
 		gorocksdb.NewDefaultEnv(),
@@ -250,6 +251,7 @@ func TestDeriveWithIncResetPublish(t *testing.T) {
 
 	var build = func(t *testing.T) *Derive {
 		d, err := NewDerive(
+			"test/derive/withIncReset",
 			schemaIndex,
 			&built.Derivations[0],
 			gorocksdb.NewDefaultEnv(),

--- a/go/ingest/ingest.go
+++ b/go/ingest/ingest.go
@@ -197,6 +197,7 @@ func (i *Ingestion) Add(collection pf.Collection, doc json.RawMessage) error {
 	}
 
 	combine, err := bindings.NewCombine(
+		spec.Collection.String(),
 		schemaIndex,
 		spec.SchemaUri,
 		spec.KeyPtrs,

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -62,6 +62,7 @@ func NewDeriveApp(
 	}
 
 	binding, err := bindings.NewDerive(
+		shard.FQN(),
 		schemaIndex,
 		derivation,
 		store_rocksdb.NewHookedEnv(store_rocksdb.NewRecorder(recorder)),

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -68,6 +68,7 @@ func NewMaterializeApp(
 		return nil, fmt.Errorf("building schema index: %w", err)
 	}
 	combiner, err := bindings.NewCombine(
+		shard.FQN(),
 		schemaIndex,
 		spec.Collection.SchemaUri,
 		spec.Collection.KeyPtrs,

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -190,7 +190,7 @@ func (c *Cluster) Verify(test *pf.TestSpec, testStep int, from, to *Clock) error
 	}
 
 	// Now feed documents into a combiner, filtering documents which are ACKs.
-	_, commons, err := c.Consumer.Catalog.GetTask(step.Collection.String())
+	task, commons, err := c.Consumer.Catalog.GetTask(step.Collection.String())
 	if err != nil {
 		return fmt.Errorf("mapping step collection to commons: %w", err)
 	}
@@ -200,6 +200,7 @@ func (c *Cluster) Verify(test *pf.TestSpec, testStep int, from, to *Clock) error
 	}
 
 	combiner, err := bindings.NewCombine(
+		task.Name(),
 		schemaIndex,
 		step.CollectionSchemaUri,
 		step.CollectionKeyPtr,


### PR DESCRIPTION
Gather prometheus metrics for Combine and Derive.
This is a minimal starting point for Flow instrumentation to support
some Grafana dashboards. Instrumentation of rocksdb sizes isn't included
here because the intent is to add that to Gazette.

These may still need changed, so I don't want to merge just yet, but it's probably good to get feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/135)
<!-- Reviewable:end -->
