### PR TITLE
Initial SSH docs - guide, connector section

### DIFF
--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -371,6 +371,62 @@ You then use this `config.yaml` within your Flow catalog.
 Flow looks for and understands the `encrypted_suffix`,
 and will remove this suffix from configuration keys before passing them to the connector.
 
+### Connecting to endpoints on secure networks
+
+In some cases, your source or destination endpoint may be within a secure network, and you may not be able
+to allow direct access to its port due to your organization's security policy.
+
+[SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding,
+provides a means for Flow to access the port indirectly through an SSH server.
+
+To set up and configure the SSH server, see the [guide](../../guides/connect-network/).
+
+:::info Beta
+Currently, Flow supports SSH tunneling on a per-connector basis; consult the appropriate connector's documentation
+to verify. Estuary plans to expand this to universally cover all connectors in the future. Additionally,
+we'll add support for other means of secure connection.
+:::
+
+After verifying that the connector is supported, you can add a `proxy` stanza to the capture or materialization
+definition to enable SSH tunneling.
+
+```yaml title="postgres-ssh-tunnel.flow.yaml"
+captures:
+  acmeCo/postgres-ssh:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-postgres:dev
+        config:
+          # When using a proxy like SSH tunneling, set to localhost
+          host: localhost
+          # 0 allows Flow to dynamically choose an open port on your local machine
+          # to connect to the proxy (recommended).
+          # If necessary, you're free to specify a different port.
+          port: 0
+          database: flow
+          user: flow_capture
+          password: secret
+          proxy:
+            # Support for other proxy types will be enabled in the future.
+            proxy_type: ssh_forwarding
+              ssh_forwarding:
+                # Location of the remote SSH server that supports tunneling.
+                ssh_endpoint: 198.21.98.1
+                # Base64-encoded private key to connect to the SSH server.
+                ssh_private_key_base64: wjkEpr7whDZQ8UqIYI4RcNRuithu7chNZg
+                # Username to connect to the SSH server.
+                ssh_user: ssh_user
+                # Host or IP address of the final endpoint to which you’ll
+                # connect via tunneling from the SSH server
+                remote_host: 127.0.0.1
+                # Port of the final endpoint to which you’ll connect via
+                # tunneling from the SSH server.
+                remote_port: 5432
+                # Port on the local machine from which you'll connect to the SSH server.
+                # This must match port, above.
+                local_port: 0
+      bindings: []
+```
 ## Available Connectors
 
 [Learn about available connectors in the reference section](../../reference/Connectors/)

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -1,0 +1,75 @@
+# Configure connections with SSH tunneling
+
+Depending on your enterprise network security, you may need to use [SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding, to allow Flow
+to securely access your endpoint. This is configured within a capture or materialization definition, but
+before you can do this, you'll need a properly configured SSH server on your internal network.
+
+These steps provide a basic roadmap, and should be followed with the help of an IT specialist in your organization,
+as details depend on your organization's policies and practices.
+
+1. Activate an [SSH implementation on a server](https://www.ssh.com/academy/ssh/server#availability-of-ssh-servers), if you don't have one already.
+Consult the documentation for your server's operating system and/or cloud service provider, as the steps will vary.
+Configure the server to your organization's standards, or reference the [SSH documentation](https://www.ssh.com/academy/ssh/sshd_config) for
+basic configuration options.
+
+2. Referencing the config files and shell output, collect the following information:
+
+   * The **endpoint** for the SSH server, which may look like the any of following:
+     * `ec2-198-21-98-1.compute-1.amazonaws.com`
+     * `198.21.98.1`
+     * `198.21.98.1:22`
+   * The SSH **user**, which will be used to log into the SSH server, for example, `sshuser`. You may choose to create a new
+  user for this workflow.
+
+3. In the `.ssh` subdirectory of your user home directory,
+   look for the PEM file that contains the private SSH key. Check that it starts with `-----BEGIN RSA PRIVATE KEY-----`,
+   which indicates it is an RSA-based file.
+   * If no such file exists, generate one using the command:
+   ```console
+      ssh-keygen -m PEM -t rsa
+      ```
+   * If a PEM file exists, but starts with `-----BEGIN OPENSSH PRIVATE KEY-----`, convert it with the command:
+   ```console
+      ssh-keygen -p -N "" -m pem -f /path/to/key
+      ```
+
+  Taken together, these configuration details would allow you to log into the SSH server from your local machine.
+  They'll allow the connector to do the same.
+
+4. The PEM files must be encoded with Base64 before they are passed to a connector.
+   You can convert it with the following bash command:
+      ``` console
+      cat <path-to-the-pem-file> | base64 -w 0
+      ```
+
+5. Configure your internal network to allow the SSH server to access the endpoint.
+  Note the internal **host** and **port**; these are necessary to open the connection.
+
+6. Configure your network to expose the SSH server endpoint to eternal traffic. The method you use
+   depends on your organization's IT policies. Currently, Estuary doesn't provide a list of static IPs for
+   whitelisting purposes, but if you require one, [contact Estuary support](mailto:support@estuary.dev).
+
+7. You can also choose a port on your localhost to use to connect to the SSH server. If you don't have a
+   reason to pick a particular point, it is recommended to set this value to `0` in the configuration.
+   This will allow Flow to dynamically pick an open port.
+
+### Configuration
+
+After you've completed the prerequisites, you should have the following parameters:
+
+* `ssh_endpoint`: the endpoint, step 2
+* `ssh_private_key_base64`: the encoded PEM file, step 4
+* `ssh_user`: the username, step 2
+* `remote_host`: the endpoint's host, step 5
+* `remote_port`: the endpoint's port, step 5
+* `local_port`: the port on the localhost used to connect to the SSH server, step 7
+
+1. Use these to add SSH tunneling to your capture or materialization definition, either by filling in the corresponding fields
+  in a web app, or by working with the YAML directly. Reference the [Connectors](../../concepts/connectors/#connecting-to-endpoints-on-secure-networks) page for a code sample.
+
+Proxies like SSH are always run on an open port on your localhost, so you'll need to re-configure other fields in your
+capture or materialization definition.
+
+2. Set the host to `localhost`.
+
+3. Set the port to the same value you chose for `local_port` in the SSH configuration.

--- a/site/docs/guides/create-dataflow.md
+++ b/site/docs/guides/create-dataflow.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Create a simple data flow
 
 Whether you're learning to use Flow or testing a new pipeline, much of your work will take place in a local or virtual environment. This guide outlines the basic steps to create and deploy a data flow using Flow's current GitOps workflow.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -3,6 +3,7 @@ This connector uses change data capture (CDC) to continuously capture updates in
 `ghcr.io/estuary/source-postgres:dev` provides the latest connector image when using the Flow GitOps environment. You can also follow the link in your browser to see past image versions.
 
 ## Prerequisites
+
 To use this connector, you'll need a PostgreSQL database setup with the following:
 * [Logical replication enabled](https://www.postgresql.org/docs/current/runtime-config-wal.html) — `wal_level=logical`
 * [User role](https://www.postgresql.org/docs/current/sql-createrole.html) with `REPLICATION` attribute
@@ -15,6 +16,7 @@ To use this connector, you'll need a PostgreSQL database setup with the followin
 
 
 ### Setup
+
 The simplest way to meet the above prerequisites is to change the WAL level and have the connector use a database superuser role.
 
 For a more restricted setup, create a new user with just the required permissions as detailed in the following steps:
@@ -57,9 +59,11 @@ ALTER SYSTEM SET wal_level = logical;
 5. Restart PostgreSQL to allow the WAL level change to take effect.
 
 ## Configuration
+
 There are various ways to configure and implement connectors. See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about these methods. The values and code sample below provide configuration details specific to the PostgreSQL source connector.
 
 ### Values
+
 | Value | Name | Type | Required/Default | Details |
 |-------|------|------|---------| --------|
 | `database` | Database | string | `"postgres"` | Logical database name to capture from. |
@@ -72,6 +76,7 @@ There are various ways to configure and implement connectors. See [connectors](.
 | `watermarks_table` | Watermarks Table | string | `"public.flow_watermarks"` | The name of the table used for watermark writes during backfills |
 
 ### Sample
+
 A minimal capture definition within the catalog spec will look like the following:
 
 ```yaml
@@ -97,3 +102,10 @@ captures:
         target: ${TENANT}/${COLLECTION_NAME}
 ```
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.
+
+## Connecting to secure networks
+
+The PostgreSQL source connector [supports SSH tunneling](../../../concepts/connectors.mdconnecting-to-endpoints-on-secure-networks)
+to allow Flow to connect to databases ports in secure networks.
+
+To set up and configure your SSH server, see the [guide](../../../guides/connect-network/).


### PR DESCRIPTION
**Description:**

Initial documentation on our support for SSH tunneling. This is time-sensitive because this capability is going to be exposed in the config manager early next week, and some documentation must be provided. 

3 files were added/changed:
* postgres connector doc - states that this connector supports SSH tunneling. Will add similar sections to other connectors as support is added, and take this out when we transition to a connector-independant workflow
* connectors concept doc - added a section for connecting to endpoints on a secure network. Long term, I imagine we'll want to break this out into separate docs, but give our current TOC structure and the amount of options available, I think it makes sense to put here for now
* New guide on setting up and configuring ssh 

**Workflow steps:**

All the files inter-link, so the user can start reading on any of the pages and get all the info they need. Ideally, the starting point should be the guide, though.

We're also expecting the user to have IT support. The hope is that the kind of user who will need SSH tunneling will have internal standards and processes they follow for this sort of thing. In the future, we may want to make this fool-proof, but that's not a priority right now.

**Documentation links affected:**
https://go.estuary.dev/ssh-connect

**Notes for reviewers:**
@jixij I'm mainly interested in accuracy, and want to make sure I didn't confuse any important technical aspects while writing this up. 

Of course, I'm open to thoughts on the overall flow and structure of this. Likewise, additional reviewers are appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/337)
<!-- Reviewable:end -->
