### PR TITLE
Update gazette dependency

### DIFF
--- a/crates/protocol/src/consumer.rs
+++ b/crates/protocol/src/consumer.rs
@@ -432,12 +432,19 @@ pub struct UnassignRequest {
     /// Only unassign shards which have a primary in FAILED status.
     #[prost(bool, tag="2")]
     pub only_failed: bool,
+    /// Avoids actually removing any shard assignments, but the response will
+    /// report which shards would have been affected.
+    #[prost(bool, tag="3")]
+    pub dry_run: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnassignResponse {
     /// Status of the Unassign RPC.
     #[prost(enumeration="Status", tag="1")]
     pub status: i32,
+    /// Shards which had assignments removed.
+    #[prost(string, repeated, tag="2")]
+    pub shards: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Status is a response status code, used across Gazette Consumer RPC APIs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e
+	go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e h1:iS3yKckWyKO6FeZf1TgffcmcXgR4T2pMnhKp7ywXstc=
-go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
+go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c h1:Kav7gx3Zy4FRNqBhhEWAvXJaKdPEO8qJKQBCxdGH0HI=
+go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
**Description:**

Updating to the latest version of Gazette which the underlying `unassign` command from Gazette and the accompanying proto changes.

See:
- https://github.com/gazette/core/pull/316

**Workflow steps:**

Supports adding the shard supervisor cron job to the k8s environments.

**Documentation links affected:**

TODO: document unassign in Gazette docs

**Notes for reviewers:**

This is a draft while I work on the shard supervisor cron job. I can't build docker images locally, so I needed to push this to build the image for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/322)
<!-- Reviewable:end -->
