### PR TITLE
convert nil resp

### DIFF
--- a/go/capture/driver/airbyte/connector.go
+++ b/go/capture/driver/airbyte/connector.go
@@ -235,6 +235,8 @@ func (o *protoOutput) Write(p []byte) (n int, err error) {
 		if o.next == 0 {
 			if _, err = o.decodeLen(o.rem); err != nil {
 				return 0, err
+			} else if o.next == 0 {
+				o.decodeMsg([]byte{})
 			}
 		} else {
 			if _, err = o.decodeMsg(o.rem); err != nil {
@@ -252,6 +254,8 @@ func (o *protoOutput) Write(p []byte) (n int, err error) {
 				return n, nil
 			} else if p, err = o.decodeLen(p); err != nil {
 				return 0, err
+			} else if o.next == 0 {
+				o.decodeMsg([]byte{})
 			}
 		} else {
 			if len(p) < o.next {

--- a/go/materialize/driver/image/driver.go
+++ b/go/materialize/driver/image/driver.go
@@ -138,10 +138,6 @@ func (d driver) Apply(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyRespo
 			},
 		),
 	)
-
-	if resp == nil {
-		resp = &pm.ApplyResponse{}
-	}
 	return resp, err
 }
 

--- a/go/materialize/driver/image/driver.go
+++ b/go/materialize/driver/image/driver.go
@@ -138,6 +138,10 @@ func (d driver) Apply(ctx context.Context, req *pm.ApplyRequest) (*pm.ApplyRespo
 			},
 		),
 	)
+
+	if resp == nil {
+		resp = &pm.ApplyResponse{}
+	}
 	return resp, err
 }
 


### PR DESCRIPTION
The `airbyte.RunConnector` is not converting an empty response from places like [this](https://github.com/estuary/connectors/blob/main/materialize-webhook/driver.go#L116), leaving nil resp variable unchanged, which causes `flowctl` to crash on [this line](https://github.com/estuary/flow/blob/master/go/flowctl/cmd-apply.go#L313).

The proposed fix sets the `nil` response variable, if not populated, to an empty response in `Apply` command of the `image` driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/253)
<!-- Reviewable:end -->
