### PR TITLE
enable snapshot testing workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,12 +147,15 @@ go-test-ci:   $(GO_BUILD_DEPS) ${GOBIN}/etcd ${GOBIN}/sops
 	./go.sh test -p ${NPROC} --tags "${GO_BUILD_TAGS}" --race --count=15 --failfast ./go/...
 
 .PHONY: catalog-test
-catalog-test: ${GOBIN}/flowctl ${GOBIN}/gazette ${GOBIN}/etcd ${GOBIN}/sops
+catalog-test: ${GOBIN}/flowctl ${GOBIN}/gazette ${GOBIN}/etcd ${GOBIN}/sops flow.schema.json
 	${GOBIN}/flowctl test --source ${ROOTDIR}/examples/local-sqlite.flow.yaml $(ARGS)
 
 .PHONY: end-to-end-test
 end-to-end-test: ${GOBIN}/flowctl ${GOBIN}/gazette ${GOBIN}/etcd ${GOBIN}/sops
 	PATH="${PATH}:${GOBIN}" ./tests/run-end-to-end.sh
+
+flow.schema.json: ${GOBIN}/flowctl
+	${GOBIN}/flowctl json-schema > $@
 
 .PHONY: package
 package: $(PACKAGE_TARGETS)

--- a/crates/models/src/build/mod.rs
+++ b/crates/models/src/build/mod.rs
@@ -598,13 +598,16 @@ pub fn materialization_shuffle(
     }
 }
 
