### PR TITLE
Phil/connector errors

### DIFF
--- a/go/capture/driver/airbyte/driver_test.go
+++ b/go/capture/driver/airbyte/driver_test.go
@@ -11,27 +11,24 @@ import (
 
 func TestOnStdoutDecodeError(t *testing.T) {
 	var publisher = testutil.NewTestLogPublisher(log.DebugLevel)
-
-	var subject = driver{
-		Logger: publisher,
-	}
 	var err = fmt.Errorf("only a test")
+	var subject = onStdoutDecodeError(publisher)
 
 	// This line should be logged because it's not json, and the error ignored.
-	var result = subject.onStdoutDecodeError([]byte("foo\n"), err)
+	var result = subject([]byte("foo\n"), err)
 	require.Nil(t, result)
 
 	publisher.RequireEventsMatching(t, []testutil.TestLogEvent{{
 		Level:   log.InfoLevel,
 		Message: "foo",
 		Fields: map[string]interface{}{
-			"logSource": "ignored invalid output from connector stdout",
+			"sourceDesc": "ignored non-json output from connector stdout",
 		},
 	}})
 
 	// This line should _not_ be logged because the error should bubble up and get logged
 	// by whatever called the connector.
-	result = subject.onStdoutDecodeError([]byte("{\"foo\": 123}"), err)
+	result = subject([]byte("{\"foo\": 123}"), err)
 	require.Equal(t, err, result)
 	require.Empty(t, publisher.TakeEvents())
 }

--- a/go/connector/run_test.go
+++ b/go/connector/run_test.go
@@ -239,3 +239,16 @@ func TestFIFOFiles(t *testing.T) {
 	// Input was zeroed on error as well.
 	require.Equal(t, []byte{0, 0, 0, 0, 0}, input)
 }
+
+func TestStderrCapture(t *testing.T) {
+	var s = connectorStderr{delegate: ioutil.Discard}
+
+	var n, err = s.Write([]byte("whoops"))
+	require.Equal(t, 6, n)
+	require.NoError(t, err)
+	require.Equal(t, "whoops", s.buffer.String())
+
+	// Expect it caps the amount of output collected.
+	s.Write(bytes.Repeat([]byte("x"), maxStderrBytes))
+	require.Equal(t, maxStderrBytes, s.buffer.Len())
+}

--- a/go/flow/ops/forward_logs_test.go
+++ b/go/flow/ops/forward_logs_test.go
@@ -256,7 +256,7 @@ func TestLogForwarding(t *testing.T) {
 	}
 
 	t.Run("LogForwardWriter", func(t *testing.T) {
-		var publisher = testutil.NewTestLogPublisher(log.DebugLevel)
+		var publisher = testutil.NewTestLogPublisher(log.TraceLevel)
 		var writer = NewLogForwardWriter(sourceDesc, fallbackLevel, publisher)
 
 		// Read from rawLogs in a bunch of random small chunks to ensure that the writer is piecing the
@@ -279,7 +279,7 @@ func TestLogForwarding(t *testing.T) {
 	})
 
 	t.Run("ForwardLogs", func(t *testing.T) {
-		var publisher = testutil.NewTestLogPublisher(log.DebugLevel)
+		var publisher = testutil.NewTestLogPublisher(log.TraceLevel)
 		ForwardLogs(sourceDesc, fallbackLevel, io.NopCloser(strings.NewReader(rawLogs)), publisher)
 		publisher.RequireEventsMatching(t, expected)
 	})

--- a/go/flow/ops/logger_test.go
+++ b/go/flow/ops/logger_test.go
@@ -1,0 +1,61 @@
+package ops
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/estuary/flow/go/flow/ops/testutil"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestAddFieldsToLogger(t *testing.T) {
+	var testLogger = testutil.NewTestLogPublisher(log.DebugLevel)
+	var subject = NewLoggerWithFields(testLogger, log.Fields{
+		"coalMine": "canary",
+		"foo":      3,
+	})
+
+	subject.Log(log.DebugLevel, nil, "one")
+	subject.Log(log.TraceLevel, log.Fields{
+		"should not": "see this",
+	}, "not gonna loggit")
+	subject.Log(log.InfoLevel, log.Fields{
+		"foo": "not three",
+	}, "two")
+	var forwardTs = time.Now().UTC()
+	subject.LogForwarded(forwardTs, log.WarnLevel, map[string]json.RawMessage{
+		"bar": json.RawMessage(`"yarr!"`),
+	}, "three")
+	subject.LogForwarded(time.Now(), log.TraceLevel, nil, "not gonna log this either")
+
+	var expected = []testutil.TestLogEvent{
+		{
+			Level: log.DebugLevel,
+			Fields: log.Fields{
+				"foo":      3,
+				"coalMine": "canary",
+			},
+			Message: "one",
+		},
+		{
+			Level: log.InfoLevel,
+			Fields: log.Fields{
+				"foo":      "not three",
+				"coalMine": "canary",
+			},
+			Message: "two",
+		},
+		{
+			Level: log.WarnLevel,
+			Fields: log.Fields{
+				"foo":      3,
+				"coalMine": "canary",
+				"bar":      "yarr!",
+			},
+			Message:   "three",
+			Timestamp: forwardTs,
+		},
+	}
+	testLogger.RequireEventsMatching(t, expected)
+}

--- a/go/flow/ops/testutil/test_log_publisher.go
+++ b/go/flow/ops/testutil/test_log_publisher.go
@@ -137,6 +137,9 @@ func (p *TestLogPublisher) Level() log.Level {
 }
 
 func (p *TestLogPublisher) Log(level log.Level, fields log.Fields, message string) error {
+	if level > p.level {
+		return nil
+	}
 	var event = TestLogEvent{
 		Timestamp: time.Now().UTC(),
 		Level:     level,
@@ -152,6 +155,9 @@ func (p *TestLogPublisher) Log(level log.Level, fields log.Fields, message strin
 }
 
 func (p *TestLogPublisher) LogForwarded(ts time.Time, level log.Level, fields map[string]json.RawMessage, message string) error {
+	if level > p.level {
+		return nil
+	}
 	var event = TestLogEvent{
 		Timestamp: ts,
 		Level:     level,

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -113,7 +113,10 @@ func (d *Derive) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err 
 // Rust-held RocksDB and its files.
 func (d *Derive) Destroy() {
 	d.taskTerm.destroy()
-	d.binding.Destroy()
+	// binding could be nil if there was a failure during initialization
+	if d.binding != nil {
+		d.binding.Destroy()
+	}
 }
 
 // BeginTxn begins a derive transaction.

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -49,7 +49,6 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 		// Re-use this build.
 	} else {
 		if t.build != nil {
-			// Cleanup a previous build.
 			if err = t.build.Close(); err != nil {
 				return err
 			}
@@ -89,8 +88,11 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 }
 
 func (t *taskTerm) destroy() {
-	if err := t.build.Close(); err != nil {
-		log.WithError(err).Error("failed to close build")
+	if t.build != nil {
+		if err := t.build.Close(); err != nil {
+			log.WithError(err).Error("failed to close build")
+		}
+		t.build = nil
 	}
 }
 


### PR DESCRIPTION
Fixes #301 
Goes back to taking a prefix of stderr for connector error messages.
Also makes some additional improvements to logging, and fixes a couple of minor tear-down issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/305)
<!-- Reviewable:end -->
