### PR TITLE
Don't apt upgrade when building release image

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -15,7 +15,6 @@ RUN apt update -y \
  && gpg --no-default-keyring --keyring "$NODE_KEYRING" --list-keys \
  && echo "deb [signed-by=$NODE_KEYRING] https://deb.nodesource.com/node_14.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list \
  && apt update -y \
- && apt upgrade -y \
  && apt install --no-install-recommends -y \
       jq \
       nodejs \


### PR DESCRIPTION
The release Dockerfile was runnign an `apt upgrade` during the build
process, which caused nodejs to be upgraded from 14.* to 16.*, which is
incompatible. This removes the extraneous upgrade command, and gets us
back onto nodejs 14.

This relates to #279 , though downgrading to node 14 does not seem to actually resolve the typescript compilation issue. An alternative to this PR would be to keep node 16 and simply upgrade the apt source to explicitly mention `16.x`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/280)
<!-- Reviewable:end -->
