### PR TITLE
Import transofrms when source schema is used

### DIFF
--- a/examples/all.flow.yaml
+++ b/examples/all.flow.yaml
@@ -13,3 +13,4 @@ import:
   - stock-stats/flow.yaml
   - temp-sensors/flow.yaml
   - wiki/flow.yaml
+  - source-schema/flow.yaml

--- a/examples/source-schema/README.md
+++ b/examples/source-schema/README.md
@@ -1,0 +1,24 @@
+# Transform Source Schemas
+
+Example of using a transform source schema to apply a more strict validation to the documents in a
+collection with a more permissive schema. This pattern allows you to be very permissive in capturing
+data from an external source, and defer validation until the derivation. The permissive capture will
+continue to accept data, but the restrictive derivation will error and stop processing when the
+first invalid document is encountered. You can then update the derivation to account for the invalid
+document, and it will catch back up from the historical data in the permissive collection.
+
+## Example
+
+We expect that documents captured by the `permissive` collection will look like 
+`{"id": "foo", "a": 1, "b": true, "c": 5.2}`. If any document doesn't match that, we still want to
+capture it, though, and just adjust our derivation so that it can cope with the new shape of the
+data. So say we capture the document `{"id": "foo", "a": "a string", "b": false, "c": 8.2}` into the
+`permissive` collection. When the `restrictive` derivation reads that document, it's going to fail
+with a validation error, since the source schema used in the derivation specifies that `a` must be
+an `integer`. This causes the `restrictive` derivation to halt processing.
+
+Then we update the `restrictive` derivation to handle the string data in `a`. First we relax the
+source schema to have `a: {type: [integer, string]}`. Then we update the code to do something
+sensible with the strings. Finally the updated derivation is applied by running `flowctl apply`, and
+it resumes processing right where it left off.
+

--- a/examples/source-schema/flow.ts
+++ b/examples/source-schema/flow.ts
@@ -1,0 +1,12 @@
+import { collections, interfaces, registers, transforms } from 'flow/modules';
+
+// Implementation for derivation flow.yaml#/collections/examples~1source-schema~1restrictive/derivation.
+export class ExamplesSourceSchemaRestrictive implements interfaces.ExamplesSourceSchemaRestrictive {
+    fromPermissivePublish(
+        source: transforms.ExamplesSourceSchemaRestrictivefromPermissiveSource,
+        _register: registers.ExamplesSourceSchemaRestrictive,
+        _previous: registers.ExamplesSourceSchemaRestrictive,
+    ): collections.ExamplesSourceSchemaRestrictive[] {
+        return [source];
+    }
+}

--- a/examples/source-schema/flow.yaml
+++ b/examples/source-schema/flow.yaml
@@ -1,0 +1,47 @@
+collections:
+  examples/source-schema/permissive:
+    schema:
+      type: object
+      description: "Allows any JSON object, as long as it has a string id field"
+      properties:
+        id: {type: string}
+      required: [id]
+    key: [/id]
+
+  examples/source-schema/restrictive:
+    schema:
+      type: object
+      properties:
+        id: {type: string}
+        a: {type: integer}
+        b: {type: boolean}
+        c: {type: number}
+      required: [id, a, b, c]
+    key: [/id]
+    derivation:
+      transform:
+        fromPermissive:
+          source:
+            name: examples/source-schema/permissive
+            schema:
+              type: object
+              description: "Require that the documents from permissive all have these fields"
+              properties:
+                id: {type: string}
+                a: {type: integer}
+                b: {type: boolean}
+                c: {type: number}
+              required: [id, a, b, c]
+          publish: {lambda: typescript}
+
+tests:
+  'document matching the source schema is passed through':
+    - ingest:
+        collection: examples/source-schema/permissive
+        documents:
+          - {id: 'one', a: 5, b: true, c: 7.65}
+    - verify:
+        collection: examples/source-schema/restrictive
+        documents:
+          - {id: 'one', a: 5, b: true, c: 7.65}
+

