### PR TITLE
Fix panic when running in develop mode with readDelay.

### DIFF
--- a/go/testing/action.go
+++ b/go/testing/action.go
@@ -75,15 +75,16 @@ func RunTestCase(graph *Graph, driver Driver, test *pf.TestSpec) (scope string, 
 		// Advance time to unblock the next PendingStat.
 		if nextReady != -1 {
 			err := driver.Advance(nextReady)
-			if err == ErrAdvanceDisabled {
-				log.WithFields(log.Fields{
-					"delay": nextReady,
-					"task":  nextName,
-				}).Warn("sleeping until next task is ready.")
-			} else if err != nil {
-				return scope, fmt.Errorf("driver.Advance: %w", err)
+			if err != nil {
+				if err == ErrAdvanceDisabled {
+					log.WithFields(log.Fields{
+						"delay": nextReady,
+						"task":  nextName,
+					}).Warn("sleeping until next task is ready.")
+				} else {
+					return scope, fmt.Errorf("driver.Advance: %w", err)
+				}
 			} else {
-				// Advance completed
 				graph.CompletedAdvance(nextReady)
 				continue
 			}

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -115,6 +115,10 @@ func (c *Cluster) Ingest(test *pf.TestSpec, testStep int) (writeAt *Clock, _ err
 
 // Advance implements Driver for a Cluster.
 func (c *Cluster) Advance(delta TestTime) error {
+	if !c.Config.DisableClockTicks {
+		panic("expected DisableClockTicks to be set")
+	}
+
 	var t1 = atomic.AddInt64((*int64)(&c.Ingester.PublishClockDeltaForTest), int64(delta))
 	var t2 = atomic.AddInt64((*int64)(&c.Consumer.Service.PublishClockDelta), int64(delta))
 	var total = time.Duration(t1)

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -116,7 +116,7 @@ func (c *Cluster) Ingest(test *pf.TestSpec, testStep int) (writeAt *Clock, _ err
 // Advance implements Driver for a Cluster.
 func (c *Cluster) Advance(delta TestTime) error {
 	if !c.Config.DisableClockTicks {
-		panic("expected DisableClockTicks to be set")
+		return ErrAdvanceDisabled
 	}
 
 	var t1 = atomic.AddInt64((*int64)(&c.Ingester.PublishClockDeltaForTest), int64(delta))

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -115,10 +115,6 @@ func (c *Cluster) Ingest(test *pf.TestSpec, testStep int) (writeAt *Clock, _ err
 
 // Advance implements Driver for a Cluster.
 func (c *Cluster) Advance(delta TestTime) error {
-	if !c.Config.DisableClockTicks {
-		panic("expected DisableClockTicks to be set")
-	}
-
 	var t1 = atomic.AddInt64((*int64)(&c.Ingester.PublishClockDeltaForTest), int64(delta))
 	var t2 = atomic.AddInt64((*int64)(&c.Consumer.Service.PublishClockDelta), int64(delta))
 	var total = time.Duration(t1)

--- a/go/testing/graph.go
+++ b/go/testing/graph.go
@@ -147,10 +147,11 @@ func (g *Graph) HasPendingWrite(collection pf.Collection) bool {
 // PopReadyStats removes and returns tracked PendingStats having ready-at
 // times equal to the current test time. It also returns the delta between
 // the current TestTime, and the next ready PendingStat (which is always
-// zero if PendingStats are returned).
-func (g *Graph) PopReadyStats() ([]PendingStat, TestTime) {
+// zero if PendingStats are returned) as well as the TaskName associated.
+func (g *Graph) PopReadyStats() ([]PendingStat, TestTime, TaskName) {
 	var ready []PendingStat
-	var nextReady TestTime = -1
+	var nextReadyTime TestTime = -1
+	var nextReadyName TaskName
 	var r, w int // Read & write index.
 
 	// Process |pending| by copying out matched elements and
@@ -158,8 +159,9 @@ func (g *Graph) PopReadyStats() ([]PendingStat, TestTime) {
 	for ; r != len(g.pending); r++ {
 		var delta = g.pending[r].ReadyAt - g.atTime
 
-		if nextReady == -1 || delta < nextReady {
-			nextReady = delta
+		if nextReadyTime == -1 || delta < nextReadyTime {
+			nextReadyTime = delta
+			nextReadyName = g.pending[r].TaskName
 		}
 
 		if delta == 0 {
@@ -171,7 +173,7 @@ func (g *Graph) PopReadyStats() ([]PendingStat, TestTime) {
 	}
 	g.pending = g.pending[:w]
 
-	return ready, nextReady
+	return ready, nextReadyTime, nextReadyName
 }
 
 // CompletedIngest tells the Graph of a completed ingestion step.

--- a/go/testing/graph.go
+++ b/go/testing/graph.go
@@ -11,6 +11,10 @@ import (
 // to wall-clock time; test time is synthetically advanced as a test progresses.
 type TestTime time.Duration
 
+func (tt TestTime) String() string {
+	return time.Duration(tt).String()
+}
+
 // TaskName is a type wrapper of a CatalogTask.Name()
 // (which is itself a pf.Capture, pf.Collection (derivation), or pf.Materialization).
 type TaskName string

--- a/go/testing/graph_test.go
+++ b/go/testing/graph_test.go
@@ -210,37 +210,43 @@ func TestReadyStats(t *testing.T) {
 		{ReadyAt: 5, TaskName: "C", ReadThrough: clockFixture(3, nil, nil)},
 	}
 
-	var ready, next = graph.PopReadyStats()
+	var ready, nextTime, nextName = graph.PopReadyStats()
 	require.Empty(t, ready)
-	require.Equal(t, TestTime(5), next)
+	require.Equal(t, TestTime(5), nextTime)
+	require.Equal(t, TaskName("C"), nextName)
 	graph.CompletedAdvance(4)
 
-	ready, next = graph.PopReadyStats()
+	ready, nextTime, nextName = graph.PopReadyStats()
 	require.Empty(t, ready)
-	require.Equal(t, TestTime(1), next)
+	require.Equal(t, TestTime(1), nextTime)
+	require.Equal(t, TaskName("C"), nextName)
 	graph.CompletedAdvance(1)
 
-	ready, next = graph.PopReadyStats()
+	ready, nextTime, nextName = graph.PopReadyStats()
 	require.Equal(t, []PendingStat{
 		{ReadyAt: 5, TaskName: "C", ReadThrough: clockFixture(3, nil, nil)},
 	}, ready)
-	require.Equal(t, TestTime(0), next)
+	require.Equal(t, TestTime(0), nextTime)
+	require.Equal(t, TaskName("C"), nextName)
 
-	ready, next = graph.PopReadyStats()
+	ready, nextTime, nextName = graph.PopReadyStats()
 	require.Empty(t, ready)
-	require.Equal(t, TestTime(5), next)
+	require.Equal(t, TestTime(5), nextTime)
+	require.Equal(t, TaskName("A"), nextName)
 	graph.CompletedAdvance(5)
 
-	ready, next = graph.PopReadyStats()
+	ready, nextTime, nextName = graph.PopReadyStats()
 	require.Equal(t, []PendingStat{
 		{ReadyAt: 10, TaskName: "A", ReadThrough: clockFixture(1, nil, nil)},
 		{ReadyAt: 10, TaskName: "B", ReadThrough: clockFixture(2, nil, nil)},
 	}, ready)
-	require.Equal(t, TestTime(0), next)
+	require.Equal(t, TestTime(0), nextTime)
+	require.Equal(t, TaskName("A"), nextName)
 
-	ready, next = graph.PopReadyStats()
+	ready, nextTime, nextName = graph.PopReadyStats()
 	require.Empty(t, ready)
-	require.Equal(t, TestTime(-1), next)
+	require.Equal(t, TestTime(-1), nextTime)
+	require.Equal(t, TaskName(""), nextName)
 }
 
 func TestTaskIndexing(t *testing.T) {


### PR DESCRIPTION
Since the testing cluster is also used by develop, I believe this check needs to be removed or logic needs to be added to handle logic from commit https://github.com/estuary/flow/commit/db72fc41f660ec1f7a5f41f0c2eaca3572c685bc as it triggers this panic when using a catalog that has readDelay (citi-bike example)

```
panic: expected DisableClockTicks to be set [recovered]
        panic: expected DisableClockTicks to be set

goroutine 1 [running]:
go.gazette.dev/core/mainboilerplate.InitDiagnosticsAndRecover.func2()
        /data/go/pkg/mod/go.gazette.dev/core@v0.89.1-0.20210914224834-2d07306a0edb/mainboilerplate/diagnostics.go:46 +0x77
panic(0x2a506c0, 0x30471e0)
        /usr/local/go/src/runtime/panic.go:971 +0x499
github.com/estuary/flow/go/testing.(*Cluster).Advance(0xc0000dd680, 0x9d29229e0000, 0x2d5e539, 0xd)
        /data/git/est/flow/go/testing/driver.go:119 +0x448
github.com/estuary/flow/go/testing.RunTestCase(0xc00127b180, 0x30ac1c0, 0xc0000dd680, 0xc0010a0000, 0xc000ea2720, 0x1, 0x1, 0x0)
        /data/git/est/flow/go/testing/action.go:75 +0x369
main.cmdDevelop.Execute(0xc000042570, 0x21, 0x2b57e13, 0x4, 0x1f900000, 0x1, 0x7ffd24abdba1, 0x9, 0x7ffd24abdbc8, 0x4, ...)
        /data/git/est/flow/go/flowctl/cmd-develop.go:263 +0x1a8d
github.com/jessevdk/go-flags.(*Parser).ParseArgs(0xc0005c21c0, 0xc00003c110, 0x7, 0x7, 0xc0005f28d0, 0xc0008bfd58, 0x10f4289, 0xc00011e2b8, 0x18)
        /data/go/pkg/mod/github.com/jessevdk/go-flags@v1.5.0/parser.go:335 +0x89d
go.gazette.dev/core/mainboilerplate.MustParseArgs(0xc0005c21c0)
        /data/go/pkg/mod/go.gazette.dev/core@v0.89.1-0.20210914224834-2d07306a0edb/mainboilerplate/config.go:49 +0x85
go.gazette.dev/core/mainboilerplate.MustParseConfig(0xc0005c21c0, 0x2d575d9, 0x8)
        /data/go/pkg/mod/go.gazette.dev/core@v0.89.1-0.20210914224834-2d07306a0edb/mainboilerplate/config.go:44 +0x36e
main.main()
        /data/git/est/flow/go/flowctl/main.go:81 +0x785
````

I am not totally sure if this ends up bypassing an important check otherwise but I replaced the check with the log line that was previously there. Feel free to close if this is not the right way to handle this. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/237)
<!-- Reviewable:end -->
