### PR TITLE
Prevent closing materialization/capture clients twice

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -97,9 +98,11 @@ func (c *Capture) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err
 		// Set the delegate to nil so that we don't try to close it again in Destory should
 		// something go wrong
 		c.delegate = nil
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			return pf.Checkpoint{}, fmt.Errorf("closing previous delegate: %w", err)
 		}
+		// The error could be a context cancelation, which we should ignore
+		err = nil
 	}
 
 	// Closure which builds a Combiner for a specified binding.

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -93,7 +93,11 @@ func (c *Capture) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err
 		"loaded specification")
 
 	if c.delegate != nil {
-		if err := c.delegate.Close(); err != nil {
+		err = c.delegate.Close()
+		// Set the delegate to nil so that we don't try to close it again in Destory should
+		// something go wrong
+		c.delegate = nil
+		if err != nil {
 			return pf.Checkpoint{}, fmt.Errorf("closing previous delegate: %w", err)
 		}
 	}


### PR DESCRIPTION
**Description:**

Fixes: #328 

In certain circumstances where a materialization or capture failed to properly
initialize, it may be possible for it to `Close` the client/delegate twice,
thus triggering a panic. This was actually observed in a materialization, but
was theoretically possible in a capture as well.

The second commit addresses the possibility that closing the capture delegate or materialization client may return a `context.Canceled`, which should be ignored.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/327)
<!-- Reviewable:end -->
