### PR TITLE
Check for context cancellation in replay reads

### DIFF
--- a/go/shuffle/reader.go
+++ b/go/shuffle/reader.go
@@ -107,6 +107,8 @@ func StartReplayRead(ctx context.Context, rb *ReadBuilder, journal pb.Journal, b
 
 			if env, err = r.next(); err == nil {
 				return env, err
+			} else if ctx.Err() != nil {
+				return message.Envelope{}, ctx.Err()
 			} else if r.resp.TerminalError != "" {
 				return message.Envelope{}, fmt.Errorf(r.resp.TerminalError)
 			} else if err == io.EOF {


### PR DESCRIPTION
Resolves #182 

Turns out that I wasn't able to reproduce this, but based on what I see in the code, it seems like this was indeed the cause of the flowctl run that overstays its welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/202)
<!-- Reviewable:end -->
