### PR TITLE
catalog builds: table ordering refactor, and improved implicit projections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,7 @@ dependencies = [
  "serde_yaml",
  "sources",
  "strsim 0.10.0",
+ "superslice",
  "thiserror",
  "tracing",
  "unicode-normalization",

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -160,6 +160,7 @@ where
         &captures,
         &collections,
         &derivations,
+        &fetches,
         &imports,
         &journal_rules,
         &materialization_bindings,

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -51,7 +51,7 @@ where
     let mut all_tables = load_and_validate(root_url, root_spec, fetcher, drivers).await;
     all_tables
         .meta
-        .push_row(uuid::Uuid::new_v4(), config.clone());
+        .insert_row(uuid::Uuid::new_v4(), config.clone());
 
     // Apply any extra journal rules of the configuration.
     for (index, rule) in config
@@ -61,7 +61,7 @@ where
         .into_iter()
         .enumerate()
     {
-        all_tables.journal_rules.push_row(
+        all_tables.journal_rules.insert_row(
             url::Url::parse(&format!("build://extra_journal_rules/{}", index)).unwrap(),
             models::names::Rule::new(&rule.rule),
             rule,
@@ -75,7 +75,7 @@ where
         .into_iter()
         .enumerate()
     {
-        all_tables.shard_rules.push_row(
+        all_tables.shard_rules.insert_row(
             url::Url::parse(&format!("build://extra_shard_rules/{}", index)).unwrap(),
             models::names::Rule::new(&rule.rule),
             rule,

--- a/crates/build/src/nodejs/mod.rs
+++ b/crates/build/src/nodejs/mod.rs
@@ -225,7 +225,7 @@ pub fn pack_package(package_dir: &path::Path) -> Result<tables::Resources, anyho
     tracing::info!("built NodeJS pack {:?}", pack);
 
     let mut resources = tables::Resources::new();
-    resources.push_row(
+    resources.insert_row(
         Url::from_file_path(&pack).unwrap(),
         flow::ContentType::NpmPackage,
         bytes::Bytes::from(std::fs::read(&pack)?),

--- a/crates/derive/src/schema_api.rs
+++ b/crates/derive/src/schema_api.rs
@@ -52,7 +52,7 @@ impl cgo::Service for API {
                 let mut table = tables::SchemaDocs::new();
                 for (uri, dom) in bundle {
                     let dom: serde_json::Value = serde_json::from_str(&dom)?;
-                    table.push_row(Url::parse(&uri)?, dom);
+                    table.insert_row(Url::parse(&uri)?, dom);
                 }
                 let index = tables::SchemaDoc::leak_index(&table)?;
 

--- a/crates/models/src/build/bundle.rs
+++ b/crates/models/src/build/bundle.rs
@@ -7,8 +7,8 @@ use url::Url;
 // Referenced external schemas are inlined into the document as definitions.
 pub fn bundled_schema(
     schema: &Url,
-    imports: &[&tables::Import],
-    schema_docs: &[&tables::SchemaDoc],
+    imports: &[tables::Import],
+    schema_docs: &[tables::SchemaDoc],
 ) -> Value {
     // Collect all dependencies of |schema|, inclusive of |schema| itself
     // (as the first item). Project each dependency to a schema document

--- a/crates/models/src/tables/behaviors.rs
+++ b/crates/models/src/tables/behaviors.rs
@@ -56,7 +56,7 @@ impl super::SchemaDoc {
 impl super::Import {
     // path_exists determines whether a forward or backwards import path exists between
     // |src_scope| and |tgt_scope|.
-    pub fn path_exists(imports: &[&Self], src_scope: &Url, tgt_scope: &Url) -> bool {
+    pub fn path_exists(imports: &[Self], src_scope: &Url, tgt_scope: &Url) -> bool {
         let edges = |from: &Url| {
             let range = imports.equal_range_by_key(&from, |import| &import.from_resource);
             imports[range].iter().map(|import| &import.to_resource)
@@ -84,7 +84,7 @@ impl super::Import {
     // directly or indirectly imports, where |src| is included as the first item.
     // |src| must not have a fragment or transitive_imports will panic.
     pub fn transitive_imports<'a>(
-        imports: &'a [&Self],
+        imports: &'a [Self],
         src: &'a Url,
     ) -> impl Iterator<Item = &'a Url> + 'a {
         assert!(!src.fragment().is_some());

--- a/crates/models/src/tables/macros.rs
+++ b/crates/models/src/tables/macros.rs
@@ -250,14 +250,14 @@ macro_rules! tables {
             /// Insert a new ordered Row into the Table.
             /// Arguments match the positional order of the table's definition.
             #[allow(dead_code)]
-            pub fn push_row(&mut self, $( $field: impl OwnOrClone<$rust_type>, )*) {
-                self.push($row {
+            pub fn insert_row(&mut self, $( $field: impl OwnOrClone<$rust_type>, )*) {
+                self.insert($row {
                     $($field: $field.own_or_clone(),)*
                 });
             }
-
+            /// Insert a new ordered Row into the Table.
             #[allow(dead_code)]
-            pub fn push(&mut self, row: $row) {
+            pub fn insert(&mut self, row: $row) {
                 use superslice::Ext;
 
                 let r = ($(&row.$order_by,)*);
@@ -268,17 +268,18 @@ macro_rules! tables {
                 });
                 self.0.insert(index, row);
             }
-
+            /// Convert the Table into an Iterator.
             #[allow(dead_code)]
             pub fn into_iter(self) -> impl Iterator<Item=$row> {
                 self.0.into_iter()
             }
+            /// Extend the Table from the given Iterator.
             #[allow(dead_code)]
             pub fn extend(&mut self, it: impl Iterator<Item=$row>) {
                 self.0.extend(it);
                 self.reindex();
             }
-
+            // Re-index the Table as a bulk operation.
             fn reindex(&mut self) {
                 self.0.sort_by(|_l, _r| {
                     let l = ($(&_l.$order_by,)*);

--- a/crates/models/src/tables/mod.rs
+++ b/crates/models/src/tables/mod.rs
@@ -9,7 +9,8 @@ use macros::*;
 pub use macros::{load_tables, persist_tables, Table, TableObj, TableRow};
 
 tables!(
-    table Fetches (row Fetch, order_by [resource], sql "fetches") {
+    table Fetches (row Fetch, order_by [depth resource], sql "fetches") {
+        depth: u32,
         resource: url::Url,
     }
 

--- a/crates/models/src/tables/mod.rs
+++ b/crates/models/src/tables/mod.rs
@@ -9,17 +9,17 @@ use macros::*;
 pub use macros::{load_tables, persist_tables, Table, TableObj, TableRow};
 
 tables!(
-    table Fetches (row Fetch, sql "fetches") {
+    table Fetches (row Fetch, order_by [resource], sql "fetches") {
         resource: url::Url,
     }
 
-    table Resources (row Resource, sql "resources") {
+    table Resources (row Resource, order_by [resource], sql "resources") {
         resource: url::Url,
         content_type: protocol::flow::ContentType,
         content: bytes::Bytes,
     }
 
-    table Imports (row Import, sql "imports") {
+    table Imports (row Import, order_by [from_resource to_resource], sql "imports") {
         scope: url::Url,
         // Resource which does the importing.
         from_resource: url::Url,
@@ -27,7 +27,7 @@ tables!(
         to_resource: url::Url,
     }
 
-    table NPMDependencies (row NPMDependency, sql "npm_dependencies") {
+    table NPMDependencies (row NPMDependency, order_by [package version], sql "npm_dependencies") {
         scope: url::Url,
         // NPM package name.
         package: String,
@@ -35,7 +35,7 @@ tables!(
         version: String,
     }
 
-    table JournalRules (row JournalRule, sql "journal_rules") {
+    table JournalRules (row JournalRule, order_by [rule], sql "journal_rules") {
         scope: url::Url,
         // Name of this rule, which also encodes its priority as
         // lexicographic order determines evaluation and application order.
@@ -44,7 +44,7 @@ tables!(
         spec: protocol::flow::journal_rules::Rule,
     }
 
-    table ShardRules (row ShardRule, sql "shard_rules") {
+    table ShardRules (row ShardRule, order_by [rule], sql "shard_rules") {
         scope: url::Url,
         // Name of this rule, which also encodes its priority as
         // lexicographic order determines evaluation and application order.
@@ -53,7 +53,7 @@ tables!(
         spec: protocol::flow::shard_rules::Rule,
     }
 
-    table Collections (row Collection, sql "collections") {
+    table Collections (row Collection, order_by [collection], sql "collections") {
         scope: url::Url,
         collection: names::Collection,
         // JSON Schema against which all collection documents are validated,
@@ -63,7 +63,7 @@ tables!(
         key: names::CompositeKey,
     }
 
-    table Projections (row Projection, sql "projections") {
+    table Projections (row Projection, order_by [collection field], sql "projections") {
         scope: url::Url,
         collection: names::Collection,
         field: String,
@@ -75,7 +75,7 @@ tables!(
         user_provided: bool,
     }
 
-    table Derivations (row Derivation, sql "derivations") {
+    table Derivations (row Derivation, order_by [derivation], sql "derivations") {
         scope: url::Url,
         derivation: names::Collection,
         // JSON Schema against which register values are validated,
@@ -85,7 +85,7 @@ tables!(
         register_initial: serde_json::Value,
     }
 
-    table Transforms (row Transform, sql "transforms") {
+    table Transforms (row Transform, order_by [derivation transform], sql "transforms") {
         scope: url::Url,
         derivation: names::Collection,
         // Read priority applied to documents processed by this transform.
@@ -115,7 +115,7 @@ tables!(
         update_lambda: Option<names::Lambda>,
     }
 
-    table Captures (row Capture, sql "captures") {
+    table Captures (row Capture, order_by [capture], sql "captures") {
         scope: url::Url,
         // Name of this capture.
         capture: names::Capture,
@@ -127,7 +127,7 @@ tables!(
         interval_seconds: u32,
     }
 
-    table CaptureBindings (row CaptureBinding, sql "capture_bindings") {
+    table CaptureBindings (row CaptureBinding, order_by [capture capture_index], sql "capture_bindings") {
         scope: url::Url,
         // Capture to which this binding belongs.
         capture: names::Capture,
@@ -139,7 +139,7 @@ tables!(
         collection: names::Collection,
     }
 
-    table Materializations (row Materialization, sql "materializations") {
+    table Materializations (row Materialization, order_by [materialization], sql "materializations") {
         scope: url::Url,
         // Name of this materialization.
         materialization: names::Materialization,
@@ -149,7 +149,7 @@ tables!(
         endpoint_spec: serde_json::Value,
     }
 
-    table MaterializationBindings (row MaterializationBinding, sql "materialization_bindings") {
+    table MaterializationBindings (row MaterializationBinding, order_by [materialization materialization_index], sql "materialization_bindings") {
         scope: url::Url,
         // Materialization to which this binding belongs.
         materialization: names::Materialization,
@@ -170,7 +170,7 @@ tables!(
         source_partitions: Option<names::PartitionSelector>,
     }
 
-    table TestSteps (row TestStep, sql "test_steps") {
+    table TestSteps (row TestStep, order_by [test step_index], sql "test_steps") {
         scope: url::Url,
         // Collection ingested or verified by this step.
         collection: names::Collection,
@@ -186,13 +186,13 @@ tables!(
         test: names::Test,
     }
 
-    table SchemaDocs (row SchemaDoc, sql "schema_docs") {
+    table SchemaDocs (row SchemaDoc, order_by [schema], sql "schema_docs") {
         schema: url::Url,
         // JSON document model of the schema.
         dom: serde_json::Value,
     }
 
-    table NamedSchemas (row NamedSchema, sql "named_schemas") {
+    table NamedSchemas (row NamedSchema, order_by [anchor_name], sql "named_schemas") {
         // Scope is the canonical non-anchor URI of this schema.
         scope: url::Url,
         // Anchor is the alternative anchor'd URI.
@@ -201,7 +201,7 @@ tables!(
         anchor_name: String,
     }
 
-    table Inferences (row Inference, sql "inferences") {
+    table Inferences (row Inference, order_by [schema location], sql "inferences") {
         // URL of the schema which is inferred, inclusive of any fragment pointer.
         schema: url::Url,
         // A location within a document verified by this schema,
@@ -211,7 +211,7 @@ tables!(
         spec: protocol::flow::Inference,
     }
 
-    table BuiltCaptures (row BuiltCapture, sql "built_captures") {
+    table BuiltCaptures (row BuiltCapture, order_by [capture], sql "built_captures") {
         scope: url::Url,
         // Name of this capture.
         capture: String,
@@ -219,7 +219,7 @@ tables!(
         spec: protocol::flow::CaptureSpec,
     }
 
-    table BuiltCollections (row BuiltCollection, sql "built_collections") {
+    table BuiltCollections (row BuiltCollection, order_by [collection], sql "built_collections") {
         scope: url::Url,
         // Name of this collection.
         collection: names::Collection,
@@ -227,7 +227,7 @@ tables!(
         spec: protocol::flow::CollectionSpec,
     }
 
-    table BuiltMaterializations (row BuiltMaterialization, sql "built_materializations") {
+    table BuiltMaterializations (row BuiltMaterialization, order_by [materialization], sql "built_materializations") {
         scope: url::Url,
         // Name of this materialization.
         materialization: String,
@@ -235,7 +235,7 @@ tables!(
         spec: protocol::flow::MaterializationSpec,
     }
 
-    table BuiltDerivations (row BuiltDerivation, sql "built_derivations") {
+    table BuiltDerivations (row BuiltDerivation, order_by [derivation], sql "built_derivations") {
         scope: url::Url,
         // Name of this derivation.
         derivation: names::Collection,
@@ -243,19 +243,19 @@ tables!(
         spec: protocol::flow::DerivationSpec,
     }
 
-    table BuiltTests (row BuiltTest, sql "built_tests") {
+    table BuiltTests (row BuiltTest, order_by [test], sql "built_tests") {
         // Name of the test case.
         test: names::Test,
         // Built specification for this test case.
         spec: protocol::flow::TestSpec,
     }
 
-    table Errors (row Error, sql "errors") {
+    table Errors (row Error, order_by [], sql "errors") {
         scope: url::Url,
         error: anyhow::Error,
     }
 
-    table Meta (row Build, sql "meta") {
+    table Meta (row Build, order_by [], sql "meta") {
         build_uuid: uuid::Uuid,
         build_config: protocol::flow::build_api::Config,
     }
@@ -483,5 +483,73 @@ impl SQLType for bytes::Bytes {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         use rusqlite::types::FromSql;
         Ok(<Vec<u8>>::column_result(value)?.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{macros::*, TableObj};
+
+    tables!(
+        table Foos (row Foo, order_by [], sql "foos") {
+            f1: u32,
+        }
+
+        table Bars (row Bar, order_by [b1], sql "bars") {
+            b1: u32,
+            b2: u32,
+        }
+
+        table Quibs (row Quib, order_by [q1 q2], sql "quibs") {
+            q1: u32,
+            q2: u32,
+        }
+    );
+
+    #[test]
+    fn test_indexing() {
+        let mut tbl = Foos::new();
+        tbl.push_row(1);
+        tbl.push_row(0);
+        tbl.push_row(2);
+        tbl.push_row(1);
+        tbl.push_row(0);
+        tbl.push_row(1);
+
+        // When order_by is empty, the initial ordering is preserved.
+        assert_eq!(
+            tbl.iter().map(|r| r.f1).collect::<Vec<_>>(),
+            vec![1, 0, 2, 1, 0, 1]
+        );
+
+        // Table ordered by a single column.
+        let mut tbl = Bars::new();
+        tbl.push_row(10, 90);
+        tbl.push_row(0, 78);
+        tbl.push_row(20, 56);
+        tbl.push_row(10, 34);
+        tbl.push_row(0, 12);
+        tbl.push_row(10, 90);
+
+        // Ordered with respect to order_by, but not to the extra columns.
+        assert_eq!(
+            tbl.iter().map(|r| (r.b1, r.b2)).collect::<Vec<_>>(),
+            vec![(0, 78), (0, 12), (10, 90), (10, 34), (10, 90), (20, 56)]
+        );
+
+        // Table ordered on a composite key.
+        let mut tbl = Quibs::new();
+        tbl.push_row(10, 90);
+        tbl.push_row(0, 78);
+        tbl.push_row(20, 56);
+        tbl.push_row(10, 34);
+        tbl.push_row(0, 12);
+        tbl.push_row(10, 90);
+
+        // Fully ordered by the composite key (both columns).
+        assert_eq!(
+            tbl.iter().map(|r| (r.q1, r.q2)).collect::<Vec<_>>(),
+            vec![(0, 12), (0, 78), (10, 34), (10, 90), (10, 90), (20, 56)]
+        );
     }
 }

--- a/crates/models/src/tables/mod.rs
+++ b/crates/models/src/tables/mod.rs
@@ -510,12 +510,12 @@ mod test {
     #[test]
     fn test_indexing() {
         let mut tbl = Foos::new();
-        tbl.push_row(1);
-        tbl.push_row(0);
-        tbl.push_row(2);
-        tbl.push_row(1);
-        tbl.push_row(0);
-        tbl.push_row(1);
+        tbl.insert_row(1);
+        tbl.insert_row(0);
+        tbl.insert_row(2);
+        tbl.insert_row(1);
+        tbl.insert_row(0);
+        tbl.insert_row(1);
 
         // When order_by is empty, the initial ordering is preserved.
         assert_eq!(
@@ -525,12 +525,12 @@ mod test {
 
         // Table ordered by a single column.
         let mut tbl = Bars::new();
-        tbl.push_row(10, 90);
-        tbl.push_row(0, 78);
-        tbl.push_row(20, 56);
-        tbl.push_row(10, 34);
-        tbl.push_row(0, 12);
-        tbl.push_row(10, 90);
+        tbl.insert_row(10, 90);
+        tbl.insert_row(0, 78);
+        tbl.insert_row(20, 56);
+        tbl.insert_row(10, 34);
+        tbl.insert_row(0, 12);
+        tbl.insert_row(10, 90);
 
         // Ordered with respect to order_by, but not to the extra columns.
         assert_eq!(
@@ -540,12 +540,12 @@ mod test {
 
         // Table ordered on a composite key.
         let mut tbl = Quibs::new();
-        tbl.push_row(10, 90);
-        tbl.push_row(0, 78);
-        tbl.push_row(20, 56);
-        tbl.push_row(10, 34);
-        tbl.push_row(0, 12);
-        tbl.push_row(10, 90);
+        tbl.insert_row(10, 90);
+        tbl.insert_row(0, 78);
+        tbl.insert_row(20, 56);
+        tbl.insert_row(10, 34);
+        tbl.insert_row(0, 12);
+        tbl.insert_row(10, 90);
 
         // Fully ordered by the composite key (both columns).
         assert_eq!(

--- a/crates/models/tests/bundle_tests.rs
+++ b/crates/models/tests/bundle_tests.rs
@@ -1,5 +1,4 @@
 use doc::inference;
-use itertools::Itertools;
 use models::tables;
 
 #[test]
@@ -20,16 +19,6 @@ fn test_bundle_generation() {
         orig_index.add(compiled).unwrap()
     }
     orig_index.verify_references().unwrap();
-
-    // Index imports and schema_docs (expected ordering of bundled_schema).
-    let imports = imports
-        .iter()
-        .sorted_by_key(|i| (&i.from_resource, &i.to_resource))
-        .collect::<Vec<_>>();
-    let schema_docs = schema_docs
-        .iter()
-        .sorted_by_key(|d| &d.schema)
-        .collect::<Vec<_>>();
 
     // We'll collect bundle documents, and snapshot them at the end.
     let mut bundle_docs = serde_json::Map::new();

--- a/crates/sources/src/loader.rs
+++ b/crates/sources/src/loader.rs
@@ -103,7 +103,10 @@ impl<F: Fetcher> Loader<F> {
         }
 
         // Mark as visited, so that recursively-loaded imports don't re-visit.
-        self.tables.borrow_mut().fetches.push_row(resource);
+        self.tables
+            .borrow_mut()
+            .fetches
+            .push_row(scope.resource_depth() as u32, resource);
 
         let content = self.fetcher.fetch(&resource, &content_type).await;
 

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__catalog_import_cycles.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__catalog_import_cycles.snap
@@ -11,28 +11,36 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
+            depth: 1,
+            resource: test://example/catalog.yaml,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/A,
         },
         Fetch {
-            resource: test://example/A.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/B,
         },
         Fetch {
-            resource: test://example/B.ts,
-        },
-        Fetch {
-            resource: test://example/C,
-        },
-        Fetch {
-            resource: test://example/C.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.yaml,
+            depth: 3,
+            resource: test://example/A.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/B.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/C,
+        },
+        Fetch {
+            depth: 4,
+            resource: test://example/C.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__catalog_import_cycles.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__catalog_import_cycles.snap
@@ -11,39 +11,44 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
-        },
-        Fetch {
             resource: test://example/A,
-        },
-        Fetch {
-            resource: test://example/B,
-        },
-        Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
-            resource: test://example/C,
         },
         Fetch {
             resource: test://example/A.ts,
         },
         Fetch {
+            resource: test://example/B,
+        },
+        Fetch {
             resource: test://example/B.ts,
+        },
+        Fetch {
+            resource: test://example/C,
         },
         Fetch {
             resource: test://example/C.ts,
         },
+        Fetch {
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            resource: test://example/catalog.yaml,
+        },
     ],
     imports: [
+        Import {
+            scope: test://example/A,
+            from_resource: test://example/A,
+            to_resource: test://example/A.ts,
+        },
         Import {
             scope: test://example/A#/import/1,
             from_resource: test://example/A,
             to_resource: test://example/B,
         },
         Import {
-            scope: test://example/B#/import/0,
-            from_resource: test://example/B,
+            scope: test://example/A#/import/0,
+            from_resource: test://example/A,
             to_resource: test://example/C,
         },
         Import {
@@ -52,33 +57,18 @@ Tables {
             to_resource: test://example/A,
         },
         Import {
-            scope: test://example/catalog.yaml,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/catalog.ts,
-        },
-        Import {
-            scope: test://example/C#/import/0,
-            from_resource: test://example/C,
-            to_resource: test://example/catalog.yaml,
-        },
-        Import {
-            scope: test://example/C#/import/1,
-            from_resource: test://example/C,
-            to_resource: test://example/B,
-        },
-        Import {
-            scope: test://example/A,
-            from_resource: test://example/A,
-            to_resource: test://example/A.ts,
-        },
-        Import {
             scope: test://example/B,
             from_resource: test://example/B,
             to_resource: test://example/B.ts,
         },
         Import {
-            scope: test://example/catalog.yaml#/import/1,
-            from_resource: test://example/catalog.yaml,
+            scope: test://example/B#/import/0,
+            from_resource: test://example/B,
+            to_resource: test://example/C,
+        },
+        Import {
+            scope: test://example/C#/import/1,
+            from_resource: test://example/C,
             to_resource: test://example/B,
         },
         Import {
@@ -87,14 +77,24 @@ Tables {
             to_resource: test://example/C.ts,
         },
         Import {
-            scope: test://example/A#/import/0,
-            from_resource: test://example/A,
-            to_resource: test://example/C,
+            scope: test://example/C#/import/0,
+            from_resource: test://example/C,
+            to_resource: test://example/catalog.yaml,
         },
         Import {
             scope: test://example/catalog.yaml#/import/0,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/A,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/B,
+        },
+        Import {
+            scope: test://example/catalog.yaml,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.ts,
         },
     ],
     journal_rules: [],
@@ -105,11 +105,6 @@ Tables {
     projections: [],
     resources: [
         Resource {
-            resource: test://example/catalog.yaml,
-            content_type: "CatalogSpec",
-            content: ".. binary ..",
-        },
-        Resource {
             resource: test://example/A,
             content_type: "CatalogSpec",
             content: ".. binary ..",
@@ -121,6 +116,11 @@ Tables {
         },
         Resource {
             resource: test://example/C,
+            content_type: "CatalogSpec",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog.yaml,
             content_type: "CatalogSpec",
             content: ".. binary ..",
         },

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__collections.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__collections.snap
@@ -18,10 +18,10 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
             resource: test://example/schema.json,

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__collections.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__collections.snap
@@ -18,12 +18,15 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/schema.json,
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__derivations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__derivations.snap
@@ -8,48 +8,48 @@ Tables {
     captures: [],
     collections: [
         Collection {
-            scope: test://example/catalog.yaml#/collections/d2~1collection,
-            collection: d2/collection,
-            schema: test://example/a-schema.json,
-            key: ["/d2-key"],
-        },
-        Collection {
             scope: test://example/catalog.yaml#/collections/d1~1collection,
             collection: d1/collection,
             schema: test://example/a-schema.json,
             key: ["/d1-key"],
         },
+        Collection {
+            scope: test://example/catalog.yaml#/collections/d2~1collection,
+            collection: d2/collection,
+            schema: test://example/a-schema.json,
+            key: ["/d2-key"],
+        },
     ],
     derivations: [
-        Derivation {
-            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation,
-            derivation: d2/collection,
-            register_schema: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
-            register_initial: null,
-        },
         Derivation {
             scope: test://example/catalog.yaml#/collections/d1~1collection/derivation,
             derivation: d1/collection,
             register_schema: test://example/reg-schema.json#/$defs/qib,
             register_initial: {"initial":["value",32]},
         },
+        Derivation {
+            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation,
+            derivation: d2/collection,
+            register_schema: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
+            register_initial: null,
+        },
     ],
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/a-schema.json,
+        },
+        Fetch {
+            resource: test://example/alt-schema.json,
         },
         Fetch {
             resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/a-schema.json,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
             resource: test://example/reg-schema.json,
-        },
-        Fetch {
-            resource: test://example/alt-schema.json,
         },
     ],
     imports: [
@@ -59,9 +59,14 @@ Tables {
             to_resource: test://example/a-schema.json,
         },
         Import {
-            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation/register/schema,
+            scope: test://example/catalog.yaml#/collections/d1~1collection/schema,
             from_resource: test://example/catalog.yaml,
-            to_resource: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
+            to_resource: test://example/a-schema.json,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/collections/d1~1collection/derivation/transform/some-name/source/schema,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/alt-schema.json,
         },
         Import {
             scope: test://example/catalog.yaml,
@@ -69,19 +74,14 @@ Tables {
             to_resource: test://example/catalog.ts,
         },
         Import {
-            scope: test://example/catalog.yaml#/collections/d1~1collection/schema,
+            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation/register/schema,
             from_resource: test://example/catalog.yaml,
-            to_resource: test://example/a-schema.json,
+            to_resource: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
         },
         Import {
             scope: test://example/catalog.yaml#/collections/d1~1collection/derivation/register/schema,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/reg-schema.json,
-        },
-        Import {
-            scope: test://example/catalog.yaml#/collections/d1~1collection/derivation/transform/some-name/source/schema,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/alt-schema.json,
         },
     ],
     journal_rules: [],
@@ -91,6 +91,21 @@ Tables {
     npm_dependencies: [],
     projections: [],
     resources: [
+        Resource {
+            resource: test://example/a-schema.json,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/alt-schema.json,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog.ts,
+            content_type: "TypescriptModule",
+            content: ".. binary ..",
+        },
         Resource {
             resource: test://example/catalog.yaml,
             content_type: "CatalogSpec",
@@ -102,61 +117,32 @@ Tables {
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/catalog.ts,
-            content_type: "TypescriptModule",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/a-schema.json,
-            content_type: "JsonSchema",
-            content: ".. binary ..",
-        },
-        Resource {
             resource: test://example/reg-schema.json,
-            content_type: "JsonSchema",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/alt-schema.json,
             content_type: "JsonSchema",
             content: ".. binary ..",
         },
     ],
     schema_docs: [
         SchemaDoc {
-            schema: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
+            schema: test://example/a-schema.json,
             dom: true,
         },
         SchemaDoc {
-            schema: test://example/a-schema.json,
+            schema: test://example/alt-schema.json,
+            dom: {"$anchor":"foobar","properties":{"d1-key":{"type":"string"},"key":{"description":"the key description","title":"the key title","type":"integer"},"moar":{"type":"number"},"shuffle":{"type":"integer"}},"type":"object"},
+        },
+        SchemaDoc {
+            schema: test://example/catalog.yaml?ptr=/collections/d2~1collection/derivation/register/schema,
             dom: true,
         },
         SchemaDoc {
             schema: test://example/reg-schema.json,
             dom: {"$defs":{"qib":true}},
         },
-        SchemaDoc {
-            schema: test://example/alt-schema.json,
-            dom: {"$anchor":"foobar","properties":{"d1-key":{"type":"string"},"key":{"description":"the key description","title":"the key title","type":"integer"},"moar":{"type":"number"},"shuffle":{"type":"integer"}},"type":"object"},
-        },
     ],
     shard_rules: [],
     test_steps: [],
     transforms: [
-        Transform {
-            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation/transform/do-the-thing,
-            derivation: d2/collection,
-            priority: 0,
-            publish_lambda: NULL,
-            read_delay_seconds: NULL,
-            shuffle_key: NULL,
-            shuffle_lambda: NULL,
-            source_collection: src/collection,
-            source_partitions: NULL,
-            source_schema: NULL,
-            transform: do-the-thing,
-            update_lambda: {"remote":"https://example/api"},
-        },
         Transform {
             scope: test://example/catalog.yaml#/collections/d1~1collection/derivation/transform/some-name,
             derivation: d1/collection,
@@ -170,6 +156,20 @@ Tables {
             source_schema: test://example/alt-schema.json#foobar,
             transform: some-name,
             update_lambda: "typescript",
+        },
+        Transform {
+            scope: test://example/catalog.yaml#/collections/d2~1collection/derivation/transform/do-the-thing,
+            derivation: d2/collection,
+            priority: 0,
+            publish_lambda: NULL,
+            read_delay_seconds: NULL,
+            shuffle_key: NULL,
+            shuffle_lambda: NULL,
+            source_collection: src/collection,
+            source_partitions: NULL,
+            source_schema: NULL,
+            transform: do-the-thing,
+            update_lambda: {"remote":"https://example/api"},
         },
     ],
 }

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__derivations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__derivations.snap
@@ -37,18 +37,23 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/a-schema.json,
-        },
-        Fetch {
-            resource: test://example/alt-schema.json,
-        },
-        Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/a-schema.json,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/alt-schema.json,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/reg-schema.json,
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
@@ -48,10 +48,10 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__endpoints_captures_materializations.snap
@@ -48,10 +48,12 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
+            depth: 1,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
-            resource: test://example/catalog.yaml,
+            depth: 2,
+            resource: test://example/catalog.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__journal_rules.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__journal_rules.snap
@@ -11,16 +11,20 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
-            resource: test://example/rules_two.ts,
+            depth: 2,
+            resource: test://example/catalog.ts,
         },
         Fetch {
+            depth: 2,
             resource: test://example/rules_two.yaml,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/rules_two.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__journal_rules.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__journal_rules.snap
@@ -11,16 +11,16 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
-        },
-        Fetch {
-            resource: test://example/rules_two.yaml,
-        },
-        Fetch {
             resource: test://example/catalog.ts,
         },
         Fetch {
+            resource: test://example/catalog.yaml,
+        },
+        Fetch {
             resource: test://example/rules_two.ts,
+        },
+        Fetch {
+            resource: test://example/rules_two.yaml,
         },
     ],
     imports: [
@@ -30,14 +30,14 @@ Tables {
             to_resource: test://example/catalog.ts,
         },
         Import {
-            scope: test://example/rules_two.yaml,
-            from_resource: test://example/rules_two.yaml,
-            to_resource: test://example/rules_two.ts,
-        },
-        Import {
             scope: test://example/catalog.yaml#/import/0,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/rules_two.yaml,
+        },
+        Import {
+            scope: test://example/rules_two.yaml,
+            from_resource: test://example/rules_two.yaml,
+            to_resource: test://example/rules_two.ts,
         },
     ],
     journal_rules: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_anchors.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_anchors.snap
@@ -18,10 +18,10 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
             resource: test://example/schema.json,

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_anchors.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_anchors.snap
@@ -18,12 +18,15 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/schema.json,
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_inline.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_inline.snap
@@ -18,22 +18,22 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
     ],
     imports: [
         Import {
-            scope: test://example/catalog.yaml#/collections/test/schema,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/catalog.yaml?ptr=/collections/test/schema,
-        },
-        Import {
             scope: test://example/catalog.yaml,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/catalog.ts,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/collections/test/schema,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.yaml?ptr=/collections/test/schema,
         },
     ],
     journal_rules: [],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_inline.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_inline.snap
@@ -18,10 +18,12 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
+            depth: 1,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
-            resource: test://example/catalog.yaml,
+            depth: 2,
+            resource: test://example/catalog.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_nested_ids.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_nested_ids.snap
@@ -18,13 +18,16 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
+            depth: 1,
+            resource: test://example/catalog.yaml,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/actual,
         },
         Fetch {
+            depth: 2,
             resource: test://example/catalog.ts,
-        },
-        Fetch {
-            resource: test://example/catalog.yaml,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_nested_ids.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_nested_ids.snap
@@ -18,25 +18,25 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/actual,
         },
         Fetch {
             resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/actual,
+            resource: test://example/catalog.yaml,
         },
     ],
     imports: [
         Import {
-            scope: test://example/catalog.yaml,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/catalog.ts,
-        },
-        Import {
             scope: test://example/catalog.yaml#/collections/a~1collection/schema,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/actual,
+        },
+        Import {
+            scope: test://example/catalog.yaml,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.ts,
         },
     ],
     journal_rules: [],
@@ -47,13 +47,13 @@ Tables {
     projections: [],
     resources: [
         Resource {
-            resource: test://example/catalog.yaml,
-            content_type: "CatalogSpec",
+            resource: test://example/actual,
+            content_type: "JsonSchema",
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/actual,
-            content_type: "JsonSchema",
+            resource: test://example/catalog.yaml,
+            content_type: "CatalogSpec",
             content: ".. binary ..",
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_references.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_references.snap
@@ -18,18 +18,23 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://external/a,
         },
         Fetch {
+            depth: 3,
             resource: test://external/b,
         },
         Fetch {
+            depth: 4,
             resource: test://external/c,
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_references.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__schema_with_references.snap
@@ -18,10 +18,10 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
             resource: test://external/a,
@@ -40,9 +40,9 @@ Tables {
             to_resource: test://example/catalog.ts,
         },
         Import {
-            scope: test://external/b#/$defs/c/$ref,
-            from_resource: test://external/b,
-            to_resource: test://external/c,
+            scope: test://example/catalog.yaml#/collections/test/schema,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://external/a,
         },
         Import {
             scope: test://external/a#/$defs/a/$ref,
@@ -50,9 +50,9 @@ Tables {
             to_resource: test://external/b,
         },
         Import {
-            scope: test://example/catalog.yaml#/collections/test/schema,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://external/a,
+            scope: test://external/b#/$defs/c/$ref,
+            from_resource: test://external/b,
+            to_resource: test://external/c,
         },
     ],
     journal_rules: [],
@@ -85,16 +85,16 @@ Tables {
     ],
     schema_docs: [
         SchemaDoc {
-            schema: test://external/c,
-            dom: true,
+            schema: test://external/a,
+            dom: {"$defs":{"a":{"$ref":"b#/$defs/c"}}},
         },
         SchemaDoc {
             schema: test://external/b,
             dom: {"$defs":{"c":{"$ref":"c"}}},
         },
         SchemaDoc {
-            schema: test://external/a,
-            dom: {"$defs":{"a":{"$ref":"b#/$defs/c"}}},
+            schema: test://external/c,
+            dom: true,
         },
     ],
     shard_rules: [],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__simple_catalog.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__simple_catalog.snap
@@ -26,22 +26,28 @@ Tables {
     ],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/schema,
         },
         Fetch {
+            depth: 2,
             resource: test://example/sibling,
         },
         Fetch {
-            resource: test://example/sibling.ts,
+            depth: 2,
+            resource: test://not/found,
         },
         Fetch {
-            resource: test://not/found,
+            depth: 3,
+            resource: test://example/sibling.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__simple_catalog.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__simple_catalog.snap
@@ -26,30 +26,25 @@ Tables {
     ],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
-        },
-        Fetch {
-            resource: test://example/sibling,
-        },
-        Fetch {
-            resource: test://not/found,
-        },
-        Fetch {
             resource: test://example/catalog.ts,
+        },
+        Fetch {
+            resource: test://example/catalog.yaml,
         },
         Fetch {
             resource: test://example/schema,
         },
         Fetch {
+            resource: test://example/sibling,
+        },
+        Fetch {
             resource: test://example/sibling.ts,
+        },
+        Fetch {
+            resource: test://not/found,
         },
     ],
     imports: [
-        Import {
-            scope: test://example/catalog.yaml#/import/1,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://not/found,
-        },
         Import {
             scope: test://example/catalog.yaml,
             from_resource: test://example/catalog.yaml,
@@ -61,14 +56,19 @@ Tables {
             to_resource: test://example/schema,
         },
         Import {
-            scope: test://example/sibling,
-            from_resource: test://example/sibling,
-            to_resource: test://example/sibling.ts,
-        },
-        Import {
             scope: test://example/catalog.yaml#/import/0,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/sibling,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://not/found,
+        },
+        Import {
+            scope: test://example/sibling,
+            from_resource: test://example/sibling,
+            to_resource: test://example/sibling.ts,
         },
     ],
     journal_rules: [],
@@ -112,13 +112,13 @@ Tables {
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/sibling,
-            content_type: "CatalogSpec",
+            resource: test://example/schema,
+            content_type: "JsonSchema",
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/schema,
-            content_type: "JsonSchema",
+            resource: test://example/sibling,
+            content_type: "CatalogSpec",
             content: ".. binary ..",
         },
     ],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test_case.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test_case.snap
@@ -11,10 +11,12 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.ts,
+            depth: 1,
+            resource: test://example/catalog.yaml,
         },
         Fetch {
-            resource: test://example/catalog.yaml,
+            depth: 2,
+            resource: test://example/catalog.ts,
         },
     ],
     imports: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test_case.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test_case.snap
@@ -11,10 +11,10 @@ Tables {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/catalog.yaml,
+            resource: test://example/catalog.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
+            resource: test://example/catalog.yaml,
         },
     ],
     imports: [

--- a/crates/sources/src/scope.rs
+++ b/crates/sources/src/scope.rs
@@ -59,9 +59,14 @@ impl<'a> Scope<'a> {
         }
     }
 
+    /// Returns the depth of the stack of resources which are in the Scope.
+    pub fn resource_depth(self) -> usize {
+        self.parent.map_or(0, |p| p.resource_depth()) + self.resource.map_or(0, |_| 1)
+    }
+
     /// Flatten the scope into its current resource URI, extended with a
     /// URL fragment-encoded JSON pointer of the current location.
-    pub fn flatten(&'a self) -> Url {
+    pub fn flatten(self) -> Url {
         let mut f = self.resource().clone();
 
         if !matches!(self.location, Location::Root) {
@@ -89,5 +94,10 @@ mod test {
         assert_eq!(s1.flatten().as_str(), "http://example/A");
         assert_eq!(s3.flatten().as_str(), "http://example/A#/foo/32");
         assert_eq!(s5.flatten().as_str(), "http://example/B#/something");
+
+        assert_eq!(s1.resource_depth(), 1);
+        assert_eq!(s3.resource_depth(), 1);
+        assert_eq!(s4.resource_depth(), 2);
+        assert_eq!(s5.resource_depth(), 2);
     }
 }

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "*"
 regex = "*"
 serde_json = { version =  "*", features = ["raw_value"] }
 strsim = "*"
+superslice = "*"
 thiserror = "*"
 tracing = "*"
 unicode-normalization = "*"

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -159,7 +159,7 @@ pub async fn walk_all_captures<D: Drivers>(
                     bindings,
                     interval_seconds: *interval_seconds,
                 };
-                built_captures.push_row(scope, name, spec);
+                built_captures.insert_row(scope, name, spec);
             }
             Err(err) => {
                 Error::CaptureDriver {

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -11,22 +11,17 @@ pub async fn walk_all_captures<D: Drivers>(
     captures: &[tables::Capture],
     collections: &[tables::Collection],
     derivations: &[tables::Derivation],
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     errors: &mut tables::Errors,
 ) -> tables::BuiltCaptures {
     let mut validations = Vec::new();
 
-    // Index |capture_bindings| on (capture, index),
-    // then group bindings having the same capture.
-    let capture_bindings = capture_bindings
-        .iter()
-        .sorted_by_key(|c| (&c.capture, c.capture_index))
-        .group_by(|c| &c.capture);
+    // Group |capture_bindings| on bindings having the same capture.
+    let capture_bindings = capture_bindings.iter().group_by(|c| &c.capture);
 
     // Walk ordered captures, left-joined by their bindings.
     for (capture, bindings) in captures
         .iter()
-        .sorted_by_key(|c| &c.capture)
         .merge_join_by(capture_bindings.into_iter(), |l, (r, _)| l.capture.cmp(r))
         .filter_map(|eob| match eob {
             EitherOrBoth::Both(capture, (_, bindings)) => Some((capture, Some(bindings))),
@@ -109,7 +104,7 @@ pub async fn walk_all_captures<D: Drivers>(
                             binding_responses.len()
                         ),
                     }
-                    .push(scope, errors);
+                    .push(&scope, errors);
                 }
 
                 // Join requests, responses and models to produce tuples
@@ -185,7 +180,7 @@ fn walk_capture_request<'a>(
     capture_bindings: Vec<&'a tables::CaptureBinding>,
     collections: &[tables::Collection],
     derivations: &[tables::Derivation],
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     errors: &mut tables::Errors,
 ) -> Option<(
     &'a tables::Capture,
@@ -230,7 +225,7 @@ fn walk_capture_binding<'a>(
     capture_binding: &tables::CaptureBinding,
     collections: &[tables::Collection],
     derivations: &[tables::Derivation],
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     errors: &mut tables::Errors,
 ) -> Option<capture::validate_request::Binding> {
     let tables::CaptureBinding {

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -19,7 +19,7 @@ pub fn walk_all_collections(
         let projections = &projections
             [projections.equal_range_by_key(&&collection.collection, |p| &p.collection)];
 
-        built_collections.push_row(
+        built_collections.insert_row(
             &collection.scope,
             &collection.collection,
             walk_collection(
@@ -116,7 +116,7 @@ fn walk_collection_projections(
             specs.push(spec);
         }
         if let Some(implicit) = implicit {
-            implicit_projections.push(implicit);
+            implicit_projections.insert(implicit);
         }
     }
 

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -3,6 +3,7 @@ use itertools::{EitherOrBoth, Itertools};
 use json::schema::types;
 use models::{build, names, tables};
 use protocol::flow;
+use superslice::Ext;
 use url::Url;
 
 pub fn walk_all_collections(
@@ -15,17 +16,15 @@ pub fn walk_all_collections(
     let mut built_collections = tables::BuiltCollections::new();
 
     for collection in collections {
-        let projections = projections
-            .iter()
-            .filter(|p| p.collection == collection.collection)
-            .collect::<Vec<_>>();
+        let projections = &projections
+            [projections.equal_range_by_key(&&collection.collection, |p| &p.collection)];
 
         built_collections.push_row(
             &collection.scope,
             &collection.collection,
             walk_collection(
                 collection,
-                &projections,
+                projections,
                 schema_shapes,
                 errors,
                 &mut implicit_projections,
@@ -38,7 +37,7 @@ pub fn walk_all_collections(
 
 fn walk_collection(
     collection: &tables::Collection,
-    projections: &[&tables::Projection],
+    projections: &[tables::Projection],
     schema_shapes: &[schema::Shape],
     errors: &mut tables::Errors,
     implicit_projections: &mut tables::Projections,
@@ -88,7 +87,7 @@ fn walk_collection(
 
 fn walk_collection_projections(
     collection: &tables::Collection,
-    projections: &[&tables::Projection],
+    projections: &[tables::Projection],
     schema_shape: &schema::Shape,
     errors: &mut tables::Errors,
     implicit_projections: &mut tables::Projections,
@@ -106,7 +105,6 @@ fn walk_collection_projections(
     let mut specs = Vec::new();
     for eob in projections
         .iter()
-        .sorted_by_key(|p| &p.field)
         .merge_join_by(schema_shape.fields.iter(), |projection, (field, _)| {
             projection.field.cmp(field)
         })
@@ -127,7 +125,7 @@ fn walk_collection_projections(
 
 fn walk_projection_with_inference(
     collection: &tables::Collection,
-    eob: EitherOrBoth<&&tables::Projection, &(String, names::JsonPointer)>,
+    eob: EitherOrBoth<&tables::Projection, &(String, names::JsonPointer)>,
     schema_shape: &schema::Shape,
     errors: &mut tables::Errors,
 ) -> (Option<flow::Projection>, Option<tables::Projection>) {

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -26,7 +26,7 @@ pub fn walk_all_derivations(
         let transforms =
             &transforms[transforms.equal_range_by_key(&&derivation.derivation, |t| &t.derivation)];
 
-        built_derivations.push_row(
+        built_derivations.insert_row(
             &derivation.scope,
             &derivation.derivation,
             walk_derivation(

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -168,6 +168,6 @@ pub enum Error {
 
 impl Error {
     pub fn push(self, scope: &url::Url, errors: &mut tables::Errors) {
-        errors.push_row(scope, anyhow::anyhow!(self));
+        errors.insert_row(scope, anyhow::anyhow!(self));
     }
 }

--- a/crates/validation/src/journal_rule.rs
+++ b/crates/validation/src/journal_rule.rs
@@ -3,11 +3,7 @@ use itertools::Itertools;
 use models::tables;
 
 pub fn walk_all_journal_rules(journal_rules: &[tables::JournalRule], errors: &mut tables::Errors) {
-    for (lhs, rhs) in journal_rules
-        .iter()
-        .sorted_by_key(|r| &r.rule)
-        .tuple_windows()
-    {
+    for (lhs, rhs) in journal_rules.iter().tuple_windows() {
         if lhs.rule == rhs.rule {
             Error::NameCollision {
                 error_class: "duplicates",

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -82,17 +82,17 @@ pub async fn validate<D: Drivers>(
     let schema_index = schema::index_compiled_schemas(&compiled_schemas, root_scope, &mut errors);
 
     let schema_refs = schema::Ref::from_tables(
-        resources,
-        named_schemas,
         collections,
         derivations,
+        named_schemas,
+        projections,
+        resources,
         transforms,
     );
 
     let (schema_shapes, inferences) = schema::walk_all_schema_refs(
         imports,
-        projections,
-        &schema_docs,
+        schema_docs,
         &schema_index,
         &schema_refs,
         &mut errors,

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -1,5 +1,4 @@
 use futures::future::LocalBoxFuture;
-use itertools::Itertools;
 use models::tables;
 use protocol;
 
@@ -70,12 +69,6 @@ pub async fn validate<D: Drivers>(
         root_scope = &r.resource;
     }
 
-    // Index for future binary searches of the import graph.
-    let imports = imports
-        .iter()
-        .sorted_by_key(|i| (&i.from_resource, &i.to_resource))
-        .collect::<Vec<_>>();
-
     let compiled_schemas = match tables::SchemaDoc::compile_all(schema_docs) {
         Ok(c) => c,
         Err(err) => {
@@ -97,7 +90,7 @@ pub async fn validate<D: Drivers>(
     );
 
     let (schema_shapes, inferences) = schema::walk_all_schema_refs(
-        &imports,
+        imports,
         projections,
         &schema_docs,
         &schema_index,
@@ -116,7 +109,7 @@ pub async fn validate<D: Drivers>(
         &built_collections,
         collections,
         derivations,
-        &imports,
+        imports,
         projections,
         &schema_index,
         &schema_shapes,
@@ -149,7 +142,7 @@ pub async fn validate<D: Drivers>(
         captures,
         collections,
         derivations,
-        &imports,
+        imports,
         &mut errors,
     );
 
@@ -158,7 +151,7 @@ pub async fn validate<D: Drivers>(
         drivers,
         &built_collections,
         collections,
-        &imports,
+        imports,
         materialization_bindings,
         materializations,
         projections,
@@ -173,7 +166,7 @@ pub async fn validate<D: Drivers>(
 
     let built_tests = test_step::walk_all_test_steps(
         collections,
-        &imports,
+        imports,
         projections,
         &schema_index,
         &schema_shapes,

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn validate<D: Drivers>(
     let compiled_schemas = match tables::SchemaDoc::compile_all(schema_docs) {
         Ok(c) => c,
         Err(err) => {
-            errors.push_row(root_scope, anyhow::anyhow!(err));
+            errors.insert_row(root_scope, anyhow::anyhow!(err));
             return Tables {
                 errors,
                 ..Default::default()

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -49,6 +49,7 @@ pub async fn validate<D: Drivers>(
     captures: &[tables::Capture],
     collections: &[tables::Collection],
     derivations: &[tables::Derivation],
+    fetches: &[tables::Fetch],
     imports: &[tables::Import],
     journal_rules: &[tables::JournalRule],
     materialization_bindings: &[tables::MaterializationBinding],
@@ -64,9 +65,11 @@ pub async fn validate<D: Drivers>(
 ) -> Tables {
     let mut errors = tables::Errors::new();
 
+    // Fetches order on the fetch depth, so take the first (lowest-depth)
+    // element as the root scope.
     let mut root_scope = &url::Url::parse("root://").unwrap();
-    if let Some(r) = resources.first() {
-        root_scope = &r.resource;
+    if let Some(f) = fetches.first() {
+        root_scope = &f.resource;
     }
 
     let compiled_schemas = match tables::SchemaDoc::compile_all(schema_docs) {
@@ -87,6 +90,7 @@ pub async fn validate<D: Drivers>(
         named_schemas,
         projections,
         resources,
+        root_scope,
         transforms,
     );
 

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -183,7 +183,7 @@ pub async fn walk_all_materializations<D: Drivers>(
                     materialization: name.to_string(),
                 };
 
-                built_materializations.push_row(scope, name, spec);
+                built_materializations.insert_row(scope, name, spec);
             }
             Err(err) => {
                 Error::MaterializationDriver {

--- a/crates/validation/src/npm_dependency.rs
+++ b/crates/validation/src/npm_dependency.rs
@@ -6,11 +6,7 @@ pub fn walk_all_npm_dependencies(
     npm_dependencies: &[tables::NPMDependency],
     errors: &mut tables::Errors,
 ) {
-    for (lhs, rhs) in npm_dependencies
-        .iter()
-        .sorted_by_key(|d| &d.package)
-        .tuple_windows()
-    {
+    for (lhs, rhs) in npm_dependencies.iter().tuple_windows() {
         if lhs.package != rhs.package {
             continue;
         } else if lhs.version != rhs.version {

--- a/crates/validation/src/reference.rs
+++ b/crates/validation/src/reference.rs
@@ -9,7 +9,7 @@ pub fn walk_reference<'a, T, F, N>(
     ref_name: &N,
     entities: &'a [T],
     entity_fn: F,
-    imports: &'a [&'a tables::Import],
+    imports: &'a [tables::Import],
     errors: &mut tables::Errors,
 ) -> Option<&'a T>
 where

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -95,12 +95,14 @@ impl<'a> Ref<'a> {
         named_schemas: &'a [tables::NamedSchema],
         projections: &'a [tables::Projection],
         resources: &'a [tables::Resource],
+        root_scope: &'a url::Url,
         transforms: &'a [tables::Transform],
     ) -> Vec<Ref<'a>> {
         let mut refs = Vec::new();
 
         // If the root resource is a JSON schema then treat it as an implicit reference.
-        match resources.first() {
+        let root = &resources[resources.equal_range_by_key(&root_scope, |r| &r.resource)];
+        match root.first() {
             Some(tables::Resource {
                 content_type: protocol::flow::ContentType::JsonSchema,
                 resource,

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -93,11 +93,7 @@ pub fn walk_all_named_schemas<'a>(
     named_schemas: &'a [tables::NamedSchema],
     errors: &mut tables::Errors,
 ) {
-    for (lhs, rhs) in named_schemas
-        .iter()
-        .sorted_by_key(|n| &n.anchor_name)
-        .tuple_windows()
-    {
+    for (lhs, rhs) in named_schemas.iter().tuple_windows() {
         if lhs.anchor_name == rhs.anchor_name {
             Error::NameCollision {
                 error_class: "duplicates",
@@ -135,7 +131,7 @@ pub fn index_compiled_schemas<'a>(
 }
 
 pub fn walk_all_schema_refs(
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     projections: &[tables::Projection],
     schema_docs: &[tables::SchemaDoc],
     schema_index: &doc::SchemaIndex<'_>,
@@ -144,12 +140,6 @@ pub fn walk_all_schema_refs(
 ) -> (Vec<Shape>, tables::Inferences) {
     let mut schema_shapes: Vec<Shape> = Vec::new();
     let mut inferences = tables::Inferences::new();
-
-    // Index schema_docs on schema CURI.
-    let schema_docs = schema_docs
-        .iter()
-        .sorted_by_key(|d| &d.schema)
-        .collect::<Vec<_>>();
 
     // Walk schema URLs (*with* fragment pointers) with their grouped references.
     for (schema, references) in schema_refs

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -279,7 +279,7 @@ pub fn walk_all_schema_refs(
         let mut fields = Vec::with_capacity(merged.len());
 
         for (field, ptr, shape, exists) in merged {
-            inferences.push_row(schema, &ptr, build::inference(shape, exists));
+            inferences.insert_row(schema, &ptr, build::inference(shape, exists));
 
             if !exists.cannot() {
                 fields.push((field, ptr)); // Note we're already ordered on |field|.

--- a/crates/validation/src/test_step.rs
+++ b/crates/validation/src/test_step.rs
@@ -31,7 +31,7 @@ pub fn walk_all_test_steps(
             .flatten()
             .collect();
 
-        built_tests.push_row(
+        built_tests.insert_row(
             test,
             flow::TestSpec {
                 test: test.to_string(),

--- a/crates/validation/src/test_step.rs
+++ b/crates/validation/src/test_step.rs
@@ -5,7 +5,7 @@ use protocol::flow::{self, test_spec::step::Type as TestStepType};
 
 pub fn walk_all_test_steps(
     collections: &[tables::Collection],
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     projections: &[tables::Projection],
     schema_index: &doc::SchemaIndex<'_>,
     schemas: &[schema::Shape],
@@ -14,11 +14,7 @@ pub fn walk_all_test_steps(
 ) -> tables::BuiltTests {
     let mut built_tests = tables::BuiltTests::new();
 
-    for (test, steps) in &test_steps
-        .iter()
-        .sorted_by_key(|s| (&s.test, s.step_index))
-        .group_by(|s| &s.test)
-    {
+    for (test, steps) in &test_steps.iter().group_by(|s| &s.test) {
         let steps: Vec<_> = steps
             .map(|test_step| {
                 walk_test_step(
@@ -57,7 +53,7 @@ pub fn walk_all_test_steps(
 
 pub fn walk_test_step(
     collections: &[tables::Collection],
-    imports: &[&tables::Import],
+    imports: &[tables::Import],
     projections: &[tables::Projection],
     schema_index: &doc::SchemaIndex<'_>,
     schema_shapes: &[schema::Shape],

--- a/crates/validation/tests/model.yaml
+++ b/crates/validation/tests/model.yaml
@@ -7,6 +7,8 @@ test://example/catalog.yaml:
     - test://example/webhook-deliveries
     - test://example/db-views
     - test://example/int-string-tests
+    - test://example/array-key
+    - test://example/from-array-key
 
   journalRules:
     123 A Rule:
@@ -288,3 +290,63 @@ driver:
           user: a-user
       bindings:
         - resourcePath: [schema, table]
+
+test://example/array-key.schema:
+  # This schema models array additionalItems which provably exist,
+  # due to minItems, but are not ordinarily generated as inferences.
+  # It excercises our ability to generate inferences from explicit
+  # locations referencing the schema from:
+  #  - Collection keys.
+  #  - Collection projections.
+  #  - Shuffle keys of transforms without source_schema.
+  #    But not shuffle keys _with_ alternate source_schema.
+  type: object
+  properties:
+    arr:
+      type: array
+      items:
+        type: object
+        properties:
+          aKey: { type: integer }
+        required: [aKey]
+      minItems: 5
+  required: [arr]
+
+test://example/array-key:
+  collections:
+    testing/array-key:
+      schema: test://example/array-key.schema
+      key: [/arr/0/aKey]
+      projections:
+        aKeyOne: /arr/1/aKey
+
+test://example/from-array-key:
+  import:
+    - test://example/array-key
+  collections:
+    testing/from-array-key:
+      schema:
+        type: object
+        properties:
+          someKey: { type: integer }
+        required: [someKey]
+      key: [/someKey]
+
+      derivation:
+        transform:
+          withSourceSchema:
+            source:
+              name: testing/array-key
+              schema: { $ref: test://example/array-key.schema }
+            shuffle:
+              # We do *not* expect a generated inference of testing/array-key
+              # because our key reference a different (inline) schema.
+              key: [/arr/2/aKey]
+            publish: { lambda: { remote: https://an/api } }
+
+          withoutSourceSchema:
+            source: { name: testing/array-key }
+            shuffle:
+              # We DO expect this shuffle generates an inference of testing/array-key.
+              key: [/arr/3/aKey]
+            publish: { lambda: { remote: https://an/api } }

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1111,6 +1111,7 @@ fn run_test(mut fixture: Value) -> tables::All {
         &captures,
         &collections,
         &derivations,
+        &fetches,
         &imports,
         &journal_rules,
         &materialization_bindings,

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -374,18 +374,92 @@ All {
     ],
     built_collections: [
         BuiltCollection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
+            scope: test://example/int-halve#/collections/testing~1int-halve,
+            collection: testing/int-halve,
             spec: CollectionSpec {
-                collection: "testing/int-string.v2",
-                schema_uri: "test://example/int-string.schema",
-                schema_json: "{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}",
+                collection: "testing/int-halve",
+                schema_uri: "test://example/int-string-len.schema",
+                schema_json: "{\"$defs\":{\"__flowInline1\":{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"},\"otherAnchor\":{\"$anchor\":\"Other\",\"type\":\"integer\"}},\"$id\":\"test://example/int-string-len.schema\",\"$ref\":\"test://example/int-string.schema\",\"additionalProperties\":{\"type\":\"boolean\"},\"properties\":{\"arr\":{\"additionalItems\":{\"$ref\":\"int-string.schema#AnAnchor\"},\"type\":\"array\"},\"bit\":{},\"int\":{},\"len\":{\"type\":\"integer\"},\"str\":{}},\"required\":[\"len\"]}",
                 key_ptrs: [
                     "/int",
                 ],
                 uuid_ptr: "/_meta/uuid",
-                partition_fields: [],
+                partition_fields: [
+                    "Len",
+                ],
                 projections: [
+                    Projection {
+                        ptr: "/extra",
+                        field: "Extra",
+                        user_provided: true,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "boolean",
+                                ],
+                                must_exist: false,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/len",
+                        field: "Len",
+                        user_provided: true,
+                        is_partition_key: true,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "",
+                        field: "Root",
+                        user_provided: true,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "object",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/arr",
+                        field: "arr",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "array",
+                                ],
+                                must_exist: false,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
                     Projection {
                         ptr: "/bit",
                         field: "bit",
@@ -398,6 +472,24 @@ All {
                                     "boolean",
                                 ],
                                 must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/extra",
+                        field: "extra",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "boolean",
+                                ],
+                                must_exist: false,
                                 string: None,
                                 title: "",
                                 description: "",
@@ -428,6 +520,24 @@ All {
                         user_provided: false,
                         is_partition_key: false,
                         is_primary_key: true,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/len",
+                        field: "len",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
                         inference: Some(
                             Inference {
                                 types: [
@@ -682,92 +792,18 @@ All {
             },
         },
         BuiltCollection {
-            scope: test://example/int-halve#/collections/testing~1int-halve,
-            collection: testing/int-halve,
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
             spec: CollectionSpec {
-                collection: "testing/int-halve",
-                schema_uri: "test://example/int-string-len.schema",
-                schema_json: "{\"$defs\":{\"__flowInline1\":{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"},\"otherAnchor\":{\"$anchor\":\"Other\",\"type\":\"integer\"}},\"$id\":\"test://example/int-string-len.schema\",\"$ref\":\"test://example/int-string.schema\",\"additionalProperties\":{\"type\":\"boolean\"},\"properties\":{\"arr\":{\"additionalItems\":{\"$ref\":\"int-string.schema#AnAnchor\"},\"type\":\"array\"},\"bit\":{},\"int\":{},\"len\":{\"type\":\"integer\"},\"str\":{}},\"required\":[\"len\"]}",
+                collection: "testing/int-string.v2",
+                schema_uri: "test://example/int-string.schema",
+                schema_json: "{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}",
                 key_ptrs: [
                     "/int",
                 ],
                 uuid_ptr: "/_meta/uuid",
-                partition_fields: [
-                    "Len",
-                ],
+                partition_fields: [],
                 projections: [
-                    Projection {
-                        ptr: "/extra",
-                        field: "Extra",
-                        user_provided: true,
-                        is_partition_key: false,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "boolean",
-                                ],
-                                must_exist: false,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
-                    Projection {
-                        ptr: "/len",
-                        field: "Len",
-                        user_provided: true,
-                        is_partition_key: true,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "integer",
-                                ],
-                                must_exist: true,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
-                    Projection {
-                        ptr: "",
-                        field: "Root",
-                        user_provided: true,
-                        is_partition_key: false,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "object",
-                                ],
-                                must_exist: true,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
-                    Projection {
-                        ptr: "/arr",
-                        field: "arr",
-                        user_provided: false,
-                        is_partition_key: false,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "array",
-                                ],
-                                must_exist: false,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
                     Projection {
                         ptr: "/bit",
                         field: "bit",
@@ -780,24 +816,6 @@ All {
                                     "boolean",
                                 ],
                                 must_exist: true,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
-                    Projection {
-                        ptr: "/extra",
-                        field: "extra",
-                        user_provided: false,
-                        is_partition_key: false,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "boolean",
-                                ],
-                                must_exist: false,
                                 string: None,
                                 title: "",
                                 description: "",
@@ -841,24 +859,6 @@ All {
                         ),
                     },
                     Projection {
-                        ptr: "/len",
-                        field: "len",
-                        user_provided: false,
-                        is_partition_key: false,
-                        is_primary_key: false,
-                        inference: Some(
-                            Inference {
-                                types: [
-                                    "integer",
-                                ],
-                                must_exist: true,
-                                string: None,
-                                title: "",
-                                description: "",
-                            },
-                        ),
-                    },
-                    Projection {
                         ptr: "/str",
                         field: "str",
                         user_provided: false,
@@ -889,158 +889,6 @@ All {
         },
     ],
     built_derivations: [
-        BuiltDerivation {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation,
-            derivation: testing/int-reverse,
-            spec: DerivationSpec {
-                collection: Some(
-                    CollectionSpec {
-                        collection: "testing/int-reverse",
-                        schema_uri: "test://example/int-string.schema",
-                        schema_json: "{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}",
-                        key_ptrs: [
-                            "/int",
-                        ],
-                        uuid_ptr: "/_meta/uuid",
-                        partition_fields: [],
-                        projections: [
-                            Projection {
-                                ptr: "/bit",
-                                field: "bit",
-                                user_provided: false,
-                                is_partition_key: false,
-                                is_primary_key: false,
-                                inference: Some(
-                                    Inference {
-                                        types: [
-                                            "boolean",
-                                        ],
-                                        must_exist: true,
-                                        string: None,
-                                        title: "",
-                                        description: "",
-                                    },
-                                ),
-                            },
-                            Projection {
-                                ptr: "",
-                                field: "flow_document",
-                                user_provided: false,
-                                is_partition_key: false,
-                                is_primary_key: false,
-                                inference: Some(
-                                    Inference {
-                                        types: [
-                                            "object",
-                                        ],
-                                        must_exist: true,
-                                        string: None,
-                                        title: "",
-                                        description: "",
-                                    },
-                                ),
-                            },
-                            Projection {
-                                ptr: "/int",
-                                field: "int",
-                                user_provided: false,
-                                is_partition_key: false,
-                                is_primary_key: true,
-                                inference: Some(
-                                    Inference {
-                                        types: [
-                                            "integer",
-                                        ],
-                                        must_exist: true,
-                                        string: None,
-                                        title: "",
-                                        description: "",
-                                    },
-                                ),
-                            },
-                            Projection {
-                                ptr: "/str",
-                                field: "str",
-                                user_provided: false,
-                                is_partition_key: false,
-                                is_primary_key: false,
-                                inference: Some(
-                                    Inference {
-                                        types: [
-                                            "string",
-                                        ],
-                                        must_exist: true,
-                                        string: Some(
-                                            String {
-                                                content_type: "",
-                                                format: "",
-                                                is_base64: false,
-                                                max_length: 0,
-                                            },
-                                        ),
-                                        title: "",
-                                        description: "",
-                                    },
-                                ),
-                            },
-                        ],
-                        ack_json_template: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
-                    },
-                ),
-                register_schema_uri: "test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema",
-                register_initial_json: "null",
-                transforms: [
-                    TransformSpec {
-                        derivation: "testing/int-reverse",
-                        transform: "reverseIntString",
-                        shuffle: Some(
-                            Shuffle {
-                                group_name: "derive/testing/int-reverse/reverseIntString",
-                                source_collection: "testing/int-string",
-                                source_partitions: Some(
-                                    LabelSelector {
-                                        include: Some(
-                                            LabelSet {
-                                                labels: [
-                                                    Label {
-                                                        name: "estuary.dev/collection",
-                                                        value: "testing/int-string",
-                                                    },
-                                                ],
-                                            },
-                                        ),
-                                        exclude: Some(
-                                            LabelSet {
-                                                labels: [],
-                                            },
-                                        ),
-                                    },
-                                ),
-                                source_uuid_ptr: "/_meta/uuid",
-                                shuffle_key_ptr: [
-                                    "/int",
-                                ],
-                                uses_source_key: true,
-                                shuffle_lambda: None,
-                                source_schema_uri: "test://example/int-string.schema",
-                                uses_source_schema: true,
-                                validate_schema_at_read: true,
-                                filter_r_clocks: true,
-                                read_delay_seconds: 0,
-                                priority: 0,
-                            },
-                        ),
-                        update_lambda: None,
-                        publish_lambda: Some(
-                            LambdaSpec {
-                                typescript: "/derive/testing/int-reverse/reverseIntString/Publish",
-                                remote: "",
-                            },
-                        ),
-                    },
-                ],
-            },
-        },
         BuiltDerivation {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation,
             derivation: testing/int-halve,
@@ -1355,6 +1203,158 @@ All {
                         publish_lambda: Some(
                             LambdaSpec {
                                 typescript: "/derive/testing/int-halve/halveSelf/Publish",
+                                remote: "",
+                            },
+                        ),
+                    },
+                ],
+            },
+        },
+        BuiltDerivation {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation,
+            derivation: testing/int-reverse,
+            spec: DerivationSpec {
+                collection: Some(
+                    CollectionSpec {
+                        collection: "testing/int-reverse",
+                        schema_uri: "test://example/int-string.schema",
+                        schema_json: "{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}",
+                        key_ptrs: [
+                            "/int",
+                        ],
+                        uuid_ptr: "/_meta/uuid",
+                        partition_fields: [],
+                        projections: [
+                            Projection {
+                                ptr: "/bit",
+                                field: "bit",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: false,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "boolean",
+                                        ],
+                                        must_exist: true,
+                                        string: None,
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                            Projection {
+                                ptr: "",
+                                field: "flow_document",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: false,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "object",
+                                        ],
+                                        must_exist: true,
+                                        string: None,
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                            Projection {
+                                ptr: "/int",
+                                field: "int",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: true,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "integer",
+                                        ],
+                                        must_exist: true,
+                                        string: None,
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                            Projection {
+                                ptr: "/str",
+                                field: "str",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: false,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "string",
+                                        ],
+                                        must_exist: true,
+                                        string: Some(
+                                            String {
+                                                content_type: "",
+                                                format: "",
+                                                is_base64: false,
+                                                max_length: 0,
+                                            },
+                                        ),
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                        ],
+                        ack_json_template: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                    },
+                ),
+                register_schema_uri: "test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema",
+                register_initial_json: "null",
+                transforms: [
+                    TransformSpec {
+                        derivation: "testing/int-reverse",
+                        transform: "reverseIntString",
+                        shuffle: Some(
+                            Shuffle {
+                                group_name: "derive/testing/int-reverse/reverseIntString",
+                                source_collection: "testing/int-string",
+                                source_partitions: Some(
+                                    LabelSelector {
+                                        include: Some(
+                                            LabelSet {
+                                                labels: [
+                                                    Label {
+                                                        name: "estuary.dev/collection",
+                                                        value: "testing/int-string",
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                        exclude: Some(
+                                            LabelSet {
+                                                labels: [],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                source_uuid_ptr: "/_meta/uuid",
+                                shuffle_key_ptr: [
+                                    "/int",
+                                ],
+                                uses_source_key: true,
+                                shuffle_lambda: None,
+                                source_schema_uri: "test://example/int-string.schema",
+                                uses_source_schema: true,
+                                validate_schema_at_read: true,
+                                filter_r_clocks: true,
+                                read_delay_seconds: 0,
+                                priority: 0,
+                            },
+                        ),
+                        update_lambda: None,
+                        publish_lambda: Some(
+                            LambdaSpec {
+                                typescript: "/derive/testing/int-reverse/reverseIntString/Publish",
                                 remote: "",
                             },
                         ),
@@ -2111,9 +2111,9 @@ All {
     ],
     collections: [
         Collection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
-            schema: test://example/int-string.schema,
+            scope: test://example/int-halve#/collections/testing~1int-halve,
+            collection: testing/int-halve,
+            schema: test://example/int-string-len.schema,
             key: ["/int"],
         },
         Collection {
@@ -2129,193 +2129,93 @@ All {
             key: ["/int"],
         },
         Collection {
-            scope: test://example/int-halve#/collections/testing~1int-halve,
-            collection: testing/int-halve,
-            schema: test://example/int-string-len.schema,
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
+            schema: test://example/int-string.schema,
             key: ["/int"],
         },
     ],
     derivations: [
-        Derivation {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation,
-            derivation: testing/int-reverse,
-            register_schema: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
-            register_initial: null,
-        },
         Derivation {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation,
             derivation: testing/int-halve,
             register_schema: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
             register_initial: 42,
         },
+        Derivation {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation,
+            derivation: testing/int-reverse,
+            register_schema: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
+            register_initial: null,
+        },
     ],
     errors: [],
     fetches: [
         Fetch {
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
             resource: test://example/catalog.yaml,
-        },
-        Fetch {
-            resource: test://example/int-string,
-        },
-        Fetch {
-            resource: test://example/int-reverse,
-        },
-        Fetch {
-            resource: test://example/int-halve,
-        },
-        Fetch {
-            resource: test://example/int-string-captures,
-        },
-        Fetch {
-            resource: test://example/webhook-deliveries,
         },
         Fetch {
             resource: test://example/db-views,
         },
         Fetch {
-            resource: test://example/int-string-tests,
+            resource: test://example/db-views.ts,
         },
         Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
-            resource: test://example/int-string.ts,
-        },
-        Fetch {
-            resource: test://example/int-string.schema,
-        },
-        Fetch {
-            resource: test://example/int-reverse.ts,
+            resource: test://example/int-halve,
         },
         Fetch {
             resource: test://example/int-halve.ts,
         },
         Fetch {
-            resource: test://example/int-string-len.schema,
+            resource: test://example/int-reverse,
+        },
+        Fetch {
+            resource: test://example/int-reverse.ts,
+        },
+        Fetch {
+            resource: test://example/int-string,
+        },
+        Fetch {
+            resource: test://example/int-string-captures,
         },
         Fetch {
             resource: test://example/int-string-captures.ts,
         },
         Fetch {
-            resource: test://example/webhook-deliveries.ts,
+            resource: test://example/int-string-len.schema,
         },
         Fetch {
-            resource: test://example/db-views.ts,
+            resource: test://example/int-string-tests,
         },
         Fetch {
             resource: test://example/int-string-tests.ts,
         },
+        Fetch {
+            resource: test://example/int-string.schema,
+        },
+        Fetch {
+            resource: test://example/int-string.ts,
+        },
+        Fetch {
+            resource: test://example/webhook-deliveries,
+        },
+        Fetch {
+            resource: test://example/webhook-deliveries.ts,
+        },
     ],
     imports: [
-        Import {
-            scope: test://example/int-string#/import/0,
-            from_resource: test://example/int-string,
-            to_resource: test://example/int-halve,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string.v2/schema,
-            from_resource: test://example/int-string,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-reverse#/import/0,
-            from_resource: test://example/int-reverse,
-            to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
-            from_resource: test://example/int-reverse,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/register/schema,
-            from_resource: test://example/int-reverse,
-            to_resource: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
-        },
-        Import {
-            scope: test://example/int-halve#/collections/testing~1int-halve/derivation/register/schema,
-            from_resource: test://example/int-halve,
-            to_resource: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
-        },
-        Import {
-            scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString/source/schema,
-            from_resource: test://example/int-halve,
-            to_resource: test://example/int-string-len.schema,
-        },
-        Import {
-            scope: test://example/int-string-captures#/import/0,
-            from_resource: test://example/int-string-captures,
-            to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/webhook-deliveries#/import/0,
-            from_resource: test://example/webhook-deliveries,
-            to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/webhook-deliveries#/import/1,
-            from_resource: test://example/webhook-deliveries,
-            to_resource: test://example/int-halve,
-        },
-        Import {
-            scope: test://example/db-views#/import/0,
-            from_resource: test://example/db-views,
-            to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/int-string-tests#/import/0,
-            from_resource: test://example/int-string-tests,
-            to_resource: test://example/int-string,
-        },
         Import {
             scope: test://example/catalog.yaml,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/catalog.ts,
         },
         Import {
-            scope: test://example/int-string,
-            from_resource: test://example/int-string,
-            to_resource: test://example/int-string.ts,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string/schema,
-            from_resource: test://example/int-string,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/catalog.yaml#/import/0,
+            scope: test://example/catalog.yaml#/import/5,
             from_resource: test://example/catalog.yaml,
-            to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/int-reverse,
-            from_resource: test://example/int-reverse,
-            to_resource: test://example/int-reverse.ts,
-        },
-        Import {
-            scope: test://example/catalog.yaml#/import/1,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/int-reverse,
-        },
-        Import {
-            scope: test://example/int-halve,
-            from_resource: test://example/int-halve,
-            to_resource: test://example/int-halve.ts,
-        },
-        Import {
-            scope: test://example/int-string-len.schema#/properties/arr/additionalItems/$ref,
-            from_resource: test://example/int-string-len.schema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-string-len.schema#/$ref,
-            from_resource: test://example/int-string-len.schema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-halve#/collections/testing~1int-halve/schema,
-            from_resource: test://example/int-halve,
-            to_resource: test://example/int-string-len.schema,
+            to_resource: test://example/db-views,
         },
         Import {
             scope: test://example/catalog.yaml#/import/2,
@@ -2323,9 +2223,14 @@ All {
             to_resource: test://example/int-halve,
         },
         Import {
-            scope: test://example/int-string-captures,
-            from_resource: test://example/int-string-captures,
-            to_resource: test://example/int-string-captures.ts,
+            scope: test://example/catalog.yaml#/import/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/int-reverse,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/0,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/int-string,
         },
         Import {
             scope: test://example/catalog.yaml#/import/3,
@@ -2333,9 +2238,9 @@ All {
             to_resource: test://example/int-string-captures,
         },
         Import {
-            scope: test://example/webhook-deliveries,
-            from_resource: test://example/webhook-deliveries,
-            to_resource: test://example/webhook-deliveries.ts,
+            scope: test://example/catalog.yaml#/import/6,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/int-string-tests,
         },
         Import {
             scope: test://example/catalog.yaml#/import/4,
@@ -2348,9 +2253,94 @@ All {
             to_resource: test://example/db-views.ts,
         },
         Import {
-            scope: test://example/catalog.yaml#/import/5,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/db-views,
+            scope: test://example/db-views#/import/0,
+            from_resource: test://example/db-views,
+            to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/int-halve,
+            from_resource: test://example/int-halve,
+            to_resource: test://example/int-halve.ts,
+        },
+        Import {
+            scope: test://example/int-halve#/collections/testing~1int-halve/derivation/register/schema,
+            from_resource: test://example/int-halve,
+            to_resource: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
+        },
+        Import {
+            scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString/source/schema,
+            from_resource: test://example/int-halve,
+            to_resource: test://example/int-string-len.schema,
+        },
+        Import {
+            scope: test://example/int-halve#/collections/testing~1int-halve/schema,
+            from_resource: test://example/int-halve,
+            to_resource: test://example/int-string-len.schema,
+        },
+        Import {
+            scope: test://example/int-reverse,
+            from_resource: test://example/int-reverse,
+            to_resource: test://example/int-reverse.ts,
+        },
+        Import {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/register/schema,
+            from_resource: test://example/int-reverse,
+            to_resource: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
+        },
+        Import {
+            scope: test://example/int-reverse#/import/0,
+            from_resource: test://example/int-reverse,
+            to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
+            from_resource: test://example/int-reverse,
+            to_resource: test://example/int-string.schema,
+        },
+        Import {
+            scope: test://example/int-string#/import/0,
+            from_resource: test://example/int-string,
+            to_resource: test://example/int-halve,
+        },
+        Import {
+            scope: test://example/int-string#/collections/testing~1int-string.v2/schema,
+            from_resource: test://example/int-string,
+            to_resource: test://example/int-string.schema,
+        },
+        Import {
+            scope: test://example/int-string#/collections/testing~1int-string/schema,
+            from_resource: test://example/int-string,
+            to_resource: test://example/int-string.schema,
+        },
+        Import {
+            scope: test://example/int-string,
+            from_resource: test://example/int-string,
+            to_resource: test://example/int-string.ts,
+        },
+        Import {
+            scope: test://example/int-string-captures#/import/0,
+            from_resource: test://example/int-string-captures,
+            to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/int-string-captures,
+            from_resource: test://example/int-string-captures,
+            to_resource: test://example/int-string-captures.ts,
+        },
+        Import {
+            scope: test://example/int-string-len.schema#/properties/arr/additionalItems/$ref,
+            from_resource: test://example/int-string-len.schema,
+            to_resource: test://example/int-string.schema,
+        },
+        Import {
+            scope: test://example/int-string-len.schema#/$ref,
+            from_resource: test://example/int-string-len.schema,
+            to_resource: test://example/int-string.schema,
+        },
+        Import {
+            scope: test://example/int-string-tests#/import/0,
+            from_resource: test://example/int-string-tests,
+            to_resource: test://example/int-string,
         },
         Import {
             scope: test://example/int-string-tests,
@@ -2358,9 +2348,19 @@ All {
             to_resource: test://example/int-string-tests.ts,
         },
         Import {
-            scope: test://example/catalog.yaml#/import/6,
-            from_resource: test://example/catalog.yaml,
-            to_resource: test://example/int-string-tests,
+            scope: test://example/webhook-deliveries#/import/1,
+            from_resource: test://example/webhook-deliveries,
+            to_resource: test://example/int-halve,
+        },
+        Import {
+            scope: test://example/webhook-deliveries#/import/0,
+            from_resource: test://example/webhook-deliveries,
+            to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/webhook-deliveries,
+            from_resource: test://example/webhook-deliveries,
+            to_resource: test://example/webhook-deliveries.ts,
         },
     ],
     inferences: [
@@ -2398,6 +2398,19 @@ All {
                         max_length: 0,
                     },
                 ),
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/int-string-len.schema,
+            location: ,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: true,
+                string: None,
                 title: "",
                 description: "",
             },
@@ -2489,19 +2502,6 @@ All {
         },
         Inference {
             schema: test://example/int-string-len.schema,
-            location: ,
-            spec: Inference {
-                types: [
-                    "object",
-                ],
-                must_exist: true,
-                string: None,
-                title: "",
-                description: "",
-            },
-        },
-        Inference {
-            schema: test://example/int-string-len.schema,
             location: /int,
             spec: Inference {
                 types: [
@@ -2561,10 +2561,10 @@ All {
         },
         Inference {
             schema: test://example/int-string.schema,
-            location: /bit,
+            location: ,
             spec: Inference {
                 types: [
-                    "boolean",
+                    "object",
                 ],
                 must_exist: true,
                 string: None,
@@ -2574,10 +2574,10 @@ All {
         },
         Inference {
             schema: test://example/int-string.schema,
-            location: ,
+            location: /bit,
             spec: Inference {
                 types: [
-                    "object",
+                    "boolean",
                 ],
                 must_exist: true,
                 string: None,
@@ -2736,6 +2736,17 @@ All {
     ],
     materialization_bindings: [
         MaterializationBinding {
+            scope: test://example/db-views#/materializations/testing~1db-views/bindings/0,
+            materialization: testing/db-views,
+            materialization_index: 0,
+            resource_spec: {"table":"the_table"},
+            collection: testing/int-string,
+            fields_exclude: [],
+            fields_include: {},
+            fields_recommended: 1,
+            source_partitions: NULL,
+        },
+        MaterializationBinding {
             scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/bindings/0,
             materialization: testing/webhook/deliveries,
             materialization_index: 0,
@@ -2757,30 +2768,19 @@ All {
             fields_recommended: 0,
             source_partitions: NULL,
         },
-        MaterializationBinding {
-            scope: test://example/db-views#/materializations/testing~1db-views/bindings/0,
-            materialization: testing/db-views,
-            materialization_index: 0,
-            resource_spec: {"table":"the_table"},
-            collection: testing/int-string,
-            fields_exclude: [],
-            fields_include: {},
-            fields_recommended: 1,
-            source_partitions: NULL,
-        },
     ],
     materializations: [
-        Materialization {
-            scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries,
-            materialization: testing/webhook/deliveries,
-            endpoint_type: "Webhook",
-            endpoint_spec: {"address":"http://example/webhook"},
-        },
         Materialization {
             scope: test://example/db-views#/materializations/testing~1db-views,
             materialization: testing/db-views,
             endpoint_type: "FlowSink",
             endpoint_spec: {"config":{"foo":"bar"},"image":"database/image"},
+        },
+        Materialization {
+            scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries,
+            materialization: testing/webhook/deliveries,
+            endpoint_type: "Webhook",
+            endpoint_spec: {"address":"http://example/webhook"},
         },
     ],
     meta: [],
@@ -2798,22 +2798,6 @@ All {
     ],
     npm_dependencies: [],
     projections: [
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string/projections/Int,
-            collection: testing/int-string,
-            field: Int,
-            location: /int,
-            partition: 0,
-            user_provided: 1,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string/projections/bit,
-            collection: testing/int-string,
-            field: bit,
-            location: /bit,
-            partition: 1,
-            user_provided: 1,
-        },
         Projection {
             scope: test://example/int-halve#/collections/testing~1int-halve/projections/Extra,
             collection: testing/int-halve,
@@ -2837,94 +2821,6 @@ All {
             location: ,
             partition: 0,
             user_provided: 1,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
-            field: bit,
-            location: /bit,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
-            field: flow_document,
-            location: ,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
-            field: int,
-            location: /int,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string.v2,
-            collection: testing/int-string.v2,
-            field: str,
-            location: /str,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse,
-            collection: testing/int-reverse,
-            field: bit,
-            location: /bit,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse,
-            collection: testing/int-reverse,
-            field: flow_document,
-            location: ,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse,
-            collection: testing/int-reverse,
-            field: int,
-            location: /int,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse,
-            collection: testing/int-reverse,
-            field: str,
-            location: /str,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string,
-            collection: testing/int-string,
-            field: flow_document,
-            location: ,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string,
-            collection: testing/int-string,
-            field: int,
-            location: /int,
-            partition: 0,
-            user_provided: 0,
-        },
-        Projection {
-            scope: test://example/int-string#/collections/testing~1int-string,
-            collection: testing/int-string,
-            field: str,
-            location: /str,
-            partition: 0,
-            user_provided: 0,
         },
         Projection {
             scope: test://example/int-halve#/collections/testing~1int-halve,
@@ -2982,6 +2878,110 @@ All {
             partition: 0,
             user_provided: 0,
         },
+        Projection {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse,
+            collection: testing/int-reverse,
+            field: bit,
+            location: /bit,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse,
+            collection: testing/int-reverse,
+            field: flow_document,
+            location: ,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse,
+            collection: testing/int-reverse,
+            field: int,
+            location: /int,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse,
+            collection: testing/int-reverse,
+            field: str,
+            location: /str,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string/projections/Int,
+            collection: testing/int-string,
+            field: Int,
+            location: /int,
+            partition: 0,
+            user_provided: 1,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string/projections/bit,
+            collection: testing/int-string,
+            field: bit,
+            location: /bit,
+            partition: 1,
+            user_provided: 1,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string,
+            collection: testing/int-string,
+            field: flow_document,
+            location: ,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string,
+            collection: testing/int-string,
+            field: int,
+            location: /int,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string,
+            collection: testing/int-string,
+            field: str,
+            location: /str,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
+            field: bit,
+            location: /bit,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
+            field: flow_document,
+            location: ,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
+            field: int,
+            location: /int,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/int-string#/collections/testing~1int-string.v2,
+            collection: testing/int-string.v2,
+            field: str,
+            location: /str,
+            partition: 0,
+            user_provided: 0,
+        },
     ],
     resources: [
         Resource {
@@ -2990,18 +2990,8 @@ All {
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/int-string,
+            resource: test://example/db-views,
             content_type: "CatalogSpec",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/int-reverse,
-            content_type: "CatalogSpec",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
-            content_type: "JsonSchema",
             content: ".. binary ..",
         },
         Resource {
@@ -3010,8 +3000,33 @@ All {
             content: ".. binary ..",
         },
         Resource {
+            resource: test://example/int-halve.ts,
+            content_type: "TypescriptModule",
+            content: ".. binary ..",
+        },
+        Resource {
             resource: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
             content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/int-reverse,
+            content_type: "CatalogSpec",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/int-reverse.ts,
+            content_type: "TypescriptModule",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/int-string,
+            content_type: "CatalogSpec",
             content: ".. binary ..",
         },
         Resource {
@@ -3020,13 +3035,8 @@ All {
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/webhook-deliveries,
-            content_type: "CatalogSpec",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/db-views,
-            content_type: "CatalogSpec",
+            resource: test://example/int-string-len.schema,
+            content_type: "JsonSchema",
             content: ".. binary ..",
         },
         Resource {
@@ -3040,37 +3050,27 @@ All {
             content: ".. binary ..",
         },
         Resource {
-            resource: test://example/int-reverse.ts,
-            content_type: "TypescriptModule",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/int-halve.ts,
-            content_type: "TypescriptModule",
-            content: ".. binary ..",
-        },
-        Resource {
-            resource: test://example/int-string-len.schema,
-            content_type: "JsonSchema",
+            resource: test://example/webhook-deliveries,
+            content_type: "CatalogSpec",
             content: ".. binary ..",
         },
     ],
     schema_docs: [
         SchemaDoc {
-            schema: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
-            dom: true,
-        },
-        SchemaDoc {
             schema: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
             dom: {"type":"integer"},
         },
         SchemaDoc {
-            schema: test://example/int-string.schema,
-            dom: {"$defs":{"anAnchor":{"$anchor":"AnAnchor","properties":{"one":{"type":"string"},"two":{"type":"integer"}},"required":["one"],"type":"object"}},"properties":{"bit":{"type":"boolean"},"int":{"type":"integer"},"str":{"type":"string"}},"required":["int","str","bit"],"type":"object"},
+            schema: test://example/int-reverse?ptr=/collections/testing~1int-reverse/derivation/register/schema,
+            dom: true,
         },
         SchemaDoc {
             schema: test://example/int-string-len.schema,
             dom: {"$defs":{"otherAnchor":{"$anchor":"Other","type":"integer"}},"$ref":"test://example/int-string.schema","additionalProperties":{"type":"boolean"},"properties":{"arr":{"additionalItems":{"$ref":"int-string.schema#AnAnchor"},"type":"array"},"bit":{},"int":{},"len":{"type":"integer"},"str":{}},"required":["len"]},
+        },
+        SchemaDoc {
+            schema: test://example/int-string.schema,
+            dom: {"$defs":{"anAnchor":{"$anchor":"AnAnchor","properties":{"one":{"type":"string"},"two":{"type":"integer"}},"required":["one"],"type":"object"}},"properties":{"bit":{"type":"boolean"},"int":{"type":"integer"},"str":{"type":"string"}},"required":["int","str","bit"],"type":"object"},
         },
     ],
     shard_rules: [],
@@ -3095,20 +3095,6 @@ All {
         },
     ],
     transforms: [
-        Transform {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
-            derivation: testing/int-reverse,
-            priority: 0,
-            publish_lambda: "typescript",
-            read_delay_seconds: NULL,
-            shuffle_key: NULL,
-            shuffle_lambda: NULL,
-            source_collection: testing/int-string,
-            source_partitions: NULL,
-            source_schema: NULL,
-            transform: reverseIntString,
-            update_lambda: NULL,
-        },
         Transform {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
             derivation: testing/int-halve,
@@ -3135,6 +3121,20 @@ All {
             source_partitions: NULL,
             source_schema: NULL,
             transform: halveSelf,
+            update_lambda: NULL,
+        },
+        Transform {
+            scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+            derivation: testing/int-reverse,
+            priority: 0,
+            publish_lambda: "typescript",
+            read_delay_seconds: NULL,
+            shuffle_key: NULL,
+            shuffle_lambda: NULL,
+            source_collection: testing/int-string,
+            source_partitions: NULL,
+            source_schema: NULL,
+            transform: reverseIntString,
             update_lambda: NULL,
         },
     ],

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -374,6 +374,184 @@ All {
     ],
     built_collections: [
         BuiltCollection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            spec: CollectionSpec {
+                collection: "testing/array-key",
+                schema_uri: "test://example/array-key.schema",
+                schema_json: "{\"$id\":\"test://example/array-key.schema\",\"properties\":{\"arr\":{\"items\":{\"properties\":{\"aKey\":{\"type\":\"integer\"}},\"required\":[\"aKey\"],\"type\":\"object\"},\"minItems\":5,\"type\":\"array\"}},\"required\":[\"arr\"],\"type\":\"object\"}",
+                key_ptrs: [
+                    "/arr/0/aKey",
+                ],
+                uuid_ptr: "/_meta/uuid",
+                partition_fields: [],
+                projections: [
+                    Projection {
+                        ptr: "/arr/1/aKey",
+                        field: "aKeyOne",
+                        user_provided: true,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/arr",
+                        field: "arr",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "array",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/arr/0/aKey",
+                        field: "arr/0/aKey",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: true,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/arr/1/aKey",
+                        field: "arr/1/aKey",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/arr/3/aKey",
+                        field: "arr/3/aKey",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "",
+                        field: "flow_document",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "object",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                ],
+                ack_json_template: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+            },
+        },
+        BuiltCollection {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key,
+            collection: testing/from-array-key,
+            spec: CollectionSpec {
+                collection: "testing/from-array-key",
+                schema_uri: "test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema",
+                schema_json: "{\"$id\":\"test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema\",\"properties\":{\"someKey\":{\"type\":\"integer\"}},\"required\":[\"someKey\"],\"type\":\"object\"}",
+                key_ptrs: [
+                    "/someKey",
+                ],
+                uuid_ptr: "/_meta/uuid",
+                partition_fields: [],
+                projections: [
+                    Projection {
+                        ptr: "",
+                        field: "flow_document",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "object",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/someKey",
+                        field: "someKey",
+                        user_provided: false,
+                        is_partition_key: false,
+                        is_primary_key: true,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                must_exist: true,
+                                string: None,
+                                title: "",
+                                description: "",
+                            },
+                        ),
+                    },
+                ],
+                ack_json_template: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+            },
+        },
+        BuiltCollection {
             scope: test://example/int-halve#/collections/testing~1int-halve,
             collection: testing/int-halve,
             spec: CollectionSpec {
@@ -889,6 +1067,163 @@ All {
         },
     ],
     built_derivations: [
+        BuiltDerivation {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation,
+            derivation: testing/from-array-key,
+            spec: DerivationSpec {
+                collection: Some(
+                    CollectionSpec {
+                        collection: "testing/from-array-key",
+                        schema_uri: "test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema",
+                        schema_json: "{\"$id\":\"test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema\",\"properties\":{\"someKey\":{\"type\":\"integer\"}},\"required\":[\"someKey\"],\"type\":\"object\"}",
+                        key_ptrs: [
+                            "/someKey",
+                        ],
+                        uuid_ptr: "/_meta/uuid",
+                        partition_fields: [],
+                        projections: [
+                            Projection {
+                                ptr: "",
+                                field: "flow_document",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: false,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "object",
+                                        ],
+                                        must_exist: true,
+                                        string: None,
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                            Projection {
+                                ptr: "/someKey",
+                                field: "someKey",
+                                user_provided: false,
+                                is_partition_key: false,
+                                is_primary_key: true,
+                                inference: Some(
+                                    Inference {
+                                        types: [
+                                            "integer",
+                                        ],
+                                        must_exist: true,
+                                        string: None,
+                                        title: "",
+                                        description: "",
+                                    },
+                                ),
+                            },
+                        ],
+                        ack_json_template: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                    },
+                ),
+                register_schema_uri: "test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema",
+                register_initial_json: "null",
+                transforms: [
+                    TransformSpec {
+                        derivation: "testing/from-array-key",
+                        transform: "withSourceSchema",
+                        shuffle: Some(
+                            Shuffle {
+                                group_name: "derive/testing/from-array-key/withSourceSchema",
+                                source_collection: "testing/array-key",
+                                source_partitions: Some(
+                                    LabelSelector {
+                                        include: Some(
+                                            LabelSet {
+                                                labels: [
+                                                    Label {
+                                                        name: "estuary.dev/collection",
+                                                        value: "testing/array-key",
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                        exclude: Some(
+                                            LabelSet {
+                                                labels: [],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                source_uuid_ptr: "/_meta/uuid",
+                                shuffle_key_ptr: [
+                                    "/arr/2/aKey",
+                                ],
+                                uses_source_key: false,
+                                shuffle_lambda: None,
+                                source_schema_uri: "test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema",
+                                uses_source_schema: false,
+                                validate_schema_at_read: true,
+                                filter_r_clocks: true,
+                                read_delay_seconds: 0,
+                                priority: 0,
+                            },
+                        ),
+                        update_lambda: None,
+                        publish_lambda: Some(
+                            LambdaSpec {
+                                typescript: "",
+                                remote: "https://an/api",
+                            },
+                        ),
+                    },
+                    TransformSpec {
+                        derivation: "testing/from-array-key",
+                        transform: "withoutSourceSchema",
+                        shuffle: Some(
+                            Shuffle {
+                                group_name: "derive/testing/from-array-key/withoutSourceSchema",
+                                source_collection: "testing/array-key",
+                                source_partitions: Some(
+                                    LabelSelector {
+                                        include: Some(
+                                            LabelSet {
+                                                labels: [
+                                                    Label {
+                                                        name: "estuary.dev/collection",
+                                                        value: "testing/array-key",
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                        exclude: Some(
+                                            LabelSet {
+                                                labels: [],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                source_uuid_ptr: "/_meta/uuid",
+                                shuffle_key_ptr: [
+                                    "/arr/3/aKey",
+                                ],
+                                uses_source_key: false,
+                                shuffle_lambda: None,
+                                source_schema_uri: "test://example/array-key.schema",
+                                uses_source_schema: true,
+                                validate_schema_at_read: true,
+                                filter_r_clocks: true,
+                                read_delay_seconds: 0,
+                                priority: 0,
+                            },
+                        ),
+                        update_lambda: None,
+                        publish_lambda: Some(
+                            LambdaSpec {
+                                typescript: "",
+                                remote: "https://an/api",
+                            },
+                        ),
+                    },
+                ],
+            },
+        },
         BuiltDerivation {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation,
             derivation: testing/int-halve,
@@ -2111,6 +2446,18 @@ All {
     ],
     collections: [
         Collection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            schema: test://example/array-key.schema,
+            key: ["/arr/0/aKey"],
+        },
+        Collection {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key,
+            collection: testing/from-array-key,
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+            key: ["/someKey"],
+        },
+        Collection {
             scope: test://example/int-halve#/collections/testing~1int-halve,
             collection: testing/int-halve,
             schema: test://example/int-string-len.schema,
@@ -2137,6 +2484,12 @@ All {
     ],
     derivations: [
         Derivation {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation,
+            derivation: testing/from-array-key,
+            register_schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema,
+            register_initial: null,
+        },
+        Derivation {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation,
             derivation: testing/int-halve,
             register_schema: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
@@ -2152,6 +2505,15 @@ All {
     errors: [],
     fetches: [
         Fetch {
+            resource: test://example/array-key,
+        },
+        Fetch {
+            resource: test://example/array-key.schema,
+        },
+        Fetch {
+            resource: test://example/array-key.ts,
+        },
+        Fetch {
             resource: test://example/catalog.ts,
         },
         Fetch {
@@ -2162,6 +2524,12 @@ All {
         },
         Fetch {
             resource: test://example/db-views.ts,
+        },
+        Fetch {
+            resource: test://example/from-array-key,
+        },
+        Fetch {
+            resource: test://example/from-array-key.ts,
         },
         Fetch {
             resource: test://example/int-halve,
@@ -2208,6 +2576,21 @@ All {
     ],
     imports: [
         Import {
+            scope: test://example/array-key#/collections/testing~1array-key/schema,
+            from_resource: test://example/array-key,
+            to_resource: test://example/array-key.schema,
+        },
+        Import {
+            scope: test://example/array-key,
+            from_resource: test://example/array-key,
+            to_resource: test://example/array-key.ts,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/7,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/array-key,
+        },
+        Import {
             scope: test://example/catalog.yaml,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/catalog.ts,
@@ -2216,6 +2599,11 @@ All {
             scope: test://example/catalog.yaml#/import/5,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/db-views,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/8,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/from-array-key,
         },
         Import {
             scope: test://example/catalog.yaml#/import/2,
@@ -2256,6 +2644,36 @@ All {
             scope: test://example/db-views#/import/0,
             from_resource: test://example/db-views,
             to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/from-array-key#/import/0,
+            from_resource: test://example/from-array-key,
+            to_resource: test://example/array-key,
+        },
+        Import {
+            scope: test://example/from-array-key,
+            from_resource: test://example/from-array-key,
+            to_resource: test://example/from-array-key.ts,
+        },
+        Import {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation/register/schema,
+            from_resource: test://example/from-array-key,
+            to_resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema,
+        },
+        Import {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            from_resource: test://example/from-array-key,
+            to_resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+        },
+        Import {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/schema,
+            from_resource: test://example/from-array-key,
+            to_resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+        },
+        Import {
+            scope: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema#/$ref,
+            from_resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            to_resource: test://example/array-key.schema,
         },
         Import {
             scope: test://example/int-halve,
@@ -2364,6 +2782,213 @@ All {
         },
     ],
     inferences: [
+        Inference {
+            schema: test://example/array-key.schema,
+            location: ,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr,
+            spec: Inference {
+                types: [
+                    "array",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr/-,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: false,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr/-/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: false,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr/0/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr/1/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/array-key.schema,
+            location: /arr/3/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema,
+            location: ,
+            spec: Inference {
+                types: [
+                    "array",
+                    "boolean",
+                    "null",
+                    "number",
+                    "object",
+                    "string",
+                ],
+                must_exist: true,
+                string: Some(
+                    String {
+                        content_type: "",
+                        format: "",
+                        is_base64: false,
+                        max_length: 0,
+                    },
+                ),
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            location: ,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            location: /arr,
+            spec: Inference {
+                types: [
+                    "array",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            location: /arr/-,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: false,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            location: /arr/-/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: false,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            location: /arr/2/aKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+            location: ,
+            spec: Inference {
+                types: [
+                    "object",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
+        Inference {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+            location: /someKey,
+            spec: Inference {
+                types: [
+                    "integer",
+                ],
+                must_exist: true,
+                string: None,
+                title: "",
+                description: "",
+            },
+        },
         Inference {
             schema: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
             location: ,
@@ -2799,6 +3424,70 @@ All {
     npm_dependencies: [],
     projections: [
         Projection {
+            scope: test://example/array-key#/collections/testing~1array-key/projections/aKeyOne,
+            collection: testing/array-key,
+            field: aKeyOne,
+            location: /arr/1/aKey,
+            partition: 0,
+            user_provided: 1,
+        },
+        Projection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            field: arr,
+            location: /arr,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            field: arr/0/aKey,
+            location: /arr/0/aKey,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            field: arr/1/aKey,
+            location: /arr/1/aKey,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            field: arr/3/aKey,
+            location: /arr/3/aKey,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/array-key#/collections/testing~1array-key,
+            collection: testing/array-key,
+            field: flow_document,
+            location: ,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key,
+            collection: testing/from-array-key,
+            field: flow_document,
+            location: ,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key,
+            collection: testing/from-array-key,
+            field: someKey,
+            location: /someKey,
+            partition: 0,
+            user_provided: 0,
+        },
+        Projection {
             scope: test://example/int-halve#/collections/testing~1int-halve/projections/Extra,
             collection: testing/int-halve,
             field: Extra,
@@ -2985,6 +3674,16 @@ All {
     ],
     resources: [
         Resource {
+            resource: test://example/array-key,
+            content_type: "CatalogSpec",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/array-key.schema,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
             resource: test://example/catalog.yaml,
             content_type: "CatalogSpec",
             content: ".. binary ..",
@@ -2992,6 +3691,26 @@ All {
         Resource {
             resource: test://example/db-views,
             content_type: "CatalogSpec",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/from-array-key,
+            content_type: "CatalogSpec",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            content_type: "JsonSchema",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+            content_type: "JsonSchema",
             content: ".. binary ..",
         },
         Resource {
@@ -3057,6 +3776,22 @@ All {
     ],
     schema_docs: [
         SchemaDoc {
+            schema: test://example/array-key.schema,
+            dom: {"properties":{"arr":{"items":{"properties":{"aKey":{"type":"integer"}},"required":["aKey"],"type":"object"},"minItems":5,"type":"array"}},"required":["arr"],"type":"object"},
+        },
+        SchemaDoc {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/register/schema,
+            dom: true,
+        },
+        SchemaDoc {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            dom: {"$ref":"test://example/array-key.schema"},
+        },
+        SchemaDoc {
+            schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/schema,
+            dom: {"properties":{"someKey":{"type":"integer"}},"required":["someKey"],"type":"object"},
+        },
+        SchemaDoc {
             schema: test://example/int-halve?ptr=/collections/testing~1int-halve/derivation/register/schema,
             dom: {"type":"integer"},
         },
@@ -3095,6 +3830,34 @@ All {
         },
     ],
     transforms: [
+        Transform {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation/transform/withSourceSchema,
+            derivation: testing/from-array-key,
+            priority: 0,
+            publish_lambda: {"remote":"https://an/api"},
+            read_delay_seconds: NULL,
+            shuffle_key: ["/arr/2/aKey"],
+            shuffle_lambda: NULL,
+            source_collection: testing/array-key,
+            source_partitions: NULL,
+            source_schema: test://example/from-array-key?ptr=/collections/testing~1from-array-key/derivation/transform/withSourceSchema/source/schema,
+            transform: withSourceSchema,
+            update_lambda: NULL,
+        },
+        Transform {
+            scope: test://example/from-array-key#/collections/testing~1from-array-key/derivation/transform/withoutSourceSchema,
+            derivation: testing/from-array-key,
+            priority: 0,
+            publish_lambda: {"remote":"https://an/api"},
+            read_delay_seconds: NULL,
+            shuffle_key: ["/arr/3/aKey"],
+            shuffle_lambda: NULL,
+            source_collection: testing/array-key,
+            source_partitions: NULL,
+            source_schema: NULL,
+            transform: withoutSourceSchema,
+            update_lambda: NULL,
+        },
         Transform {
             scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
             derivation: testing/int-halve,

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -2505,72 +2505,95 @@ All {
     errors: [],
     fetches: [
         Fetch {
-            resource: test://example/array-key,
-        },
-        Fetch {
-            resource: test://example/array-key.schema,
-        },
-        Fetch {
-            resource: test://example/array-key.ts,
-        },
-        Fetch {
-            resource: test://example/catalog.ts,
-        },
-        Fetch {
+            depth: 1,
             resource: test://example/catalog.yaml,
         },
         Fetch {
+            depth: 2,
+            resource: test://example/array-key,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/db-views,
         },
         Fetch {
-            resource: test://example/db-views.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/from-array-key,
         },
         Fetch {
-            resource: test://example/from-array-key.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/int-halve,
         },
         Fetch {
-            resource: test://example/int-halve.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/int-reverse,
         },
         Fetch {
-            resource: test://example/int-reverse.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/int-string,
         },
         Fetch {
+            depth: 2,
             resource: test://example/int-string-captures,
         },
         Fetch {
-            resource: test://example/int-string-captures.ts,
-        },
-        Fetch {
-            resource: test://example/int-string-len.schema,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/int-string-tests,
         },
         Fetch {
-            resource: test://example/int-string-tests.ts,
-        },
-        Fetch {
-            resource: test://example/int-string.schema,
-        },
-        Fetch {
-            resource: test://example/int-string.ts,
-        },
-        Fetch {
+            depth: 2,
             resource: test://example/webhook-deliveries,
         },
         Fetch {
+            depth: 3,
+            resource: test://example/array-key.schema,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/array-key.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/db-views.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/from-array-key.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-halve.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-reverse.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-string-captures.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-string-len.schema,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-string-tests.ts,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-string.schema,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/int-string.ts,
+        },
+        Fetch {
+            depth: 3,
             resource: test://example/webhook-deliveries.ts,
         },
     ],

--- a/crates/validation/tests/snapshots/scenario_tests__incompatible_npm_packages.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__incompatible_npm_packages.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/validation/tests/scenario_tests.rs
 expression: errors
+
 ---
 [
     Error {
-        scope: test://example/catalog.yaml#/npmDependencies/pkg-2,
-        error: package pkg-2 is repeated with incompatible versions "different" here, vs "differ ent" at test://example/int-string#/npmDependencies/pkg-2,
+        scope: test://example/int-string#/npmDependencies/pkg-2,
+        error: package pkg-2 is repeated with incompatible versions "differ ent" here, vs "different" at test://example/catalog.yaml#/npmDependencies/pkg-2,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
@@ -5,6 +5,10 @@ expression: errors
 ---
 [
     Error {
+        scope: test://example/catalog.yaml#/collections/,
+        error: collection name cannot be empty,
+    },
+    Error {
         scope: test://example/catalog.yaml#/collections/~1bad~1name,
         error: /bad/name cannot be used as name for collection ("/" is invalid),
     },
@@ -23,10 +27,6 @@ expression: errors
     Error {
         scope: test://example/catalog.yaml#/collections/bad~1name~1,
         error: bad/name/ cannot be used as name for collection ("/" is invalid),
-    },
-    Error {
-        scope: test://example/catalog.yaml#/collections/,
-        error: collection name cannot be empty,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/,

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
@@ -34,7 +34,7 @@ expression: errors
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing,
-        error: collection testing is a prohibited prefix of capture testing/db-cdc, defined at test://example/int-string-captures#/captures/testing~1db-cdc,
+        error: collection testing is a prohibited prefix of collection testing/array-key, defined at test://example/array-key#/collections/testing~1array-key,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing~1Int-Halve,

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
@@ -5,8 +5,8 @@ expression: errors
 ---
 [
     Error {
-        scope: test://example/int-string#/collections/testing~1int-string.v2,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
+        scope: test://example/int-halve#/collections/testing~1int-halve,
+        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse,
@@ -17,11 +17,7 @@ expression: errors
         error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
     },
     Error {
-        scope: test://example/int-halve#/collections/testing~1int-halve,
-        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
-    },
-    Error {
-        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        scope: test://example/int-string#/collections/testing~1int-string.v2,
         error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
     },
     Error {
@@ -31,5 +27,9 @@ expression: errors
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveSelf,
         error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
+    },
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__schema_fragment_not_found.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__schema_fragment_not_found.snap
@@ -13,6 +13,10 @@ expression: errors
         error: referenced schema fragment location test://example/int-string.schema#/not/found does not exist,
     },
     Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        error: referenced schema fragment location test://example/int-string.schema#/not/found does not exist,
+    },
+    Error {
         scope: test://example/int-string#/collections/testing~1int-string,
         error: location /int is unknown in schema test://example/int-string.schema#/not/found,
     },

--- a/crates/validation/tests/snapshots/scenario_tests__schema_fragment_not_found.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__schema_fragment_not_found.snap
@@ -29,15 +29,15 @@ expression: errors
         error: location /bit is unknown in schema test://example/int-string.schema#/not/found,
     },
     Error {
-        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
-        error: location /int is unknown in schema test://example/int-string.schema#/not/found,
-    },
-    Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
         error: location /len is unknown in schema test://example/int-string-len.schema#/not/found,
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
         error: location /int is unknown in schema test://example/int-string-len.schema#/not/found,
+    },
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        error: location /int is unknown in schema test://example/int-string.schema#/not/found,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__unknown_locations.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__unknown_locations.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/validation/tests/scenario_tests.rs
 expression: errors
+
 ---
 [
     Error {
@@ -12,11 +13,11 @@ expression: errors
         error: location /unknown/projection is unknown in schema test://example/int-string.schema,
     },
     Error {
-        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
-        error: location /unknown/key is unknown in schema test://example/int-string.schema,
-    },
-    Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
         error: location /unknown/shuffle is unknown in schema test://example/int-string-len.schema,
+    },
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        error: location /unknown/key is unknown in schema test://example/int-string.schema,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__use_without_import.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__use_without_import.snap
@@ -5,12 +5,12 @@ expression: errors
 ---
 [
     Error {
-        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
-        error: transform reverseIntString references collection testing/int-string, defined at test://example/int-string#/collections/testing~1int-string, without importing it or being imported by it,
-    },
-    Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
         error: transform halveIntString references collection testing/int-string, defined at test://example/int-string#/collections/testing~1int-string, without importing it or being imported by it,
+    },
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
+        error: transform reverseIntString references collection testing/int-string, defined at test://example/int-string#/collections/testing~1int-string, without importing it or being imported by it,
     },
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/bindings/0,


### PR DESCRIPTION
Definitely review this commit by commit. They tell the story of how this change set came together.

It was a bit of a rabbit hole to fix a seemingly minor bug. I found myself really, really wanting reliable guarantees that tables were ordered by their natural keys, that could be leveraged for lookups throughout the validation codebase. It's a little more complicated than simply slapping a BTreeSet into the mix, because our tables are actually _multi_sets. We want to represent multiple instances of various entities, so that we can generate good catalog build errors as we walk those duplicates.

Fixes #231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/232)
<!-- Reviewable:end -->
