### PR TITLE
More helpful error message for unquoted nulls

### DIFF
--- a/crates/json/src/schema/build.rs
+++ b/crates/json/src/schema/build.rs
@@ -24,8 +24,8 @@ pub enum Error {
     ExpectedSchema,
     #[error("unexpected fragment component '{0}' of $id keyword")]
     UnexpectedFragment(String),
-    #[error("expected a type or array of types")]
-    ExpectedType,
+    #[error("expected a type or array of types: {0}")]
+    ExpectedType(sj::Error),
     #[error("expected an unsigned integer")]
     ExpectedUnsigned,
     #[error("expected a number")]
@@ -473,7 +473,7 @@ fn build_curi(curi: url::Url, id: Option<&sj::Value>) -> Result<url::Url, Error>
 }
 
 fn extract_type_mask(v: &sj::Value) -> Result<types::Set, Error> {
-    types::Set::deserialize(v).map_err(|_| ExpectedType)
+    types::Set::deserialize(v).map_err(|e| ExpectedType(e))
 }
 
 fn extract_hash(v: &sj::Value) -> HashedLiteral {


### PR DESCRIPTION
It's really easy to forget to quote `null` when it's used as a string in
JSON schemas. This adds a more helpful error message when deserializing
JSON schema `type` values. If you write `type: [string, null]`, you will
now see an error message telling you that "null" must be written with
quotes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/140)
<!-- Reviewable:end -->
