### PR TITLE
typescript: generated stubs should use underscores

### DIFF
--- a/crates/build/src/nodejs/generators.rs
+++ b/crates/build/src/nodejs/generators.rs
@@ -192,7 +192,7 @@ export interface {name} {{
         .unwrap();
 
         for method in methods {
-            let signature = method.signature().into_iter().join("\n    ");
+            let signature = method.signature(false).into_iter().join("\n    ");
             writeln!(w, "    {};", signature).unwrap();
         }
         w.push_str("}\n");
@@ -322,7 +322,7 @@ export class {name} implements interfaces.{name} {{
             .unwrap();
 
             for method in methods {
-                let signature = method.signature().into_iter().join("\n    ");
+                let signature = method.signature(true).into_iter().join("\n    ");
                 writeln!(w, "    {} {{", signature).unwrap();
                 w.push_str("        throw new Error(\"Not implemented\");\n    }\n");
             }

--- a/crates/build/src/nodejs/interface.rs
+++ b/crates/build/src/nodejs/interface.rs
@@ -19,7 +19,7 @@ impl MethodType {
         w
     }
 
-    pub fn signature(&self, transform: &tables::Transform) -> Vec<String> {
+    pub fn signature(&self, transform: &tables::Transform, underscore: bool) -> Vec<String> {
         let tables::Transform {
             derivation,
             source_collection,
@@ -39,8 +39,10 @@ impl MethodType {
         let tgt = camel_case(derivation, true);
 
         let mut lines = Vec::new();
+        let underscore = if underscore { "_" } else { "" };
+
         lines.push(format!("{}(", self.method_name(transform)));
-        lines.push(format!("    source: {},", src));
+        lines.push(format!("    {}source: {},", underscore, src));
 
         match self {
             MethodType::Shuffle => {
@@ -50,8 +52,8 @@ impl MethodType {
                 lines.push(format!("): registers.{}[]", tgt));
             }
             MethodType::Publish => {
-                lines.push(format!("    register: registers.{},", tgt));
-                lines.push(format!("    previous: registers.{},", tgt));
+                lines.push(format!("    {}register: registers.{},", underscore, tgt));
+                lines.push(format!("    {}previous: registers.{},", underscore, tgt));
                 lines.push(format!("): collections.{}[]", tgt));
             }
         }
@@ -67,8 +69,8 @@ pub struct Method<'a> {
 }
 
 impl<'a> Method<'a> {
-    pub fn signature(&self) -> Vec<String> {
-        self.type_.signature(&self.transform)
+    pub fn signature(&self, underscore: bool) -> Vec<String> {
+        self.type_.signature(&self.transform, underscore)
     }
 }
 

--- a/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
+++ b/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
@@ -393,14 +393,14 @@ expression: intents
     // Implementation for derivation sub/module.yaml#/collections/local~1derivation/derivation.
     export class LocalDerivation implements interfaces.LocalDerivation {
         thereItIsUpdate(
-            source: collections.LocalDerivation,
+            _source: collections.LocalDerivation,
         ): registers.LocalDerivation[] {
             throw new Error("Not implemented");
         }
         whootPublish(
-            source: collections.SomeInput,
-            register: registers.LocalDerivation,
-            previous: registers.LocalDerivation,
+            _source: collections.SomeInput,
+            _register: registers.LocalDerivation,
+            _previous: registers.LocalDerivation,
         ): collections.LocalDerivation[] {
             throw new Error("Not implemented");
         }


### PR DESCRIPTION
To avoid linter errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/149)
<!-- Reviewable:end -->