--- a/flow_generated/flow/collections.d.ts
+++ b/flow_generated/flow/collections.d.ts
@@ -417,6 +417,21 @@ export type ExamplesShoppingUsers = /* A user who may buy things from our site *
     name: string;
 };
 
+// Generated from examples/source-schema/flow.yaml?ptr=/collections/examples~1source-schema~1permissive/schema.
+// Referenced as schema of examples/source-schema/flow.yaml#/collections/examples~1source-schema~1permissive.
+export type ExamplesSourceSchemaPermissive = /* Allows any JSON object, as long as it has a string id field */ {
+    id: string;
+};
+
+// Generated from examples/source-schema/flow.yaml?ptr=/collections/examples~1source-schema~1restrictive/schema.
+// Referenced as schema of examples/source-schema/flow.yaml#/collections/examples~1source-schema~1restrictive.
+export type ExamplesSourceSchemaRestrictive = {
+    a: number;
+    b: boolean;
+    c: number;
+    id: string;
+};
+
 // Generated from examples/wiki/edits.flow.yaml?ptr=/collections/examples~1wiki~1edits/schema.
 // Referenced as schema of examples/wiki/edits.flow.yaml#/collections/examples~1wiki~1edits.
 export type ExamplesWikiEdits = {

--- a/flow_generated/flow/interfaces.d.ts
+++ b/flow_generated/flow/interfaces.d.ts
@@ -161,6 +161,16 @@ export interface ExamplesShoppingPurchases {
     ): collections.ExamplesShoppingPurchases[];
 }
 
