### PR TITLE
downgrade from Go 1.16.7 => 1.16.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,7 @@
 	// Run extra environment setup required to build & test Flow.
 	// We're using a base image which is compatible with our CI runner,
 	// and thus use the same make target.
-	"postCreateCommand": "make extra-ci-runner-setup && go mod download",
+	"postCreateCommand": "make extra-ci-runner-setup && make package",
 	// This user matches the user that's created inside the flow image
 	"remoteUser": "flow",
 	"overrideCommand": false

--- a/.devcontainer/github-ubuntu-2004.Dockerfile
+++ b/.devcontainer/github-ubuntu-2004.Dockerfile
@@ -82,8 +82,9 @@ RUN rustup set profile default \
  && rustup component add clippy rustfmt rust-docs
 
 ## Install Go.
-ARG GOLANG_VERSION=1.16.7
-ARG GOLANG_SHA256=7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04
+## TODO(johnny): Downgrade from 1.16.7 => 1.16.6 (#191)
+ARG GOLANG_VERSION=1.16.6
+ARG GOLANG_SHA256=be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d
 ENV PATH=/usr/local/go/bin:$PATH
 
 RUN curl -L -o /tmp/golang.tgz \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,10 @@ jobs:
           submodules: true
 
       # We require a minimal Go version of 1.16.
+      # TODO(johnny): Temporarily downgrade from 1.16.7 => 1.16.6 (issue #191).
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.16"
+          go-version: "1.16.6"
 
       - run: make extra-ci-runner-setup
       - run: make print-versions

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,11 @@ GO_BUILD_DEPS = \
 # Build rules:
 
 # `protoc-gen-gogo` is used to compile Go protobufs.
+# We use the go module system to pull down, locate, and include additional
+# protobuf sources during the build. For example, Flow protobufs include
+# Gazette protobufs, which are located via the `go mod` tool.
 ${TOOLBIN}/protoc-gen-gogo:
-	./go.sh mod download github.com/golang/protobuf
+	./go.sh mod download
 	./go.sh build -o $@ github.com/gogo/protobuf/protoc-gen-gogo
 
 # `etcd` is used for testing, and packaged as a release artifact.


### PR DESCRIPTION
Also have Codespaces build the entire project on first initialization.

Fixes #191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/200)
<!-- Reviewable:end -->
