### PR TITLE
Revert nodejs to v14 LTS release

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -13,7 +13,7 @@ RUN apt update -y \
  && export NODE_KEYRING=/usr/share/keyrings/nodesource.gpg \
  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$NODE_KEYRING" >/dev/null \
  && gpg --no-default-keyring --keyring "$NODE_KEYRING" --list-keys \
- && echo "deb [signed-by=$NODE_KEYRING] https://deb.nodesource.com/node_16.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list \
+ && echo "deb [signed-by=$NODE_KEYRING] https://deb.nodesource.com/node_14.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list \
  && apt update -y \
  && apt upgrade -y \
  && apt install --no-install-recommends -y \

--- a/scripts/flowctl.sh
+++ b/scripts/flowctl.sh
@@ -29,6 +29,7 @@ DOCKER_UID="$UID"
 DOCKER_IMAGE="quay.io/estuary/flow:dev"
 DOCKER_EXTRA_OPTS=""
 DOCKER_COMMAND="flowctl"
+DOCKER_PULL="missing"
 FLOWCTL_DIRECTORY=$(pwd)
 FLOWCTL_SOURCE=""
 FLOWCTL_CONTAINAER_DIRECTORY="/home/flow/project"
@@ -108,6 +109,9 @@ for (( argpos=0; argpos < "${#ARGS[@]}"; argpos++ )); do
         --docker-image*)
             parse_option "--docker-image" DOCKER_IMAGE "consume" $ARGS
             ;;
+        --docker-pull*)
+            parse_option "--docker-pull" DOCKER_PULL "consume" $ARGS
+            ;;
         --debug-script*)
             parse_option "--debug-script" DEBUG_SCRIPT "consume" $ARGS
             ;;
@@ -182,6 +186,7 @@ CMD="${DOCKER_EXEC} run -it --rm \
 -v ${FLOWCTL_DIRECTORY}:${FLOWCTL_CONTAINAER_DIRECTORY} \
 -v ${DOCKER_SOCK}:/var/run/docker.sock \
 --network ${FLOWCTL_NETWORK} \
+--pull ${DOCKER_PULL} \
 ${DOCKER_EXTRA_OPTS} \
 -v /var/tmp:/var/tmp -e TMPDIR=/var/tmp \
 -e HOME=/tmp \


### PR DESCRIPTION
Because of this issue with Docker For Mac https://github.com/docker/for-mac/issues/5831
Using the flowctl.sh script does not work on M1 Macs when it is using Node 16. This PR reverts back to Node V14 which is the LTS release anyhow and does include the nullish collating operator which I understand was the main driver for upgrading Node.
It also adds a command option to ensure the flow docker image is up to date as part of the `flowctl.sh` script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/245)
<!-- Reviewable:end -->