-pub fn test_step_spec(test_step: &tables::TestStep) -> flow::test_spec::Step {
+pub fn test_step_spec(
+    test_step: &tables::TestStep,
+    documents: &Vec<Value>,
+) -> flow::test_spec::Step {
     let tables::TestStep {
         scope,
         test: _,
         description,
         collection,
-        documents,
+        documents: _,
         partitions,
         step_index,
         step_type,
@@ -617,7 +620,7 @@ pub fn test_step_spec(test_step: &tables::TestStep) -> flow::test_spec::Step {
         collection: collection.to_string(),
         docs_json_lines: documents
             .iter()
-            .map(|d| d.to_string())
+            .map(|d| serde_json::to_string(d).expect("object cannot fail to serialize"))
             .collect::<Vec<_>>()
             .join("\n"),
         partitions: Some(journal_selector(collection, partitions)),

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -38,7 +38,7 @@ pub use resources::{ContentType, Import, ResourceDef};
 pub use schemas::Schema;
 pub use shards::ShardTemplate;
 pub use shuffles::{Lambda, PartitionSelector, Shuffle};
-pub use tests::{TestStep, TestStepIngest, TestStepVerify};
+pub use tests::{TestDocuments, TestStep, TestStepIngest, TestStepVerify};
 
 /// Object is an alias for a JSON object.
 pub type Object = serde_json::Map<String, serde_json::Value>;

--- a/crates/models/src/resources.rs
+++ b/crates/models/src/resources.rs
@@ -75,6 +75,8 @@ pub enum ContentType {
     TypescriptModule,
     /// Configuration file.
     Config,
+    /// Fixture of documents.
+    DocumentsFixture,
     /// Resource is a compiled NPM package.
     #[schemars(skip)]
     NpmPackage,
@@ -94,6 +96,7 @@ impl From<ProtoContentType> for ContentType {
             ProtoContentType::TypescriptModule => Self::TypescriptModule,
             ProtoContentType::NpmPackage => Self::NpmPackage,
             ProtoContentType::Config => Self::Config,
+            ProtoContentType::DocumentsFixture => Self::DocumentsFixture,
         }
     }
 }
@@ -105,6 +108,7 @@ impl Into<ProtoContentType> for ContentType {
             Self::TypescriptModule => ProtoContentType::TypescriptModule,
             Self::NpmPackage => ProtoContentType::NpmPackage,
             Self::Config => ProtoContentType::Config,
+            Self::DocumentsFixture => ProtoContentType::DocumentsFixture,
         }
     }
 }

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -21,8 +21,11 @@ use super::{Object, RelativeUrl};
 #[schemars(example = "Schema::example_inline_basic")]
 #[schemars(example = "Schema::example_inline_counter")]
 pub enum Schema {
+    /// Relative URL to a schema file.
     Url(RelativeUrl),
+    /// Inline schema document.
     Object(Object),
+    /// Inline schema document (alternate boolean form).
     Bool(bool),
 }
 

--- a/crates/models/src/tables/mod.rs
+++ b/crates/models/src/tables/mod.rs
@@ -189,7 +189,7 @@ tables!(
         // Collection ingested or verified by this step.
         collection: models::Collection,
         // Documents ingested or verified by this step.
-        documents: Vec<serde_json::Value>,
+        documents: url::Url,
         // When verifying, selector over logical partitions of the collection.
         partitions: Option<models::PartitionSelector>,
         // Enumerated index of this test step.

--- a/crates/protocol/src/flow.rs
+++ b/crates/protocol/src/flow.rs
@@ -1028,4 +1028,5 @@ pub enum ContentType {
     TypescriptModule = 2,
     NpmPackage = 3,
     Config = 4,
+    DocumentsFixture = 5,
 }

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations.snap
@@ -81,7 +81,7 @@ Tables {
     errors: [
         Error {
             scope: test://example/malformed-config.yaml,
-            error: failed to parse YAML (location None)
+            error: failed to parse configuration document (location None) (https://go.estuary.dev/qpSUoq)
             
             Caused by:
                 0: invalid utf-8 sequence of 1 bytes from index 1

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case.snap
@@ -8,7 +8,36 @@ Tables {
     captures: [],
     collections: [],
     derivations: [],
-    errors: [],
+    errors: [
+        Error {
+            scope: test://example/catalog-err-not-an-array.yaml,
+            error: failed to parse YAML (location None)
+            
+            Caused by:
+                data did not match any variant of untagged enum TestDocuments,
+        },
+        Error {
+            scope: test://example/catalog-err-not-an-object.yaml,
+            error: failed to parse YAML (location None)
+            
+            Caused by:
+                data did not match any variant of untagged enum TestDocuments,
+        },
+        Error {
+            scope: test://example/not-an-array.json,
+            error: failed to parse JSON document fixtures (https://go.estuary.dev/NGT3es)
+            
+            Caused by:
+                invalid type: map, expected a sequence at line 1 column 0,
+        },
+        Error {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/1,
+            error: failed to fetch resource test://example/not-found.json
+            
+            Caused by:
+                fixture not found,
+        },
+    ],
     fetches: [
         Fetch {
             depth: 1,
@@ -16,14 +45,83 @@ Tables {
         },
         Fetch {
             depth: 2,
+            resource: test://example/catalog-err-not-an-array.yaml,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/catalog-err-not-an-object.yaml,
+        },
+        Fetch {
+            depth: 2,
             resource: test://example/catalog.ts,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/not-an-array.json,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/not-found.json,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/snapshots/ingest.json,
+        },
+        Fetch {
+            depth: 2,
+            resource: test://example/snapshots/verify.json,
         },
     ],
     imports: [
         Import {
+            scope: test://example/catalog.yaml#/import/0,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog-err-not-an-array.yaml,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/import/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog-err-not-an-object.yaml,
+        },
+        Import {
             scope: test://example/catalog.yaml,
             from_resource: test://example/catalog.yaml,
             to_resource: test://example/catalog.ts,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/0,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/0,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/1,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/2,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/2,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/0,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/not-an-array.json,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/1,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/not-found.json,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/3,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/snapshots/ingest.json,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/4,
+            from_resource: test://example/catalog.yaml,
+            to_resource: test://example/snapshots/verify.json,
         },
     ],
     materialization_bindings: [],
@@ -33,8 +131,48 @@ Tables {
     projections: [],
     resources: [
         Resource {
+            resource: test://example/catalog-err-not-an-array.yaml,
+            content_type: "CATALOG",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog-err-not-an-object.yaml,
+            content_type: "CATALOG",
+            content: ".. binary ..",
+        },
+        Resource {
             resource: test://example/catalog.yaml,
             content_type: "CATALOG",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/0,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/1,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/2,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/not-an-array.json,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/snapshots/ingest.json,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/snapshots/verify.json,
+            content_type: "DOCUMENTS_FIXTURE",
             content: ".. binary ..",
         },
     ],
@@ -42,11 +180,31 @@ Tables {
     storage_mappings: [],
     test_steps: [
         TestStep {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/0,
+            test: acmeCo/errors/test,
+            description: This isn't an array.,
+            collection: test/collection,
+            documents: test://example/not-an-array.json,
+            partitions: NULL,
+            step_index: 0,
+            step_type: "Ingest",
+        },
+        TestStep {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/1,
+            test: acmeCo/errors/test,
+            description: This is missing.,
+            collection: test/collection,
+            documents: test://example/not-found.json,
+            partitions: NULL,
+            step_index: 1,
+            step_type: "Verify",
+        },
+        TestStep {
             scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/0,
             test: acmeCo/widgest/test,
             description: Import some foos,
             collection: test/collection,
-            documents: [{"ingest":1},true],
+            documents: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/0,
             partitions: NULL,
             step_index: 0,
             step_type: "Ingest",
@@ -56,7 +214,7 @@ Tables {
             test: acmeCo/widgest/test,
             description: Verify without a selector.,
             collection: test/collection,
-            documents: [{"verify":2},false],
+            documents: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/1,
             partitions: NULL,
             step_index: 1,
             step_type: "Verify",
@@ -66,9 +224,29 @@ Tables {
             test: acmeCo/widgest/test,
             description: ,
             collection: test/collection,
-            documents: [{"verify":3},"fin"],
+            documents: test://example/catalog.yaml?ptr=/tests/acmeCo~1widgest~1test/2,
             partitions: {"include":{"a_field":["some-val"]},"exclude":{}},
             step_index: 2,
+            step_type: "Verify",
+        },
+        TestStep {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/3,
+            test: acmeCo/widgest/test,
+            description: Import more foos via file fixture.,
+            collection: test/collection,
+            documents: test://example/snapshots/ingest.json,
+            partitions: NULL,
+            step_index: 3,
+            step_type: "Ingest",
+        },
+        TestStep {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1widgest~1test/4,
+            test: acmeCo/widgest/test,
+            description: Verify via file fixture.,
+            collection: test/collection,
+            documents: test://example/snapshots/verify.json,
+            partitions: NULL,
+            step_index: 4,
             step_type: "Verify",
         },
     ],

--- a/crates/sources/src/scenarios/test_test_case.yaml
+++ b/crates/sources/src/scenarios/test_test_case.yaml
@@ -1,19 +1,61 @@
 test://example/catalog.yaml:
+  import:
+    - catalog-err-not-an-array.yaml
+    - catalog-err-not-an-object.yaml
+
   tests:
     acmeCo/widgest/test:
       - ingest:
           description: Import some foos
           collection: test/collection
-          documents: [{ "ingest": 1 }, true]
+          documents: [{ "ingest": 1 }, { "next": "ingest" }]
       # No selector.
       - verify:
           description: Verify without a selector.
           collection: test/collection
-          documents: [{ "verify": 2 }, false]
+          documents: [{ "verify": 2 }, { "next": false }]
       # With selector.
       - verify:
           collection: test/collection
           partitions:
             include: { "a_field": ["some-val"] }
             exclude: {}
-          documents: [{ "verify": 3 }, "fin"]
+          documents: [{ "verify": 3 }, { "fin": null }]
+      - ingest:
+          description: Import more foos via file fixture.
+          collection: test/collection
+          documents: ./snapshots/ingest.json
+      - verify:
+          description: Verify via file fixture.
+          collection: test/collection
+          documents: ./snapshots/verify.json
+
+    acmeCo/errors/test:
+      - ingest:
+          description: This isn't an array.
+          collection: test/collection
+          documents: ./not-an-array.json
+      - verify:
+          description: This is missing.
+          collection: test/collection
+          documents: ./not-found.json
+
+test://example/snapshots/ingest.json: [{ an: ingest }]
+
+test://example/snapshots/verify.json: [{ a: verify }]
+
+test://example/not-an-array.json: { whoops: true }
+
+test://example/catalog-err-not-an-array.yaml:
+  tests:
+    acmeCo/parse/failure:
+      - ingest:
+          collection: test/collection
+          documents: { "not": "an array" }
+
+test://example/catalog-err-not-an-object.yaml:
+  tests:
+    acmeCo/parse/failure:
+      - ingest:
+          collection: test/collection
+          documents: ["not-an-object"]

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -178,7 +178,7 @@ expression: "&schema"
                 "description": "Description of the ingestion.",
                 "documents": [
                   {
-                    "example": "document"
+                    "a": "document"
                   },
                   {
                     "another": "document"
@@ -192,7 +192,10 @@ expression: "&schema"
                 "description": "Description of the verification.",
                 "documents": [
                   {
-                    "expected": "document"
+                    "a": "document"
+                  },
+                  {
+                    "another": "document"
                   }
                 ],
                 "partitions": null
@@ -486,7 +489,8 @@ expression: "&schema"
         "CATALOG",
         "JSON_SCHEMA",
         "TYPESCRIPT_MODULE",
-        "CONFIG"
+        "CONFIG",
+        "DOCUMENTS_FIXTURE"
       ]
     },
     "Derivation": {
@@ -1048,13 +1052,16 @@ expression: "&schema"
       ],
       "anyOf": [
         {
+          "description": "Relative URL to a schema file.",
           "$ref": "#/definitions/RelativeUrl"
         },
         {
+          "description": "Inline schema document.",
           "type": "object",
           "additionalProperties": true
         },
         {
+          "description": "Inline schema document (alternate boolean form).",
           "type": "boolean"
         }
       ]
@@ -1247,6 +1254,34 @@ expression: "&schema"
       "type": "string",
       "pattern": "^[a-zA-Z0-9\\-_\\.]+(/[a-zA-Z0-9\\-_\\.]+)*$"
     },
+    "TestDocuments": {
+      "description": "A test step describes either an \"ingest\" of document fixtures into a collection, or a \"verify\" of expected document fixtures from a collection.",
+      "examples": [
+        "../path/to/test-documents.json",
+        [
+          {
+            "a": "document"
+          },
+          {
+            "another": "document"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "description": "Relative URL to a file of documents.",
+          "$ref": "#/definitions/RelativeUrl"
+        },
+        {
+          "description": "An inline array of documents.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      ]
+    },
     "TestStep": {
       "description": "A test step describes either an \"ingest\" of document fixtures into a collection, or a \"verify\" of expected document fixtures from a collection.",
       "examples": [
@@ -1256,7 +1291,7 @@ expression: "&schema"
             "description": "Description of the ingestion.",
             "documents": [
               {
-                "example": "document"
+                "a": "document"
               },
               {
                 "another": "document"
@@ -1270,7 +1305,10 @@ expression: "&schema"
             "description": "Description of the verification.",
             "documents": [
               {
-                "expected": "document"
+                "a": "document"
+              },
+              {
+                "another": "document"
               }
             ],
             "partitions": null
@@ -1314,7 +1352,7 @@ expression: "&schema"
           "description": "Description of the ingestion.",
           "documents": [
             {
-              "example": "document"
+              "a": "document"
             },
             {
               "another": "document"
@@ -1340,8 +1378,7 @@ expression: "&schema"
         "documents": {
           "title": "Documents to ingest.",
           "description": "Each document must conform to the collection's schema.",
-          "type": "array",
-          "items": true
+          "$ref": "#/definitions/TestDocuments"
         }
       },
       "additionalProperties": false
@@ -1354,7 +1391,10 @@ expression: "&schema"
           "description": "Description of the verification.",
           "documents": [
             {
-              "expected": "document"
+              "a": "document"
+            },
+            {
+              "another": "document"
             }
           ],
           "partitions": null
@@ -1378,8 +1418,7 @@ expression: "&schema"
         "documents": {
           "title": "Documents to verify.",
           "description": "Each document may contain only a portion of the matched document's properties, and any properties present in the actual document but not in this document fixture are ignored. All other values must match or the test will fail.",
-          "type": "array",
-          "items": true
+          "$ref": "#/definitions/TestDocuments"
         },
         "partitions": {
           "title": "Selector over partitions to verify.",

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -192,6 +192,7 @@ pub async fn validate<D: Drivers>(
         collections,
         imports,
         projections,
+        resources,
         &schema_index,
         &schema_shapes,
         test_steps,

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -4268,6 +4268,16 @@ All {
             to_resource: test://example/int-string-tests.ts,
         },
         Import {
+            scope: test://example/int-string-tests#/tests/testing~1test/0,
+            from_resource: test://example/int-string-tests,
+            to_resource: test://example/int-string-tests?ptr=/tests/testing~1test/0,
+        },
+        Import {
+            scope: test://example/int-string-tests#/tests/testing~1test/1,
+            from_resource: test://example/int-string-tests,
+            to_resource: test://example/int-string-tests?ptr=/tests/testing~1test/1,
+        },
+        Import {
             scope: test://example/webhook-deliveries#/import/1,
             from_resource: test://example/webhook-deliveries,
             to_resource: test://example/int-halve,
@@ -5209,6 +5219,16 @@ All {
             content: ".. binary ..",
         },
         Resource {
+            resource: test://example/int-string-tests?ptr=/tests/testing~1test/0,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
+            resource: test://example/int-string-tests?ptr=/tests/testing~1test/1,
+            content_type: "DOCUMENTS_FIXTURE",
+            content: ".. binary ..",
+        },
+        Resource {
             resource: test://example/int-string.schema,
             content_type: "JSON_SCHEMA",
             content: ".. binary ..",
@@ -5281,7 +5301,7 @@ All {
             test: testing/test,
             description: ,
             collection: testing/int-string,
-            documents: [{"bit":true,"int":42,"str":"string A"},{"bit":true,"int":52,"str":"string B"}],
+            documents: test://example/int-string-tests?ptr=/tests/testing~1test/0,
             partitions: NULL,
             step_index: 0,
             step_type: "Ingest",
@@ -5291,7 +5311,7 @@ All {
             test: testing/test,
             description: expect stuff happens,
             collection: testing/int-string,
-            documents: [{"str":"string A"},{"str":"string B"}],
+            documents: test://example/int-string-tests?ptr=/tests/testing~1test/1,
             partitions: {"include":{"bit":[true]},"exclude":{}},
             step_index: 1,
             step_type: "Verify",

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -173,7 +173,7 @@
                 "description": "Description of the ingestion.",
                 "documents": [
                   {
-                    "example": "document"
+                    "a": "document"
                   },
                   {
                     "another": "document"
@@ -187,7 +187,10 @@
                 "description": "Description of the verification.",
                 "documents": [
                   {
-                    "expected": "document"
+                    "a": "document"
+                  },
+                  {
+                    "another": "document"
                   }
                 ],
                 "partitions": null
@@ -481,7 +484,8 @@
         "CATALOG",
         "JSON_SCHEMA",
         "TYPESCRIPT_MODULE",
-        "CONFIG"
+        "CONFIG",
+        "DOCUMENTS_FIXTURE"
       ]
     },
     "Derivation": {
@@ -1043,13 +1047,16 @@
       ],
       "anyOf": [
         {
+          "description": "Relative URL to a schema file.",
           "$ref": "#/definitions/RelativeUrl"
         },
         {
+          "description": "Inline schema document.",
           "type": "object",
           "additionalProperties": true
         },
         {
+          "description": "Inline schema document (alternate boolean form).",
           "type": "boolean"
         }
       ]
@@ -1242,6 +1249,34 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9\\-_\\.]+(/[a-zA-Z0-9\\-_\\.]+)*$"
     },
+    "TestDocuments": {
+      "description": "A test step describes either an \"ingest\" of document fixtures into a collection, or a \"verify\" of expected document fixtures from a collection.",
+      "examples": [
+        "../path/to/test-documents.json",
+        [
+          {
+            "a": "document"
+          },
+          {
+            "another": "document"
+          }
+        ]
+      ],
+      "anyOf": [
+        {
+          "description": "Relative URL to a file of documents.",
+          "$ref": "#/definitions/RelativeUrl"
+        },
+        {
+          "description": "An inline array of documents.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      ]
+    },
     "TestStep": {
       "description": "A test step describes either an \"ingest\" of document fixtures into a collection, or a \"verify\" of expected document fixtures from a collection.",
       "examples": [
@@ -1251,7 +1286,7 @@
             "description": "Description of the ingestion.",
             "documents": [
               {
-                "example": "document"
+                "a": "document"
               },
               {
                 "another": "document"
@@ -1265,7 +1300,10 @@
             "description": "Description of the verification.",
             "documents": [
               {
-                "expected": "document"
+                "a": "document"
+              },
+              {
+                "another": "document"
               }
             ],
             "partitions": null
@@ -1309,7 +1347,7 @@
           "description": "Description of the ingestion.",
           "documents": [
             {
-              "example": "document"
+              "a": "document"
             },
             {
               "another": "document"
@@ -1335,8 +1373,7 @@
         "documents": {
           "title": "Documents to ingest.",
           "description": "Each document must conform to the collection's schema.",
-          "type": "array",
-          "items": true
+          "$ref": "#/definitions/TestDocuments"
         }
       },
       "additionalProperties": false
@@ -1349,7 +1386,10 @@
           "description": "Description of the verification.",
           "documents": [
             {
-              "expected": "document"
+              "a": "document"
+            },
+            {
+              "another": "document"
             }
           ],
           "partitions": null
@@ -1373,8 +1413,7 @@
         "documents": {
           "title": "Documents to verify.",
           "description": "Each document may contain only a portion of the matched document's properties, and any properties present in the actual document but not in this document fixture are ignored. All other values must match or the test will fail.",
-          "type": "array",
-          "items": true
+          "$ref": "#/definitions/TestDocuments"
         },
         "partitions": {
           "title": "Selector over partitions to verify.",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.18.2
 	github.com/alecthomas/jsonschema v0.0.0-20210818095345-1014919a589c
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
-	github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a
+	github.com/estuary/protocols v0.0.0-20211213235942-5170046767ab
 	github.com/fatih/color v1.7.0
 	github.com/go-openapi/jsonpointer v0.19.3
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0 h1:d
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a h1:2S/0GAvLKkayZmRTMjIr9uSpJSPYsrqPaKJ4hE1fRr4=
-github.com/estuary/protocols v0.0.0-20211129055338-9259b2dca80a/go.mod h1:HvGdE/2z4CCCn+XcjMujL3AQ2Skc/KKz6ds42UJnwc8=
+github.com/estuary/protocols v0.0.0-20211213235942-5170046767ab h1:LVjVdSFu5ddEISEtA0nJEqhlA2ynUTDjqiSa0eylIl0=
+github.com/estuary/protocols v0.0.0-20211213235942-5170046767ab/go.mod h1:HvGdE/2z4CCCn+XcjMujL3AQ2Skc/KKz6ds42UJnwc8=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=

--- a/go/flowctl/cmd-test.go
+++ b/go/flowctl/cmd-test.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/broker/protocol"
@@ -19,7 +18,7 @@ type cmdTest struct {
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
 	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
-	Timeout     time.Duration         `long:"timeout" default:"10m" description:"Maximum time for a test invocation"`
+	Snapshot    string                `long:"snapshot" description:"When set, failed test verifications produce snapshots into the given base directory"`
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 }
@@ -102,6 +101,7 @@ func (cmd cmdTest) Execute(_ []string) (retErr error) {
 	var test = apiTest{
 		BuildID:    buildID,
 		BuildsRoot: buildsRoot,
+		Snapshot:   cmd.Snapshot,
 	}
 	test.Broker.Address = protocol.Endpoint(brokerAddr)
 	test.Consumer.Address = protocol.Endpoint(consumerAddr)


### PR DESCRIPTION
**Description:**

Support a snapshot testing workflow through:
1) Allowing `documents` of ingest and verity test steps to be a relative URL, in addition to the current inline array of documents. If given as a URL, the file MUST be a JSON array of document objects.
2) Offering a `--snapshot` flag in `flowctl test` & `flowctl api test`, which will generate nicely formatted JSON encodings (array of documents) of actual documents produced into a collection during the test run.

**Workflow steps:**

Before this PR, users were required to either a) edit document fixtures and expectations by hand within the catalog, or b) copy and past document fixtures into test and verification steps. Users (I) would copy terminal output and tediously re-format it into the catalog test which is under development.

Essentially the whole workflow presumes you're writing novel documents to ingest and verify by hand, which often you are, but certainly not always.

Now:

### I have pre-existing sample fixtures

A user needs to format their example documents as an encoded JSON array in a file. Then the test step names the file by a relative or absolute URL. It's permitted to link to files that exist externally to the current repo.

### I want to run the transformation and inspect its output

It's common to want to run a transformation over an input and then visually inspect it's output for correctness, rather than trying to craft the expected output ahead of time. This is now accomplished by running `flowctl test --snapshot ./snapshots`. Then, if a test verification fails, `flowctl` writes out what it _should_ have been to `./snapshots/the/test/name/verify-2.json`, where 2 is the index of the failed verification step.

In more detail, I might:
* Write a verification step of a test under development by using `documents: []` as a placeholder.
* Run `flowctl test --snapshot` to generate the snapshot of what it _actually_ is
* Inspect the output to ensure it's correctness.

When I'm satisfied that it's correct, I can prevent regressions by:
* Updating the verification step => `documents: ../path/to/snapshots/the/test/name/verify-2.json`
* Version the snapshot in git.

**Documentation links affected:**

New shortlinks:

https://go.estuary.dev/NGT3es -> https://docs.estuary.dev/replace-me-with-docs-for-document-fixtures
https://go.estuary.dev/qpSUoq -> https://docs.estuary.dev/replace-me-with-docs-for-connector-configs

https://docs.estuary.dev/reference/catalog-reference/captures/endpoint-configurations
https://docs.estuary.dev/reference/catalog-reference/materialization/endpoints
https://docs.estuary.dev/concepts/catalog-entities/tests

**Notes for reviewers:**

Minior protocols update, which i'll merge at the same time.
https://github.com/estuary/protocols/pull/19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/312)
<!-- Reviewable:end -->
