### PR TITLE
Enable debug info in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,6 @@
 resolver = "2"
 members = [ "crates/*"]
 
-[profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
-
 [profile.release]
 incremental = true
 debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.


### PR DESCRIPTION
This should make debugging more consistent. Without this change it was impossible to (for example, on my machine) place a breakpoint in the file `collection.rs`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/198)
<!-- Reviewable:end -->
