### PR TITLE
capture/materialize: in-process drivers must deep copy specifications

### DIFF
--- a/go/capture/driver/airbyte/driver.go
+++ b/go/capture/driver/airbyte/driver.go
@@ -56,6 +56,10 @@ func (c ResourceSpec) Validate() error {
 }
 
 // driver implements the pm.DriverServer interface.
+// Though driver is a gRPC service stub, it's called in synchronous and
+// in-process contexts to minimize ser/de & memory copies. As such it
+// doesn't get to assume deep ownership of its requests, and must
+// proto.Clone() shared state before mutating it.
 type driver struct {
 	networkName string
 }


### PR DESCRIPTION
MaterializationSpec is shared with the catalog KeySpace and must be copied.
Audit and document this restriction in drivers.

Tested:
 * Started with a `flowctl develop` catalog having a built-in Snowflake materialization
 * Executed `flowctl shard split` while that catalog was running (1 -> 2 shards).
 * Transitioned the catalog materialization in-place to using the `materialize-snowflake` connector.
 * Executed `flowctl shard split` 2x while _that_ catalog was running (2 -> 4 shards).

Issue #247

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/248)
<!-- Reviewable:end -->
