### PR TITLE
Update dbname to database in specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ materializations:
         # (Use host: host.docker.internal when running Docker for Windows/Mac).
         host: localhost
         password: password
-        dbname: postgres
+        database: postgres
         user: postgres
         port: 5432
     bindings:

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
@@ -102,7 +102,7 @@ Tables {
             scope: test://example/catalog.yaml#/materializations/a~1materialization,
             materialization: a/materialization,
             endpoint_type: "Postgresql",
-            endpoint_spec: {"dbname":null,"host":"localhost","password":"whoops","port":null,"user":"somebody"},
+            endpoint_spec: {"host":"localhost","password":"whoops","user":"somebody"},
         },
         Materialization {
             scope: test://example/catalog.yaml#/materializations/to~1sqlite,

--- a/crates/sources/src/specs.rs
+++ b/crates/sources/src/specs.rs
@@ -375,13 +375,15 @@ pub struct PostgresConfig {
     /// # Host address of the database.
     pub host: String,
     /// # Port of the database (default: 5432).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
     /// # Connection user.
     pub user: String,
     /// # Connection password.
     pub password: String,
     /// # Logical database (default: $user).
-    pub dbname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
 }
 
 /// Sqlite endpoint configuration.

--- a/examples/acmeBank.flow.yaml
+++ b/examples/acmeBank.flow.yaml
@@ -50,7 +50,7 @@ collections:
 #        # (Use host: host.docker.internal when running Docker for Windows/Mac).
 #        host: localhost
 #        password: password
-#        dbname: postgres
+#        database: postgres
 #        user: postgres
 #        port: 5432
 #    bindings:


### PR DESCRIPTION
The postgres materialization config was changed from using 'dbname' to
'database'. This change updates the specs on the rust side to match
that. This also adds serde attributes to optional fields to prevent them
from being serialized if they are `None`. Without those attributes,
undefined fields were being serialized in the connector config as
explicit nulls.

Fixes #216

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/217)
<!-- Reviewable:end -->
