### PR TITLE
flowctl: `api delete`, `api await`, and `deploy` commands

### DIFF
--- a/go/flow/.snapshots/TestConvergence-deletion-empty-cluster
+++ b/go/flow/.snapshots/TestConvergence-deletion-empty-cluster
@@ -1,0 +1,2 @@
+([]protocol.ApplyRequest_Change) <nil>
+([]protocol.ApplyRequest_Change) <nil>

--- a/go/flow/.snapshots/TestConvergence-deletion-full-cluster
+++ b/go/flow/.snapshots/TestConvergence-deletion-full-cluster
@@ -1,0 +1,13 @@
+([]protocol.ApplyRequest_Change) (len=3) {
+  (protocol.ApplyRequest_Change) expect_mod_revision:44 delete:"derivation/example/derivation/10000000-60000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:55 delete:"derivation/example/derivation/30000000-60000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:66 delete:"derivation/example/derivation/30000000-80000000" 
+}
+([]protocol.ApplyRequest_Change) (len=6) {
+  (protocol.ApplyRequest_Change) expect_mod_revision:11 delete:"example/collection/a_bool=true/a_str=a-val/pivot=10000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:22 delete:"example/collection/a_bool=true/a_str=a-val/pivot=40000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:33 delete:"example/collection/a_bool=false/a_str=other-val/pivot=00" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:77 delete:"recovery/derivation/example/derivation/10000000-60000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:88 delete:"recovery/derivation/example/derivation/30000000-60000000" ,
+  (protocol.ApplyRequest_Change) expect_mod_revision:99 delete:"recovery/derivation/example/derivation/30000000-80000000" 
+}

--- a/go/flow/.snapshots/TestConvergence-list-partitions-at-build-request
+++ b/go/flow/.snapshots/TestConvergence-list-partitions-at-build-request
@@ -1,0 +1,1 @@
+(protocol.ListRequest) selector:<include:<labels:<name:"estuary.dev/build" value:"bar-build" > labels:<name:"estuary.dev/collection" value:"example/collection" > > exclude:<> > 

--- a/go/flow/.snapshots/TestConvergence-list-shards-at-build-request
+++ b/go/flow/.snapshots/TestConvergence-list-shards-at-build-request
@@ -1,0 +1,1 @@
+(protocol.ListRequest) selector:<include:<labels:<name:"estuary.dev/build" value:"foo-build" > labels:<name:"estuary.dev/task-name" value:"example/derivation" > labels:<name:"estuary.dev/task-type" value:"derivation" > > exclude:<> > 

--- a/go/flow/journals.go
+++ b/go/flow/journals.go
@@ -3,12 +3,9 @@ package flow
 import (
 	"context"
 	"fmt"
-	"path"
 
-	pf "github.com/estuary/protocols/flow"
-	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.gazette.dev/core/allocator"
+	"go.gazette.dev/core/broker"
 	"go.gazette.dev/core/keyspace"
 )
 
@@ -18,41 +15,10 @@ type Journals struct {
 	*keyspace.KeySpace
 }
 
