### PR TITLE
Phil/rust metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator"
+version = "0.0.0"
+dependencies = [
+ "jemalloc-ctl",
+ "jemallocator",
+ "lazy_static",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,7 @@ dependencies = [
 name = "bindings"
 version = "0.0.0"
 dependencies = [
+ "allocator",
  "anyhow",
  "build",
  "cbindgen",
@@ -279,6 +289,7 @@ dependencies = [
 name = "derive"
 version = "0.0.0"
 dependencies = [
+ "allocator",
  "anyhow",
  "bytes",
  "doc",
@@ -295,6 +306,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "stats_alloc",
  "tempfile",
  "thiserror",
  "tracing",
@@ -401,6 +413,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "funty"
@@ -632,6 +650,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +879,25 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
 
 [[package]]
 name = "pathdiff"
@@ -1297,6 +1366,12 @@ dependencies = [
  "url",
  "yaml-merge-keys",
 ]
+
+[[package]]
+name = "stats_alloc"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 
 [patch.'crates-io']
 rocksdb = { git = "https://github.com/jgraettinger/rust-rocksdb" }
-librocksdb-sys = { git = "https://github.com/jgraettinger/rust-rocksdb", path = "librocksdb-sys" }
+librocksdb-sys = { git = "https://github.com/jgraettinger/rust-rocksdb" }

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "allocator"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+lazy_static = "*"
+jemallocator = "*"
+jemalloc-ctl = "*"
+

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -1,0 +1,166 @@
+use jemalloc_ctl::{epoch, epoch_mib, stats, thread};
+use jemallocator::Jemalloc;
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[global_allocator]
+static ALLOC: FlowAllocator = FlowAllocator;
+
+/// Statistics related to memory allocations for the entire (rust portion) of the application. The
+/// precise meaning of each field is included in the [jemalloc man
+/// page](http://jemalloc.net/jemalloc.3.html). Each field in this struct can be found in the man
+/// page prefixed by "stats.". The TLDR is that the fields in this struct are all effectively
+/// gauges of the number of bytes.
+#[derive(Debug)]
+pub struct JemallocGlobalStats {
+    pub active: u64,
+    pub allocated: u64,
+    pub mapped: u64,
+    pub metadata: u64,
+    pub resident: u64,
+    pub retained: u64,
+
+    /// counts are not part of the stats exposed by jemalloc, so see the struct definition for the
+    /// meanings.
+    pub counts: AllocationCounts,
+}
+
+/// Counts are collected by instrumenting the global allocator, rather than introspecting it.
+/// These are monotonic counters of allocator invocations.
+#[derive(Debug)]
+pub struct AllocationCounts {
+    /// Total number of allocation operations performed.
+    pub alloc_ops: u64,
+    /// Total number of deallocation operations performed.
+    pub dealloc_ops: u64,
+    /// Total number of reallocation operations performed.
+    pub realloc_ops: u64,
+}
+
+/// Returns the current global (to rust) memory stats.
+pub fn current_mem_stats() -> JemallocGlobalStats {
+    MEM_STATS.current()
+}
+
+/// Memory allocation statistics that are scoped to a specific thread.
+/// These are exposed by jemalloc, and the values are in terms of bytes.
+#[derive(Debug, Clone, Copy)]
+pub struct ThreadStats {
+    pub allocated: u64,
+    pub deallocated: u64,
+}
+
+impl std::ops::Sub for ThreadStats {
+    type Output = ThreadStats;
+    fn sub(self, rhs: Self) -> Self::Output {
+        ThreadStats {
+            allocated: rhs.allocated - self.allocated,
+            deallocated: rhs.deallocated - self.deallocated,
+        }
+    }
+}
+
+/// Allows reading memory allocation stats for the current thread.
+pub struct ThreadStatsReader {
+    allocated: thread::ThreadLocal<u64>,
+    deallocated: thread::ThreadLocal<u64>,
+}
+
+impl ThreadStatsReader {
+    pub fn new() -> ThreadStatsReader {
+        ThreadStatsReader {
+            allocated: THREAD_ALLOC_MIB.read().unwrap(),
+            deallocated: THREAD_DEALLOC_MIB.read().unwrap(),
+        }
+    }
+
+    /// Return the current cumulative totals for the current thread.
+    pub fn current(&self) -> ThreadStats {
+        ThreadStats {
+            allocated: self.allocated.get(),
+            deallocated: self.deallocated.get(),
+        }
+    }
+}
+
+/// A helper that reads allocation stats from jemalloc using the MIB API, which caches the lookups
+/// of string keys to make reading the values faster.
+struct GlobalStatReader {
+    epoch_mib: epoch_mib,
+    active_mib: stats::active_mib,
+    allocated_mib: stats::allocated_mib,
+    mapped_mib: stats::mapped_mib,
+    metadata_mib: stats::metadata_mib,
+    resident_mib: stats::resident_mib,
+    retained_mib: stats::retained_mib,
+}
+
+impl GlobalStatReader {
+    fn new() -> GlobalStatReader {
+        GlobalStatReader {
+            epoch_mib: epoch::mib().unwrap(),
+            active_mib: stats::active::mib().unwrap(),
+            allocated_mib: stats::allocated::mib().unwrap(),
+            mapped_mib: stats::mapped::mib().unwrap(),
+            metadata_mib: stats::metadata::mib().unwrap(),
+            resident_mib: stats::resident::mib().unwrap(),
+            retained_mib: stats::retained::mib().unwrap(),
+        }
+    }
+
+    fn current(&self) -> JemallocGlobalStats {
+        // The epoch needs advanced in order to updated jemalloc's internal caches of statistics.
+        // Without this, values may be quite stale.
+        self.epoch_mib.advance().unwrap();
+        JemallocGlobalStats {
+            active: self.active_mib.read().unwrap() as u64,
+            allocated: self.allocated_mib.read().unwrap() as u64,
+            mapped: self.mapped_mib.read().unwrap() as u64,
+            metadata: self.metadata_mib.read().unwrap() as u64,
+            resident: self.resident_mib.read().unwrap() as u64,
+            retained: self.retained_mib.read().unwrap() as u64,
+            counts: FlowAllocator::get_counts(),
+        }
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref MEM_STATS: GlobalStatReader = GlobalStatReader::new();
+    static ref THREAD_ALLOC_MIB: thread::allocatedp_mib = thread::allocatedp::mib().unwrap();
+    static ref THREAD_DEALLOC_MIB: thread::deallocatedp_mib = thread::deallocatedp::mib().unwrap();
+}
+
+static ALLOCS_COUNT: AtomicU64 = AtomicU64::new(0);
+static DEALLOCS_COUNT: AtomicU64 = AtomicU64::new(0);
+static REALLOCS_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// This allocator exists solely to instrument invocations of Jemalloc, which is the actual
+/// allocator we're using.
+struct FlowAllocator;
+impl FlowAllocator {
+    fn get_counts() -> AllocationCounts {
+        AllocationCounts {
+            alloc_ops: ALLOCS_COUNT.load(Ordering::SeqCst),
+            dealloc_ops: DEALLOCS_COUNT.load(Ordering::SeqCst),
+            realloc_ops: REALLOCS_COUNT.load(Ordering::SeqCst),
+        }
+    }
+}
+unsafe impl GlobalAlloc for FlowAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS_COUNT.fetch_add(1, Ordering::SeqCst);
+        Jemalloc.alloc(layout)
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCS_COUNT.fetch_add(1, Ordering::SeqCst);
+        Jemalloc.alloc_zeroed(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCS_COUNT.fetch_add(1, Ordering::SeqCst);
+        Jemalloc.dealloc(ptr, layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        REALLOCS_COUNT.fetch_add(1, Ordering::SeqCst);
+        Jemalloc.realloc(ptr, layout, new_size)
+    }
+}

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -10,8 +10,8 @@ crate_type = ["staticlib"]
 [dependencies]
 build = { path = "../build", version = "0.0.0" }
 derive = { path = "../derive", version = "0.0.0" }
+allocator = { path = "../allocator", version = "0.0.0" }
 protocol = { path = "../protocol", version = "0.0.0" }
-
 tracing = "*"
 tracing-subscriber = "*"
 anyhow = "*"

--- a/crates/bindings/flow_bindings.h
+++ b/crates/bindings/flow_bindings.h
@@ -77,6 +77,29 @@ typedef struct In16 {
   struct In4 in3;
 } In16;
 
+/**
+ * Statistics related to memory allocations for the entire (rust portion) of the application. The
+ * precise meaning of most fields are included in the [jemalloc man
+ * page](http://jemalloc.net/jemalloc.3.html). The first group of fields in this struct can be
+ * found in the man page prefixed by "stats.". These fields are all gauges that are in terms of
+ * bytes.
+ *
+ * The `_ops_total` fields are _not_ provided by jemalloc, but instead come from instrumenting the
+ * allocator to track the number of invocations. Those represent monotonic counters of the number
+ * of invocations.
+ */
+typedef struct GlobalMemoryStats {
+  uint64_t active;
+  uint64_t allocated;
+  uint64_t mapped;
+  uint64_t metadata;
+  uint64_t resident;
+  uint64_t retained;
+  uint64_t alloc_ops_total;
+  uint64_t dealloc_ops_total;
+  uint64_t realloc_ops_total;
+} GlobalMemoryStats;
+
 struct Channel *build_create(void);
 
 void build_invoke1(struct Channel *ch, struct In1 i);
@@ -116,6 +139,11 @@ void extract_invoke4(struct Channel *ch, struct In4 i);
 void extract_invoke16(struct Channel *ch, struct In16 i);
 
 void extract_drop(struct Channel *ch);
+
+/**
+ * Returns general statistics on memory allocations perfomed from within libbindings.
+ */
+struct GlobalMemoryStats get_memory_stats(void);
 
 struct Channel *schema_create(void);
 

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -4,6 +4,7 @@ mod build;
 mod combine;
 mod derive;
 mod extract;
+mod metrics;
 mod schema;
 mod upper_case;
 

--- a/crates/bindings/src/metrics.rs
+++ b/crates/bindings/src/metrics.rs
@@ -1,0 +1,48 @@
+use allocator::current_mem_stats;
+
+/// Statistics related to memory allocations for the entire (rust portion) of the application. The
+/// precise meaning of most fields are included in the [jemalloc man
+/// page](http://jemalloc.net/jemalloc.3.html). The first group of fields in this struct can be
+/// found in the man page prefixed by "stats.". These fields are all gauges that are in terms of
+/// bytes.
+///
+/// The `_ops_total` fields are _not_ provided by jemalloc, but instead come from instrumenting the
+/// allocator to track the number of invocations. Those represent monotonic counters of the number
+/// of invocations.
+#[derive(Debug)]
+#[repr(C)]
+pub struct GlobalMemoryStats {
+    pub active: u64,
+    pub allocated: u64,
+    pub mapped: u64,
+    pub metadata: u64,
+    pub resident: u64,
+    pub retained: u64,
+
+    pub alloc_ops_total: u64,
+    pub dealloc_ops_total: u64,
+    pub realloc_ops_total: u64,
+}
+
+impl From<allocator::JemallocGlobalStats> for GlobalMemoryStats {
+    fn from(s: allocator::JemallocGlobalStats) -> Self {
+        GlobalMemoryStats {
+            active: s.active,
+            allocated: s.allocated,
+            mapped: s.mapped,
+            metadata: s.metadata,
+            resident: s.resident,
+            retained: s.retained,
+
+            alloc_ops_total: s.counts.alloc_ops,
+            dealloc_ops_total: s.counts.dealloc_ops,
+            realloc_ops_total: s.counts.realloc_ops,
+        }
+    }
+}
+
+/// Returns general statistics on memory allocations perfomed from within libbindings.
+#[no_mangle]
+pub extern "C" fn get_memory_stats() -> GlobalMemoryStats {
+    current_mem_stats().into()
+}

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 doc = { path = "../doc", version = "0.0.0" }
 json = { path = "../json", version = "0.0.0" }
+allocator = { path = "../allocator", version = "0.0.0" }
 models = { path = "../models", version = "0.0.0" }
 protocol = { path = "../protocol", version = "0.0.0" }
 tuple = { path = "../tuple", version = "0.0.0" }
@@ -22,6 +23,7 @@ rocksdb = { version = "*", default-features = false, features = ["snappy", "rtti
 rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
 serde = { version = "*", features = ["derive"] }
 serde_json = { version =  "*"}
+stats_alloc = "*"
 thiserror = "*"
 tracing = "*"
 tracing-futures = "*"

--- a/crates/derive/src/combiner.rs
+++ b/crates/derive/src/combiner.rs
@@ -65,6 +65,10 @@ impl Combiner {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
     /// Reduce the fully reduced left-hand document with a partially reduced right-hand
     /// document that's already in the Combiner. It's an error if there is already a fully
     /// reduced right-hand document.

--- a/go/bindings/build.go
+++ b/go/bindings/build.go
@@ -229,6 +229,7 @@ func BuildCatalog(args BuildArgs) (*catalog.BuiltCatalog, error) {
 
 func newBuildSvc() *service {
 	return newService(
+		"build",
 		func() *C.Channel { return C.build_create() },
 		func(ch *C.Channel, in C.In1) { C.build_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.build_invoke4(ch, in) },

--- a/go/bindings/combine.go
+++ b/go/bindings/combine.go
@@ -176,6 +176,7 @@ func drainCombineToCallback(
 
 func newCombineSvc() *service {
 	return newService(
+		"combine",
 		func() *C.Channel { return C.combine_create() },
 		func(ch *C.Channel, in C.In1) { C.combine_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.combine_invoke4(ch, in) },

--- a/go/bindings/derive.go
+++ b/go/bindings/derive.go
@@ -306,6 +306,7 @@ func (d *Derive) Destroy() {
 
 func newDeriveSvc() *service {
 	return newService(
+		"derive",
 		func() *C.Channel { return C.derive_create() },
 		func(ch *C.Channel, in C.In1) { C.derive_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.derive_invoke4(ch, in) },

--- a/go/bindings/extract.go
+++ b/go/bindings/extract.go
@@ -101,6 +101,7 @@ func (e *Extractor) Extract() ([]pf.UUIDParts, [][]byte, error) {
 
 func newExtractSvc() *service {
 	return newService(
+		"extract",
 		func() *C.Channel { return C.extract_create() },
 		func(ch *C.Channel, in C.In1) { C.extract_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.extract_invoke4(ch, in) },

--- a/go/bindings/metrics.go
+++ b/go/bindings/metrics.go
@@ -1,0 +1,109 @@
+package bindings
+
+/*
+#include "../../crates/bindings/flow_bindings.h"
+*/
+import "C"
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// A prometheus.Collector that exposes general rust metrics that are exposed by libbindings as
+// prometheus metrics.
+type promCollector struct{}
+
+// Describe implements prometheus.Collector for promCollector
+func (c *promCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+// Collect implements prometheus.Collector for promCollector
+func (c *promCollector) Collect(ch chan<- prometheus.Metric) {
+	var stats = C.get_memory_stats()
+	var gauge = func(desc *prometheus.Desc, value C.uint64_t) {
+		ch <- prometheus.MustNewConstMetric(
+			desc,
+			prometheus.GaugeValue,
+			float64(value),
+		)
+	}
+	gauge(activeBytesDesc, stats.active)
+	gauge(allocBytesDesc, stats.allocated)
+	gauge(mappedBytesDesc, stats.mapped)
+	gauge(metadataBytesDesc, stats.metadata)
+	gauge(residentBytesDesc, stats.resident)
+	gauge(retainedBytesDesc, stats.retained)
+
+	var counter = func(desc *prometheus.Desc, value C.uint64_t) {
+		ch <- prometheus.MustNewConstMetric(
+			desc,
+			prometheus.CounterValue,
+			float64(value),
+		)
+	}
+	counter(allocOpsDesc, stats.alloc_ops_total)
+	counter(deallocOpsDesc, stats.dealloc_ops_total)
+	counter(reallocOpsDesc, stats.realloc_ops_total)
+}
+
+var promCollectorInstance = &promCollector{}
+
+var registration = sync.Once{}
+
+// RegisterPrometheusCollector initializes prometheus metric collection that's pulled from the rust
+// libbindings. Subsequent calls to this function will panic.
+func RegisterPrometheusCollector() {
+	prometheus.MustRegister(promCollectorInstance)
+}
+
+var (
+	activeBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_active_bytes",
+		"Total number of bytes in active pages allocated by the application.",
+		nil, nil,
+	)
+	allocBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_alloc_bytes",
+		"Total bytes of all allocations performed by Rust code",
+		nil, nil,
+	)
+	mappedBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_mapped_bytes",
+		"Total number of bytes in active extents mapped by the allocator.",
+		nil, nil,
+	)
+	metadataBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_metadata_bytes",
+		"Total number of bytes dedicated to metadata, which comprise base allocations used for bootstrap-sensitive allocator metadata structures",
+		nil, nil,
+	)
+	residentBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_resident_bytes",
+		"Maximum number of bytes in physically resident data pages mapped by the allocator",
+		nil, nil,
+	)
+	retainedBytesDesc = prometheus.NewDesc(
+		"flow_rust_mem_retained_bytes",
+		"Total number of bytes in virtual memory mappings that were retained rather than being returned to the operating system",
+		nil, nil,
+	)
+
+	allocOpsDesc = prometheus.NewDesc(
+		"flow_rust_mem_alloc_ops_total",
+		"Count of allocation operations performed by Rust code",
+		nil, nil,
+	)
+	deallocOpsDesc = prometheus.NewDesc(
+		"flow_rust_mem_dealloc_ops_total",
+		"Count of deallocation operations performed by Rust code",
+		nil, nil,
+	)
+	reallocOpsDesc = prometheus.NewDesc(
+		"flow_rust_mem_realloc_ops_total",
+		"Count of reallocation operations performed by Rust code",
+		nil, nil,
+	)
+)

--- a/go/bindings/schema.go
+++ b/go/bindings/schema.go
@@ -36,6 +36,7 @@ func NewSchemaIndex(bundle *pf.SchemaBundle) (*SchemaIndex, error) {
 
 func newSchemaService() *service {
 	return newService(
+		"schema",
 		func() *C.Channel { return C.schema_create() },
 		func(ch *C.Channel, in C.In1) { C.schema_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.schema_invoke4(ch, in) },

--- a/go/bindings/upper_case.go
+++ b/go/bindings/upper_case.go
@@ -15,6 +15,7 @@ import (
 // Frame Code.
 func newUpperCase() *service {
 	return newService(
+		"uppercase",
 		func() *C.Channel { return C.upper_case_create() },
 		func(ch *C.Channel, in C.In1) { C.upper_case_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.upper_case_invoke4(ch, in) },
@@ -27,6 +28,7 @@ func newUpperCase() *service {
 // but still produces an (empty) output Frame for each input.
 func newNoOpService() *service {
 	return newService(
+		"noop",
 		func() *C.Channel {
 			var ch = (*C.Channel)(C.calloc(C.sizeof_Channel, 1))
 			ch.out_ptr = (*C.Out)(C.calloc(C.sizeof_Out, 512))

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
 	"github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/shuffle"
@@ -172,6 +173,7 @@ func (f *FlowConsumer) ClearRegistersForTest(ctx context.Context) error {
 
 // InitApplication starts shared services of the flow-consumer.
 func (f *FlowConsumer) InitApplication(args runconsumer.InitArgs) error {
+	bindings.RegisterPrometheusCollector()
 	var config = *args.Config.(*FlowConsumerConfig)
 
 	// Load catalog & journal keyspaces, and queue tasks that watch each for updates.


### PR DESCRIPTION
Adds a bunch of instrumentation around memory allocations in Rust. At this point, these are all generic metrics. Stats that can be scoped to a particular catalog task will be exposed separately in a later PR as part of the derive, combine, and extract services.

Relates to #226

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/233)
<!-- Reviewable:end -->
