### PR TITLE
Set the ResourcePath in webhook driver validation

### DIFF
--- a/crates/models/src/build/mod.rs
+++ b/crates/models/src/build/mod.rs
@@ -225,7 +225,7 @@ pub fn encode_resource_path(resource_path: &[impl AsRef<str>]) -> String {
     for c in parts.join("/").chars() {
         match c {
             // Note that '%' is not included (it must be escaped).
-            '-' | '_' | '+' | '/' | '.' | '=' => name.push(c),
+            '-' | '_' | '+' | '.' | '=' => name.push(c),
             _ if c.is_alphanumeric() => name.push(c),
             c => name.extend(percent_encoding::utf8_percent_encode(
                 &c.to_string(),
@@ -248,7 +248,15 @@ mod test {
             "a/part%".to_string(),
             "_¾the-=res+.".to_string(),
         ]);
-        assert_eq!(&out, "he%21lo৬/a/part%25/_¾the-=res+.");
+        assert_eq!(&out, "he%21lo৬%2Fa%2Fpart%25%2F_¾the-=res+.");
+    }
+
+    #[test]
+    fn test_arbitrary_webhook_urls() {
+        let url =
+            "http://user:password@foo.bar.example.com:9000/hooks///baz?type=critical&test=true";
+        let out = encode_resource_path(&vec![url.to_string()]);
+        assert_eq!(&out, "http%3A%2F%2Fuser%3Apassword%40foo.bar.example.com%3A9000%2Fhooks%2F%2F%2Fbaz%3Ftype=critical%26test=true");
     }
 }
 

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -1686,7 +1686,7 @@ All {
                         delta_updates: true,
                         shuffle: Some(
                             Shuffle {
-                                group_name: "materialize/testing/webhook/deliveries/Web%21hook/foo%20bar",
+                                group_name: "materialize/testing/webhook/deliveries/Web%21hook%2Ffoo%20bar",
                                 source_collection: "testing/int-string",
                                 source_partitions: Some(
                                     LabelSelector {
@@ -1954,7 +1954,7 @@ All {
                         delta_updates: true,
                         shuffle: Some(
                             Shuffle {
-                                group_name: "materialize/testing/webhook/deliveries/targe+/two",
+                                group_name: "materialize/testing/webhook/deliveries/targe+%2Ftwo",
                                 source_collection: "testing/int-halve",
                                 source_partitions: Some(
                                     LabelSelector {

--- a/go.mod
+++ b/go.mod
@@ -33,4 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
-replace go.gazette.dev/core => github.com/jgraettinger/gazette v0.0.0-20210712201359-6e93807e1f32
+replace go.gazette.dev/core => github.com/jgraettinger/gazette v0.0.0-20210723193831-214b3ba8ba58

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LF
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jgraettinger/cockroach-encoding v1.1.0 h1:TRSWxnWdjgT1hcfn3aFa3dwhzNa8VHifsKj3gj8cD6E=
 github.com/jgraettinger/cockroach-encoding v1.1.0/go.mod h1:gcht+UqiTiDC6NEF7DLHUXQStSlWjogvhlkAttXVtmE=
-github.com/jgraettinger/gazette v0.0.0-20210712201359-6e93807e1f32 h1:NGlUPoEsn97MuUPWngxsZd2DSrXlrhhtbZfU/H6vmNg=
-github.com/jgraettinger/gazette v0.0.0-20210712201359-6e93807e1f32/go.mod h1:mLiMduRn0QAZdBbVIzXu3Mv6Dq5UsivgZ7Kcy6J7Ucc=
+github.com/jgraettinger/gazette v0.0.0-20210723193831-214b3ba8ba58 h1:HkysM6GFb53wRw60FtYbiu5OBeJKKq0ODeGNbZEF4pY=
+github.com/jgraettinger/gazette v0.0.0-20210723193831-214b3ba8ba58/go.mod h1:mLiMduRn0QAZdBbVIzXu3Mv6Dq5UsivgZ7Kcy6J7Ucc=
 github.com/jgraettinger/urkel v0.1.2/go.mod h1:PQ2/GQdeAtepWvfbEczTdzYM+bmB0qgB0L23qeUaKbA=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/go/materialize/driver/webhook/driver.go
+++ b/go/materialize/driver/webhook/driver.go
@@ -90,6 +90,7 @@ func (driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.Valida
 			Constraints: constraints,
 			// Only delta updates are supported by webhooks.
 			DeltaUpdates: true,
+			ResourcePath: []string{resolved.String()},
 		})
 	}
 


### PR DESCRIPTION
Webhooks use the endpoint address url as the ResourcePath. This means we need to return that ResourcePath from the webhook driver and thoroughly percent-encode it before sending it over to Gazette.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/170)
<!-- Reviewable:end -->
