### PR TITLE
Publish Docker images to ghcr.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,11 @@ jobs:
           echo "${{ secrets.QUAY_TOKEN }}" | \
             docker login --username ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
 
+      - name: Login to GitHub container registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            docker login --username ${{ github.actor }} --password-stdin ghcr.io
+
       - name: Cache/Restore Rust dependencies.
         uses: actions/cache@v2
         with:
@@ -77,8 +82,8 @@ jobs:
         shell: bash
       - run: make package
       - run: make docker-image
-      - run: make docker-push-to-quay
+      - run: make docker-push
       - if: ${{ github.ref == 'refs/heads/master' }}
-        run: make docker-push-quay-dev
+        run: make docker-push-dev
       - run: cargo install cargo-cache --no-default-features --features ci-autoclean
       - run: cargo-cache

--- a/Makefile
+++ b/Makefile
@@ -153,25 +153,23 @@ package: $(PACKAGE_TARGETS)
 docker-image:
 	docker build \
 		--file ${ROOTDIR}/.devcontainer/release.Dockerfile \
-		--tag docker.pkg.github.com/estuary/flow/bin:${VERSION} \
 		--tag quay.io/estuary/flow:${VERSION} \
 		--tag quay.io/estuary/flow:dev \
+		--tag ghcr.io/estuary/flow:${VERSION} \
+		--tag ghcr.io/estuary/flow:dev \
 		${PKGDIR}/
 
-.PHONY: docker-push-to-quay
-docker-push-to-quay:
+.PHONY: docker-push
+docker-push:
 	docker push quay.io/estuary/flow:${VERSION}
+	docker push ghcr.io/estuary/flow:${VERSION}
 
 # This is used by the GH Action workflow to push the 'dev' tag.
 # It is invoked only for builds on the master branch.
-.PHONY: docker-push-quay-dev
-docker-push-quay-dev:
+.PHONY: docker-push-dev
+docker-push-dev:
 	docker push quay.io/estuary/flow:dev
-
-# This works , but is currently disabled. See comment in .github/workflows/main.yml.
-# .PHONY: docker-push-to-github
-# docker-push-to-github: docker-image
-# 	docker push docker.pkg.github.com/estuary/flow/bin:${VERSION}
+	docker push ghcr.io/estuary/flow:dev
 
 ##########################################################################
 # Make targets used for development:


### PR DESCRIPTION
We'd like to consolidate on using GitHub's container registry.

We still reference the quay.io hosted images everywhere, so we can't reasonably remove that all at once. So we'll start by publishing the images to both registries, then we can update the quay.io references to use ghcr.io instead, then we can sunset quay.io entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/218)
<!-- Reviewable:end -->
