### PR TITLE
Phil/rust logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,15 @@ dependencies = [
  "allocator",
  "anyhow",
  "build",
+ "bytes",
  "cbindgen",
+ "chrono",
  "derive",
+ "prost",
  "protocol",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -270,6 +276,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "time",
  "winapi",
 ]
 
@@ -1474,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -1486,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "4a9ea2a613fe4cd7118b2bb101a25d8ae6192e1975179b67b2f17afd11e70ac8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1734,6 +1741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1932,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -9,11 +9,17 @@ crate_type = ["staticlib"]
 
 [dependencies]
 build = { path = "../build", version = "0.0.0" }
+bytes = "*"
+chrono = "*"
 derive = { path = "../derive", version = "0.0.0" }
 allocator = { path = "../allocator", version = "0.0.0" }
+prost = "*"
 protocol = { path = "../protocol", version = "0.0.0" }
+serde = "*"
+serde_json = {version = "*", features = ["raw_value"]}
+thiserror = "*"
 tracing = "*"
-tracing-subscriber = "*"
+tracing-subscriber = {version = "*", features = ["chrono"]}
 anyhow = "*"
 
 [build-dependencies]

--- a/crates/bindings/flow_bindings.h
+++ b/crates/bindings/flow_bindings.h
@@ -43,6 +43,7 @@ typedef struct Channel {
   uint8_t *err_ptr;
   uintptr_t err_len;
   uintptr_t err_cap;
+  uint8_t *log_subscriber;
 } Channel;
 
 /**
@@ -100,7 +101,7 @@ typedef struct GlobalMemoryStats {
   uint64_t realloc_ops_total;
 } GlobalMemoryStats;
 
-struct Channel *build_create(void);
+struct Channel *build_create(int32_t log_level, int32_t log_dest_fd);
 
 void build_invoke1(struct Channel *ch, struct In1 i);
 
@@ -110,7 +111,7 @@ void build_invoke16(struct Channel *ch, struct In16 i);
 
 void build_drop(struct Channel *ch);
 
-struct Channel *combine_create(void);
+struct Channel *combine_create(int32_t log_level, int32_t log_dest_fd);
 
 void combine_invoke1(struct Channel *ch, struct In1 i);
 
@@ -120,7 +121,7 @@ void combine_invoke16(struct Channel *ch, struct In16 i);
 
 void combine_drop(struct Channel *ch);
 
-struct Channel *derive_create(void);
+struct Channel *derive_create(int32_t log_level, int32_t log_dest_fd);
 
 void derive_invoke1(struct Channel *ch, struct In1 i);
 
@@ -130,7 +131,7 @@ void derive_invoke16(struct Channel *ch, struct In16 i);
 
 void derive_drop(struct Channel *ch);
 
-struct Channel *extract_create(void);
+struct Channel *extract_create(int32_t log_level, int32_t log_dest_fd);
 
 void extract_invoke1(struct Channel *ch, struct In1 i);
 
@@ -145,7 +146,7 @@ void extract_drop(struct Channel *ch);
  */
 struct GlobalMemoryStats get_memory_stats(void);
 
-struct Channel *schema_create(void);
+struct Channel *schema_create(int32_t log_level, int32_t log_dest_fd);
 
 void schema_invoke1(struct Channel *ch, struct In1 i);
 
@@ -155,7 +156,7 @@ void schema_invoke16(struct Channel *ch, struct In16 i);
 
 void schema_drop(struct Channel *ch);
 
-struct Channel *upper_case_create(void);
+struct Channel *upper_case_create(int32_t log_level, int32_t log_dest_fd);
 
 void upper_case_invoke1(struct Channel *ch, struct In1 i);
 

--- a/crates/bindings/src/build.rs
+++ b/crates/bindings/src/build.rs
@@ -2,8 +2,8 @@ use crate::service::{self, Channel};
 use build::API;
 
 #[no_mangle]
