### PR TITLE
Switch JSON schema to use fancy-regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,18 +307,19 @@ dependencies = [
 name = "doc"
 version = "0.0.0"
 dependencies = [
+ "fancy-regex",
  "insta",
  "itertools",
  "json",
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tinyvec",
+ "tracing",
  "url",
 ]
 
@@ -352,6 +368,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -617,16 +643,17 @@ dependencies = [
 name = "json"
 version = "0.0.0"
 dependencies = [
+ "fancy-regex",
  "fxhash",
  "glob",
  "itertools",
  "percent-encoding",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tinyvec",
+ "tracing",
  "url",
 ]
 

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -9,12 +9,13 @@ json = { path = "../json", version = "0.0.0" }
 
 itertools = "*"
 lazy_static = "*"
-regex = "*"
+fancy-regex = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = { version =  "*", features = ["raw_value"] }
 serde_yaml = "*"
 thiserror = "*"
 tinyvec = {version = "*", features = ["alloc"]}
+tracing = "*"
 url = "*"
 
 [dev-dependencies]

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -8,12 +8,13 @@ edition = "2018"
 fxhash = "*"
 itertools = "*"
 percent-encoding = "*"
-regex = "*"
+fancy-regex = "*"
 serde = "*"
 serde_json = "*"
 serde_yaml = "*"
 thiserror = "*"
 tinyvec = {version = "*", features = ["alloc"]}
+tracing = "*"
 url = "*"
 
 [dev-dependencies]

--- a/crates/json/src/schema/build.rs
+++ b/crates/json/src/schema/build.rs
@@ -3,7 +3,7 @@ use crate::schema::{
     Schema, Validation,
 };
 use crate::{de, NoopWalker, Number};
-use regex;
+use fancy_regex as regex;
 use serde::Deserialize;
 use serde_json as sj;
 use thiserror;

--- a/crates/json/src/schema/mod.rs
+++ b/crates/json/src/schema/mod.rs
@@ -118,7 +118,7 @@ pub enum Application {
         name_interned: intern::Set,
     },
     PatternProperties {
-        re: regex::Regex,
+        re: fancy_regex::Regex,
     },
     AdditionalProperties,
     UnevaluatedProperties,
@@ -231,7 +231,7 @@ pub enum Validation {
     // String-specific validations.
     MaxLength(usize),
     MinLength(usize),
-    Pattern(regex::Regex),
+    Pattern(fancy_regex::Regex),
     // Format(String),
 
     // Number-specific validations.

--- a/crates/json/tests/schema_test.rs
+++ b/crates/json/tests/schema_test.rs
@@ -22,6 +22,9 @@ fn test_bassssic() -> Result {
        },
        "patternProperties": {
            "foo$": true,
+           // use a "fancy" regex to ensure that we're compiling these with a regex library that
+           // supports them.
+           r##"r(#*)".*?"\1"##: true,
        },
        "readOnly": true,
        "required": ["baz", "foo"],


### PR DESCRIPTION
Resolves #196

Changes our JSON schema to use the `fancy-regex` crate so that
look-ahead and look-behind are supported. This brings us into compliance
with the JSON Schema standard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/201)
<!-- Reviewable:end -->
