### PR TITLE
Make Flow key and rclock ranges inclusive

### DIFF
--- a/crates/protocol/src/flow.rs
+++ b/crates/protocol/src/flow.rs
@@ -427,7 +427,7 @@ pub mod test_spec {
 /// is responsible for.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RangeSpec {
-    /// [begin, end) exclusive range of keys to be shuffled to this reader.
+    /// [begin, end] inclusive range of keys to be shuffled to this reader.
     /// Ranges are with respect to a 32-bit hash of a packed document key.
     ///
     /// The choice of hash function is important: while it need not be
@@ -443,7 +443,7 @@ pub struct RangeSpec {
     pub key_begin: u32,
     #[prost(fixed32, tag="3")]
     pub key_end: u32,
-    /// Rotated [begin, end) exclusive ranges of Clocks.
+    /// Rotated [begin, end] inclusive ranges of Clocks.
     #[prost(fixed32, tag="4")]
     pub r_clock_begin: u32,
     #[prost(fixed32, tag="5")]

--- a/go/labels/labels.go
+++ b/go/labels/labels.go
@@ -22,7 +22,7 @@ const (
 	KeyBegin = "estuary.dev/key-begin"
 	// KeyBeginMin is the minimum possible key.
 	KeyBeginMin = "00000000"
-	// KeyEnd is a hexadecimal encoding of the ending key range (exclusive)
+	// KeyEnd is a hexadecimal encoding of the ending key range (inclusive)
 	// managed by this journal or shard, in an order-preserving packed []byte embedding.
 	KeyEnd = "estuary.dev/key-end"
 	// KeyEndMax is the maximum possible key.
@@ -42,13 +42,13 @@ const (
 	TaskTypeDerivation = "derivation"
 	// TaskTypeMaterialization is a "materialization" TaskType.
 	TaskTypeMaterialization = "materialization"
-	// RClockBegin is a uint64 in big-endian 16-char hexadecimal notation,
+	// RClockBegin is a uint32 in big-endian 8-char hexadecimal notation,
 	// which is the beginning rotated clock range (inclusive) managed by this shard.
 	RClockBegin = "estuary.dev/rclock-begin"
 	// RClockBeginMin is the minimum possible RClock.
 	RClockBeginMin = KeyBeginMin
-	// RClockEnd is a uint64 in big-endian 16-char hexadecimal notation,
-	// which is the ending rotated clock range (exclusive) managed by this shard.
+	// RClockEnd is a uint32 in big-endian 8-char hexadecimal notation,
+	// which is the ending rotated clock range (inclusive) managed by this shard.
 	RClockEnd = "estuary.dev/rclock-end"
 	// RClockEndMax is the maximum possible RClock.
 	RClockEndMax = KeyEndMax

--- a/go/labels/labels_test.go
+++ b/go/labels/labels_test.go
@@ -67,13 +67,13 @@ func TestRangeSpecParsingCases(t *testing.T) {
 		KeyEnd, KeyBeginMin,
 		RClockBegin, RClockBeginMin,
 		RClockEnd, RClockEndMax))
-	require.EqualError(t, err, "expected KeyBegin < KeyEnd (ffffffff vs 00000000)")
+	require.EqualError(t, err, "expected KeyBegin <= KeyEnd (ffffffff vs 00000000)")
 	_, err = ParseRangeSpec(pb.MustLabelSet(
 		KeyBegin, KeyBeginMin,
 		KeyEnd, KeyEndMax,
 		RClockBegin, RClockEndMax,
 		RClockEnd, RClockBeginMin))
-	require.EqualError(t, err, "expected RClockBegin < RClockEnd (ffffffff vs 00000000)")
+	require.EqualError(t, err, "expected RClockBegin <= RClockEnd (ffffffff vs 00000000)")
 }
 
 func TestRoundTripRangeSpecToLabels(t *testing.T) {

--- a/go/protocols/flow/flow.pb.go
+++ b/go/protocols/flow/flow.pb.go
@@ -1296,7 +1296,7 @@ var xxx_messageInfo_TestSpec_Step proto.InternalMessageInfo
 // RangeSpec describes the ranges of shuffle keys and r-clocks which a reader
 // is responsible for.
 type RangeSpec struct {
-	// [begin, end) exclusive range of keys to be shuffled to this reader.
+	// [begin, end] inclusive range of keys to be shuffled to this reader.
 	// Ranges are with respect to a 32-bit hash of a packed document key.
 	//
 	// The choice of hash function is important: while it need not be
@@ -1310,7 +1310,7 @@ type RangeSpec struct {
 	// checksum, using a fixed 32-byte key.
 	KeyBegin uint32 `protobuf:"fixed32,2,opt,name=key_begin,json=keyBegin,proto3" json:"key_begin,omitempty"`
 	KeyEnd   uint32 `protobuf:"fixed32,3,opt,name=key_end,json=keyEnd,proto3" json:"key_end,omitempty"`
-	// Rotated [begin, end) exclusive ranges of Clocks.
+	// Rotated [begin, end] inclusive ranges of Clocks.
 	RClockBegin          uint32   `protobuf:"fixed32,4,opt,name=r_clock_begin,json=rClockBegin,proto3" json:"r_clock_begin,omitempty"`
 	RClockEnd            uint32   `protobuf:"fixed32,5,opt,name=r_clock_end,json=rClockEnd,proto3" json:"r_clock_end,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/go/protocols/flow/flow.proto
+++ b/go/protocols/flow/flow.proto
@@ -378,7 +378,7 @@ message RangeSpec {
   // RangeSpec implements a custom Go String().
   option (gogoproto.goproto_stringer) = false;
 
-  // [begin, end) exclusive range of keys to be shuffled to this reader.
+  // [begin, end] inclusive range of keys to be shuffled to this reader.
   // Ranges are with respect to a 32-bit hash of a packed document key.
   //
   // The choice of hash function is important: while it need not be
@@ -392,7 +392,7 @@ message RangeSpec {
   // checksum, using a fixed 32-byte key.
   fixed32 key_begin = 2;
   fixed32 key_end = 3;
-  // Rotated [begin, end) exclusive ranges of Clocks.
+  // Rotated [begin, end] inclusive ranges of Clocks.
   fixed32 r_clock_begin = 4;
   fixed32 r_clock_end = 5;
 }

--- a/go/protocols/flow/shuffle_extensions.go
+++ b/go/protocols/flow/shuffle_extensions.go
@@ -47,10 +47,10 @@ func (m *JournalShuffle) Validate() error {
 
 // Validate returns a validation error of the RangeSpec.
 func (m *RangeSpec) Validate() error {
-	if m.KeyBegin >= m.KeyEnd {
-		return pb.NewValidationError("expected KeyBegin < KeyEnd (%08x vs %08x)", m.KeyBegin, m.KeyEnd)
-	} else if m.RClockBegin >= m.RClockEnd {
-		return pb.NewValidationError("expected RClockBegin < RClockEnd (%08x vs %08x)", m.RClockBegin, m.RClockEnd)
+	if m.KeyBegin > m.KeyEnd {
+		return pb.NewValidationError("expected KeyBegin <= KeyEnd (%08x vs %08x)", m.KeyBegin, m.KeyEnd)
+	} else if m.RClockBegin > m.RClockEnd {
+		return pb.NewValidationError("expected RClockBegin <= RClockEnd (%08x vs %08x)", m.RClockBegin, m.RClockEnd)
 	}
 	return nil
 }
@@ -62,11 +62,11 @@ func (m *RangeSpec) Less(r *RangeSpec) bool {
 	// If lhs & rhs share the exact same key range, then they order
 	// with respect to their RClock range.
 	if m.KeyBegin == r.KeyBegin && m.KeyEnd == r.KeyEnd {
-		if m.RClockBegin < r.RClockBegin && m.RClockEnd <= r.RClockBegin {
+		if m.RClockBegin < r.RClockBegin && m.RClockEnd < r.RClockBegin {
 			return true
 		}
 	}
-	return m.KeyBegin < r.KeyBegin && m.KeyEnd <= r.KeyBegin
+	return m.KeyBegin < r.KeyBegin && m.KeyEnd < r.KeyBegin
 }
 
 // Equal returns true if this RangeSpec exactly equals the other.

--- a/go/protocols/flow/shuffle_extensions_test.go
+++ b/go/protocols/flow/shuffle_extensions_test.go
@@ -60,7 +60,7 @@ func TestShuffleRequest(t *testing.T) {
 		Range: RangeSpec{
 			KeyBegin:    42,
 			KeyEnd:      32,
-			RClockBegin: 0,
+			RClockBegin: 1,
 			RClockEnd:   0,
 		},
 		Offset:    -1,
@@ -71,9 +71,9 @@ func TestShuffleRequest(t *testing.T) {
 	m.Resolution.Etcd.ClusterId = 1234
 	require.EqualError(t, m.Validate(), "Shuffle.Coordinator: not a valid token (bad coordinator)")
 	m.Shuffle.Coordinator = "a-coordinator"
-	require.EqualError(t, m.Validate(), "Range: expected KeyBegin < KeyEnd (0000002a vs 00000020)")
+	require.EqualError(t, m.Validate(), "Range: expected KeyBegin <= KeyEnd (0000002a vs 00000020)")
 	m.Range.KeyEnd = 52
-	require.EqualError(t, m.Validate(), "Range: expected RClockBegin < RClockEnd (00000000 vs 00000000)")
+	require.EqualError(t, m.Validate(), "Range: expected RClockBegin <= RClockEnd (00000001 vs 00000000)")
 	m.Range.RClockEnd = 12345
 	require.EqualError(t, m.Validate(), "invalid Offset (-1; expected 0 <= Offset <= MaxInt64)")
 	m.Offset = 200
@@ -119,7 +119,7 @@ func TestRangeSpecOrdering(t *testing.T) {
 	require.False(t, other.Equal(&model))
 
 	// |model| and |other| are continuous r-clock ranges, but non-overlapping.
-	other.RClockBegin = 0xd0
+	other.RClockBegin = 0xd1
 	require.True(t, model.Less(&other))
 	require.False(t, other.Less(&model))
 	require.False(t, other.Equal(&model))
@@ -131,7 +131,7 @@ func TestRangeSpecOrdering(t *testing.T) {
 
 	// |model| and |other| cover discontinuous chunks of key range.
 	// They continue to cover overlapping r-clock range.
-	model.KeyEnd = 0xa0
+	model.KeyEnd = 0x9f
 	other.KeyBegin = 0xaa
 	require.True(t, model.Less(&other))
 	require.False(t, other.Less(&model))

--- a/go/runtime/split_workflow.go
+++ b/go/runtime/split_workflow.go
@@ -192,11 +192,11 @@ func StartSplit(ctx context.Context, svc *consumer.Service, req *pf.SplitRequest
 	var lhsRange, rhsRange = parentRange, parentRange
 
 	if req.SplitOnKey {
-		var pivot = (parentRange.KeyBegin / 2) + (parentRange.KeyEnd / 2)
-		lhsRange.KeyEnd, rhsRange.KeyBegin = pivot, pivot
+		var pivot = uint32((uint64(parentRange.KeyBegin) + uint64(parentRange.KeyEnd) - 1) / 2)
+		lhsRange.KeyEnd, rhsRange.KeyBegin = pivot, pivot+1
 	} else {
-		var pivot = (parentRange.RClockBegin / 2) + (parentRange.RClockEnd / 2)
-		lhsRange.RClockEnd, rhsRange.RClockBegin = pivot, pivot
+		var pivot = uint32((uint64(parentRange.RClockBegin) + uint64(parentRange.RClockEnd) - 1) / 2)
+		lhsRange.RClockEnd, rhsRange.RClockBegin = pivot, pivot+1
 	}
 	rhsSpec.LabelSet = labels.EncodeRange(rhsRange, rhsSpec.LabelSet)
 

--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -586,12 +586,12 @@ func newShuffleMembers(specs []*pc.ShardSpec) ([]shuffleMember, error) {
 // rangeSpan locates the span of []shuffleMember having owned key ranges
 // which overlap the given range.
 func rangeSpan(s []shuffleMember, begin, end uint32) (start, stop int) {
-	// Find the index of the first subscriber having |begin| < |keyEnd|.
+	// Find the index of the first subscriber having |begin| <= |keyEnd|.
 	start = sort.Search(len(s), func(i int) bool {
-		return begin < s[i].range_.KeyEnd
+		return begin <= s[i].range_.KeyEnd
 	})
 	// Walk forwards while |keyBegin| < |end|.
-	for stop = start; stop != len(s) && s[stop].range_.KeyBegin < end; stop++ {
+	for stop = start; stop != len(s) && s[stop].range_.KeyBegin <= end; stop++ {
 	}
 	return
 }

--- a/go/shuffle/read_test.go
+++ b/go/shuffle/read_test.go
@@ -395,7 +395,7 @@ func TestShuffleMemberOrdering(t *testing.T) {
 		start, stop int
 	}{
 		// Exact matches of ranges.
-		{0xaaaaaaaa, 0xbbbbbbbb, 0, 1},
+		{0xaaaaaaaa, 0xbbbbbbba, 0, 1},
 		{0xbbbbbbbb, 0xffffffff, 1, 3},
 		// Partial overlap of single entry at list begin & end.
 		{0xa0000000, 0xb0000000, 0, 1},
@@ -452,9 +452,9 @@ func buildReadTestJournalsAndTransforms() (flow.Journals, []*pc.ShardSpec, *pf.C
 		part  int
 	}{
 		{"1", "abc", "cccccccc", "ffffffff", 0}, // foo/bar=1/baz=abc/part=00
-		{"1", "abc", "bbbbbbbb", "cccccccc", 1}, // foo/bar=1/baz=abc/part=01
-		{"1", "def", "aaaaaaaa", "bbbbbbbb", 0}, // foo/bar=1/baz=def/part=00
-		{"2", "def", "aaaaaaaa", "bbbbbbbb", 0}, // foo/bar=2/baz=def/part=00
+		{"1", "abc", "bbbbbbbb", "cccccccb", 1}, // foo/bar=1/baz=abc/part=01
+		{"1", "def", "aaaaaaaa", "bbbbbbba", 0}, // foo/bar=1/baz=def/part=00
+		{"2", "def", "aaaaaaaa", "bbbbbbba", 0}, // foo/bar=2/baz=def/part=00
 		{"2", "def", "bbbbbbbb", "ffffffff", 1}, // foo/bar=2/baz=def/part=01
 	} {
 		var name = fmt.Sprintf("foo/bar=%s/baz=%s/part=%02d", j.bar, j.baz, j.part)
@@ -478,12 +478,12 @@ func buildReadTestJournalsAndTransforms() (flow.Journals, []*pc.ShardSpec, *pf.C
 	var shards = []*pc.ShardSpec{
 		{Id: "shard/0", LabelSet: pb.MustLabelSet(
 			labels.KeyBegin, "aaaaaaaa",
-			labels.KeyEnd, "bbbbbbbb",
+			labels.KeyEnd, "bbbbbbba",
 			labels.RClockBegin, "00000000",
 			labels.RClockEnd, "ffffffff")},
 		{Id: "shard/1", LabelSet: pb.MustLabelSet(
 			labels.KeyBegin, "bbbbbbbb",
-			labels.KeyEnd, "cccccccc",
+			labels.KeyEnd, "cccccccb",
 			labels.RClockBegin, "00000000",
 			labels.RClockEnd, "ffffffff")},
 		{Id: "shard/2", LabelSet: pb.MustLabelSet(

--- a/go/shuffle/reader_test.go
+++ b/go/shuffle/reader_test.go
@@ -174,7 +174,7 @@ func TestConsumerIntegration(t *testing.T) {
 			MaxTxnDuration:    time.Second,
 			LabelSet: flowLabels.EncodeRange(pf.RangeSpec{
 				KeyBegin:    uint32((math.MaxUint32 / len(shards)) * i),
-				KeyEnd:      uint32((math.MaxUint32 / len(shards)) * (i + 1)),
+				KeyEnd:      uint32((math.MaxUint32/len(shards))*(i+1) - 1),
 				RClockBegin: 0,
 				RClockEnd:   math.MaxUint32,
 			}, pb.LabelSet{}),

--- a/go/shuffle/subscriber.go
+++ b/go/shuffle/subscriber.go
@@ -65,9 +65,9 @@ type subscribers []subscriber
 
 // keySpan locates the span of indices having ranges which cover the given key.
 func (s subscribers) keySpan(key uint32) (start, stop int) {
-	// Find the index of the first subscriber having |key| < KeyEnd.
+	// Find the index of the first subscriber having |key| <= KeyEnd.
 	start = sort.Search(len(s), func(i int) bool {
-		return key < s[i].Range.KeyEnd
+		return key <= s[i].Range.KeyEnd
 	})
 	// Walk forwards while KeyBegin <= |key|.
 	for stop = start; stop != len(s) && s[stop].Range.KeyBegin <= key; stop++ {

--- a/go/shuffle/subscriber_test.go
+++ b/go/shuffle/subscriber_test.go
@@ -89,11 +89,11 @@ func TestSubscriberKeyRangesWithShuffledAdd(t *testing.T) {
 		mk(10, 100),  // 0
 		mk(10, 100),  // 1
 		mk(10, 100),  // 2
-		mk(200, 300), // 3
-		mk(300, 400), // 4
-		mk(300, 400), // 5
-		mk(600, 700), // 6
-		mk(600, 700), // 7
+		mk(200, 299), // 3
+		mk(300, 399), // 4
+		mk(300, 399), // 5
+		mk(600, 699), // 6
+		mk(600, 699), // 7
 		mk(900, 999), // 8
 	}
 	// Perturb fixtures randomly; we should not depend on order.
@@ -114,7 +114,7 @@ func TestSubscriberKeyRangesWithShuffledAdd(t *testing.T) {
 		{0, 0, 0},
 		{10, 0, 3},
 		{50, 0, 3},
-		{100, 3, 3},
+		{100, 0, 3},
 		{111, 3, 3},
 		{200, 3, 4},
 		{350, 4, 6},
@@ -125,12 +125,12 @@ func TestSubscriberKeyRangesWithShuffledAdd(t *testing.T) {
 		{690, 6, 8},
 		{899, 8, 8},
 		{950, 8, 9},
-		{999, 9, 9},
+		{999, 8, 9},
 		{10000, 9, 9},
 	} {
 		var start, stop = s.keySpan(tc.k)
-		require.Equal(t, tc.start, start)
-		require.Equal(t, tc.stop, stop)
+		require.Equalf(t, tc.start, start, "tc: %#v, actualStart: %v", tc, start)
+		require.Equalf(t, tc.stop, stop, "tc: %#v, actualStop: %v", tc, stop)
 	}
 
 	for _, tc := range []struct {
@@ -139,14 +139,14 @@ func TestSubscriberKeyRangesWithShuffledAdd(t *testing.T) {
 	}{
 		// Repetitions of key-ranges are fine.
 		{10, 100, 3},
-		{300, 400, 6},
+		{300, 399, 6},
 		// As are insertions into list middle.
-		{100, 200, 3},
+		{101, 199, 3},
 		{450, 460, 6},
 		// Or begining.
-		{0, 10, 0},
+		{0, 9, 0},
 		// Or end.
-		{999, 1000, 9},
+		{1000, 1001, 9},
 
 		// Overlaps are not a okay, at beginning.
 		{0, 11, -1},
@@ -163,10 +163,10 @@ func TestSubscriberKeyRangesWithShuffledAdd(t *testing.T) {
 			RClockEnd: math.MaxUint32,
 		})
 		if tc.index != -1 {
-			require.NoError(t, err)
+			require.NoErrorf(t, err, "tc: %#v", tc)
 			require.Equal(t, tc.index, ind)
 		} else {
-			require.Error(t, err)
+			require.Errorf(t, err, "tc: %#v, index: %v", tc, ind)
 		}
 	}
 }
@@ -211,16 +211,16 @@ func TestSubscriberResponseStaging(t *testing.T) {
 			Shuffle: pf.JournalShuffle{Shuffle: &pf.Shuffle{FilterRClocks: true}},
 			Range: pf.RangeSpec{
 				KeyBegin:    0,
-				KeyEnd:      1 << 31,
+				KeyEnd:      1<<31 - 1,
 				RClockBegin: 0,
-				RClockEnd:   1 << 31,
+				RClockEnd:   1<<31 - 1,
 			},
 		},
 		{ // Sees first half of keyspace, and second half of clocks.
 			Shuffle: pf.JournalShuffle{Shuffle: &pf.Shuffle{FilterRClocks: true}},
 			Range: pf.RangeSpec{
 				KeyBegin:    0x00000000,
-				KeyEnd:      1 << 31,
+				KeyEnd:      1<<31 - 1,
 				RClockBegin: 1 << 31,
 				RClockEnd:   1<<32 - 1,
 			},


### PR DESCRIPTION
The ranges used for key and rclock values were inclusive at the
beginning and exclusive at the end. This ended up being a little tricky
to work with, as it required a special case for handling hashed values
at the MaxUint32 boundary. It also presented challenges when
constructing Flow 32 bit range specs from other (kinesis, for example)
ranges that use more bits to represent their ranges. Just using the high
32 bits from larger representations could result in 32 bit ranges where
begin == end (empty ranges), which require even more special cases.

The solution implemented here is to make these ranges inclusive on both
ends. This allows the ranges to fully represent all possible hashed
values, and requires no special cases for MaxUint32. Ranges where begin
== end are now also valid and non-empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/157)
<!-- Reviewable:end -->