-pub extern "C" fn build_create() -> *mut Channel {
-    service::create::<API>()
+pub extern "C" fn build_create(log_level: i32, log_dest_fd: i32) -> *mut Channel {
+    service::create::<API>(log_level, log_dest_fd)
 }
 #[no_mangle]
 pub extern "C" fn build_invoke1(ch: *mut Channel, i: service::In1) {

--- a/crates/bindings/src/combine.rs
+++ b/crates/bindings/src/combine.rs
@@ -2,8 +2,8 @@ use crate::service::{self, Channel};
 use derive::combine_api::API;
 
 #[no_mangle]
-pub extern "C" fn combine_create() -> *mut Channel {
-    service::create::<API>()
+pub extern "C" fn combine_create(log_level: i32, log_dest_fd: i32) -> *mut Channel {
+    service::create::<API>(log_level, log_dest_fd)
 }
 #[no_mangle]
 pub extern "C" fn combine_invoke1(ch: *mut Channel, i: service::In1) {

--- a/crates/bindings/src/derive.rs
+++ b/crates/bindings/src/derive.rs
@@ -2,8 +2,8 @@ use crate::service::{self, Channel};
 use derive::derive_api::API;
 
 #[no_mangle]
-pub extern "C" fn derive_create() -> *mut Channel {
-    service::create::<API>()
+pub extern "C" fn derive_create(log_level: i32, log_dest_fd: i32) -> *mut Channel {
+    service::create::<API>(log_level, log_dest_fd)
 }
 #[no_mangle]
 pub extern "C" fn derive_invoke1(ch: *mut Channel, i: service::In1) {

--- a/crates/bindings/src/extract.rs
+++ b/crates/bindings/src/extract.rs
@@ -2,8 +2,8 @@ use crate::service::{self, Channel};
 use derive::extract_api::API;
 
 #[no_mangle]
-pub extern "C" fn extract_create() -> *mut Channel {
-    service::create::<API>()
+pub extern "C" fn extract_create(log_level: i32, log_dest_fd: i32) -> *mut Channel {
+    service::create::<API>(log_level, log_dest_fd)
 }
 #[no_mangle]
 pub extern "C" fn extract_invoke1(ch: *mut Channel, i: service::In1) {

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod logging;
 pub(crate) mod service;
 
 mod build;
@@ -7,16 +8,3 @@ mod extract;
 mod metrics;
 mod schema;
 mod upper_case;
-
-/// Setup a global tracing subscriber using the RUST_LOG env variable.
-pub fn setup_env_tracing() {
-    static SUBSCRIBE: std::sync::Once = std::sync::Once::new();
-
-    SUBSCRIBE.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_writer(std::io::stderr)
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
-}

--- a/crates/bindings/src/logging.rs
+++ b/crates/bindings/src/logging.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use std::fs::File;
 use std::io::{self, Write};
-use std::mem::ManuallyDrop;
 use std::sync::{Arc, Mutex};
 
 /// Setup a global tracing subscriber using the RUST_LOG env variable. This subscriber is only used
@@ -74,7 +73,7 @@ where
 /// subscriber, though, so `FileWriter` should not be used with a global subscriber. The
 /// `ManuallyDrop` is here because `service::create` says that we should not close this file.
 #[derive(Clone)]
-pub struct FileWriter(Arc<Mutex<ManuallyDrop<File>>>);
+pub struct FileWriter(Arc<Mutex<File>>);
 impl FileWriter {
     /// Creates a new `FileWriter`, which will write to the given `file_descriptor`. It's the
     /// caller's responsibility to ensure that the given file descriptor is valid, and not being
@@ -83,7 +82,7 @@ impl FileWriter {
         use std::os::unix::io::FromRawFd;
 
         let file = File::from_raw_fd(file_decriptor);
-        FileWriter(Arc::new(Mutex::new(ManuallyDrop::new(file))))
+        FileWriter(Arc::new(Mutex::new(file)))
     }
 }
 impl Write for FileWriter {

--- a/crates/bindings/src/logging.rs
+++ b/crates/bindings/src/logging.rs
@@ -1,0 +1,303 @@
+use chrono::Utc;
+use std::fs::File;
+use std::io::{self, Write};
+use std::mem::ManuallyDrop;
+use std::sync::{Arc, Mutex};
+
+/// Setup a global tracing subscriber using the RUST_LOG env variable. This subscriber is only used
+/// for tracing that's performed on background threads, since a thread local subscriber is used for
+/// all service invocations. This global subscriber is just a fallback so that we don't lose spans
+/// and events that happen to be generated from other threads.
+pub fn setup_env_tracing() {
+    static SUBSCRIBE: std::sync::Once = std::sync::Once::new();
+
+    SUBSCRIBE.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_writer(std::io::stderr)
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}
+
+/// Creates a new thread local subscriber, which can be used with the `tracing::dispatcher` to
+/// capture logs for a single thread. All logs that pass the filter will be written to the given
+/// `MakeWriter`.
+///
+/// The logs will be formatted in a way that's compatible with the log forwarding in:
+/// go/flow/ops/forward_logs.go
+/// The logs will be formatted as JSON, with all fields flattened into the top level object. The
+/// timestamps will be formatted as RFC3339 with nanosecond precision.
+pub fn new_thread_local_subscriber<W>(flow_level_filter: i32, write: W) -> tracing::Dispatch
+where
+    W: tracing_subscriber::fmt::MakeWriter + Send + Sync + 'static,
+{
+    let level_filter = level_filter(flow_level_filter);
+
+    let subs = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(level_filter)
+        .with_writer(write)
+        .json()
+        // Without this, many fields (including the message) would get nested inside of a `"fields"`
+        // object, which just makes parsing more difficult.
+        .flatten_event(true)
+        // The default timestamp formatting did not spark joy, so I made this one that writes in
+        // RFC3339 with nanosecond precision (and a Z at the end, as god intended).
+        .with_timer(TimeFormatter)
+        // Using CLOSE span events seems like the best balance between helpfulness and verbosity.
+        // Any Spans that are created will only be logged once they're done with (i.e. once a
+        // `Future` has been `await`ed). This means that timing information will be recorded for
+        // each span, and all fields will have had their values recorded. It also means that there
+        // will be only 1 log line per span, so shouldn't be too overwhelming.
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        // Adds info on the current span to each event emitted from within it. This might be a
+        // little verbose, but we don't really use many spans so :shrug:
+        .with_current_span(true)
+        // This stuff just seems too verbose to be worth it.
+        .with_span_list(false)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        // "target" here refers to the rust module path (typically) from which the trace event
+        // originated. It's not clear how useful it really is, especially for users of Flow, so I
+        // left it disabled for now. But I could also see an argument for including it, so if
+        // that's what you're here to do then go for it.
+        .with_target(false)
+        .finish();
+    tracing::Dispatch::new(subs)
+}
+
+/// Ugh, this is annoying, mostly because of [this issue](https://github.com/tokio-rs/tracing/issues/675).
+/// Tracing uses a layer of indirection where the actual `Write` impl is created on demand by a
+/// `MakeWriter`, which is unable to return a reference. This is why we need our own `Write` impl.
+/// The `Arc` and `Mutex` are required because tracing requires it to be `Send` and `Sync`. The
+/// mutex probably doesn't prevent logs from being interleaved if multiple threads are using this
+/// subscriber, though, so `FileWriter` should not be used with a global subscriber. The
+/// `ManuallyDrop` is here because `service::create` says that we should not close this file.
+#[derive(Clone)]
+pub struct FileWriter(Arc<Mutex<ManuallyDrop<File>>>);
+impl FileWriter {
+    /// Creates a new `FileWriter`, which will write to the given `file_descriptor`. It's the
+    /// caller's responsibility to ensure that the given file descriptor is valid, and not being
+    /// written to from anywhere else. This is why creating a `FileWriter` is unsafe.
+    pub unsafe fn new(file_decriptor: i32) -> FileWriter {
+        use std::os::unix::io::FromRawFd;
+
+        let file = File::from_raw_fd(file_decriptor);
+        FileWriter(Arc::new(Mutex::new(ManuallyDrop::new(file))))
+    }
+}
+impl Write for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut guard = self.0.lock().unwrap();
+        guard.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut guard = self.0.lock().unwrap();
+        guard.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let mut guard = self.0.lock().unwrap();
+        guard.write_vectored(bufs)
+    }
+}
+impl tracing_subscriber::fmt::MakeWriter for FileWriter {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+// The plain Fixed::RFC3339 format adds "+0:00" instead of "Z", and I know it's stupid but it
+// bothered me and so I "fixed" it using this monstrosity.
+struct TimeFormatter;
+impl tracing_subscriber::fmt::time::FormatTime for TimeFormatter {
+    fn format_time(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        use chrono::format::{Fixed, Item, Numeric::*, Pad::Zero};
+        // We specify the format in this way so that we can avoid formatting into an intermediate
+        // String.
+
+        const RFC3339: &'static [Item<'static>] = &[
+            Item::Numeric(Year, Zero),
+            Item::Literal("-"),
+            Item::Numeric(Month, Zero),
+            Item::Literal("-"),
+            Item::Numeric(Day, Zero),
+            Item::Literal("T"),
+            Item::Numeric(Hour, Zero),
+            Item::Literal(":"),
+            Item::Numeric(Minute, Zero),
+            Item::Literal(":"),
+            Item::Numeric(Second, Zero),
+            Item::Fixed(Fixed::Nanosecond9),
+            Item::Fixed(Fixed::TimezoneOffsetColonZ),
+        ];
+
+        write!(w, "{}", Utc::now().format_with_items(RFC3339.iter()))
+    }
+}
+
+// Takes the `i32` representation of a `protocol::flow::LogLevelFilter` and returns an equivalent
+// filter that works with `tracing`.
+fn level_filter(flow_level_filter: i32) -> tracing::level_filters::LevelFilter {
+    use protocol::flow::LogLevelFilter as FLevel;
+    use tracing::level_filters::LevelFilter as TLevel;
+
+    match FLevel::from_i32(flow_level_filter).unwrap_or(FLevel::Warn) {
+        FLevel::Off => TLevel::OFF,
+        FLevel::Trace => TLevel::TRACE,
+        FLevel::Debug => TLevel::DEBUG,
+        FLevel::Info => TLevel::INFO,
+        FLevel::Warn => TLevel::WARN,
+        FLevel::Error => TLevel::ERROR,
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use protocol::flow::LogLevelFilter;
+    use serde_json::{json, Value};
+    use std::io::BufRead;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    pub struct TestWriter(pub Arc<Mutex<Vec<u8>>>);
+    impl TestWriter {
+        pub fn new() -> TestWriter {
+            TestWriter(Arc::new(Mutex::new(Vec::with_capacity(1024))))
+        }
+
+        pub fn into_output(self) -> Vec<u8> {
+            let mutex = Arc::try_unwrap(self.0)
+                .expect("There are still outstanding references to test writer output");
+            mutex.into_inner().unwrap()
+        }
+    }
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut guard = self.0.lock().unwrap();
+            guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    impl tracing_subscriber::fmt::MakeWriter for TestWriter {
+        type Writer = Self;
+
+        fn make_writer(&self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn no_outputs_produced_when_level_filter_is_off() {
+        let writer = TestWriter::new();
+        let subscriber = new_thread_local_subscriber(LogLevelFilter::Off as i32, writer.clone());
+
+        tracing::dispatcher::with_default(&subscriber, || {
+            tracing_test(7, "hope you don't see me");
+        });
+        // Drop the subscriber so that we can safely unwrap the reference counted output.
+        std::mem::drop(subscriber);
+        let bytes = writer.into_output();
+        assert!(
+            bytes.is_empty(),
+            "oh no: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    #[test]
+    fn test_logging_output_format() {
+        let writer = TestWriter::new();
+        let subscriber = new_thread_local_subscriber(LogLevelFilter::Debug as i32, writer.clone());
+
+        tracing::dispatcher::with_default(&subscriber, || {
+            tracing_test(3, "somestr");
+        });
+        // Drop the subscriber so that we can safely unwrap the reference counted output.
+        std::mem::drop(subscriber);
+        let bytes = writer.into_output();
+        let mut lines = bytes.lines();
+
+        let expected_logs = vec![
+            json!({
+                "level": "DEBUG",
+                "is_empty": false,
+                "message": "debug inside nested",
+                "span": {"name": "nested_func", "string_arg": "\"the int is 3 and the str is somestr\""},
+            }),
+            json!({
+                "level": "WARN",
+                "message": "string might be odd",
+                "is_odd": false,
+                "span": {"name": "nested_func", "string_arg": "\"the int is 3 and the str is somestr\""},
+            }),
+            json!({
+                "level":"INFO",
+                "message":"close",
+                "span":{"name":"nested_func", "string_arg": "\"the int is 3 and the str is somestr\""}
+            }),
+            json!({
+                "level": "ERROR",
+                "message": "oh no an error",
+                "error": "this is only a test",
+            }),
+        ];
+
+        for (i, expected) in expected_logs.into_iter().enumerate() {
+            let line = lines
+                .next()
+                .unwrap_or_else(|| panic!("missing actual log at index: {}", i))
+                .unwrap_or_else(|e| panic!("failed to read actual log at index: {}: {:?}", i, e));
+            let actual: Value = serde_json::from_str(&line).unwrap_or_else(|e| {
+                panic!(
+                    "failed to deserialize actual log line: '{}', error: {}",
+                    &line, e
+                );
+            });
+            let actual_map = actual.as_object().expect("expected object");
+
+            let expected_map = expected.as_object().unwrap();
+            for (field, expected_val) in expected_map.iter() {
+                assert_eq!(
+                    Some(expected_val),
+                    actual_map.get(field),
+                    "mismatched {} for document {}, expected: {}, actual: {}",
+                    field,
+                    i,
+                    expected,
+                    actual
+                );
+            }
+        }
+        let next_line = lines.next();
+        assert!(
+            next_line.is_none(),
+            "expected no more logs, got: {:?}",
+            next_line
+        );
+    }
+
+    fn tracing_test(int_arg: i64, str_arg: &str) -> bool {
+        tracing::trace!(dummy_arg = "dummy", "this should not be logged");
+        let s = format!("the int is {} and the str is {}", int_arg, str_arg);
+        let b = nested_func(s);
+        let err = std::io::Error::new(std::io::ErrorKind::Other, "this is only a test");
+        tracing::error!(error = %err, "oh no an error");
+        b
+    }
+
+    #[tracing::instrument]
+    fn nested_func(string_arg: String) -> bool {
+        tracing::debug!(is_empty = string_arg.is_empty(), "debug inside nested");
+        let is_odd = string_arg.len() % 2 == 0;
+        tracing::warn!(is_odd, "string might be odd");
+        is_odd
+    }
+}

--- a/crates/bindings/src/schema.rs
+++ b/crates/bindings/src/schema.rs
@@ -2,8 +2,8 @@ use crate::service::{self, Channel};
 use derive::schema_api::API;
 
 #[no_mangle]
-pub extern "C" fn schema_create() -> *mut Channel {
-    service::create::<API>()
+pub extern "C" fn schema_create(log_level: i32, log_dest_fd: i32) -> *mut Channel {
+    service::create::<API>(log_level, log_dest_fd)
 }
 #[no_mangle]
 pub extern "C" fn schema_invoke1(ch: *mut Channel, i: service::In1) {

--- a/crates/bindings/src/service.rs
+++ b/crates/bindings/src/service.rs
@@ -124,13 +124,12 @@ pub struct Channel {
 }
 
 /// Create a new Service instance, wrapped in an owning Channel.
-/// This is intended to be monomorphized by each Service implementation,
-/// and exposed via cbindgen.  See the UpperCase service for an example.
-/// All logs will be written to the `log_dest_file_descriptor`. This file descriptor will *not* be
-/// closed when the service is destroyed. It is the caller's responsibility to close it if and when
-/// desired. If the `log_dest_file_descriptor` is <= 0, then logging will be disabled entirely for
-/// this service. Each service must use a unique `log_dest_file_descriptor` to avoid interleaved
-/// logs making the JSON output unparseable.
+/// This is intended to be monomorphized by each Service implementation, and exposed via cbindgen.
+/// See the UpperCase service for an example. All logs will be written to the
+/// `log_dest_file_descriptor`. This file descriptor will be closed when the service is destroyed.
+/// If the `log_dest_file_descriptor` is <= 0, then logging will be disabled entirely for this
+/// service. Each service must use a unique `log_dest_file_descriptor` to avoid interleaved logs
+/// making the JSON output unparseable.
 #[inline]
 pub fn create<S: Service>(log_level_filter: i32, log_dest_file_descriptor: i32) -> *mut Channel {
     // Use service creation as a common entry hook through which we can install global tracing and
@@ -250,7 +249,6 @@ pub fn drop<S: Service>(ch: *mut Channel) {
         err_cap,
 
         log_subscriber,
-        ..
     } = *unsafe { Box::from_raw(ch) };
 
     // Drop svc_impl, arena, out, and tracing subscriber.
@@ -258,5 +256,5 @@ pub fn drop<S: Service>(ch: *mut Channel) {
     unsafe { Vec::<u8>::from_raw_parts(arena_ptr, arena_len, arena_cap) };
     unsafe { Vec::<Out>::from_raw_parts(out_ptr, out_len, out_cap) };
     unsafe { String::from_raw_parts(err_ptr, err_len, err_cap) };
-    unsafe { Box::from_raw(log_subscriber) };
+    unsafe { Box::from_raw(log_subscriber as *mut tracing::Dispatch) };
 }

--- a/crates/bindings/src/service.rs
+++ b/crates/bindings/src/service.rs
@@ -1,4 +1,5 @@
-pub use protocol::cgo::{Out, Service};
+use crate::logging::{new_thread_local_subscriber, FileWriter};
+pub use protocol::cgo::{self, Out, Service};
 
 /// InN is a variadic input which invokes itself against a Service.
 pub trait InN {
@@ -113,16 +114,42 @@ pub struct Channel {
     err_ptr: *mut u8,
     err_len: usize,
     err_cap: usize,
+
+    // The tracing Dispatch that will be used for logging when this channel is used to invoke a
+    // service. Dispatch is the type-erased form that is used by the tracing crate. Once the
+    // channel is created, we no longer care about the specific implementation of the Subscriber.
+    // The representation here is just a plain pointer so the the Dispatch type doesn't need to be
+    // defined in libbindings.h.
+    log_subscriber: *mut u8,
 }
 
 /// Create a new Service instance, wrapped in an owning Channel.
 /// This is intended to be monomorphized by each Service implementation,
 /// and exposed via cbindgen.  See the UpperCase service for an example.
+/// All logs will be written to the `log_dest_file_descriptor`. This file descriptor will *not* be
+/// closed when the service is destroyed. It is the caller's responsibility to close it if and when
+/// desired. If the `log_dest_file_descriptor` is <= 0, then logging will be disabled entirely for
+/// this service. Each service must use a unique `log_dest_file_descriptor` to avoid interleaved
+/// logs making the JSON output unparseable.
 #[inline]
-pub fn create<S: Service>() -> *mut Channel {
-    // Use service creation as a common entry hook through which we can
-    // install global tracing and logging.
-    crate::setup_env_tracing();
+pub fn create<S: Service>(log_level_filter: i32, log_dest_file_descriptor: i32) -> *mut Channel {
+    // Use service creation as a common entry hook through which we can install global tracing and
+    // logging. The global subscriber that's initialized here will only be used as a fallback for
+    // logs that are produced from other threads, so this is really just a bit of insurance to make
+    // sure we don't miss anything important.
+    crate::logging::setup_env_tracing();
+
+    // Now initialize the subscriber that will forward all the logs for this service to the
+    // `log_dest_file_descriptor`, if logging is enabled. If disabled, then we'll set a no-op
+    // subscriber.
+    let subscriber = if log_dest_file_descriptor > 0 {
+        new_thread_local_subscriber(log_level_filter, unsafe {
+            FileWriter::new(log_dest_file_descriptor)
+        })
+    } else {
+        tracing::Dispatch::none()
+    };
+    let dispatch = Box::into_raw(Box::new(subscriber));
 
     let svc_impl = Box::new(S::create());
     let svc_impl = Box::leak(svc_impl) as *mut S as *mut ServiceImpl;
@@ -138,6 +165,7 @@ pub fn create<S: Service>() -> *mut Channel {
         err_ptr: 0 as *mut u8,
         err_len: 0,
         err_cap: 0,
+        log_subscriber: dispatch as *mut u8,
     });
     Box::leak(ch)
 }
@@ -158,7 +186,26 @@ pub fn invoke<S: Service, I: InN>(ch: *mut Channel, i: I) {
     let mut err_str = unsafe { String::from_raw_parts(ch.err_ptr, ch.err_len, ch.err_cap) };
     let svc_impl = unsafe { &mut *(ch.svc_impl as *mut S) };
 
-    let r = i.invoke(svc_impl, &mut arena, &mut out);
+    let dispatch = unsafe { &*(ch.log_subscriber as *mut tracing::Dispatch) };
+    let r = tracing::dispatcher::with_default(dispatch, || {
+        let result = i.invoke(svc_impl, &mut arena, &mut out);
+        if let Err(err) = &result {
+            // Errors get passed to the go side as a simple string, but we'd ideally like to
+            // include JSON representation of the error in the logs. So we always log errors here
+            // on the Rust side so that logs can include all the gory details, but the error
+            // that's returned to Go has the more human-readable representation.
+            //
+            // For now, we are serializing errors to a JSON string and setting them as the error
+            // field. Yes, this is gross because that field will be a string containing json
+            // instead of an actual json object. But the tracing project is planning to support
+            // serialization of nested objects soon, so we should be able to switch this with an
+            // impl that will serialize the error as a json object.
+            // see: https://github.com/tokio-rs/tracing/issues/1570
+            let err_json = serde_json::to_string(err).expect("serializing error cannot fail");
+            tracing::error!(error = err_json.as_str(), "{}", err);
+        }
+        result
+    });
     if let Err(err) = r {
         // Set terminal error string.
         err_str = format!("{:?}", anyhow::Error::new(err));
@@ -201,11 +248,15 @@ pub fn drop<S: Service>(ch: *mut Channel) {
         err_ptr,
         err_len,
         err_cap,
+
+        log_subscriber,
+        ..
     } = *unsafe { Box::from_raw(ch) };
 
-    // Drop svc_impl, arena, and out.
+    // Drop svc_impl, arena, out, and tracing subscriber.
     unsafe { Box::from_raw(svc_impl as *mut S) };
     unsafe { Vec::<u8>::from_raw_parts(arena_ptr, arena_len, arena_cap) };
     unsafe { Vec::<Out>::from_raw_parts(out_ptr, out_len, out_cap) };
     unsafe { String::from_raw_parts(err_ptr, err_len, err_cap) };
+    unsafe { Box::from_raw(log_subscriber) };
 }

--- a/crates/build/src/api.rs
+++ b/crates/build/src/api.rs
@@ -7,20 +7,33 @@ use protocol::{
     flow::build_api::{self, Code},
     materialize,
 };
+use serde::Serialize;
 use std::rc::Rc;
 use std::task::Poll;
 use url::Url;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Serialize)]
 pub enum Error {
     #[error("protocol error (invalid state or invocation)")]
     InvalidState,
     #[error("Protobuf decoding error")]
+    #[serde(serialize_with = "serialize_as_display")]
     ProtoDecode(#[from] prost::DecodeError),
     #[error(transparent)]
+    #[serde(serialize_with = "serialize_as_display")]
     UTF8Error(#[from] std::str::Utf8Error),
     #[error(transparent)]
+    #[serde(serialize_with = "serialize_as_display")]
     Anyhow(#[from] anyhow::Error),
+}
+
+fn serialize_as_display<T, S>(thing: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: std::fmt::Display,
+    S: serde::ser::Serializer,
+{
+    let s = thing.to_string();
+    serializer.serialize_str(&s)
 }
 
 // Fetcher implements sources::Fetcher, and delegates to Go via Trampoline.

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -27,7 +27,7 @@ stats_alloc = "*"
 thiserror = "*"
 tracing = "*"
 tracing-futures = "*"
-url = "*"
+url = {version = "*", features = ["serde"]}
 uuid = "*"
 
 [dev-dependencies]

--- a/crates/derive/src/combiner.rs
+++ b/crates/derive/src/combiner.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 use url::Url;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
     #[error("failed to combine documents having shared key")]
     Reduction(#[from] reduce::Error),

--- a/crates/derive/src/derive_api.rs
+++ b/crates/derive/src/derive_api.rs
@@ -7,15 +7,17 @@ use protocol::{
     flow::derive_api::{self, Code},
 };
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
     #[error("RocksDB error: {0}")]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     Rocks(#[from] rocksdb::Error),
     #[error("register database error")]
     RegisterErr(#[from] registers::Error),
     #[error(transparent)]
     PipelineErr(#[from] pipeline::Error),
     #[error("Protobuf decoding error")]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     ProtoDecode(#[from] prost::DecodeError),
     #[error("protocol error (invalid state or invocation)")]
     InvalidState,
@@ -36,6 +38,7 @@ enum State {
     Flushing(Pipeline),
     Prepare(Pipeline),
 }
+
 impl cgo::Service for API {
     type Error = Error;
 

--- a/crates/derive/src/registers.rs
+++ b/crates/derive/src/registers.rs
@@ -8,19 +8,23 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use url::Url;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
     #[error("RocksDB error: {0}")]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     Rocks(#[from] rocksdb::Error),
-    #[error("JSON error: {0}")]
+    #[error(transparent)]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     Json(#[from] serde_json::Error),
     #[error("protobuf error: {0}")]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     Proto(#[from] prost::DecodeError),
     #[error("failed to reduce register documents")]
     Reduce(#[from] reduce::Error),
     #[error("document is invalid: {0:#}")]
     FailedValidation(#[from] FailedValidation),
     #[error(transparent)]
+    #[serde(serialize_with = "crate::serialize_as_display")]
     SchemaIndex(#[from] json::schema::index::Error),
 }
 

--- a/crates/doc/src/reduce/mod.rs
+++ b/crates/doc/src/reduce/mod.rs
@@ -10,7 +10,7 @@ pub use strategy::Strategy;
 
 type Index<'a> = &'a [(&'a Strategy, u64)];
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
     #[error("'append' strategy expects arrays")]
     AppendWrongType,

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "*"
 serde_yaml = "*"
 thiserror = "*"
 tracing = "*"
-url = "*"
+url = {version = "*", features = ["serde"]}
 
 [dev-dependencies]
 criterion = "*"

--- a/crates/json/src/schema/index.rs
+++ b/crates/json/src/schema/index.rs
@@ -2,7 +2,7 @@ use crate::schema::{Annotation, Application, Keyword, Schema};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
     #[error("duplicate canonical URI: '{0}'")]
     DuplicateCanonicalURI(url::Url),

--- a/crates/protocol/build.rs
+++ b/crates/protocol/build.rs
@@ -79,6 +79,14 @@ fn main() {
         proto_include[1].join("flow/flow.proto"),
         proto_include[1].join("materialize/materialize.proto"),
     ];
+    // Tell cargo to re-run this build script if any of the protobuf files are modified.
+    for path in proto_build.iter() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    // According to (https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+    // setting rerun-if-changed will override the default, so we explicitly tell it to re-run if
+    // any files in the crate root are modified.
+    println!("cargo:rerun-if-changed=.");
 
     let mut builder = prost_build::Config::new();
     builder.out_dir(Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("src"));

--- a/crates/protocol/src/cgo.rs
+++ b/crates/protocol/src/cgo.rs
@@ -1,11 +1,12 @@
 use bytes::{Buf, BufMut};
 use prost::Message;
+use serde::Serialize;
 use std::{cell::RefCell, collections::HashMap};
 
 /// Service is a trait implemented by Rust services which may be called from Go.
 pub trait Service {
     /// Error type returned by Service invocations.
-    type Error: std::error::Error + Send + Sync + 'static;
+    type Error: std::error::Error + Serialize + Send + Sync + 'static;
 
     /// Create a new instance of the Service.
     fn create() -> Self;

--- a/crates/protocol/src/flow.rs
+++ b/crates/protocol/src/flow.rs
@@ -1029,6 +1029,19 @@ pub enum EndpointType {
     AirbyteSource = 7,
     FlowSink = 8,
 }
+/// LogLevelFilter is a common representation of a simple logging filter, which is shared between
+/// Rust and Go code. This enum is not used directly within other messages here because logging is
+/// configured at the time that Rust Service instances are created, not when they're configured.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LogLevelFilter {
+    Off = 0,
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
 /// ContentType enumerates the content types understood by Flow.
 #[derive(serde::Deserialize, serde::Serialize)] #[serde(deny_unknown_fields)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20210818095345-1014919a589c
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
-	github.com/estuary/protocols v0.0.0-20211006013521-9b8d02b54d19
+	github.com/estuary/protocols v0.0.0-20211018140445-5adfa253d11d
 	github.com/evanphx/json-patch/v5 v5.5.0
 	github.com/fatih/color v1.7.0
 	github.com/go-openapi/jsonpointer v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/protocols v0.0.0-20211006013521-9b8d02b54d19 h1:3R8n+MILPsx2+JFm/KE8Jq6AAeWJoj4Fu1j8hBeTBnE=
-github.com/estuary/protocols v0.0.0-20211006013521-9b8d02b54d19/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
 github.com/estuary/protocols v0.0.0-20211018140445-5adfa253d11d h1:EjDwnYX63X51DQRFm+4M8pkiPFGFj/W2fM9AJKmmMa0=
 github.com/estuary/protocols v0.0.0-20211018140445-5adfa253d11d/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/estuary/protocols v0.0.0-20211006013521-9b8d02b54d19 h1:3R8n+MILPsx2+JFm/KE8Jq6AAeWJoj4Fu1j8hBeTBnE=
 github.com/estuary/protocols v0.0.0-20211006013521-9b8d02b54d19/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
+github.com/estuary/protocols v0.0.0-20211018140445-5adfa253d11d h1:EjDwnYX63X51DQRFm+4M8pkiPFGFj/W2fM9AJKmmMa0=
+github.com/estuary/protocols v0.0.0-20211018140445-5adfa253d11d/go.mod h1:CcYehV5RxFk0tNW/K/9w08YvHuzhkEFARuomzDn4nhk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=

--- a/go/bindings/derive_test.go
+++ b/go/bindings/derive_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/flow/go/flow/ops"
 	"github.com/estuary/protocols/fdb/tuple"
 	pf "github.com/estuary/protocols/flow"
 	_ "github.com/mattn/go-sqlite3" // Import for registration side-effect.
@@ -58,7 +59,7 @@ func TestDeriveWithIntStrings(t *testing.T) {
 		derivation.Collection.GetProjection(field).IsPartitionKey = true
 	}
 
-	derive, err := NewDerive(nil, t.TempDir())
+	derive, err := NewDerive(nil, t.TempDir(), ops.StdLogPublisher())
 	require.NoError(t, err)
 
 	// Loop to exercise multiple transactions.
@@ -253,7 +254,7 @@ func TestDeriveWithIncResetPublish(t *testing.T) {
 	}
 
 	var build = func(t *testing.T) *Derive {
-		d, err := NewDerive(nil, t.TempDir())
+		d, err := NewDerive(nil, t.TempDir(), ops.StdLogPublisher())
 		require.NoError(t, err)
 		require.NoError(t, d.Configure("test/derive/withIncReset", schemaIndex, &built.Derivations[0], lambdaClient))
 		return d

--- a/go/bindings/extract_test.go
+++ b/go/bindings/extract_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestExtractorBasic(t *testing.T) {
-	var ex = NewExtractor()
+	var ex, err = NewExtractor()
+	require.NoError(t, err)
 	require.NoError(t, ex.Configure("/0", []string{"/1", "/2", "/3"}, "", nil))
 	ex.Document([]byte(`["9f2952f3-c6a3-11ea-8802-080607050309", 42, "a-string", [true, null]]`))
 	ex.Document([]byte(`["9f2952f3-c6a3-12fb-8801-080607050309", 52, "other-string", {"k": "v"}]`))
@@ -63,7 +64,8 @@ func TestExtractorValidation(t *testing.T) {
 	schemaIndex, err := NewSchemaIndex(&built.Schemas)
 	require.NoError(t, err)
 
-	var ex = NewExtractor()
+	ex, err := NewExtractor()
+	require.NoError(t, err)
 	require.NoError(t, ex.Configure("/uuid", []string{"/s"}, built.Collections[0].SchemaUri, schemaIndex))
 
 	ex.Document([]byte(`{"uuid": "9f2952f3-c6a3-12fb-8801-080607050309", "i": 32, "s": "valid"}`))         // Valid.
@@ -75,7 +77,8 @@ func TestExtractorValidation(t *testing.T) {
 }
 
 func TestExtractorIntegerBoundaryCases(t *testing.T) {
-	var ex = NewExtractor()
+	var ex, err = NewExtractor()
+	require.NoError(t, err)
 	require.NoError(t, ex.Configure("/0", []string{"/1"}, "", nil))
 
 	var minInt64 = strconv.FormatInt(math.MinInt64, 10)
@@ -106,7 +109,8 @@ func TestExtractorIntegerBoundaryCases(t *testing.T) {
 }
 
 func TestExtractorEmpty(t *testing.T) {
-	var ex = NewExtractor()
+	var ex, err = NewExtractor()
+	require.NoError(t, err)
 	require.NoError(t, ex.Configure("/0", []string{"/1"}, "", nil))
 
 	uuids, packed, err := ex.Extract()

--- a/go/bindings/schema.go
+++ b/go/bindings/schema.go
@@ -3,6 +3,9 @@ package bindings
 // #include "../../crates/bindings/flow_bindings.h"
 import "C"
 import (
+	"fmt"
+
+	"github.com/estuary/flow/go/flow/ops"
 	pf "github.com/estuary/protocols/flow"
 )
 
@@ -14,14 +17,17 @@ type SchemaIndex struct {
 
 // NewSchemaIndex builds and indexes the provided bundle of schemas.
 func NewSchemaIndex(bundle *pf.SchemaBundle) (*SchemaIndex, error) {
-	var svc = newSchemaService()
+	var svc, err = newSchemaService()
+	if err != nil {
+		return nil, fmt.Errorf("creating schema service: %w", err)
+	}
 	defer svc.destroy()
 
 	if err := svc.sendMessage(1, bundle); err != nil {
 		panic(err) // Encoding is infalliable.
 	}
 
-	var _, out, err = svc.poll()
+	_, out, err := svc.poll()
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +40,14 @@ func NewSchemaIndex(bundle *pf.SchemaBundle) (*SchemaIndex, error) {
 	}, nil
 }
 
-func newSchemaService() *service {
+func newSchemaService() (*service, error) {
 	return newService(
 		"schema",
-		func() *C.Channel { return C.schema_create() },
+		func(logFilter, logDest C.int32_t) *C.Channel { return C.schema_create(logFilter, logDest) },
 		func(ch *C.Channel, in C.In1) { C.schema_invoke1(ch, in) },
 		func(ch *C.Channel, in C.In4) { C.schema_invoke4(ch, in) },
 		func(ch *C.Channel, in C.In16) { C.schema_invoke16(ch, in) },
 		func(ch *C.Channel) { C.schema_drop(ch) },
+		ops.StdLogPublisher(),
 	)
 }

--- a/go/bindings/upper_case_test.go
+++ b/go/bindings/upper_case_test.go
@@ -100,7 +100,7 @@ func TestLotsOfLogs(t *testing.T) {
 		}
 		var _, _, err = svc.poll()
 		require.NoError(t, err)
-		logPublisher.WaitForLogs(t, time.Millisecond*500, n)
+		logPublisher.WaitForLogs(t, time.Second, n)
 		logPublisher.RequireEventsMatching(t, expectedLogs)
 	}
 }

--- a/go/bindings/upper_case_test.go
+++ b/go/bindings/upper_case_test.go
@@ -54,6 +54,9 @@ func TestLogsForwardedFromService(t *testing.T) {
 
 	svc.sendMessage(2, frameableString("whoops"))
 	_, _, err = svc.poll()
+	// Destroying the service should cause the logging file to be closed, which will result in that
+	// last log event. We assert that we git the final log event because it means that destroying
+	// the service caused the logging file descriptor to be closed, ending the log forwarding goroutine.
 	svc.destroy()
 
 	logPublisher.WaitForLogs(t, time.Millisecond*500, 2)

--- a/go/flow/ops/forward_logs.go
+++ b/go/flow/ops/forward_logs.go
@@ -1,0 +1,207 @@
+package ops
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const LOG_SOURCE_FIELD = "logSource"
+
+// ForwardLogs reads lines from |logSource| and forwards them to the |publisher|. It attempts to
+// parse each line as a JSON-encoded structured log event, so that it will be logged at the level
+// indicated in the line. If it's unable to parse the line, then the whole line will be used as the
+// message of the log event, and it will be logged at the |fallbackLevel|. The |sourceDesc| will be
+// added as the "logSource" field on every event, regardless of whether it parses. The |logSource|
+// will be closed automatically after the first error or EOF is encountered.
+//
+// The parsing of JSON log lines is intentionally pretty permissive. The parsing will attempt to
+// extract fields for the level, timestamp, and message by looking for properties matching those
+// names, ignoring (ascii) case. Common abreviations of those fields (such as "ts" for "timestamp")
+// are also accepted. If your log event defines multiple properties that match a given field (e.g.
+// both "message" and "msg"), then which one gets used is undefined. All other fields present in the
+// JSON object, apart from those that defined the level, timestamp, or message, will be added to the
+// `fields` of the event.
+// For an example of how to configure a `tracing_subscriber` in Rust so that
+// it's compatible with this format, check out: crates/bindings/src/logging.rs
+func ForwardLogs(sourceDesc string, fallbackLevel log.Level, logSource io.ReadCloser, publisher LogPublisher) {
+	var reader = bufio.NewReader(logSource)
+	defer logSource.Close()
+	var jsonLogs, textLogs int
+	// Serialize this once up front instead of separately for each message.
+	var sourceDescJsonString, err = json.Marshal(sourceDesc)
+	if err != nil {
+		panic(fmt.Sprintf("serializing sourceDesc: %v", err))
+	}
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				publisher.Log(log.ErrorLevel, log.Fields{
+					"error":          err,
+					LOG_SOURCE_FIELD: sourceDesc,
+				}, "failed to read logs from source")
+			}
+			break
+		}
+		// Remove the trailing newline, since it'd be weird for it to be included in the output
+		line = bytes.TrimSuffix(line, []byte{'\n'})
+		if len(line) == 0 {
+			continue
+		}
+
+		// Try to parse the line as a structure json log event. If it parses, then we'll be able to
+		// pass through the properties and keep everything in a nice sensible shape.
+		var event = logEvent{}
+		if err = json.Unmarshal(line, &event); err == nil {
+			jsonLogs++
+			event.Fields[LOG_SOURCE_FIELD] = json.RawMessage(sourceDescJsonString)
+			// Default the timestamp and log level if they are not set.
+			if event.Timestamp.IsZero() {
+				event.Timestamp = time.Now().UTC()
+			}
+			var level = fallbackLevel
+			if !event.Level.isZero() {
+				level = log.Level(event.Level)
+			}
+			publisher.LogForwarded(event.Timestamp, level, event.Fields, event.Message)
+		} else {
+			// fallback to logging the raw text of each line, along with the
+			textLogs++
+			var fields = map[string]json.RawMessage{
+				LOG_SOURCE_FIELD: json.RawMessage(sourceDescJsonString),
+			}
+			publisher.LogForwarded(time.Now().UTC(), fallbackLevel, fields, string(line))
+		}
+	}
+	publisher.Log(log.TraceLevel, log.Fields{
+		"jsonLines":      jsonLogs,
+		"textLines":      textLogs,
+		LOG_SOURCE_FIELD: sourceDesc,
+	}, "finished forwarding logs")
+}
+
+// jsonLogLevel is just a wrapper around a log.Level that allows for more flexible deserialization.
+type jsonLogLevel log.Level
+
+func (l jsonLogLevel) isZero() bool {
+	return l == 0
+}
+
+var INVALID_LOG_LEVEL = errors.New("invalid log level")
+
+func (l *jsonLogLevel) UnmarshalJSON(b []byte) error {
+	// 5 is the shortest valid length (3 for err + 2 for quotes)
+	if len(b) < 5 {
+		return INVALID_LOG_LEVEL
+	}
+	// Strip the quotes. Even if they're not quotes, we don't care, since there's no possible
+	// non-string JSON token that would match any of these values.
+	b = b[1 : len(b)-1]
+
+	// Match against case-insensitive prefixes of common log levels. This is just an easy way to
+	// match multiple common spellings for things like "WARN" vs "warning".
+	for _, candidate := range []struct {
+		prefix string
+		level  log.Level
+	}{
+		{
+			prefix: "debug",
+			level:  log.DebugLevel,
+		},
+		{
+			prefix: "info",
+			level:  log.InfoLevel,
+		},
+		{
+			prefix: "trace",
+			level:  log.TraceLevel,
+		},
+		{
+			prefix: "warn",
+			level:  log.WarnLevel,
+		},
+		{
+			prefix: "err",
+			level:  log.ErrorLevel,
+		},
+		{
+			prefix: "fatal",
+			level:  log.ErrorLevel,
+		},
+		{
+			prefix: "panic",
+			level:  log.ErrorLevel,
+		},
+	} {
+		if len(b) >= len(candidate.prefix) && eqIgnoreAsciiCase(candidate.prefix, b[0:len(candidate.prefix)]) {
+			*l = jsonLogLevel(candidate.level)
+			return nil
+		}
+	}
+
+	return INVALID_LOG_LEVEL
+}
+
+func eqIgnoreAsciiCase(a string, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, aByte := range []byte(a) {
+		if aByte != b[i] && (aByte^32) != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type logEvent struct {
+	Level     jsonLogLevel
+	Timestamp time.Time
+	Fields    map[string]json.RawMessage
+	Message   string
+}
+
+func (e *logEvent) UnmarshalJSON(b []byte) error {
+	*e = logEvent{}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	for k, v := range m {
+		if fieldMatches(k, "timestamp", "time", "ts") && e.Timestamp.IsZero() {
+			var t time.Time
+			if err := json.Unmarshal([]byte(v), &t); err == nil {
+				e.Timestamp = t
+				delete(m, k)
+			}
+		} else if fieldMatches(k, "level", "lvl") && e.Level.isZero() {
+			if err := json.Unmarshal([]byte(v), &e.Level); err == nil {
+				delete(m, k)
+			}
+		} else if fieldMatches(k, "message", "msg") && e.Message == "" {
+			var s string
+			if err := json.Unmarshal(v, &s); err == nil {
+				e.Message = s
+				delete(m, k)
+			}
+		}
+	}
+	e.Fields = m
+	return nil
+}
+
+func fieldMatches(field string, allowed ...string) bool {
+	for _, candidate := range allowed {
+		if eqIgnoreAsciiCase(field, []byte(candidate)) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/flow/ops/forward_logs_test.go
+++ b/go/flow/ops/forward_logs_test.go
@@ -1,0 +1,190 @@
+package ops
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/estuary/flow/go/flow/ops/testutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLevelUnmarshaling(t *testing.T) {
+	var testCases = []struct {
+		input     string
+		expect    log.Level
+		expectErr error
+	}{
+		{input: `"inFormation"`, expect: log.InfoLevel},
+		{input: `"info"`, expect: log.InfoLevel},
+		{input: `"INFO"`, expect: log.InfoLevel},
+		{input: `"WARN"`, expect: log.WarnLevel},
+		{input: `"warning"`, expect: log.WarnLevel},
+		{input: `"Trace"`, expect: log.TraceLevel},
+		// This is just documenting the weird edge case.
+		{input: `"Trace a line in the sand"`, expect: log.TraceLevel},
+		{input: `"FATAL"`, expect: log.ErrorLevel},
+		{input: `"panic"`, expect: log.ErrorLevel},
+		{input: `{ "level": "info" }`, expectErr: INVALID_LOG_LEVEL},
+		{input: `"not a real level"`, expectErr: INVALID_LOG_LEVEL},
+		{input: `4`, expectErr: INVALID_LOG_LEVEL},
+	}
+
+	for _, testCase := range testCases {
+		var actual jsonLogLevel
+		var err = json.Unmarshal([]byte(testCase.input), &actual)
+		if testCase.expectErr == nil {
+			require.NoErrorf(t, err, "case failed: %+v", testCase)
+		} else {
+			require.Equalf(t, testCase.expectErr, err, "expectErr: %+v, actual: %v", testCase, err)
+		}
+		require.Equalf(t, testCase.expect, log.Level(actual), "mismatched: %+v, actual: %v", testCase, actual)
+	}
+}
+
+func TestLogEventUnmarshaling(t *testing.T) {
+	var doTest = func(line string, expected testutil.TestLogEvent) {
+		var actual logEvent
+		require.NoError(t, json.Unmarshal([]byte(line), &actual), "failed to parse line:", line)
+
+		var actualEvent = testutil.TestLogEvent{
+			Level:     log.Level(actual.Level),
+			Timestamp: actual.Timestamp,
+			Message:   actual.Message,
+			Fields:    testutil.NormalizeFields(actual.Fields),
+		}
+		require.Truef(t, expected.Matches(&actualEvent), "mismatched event for line: %s, expected: %+v, actual: %+v", line, expected, actualEvent)
+	}
+
+	doTest(
+		`{"lvl": "info", "msg": "foo", "ts": "2021-09-10T12:01:07.01234567Z"}`,
+		testutil.TestLogEvent{
+			Level:     log.InfoLevel,
+			Message:   "foo",
+			Timestamp: timestamp("2021-09-10T12:01:07.01234567Z"),
+		},
+	)
+	doTest(
+		`{"level": "TRace", "message": "yea boi", "fieldA": "valA", "ts": "2021-09-10T12:01:06.01234567Z"}`,
+		testutil.TestLogEvent{
+			Level:     log.TraceLevel,
+			Message:   "yea boi",
+			Timestamp: timestamp("2021-09-10T12:01:06.01234567Z"),
+			Fields: map[string]interface{}{
+				"fieldA": "valA",
+			},
+		},
+	)
+	doTest(
+		`{"LVL": "not a real level", "message": {"wat": "huh"}, "fieldA": "valA", "ts": "not a real timestamp"}`,
+		testutil.TestLogEvent{
+			Fields: map[string]interface{}{
+				"fieldA":  "valA",
+				"LVL":     "not a real level",
+				"ts":      "not a real timestamp",
+				"message": map[string]interface{}{"wat": "huh"},
+			},
+		},
+	)
+	doTest(`{}`, testutil.TestLogEvent{})
+}
+
+func TestLogForwarding(t *testing.T) {
+	var rawLogs = `
+{"level": "TRace a line in the sand", "message": "yea boi", "fieldA": "valA", "ts": "2021-09-10T12:01:06.01234567Z"}
+{"lVl": "iNfO", "MSG": "infoMessage", "fieldA": "valA", "ts": "2021-09-10T12:01:07.01234567Z"}
+{"lEVEl": "warning", "Message": "warnMessage", "fieldA": "warnValA", "TimeStamp": "2021-09-10T12:01:08.01234567Z"}
+2021-09-10T12:01:09.456Z INFO some text
+{"foo": "bar"}
+ a b c
+ {"Lvl": "not even close to a real level"}
+    `
+
+	var publisher = testutil.NewTestLogPublisher(log.DebugLevel)
+
+	var sourceDesc = "testSource"
+	var fallbackLevel = log.WarnLevel
+	ForwardLogs(sourceDesc, fallbackLevel, io.NopCloser(strings.NewReader(rawLogs)), publisher)
+
+	var expected = []testutil.TestLogEvent{
+		{
+			Level:   log.TraceLevel,
+			Message: "yea boi",
+			Fields: map[string]interface{}{
+				"fieldA":    "valA",
+				"logSource": sourceDesc,
+			},
+			Timestamp: timestamp("2021-09-10T12:01:06.01234567Z"),
+		},
+		{
+			Level:   log.InfoLevel,
+			Message: "infoMessage",
+			Fields: map[string]interface{}{
+				"fieldA":    "valA",
+				"logSource": sourceDesc,
+			},
+			Timestamp: timestamp("2021-09-10T12:01:07.01234567Z"),
+		},
+		{
+			Level:   log.WarnLevel,
+			Message: "warnMessage",
+			Fields: map[string]interface{}{
+				"fieldA":    "warnValA",
+				"logSource": sourceDesc,
+			},
+			Timestamp: timestamp("2021-09-10T12:01:08.01234567Z"),
+		},
+		{
+			Level:   log.WarnLevel,
+			Message: "2021-09-10T12:01:09.456Z INFO some text",
+			Fields: map[string]interface{}{
+				"logSource": sourceDesc,
+			},
+		},
+		{
+			Level:   log.WarnLevel,
+			Message: "",
+			Fields: map[string]interface{}{
+				"logSource": sourceDesc,
+				"foo":       "bar",
+			},
+		},
+		{
+			Level:   log.WarnLevel,
+			Message: " a b c",
+			Fields: map[string]interface{}{
+				"logSource": sourceDesc,
+			},
+		},
+		{
+			Level:   log.WarnLevel,
+			Message: "",
+			Fields: map[string]interface{}{
+				"logSource": sourceDesc,
+				"Lvl":       "not even close to a real level",
+			},
+		},
+		{
+			Level:   log.TraceLevel,
+			Message: "finished forwarding logs",
+			Fields: map[string]interface{}{
+				"logSource": sourceDesc,
+				"jsonLines": 5,
+				"textLines": 2,
+			},
+		},
+	}
+
+	publisher.RequireEventsMatching(t, expected)
+}
+
+func timestamp(strVal string) time.Time {
+	var t, err = time.Parse(time.RFC3339, strVal)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/go/flow/ops/testutil/test_log_publisher.go
+++ b/go/flow/ops/testutil/test_log_publisher.go
@@ -1,0 +1,166 @@
+package testutil
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogEvent represents either a log event that has been written to a TestLogPublisher, or an
+// expected event to match against.
+type TestLogEvent struct {
+	Timestamp time.Time
+	Level     log.Level
+	Message   string
+	Fields    map[string]interface{}
+}
+
+// Matches asserts that the |actual| log event matches the |expected| receiver.
+// If the expected timestamp is zero, then no check will be done on the timestamp.
+// Extra fields are allowed on the actual event, and only the fields present on the expected event
+// will be checked.
+func (expected *TestLogEvent) Matches(actual *TestLogEvent) bool {
+	if actual == nil {
+		return expected == nil
+	}
+	if expected.Level != actual.Level || expected.Message != actual.Message {
+		return false
+	}
+	if !expected.Timestamp.IsZero() && expected.Timestamp.Format(time.RFC3339Nano) != actual.Timestamp.Format(time.RFC3339Nano) {
+		return false
+	}
+	for key, expectedField := range expected.Fields {
+		var actualField, ok = actual.Fields[key]
+		if !ok {
+			return false
+		}
+		var expectedJson, err = json.Marshal(&expectedField)
+		if err != nil {
+			panic(err)
+		}
+		actualJson, err := json.Marshal(&actualField)
+		if err != nil {
+			panic(err)
+		}
+
+		if string(expectedJson) != string(actualJson) {
+			return false
+		}
+	}
+	return true
+}
+
+func NormalizeFields(fields interface{}) map[string]interface{} {
+	var fieldsJson, err = json.Marshal(fields)
+	if err != nil {
+		panic(err)
+	}
+	var m = make(map[string]interface{})
+	err = json.Unmarshal(fieldsJson, &m)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// TestLogPublisher is an ops.LogPublisher that collects all log events in memory and allows for
+// assertions that they match expected events.
+type TestLogPublisher struct {
+	mutex  sync.Mutex
+	events []TestLogEvent
+	level  log.Level
+}
+
+func NewTestLogPublisher(level log.Level) *TestLogPublisher {
+	return &TestLogPublisher{
+		level: level,
+	}
+}
+
+// WaitForLogs waits at most |timeout| for |logCount| number of log events to be available. If the
+// expected number of events have not been logged prior to the |timeout| expiration, this will fail
+// the test immediately.
+func (p *TestLogPublisher) WaitForLogs(t *testing.T, timeout time.Duration, logCount int) {
+	var deadline = time.Now().Add(timeout)
+	var n int
+	for time.Now().Before(deadline) {
+		p.mutex.Lock()
+		n = len(p.events)
+		p.mutex.Unlock()
+		if n >= logCount {
+			return
+		}
+	}
+	require.FailNowf(t, "WaitForLogs failed", "timed out after %s waiting on %d logs, only got: %d", timeout.String(), logCount, n)
+}
+
+// RequireEventsMatching requires that the |expected| events have been logged. It performs this
+// check immediately and fails the test if any events do not match, or if the number of expected and
+// actual log events is not the same. This function consumes all of the current events, so
+// subsequent calls to RequireEventsMatching will fail.
+func (p *TestLogPublisher) RequireEventsMatching(t *testing.T, expected []TestLogEvent) {
+	var actual = p.TakeEvents()
+
+	for i, expectedEvent := range expected {
+		if len(actual) <= i {
+			break // error will have been reported by the length check
+		}
+		if !expectedEvent.Matches(&actual[i]) {
+			require.Failf(t, "mismatched event", "event %d mismatched, expected: %+v, actual: %+v", i, expectedEvent, actual[i])
+		}
+	}
+	if len(actual) > len(expected) {
+		require.Failf(t, "more actual logs than expected", "Extra actual: %+v", actual[len(expected):])
+	} else if len(actual) < len(expected) {
+		require.Failf(t, "more expected logs than actual", "Extra expected: %+v", expected[len(actual):])
+	}
+}
+
+// Immediately take all of the events that have been logged up until this point.
+func (p *TestLogPublisher) TakeEvents() []TestLogEvent {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	var events = p.events
+	p.events = nil
+	return events
+}
+
+func (p *TestLogPublisher) Level() log.Level {
+	return p.level
+}
+
+func (p *TestLogPublisher) Log(level log.Level, fields log.Fields, message string) error {
+	var event = TestLogEvent{
+		Timestamp: time.Now().UTC(),
+		Level:     level,
+		Message:   message,
+		Fields:    NormalizeFields(fields),
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.events = append(p.events, event)
+	return nil
+}
+
+func (p *TestLogPublisher) LogForwarded(ts time.Time, level log.Level, fields map[string]json.RawMessage, message string) error {
+	var event = TestLogEvent{
+		Timestamp: ts,
+		Level:     level,
+		Message:   message,
+		Fields:    NormalizeFields(fields),
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.events = append(p.events, event)
+	return nil
+}

--- a/go/flow/ops/testutil/test_log_publisher.go
+++ b/go/flow/ops/testutil/test_log_publisher.go
@@ -96,7 +96,8 @@ func (p *TestLogPublisher) WaitForLogs(t *testing.T, timeout time.Duration, logC
 			return
 		}
 	}
-	require.FailNowf(t, "WaitForLogs failed", "timed out after %s waiting on %d logs, only got: %d", timeout.String(), logCount, n)
+	var events = p.TakeEvents()
+	require.FailNowf(t, "WaitForLogs failed", "timed out after %s waiting on %d logs, only got %d: %+v", timeout.String(), logCount, n, events)
 }
 
 // RequireEventsMatching requires that the |expected| events have been logged. It performs this

--- a/go/flowctl/cmd-combine.go
+++ b/go/flowctl/cmd-combine.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/estuary/flow/go/bindings"
+	"github.com/estuary/flow/go/flow/ops"
 	pf "github.com/estuary/protocols/flow"
 	log "github.com/sirupsen/logrus"
 	pb "go.gazette.dev/core/broker/protocol"
@@ -66,7 +67,10 @@ func (cmd cmdCombine) Execute(_ []string) error {
 		return fmt.Errorf("building schema bundle: %w", err)
 	}
 
-	var combine = bindings.NewCombine()
+	combine, err := bindings.NewCombine(ops.StdLogPublisher())
+	if err != nil {
+		return fmt.Errorf("creating combiner: %w", err)
+	}
 	combine.Configure(
 		"flowctl/combine",
 		schemaIndex,

--- a/go/ingest/ingest.go
+++ b/go/ingest/ingest.go
@@ -201,6 +201,9 @@ func (i *Ingestion) Add(collection pf.Collection, doc json.RawMessage) error {
 	}
 
 	combine, err := bindings.NewCombine(ops.StdLogPublisher())
+	if err != nil {
+		return fmt.Errorf("creating combiner: %w", err)
+	}
 	if err = combine.Configure(
 		"ingester",
 		schemaIndex,

--- a/go/ingest/ingest.go
+++ b/go/ingest/ingest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/ops"
 	"github.com/estuary/protocols/fdb/tuple"
 	pf "github.com/estuary/protocols/flow"
 	"go.gazette.dev/core/broker/client"
@@ -199,7 +200,7 @@ func (i *Ingestion) Add(collection pf.Collection, doc json.RawMessage) error {
 		return err
 	}
 
-	var combine = bindings.NewCombine()
+	combine, err := bindings.NewCombine(ops.StdLogPublisher())
 	if err = combine.Configure(
 		"ingester",
 		schemaIndex,

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -273,7 +273,10 @@ func (c *Capture) readTransaction(fqn string, ch <-chan capture.CaptureResponse,
 	}()
 
 	for i, b := range c.task.Capture.Bindings {
-		combiners[i] = bindings.NewCombine()
+		combiners[i], err = bindings.NewCombine(c.LogPublisher)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating combiner: %w", err)
+		}
 
 		if err := combiners[i].Configure(
 			fqn,

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -159,7 +159,11 @@ func (m *Materialize) RestoreCheckpoint(shard consumer.Shard) (cp pc.Checkpoint,
 	m.flighted = m.flighted[:0]
 
 	for i, b := range m.task.Materialization.Bindings {
-		m.combiners = append(m.combiners, bindings.NewCombine())
+		combiner, err := bindings.NewCombine(m.LogPublisher)
+		if err != nil {
+			return pc.Checkpoint{}, fmt.Errorf("creating combiner: %w", err)
+		}
+		m.combiners = append(m.combiners, combiner)
 		m.flighted = append(m.flighted, make(map[string]json.RawMessage))
 
 		if err = m.combiners[i].Configure(

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -74,7 +74,7 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 	if err != nil {
 		return fmt.Errorf("creating log publisher: %w", err)
 	}
-	t.LogPublisher.Log(log.InfoLevel, log.Fields{
+	t.Log(log.InfoLevel, log.Fields{
 		"revision":     t.revision,
 		"lastRevision": lastRevision,
 	}, "initialized catalog task term")

--- a/go/shuffle/ring.go
+++ b/go/shuffle/ring.go
@@ -98,7 +98,10 @@ func (c *Coordinator) subscribe(sub subscriber) error {
 		maybeValidateSchemaURI = sub.Shuffle.SourceSchemaUri
 	}
 
-	var ex = bindings.NewExtractor()
+	ex, err := bindings.NewExtractor()
+	if err != nil {
+		return fmt.Errorf("creating extractor: %w", err)
+	}
 	if ex.Configure(
 		sub.Shuffle.SourceUuidPtr,
 		sub.Shuffle.ShuffleKeyPtr,

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/estuary/flow/go/bindings"
+	"github.com/estuary/flow/go/flow/ops"
 	flowLabels "github.com/estuary/flow/go/labels"
 	pf "github.com/estuary/protocols/flow"
 	"github.com/nsf/jsondiff"
@@ -184,7 +185,10 @@ func (c *Cluster) Verify(test *pf.TestSpec, testStep int, from, to *Clock) error
 	}
 
 	// Feed documents into an extractor, to extract UUIDs.
-	var extractor = bindings.NewExtractor()
+	extractor, err := bindings.NewExtractor()
+	if err != nil {
+		return fmt.Errorf("creating extractor: %w", err)
+	}
 	if err = extractor.Configure(step.CollectionUuidPtr, nil, "", nil); err != nil {
 		return fmt.Errorf("failed to build extractor: %w", err)
 	}
@@ -209,7 +213,10 @@ func (c *Cluster) Verify(test *pf.TestSpec, testStep int, from, to *Clock) error
 		return err
 	}
 
-	var combiner = bindings.NewCombine()
+	combiner, err := bindings.NewCombine(ops.StdLogPublisher())
+	if err != nil {
+		return fmt.Errorf("creating combiner: %w", err)
+	}
 	if err = combiner.Configure(
 		task.Name(),
 		schemaIndex,


### PR DESCRIPTION
Adds log forwarding from Services implemented in Rust to the appropriate log destination for each task. For runtime tasks, these logs will be published to the `ops/<tenant>/logs` collection. For build/apply-time operations, logs will be forwarded to the `logrus` package.

Forwarding logs from connectors' stderr streams is coming in a separate PR, as is the collection and publishing of stats from the Rust side.

This implements the "From Rust Services" bullet in #206

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/273)
<!-- Reviewable:end -->
