### PR TITLE
Add snowsql to flow docker image

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bullseye-slim
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh
 # mappings to directly query AWS/Azure/GCP metadata APIs.
+# Unzip is required by the snowsql installer.
 RUN apt-get update -y \
  && apt-get install --no-install-recommends -y \
       ca-certificates \
@@ -13,6 +14,7 @@ RUN apt-get update -y \
       libzstd1 \
       nodejs \
       npm \
+      unzip \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy binaries & libraries to the image.
@@ -24,4 +26,30 @@ RUN ldconfig
 # Run as non-privileged "flow" user.
 RUN useradd flow --create-home --shell /usr/sbin/nologin
 USER flow
+
+WORKDIR /home/flow
+# Install snowsql, which is required by the snowflake driver.
+# This must be done as the flow user, since snowsql always puts its actual binaries in ~/.snowsql.
+# LC_ALL and LANG are required at runtime by the snowsql cli
+# The DEST and LOGIN_SHELL vars are needed by the installer in order to run in non-interactive mode.
+# The VERSION vars are only here to make version updates easier.
+# The PATH must be modified to include the install location, since .profile will not be loaded.
+ENV LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    SNOWSQL_DEST=/home/flow/bin \
+    SNOWSQL_LOGIN_SHELL=/home/flow/.profile \
+    SNOWSQL_MINOR_VERSION=1.2 \
+    SNOWSQL_FULL_VERSION=1.2.14 \
+    SNOWSQL_SHA256=1afb83a22b9ccb2f8e84c2abe861da503336cb3b882fcc2e8399f86ac76bc2a9 \
+    PATH="/home/flow/bin:${PATH}"
+RUN curl -o snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
+  https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/${SNOWSQL_MINOR_VERSION}/linux_x86_64/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
+  && echo "${SNOWSQL_SHA256} snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash" | sha256sum -c - \
+  && touch ${SNOWSQL_LOGIN_SHELL} \
+  && bash snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
+  && rm -f snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
+  # Defying all reason and expectations, _this_ is what actually installs snowsql.
+  # It will print a help message as if there was a problem, but it works as long as it exits 0.
+  && snowsql -v ${SNOWSQL_FULL_VERSION}
+
 WORKDIR /home/flow/project

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_flow_materializations
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_flow_materializations
@@ -1,5 +1,5 @@
 -- This table is the source of truth for all materializations into this system.
-CREATE TABLE IF NOT EXISTS "flow_materializations" (
+CREATE TABLE IF NOT EXISTS flow_materializations (
 	-- The name of the target table of the materialization, which may or may not include a schema and catalog prefix
 	table_name TEXT NOT NULL,
 	-- Specification of the materialization, encoded as base64 protobuf.

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_gazette_checkpoints
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_gazette_checkpoints
@@ -1,5 +1,5 @@
 -- This table holds journal checkpoints, which Flow manages in order to ensure exactly-once updates for materializations
-CREATE TABLE IF NOT EXISTS "gazette_checkpoints" (
+CREATE TABLE IF NOT EXISTS gazette_checkpoints (
 	-- The id of the consumer shard. Note that a single collection may have multiple consumer shards materializing it, and each will have a separate checkpoint.
 	shard_fqn TEXT NOT NULL,
 	-- This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_test_table
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-postgres_test_table
@@ -1,7 +1,7 @@
 -- this is a test
 -- multiline
 -- comment
-CREATE TABLE "test_table" (
+CREATE TABLE test_table (
 	-- key_a
 	-- multiline
 	-- comment

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_flow_materializations
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_flow_materializations
@@ -1,5 +1,5 @@
 -- This table is the source of truth for all materializations into this system.
-CREATE TABLE IF NOT EXISTS "flow_materializations" (
+CREATE TABLE IF NOT EXISTS flow_materializations (
 	-- The name of the target table of the materialization, which may or may not include a schema and catalog prefix
 	table_name TEXT NOT NULL,
 	-- Specification of the materialization, encoded as base64 protobuf.

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_gazette_checkpoints
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_gazette_checkpoints
@@ -1,5 +1,5 @@
 -- This table holds journal checkpoints, which Flow manages in order to ensure exactly-once updates for materializations
-CREATE TABLE IF NOT EXISTS "gazette_checkpoints" (
+CREATE TABLE IF NOT EXISTS gazette_checkpoints (
 	-- The id of the consumer shard. Note that a single collection may have multiple consumer shards materializing it, and each will have a separate checkpoint.
 	shard_fqn TEXT NOT NULL,
 	-- This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.

--- a/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_test_table
+++ b/go/materialize/driver/sql2/.snapshots/TestSQLGenerator-sqlite_test_table
@@ -1,7 +1,7 @@
 -- this is a test
 -- multiline
 -- comment
-CREATE TABLE "test_table" (
+CREATE TABLE test_table (
 	-- key_a
 	-- multiline
 	-- comment

--- a/go/materialize/driver/sql2/endpoint.go
+++ b/go/materialize/driver/sql2/endpoint.go
@@ -95,6 +95,7 @@ func (e *Endpoint) ApplyStatements(statements []string) error {
 	}
 
 	for i, stmt := range statements {
+		log.WithField("sql", stmt).Debug("executing statement")
 		if _, err := txn.Exec(stmt); err != nil {
 			_ = txn.Rollback()
 			return fmt.Errorf("executing statement %d: %w", i, err)

--- a/go/materialize/driver/sql2/sqlgen.go
+++ b/go/materialize/driver/sql2/sqlgen.go
@@ -443,7 +443,7 @@ func (gen *Generator) CreateTable(table *Table) (string, error) {
 	if table.IfNotExists {
 		builder.WriteString("IF NOT EXISTS ")
 	}
-	gen.IdentifierQuotes.writeWrapped(&builder, table.Identifier)
+	builder.WriteString(table.Identifier)
 	builder.WriteString(" (\n\t")
 
 	for i, column := range table.Columns {


### PR DESCRIPTION
The snowsql cli is required by the snowflake materialization driver for
the materialization initialization process. This adds the CLI to the
docker image so that it's available in all environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/138)
<!-- Reviewable:end -->