-// GetJournal returns the named JournalSpec and its current Etcd ModRevision.
-// If |name| is not a journal, it returns nil and revision zero.
-func (j Journals) GetJournal(name pf.Journal) (_ *pf.JournalSpec, revision int64) {
-	j.Mu.RLock()
-	defer j.Mu.RUnlock()
-
-	var ind, found = j.Search(path.Join(j.Root + "/" + name.String()))
-	if found {
-		return j.KeyValues[ind].Decoded.(*pf.JournalSpec), j.KeyValues[ind].Raw.ModRevision
-	}
-	return nil, 0
-}
-
 // NewJournalsKeySpace builds a KeySpace over all JournalSpecs managed by the
 // broker cluster utilizing the |brokerRoot| Etcd prefix.
 func NewJournalsKeySpace(ctx context.Context, etcd *clientv3.Client, root string) (Journals, error) {
-	if root != path.Clean(root) {
-		return Journals{}, fmt.Errorf("%q is not a clean path", root)
-	}
-
-	var journals = Journals{
-		KeySpace: keyspace.NewKeySpace(
-			path.Clean(root+allocator.ItemsPrefix),
-			func(raw *mvccpb.KeyValue) (interface{}, error) {
-				var s = new(pf.JournalSpec)
-
-				if err := s.Unmarshal(raw.Value); err != nil {
-					return nil, err
-				} else if err = s.Validate(); err != nil {
-					return nil, err
-				}
-				return s, nil
-			},
-		),
-	}
+	var journals = Journals{KeySpace: broker.NewKeySpace(root)}
 
 	if err := journals.KeySpace.Load(ctx, etcd, 0); err != nil {
 		return Journals{}, fmt.Errorf("initial load of %q: %w", root, err)

--- a/go/flowctl/cmd-api-activate.go
+++ b/go/flowctl/cmd-api-activate.go
@@ -234,17 +234,10 @@ func pingAndFetchConfig(ctx context.Context, sc pc.ShardClient, jc pb.JournalCli
 		return fakeConfig{}, fmt.Errorf("pinging journal client: %w", err)
 	}
 
-	var out = fakeConfig{
+	return fakeConfig{
 		JournalsEtcd: journalsResp.Header.Etcd,
 		ShardsEtcd:   shardResp.Header.Etcd,
-	}
-
-	// TODO(johnny): Because this is the broker Etcd header, it may reflect modifications
-	// which are larger than the largest journals revision. As a work around for now,
-	// narrow to a revision we know it's possible to read through.
-	out.JournalsEtcd.Revision = 1
-
-	return out, nil
+	}, nil
 }
 
 // loadFromCatalog loads collections and tasks in |names| from the catalog.

--- a/go/flowctl/cmd-api-delete.go
+++ b/go/flowctl/cmd-api-delete.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/estuary/flow/go/capture"
+	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/ops"
+	"github.com/estuary/flow/go/materialize"
+	pf "github.com/estuary/protocols/flow"
+	log "github.com/sirupsen/logrus"
+	pb "go.gazette.dev/core/broker/protocol"
+	mbp "go.gazette.dev/core/mainboilerplate"
+)
+
+type apiDelete struct {
+	All         bool                  `long:"all" description:"Delete all tasks and collections"`
+	Broker      mbp.ClientConfig      `group:"Broker" namespace:"broker" env-namespace:"BROKER"`
+	BuildID     string                `long:"build-id" required:"true" description:"ID of this build"`
+	BuildsRoot  string                `long:"builds-root" required:"true" env:"BUILDS_ROOT" description:"Base URL for fetching Flow catalog builds"`
+	Consumer    mbp.ClientConfig      `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
+	DryRun      bool                  `long:"dry-run" description:"Print actions that would be taken, but don't actually take them"`
+	Names       []string              `long:"name" description:"Name of task or collection to activate. May be repeated many times"`
+	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
+	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
+}
+
+func (cmd apiDelete) execute(ctx context.Context) error {
+	var builds, err = flow.NewBuildService(cmd.BuildsRoot)
+	if err != nil {
+		return err
+	}
+
+	ctx = pb.WithDispatchDefault(ctx)
+	var sc = cmd.Consumer.MustShardClient(ctx)
+	var jc = cmd.Broker.MustJournalClient(ctx)
+
+	// Fetch configuration from the data plane.
+	_, err = pingAndFetchConfig(ctx, sc, jc)
+	if err != nil {
+		return err
+	}
+
+	var build = builds.Open(cmd.BuildID)
+	defer build.Close()
+
+	// Identify collections and tasks of the build to delete.
+	var collections []*pf.CollectionSpec
+	var tasks []pf.Task
+
+	if err := build.Extract(func(db *sql.DB) error {
+		collections, tasks, err = loadFromCatalog(db, cmd.Names, cmd.All, false)
+		return err
+	}); err != nil {
+		return fmt.Errorf("extracting from build: %w", err)
+	}
+
+	shards, journals, err := flow.DeletionChanges(ctx, jc, sc, collections, tasks, cmd.BuildID)
+	if err != nil {
+		return err
+	}
+	if err = applyAllChanges(ctx, sc, jc, shards, journals, cmd.DryRun); err != nil {
+		return err
+	}
+
+	// Remove captures from endpoints, now that we've deleted the
+	// task shards that reference them.
+	for _, t := range tasks {
+		var spec, ok = t.(*pf.CaptureSpec)
+		if !ok {
+			continue
+		}
+
+		_, err := capture.NewDriver(ctx,
+			spec.EndpointType, json.RawMessage(spec.EndpointSpecJson), cmd.Network, ops.StdLogger())
+		if err != nil {
+			return fmt.Errorf("building driver for capture %q: %w", spec.Capture, err)
+		}
+
+		// TODO(johnny): This requires supporting protocol changes to enable.
+		/*
+			response, err := driver.Delete(ctx, &pc.DeleteRequest{
+				Capture: spec,
+				Version:         spec.ShardTemplate.LabelSet.ValueOf(labels.Build),
+				DryRun:          cmd.DryRun,
+			})
+			if err != nil {
+				return fmt.Errorf("deleting capture %q: %w", spec.Capture, err)
+			}
+
+			if response.ActionDescription != "" {
+				fmt.Println("Deleting capture ", spec.Capture, ":")
+				fmt.Println(response.ActionDescription)
+			}
+		*/
+		log.WithFields(log.Fields{"name": spec.Capture}).
+			Info("deleted capture from endpoint")
+	}
+
+	// Remove materializations from endpoints, now that we've deleted the
+	// task shards that reference them.
+	for _, t := range tasks {
+		var spec, ok = t.(*pf.MaterializationSpec)
+		if !ok {
+			continue
+		}
+
+		_, err := materialize.NewDriver(ctx,
+			spec.EndpointType, json.RawMessage(spec.EndpointSpecJson), cmd.Network, ops.StdLogger())
+		if err != nil {
+			return fmt.Errorf("building driver for materialization %q: %w", spec.Materialization, err)
+		}
+
+		// TODO(johnny): This requires supporting protocol changes to enable.
+		/*
+			response, err := driver.Delete(ctx, &pm.DeleteRequest{
+				Materialization: spec,
+				Version:         spec.ShardTemplate.LabelSet.ValueOf(labels.Build),
+				DryRun:          cmd.DryRun,
+			})
+			if err != nil {
+				return fmt.Errorf("deleting materialization %q: %w", spec.Materialization, err)
+			}
+
+			if response.ActionDescription != "" {
+				fmt.Println("Deleting materialization ", spec.Materialization, ":")
+				fmt.Println(response.ActionDescription)
+			}
+		*/
+		log.WithFields(log.Fields{"name": spec.Materialization}).
+			Info("deleted materialization from endpoint")
+	}
+
+	if err := build.Close(); err != nil {
+		return fmt.Errorf("closing build: %w", err)
+	}
+	return nil
+}
+
+func (cmd apiDelete) Execute(_ []string) error {
+	defer mbp.InitDiagnosticsAndRecover(cmd.Diagnostics)()
+	mbp.InitLog(cmd.Log)
+
+	log.WithFields(log.Fields{
+		"config":    cmd,
+		"version":   mbp.Version,
+		"buildDate": mbp.BuildDate,
+	}).Info("flowctl configuration")
+	pb.RegisterGRPCDispatcher("local")
+
+	return cmd.execute(context.Background())
+}

--- a/go/flowctl/cmd-deploy.go
+++ b/go/flowctl/cmd-deploy.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	pb "go.gazette.dev/core/broker/protocol"
+	mbp "go.gazette.dev/core/mainboilerplate"
+)
+
+type cmdDeploy struct {
+	Broker      mbp.ClientConfig      `group:"Broker" namespace:"broker" env-namespace:"BROKER"`
+	Consumer    mbp.ClientConfig      `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
+	Directory   string                `long:"directory" default:"." description:"Build directory"`
+	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
+	Cleanup     bool                  `long:"wait-and-cleanup" description:"Keep running after deploy until Ctrl-C. Then, delete the deployment from the dataplane."`
+	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
+	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
+}
+
+func (cmd cmdDeploy) Execute(_ []string) (retErr error) {
+	defer mbp.InitDiagnosticsAndRecover(cmd.Diagnostics)()
+	mbp.InitLog(cmd.Log)
+
+	log.WithFields(log.Fields{
+		"config":    cmd,
+		"version":   mbp.Version,
+		"buildDate": mbp.BuildDate,
+	}).Info("flowctl configuration")
+	pb.RegisterGRPCDispatcher("local")
+
+	var err error
+	if cmd.Directory, err = filepath.Abs(cmd.Directory); err != nil {
+		return fmt.Errorf("filepath.Abs: %w", err)
+	}
+
+	// Build into a new database. Arrange to clean it up on exit if asked.
+	var buildID = newBuildID()
+	if cmd.Cleanup {
+		defer func() { _ = os.Remove(filepath.Join(cmd.Directory, buildID)) }()
+	}
+
+	if err := (apiBuild{
+		BuildID:    buildID,
+		Directory:  cmd.Directory,
+		FileRoot:   "/",
+		Network:    cmd.Network,
+		Source:     cmd.Source,
+		SourceType: "catalog",
+		TSPackage:  true,
+	}.execute(context.Background())); err != nil {
+		return err
+	}
+
+	// TODO(johnny): Ask the data plane, rather than assuming cmd.Directory.
+	var buildsRoot = "file://" + cmd.Directory + "/"
+
+	// TODO(johnny): Move into the data plane's advertised buildsRoot.
+
+	// Activate the built database into the data plane.
+	var activate = apiActivate{
+		Broker:        cmd.Broker,
+		Consumer:      cmd.Consumer,
+		BuildID:       buildID,
+		BuildsRoot:    buildsRoot,
+		Network:       cmd.Network,
+		InitialSplits: 1,
+		All:           true,
+	}
+	if err = activate.execute(context.Background()); err != nil {
+		return err
+	}
+
+	if !cmd.Cleanup {
+		return nil // All done.
+	}
+
+	// Install a signal handler which will cancel our context.
+	var sigCh = make(chan os.Signal)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	fmt.Println("Deployment done. Waiting for Ctrl-C to clean up and exit.")
+	<-sigCh
+	fmt.Println("Signaled to exit. Cleaning up deployment.")
+
+	// Delete derivations and collections from the local dataplane.
+	var delete = apiDelete{
+		Broker:     cmd.Broker,
+		Consumer:   cmd.Consumer,
+		BuildID:    buildID,
+		BuildsRoot: buildsRoot,
+		Network:    cmd.Network,
+		All:        true,
+	}
+	if err = delete.execute(context.Background()); err != nil {
+		return err
+	}
+
+	fmt.Println("All done.")
+	return nil
+}

