### PR TITLE
Phil/debugging key extract

### DIFF
--- a/go/bindings/combine.go
+++ b/go/bindings/combine.go
@@ -60,9 +60,6 @@ func (c *Combine) Configure(
 	keyPtrs []string,
 	fieldPtrs []string,
 ) error {
-	if len(keyPtrs) == 0 || keyPtrs[0] == "" {
-		return fmt.Errorf("attempt to configure with empty keyPtrs")
-	}
 	combineConfigureCounter.WithLabelValues(fqn, collection.String()).Inc()
 
 	c.metrics = newCombineMetrics(fqn, collection)

--- a/go/bindings/combine.go
+++ b/go/bindings/combine.go
@@ -60,6 +60,9 @@ func (c *Combine) Configure(
 	keyPtrs []string,
 	fieldPtrs []string,
 ) error {
+	if len(keyPtrs) == 0 || keyPtrs[0] == "" {
+		return fmt.Errorf("attempt to configure with empty keyPtrs")
+	}
 	combineConfigureCounter.WithLabelValues(fqn, collection.String()).Inc()
 
 	c.metrics = newCombineMetrics(fqn, collection)

--- a/go/flowctl/cmd-combine.go
+++ b/go/flowctl/cmd-combine.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/estuary/flow/go/bindings"
+	pf "github.com/estuary/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	pb "go.gazette.dev/core/broker/protocol"
+	mbp "go.gazette.dev/core/mainboilerplate"
+)
+
+type cmdCombine struct {
+	Directory   string                `long:"directory" default:"." description:"Build directory"`
+	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
+	Collection  string                `long:"collection" required:"true" description:"The name of the collection from which to take the schema and key"`
+	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
+	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
+}
+
+func (cmd cmdCombine) Execute(_ []string) error {
+	defer mbp.InitDiagnosticsAndRecover(cmd.Diagnostics)()
+	mbp.InitLog(cmd.Log)
+
+	log.WithFields(log.Fields{
+		"config":    cmd,
+		"version":   mbp.Version,
+		"buildDate": mbp.BuildDate,
+	}).Info("flowctl configuration")
+	pb.RegisterGRPCDispatcher("local")
+
+	var err error
+	if cmd.Directory, err = filepath.Abs(cmd.Directory); err != nil {
+		return fmt.Errorf("filepath.Abs: %w", err)
+	}
+	var ctx = context.Background()
+
+	catalog, err := buildCatalog(ctx, pf.BuildAPI_Config{
+		CatalogPath: filepath.Join(cmd.Directory, "catalog.db"),
+		Directory:   cmd.Directory,
+		Source:      cmd.Source,
+		SourceType:  pf.ContentType_CATALOG_SPEC,
+	})
+	if err != nil {
+		return err
+	}
+
+	var collection *pf.CollectionSpec
+	for _, c := range catalog.Collections {
+		if c.Collection.String() == cmd.Collection {
+			collection = &c
+			break
+		}
+	}
+	if collection == nil {
+		return fmt.Errorf("The catalog does not define a collection named: %q", cmd.Collection)
+	}
+	schemaIndex, err := bindings.NewSchemaIndex(&catalog.Schemas)
+	if err != nil {
+		return fmt.Errorf("building schema bundle: %w", err)
+	}
+
+	var combine = bindings.NewCombine()
+	combine.Configure(
+		"flowctl/combine",
+		schemaIndex,
+		collection.Collection,
+		collection.SchemaUri,
+		"",
+		collection.KeyPtrs,
+		nil,
+	)
+
+	type FlowDoc struct {
+		Meta struct {
+			Ack bool `json:"ack"`
+		} `json:"_meta"`
+	}
+
+	var scanner = bufio.NewScanner(os.Stdin)
+	var inputDocs = 0
+	var inputBytes uint64 = 0
+	for scanner.Scan() {
+		var bytes = append([]byte(nil), scanner.Bytes()...)
+		inputDocs++
+		inputBytes = inputBytes + uint64(len(bytes))
+
+		// Filter out acknowledgements, and also ensure that each input document is valid json.
+		var doc FlowDoc
+		if err = json.Unmarshal(bytes, &doc); err != nil {
+			return fmt.Errorf("invalid json at line %d: %w", inputDocs, err)
+		}
+		if doc.Meta.Ack {
+			continue
+		}
+
+		log.WithField("line", string(bytes)).Trace("adding input line")
+		if err = combine.CombineRight(json.RawMessage(bytes)); err != nil {
+			return fmt.Errorf("at stdin line %d: %w", inputDocs, err)
+		}
+
+		if inputDocs%10000 == 0 {
+			log.WithFields(log.Fields{
+				"inputDocs":  inputDocs,
+				"inputBytes": inputBytes,
+			}).Info("read input progress")
+		}
+	}
+	if err = combine.PrepareToDrain(); err != nil {
+		return fmt.Errorf("preparing to drain: %w", err)
+	}
+
+	var outputDocs = 0
+	var outputBytes uint64 = 0
+	err = combine.Drain(func(full bool, doc json.RawMessage, packedKey []byte, packedFields []byte) error {
+		outputDocs++
+		outputBytes = outputBytes + uint64(len(doc))
+		fmt.Println(string(doc))
+
+		if len(packedKey) <= 1 {
+			return fmt.Errorf("Failed to extract key from output docuement: %d", outputDocs)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("draining document %d: %w", outputDocs, err)
+	}
+
+	log.WithFields(log.Fields{
+		"inputDocs":   inputDocs,
+		"inputBytes":  inputBytes,
+		"outputDocs":  outputDocs,
+		"outputBytes": outputBytes,
+	}).Info("completed combine")
+	return nil
+}

--- a/go/flowctl/main.go
+++ b/go/flowctl/main.go
@@ -47,6 +47,10 @@ update, refactor, and otherwise incorporate the generated entities
 into their broader Flow catalog.
 `, &cmdDiscover{})
 
+	addCmd(parser, "combine", "Combine documents from stdin", `
+Read documents from stdin, validate and combine them on the collection's key, and print the results to stdout. The input documents must be JSON encoded and given one per line, and the output documents will be printed in the same way.
+`, &cmdCombine{})
+
 	addCmd(parser, "json-schema", "Print the catalog JSON schema", `
 Print the JSON schema specification of Flow catalogs, as understood by this
 specific build of Flow. This JSON schema can be used to enable IDE support

--- a/go/flowctl/main.go
+++ b/go/flowctl/main.go
@@ -47,9 +47,14 @@ update, refactor, and otherwise incorporate the generated entities
 into their broader Flow catalog.
 `, &cmdDiscover{})
 
-	addCmd(parser, "combine", "Combine documents from stdin", `
+	// The combine subcommand is hidden from help messages and such because we're uncertain of its
+	// value, so don't want to expose it to users. We might just want to delete this, but leaving it
+	// hidden for now. This was added to aid in debugging:
+	// https://github.com/estuary/flow/issues/238
+	var combineCommand = addCmd(parser, "combine", "Combine documents from stdin", `
 Read documents from stdin, validate and combine them on the collection's key, and print the results to stdout. The input documents must be JSON encoded and given one per line, and the output documents will be printed in the same way.
 `, &cmdCombine{})
+	combineCommand.Hidden = true
 
 	addCmd(parser, "json-schema", "Print the catalog JSON schema", `
 Print the JSON schema specification of Flow catalogs, as understood by this
@@ -88,7 +93,8 @@ exit (via SIGTERM).
 
 func addCmd(to interface {
 	AddCommand(string, string, string, interface{}) (*flags.Command, error)
-}, a, b, c string, iface interface{}) {
-	var _, err = to.AddCommand(a, b, c, iface)
+}, a, b, c string, iface interface{}) *flags.Command {
+	var cmd, err = to.AddCommand(a, b, c, iface)
 	mbp.Must(err, "failed to add flags parser command")
+	return cmd
 }

--- a/go/materialize/driver/snowflake/snowflake.go
+++ b/go/materialize/driver/snowflake/snowflake.go
@@ -293,9 +293,6 @@ func (t *transactor) addBinding(targetName string, spec *pf.MaterializationSpec_
 func (d *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, loaded func(int, json.RawMessage) error) error {
 	for it.Next() {
 		var b = d.bindings[it.Binding]
-		if len(it.Key) == 0 {
-			return fmt.Errorf("load was given an empty key: %+v", it)
-		}
 		if converted, err := b.load.params.Convert(it.Key); err != nil {
 			return fmt.Errorf("converting Load key: %w", err)
 		} else if err = b.load.stage.Encode(converted); err != nil {

--- a/go/materialize/driver/snowflake/snowflake.go
+++ b/go/materialize/driver/snowflake/snowflake.go
@@ -293,7 +293,9 @@ func (t *transactor) addBinding(targetName string, spec *pf.MaterializationSpec_
 func (d *transactor) Load(it *pm.LoadIterator, _ <-chan struct{}, loaded func(int, json.RawMessage) error) error {
 	for it.Next() {
 		var b = d.bindings[it.Binding]
-
+		if len(it.Key) == 0 {
+			return fmt.Errorf("load was given an empty key: %+v", it)
+		}
 		if converted, err := b.load.params.Convert(it.Key); err != nil {
 			return fmt.Errorf("converting Load key: %w", err)
 		} else if err = b.load.stage.Encode(converted); err != nil {

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -272,15 +272,14 @@ func drainBinding(
 	// Drain the combiner into materialization Store requests.
 	if err := combiner.Drain(func(full bool, docRaw json.RawMessage, packedKey, packedValues []byte) error {
 		// Inlined use of string(packedKey) clues compiler escape analysis to avoid allocation.
-		if flightedDoc, ok := flighted[string(packedKey)]; !ok {
+		if _, ok := flighted[string(packedKey)]; !ok {
 			var key, _ = tuple.Unpack(packedKey)
 			return fmt.Errorf(
 				"driver implementation error: "+
-					"loaded key %v (rawKey: %q) was not requested by Flow in this transaction (document %s), (flightedDoc: %s)",
+					"loaded key %v (rawKey: %q) was not requested by Flow in this transaction (document %s)",
 				key,
 				string(packedKey),
 				string(docRaw),
-				string(flightedDoc),
 			)
 		}
 


### PR DESCRIPTION
Here's an example of the output when I fed 5 documents into the hacked together `flowctl combine` subcommand, just to show the memory usage instrumentation.

```
Sep 17 17:15:42.639 TRACE derive::combine_api: invoke code=Configure
Sep 17 17:15:42.639 DEBUG derive::combine_api: configuring combiner schema_index=140062775890064 schema_uri="dummy://schema-uri/foo" key_ptr=["/auction_id"]
Sep 17 17:15:42.639 DEBUG derive::combine_api: configure schema_index_memptr=140062775890064 schema_uri="dummy://schema-uri/foo" key_ptr=["/auction_id"] field_ptrs=[] uuid_placeholder_ptr=""
Sep 17 17:15:42.639 TRACE derive::combine_api: mem usage allocated_bytes=208 diff_this_invoke=208
Sep 17 17:15:42.639 TRACE derive::combine_api: invoke code=CombineRight
Sep 17 17:15:42.639 TRACE derive::combine_api: mem usage allocated_bytes=41224 diff_this_invoke=41016
Sep 17 17:15:42.639 TRACE derive::combine_api: invoke code=CombineRight
Sep 17 17:15:42.640 TRACE derive::combine_api: mem usage allocated_bytes=70992 diff_this_invoke=29768
Sep 17 17:15:42.640 TRACE derive::combine_api: invoke code=CombineRight
Sep 17 17:15:42.640 TRACE derive::combine_api: mem usage allocated_bytes=100776 diff_this_invoke=29784
Sep 17 17:15:42.640 TRACE derive::combine_api: invoke code=CombineRight
Sep 17 17:15:42.640 TRACE derive::combine_api: mem usage allocated_bytes=130568 diff_this_invoke=29792
Sep 17 17:15:42.640 TRACE derive::combine_api: invoke code=CombineRight
Sep 17 17:15:42.640 TRACE derive::combine_api: mem usage allocated_bytes=160336 diff_this_invoke=29768
Sep 17 17:15:42.640 TRACE derive::combine_api: invoke code=Drain
Sep 17 17:15:42.640 DEBUG derive::combine_api: memory before draining allocated_before_drain=160336
Sep 17 17:15:42.640 DEBUG derive::combine_api: drain_combiner arena_len=0 combiner_len=5 key_ptrs=[[Property("auction_id")]] field_ptrs=[] uuid_placeholder_ptr=""
Sep 17 17:15:42.641 TRACE derive::combine_api: mem usage allocated_bytes=43760 diff_this_invoke=-116576
INFO[0000] completed combine                             inputBytes=29262 inputDocs=5 outputBytes=29262 outputDocs=5
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/240)
<!-- Reviewable:end -->
