### PR TITLE
Handle refactoring in protocols repo to support other SQLish databases without support for Go's sql.DB driver framework.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20210818095345-1014919a589c
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
-	github.com/estuary/protocols v0.0.0-20210909024935-863b8c43e714
+	github.com/estuary/protocols v0.0.0-20211005195709-f439c7e8908d
 	github.com/evanphx/json-patch/v5 v5.5.0
 	github.com/fatih/color v1.7.0
 	github.com/go-openapi/jsonpointer v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/protocols v0.0.0-20210909024935-863b8c43e714 h1:mFXByMG89PiTz0EP+JsQdFIib5KAnetSV+8TqUO0/hA=
-github.com/estuary/protocols v0.0.0-20210909024935-863b8c43e714/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
+github.com/estuary/protocols v0.0.0-20211005195709-f439c7e8908d h1:4LNI1mkDtcV/iSUkwAZA+uwpHE1LMKgUe2NxcJLXn8w=
+github.com/estuary/protocols v0.0.0-20211005195709-f439c7e8908d/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=

--- a/go/materialize/driver/image/driver.go
+++ b/go/materialize/driver/image/driver.go
@@ -39,7 +39,7 @@ type driver struct {
 }
 
 // NewDriver returns a new Docker image driver.
-func NewDriver(networkName string) pm.DriverServer { return driver{} }
+func NewDriver(networkName string) pm.DriverServer { return driver{networkName: networkName} }
 
 // Spec returns the specification of the connector.
 func (d driver) Spec(ctx context.Context, req *pm.SpecRequest) (*pm.SpecResponse, error) {

--- a/go/materialize/driver/postgres/sqlgen_test.go
+++ b/go/materialize/driver/postgres/sqlgen_test.go
@@ -30,7 +30,7 @@ func TestSQLGeneration(t *testing.T) {
 
 	var gen = sqlDriver.PostgresSQLGenerator()
 	var spec = &built.Materializations[0]
-	var table = sqlDriver.TableForMaterialization("test_table", "", &gen.IdentifierQuotes, spec.Bindings[0])
+	var table = sqlDriver.TableForMaterialization("test_table", "", gen.IdentifierRenderer, spec.Bindings[0])
 
 	keyCreate, keyInsert, keyJoin, err := postgres.BuildSQL(&gen, 123, table, spec.Bindings[0].FieldSelection)
 	require.NoError(t, err)

--- a/go/materialize/driver/snowflake/snowflake_test.go
+++ b/go/materialize/driver/snowflake/snowflake_test.go
@@ -34,7 +34,7 @@ func TestQueryGeneration(t *testing.T) {
 
 	var gen = snowflake.SQLGenerator()
 	var spec = &built.Materializations[0]
-	var table = sqlDriver.TableForMaterialization("test_table", "", &gen.IdentifierQuotes, spec.Bindings[0])
+	var table = sqlDriver.TableForMaterialization("test_table", "", gen.IdentifierRenderer, spec.Bindings[0])
 
 	var loadUUID = uuid.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	var storeUUID = uuid.UUID{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}

--- a/go/materialize/driver/sqlite/sqlite_test.go
+++ b/go/materialize/driver/sqlite/sqlite_test.go
@@ -41,7 +41,7 @@ func TestSQLGeneration(t *testing.T) {
 
 	var gen = sqlDriver.SQLiteSQLGenerator()
 	var spec = &built.Materializations[0]
-	var table = sqlDriver.TableForMaterialization("test_table", "", &gen.IdentifierQuotes, spec.Bindings[0])
+	var table = sqlDriver.TableForMaterialization("test_table", "", gen.IdentifierRenderer, spec.Bindings[0])
 
 	keyCreate, keyInsert, keyJoin, keyTruncate, err := sqlite.BuildSQL(
 		&gen, 123, table, spec.Bindings[0].FieldSelection)
@@ -412,10 +412,10 @@ func TestSQLiteDriver(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 
 	// Last thing is to snapshot the database tables we care about.
-	var quotes = sqlDriver.DoubleQuotes()
+	var identifierRenderer = sqlDriver.NewRenderer(nil, sqlDriver.DoubleQuotesWrapper(), sqlDriver.DefaultUnwrappedIdentifiers)
 	var tab = sqlDriver.TableForMaterialization(
 		"test_target", // Matches fixture in testdata/driver-steps.yaml
-		"", &quotes,
+		"", identifierRenderer,
 		&pf.MaterializationSpec_Binding{
 			Collection:     model.Bindings[0].Collection,
 			FieldSelection: fields,


### PR DESCRIPTION
This PR handles a refactoring of the protocols repo in https://github.com/estuary/protocols/pull/8.

In order to support BigQuery as well as any other SQLish database that does not directly have support in Go's *sql.DB driver framework, I needed to refactor the Endpoint in protocols into an Interface. As well, I somewhat standardized a Renderer for handling identifier and field encapsulation and sanitization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/254)
<!-- Reviewable:end -->
