### PR TITLE
go/flow: when mapping hashes to partitions, account for inclusive KeyEnd

### DIFF
--- a/go/flow/mapping.go
+++ b/go/flow/mapping.go
@@ -190,7 +190,7 @@ func (m *Mapper) pickPartition(logicalPrefix []byte, hexKey []byte) *pb.JournalS
 	// Note we're performing this comparasion in a hex-encoded space.
 	var ind = sort.Search(len(physical), func(i int) bool {
 		var keyEnd = physical[i].Decoded.(*pb.JournalSpec).LabelSet.ValueOf(flowLabels.KeyEnd)
-		return keyEnd > string(hexKey)
+		return keyEnd >= string(hexKey)
 	})
 
 	if ind == len(physical) {

--- a/go/flow/mapping_test.go
+++ b/go/flow/mapping_test.go
@@ -47,7 +47,7 @@ func TestPartitionPicking(t *testing.T) {
 		}},
 		{Decoded: &pb.JournalSpec{
 			Name:     "a/collection/bar=32/foo=A/pivot=77",
-			LabelSet: pb.MustLabelSet(flowLabels.KeyBegin, "77", flowLabels.KeyEnd, "dd"),
+			LabelSet: pb.MustLabelSet(flowLabels.KeyBegin, "78", flowLabels.KeyEnd, "dd"),
 		}},
 		{Decoded: &pb.JournalSpec{
 			Name:     "a/collection/bar=42/foo=A/pivot=00",
@@ -72,6 +72,16 @@ func TestPartitionPicking(t *testing.T) {
 	require.Equal(t,
 		"a/collection/bar=42/foo=A/pivot=00",
 		m.pickPartition([]byte("/items/a/collection/bar=42/foo=A/"), []byte("ab")).Name.String(),
+	)
+
+	// Issue #255 regression cases.
+	require.Equal(t,
+		"a/collection/bar=32/foo=A/pivot=00",
+		m.pickPartition([]byte("/items/a/collection/bar=32/foo=A/"), []byte("77")).Name.String(),
+	)
+	require.Equal(t,
+		"a/collection/bar=42/foo=A/pivot=00",
+		m.pickPartition([]byte("/items/a/collection/bar=42/foo=A/"), []byte("dd")).Name.String(),
 	)
 }
 


### PR DESCRIPTION
Issue #255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/256)
<!-- Reviewable:end -->
