### PR TITLE
Make the default target to build the rust side and then the go side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ GO_BUILD_DEPS = \
 ##########################################################################
 # Build rules:
 
+.PHONY: default
+default: rust-build package
+
 # `etcd` is used for testing, and packaged as a release artifact.
 ${TOOLBIN}/etcd:
 	mkdir -p ${TOOLBIN} \


### PR DESCRIPTION
I struggled a little bit at first to figure out how to build flowctl.. And then realized today that if the rust side changes it must be built beforehand. This just adds a default target and builds them both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/219)
<!-- Reviewable:end -->
