### PR TITLE
flowctl: remove --builds-root flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ docker run --rm -e POSTGRES_PASSWORD=password -p 5432:5432 postgres -c log_sta
 
 Start a Flow data plane on your machine:
 ```console
-$ flowctl temp-data-plane --builds-root file://$(pwd)/
+$ flowctl temp-data-plane
 export BROKER_ADDRESS=http://localhost:8080
 export CONSUMER_ADDRESS=http://localhost:9000
 ```


### PR DESCRIPTION
**Description:**

`flowctl` commands which interact with data planes, now ask the data plane what it's configured `--flow.builds-root` is, instead of requiring a `--builds-root` argument to be explicitly passed.

Similarly, `flowctl temp-data-plane` no longer takes a --builds-root, and instead uses a `./builds/` subdirectory of the temporary directory which is provisioned for the data plane.

**Workflow steps:**

Where before you passed `--builds-root`, now you don't.

**Documentation links affected:**

The top-level README example is updated, and updates to the `flow-template` repository are required.
To my knowledge we hadn't documented this elsewhere yet.

**Notes for reviewers:**

Enjoy the fewer flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/314)
<!-- Reviewable:end -->
