### PR TITLE
Pin `bitvec` dependency to 0.19

### DIFF
--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Estuary Technologies, Inc"]
 edition = "2018"
 
 [dependencies]
-bitvec = "*"
+bitvec = "0.19"
 fancy-regex = "*"
 fxhash = "*"
 itertools = "*"


### PR DESCRIPTION
Our `json` create directly depends on `bitvec`, but we also on `nom` in a different crate. `nom` also depends on `bitvec`. We've not specified a version, but rather relied on Cargo to resolve a working version for
`bitvec`.

Now, `bitvec`'s `0.20.0` release introduced some semver breaking changes. `nom` has `bitvec` pinned at `0.19`. This causes Cargo to resolve `flow`'s dependency on `bitvec` to be `0.19`, rather than the latest `0.2x.x` release.

However, other crates which depend on our `json` crate to fail to pickup the `nom` constraint. This allows them to resolve `bitvec` to the `0.2x.x` releases. This are incompatible with the code we've written in the `json` crate.

Pinning `bitvec` to the `0.19.x` releases prevents dependent crates from trying to use an incompatible version of `bitvec`. :tada: 

Eventually we'll probably upgrade our `nom` dependency, which no longer depends on `bitvec`. This would remove the necessity of using `0.19.x`, but we'd still have to update our code in `json` to use the new APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/246)
<!-- Reviewable:end -->
