### PR TITLE
Add the ability to provide extra docker args to the connector docker call

### DIFF
--- a/go/capture/driver/airbyte/connector_test.go
+++ b/go/capture/driver/airbyte/connector_test.go
@@ -189,3 +189,20 @@ func TestStderrCapture(t *testing.T) {
 	s.Write(bytes.Repeat([]byte("x"), maxStderrBytes))
 	require.Equal(t, maxStderrBytes, s.buffer.Len())
 }
+
+func TestParseArgs(t *testing.T) {
+
+	var tests = map[string][]string{
+		``:                         {},
+		`             `:            {},
+		`--platform "amd64/linux"`: {"--platform", "amd64/linux"},
+		`--thing "this" and 'that' --whatever=option`: {"--thing", "this", "and", "that", "--whatever=option"},
+		`option one two " "`:                          {"option", "one", "two", " "},
+		`trailing space   `:                           {"trailing", "space"},
+	}
+
+	for test, result := range tests {
+		require.Equal(t, result, parseArgs(test))
+	}
+
+}


### PR DESCRIPTION
Add support for a DOCKER_EXTRA_CONNECTOR_OPTS environment variable which will specify additional arguments to the docker command that runs connectors. This is primarily used to pass platform arguments to docker when running our containers on an M1 Mac for example.

We had talked about adding arbitrary options to docker. Turns out we need this to make M1 Mac work. (as well as it will work)

M1 Mac will work, however it seems to produce somewhat random Segfaults from the connector. The better solution might be to cross compile and connectors we can for arm64. I may do that when I get the BigQuery connector rolling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/249)
<!-- Reviewable:end -->
