### PR TITLE
add network params

### DIFF
--- a/go/flowctl/cmd-combine.go
+++ b/go/flowctl/cmd-combine.go
@@ -22,6 +22,7 @@ import (
 
 type cmdCombine struct {
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
+	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	Collection  string                `long:"collection" required:"true" description:"The name of the collection from which to take the schema and key"`
 	MaxDocs     uint64                `long:"max-docs" default:"0" description:"Maximum number of documents to add to the combiner before draining it. If 0, then there is no maximum"`
@@ -47,10 +48,11 @@ func (cmd cmdCombine) Execute(_ []string) error {
 	var ctx = context.Background()
 
 	var config = pf.BuildAPI_Config{
-		BuildId:    newBuildID(),
-		Directory:  cmd.Directory,
-		Source:     cmd.Source,
-		SourceType: pf.ContentType_CATALOG_SPEC,
+		BuildId:          newBuildID(),
+		Directory:        cmd.Directory,
+		Source:           cmd.Source,
+		SourceType:       pf.ContentType_CATALOG_SPEC,
+		ConnectorNetwork: cmd.Network,
 	}
 	// Cleanup output database.
 	defer func() { _ = os.Remove(config.OutputPath()) }()

--- a/go/flowctl/cmd-temp-data-plane.go
+++ b/go/flowctl/cmd-temp-data-plane.go
@@ -19,6 +19,7 @@ type cmdTempDataPlane struct {
 	BrokerPort   uint16                `long:"broker-port" default:"8080" description:"Port bound by Gazette broker"`
 	BuildsRoot   string                `long:"builds-root" required:"true" env:"BUILDS_ROOT" description:"Base URL for fetching Flow catalog builds"`
 	ConsumerPort uint16                `long:"consumer-port" default:"9000" description:"Port bound by Flow consumer"`
+	Network      string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
 	Poll         bool                  `long:"poll" description:"Poll connectors, rather than running them continuously. Required in order to use 'flowctl api poll'"`
 	Sigterm      bool                  `long:"sigterm" hidden:"true" description:"Send SIGTERM rather than SIGKILL on exit"`
 	Tempdir      string                `long:"tempdir" description:"Directory for data plane files. If not set, a temporary directory is created and then deleted upon exit"`
@@ -195,6 +196,7 @@ func (cmd cmdTempDataPlane) consumerCmd(ctx context.Context, execdir, tempdir, b
 		"--consumer.watch-delay", "0ms", // Speed test execution.
 		"--etcd.address", etcdAddr,
 		"--flow.builds-root", buildsRoot,
+		"--flow.network", cmd.Network,
 		"--flow.test-apis",
 		"--log.format", cmd.Log.Format,
 		"--log.level", cmd.Log.Level,


### PR DESCRIPTION
Encountered the missing network paratemeres when writing tests for elastic search connector.
Although these changes are no longer needed, after some refactor to the connector test, it might worth adding these parameters for completeness. 
( Assuming there are no other considerations in setting the network parameters on the `temp-data-plane` and `comibine` commands.)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/307)
<!-- Reviewable:end -->
