### PR TITLE
Keep stdin open when Flow runs docker containers

### DIFF
--- a/go/capture/driver/airbyte/connector.go
+++ b/go/capture/driver/airbyte/connector.go
@@ -51,6 +51,10 @@ func RunConnector(
 	var imageArgs = []string{
 		"docker",
 		"run",
+		// Without the --interactive flag, running connectors with docker-for-mac will sometimes
+		// result in no output on stdout. I have absolutely no idea why. If you ever learn the
+		// reason for this, please explain to Phil.
+		"--interactive",
 		"--rm",
 	}
 	for name, m := range jsonFiles {

--- a/go/materialize/driver/jsonimage/driver.go
+++ b/go/materialize/driver/jsonimage/driver.go
@@ -199,12 +199,16 @@ func invokeConnector(
 ) error {
 
 	/*
-		return exec.Command(
-			"docker",
-			"run",
-			"--rm",
-			c.Image,
-		)
+	   return exec.Command(
+	       "docker",
+	       "run",
+	       // Without the --interactive flag, running connectors with docker-for-mac will sometimes
+	       // result in no output on stdout. I have absolutely no idea why. If you ever learn the
+	       // reason for this, please explain to Phil.
+	       "--interactive",
+	       "--rm",
+	       c.Image,
+	   )
 	*/
 	var parts = strings.Split(image, " ")
 	var cmd = exec.Command(parts[0], parts[1:]...)


### PR DESCRIPTION
When Flow is running on a mac using docker-for-mac, containers will
often not produce any output on stdout unless the `--interactive` flag
is provided. I have absolutely no idea why, but it seems to work
reliably with that flag added, and I don't see a down side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/176)
<!-- Reviewable:end -->
