### PR TITLE
typescript linting should use current project files

### DIFF
--- a/crates/build/src/nodejs/generators.rs
+++ b/crates/build/src/nodejs/generators.rs
@@ -232,14 +232,14 @@ pub fn routes_ts(_package_dir: &path::Path, interfaces: &[Interface<'_>]) -> Str
     for interface in interfaces {
         writeln!(
             w,
-            "let __{class}: interfaces.{class} = new {class}();",
+            "const __{class}: interfaces.{class} = new {class}();",
             class = camel_case(&interface.derivation.derivation, true)
         )
         .unwrap();
     }
 
     w.push_str("\n// Now build the router that's used for transformation lambda dispatch.\n");
-    w.push_str("let routes: { [path: string]: Lambda | undefined } = {\n");
+    w.push_str("const routes: { [path: string]: Lambda | undefined } = {\n");
 
     for interface in interfaces {
         let derivation: &str = &interface.derivation.derivation;

--- a/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
+++ b/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
@@ -216,11 +216,11 @@ expression: intents
     } from '../../flow_generated/external/example/external/module';
     
     // Build instances of each class, which will be bound to this module's router.
-    let __ExternalDerivation: interfaces.ExternalDerivation = new ExternalDerivation();
-    let __LocalDerivation: interfaces.LocalDerivation = new LocalDerivation();
+    const __ExternalDerivation: interfaces.ExternalDerivation = new ExternalDerivation();
+    const __LocalDerivation: interfaces.LocalDerivation = new LocalDerivation();
     
     // Now build the router that's used for transformation lambda dispatch.
-    let routes: { [path: string]: Lambda | undefined } = {
+    const routes: { [path: string]: Lambda | undefined } = {
         '/derive/external/derivation/somethingSomething/Publish': __ExternalDerivation.somethingSomethingPublish.bind(
             __ExternalDerivation,
         ) as Lambda,
@@ -382,8 +382,7 @@ expression: intents
         "clean": "rm -r dist/",
         "compile": "tsc",
         "develop": "node dist/flow_generated/flow/main.js",
-        "lint": "eslint --fix **/*.ts",
-        "prettify": "prettier --write **/*.ts"
+        "lint": "cd flow_generated && eslint --fix $(jq '.files[]' -r tsconfig-files.json)"
       },
       "version": "0.0.0"
     }

--- a/examples/marketing/flow.ts
+++ b/examples/marketing/flow.ts
@@ -30,7 +30,7 @@ export class MarketingClicksWithViews implements interfaces.MarketingClicksWithV
 
 export class MarketingPurchaseWithOffers implements interfaces.MarketingPurchaseWithOffers {
     indexClicksUpdate(source: collections.MarketingClicksWithViews): [registers.MarketingPurchaseWithOffers] {
-        let hour = moment.utc(source.timestamp).format('YYYY-MM-DD-HH');
+        const hour = moment.utc(source.timestamp).format('YYYY-MM-DD-HH');
         return [
             {
                 lastSeen: source.timestamp,
@@ -40,7 +40,7 @@ export class MarketingPurchaseWithOffers implements interfaces.MarketingPurchase
         ];
     }
     indexViewsUpdate(source: collections.MarketingViewsWithCampaign): [registers.MarketingPurchaseWithOffers] {
-        let day = moment.utc(source.timestamp).format('YYYY-MM-DD');
+        const day = moment.utc(source.timestamp).format('YYYY-MM-DD');
         return [
             {
                 lastSeen: source.timestamp,

--- a/examples/net-trace/services.flow.ts
+++ b/examples/net-trace/services.flow.ts
@@ -10,8 +10,8 @@ export class ExamplesNetTraceServices implements interfaces.ExamplesNetTraceServ
         _previous: registers.ExamplesNetTraceServices,
     ): collections.ExamplesNetTraceServices[] {
         // Use moment.js to deal with oddball timestamp format, and truncate to current date.
-        let date = moment(source.timestamp, 'DD/MM/YYYYhh:mm:ss').format('YYYY-MM-DD');
-        let out = [];
+        const date = moment(source.timestamp, 'DD/MM/YYYYhh:mm:ss').format('YYYY-MM-DD');
+        const out = [];
 
         if (source.src.port < 1024) {
             source.src.ip = source.src.ip.split('.').slice(0, -1).join('.');

--- a/examples/re-key/flow.ts
+++ b/examples/re-key/flow.ts
@@ -31,9 +31,9 @@ export class ExamplesReKeyStableEvents implements interfaces.ExamplesReKeyStable
         previous: registers.ExamplesReKeyStableEvents,
     ): collections.ExamplesReKeyStableEvents[] {
         // Publish previous register.events, enriched with the just-learned stable ID.
-        let out = [];
+        const out = [];
         if (register.stable_id && previous.events) {
-            for (var event of previous.events) {
+            for (const event of previous.events) {
                 out.push({ stable_id: register.stable_id, ...event });
             }
         }

--- a/examples/segment/flow.ts
+++ b/examples/segment/flow.ts
@@ -2,7 +2,7 @@ import { anchors, collections, interfaces, registers } from 'flow/modules';
 
 // detail maps a segment event into a SegmentDetail.
 function detail(event: collections.ExamplesSegmentEvents): anchors.SegmentDetail {
-    let rest = {
+    const rest = {
         segment: event.segment,
         last: event.timestamp,
     };
@@ -67,7 +67,7 @@ export class ExamplesSegmentToggles implements interfaces.ExamplesSegmentToggles
         _register: registers.ExamplesSegmentToggles,
         previous: registers.ExamplesSegmentToggles,
     ): collections.ExamplesSegmentToggles[] {
-        let { event: last, firstAdd } = previous;
+        const { event: last, firstAdd } = previous;
 
         // Only publish a toggle if the user has been added to the segment at
         // least once, and the |last| event add / remove status is different from

--- a/examples/soak-tests/set-ops/flow.ts
+++ b/examples/soak-tests/set-ops/flow.ts
@@ -28,7 +28,7 @@ export class SoakSetOpsSetsRegister implements interfaces.SoakSetOpsSetsRegister
 
 function operationToSet(source: collections.SoakSetOpsOperations): [collections.SoakSetOpsSets] {
     if (source.Type == 'add' || source.Type == 'remove') {
-        let mutate = source as anchors.MutateOp;
+        const mutate = source as anchors.MutateOp;
 
         return [
             {
@@ -43,7 +43,7 @@ function operationToSet(source: collections.SoakSetOpsOperations): [collections.
         ];
     }
 
-    let verify = source as anchors.VerifyOp;
+    const verify = source as anchors.VerifyOp;
 
     return [
         {

--- a/examples/temp-sensors/flow.ts
+++ b/examples/temp-sensors/flow.ts
@@ -2,65 +2,67 @@ import { collections, interfaces, registers } from 'flow/modules';
 
 // Implementation for derivation examples/temp-sensors/flow.yaml#/collections/temperature~1averageByLocation/derivation.
 export class TemperatureAverageByLocation implements interfaces.TemperatureAverageByLocation {
-    avgTempLocationSensorsUpdate(
-        source: collections.TemperatureSensors,
-    ): registers.TemperatureAverageByLocation[] {
+    avgTempLocationSensorsUpdate(source: collections.TemperatureSensors): registers.TemperatureAverageByLocation[] {
         // Update the register when a new location arrives.
         return [{ locationName: source.locationName }];
     }
     avgTempLocationSensorsPublish(
         source: collections.TemperatureSensors,
         register: registers.TemperatureAverageByLocation,
-        previous: registers.TemperatureAverageByLocation,
+        _previous: registers.TemperatureAverageByLocation,
     ): collections.TemperatureAverageByLocation[] {
         // If we have a reading for a new location, update the collection.  Else, don't update it
         // but keep it around in the register for when a reading arrives.
-        if (register.numReadings) {
-            var avg = Math.round(register.totalC! / register.numReadings! * 100) / 100.0;
-            return [{
-                sensorId: source.id,
-                numReadings: register.numReadings,
-                avgC: avg,
-                totalC: register.totalC,
-                minTempC: register.minTempC,
-                maxTempC: register.maxTempC,
-                lastReading: register.lastReading,
-                locationName: source.locationName
-            }];
+        if (register.numReadings && register.totalC) {
+            const avg = Math.round((register.totalC / register.numReadings) * 100) / 100.0;
+            return [
+                {
+                    sensorId: source.id,
+                    numReadings: register.numReadings,
+                    avgC: avg,
+                    totalC: register.totalC,
+                    minTempC: register.minTempC,
+                    maxTempC: register.maxTempC,
+                    lastReading: register.lastReading,
+                    locationName: source.locationName,
+                },
+            ];
         } else {
-            return []
+            return [];
         }
     }
-    avgTempLocationTempsUpdate(
-        source: collections.TemperatureAverageTemps,
-    ): registers.TemperatureAverageByLocation[] {
+    avgTempLocationTempsUpdate(source: collections.TemperatureAverageTemps): registers.TemperatureAverageByLocation[] {
         // Update the register with stats when a new reading comes in.  This can be used later
         // if a location arrives in for this sensor to ensure a fully reactive join.
-        return [{
-            numReadings: source.numReadings,
-            totalC: source.totalC,
-            minTempC: source.minTempC,
-            maxTempC: source.maxTempC,
-            lastReading: source.lastReading,
-        }];
+        return [
+            {
+                numReadings: source.numReadings,
+                totalC: source.totalC,
+                minTempC: source.minTempC,
+                maxTempC: source.maxTempC,
+                lastReading: source.lastReading,
+            },
+        ];
     }
     avgTempLocationTempsPublish(
         source: collections.TemperatureAverageTemps,
         register: registers.TemperatureAverageByLocation,
-        previous: registers.TemperatureAverageByLocation,
+        _previous: registers.TemperatureAverageByLocation,
     ): collections.TemperatureAverageByLocation[] {
-        var avg = Math.round(source.totalC! / source.numReadings! * 100) / 100.0;
+        const avg = Math.round((source.totalC / source.numReadings) * 100) / 100.0;
         // Always update the collection when a new reading comes in.
-        return [{
-            sensorId: source.sensorId,
-            numReadings: source.numReadings,
-            avgC: avg,
-            totalC: source.totalC,
-            minTempC: source.minTempC,
-            maxTempC: source.maxTempC,
-            lastReading: source.lastReading,
-            locationName: register.locationName
-        }];
+        return [
+            {
+                sensorId: source.sensorId,
+                numReadings: source.numReadings,
+                avgC: avg,
+                totalC: source.totalC,
+                minTempC: source.minTempC,
+                maxTempC: source.maxTempC,
+                lastReading: source.lastReading,
+                locationName: register.locationName,
+            },
+        ];
     }
 }
 
@@ -68,18 +70,20 @@ export class TemperatureAverageByLocation implements interfaces.TemperatureAvera
 export class TemperatureAverageTemps implements interfaces.TemperatureAverageTemps {
     averageTempsPublish(
         source: collections.TemperatureReadings,
-        register: registers.TemperatureAverageTemps,
-        previous: registers.TemperatureAverageTemps,
+        _register: registers.TemperatureAverageTemps,
+        _previous: registers.TemperatureAverageTemps,
     ): collections.TemperatureAverageTemps[] {
         // This will execute on every reading so by setting numReadings to 1 for a single document, we'll sum the number of documents correctly by using
         // reduction annotations. Reduction annotations will handle ensuring temps and other fields are correctly minimized, maximized, or summed.
-        return [{
-            sensorId: source.sensorId,
-            numReadings: 1,
-            totalC: source.tempC,
-            minTempC: source.tempC,
-            maxTempC: source.tempC,
-            lastReading: source.timestamp
-        }]
+        return [
+            {
+                sensorId: source.sensorId,
+                numReadings: 1,
+                totalC: source.tempC,
+                minTempC: source.tempC,
+                maxTempC: source.tempC,
+                lastReading: source.timestamp,
+            },
+        ];
     }
 }

--- a/examples/wiki/pages.flow.ts
+++ b/examples/wiki/pages.flow.ts
@@ -7,7 +7,7 @@ export class ExamplesWikiPages implements interfaces.ExamplesWikiPages {
         _register: registers.ExamplesWikiPages,
         _previous: registers.ExamplesWikiPages,
     ): collections.ExamplesWikiPages[] {
-        let stats = { cnt: 1, add: source.added, del: source.deleted };
+        const stats = { cnt: 1, add: source.added, del: source.deleted };
 
         if (source.countryIsoCode) {
             return [

--- a/flow_generated/flow/anchors.d.ts
+++ b/flow_generated/flow/anchors.d.ts
@@ -2,7 +2,7 @@
 export type __module = null;
 
 // Generated from examples/stock-stats/schemas/exchange.schema.yaml.
-export type Exchange = /* Enum of market exchange codes. */ "NASDAQ" | "NYSE" | "SEHK";
+export type Exchange = /* Enum of market exchange codes. */ 'NASDAQ' | 'NYSE' | 'SEHK';
 
 // Generated from examples/soak-tests/set-ops/schema.yaml#/$defs/header.
 export type Header = /* Common properties of generated operations */ {
@@ -32,7 +32,7 @@ export type MutateOp = /* Operation which mutates a stream */ {
     ID: number;
     Ones: number;
     Op: number;
-    Type: "add" | "remove";
+    Type: 'add' | 'remove';
     Values: {
         [k: string]: number;
     };
@@ -87,7 +87,7 @@ export type VerifyOp = /* Operation which verifies the expected value of a strea
     Op: number;
     TotalAdd: number;
     TotalRemove: number;
-    Type: "verify";
+    Type: 'verify';
     Values: {
         [k: string]: number;
     };

--- a/flow_generated/flow/collections.d.ts
+++ b/flow_generated/flow/collections.d.ts
@@ -39,9 +39,11 @@ export type ExampleReductionsFwwLww = {
 // Referenced as schema of examples/reduction-types/merge.flow.yaml#/collections/example~1reductions~1merge.
 export type ExampleReductionsMerge = {
     key: string;
-    value?: {
-        [k: string]: number;
-    } | number[];
+    value?:
+        | {
+              [k: string]: number;
+          }
+        | number[];
 };
 
 // Generated from examples/reduction-types/merge_key.flow.yaml?ptr=/collections/example~1reductions~1merge-key/schema.
@@ -97,7 +99,7 @@ export type ExampleReductionsSum = {
 // Generated from examples/reduction-types/reset_counter.flow.yaml?ptr=/collections/example~1reductions~1sum-reset/schema.
 // Referenced as schema of examples/reduction-types/reset_counter.flow.yaml#/collections/example~1reductions~1sum-reset.
 export type ExampleReductionsSumReset = {
-    action?: "reset" | "sum";
+    action?: 'reset' | 'sum';
     key: string;
     value?: number;
 };
@@ -165,7 +167,7 @@ export type ExamplesCitiBikeRides = /* Ride within the Citi Bike system */ {
         timestamp: /* Timestamp as YYYY-MM-DD HH:MM:SS.F in UTC */ string;
     };
     gender?: /* Gender of the rider (Zero=unknown; 1=male; 2=female) */ 0 | 1 | 2;
-    user_type?: /* Subscriber, or pay-as-you-go Customer */ "Customer" | "Subscriber";
+    user_type?: /* Subscriber, or pay-as-you-go Customer */ 'Customer' | 'Subscriber';
 };
 
 // Generated from examples/citi-bike/rides-and-relocations.flow.yaml?ptr=/collections/examples~1citi-bike~1rides-and-relocations/schema.
@@ -198,7 +200,7 @@ export type ExamplesCitiBikeRidesAndRelocations = /* Ride within the Citi Bike s
     };
     gender?: /* Gender of the rider (Zero=unknown; 1=male; 2=female) */ 0 | 1 | 2;
     relocation?: true;
-    user_type?: /* Subscriber, or pay-as-you-go Customer */ "Customer" | "Subscriber";
+    user_type?: /* Subscriber, or pay-as-you-go Customer */ 'Customer' | 'Subscriber';
 };
 
 // Generated from examples/citi-bike/station.schema.yaml.
@@ -591,7 +593,7 @@ export type SoakSetOpsOperations = /* Union type over MutateOp and VerifyOp */ {
     ID: number;
     Ones: number;
     Op: number;
-    Type: "add" | "remove" | "verify";
+    Type: 'add' | 'remove' | 'verify';
     Values: {
         [k: string]: number;
     };
@@ -671,15 +673,33 @@ export type StockTicks = /* Level-one market tick of a security. */ {
     [k: string]: Record<string, unknown> | boolean | string | null | undefined;
 };
 
-// Generated from examples/temp-sensors/schemas.yaml#/$defs/locationTemps.
-// Referenced as schema of examples/temp-sensors/flow.yaml#/collections/temperature~1average-by-location.
-export type TemperatureAverageByLocation = /* Average temperature information for a particular location */ {
-    averageTempC: number;
+// Generated from examples/temp-sensors/schemas.yaml#/$defs/avgTempsWithLocation.
+// Referenced as schema of examples/temp-sensors/flow.yaml#/collections/temperature~1averageByLocation.
+export type TemperatureAverageByLocation = /* Average temperature with location added */ {
+    avgC?: number;
+    lastReading?: /* Timestamp of the most recent reading for this named location */ string;
+    location?: /* GeoJSON Point */ /* The precise geographic location of the sensor */ {
+        bbox?: number[];
+        coordinates: number[];
+        type: 'Point';
+    };
+    locationName?: string | null;
+    maxTempC?: number;
+    minTempC?: number;
+    numReadings?: number;
+    sensorId: number;
+    totalC?: number;
+};
+
+// Generated from examples/temp-sensors/schemas.yaml#/$defs/averageTemps.
+// Referenced as schema of examples/temp-sensors/flow.yaml#/collections/temperature~1averageTemps.
+export type TemperatureAverageTemps = /* Average temperature information for a particular sensor */ {
     lastReading: /* Timestamp of the most recent reading for this named location */ string;
-    locationName: string | null;
     maxTempC: number;
     minTempC: number;
+    numReadings: number;
     sensorId: number;
+    totalC: number;
 };
 
 // Generated from examples/temp-sensors/schemas.yaml#/$defs/tempReading.
@@ -697,7 +717,7 @@ export type TemperatureSensors = /* A sensor that produces temperature readings 
     location?: /* GeoJSON Point */ /* The precise geographic location of the sensor */ {
         bbox?: number[];
         coordinates: number[];
-        type: "Point";
+        type: 'Point';
     };
     locationName: /* Human readable name of the sensor location */ string;
 };

--- a/flow_generated/flow/interfaces.d.ts
+++ b/flow_generated/flow/interfaces.d.ts
@@ -26,9 +26,7 @@ export interface ExamplesCitiBikeIdleBikes {
         register: registers.ExamplesCitiBikeIdleBikes,
         previous: registers.ExamplesCitiBikeIdleBikes,
     ): collections.ExamplesCitiBikeIdleBikes[];
-    liveRidesUpdate(
-        source: collections.ExamplesCitiBikeRides,
-    ): registers.ExamplesCitiBikeIdleBikes[];
+    liveRidesUpdate(source: collections.ExamplesCitiBikeRides): registers.ExamplesCitiBikeIdleBikes[];
 }
 
 // Generated from derivation examples/citi-bike/last-seen.flow.yaml#/collections/examples~1citi-bike~1last-seen/derivation.
@@ -44,9 +42,7 @@ export interface ExamplesCitiBikeLastSeen {
 // Generated from derivation examples/citi-bike/rides-and-relocations.flow.yaml#/collections/examples~1citi-bike~1rides-and-relocations/derivation.
 // Required to be implemented by examples/citi-bike/rides-and-relocations.flow.ts.
 export interface ExamplesCitiBikeRidesAndRelocations {
-    fromRidesUpdate(
-        source: collections.ExamplesCitiBikeRides,
-    ): registers.ExamplesCitiBikeRidesAndRelocations[];
+    fromRidesUpdate(source: collections.ExamplesCitiBikeRides): registers.ExamplesCitiBikeRidesAndRelocations[];
     fromRidesPublish(
         source: collections.ExamplesCitiBikeRides,
         register: registers.ExamplesCitiBikeRidesAndRelocations,
@@ -77,17 +73,13 @@ export interface ExamplesNetTraceServices {
 // Generated from derivation examples/re-key/flow.yaml#/collections/examples~1re-key~1stable_events/derivation.
 // Required to be implemented by examples/re-key/flow.ts.
 export interface ExamplesReKeyStableEvents {
-    fromAnonymousEventsUpdate(
-        source: collections.ExamplesReKeyAnonymousEvents,
-    ): registers.ExamplesReKeyStableEvents[];
+    fromAnonymousEventsUpdate(source: collections.ExamplesReKeyAnonymousEvents): registers.ExamplesReKeyStableEvents[];
     fromAnonymousEventsPublish(
         source: collections.ExamplesReKeyAnonymousEvents,
         register: registers.ExamplesReKeyStableEvents,
         previous: registers.ExamplesReKeyStableEvents,
     ): collections.ExamplesReKeyStableEvents[];
-    fromIdMappingsUpdate(
-        source: collections.ExamplesReKeyMappings,
-    ): registers.ExamplesReKeyStableEvents[];
+    fromIdMappingsUpdate(source: collections.ExamplesReKeyMappings): registers.ExamplesReKeyStableEvents[];
     fromIdMappingsPublish(
         source: collections.ExamplesReKeyMappings,
         register: registers.ExamplesReKeyStableEvents,
@@ -118,9 +110,7 @@ export interface ExamplesSegmentProfiles {
 // Generated from derivation examples/segment/flow.yaml#/collections/examples~1segment~1toggles/derivation.
 // Required to be implemented by examples/segment/flow.ts.
 export interface ExamplesSegmentToggles {
-    fromSegmentationUpdate(
-        source: collections.ExamplesSegmentEvents,
-    ): registers.ExamplesSegmentToggles[];
+    fromSegmentationUpdate(source: collections.ExamplesSegmentEvents): registers.ExamplesSegmentToggles[];
     fromSegmentationPublish(
         source: collections.ExamplesSegmentEvents,
         register: registers.ExamplesSegmentToggles,
@@ -136,9 +126,7 @@ export interface ExamplesShoppingCartUpdatesWithProducts {
         register: registers.ExamplesShoppingCartUpdatesWithProducts,
         previous: registers.ExamplesShoppingCartUpdatesWithProducts,
     ): collections.ExamplesShoppingCartUpdatesWithProducts[];
-    productsUpdate(
-        source: collections.ExamplesShoppingProducts,
-    ): registers.ExamplesShoppingCartUpdatesWithProducts[];
+    productsUpdate(source: collections.ExamplesShoppingProducts): registers.ExamplesShoppingCartUpdatesWithProducts[];
 }
 
 // Generated from derivation examples/shopping/carts.flow.yaml#/collections/examples~1shopping~1carts/derivation.
@@ -165,9 +153,7 @@ export interface ExamplesShoppingCarts {
 // Generated from derivation examples/shopping/purchases.flow.yaml#/collections/examples~1shopping~1purchases/derivation.
 // Required to be implemented by examples/shopping/purchases.flow.ts.
 export interface ExamplesShoppingPurchases {
-    cartsUpdate(
-        source: collections.ExamplesShoppingCarts,
-    ): registers.ExamplesShoppingPurchases[];
+    cartsUpdate(source: collections.ExamplesShoppingCarts): registers.ExamplesShoppingPurchases[];
     purchaseActionsPublish(
         source: collections.ExamplesShoppingCartPurchaseRequests,
         register: registers.ExamplesShoppingPurchases,
@@ -188,9 +174,7 @@ export interface ExamplesWikiPages {
 // Generated from derivation examples/marketing/flow.yaml#/collections/marketing~1clicks-with-views/derivation.
 // Required to be implemented by examples/marketing/flow.ts.
 export interface MarketingClicksWithViews {
-    indexViewsUpdate(
-        source: collections.MarketingViewsWithCampaign,
-    ): registers.MarketingClicksWithViews[];
+    indexViewsUpdate(source: collections.MarketingViewsWithCampaign): registers.MarketingClicksWithViews[];
     joinClickWithIndexedViewsPublish(
         source: collections.MarketingOfferClicks,
         register: registers.MarketingClicksWithViews,
@@ -201,12 +185,8 @@ export interface MarketingClicksWithViews {
 // Generated from derivation examples/marketing/flow.yaml#/collections/marketing~1purchase-with-offers/derivation.
 // Required to be implemented by examples/marketing/flow.ts.
 export interface MarketingPurchaseWithOffers {
-    indexClicksUpdate(
-        source: collections.MarketingClicksWithViews,
-    ): registers.MarketingPurchaseWithOffers[];
-    indexViewsUpdate(
-        source: collections.MarketingViewsWithCampaign,
-    ): registers.MarketingPurchaseWithOffers[];
+    indexClicksUpdate(source: collections.MarketingClicksWithViews): registers.MarketingPurchaseWithOffers[];
+    indexViewsUpdate(source: collections.MarketingViewsWithCampaign): registers.MarketingPurchaseWithOffers[];
     joinPurchaseWithViewsAndClicksPublish(
         source: collections.MarketingPurchases,
         register: registers.MarketingPurchaseWithOffers,
@@ -217,9 +197,7 @@ export interface MarketingPurchaseWithOffers {
 // Generated from derivation examples/marketing/flow.yaml#/collections/marketing~1views-with-campaign/derivation.
 // Required to be implemented by examples/marketing/flow.ts.
 export interface MarketingViewsWithCampaign {
-    indexCampaignsUpdate(
-        source: collections.MarketingCampaigns,
-    ): registers.MarketingViewsWithCampaign[];
+    indexCampaignsUpdate(source: collections.MarketingCampaigns): registers.MarketingViewsWithCampaign[];
     joinViewWithIndexedCampaignPublish(
         source: collections.MarketingOfferViews,
         register: registers.MarketingViewsWithCampaign,
@@ -230,17 +208,13 @@ export interface MarketingViewsWithCampaign {
 // Generated from derivation examples/derive-patterns/join-inner.flow.yaml#/collections/patterns~1inner-join/derivation.
 // Required to be implemented by examples/derive-patterns/join-inner.flow.ts.
 export interface PatternsInnerJoin {
-    fromIntsUpdate(
-        source: collections.PatternsInts,
-    ): registers.PatternsInnerJoin[];
+    fromIntsUpdate(source: collections.PatternsInts): registers.PatternsInnerJoin[];
     fromIntsPublish(
         source: collections.PatternsInts,
         register: registers.PatternsInnerJoin,
         previous: registers.PatternsInnerJoin,
     ): collections.PatternsInnerJoin[];
-    fromStringsUpdate(
-        source: collections.PatternsStrings,
-    ): registers.PatternsInnerJoin[];
+    fromStringsUpdate(source: collections.PatternsStrings): registers.PatternsInnerJoin[];
     fromStringsPublish(
         source: collections.PatternsStrings,
         register: registers.PatternsInnerJoin,
@@ -256,9 +230,7 @@ export interface PatternsOneSidedJoin {
         register: registers.PatternsOneSidedJoin,
         previous: registers.PatternsOneSidedJoin,
     ): collections.PatternsOneSidedJoin[];
-    updateRHSUpdate(
-        source: collections.PatternsStrings,
-    ): registers.PatternsOneSidedJoin[];
+    updateRHSUpdate(source: collections.PatternsStrings): registers.PatternsOneSidedJoin[];
 }
 
 // Generated from derivation examples/derive-patterns/join-outer.flow.yaml#/collections/patterns~1outer-join/derivation.
@@ -289,9 +261,7 @@ export interface PatternsSumsDb {
 // Generated from derivation examples/derive-patterns/summer.flow.yaml#/collections/patterns~1sums-register/derivation.
 // Required to be implemented by examples/derive-patterns/summer.flow.ts.
 export interface PatternsSumsRegister {
-    fromIntsUpdate(
-        source: collections.PatternsInts,
-    ): registers.PatternsSumsRegister[];
+    fromIntsUpdate(source: collections.PatternsInts): registers.PatternsSumsRegister[];
     fromIntsPublish(
         source: collections.PatternsInts,
         register: registers.PatternsSumsRegister,
@@ -302,9 +272,7 @@ export interface PatternsSumsRegister {
 // Generated from derivation examples/derive-patterns/zero-crossing.flow.yaml#/collections/patterns~1zero-crossing/derivation.
 // Required to be implemented by examples/derive-patterns/zero-crossing.flow.ts.
 export interface PatternsZeroCrossing {
-    fromIntsUpdate(
-        source: collections.PatternsInts,
-    ): registers.PatternsZeroCrossing[];
+    fromIntsUpdate(source: collections.PatternsInts): registers.PatternsZeroCrossing[];
     fromIntsPublish(
         source: collections.PatternsInts,
         register: registers.PatternsZeroCrossing,
@@ -325,9 +293,7 @@ export interface SoakSetOpsSets {
 // Generated from derivation examples/soak-tests/set-ops/flow.yaml#/collections/soak~1set-ops~1sets-register/derivation.
 // Required to be implemented by examples/soak-tests/set-ops/flow.ts.
 export interface SoakSetOpsSetsRegister {
-    onOperationUpdate(
-        source: collections.SoakSetOpsOperations,
-    ): registers.SoakSetOpsSetsRegister[];
+    onOperationUpdate(source: collections.SoakSetOpsOperations): registers.SoakSetOpsSetsRegister[];
     onOperationPublish(
         source: collections.SoakSetOpsOperations,
         register: registers.SoakSetOpsSetsRegister,
@@ -345,23 +311,29 @@ export interface StockDailyStats {
     ): collections.StockDailyStats[];
 }
 
-// Generated from derivation examples/temp-sensors/flow.yaml#/collections/temperature~1average-by-location/derivation.
+// Generated from derivation examples/temp-sensors/flow.yaml#/collections/temperature~1averageByLocation/derivation.
 // Required to be implemented by examples/temp-sensors/flow.ts.
 export interface TemperatureAverageByLocation {
-    readingsUpdate(
-        source: collections.TemperatureReadings,
-    ): registers.TemperatureAverageByLocation[];
-    readingsPublish(
-        source: collections.TemperatureReadings,
-        register: registers.TemperatureAverageByLocation,
-        previous: registers.TemperatureAverageByLocation,
-    ): collections.TemperatureAverageByLocation[];
-    sensorsUpdate(
-        source: collections.TemperatureSensors,
-    ): registers.TemperatureAverageByLocation[];
-    sensorsPublish(
+    avgTempLocationSensorsUpdate(source: collections.TemperatureSensors): registers.TemperatureAverageByLocation[];
+    avgTempLocationSensorsPublish(
         source: collections.TemperatureSensors,
         register: registers.TemperatureAverageByLocation,
         previous: registers.TemperatureAverageByLocation,
     ): collections.TemperatureAverageByLocation[];
+    avgTempLocationTempsUpdate(source: collections.TemperatureAverageTemps): registers.TemperatureAverageByLocation[];
+    avgTempLocationTempsPublish(
+        source: collections.TemperatureAverageTemps,
+        register: registers.TemperatureAverageByLocation,
+        previous: registers.TemperatureAverageByLocation,
+    ): collections.TemperatureAverageByLocation[];
+}
+
+// Generated from derivation examples/temp-sensors/flow.yaml#/collections/temperature~1averageTemps/derivation.
+// Required to be implemented by examples/temp-sensors/flow.ts.
+export interface TemperatureAverageTemps {
+    averageTempsPublish(
+        source: collections.TemperatureReadings,
+        register: registers.TemperatureAverageTemps,
+        previous: registers.TemperatureAverageTemps,
+    ): collections.TemperatureAverageTemps[];
 }

--- a/flow_generated/flow/registers.d.ts
+++ b/flow_generated/flow/registers.d.ts
@@ -44,10 +44,12 @@ export type ExamplesReKeyStableEvents = /* Register that's keyed on anonymous ID
   1) Stores anonymous events prior to a stable ID being known, and thereafter
   2) Stores a mapped stable ID for this anonymous ID.
  */ {
-    events: /* An interesting event, keyed on an anonymous ID */ {
-        anonymous_id: string;
-        event_id: string;
-    }[] | null;
+    events: /* An interesting event, keyed on an anonymous ID */
+    | {
+              anonymous_id: string;
+              event_id: string;
+          }[]
+        | null;
     stable_id?: string;
 };
 
@@ -222,13 +224,23 @@ export type SoakSetOpsSetsRegister = /* Output merges expected and actual values
 // Referenced as register_schema of examples/stock-stats/flow.yaml#/collections/stock~1daily-stats/derivation.
 export type StockDailyStats = unknown;
 
-// Generated from examples/temp-sensors/schemas.yaml#/$defs/averageTempsRegister.
-// Referenced as register_schema of examples/temp-sensors/flow.yaml#/collections/temperature~1average-by-location/derivation.
+// Generated from examples/temp-sensors/schemas.yaml#/$defs/tempToLocationRegister.
+// Referenced as register_schema of examples/temp-sensors/flow.yaml#/collections/temperature~1averageByLocation/derivation.
 export type TemperatureAverageByLocation = {
-    lastReading?: string;
+    avgC?: number;
+    lastReading?: /* Timestamp of the most recent reading for this named location */ string;
+    location?: /* GeoJSON Point */ /* The precise geographic location of the sensor */ {
+        bbox?: number[];
+        coordinates: number[];
+        type: 'Point';
+    };
     locationName?: string | null;
     maxTempC?: number;
     minTempC?: number;
     numReadings?: number;
     totalC?: number;
 };
+
+// Generated from examples/temp-sensors/flow.yaml?ptr=/collections/temperature~1averageTemps/derivation/register/schema.
+// Referenced as register_schema of examples/temp-sensors/flow.yaml#/collections/temperature~1averageTemps/derivation.
+export type TemperatureAverageTemps = unknown;

--- a/flow_generated/flow/routes.ts
+++ b/flow_generated/flow/routes.ts
@@ -8,46 +8,25 @@ export type Lambda = (source: Document, register?: Document, previous?: Document
 // "Use" imported modules, even if they're empty, to satisfy compiler and linting.
 export type __interfaces_module = interfaces.__module;
 // Import derivation classes from their implementation modules.
-import {
-    AcmeBankBalances,
-} from '../../examples/acmeBank.flow';
+import { AcmeBankBalances } from '../../examples/acmeBank.flow';
 
-import {
-    ExamplesCitiBikeIdleBikes,
-} from '../../examples/citi-bike/idle-bikes.flow';
+import { ExamplesCitiBikeIdleBikes } from '../../examples/citi-bike/idle-bikes.flow';
 
-import {
-    ExamplesCitiBikeLastSeen,
-} from '../../examples/citi-bike/last-seen.flow';
+import { ExamplesCitiBikeLastSeen } from '../../examples/citi-bike/last-seen.flow';
 
-import {
-    ExamplesCitiBikeRidesAndRelocations,
-} from '../../examples/citi-bike/rides-and-relocations.flow';
+import { ExamplesCitiBikeRidesAndRelocations } from '../../examples/citi-bike/rides-and-relocations.flow';
 
-import {
-    ExamplesCitiBikeStations,
-} from '../../examples/citi-bike/stations.flow';
+import { ExamplesCitiBikeStations } from '../../examples/citi-bike/stations.flow';
 
-import {
-    PatternsInnerJoin,
-} from '../../examples/derive-patterns/join-inner.flow';
+import { PatternsInnerJoin } from '../../examples/derive-patterns/join-inner.flow';
 
-import {
-    PatternsOneSidedJoin,
-} from '../../examples/derive-patterns/join-one-sided.flow';
+import { PatternsOneSidedJoin } from '../../examples/derive-patterns/join-one-sided.flow';
 
-import {
-    PatternsOuterJoin,
-} from '../../examples/derive-patterns/join-outer.flow';
+import { PatternsOuterJoin } from '../../examples/derive-patterns/join-outer.flow';
 
-import {
-    PatternsSumsDb,
-    PatternsSumsRegister,
-} from '../../examples/derive-patterns/summer.flow';
+import { PatternsSumsDb, PatternsSumsRegister } from '../../examples/derive-patterns/summer.flow';
 
-import {
-    PatternsZeroCrossing,
-} from '../../examples/derive-patterns/zero-crossing.flow';
+import { PatternsZeroCrossing } from '../../examples/derive-patterns/zero-crossing.flow';
 
 import {
     MarketingClicksWithViews,
@@ -55,13 +34,9 @@ import {
     MarketingViewsWithCampaign,
 } from '../../examples/marketing/flow';
 
-import {
-    ExamplesNetTraceServices,
-} from '../../examples/net-trace/services.flow';
+import { ExamplesNetTraceServices } from '../../examples/net-trace/services.flow';
 
-import {
-    ExamplesReKeyStableEvents,
-} from '../../examples/re-key/flow';
+import { ExamplesReKeyStableEvents } from '../../examples/re-key/flow';
 
 import {
     ExamplesSegmentMemberships,
@@ -69,66 +44,52 @@ import {
     ExamplesSegmentToggles,
 } from '../../examples/segment/flow';
 
-import {
-    ExamplesShoppingCartUpdatesWithProducts,
-} from '../../examples/shopping/cart-updates-with-products.flow';
+import { ExamplesShoppingCartUpdatesWithProducts } from '../../examples/shopping/cart-updates-with-products.flow';
 
-import {
-    ExamplesShoppingCarts,
-} from '../../examples/shopping/carts.flow';
+import { ExamplesShoppingCarts } from '../../examples/shopping/carts.flow';
 
-import {
-    ExamplesShoppingPurchases,
-} from '../../examples/shopping/purchases.flow';
+import { ExamplesShoppingPurchases } from '../../examples/shopping/purchases.flow';
 
-import {
-    SoakSetOpsSets,
-    SoakSetOpsSetsRegister,
-} from '../../examples/soak-tests/set-ops/flow';
+import { SoakSetOpsSets, SoakSetOpsSetsRegister } from '../../examples/soak-tests/set-ops/flow';
 
-import {
-    StockDailyStats,
-} from '../../examples/stock-stats/flow';
+import { StockDailyStats } from '../../examples/stock-stats/flow';
 
-import {
-    TemperatureAverageByLocation,
-} from '../../examples/temp-sensors/flow';
+import { TemperatureAverageByLocation, TemperatureAverageTemps } from '../../examples/temp-sensors/flow';
 
-import {
-    ExamplesWikiPages,
-} from '../../examples/wiki/pages.flow';
+import { ExamplesWikiPages } from '../../examples/wiki/pages.flow';
 
 // Build instances of each class, which will be bound to this module's router.
-let __AcmeBankBalances: interfaces.AcmeBankBalances = new AcmeBankBalances();
-let __ExamplesCitiBikeIdleBikes: interfaces.ExamplesCitiBikeIdleBikes = new ExamplesCitiBikeIdleBikes();
-let __ExamplesCitiBikeLastSeen: interfaces.ExamplesCitiBikeLastSeen = new ExamplesCitiBikeLastSeen();
-let __ExamplesCitiBikeRidesAndRelocations: interfaces.ExamplesCitiBikeRidesAndRelocations = new ExamplesCitiBikeRidesAndRelocations();
-let __ExamplesCitiBikeStations: interfaces.ExamplesCitiBikeStations = new ExamplesCitiBikeStations();
-let __ExamplesNetTraceServices: interfaces.ExamplesNetTraceServices = new ExamplesNetTraceServices();
-let __ExamplesReKeyStableEvents: interfaces.ExamplesReKeyStableEvents = new ExamplesReKeyStableEvents();
-let __ExamplesSegmentMemberships: interfaces.ExamplesSegmentMemberships = new ExamplesSegmentMemberships();
-let __ExamplesSegmentProfiles: interfaces.ExamplesSegmentProfiles = new ExamplesSegmentProfiles();
-let __ExamplesSegmentToggles: interfaces.ExamplesSegmentToggles = new ExamplesSegmentToggles();
-let __ExamplesShoppingCartUpdatesWithProducts: interfaces.ExamplesShoppingCartUpdatesWithProducts = new ExamplesShoppingCartUpdatesWithProducts();
-let __ExamplesShoppingCarts: interfaces.ExamplesShoppingCarts = new ExamplesShoppingCarts();
-let __ExamplesShoppingPurchases: interfaces.ExamplesShoppingPurchases = new ExamplesShoppingPurchases();
-let __ExamplesWikiPages: interfaces.ExamplesWikiPages = new ExamplesWikiPages();
-let __MarketingClicksWithViews: interfaces.MarketingClicksWithViews = new MarketingClicksWithViews();
-let __MarketingPurchaseWithOffers: interfaces.MarketingPurchaseWithOffers = new MarketingPurchaseWithOffers();
-let __MarketingViewsWithCampaign: interfaces.MarketingViewsWithCampaign = new MarketingViewsWithCampaign();
-let __PatternsInnerJoin: interfaces.PatternsInnerJoin = new PatternsInnerJoin();
-let __PatternsOneSidedJoin: interfaces.PatternsOneSidedJoin = new PatternsOneSidedJoin();
-let __PatternsOuterJoin: interfaces.PatternsOuterJoin = new PatternsOuterJoin();
-let __PatternsSumsDb: interfaces.PatternsSumsDb = new PatternsSumsDb();
-let __PatternsSumsRegister: interfaces.PatternsSumsRegister = new PatternsSumsRegister();
-let __PatternsZeroCrossing: interfaces.PatternsZeroCrossing = new PatternsZeroCrossing();
-let __SoakSetOpsSets: interfaces.SoakSetOpsSets = new SoakSetOpsSets();
-let __SoakSetOpsSetsRegister: interfaces.SoakSetOpsSetsRegister = new SoakSetOpsSetsRegister();
-let __StockDailyStats: interfaces.StockDailyStats = new StockDailyStats();
-let __TemperatureAverageByLocation: interfaces.TemperatureAverageByLocation = new TemperatureAverageByLocation();
+const __AcmeBankBalances: interfaces.AcmeBankBalances = new AcmeBankBalances();
+const __ExamplesCitiBikeIdleBikes: interfaces.ExamplesCitiBikeIdleBikes = new ExamplesCitiBikeIdleBikes();
+const __ExamplesCitiBikeLastSeen: interfaces.ExamplesCitiBikeLastSeen = new ExamplesCitiBikeLastSeen();
+const __ExamplesCitiBikeRidesAndRelocations: interfaces.ExamplesCitiBikeRidesAndRelocations = new ExamplesCitiBikeRidesAndRelocations();
+const __ExamplesCitiBikeStations: interfaces.ExamplesCitiBikeStations = new ExamplesCitiBikeStations();
+const __ExamplesNetTraceServices: interfaces.ExamplesNetTraceServices = new ExamplesNetTraceServices();
+const __ExamplesReKeyStableEvents: interfaces.ExamplesReKeyStableEvents = new ExamplesReKeyStableEvents();
+const __ExamplesSegmentMemberships: interfaces.ExamplesSegmentMemberships = new ExamplesSegmentMemberships();
+const __ExamplesSegmentProfiles: interfaces.ExamplesSegmentProfiles = new ExamplesSegmentProfiles();
+const __ExamplesSegmentToggles: interfaces.ExamplesSegmentToggles = new ExamplesSegmentToggles();
+const __ExamplesShoppingCartUpdatesWithProducts: interfaces.ExamplesShoppingCartUpdatesWithProducts = new ExamplesShoppingCartUpdatesWithProducts();
+const __ExamplesShoppingCarts: interfaces.ExamplesShoppingCarts = new ExamplesShoppingCarts();
+const __ExamplesShoppingPurchases: interfaces.ExamplesShoppingPurchases = new ExamplesShoppingPurchases();
+const __ExamplesWikiPages: interfaces.ExamplesWikiPages = new ExamplesWikiPages();
+const __MarketingClicksWithViews: interfaces.MarketingClicksWithViews = new MarketingClicksWithViews();
+const __MarketingPurchaseWithOffers: interfaces.MarketingPurchaseWithOffers = new MarketingPurchaseWithOffers();
+const __MarketingViewsWithCampaign: interfaces.MarketingViewsWithCampaign = new MarketingViewsWithCampaign();
+const __PatternsInnerJoin: interfaces.PatternsInnerJoin = new PatternsInnerJoin();
+const __PatternsOneSidedJoin: interfaces.PatternsOneSidedJoin = new PatternsOneSidedJoin();
+const __PatternsOuterJoin: interfaces.PatternsOuterJoin = new PatternsOuterJoin();
+const __PatternsSumsDb: interfaces.PatternsSumsDb = new PatternsSumsDb();
+const __PatternsSumsRegister: interfaces.PatternsSumsRegister = new PatternsSumsRegister();
+const __PatternsZeroCrossing: interfaces.PatternsZeroCrossing = new PatternsZeroCrossing();
+const __SoakSetOpsSets: interfaces.SoakSetOpsSets = new SoakSetOpsSets();
+const __SoakSetOpsSetsRegister: interfaces.SoakSetOpsSetsRegister = new SoakSetOpsSetsRegister();
+const __StockDailyStats: interfaces.StockDailyStats = new StockDailyStats();
+const __TemperatureAverageByLocation: interfaces.TemperatureAverageByLocation = new TemperatureAverageByLocation();
+const __TemperatureAverageTemps: interfaces.TemperatureAverageTemps = new TemperatureAverageTemps();
 
 // Now build the router that's used for transformation lambda dispatch.
-let routes: { [path: string]: Lambda | undefined } = {
+const routes: { [path: string]: Lambda | undefined } = {
     '/derive/acmeBank/balances/fromTransfers/Publish': __AcmeBankBalances.fromTransfersPublish.bind(
         __AcmeBankBalances,
     ) as Lambda,
@@ -249,9 +210,7 @@ let routes: { [path: string]: Lambda | undefined } = {
     '/derive/patterns/outer-join/fromStrings/Publish': __PatternsOuterJoin.fromStringsPublish.bind(
         __PatternsOuterJoin,
     ) as Lambda,
-    '/derive/patterns/sums-db/fromInts/Publish': __PatternsSumsDb.fromIntsPublish.bind(
-        __PatternsSumsDb,
-    ) as Lambda,
+    '/derive/patterns/sums-db/fromInts/Publish': __PatternsSumsDb.fromIntsPublish.bind(__PatternsSumsDb) as Lambda,
     '/derive/patterns/sums-register/fromInts/Update': __PatternsSumsRegister.fromIntsUpdate.bind(
         __PatternsSumsRegister,
     ) as Lambda,
@@ -273,20 +232,21 @@ let routes: { [path: string]: Lambda | undefined } = {
     '/derive/soak/set-ops/sets-register/onOperation/Publish': __SoakSetOpsSetsRegister.onOperationPublish.bind(
         __SoakSetOpsSetsRegister,
     ) as Lambda,
-    '/derive/stock/daily-stats/fromTicks/Publish': __StockDailyStats.fromTicksPublish.bind(
-        __StockDailyStats,
-    ) as Lambda,
-    '/derive/temperature/average-by-location/readings/Update': __TemperatureAverageByLocation.readingsUpdate.bind(
+    '/derive/stock/daily-stats/fromTicks/Publish': __StockDailyStats.fromTicksPublish.bind(__StockDailyStats) as Lambda,
+    '/derive/temperature/averageByLocation/avgTempLocationSensors/Update': __TemperatureAverageByLocation.avgTempLocationSensorsUpdate.bind(
         __TemperatureAverageByLocation,
     ) as Lambda,
-    '/derive/temperature/average-by-location/readings/Publish': __TemperatureAverageByLocation.readingsPublish.bind(
+    '/derive/temperature/averageByLocation/avgTempLocationSensors/Publish': __TemperatureAverageByLocation.avgTempLocationSensorsPublish.bind(
         __TemperatureAverageByLocation,
     ) as Lambda,
-    '/derive/temperature/average-by-location/sensors/Update': __TemperatureAverageByLocation.sensorsUpdate.bind(
+    '/derive/temperature/averageByLocation/avgTempLocationTemps/Update': __TemperatureAverageByLocation.avgTempLocationTempsUpdate.bind(
         __TemperatureAverageByLocation,
     ) as Lambda,
-    '/derive/temperature/average-by-location/sensors/Publish': __TemperatureAverageByLocation.sensorsPublish.bind(
+    '/derive/temperature/averageByLocation/avgTempLocationTemps/Publish': __TemperatureAverageByLocation.avgTempLocationTempsPublish.bind(
         __TemperatureAverageByLocation,
+    ) as Lambda,
+    '/derive/temperature/averageTemps/averageTemps/Publish': __TemperatureAverageTemps.averageTempsPublish.bind(
+        __TemperatureAverageTemps,
     ) as Lambda,
 };
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "clean": "rm -r dist/",
     "compile": "tsc",
     "develop": "node dist/flow_generated/flow/main.js",
-    "lint": "eslint --fix **/*.ts",
-    "prettify": "prettier --write **/*.ts"
+    "lint": "cd flow_generated && eslint --fix $(jq '.files[]' -r tsconfig-files.json)"
   },
   "version": "0.0.0"
 }


### PR DESCRIPTION
package.json is updated so that `npm run lint` uses
"flow_generated/tsconfig-files.json" as its source of files to lint.

An immediate benefit is that it unbreaks the experience of running
`flowctl test` on just a subset of a larger catalog. Currently that will
barf because the linter observes typescript files *not* configured under
the current typescript project and produces an error.

In doing this I realized that our current glob pattern doesn't capture
multiple levels of directory hierarchy, and that our linting was
actually broken. This commit includes a bunch of linter updates / fixes
to get linting passing as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/142)
<!-- Reviewable:end -->
