### PR TITLE
require that keyed locations not be `null`

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -68,7 +68,7 @@ pub enum Error {
         type_: types::Set,
         schema: Url,
     },
-    #[error("location {ptr} accepts {type_:?} in schema {schema}, but {disallowed:?} is disallowed in locations used as keys")]
+    #[error("location {ptr} accepts {type_:?} in schema {schema}, but {disallowed:?} is disallowed in locations used as keys (https://go.estuary.dev/CigSvN)")]
     KeyWrongType {
         ptr: String,
         type_: types::Set,

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -347,7 +347,7 @@ pub fn walk_keyed_location(
     }
 
     // Prohibit types not suited to being keys.
-    let disallowed = shape.type_ & (types::OBJECT | types::ARRAY | types::FRACTIONAL);
+    let disallowed = shape.type_ & (types::OBJECT | types::ARRAY | types::FRACTIONAL | types::NULL);
 
     if disallowed != types::INVALID {
         Error::KeyWrongType {

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
@@ -6,30 +6,30 @@ expression: errors
 [
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve,
-        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string.v2,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
-        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveSelf,
-        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string-len.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse/derivation/transform/reverseIntString,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but "fractional", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__schema_reference_verification.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__schema_reference_verification.snap
@@ -14,7 +14,7 @@ expression: errors
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve,
-        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "null", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve,
@@ -34,7 +34,7 @@ expression: errors
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveIntString,
-        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "null", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveSelf,
@@ -46,6 +46,6 @@ expression: errors
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/derivation/transform/halveSelf,
-        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "object" is disallowed in locations used as keys,
+        error: location /int accepts "array", "boolean", "null", "number", "object", "string" in schema test://example/int-string-len.schema, but "array", "fractional", "null", "object" is disallowed in locations used as keys (https://go.estuary.dev/CigSvN),
     },
 ]

--- a/examples/reduction-types/append.flow.yaml
+++ b/examples/reduction-types/append.flow.yaml
@@ -4,7 +4,7 @@ collections:
       type: object
       reduce: { strategy: merge }
       properties:
-        key: { type: string }
+        key: { type: [string, integer] }
         value:
           # Append only works with type "array".
           # Others will error at build time.

--- a/flow_generated/flow/collections.d.ts
+++ b/flow_generated/flow/collections.d.ts
@@ -23,7 +23,7 @@ export type AcmeBankTransfers = {
 // Generated from examples/reduction-types/append.flow.yaml?ptr=/collections/example~1reductions~1append/schema.
 // Referenced as schema of examples/reduction-types/append.flow.yaml#/collections/example~1reductions~1append.
 export type ExampleReductionsAppend = {
-    key: string;
+    key: number | string;
     value?: unknown[];
 };
 

--- a/go/flow/testdata/specs_test.flow.yaml
+++ b/go/flow/testdata/specs_test.flow.yaml
@@ -4,9 +4,9 @@ collections:
       type: object
       properties:
         a_key: { type: string }
-        a_val: { type: integer }
+        a_val: { type: [integer, "null"] }
         a_bool: { type: boolean }
-        a_str: { type: [string, "null"] }
+        a_str: { type: string }
       required: [a_key, a_bool, a_str]
     key: [/a_key]
     projections:


### PR DESCRIPTION
**Description:**

Further restrict disallowed types of keyed locations to include NULL (in addition to object, array, and fractional).

**Workflow steps:**

* Catalogs which previously used null-able keyed locations will now error (I'm unaware of any)
* Attempts to use a nullable location as a key (a collection key or shuffle key) will produce an error:

```
$ flowctl check --source flow.yaml 
requests-rollup.flow.yaml error at /collections/acmeCo~1requests-rollup.v1 :
location /deal/id accepts "null", "string" in schema file:///workspaces/acmeCo/requests-rollup.schema.yaml, but "null" is disallowed in locations used as keys
```

**Documentation links affected:**

https://docs.estuary.dev/concepts/catalog-entities/collections#allowed-key-field-types

Two updates to make to this section:
 * Null is no longer an allowed type for keyed locations
 * Flow *does* allow keyed locations to have multiple types (to be a string or an integer, for example). However certain materialization _connectors_ may prohibit keys participating in a materialization from taking multiple types. A SQL DB can't, for example, represent a primary key that could be either an INTEGER or TEXT, and the connector will therefore report an error at build time if you attempt to materialize the collection using such a connector. We may want to note that, in general, materialization connectors may impose extra typing restrictions which will become build-time errors, and give the example of a SQL primary key.

/cc @oliviamiannone 

**Notes for reviewers:**

Nada 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/310)
<!-- Reviewable:end -->
