### PR TITLE
assorted fixes from attempting to reproduce snowflake timeouts plus backoff cancellation

### DIFF
--- a/go/capture/driver/airbyte/connector_test.go
+++ b/go/capture/driver/airbyte/connector_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -147,14 +148,14 @@ func TestProtoRecordBreaks(t *testing.T) {
 }
 
 func TestStderrCapture(t *testing.T) {
-	var s = new(connectorStderr)
+	var s = connectorStderr{delegate: ioutil.Discard}
 
 	var n, err = s.Write([]byte("whoops"))
 	require.Equal(t, 6, n)
 	require.NoError(t, err)
-	require.Equal(t, "whoops", s.err.String())
+	require.Equal(t, "whoops", s.buffer.String())
 
 	// Expect it caps the amount of output collected.
 	s.Write(bytes.Repeat([]byte("x"), maxStderrBytes))
-	require.Equal(t, maxStderrBytes, s.err.Len())
+	require.Equal(t, maxStderrBytes, s.buffer.Len())
 }

--- a/go/flowctl/cmd-develop.go
+++ b/go/flowctl/cmd-develop.go
@@ -183,16 +183,12 @@ func (cmd cmdDevelop) Execute(_ []string) error {
 	// Apply capture shard specs.
 	if err = applyCaptureShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
 		return fmt.Errorf("applying capture shards: %w", err)
-	}
-	// Apply derivation shard specs.
-	if err = applyDerivationShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
+	} else if err = applyDerivationShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
 		return fmt.Errorf("applying derivation shards: %w", err)
-	}
-	// Apply materialization shards.
-	if err = applyMaterializationShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
+	} else if err = applyMaterializationShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
 		return fmt.Errorf("applying materialization shards: %w", err)
 	} else if err = cluster.WaitForShardsToAssign(); err != nil {
-		return err
+		return fmt.Errorf("waiting for shards to assign: %w", err)
 	}
 
 	if cmd.Poll {

--- a/go/flowctl/cmd-test.go
+++ b/go/flowctl/cmd-test.go
@@ -167,7 +167,7 @@ func (cmd cmdTest) Execute(_ []string) (retErr error) {
 	if err = applyDerivationShards(ctx, built, cluster.Shards, cmd.Shards, catalogRevision); err != nil {
 		return fmt.Errorf("applying derivation shards: %w", err)
 	} else if err = cluster.WaitForShardsToAssign(); err != nil {
-		return err
+		return fmt.Errorf("waiting for shards to assign: %w", err)
 	}
 
 	// Run all test cases ordered by their scope, which implicitly orders on resource file and test name.

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -126,11 +126,10 @@ func (c *Capture) openCapture(ctx context.Context) (<-chan capture.CaptureRespon
 	}
 	var driverRx = capture.CaptureResponseChannel(driverStream)
 
-	var opened = <-driverRx
-	if opened.Error != nil {
-		return nil, fmt.Errorf("reading Opened: %w", opened.Error)
+	if opened, err := capture.Rx(driverRx, true); err != nil {
+		return nil, fmt.Errorf("reading Opened: %w", err)
 	} else if opened.Opened == nil {
-		return nil, fmt.Errorf("expected Opened, got %#v", opened.CaptureResponse.String())
+		return nil, fmt.Errorf("expected Opened, got %#v", opened.String())
 	}
 
 	return driverRx, nil


### PR DESCRIPTION
See individual comments. I observed some crashes from `flowctl` due to poorly behaved materialization connectors (because, to be fair, I was kill -9'ing them).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/242)
<!-- Reviewable:end -->