+// Generated from derivation examples/source-schema/flow.yaml#/collections/examples~1source-schema~1restrictive/derivation.
+// Required to be implemented by examples/source-schema/flow.ts.
+export interface ExamplesSourceSchemaRestrictive {
+    fromPermissivePublish(
+        source: transforms.ExamplesSourceSchemaRestrictivefromPermissiveSource,
+        register: registers.ExamplesSourceSchemaRestrictive,
+        previous: registers.ExamplesSourceSchemaRestrictive,
+    ): collections.ExamplesSourceSchemaRestrictive[];
+}
+
 // Generated from derivation examples/wiki/pages.flow.yaml#/collections/examples~1wiki~1pages/derivation.
 // Required to be implemented by examples/wiki/pages.flow.ts.
 export interface ExamplesWikiPages {

--- a/flow_generated/flow/registers.d.ts
+++ b/flow_generated/flow/registers.d.ts
@@ -116,6 +116,10 @@ export type ExamplesShoppingPurchases = /* Roll up of all products that users ha
     userId: number;
 };
 
+// Generated from examples/source-schema/flow.yaml?ptr=/collections/examples~1source-schema~1restrictive/derivation/register/schema.
+// Referenced as register_schema of examples/source-schema/flow.yaml#/collections/examples~1source-schema~1restrictive/derivation.
+export type ExamplesSourceSchemaRestrictive = unknown;
+
 // Generated from examples/wiki/pages.flow.yaml?ptr=/collections/examples~1wiki~1pages/derivation/register/schema.
 // Referenced as register_schema of examples/wiki/pages.flow.yaml#/collections/examples~1wiki~1pages/derivation.
 export type ExamplesWikiPages = unknown;

--- a/flow_generated/flow/routes.ts
+++ b/flow_generated/flow/routes.ts
@@ -52,6 +52,8 @@ import { ExamplesShoppingPurchases } from '../../examples/shopping/purchases.flo
 
 import { SoakSetOpsSets, SoakSetOpsSetsRegister } from '../../examples/soak-tests/set-ops/flow';
 
+import { ExamplesSourceSchemaRestrictive } from '../../examples/source-schema/flow';
+
 import { StockDailyStats } from '../../examples/stock-stats/flow';
 
 import { TemperatureAverageByLocation, TemperatureAverageTemps } from '../../examples/temp-sensors/flow';
@@ -72,6 +74,7 @@ const __ExamplesSegmentToggles: interfaces.ExamplesSegmentToggles = new Examples
 const __ExamplesShoppingCartUpdatesWithProducts: interfaces.ExamplesShoppingCartUpdatesWithProducts = new ExamplesShoppingCartUpdatesWithProducts();
 const __ExamplesShoppingCarts: interfaces.ExamplesShoppingCarts = new ExamplesShoppingCarts();
 const __ExamplesShoppingPurchases: interfaces.ExamplesShoppingPurchases = new ExamplesShoppingPurchases();
+const __ExamplesSourceSchemaRestrictive: interfaces.ExamplesSourceSchemaRestrictive = new ExamplesSourceSchemaRestrictive();
 const __ExamplesWikiPages: interfaces.ExamplesWikiPages = new ExamplesWikiPages();
 const __MarketingClicksWithViews: interfaces.MarketingClicksWithViews = new MarketingClicksWithViews();
 const __MarketingPurchaseWithOffers: interfaces.MarketingPurchaseWithOffers = new MarketingPurchaseWithOffers();
@@ -161,6 +164,9 @@ const routes: { [path: string]: Lambda | undefined } = {
     ) as Lambda,
     '/derive/examples/shopping/purchases/purchaseActions/Publish': __ExamplesShoppingPurchases.purchaseActionsPublish.bind(
         __ExamplesShoppingPurchases,
+    ) as Lambda,
+    '/derive/examples/source-schema/restrictive/fromPermissive/Publish': __ExamplesSourceSchemaRestrictive.fromPermissivePublish.bind(
+        __ExamplesSourceSchemaRestrictive,
     ) as Lambda,
     '/derive/examples/wiki/pages/rollUpEdits/Publish': __ExamplesWikiPages.rollUpEditsPublish.bind(
         __ExamplesWikiPages,

--- a/flow_generated/flow/transforms.d.ts
+++ b/flow_generated/flow/transforms.d.ts
@@ -4,6 +4,15 @@ import * as anchors from './anchors';
 export type __module = null;
 export type __anchors_module = anchors.__module;
 
+// Generated from examples/source-schema/flow.yaml?ptr=/collections/examples~1source-schema~1restrictive/derivation/transform/fromPermissive/source/schema.
+// Referenced as source schema of transform examples/source-schema/flow.yaml#/collections/examples~1source-schema~1restrictive/derivation/transform/fromPermissive.
+export type ExamplesSourceSchemaRestrictivefromPermissiveSource = /* Require that the documents from permissive all have these fields */ {
+    a: number;
+    b: boolean;
+    c: number;
+    id: string;
+};
+
 // Generated from examples/stock-stats/schemas/L1-tick.schema.yaml#/$defs/withRequired.
 // Referenced as source schema of transform examples/stock-stats/flow.yaml#/collections/stock~1daily-stats/derivation/transform/fromTicks.
 export type StockDailyStatsfromTicksSource = /* Level-one market tick of a security. */ {

--- a/flow_generated/tsconfig-files.json
+++ b/flow_generated/tsconfig-files.json
@@ -18,6 +18,7 @@
     "../examples/shopping/carts.flow.ts",
     "../examples/shopping/purchases.flow.ts",
     "../examples/soak-tests/set-ops/flow.ts",
+    "../examples/source-schema/flow.ts",
     "../examples/stock-stats/flow.ts",
     "../examples/temp-sensors/flow.ts",
     "../examples/wiki/pages.flow.ts",


### PR DESCRIPTION
Typescript stubs were being generated without importing the `transforms`
module, even when a transform source schema was used. This resulted in a
typescript compilation error since the `source` function parameter
references `transforms`. This now conditionally imports `transofrms`
during stub generation if any transforms in the file use a source
schema.

Also adds a source-schema example catalog with a brief README explaining
their use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/144)
<!-- Reviewable:end -->
