### PR TITLE
Add DOM to tsconfig libs

### DIFF
--- a/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
+++ b/crates/build/src/nodejs/snapshots/build__nodejs__scenario_test__scenario.snap
@@ -410,7 +410,12 @@ expression: intents
     		"forceConsistentCasingInFileNames": true,
     		"incremental": true,
     		"lib": [
-    			"ES2019"
+    			"ES2019",
+    			// DOM is added here only to provide the `AbortController` types, which are
+    			// used by other nodejs types. This fix was taken from
+    			// (https://stackoverflow.com/a/59893096) to fix the Typescript compilation
+    			// issue described in estuary/flow#279
+    			"DOM"
     		],
     		"module": "commonjs",
     		"noEmitOnError": true,
@@ -435,5 +440,6 @@ expression: intents
     		}
     	},
     	"extends": "./flow_generated/tsconfig-files"
-    },
+    }
+    ,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,12 @@
 		"forceConsistentCasingInFileNames": true,
 		"incremental": true,
 		"lib": [
-			"ES2019"
+			"ES2019",
+			// DOM is added here only to provide the `AbortController` types, which are
+			// used by other nodejs types. This fix was taken from
+			// (https://stackoverflow.com/a/59893096) to fix the Typescript compilation
+			// issue described in estuary/flow#279
+			"DOM"
 		],
 		"module": "commonjs",
 		"noEmitOnError": true,


### PR DESCRIPTION
This is a nauseating workaround to allow typescript packages to compile
using more recent versions of the `@node/types` package. It adds `DOM`
to the list of libs in `tsconfig.json`, which tells the Typscript
compiler about the `AbortController` and related types.

Fixes #279

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/281)
<!-- Reviewable:end -->
