### PR TITLE
Makefile: include `sops` in package artifact

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -3,7 +3,6 @@ FROM debian:bullseye-slim
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh
 # mappings to directly query AWS/Azure/GCP metadata APIs.
-# Unzip is required by the snowsql installer.
 RUN apt update -y \
  && apt install --no-install-recommends -y \
       ca-certificates \
@@ -19,7 +18,6 @@ RUN apt update -y \
  && apt install --no-install-recommends -y \
       jq \
       nodejs \
-      unzip \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -o docker-cli.deb 'https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/docker-ce-cli_20.10.7~3-0~debian-bullseye_amd64.deb' && \
@@ -28,31 +26,6 @@ RUN curl -o docker-cli.deb 'https://download.docker.com/linux/debian/dists/bulls
 
 # Create a non-privileged "flow" user.
 RUN useradd flow --create-home --shell /usr/sbin/nologin
-
-# Install snowsql, which is required by the snowflake driver.
-# This must be done as the flow user, since snowsql always puts its actual binaries in ~/.snowsql.
-# LC_ALL and LANG are required at runtime by the snowsql cli
-# The DEST and LOGIN_SHELL vars are needed by the installer in order to run in non-interactive mode.
-# The VERSION vars are only here to make version updates easier.
-# The PATH must be modified to include the install location, since .profile will not be loaded.
-USER flow
-ENV LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    SNOWSQL_DEST=/home/flow/bin \
-    SNOWSQL_LOGIN_SHELL=/home/flow/.profile \
-    SNOWSQL_MINOR_VERSION=1.2 \
-    SNOWSQL_FULL_VERSION=1.2.14 \
-    SNOWSQL_SHA256=1afb83a22b9ccb2f8e84c2abe861da503336cb3b882fcc2e8399f86ac76bc2a9 \
-    PATH="/home/flow/bin:${PATH}"
-RUN curl -o /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/${SNOWSQL_MINOR_VERSION}/linux_x86_64/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  && echo "${SNOWSQL_SHA256} /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash" | sha256sum -c - \
-  && touch ${SNOWSQL_LOGIN_SHELL} \
-  && bash /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  && rm -f /tmp/snowsql-${SNOWSQL_FULL_VERSION}-linux_x86_64.bash \
-  # Defying all reason and expectations, _this_ is what actually installs snowsql.
-  # It will print a help message as if there was a problem, but it works as long as it exits 0.
-  && snowsql -v ${SNOWSQL_FULL_VERSION}
 
 # Copy binaries & libraries to the image, owned by root.
 USER root

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ ETCD_SHA256 = 2ac029e47bab752dacdb7b30032f230f49e2f457cbc32e8f555c2210bb5ff107
 PACKAGE_TARGETS = \
 	${PKGDIR}/bin/etcd \
 	${PKGDIR}/bin/flowctl \
-	${PKGDIR}/bin/gazette
+	${PKGDIR}/bin/gazette \
+	${PKGDIR}/bin/sops
 
 ##########################################################################
 # Configure Go build & test behaviors.
@@ -95,6 +96,8 @@ ${PKGDIR}:
 	mkdir ${PKGDIR}/lib
 ${PKGDIR}/bin/etcd: ${PKGDIR} ${GOBIN}/etcd
 	cp ${GOBIN}/etcd $@
+${PKGDIR}/bin/sops: ${PKGDIR} ${GOBIN}/sops
+	cp ${GOBIN}/sops $@
 ${PKGDIR}/bin/flowctl:     ${PKGDIR} ${GOBIN}/flowctl
 	cp ${GOBIN}/flowctl $@
 ${PKGDIR}/bin/gazctl: ${PKGDIR} ${GOBIN}/gazctl
@@ -135,16 +138,16 @@ rust-test:
 	FLOW_VERSION=${VERSION} cargo test --release --locked
 
 .PHONY: go-test-fast
-go-test-fast: $(GO_BUILD_DEPS) ${GOBIN}/etcd
+go-test-fast: $(GO_BUILD_DEPS) ${GOBIN}/etcd ${GOBIN}/sops
 	./go.sh test -p ${NPROC} --tags "${GO_BUILD_TAGS}" ./go/...
 
 .PHONY: go-test-ci
-go-test-ci:   $(GO_BUILD_DEPS) ${GOBIN}/etcd
+go-test-ci:   $(GO_BUILD_DEPS) ${GOBIN}/etcd ${GOBIN}/sops
 	GORACE="halt_on_error=1" \
 	./go.sh test -p ${NPROC} --tags "${GO_BUILD_TAGS}" --race --count=15 --failfast ./go/...
 
 .PHONY: catalog-test
-catalog-test: ${GOBIN}/flowctl ${GOBIN}/gazette ${GOBIN}/etcd
+catalog-test: ${GOBIN}/flowctl ${GOBIN}/gazette ${GOBIN}/etcd ${GOBIN}/sops
 	${GOBIN}/flowctl test --source ${ROOTDIR}/examples/local-sqlite.flow.yaml $(ARGS)
 
 .PHONY: end-to-end-test


### PR DESCRIPTION
Drop snowsql as it's no longer needed (moved to materialize-snowflake
connector).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/308)
<!-- Reviewable:end -->
