### PR TITLE
Disable docker logs for all connectors

### DIFF
--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -59,6 +59,17 @@ func Run(
 		"run",
 		"--interactive",
 		"--rm",
+		// Tell docker not to persist any container stdout/stderr output.
+		// Containers may write _lots_ of output to std streams, and docker's
+		// logging drivers may persist all or some of that to disk, which could
+		// easily exhaust all available disk space. The default logging driver
+		// does this. Setting the log driver here means that we don't rely on
+		// any user-defined docker configuration for this, but it also means
+		// that running `docker logs` to see the output of a connector will not
+		// work. This is acceptable, since all of the stderr output is logged
+		// into the ops collections.
+		"--log-driver",
+		"none",
 	}
 
 	if networkName != "" {


### PR DESCRIPTION
**Description:**

The default docker daemon configuration will cause all stdout/err output to be
persisted to disk, which results in eventual disk exhaustion. Previously, we
expected the daemon configuration to specify a more reasonable log-driver in
any environment in which Flow would run, but this turns out to be difficult in
environments such as codespaces, which don't give you direct control over the
daemon configuration. In any case, it's really easy to forget to configure the
default log driver, and there's no longer much use for running `docker logs`
now that we're publishing all connector stderr output to the ops logs
collections. So this changes Flow to always run connectors with docker log
collection disabled, which should prevent any future disk exhaustion without
anyone needing to change their daemon config.

**Workflow steps:**

users no longer need to modify their `daemon.json` file in order to run Flow. I don't _think_ we had previously documented the need for this, so I don't think there should be any impact on docs.

**Documentation links affected:** n/a

**Notes for reviewers:** none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/320)
<!-- Reviewable:end -->