--- a/go/flowctl/cmd-shards-split.go
+++ b/go/flowctl/cmd-shards-split.go
@@ -46,7 +46,9 @@ func (cmd cmdSplit) execute(ctx context.Context) error {
 	var sc = cmd.Consumer.MustShardClient(ctx)
 	var jc = cmd.Broker.MustJournalClient(ctx)
 
-	if err = pingClients(ctx, sc, jc); err != nil {
+	// Fetch configuration from the data plane.
+	_, err = pingAndFetchConfig(ctx, sc, jc)
+	if err != nil {
 		return err
 	}
 

--- a/go/flowctl/cmd-test.go
+++ b/go/flowctl/cmd-test.go
@@ -54,8 +54,8 @@ func (cmd cmdTest) Execute(_ []string) (retErr error) {
 	var ctx, cancel = signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	// Start a local data plane bound to our context.
-	var dataPlane = cmdLocalDataPlane{
+	// Start a temporary data plane bound to our context.
+	var dataPlane = cmdTempDataPlane{
 		BuildsRoot:  buildsRoot,
 		UnixSockets: true,
 		Log: mbp.LogConfig{

--- a/go/flowctl/main.go
+++ b/go/flowctl/main.go
@@ -53,16 +53,17 @@ specific build of Flow. This JSON schema can be used to enable IDE support
 and auto-completions.
 `, &cmdJSONSchema{})
 
-	addCmd(parser, "local-data-plane", "Run an ephemeral, local data plane", `
+	addCmd(parser, "temp-data-plane", "Run an ephemeral, temporary local data plane", `
 Run a local data plane by shelling out to start Etcd, Gazette, and the Flow consumer.
 A local data plane is intended for local development and testing, and doesn't persist
 fragments to the configured storage mappings of collections and Flow tasks.
+Upon exit, all data is discarded.
 
 If you intend to use a local data plane with 'flowctl api await', then you must
 use the --poll flag, such that connectors poll their sources and then exit
 rather than tailing sources continuously. This is uncommon, and typically only
 used for integration testing workflows.
-`, &cmdLocalDataPlane{})
+`, &cmdTempDataPlane{})
 
 	addCmd(parser, "deploy", "Build a catalog and deploy it to a data plane", `
 Build a catalog from --source. Then, activate it into a data plane.

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -102,13 +102,11 @@ func (c *Capture) StartReadingMessages(shard consumer.Shard, cp pf.Checkpoint,
 	// Build a context to capture under, and arrange for it to be cancelled
 	// if the shard specification is updated.
 	var ctx, cancel = context.WithCancel(shard.Context())
-	signalOnSpecUpdate(c.host.Service.State.KS, shard, c.shardSpec, cancel)
+	go signalOnSpecUpdate(c.host.Service.State.KS, shard, c.shardSpec, cancel)
 
 	var driverRx, err = c.openCapture(ctx)
 	if err != nil {
-		c.Log(log.ErrorLevel, log.Fields{
-			"error": err.Error(),
-		}, "failed to open capture")
+		c.Log(log.ErrorLevel, log.Fields{"error": err.Error()}, "failed to open capture")
 		ch <- consumer.EnvelopeOrError{Error: err}
 		return
 	}

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -341,7 +341,7 @@ func (c *Capture) ReadThrough(offsets pf.Offsets) (pf.Offsets, error) {
 }
 
 func (c *Capture) ConsumeMessage(shard consumer.Shard, env message.Envelope, pub *message.Publisher) error {
-	var mapper = flow.NewMapper(shard.Context(), shard.JournalClient(), c.host.Journals)
+	var mapper = flow.NewMapper(shard.Context(), c.host.Service.Etcd, c.host.Journals, shard.FQN())
 	var msg = env.Message.(*captureMessage)
 
 	if msg.eof {

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -144,7 +144,7 @@ func (d *Derive) ConsumeMessage(_ consumer.Shard, env message.Envelope, _ *messa
 // FinalizeTxn finishes and drains the derive worker transaction,
 // and publishes each combined document to the derived collection.
 func (d *Derive) FinalizeTxn(shard consumer.Shard, pub *message.Publisher) error {
-	var mapper = flow.NewMapper(shard.Context(), shard.JournalClient(), d.host.Journals)
+	var mapper = flow.NewMapper(shard.Context(), d.host.Service.Etcd, d.host.Journals, shard.FQN())
 	var collection = &d.derivation.Collection
 
 	return d.binding.Drain(func(full bool, doc json.RawMessage, packedKey, packedPartitions []byte) error {

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -69,9 +69,14 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 		return err
 	}
 
-	t.LogPublisher, err = NewLogPublisher(shard.Context(), shard.JournalClient(),
-		host.Journals, t.labels, logsCollection, t.schemaIndex)
-	if err != nil {
+	// TODO(johnny): close old LogPublisher here, and in destroy() ?
+	if t.LogPublisher, err = NewLogPublisher(
+		t.labels,
+		logsCollection,
+		t.schemaIndex,
+		shard.JournalClient(),
+		flow.NewMapper(shard.Context(), host.Service.Etcd, host.Journals, shard.FQN()),
+	); err != nil {
 		return fmt.Errorf("creating log publisher: %w", err)
 	}
 

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -69,7 +69,8 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 		return err
 	}
 
-	t.LogPublisher, err = host.LogService.NewPublisher(t.labels, logsCollection, t.schemaIndex)
+	t.LogPublisher, err = NewLogPublisher(shard.Context(), shard.JournalClient(),
+		host.Journals, t.labels, logsCollection, t.schemaIndex)
 	if err != nil {
 		return fmt.Errorf("creating log publisher: %w", err)
 	}

--- a/go/runtime/testing.go
+++ b/go/runtime/testing.go
@@ -154,7 +154,7 @@ func (f *FlowTesting) Ingest(ctx context.Context, req *pf.IngestRequest) (*pf.In
 
 	// Drain the combiner, mapping documents to logical partitions and writing
 	// them as uncommitted messages.
-	var mapper = flow.NewMapper(ctx, f.Service.Journals, f.Journals)
+	var mapper = flow.NewMapper(ctx, f.Service.Etcd, f.Journals, f.Service.State.LocalKey)
 	if err = combiner.Drain(func(full bool, doc json.RawMessage, packedKey, packedPartitions []byte) error {
 		if full {
 			panic("ingest produces only partially combined documents")

--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -496,10 +496,11 @@ func walkReads(id pc.ShardID, shardSpecs []*pc.ShardSpec, allJournals flow.Journ
 	defer allJournals.Mu.RUnlock()
 
 	for _, shuffle := range shuffles {
-		var sources = allJournals.Prefixed(allJournals.Root + "/" + shuffle.SourceCollection.String() + "/")
+		var prefix = allocator.ItemKey(allJournals.KeySpace, shuffle.SourceCollection.String()) + "/"
+		var sources = allJournals.Prefixed(prefix)
 
 		for _, kv := range sources {
-			var source = kv.Decoded.(*pb.JournalSpec)
+			var source = kv.Decoded.(allocator.Item).ItemValue.(*pb.JournalSpec)
 
 			if !shuffle.SourcePartitions.Matches(source.LabelSet) {
 				continue

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -443,10 +443,6 @@ func Initialize(ctx context.Context, driver *ClusterDriver, graph *Graph) error 
 			offsets[journal.Spec.Name] = r.Response.Offset
 		}
 
-		// TODO(johnny): switch to using the entire broker keyspace, rather than a narrowed
-		// version only looking at journals, so that etcd revisions are compatible.
-		list.Header.Etcd.Revision = 1
-
 		// Track it as a completed ingestion.
 		graph.CompletedIngest(collection.Collection, &Clock{Etcd: list.Header.Etcd, Offsets: offsets})
 	}


### PR DESCRIPTION
`api delete` is a low-level API for deleting activated tasks and
collections of a catalog build.

Also add supporting convergence routines and tests to make it work.

`deploy` is a user-facing workflow which builds a catalog, deploys it to
a data-plane and, if asked, will await a Ctrl-C and then clean up the
deployment before exiting. It's a first attempt at tackling a super
common local development workflow, and is a replacement for the
(removed) `develop` command.

Also add `api await` which monitors the execution of catalog dataflow in
a configured data plane, and exits once all captures have completed one
invocation and all downstream effects have propagated.

Issue #287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/289)
<!-- Reviewable:end -->
