### PR TITLE
Add Control Plane Skeleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_flow:
     runs-on: ubuntu-20.04
 
     steps:
@@ -84,3 +84,51 @@ jobs:
       # Cleanup in preparation for populating the build cache.
       - run: cargo install cargo-cache --no-default-features --features ci-autoclean
       - run: cargo-cache
+
+  build_control:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=$(echo $GITHUB_SHA | head -c7)
+          echo ::set-output name=tag::${TAG}
+
+      - name: Login to GitHub container registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            docker login --username ${{ github.actor }} --password-stdin ghcr.io
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: control.Dockerfile
+          load: true
+          tags: ghcr.io/estuary/control:test
+
+      - name: Push control image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: control.Dockerfile
+          push: true
+          tags: ghcr.io/estuary/control:${{ steps.prep.outputs.tag }}
+
+      - name: Push control image with 'dev' tag
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: control.Dockerfile
+          push: true # See 'if' above
+          tags: ghcr.io/estuary/control:dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,23 @@ jobs:
   build_control:
     runs-on: ubuntu-20.04
 
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          # `POSTGRES_HOST` is set to `postgres`
+          POSTGRES_DB: flow
+          POSTGRES_PASSWORD: flow
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: flow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -107,6 +124,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: |
+            network=host
 
       - name: Build Docker Image
         uses: docker/build-push-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,13 +396,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "terminal_size",
  "winapi",
 ]
@@ -415,7 +415,10 @@ dependencies = [
  "axum",
  "chrono",
  "hyper",
+ "insta",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
  "tower",
  "tower-http",
@@ -1039,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.7.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+checksum = "b3cb858fc306825b542b1311d5fd536e4483680528f303a17a1d6803b0f6ce17"
 dependencies = [
  "console",
  "lazy_static",
@@ -2105,9 +2108,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -2124,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2146,11 +2149,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa 0.4.7",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2217,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "axum",
  "chrono",
  "config",
+ "ctor",
  "hyper",
  "insta",
  "once_cell",
@@ -566,6 +567,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -70,6 +70,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -196,9 +205,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -221,7 +230,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -295,9 +313,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "caseless"
@@ -370,6 +388,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
+ "serde 1.0.133",
  "time",
  "winapi",
 ]
@@ -444,6 +463,8 @@ dependencies = [
  "reqwest",
  "serde 1.0.133",
  "serde_json",
+ "serde_with",
+ "sqlx",
  "tokio",
  "tower",
  "tower-http",
@@ -466,6 +487,30 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "criterion"
@@ -538,6 +583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +600,16 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.5",
+ "subtle",
 ]
 
 [[package]]
@@ -575,6 +640,41 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -616,7 +716,36 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -638,6 +767,12 @@ dependencies = [
  "tracing",
  "url",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
@@ -782,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -792,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
@@ -808,19 +943,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.16"
+name = "futures-intrusive"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -828,23 +972,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -854,8 +997,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -875,6 +1016,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -953,6 +1104,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1047,6 +1214,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1339,6 +1512,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1542,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1458,6 +1648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1722,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1670,7 +1877,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -1786,16 +1993,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1891,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1979,6 +2180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2261,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.17.0"
 source = "git+https://github.com/jgraettinger/rust-rocksdb#d2ece51f0b120a38ea89c137a1dbb4f7a871e7e0"
@@ -2095,6 +2321,25 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
@@ -2150,6 +2395,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2263,6 +2518,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+dependencies = [
+ "chrono",
+ "rustversion",
+ "serde 1.0.133",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,10 +2559,36 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2324,9 +2629,9 @@ checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
@@ -2365,6 +2670,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "sqlformat"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+dependencies = [
+ "itertools",
+ "nom 7.1.0",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692749de69603d81e016212199d73a2e14ee20e2def7d7914919e8db5d4d48b9"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518be6f6fff5ca76f985d434f9c37f3662af279642acf730388f271dff7b9016"
+dependencies = [
+ "ahash",
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "dirs",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "hmac",
+ "indexmap",
+ "itoa 1.0.1",
+ "libc",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "rand",
+ "rustls",
+ "serde 1.0.133",
+ "serde_json",
+ "sha-1 0.9.8",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+ "webpki",
+ "webpki-roots",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e45140529cf1f90a5e1c2e561500ca345821a1c513652c8f486bbf07407cc8"
+dependencies = [
+ "dotenv",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8061cbaa91ee75041514f67a09398c65a64efed72c90151ecd47593bad53da99"
+dependencies = [
+ "once_cell",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2790,16 @@ name = "stats_alloc"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strsim"
@@ -2389,6 +2814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "superslice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,9 +2827,9 @@ checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2452,18 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2551,6 +2982,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2801,6 +3254,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3482,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "which"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3508,16 @@ checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
  "either",
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +82,51 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "axum"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8757fdd8f5b3ef2838f0e83fff84c4b89c12c93ff95b8448686d10a82ac86a53"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca6c0b218388a7ed6a8d25e94f7dea5498daaa4fd8c711fb3ff166041b06fda"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "base64"
@@ -114,7 +170,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.19",
 ]
 
 [[package]]
@@ -354,6 +410,14 @@ dependencies = [
 [[package]]
 name = "control"
 version = "0.1.0"
+dependencies = [
+ "axum",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber 0.3.5",
+]
 
 [[package]]
 name = "criterion"
@@ -443,7 +507,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -590,6 +654,12 @@ name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -785,6 +855,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.1",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +908,29 @@ checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 0.4.7",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -845,6 +978,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +1000,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jemalloc-ctl"
@@ -1003,6 +1151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,16 +1184,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "memchr"
-version = "2.4.0"
+name = "matchit"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -1045,6 +1217,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1095,6 +1295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1349,31 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "paste"
@@ -1713,7 +1947,19 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -1758,6 +2004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2029,16 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "sources"
@@ -1835,6 +2100,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "tap"
@@ -1940,6 +2211,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,12 +2264,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.26"
+name = "tower"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ee603d6e665ecc7e0f8d479eedb4626bd4726f0ee6119cee5b3a6bf184cac0"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1962,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1973,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -2020,7 +2384,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -2034,6 +2398,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-subscriber"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "treediff"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2423,12 @@ checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
 dependencies = [
  "serde_json",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuple"
@@ -2220,6 +2608,16 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "control"
+version = "0.1.0"
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "async-trait"
@@ -411,13 +411,33 @@ dependencies = [
 name = "control"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "chrono",
+ "hyper",
+ "reqwest",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.5",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "criterion"
@@ -606,6 +626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +689,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -813,6 +857,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "h2"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +983,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -931,6 +995,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -985,6 +1062,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1101,9 +1184,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"
@@ -1283,6 +1366,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1450,39 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1809,6 +1943,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.17.0"
 source = "git+https://github.com/jgraettinger/rust-rocksdb#d2ece51f0b120a38ea89c137a1dbb4f7a871e7e0"
@@ -1865,6 +2035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +2073,29 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2238,6 +2441,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2652,6 +2865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2955,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +108,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -166,7 +172,7 @@ dependencies = [
  "derive",
  "prost",
  "protocol",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "thiserror",
  "tracing",
@@ -236,7 +242,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -258,7 +264,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "schemars",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "sources",
@@ -324,7 +330,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "syn",
  "tempfile",
@@ -346,7 +352,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
 dependencies = [
- "nom",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -363,7 +369,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
  "time",
  "winapi",
 ]
@@ -395,6 +401,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.2",
+ "rust-ini",
+ "serde 1.0.133",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,10 +436,12 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "config",
  "hyper",
  "insta",
+ "once_cell",
  "reqwest",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "tokio",
  "tower",
@@ -455,12 +479,12 @@ dependencies = [
  "csv",
  "itertools",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.14",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
- "serde",
+ "serde 1.0.133",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -532,7 +556,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.7",
  "ryu",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -563,7 +587,7 @@ dependencies = [
  "protocol",
  "rocksdb",
  "rusqlite",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "stats_alloc",
  "tempfile",
@@ -595,7 +619,7 @@ dependencies = [
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -973,7 +997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -1050,7 +1074,7 @@ dependencies = [
  "lazy_static",
  "pest",
  "pest_derive",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "similar",
@@ -1154,7 +1178,7 @@ dependencies = [
  "glob",
  "itertools",
  "percent-encoding",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1168,7 +1192,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
 dependencies = [
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "treediff",
 ]
@@ -1184,6 +1208,19 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1353,7 +1390,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "schemars",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "superslice",
@@ -1388,6 +1425,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
@@ -1414,7 +1462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1438,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -1546,7 +1603,7 @@ dependencies = [
  "fixedbitset 0.4.0",
  "indexmap",
  "itertools",
- "num-traits",
+ "num-traits 0.2.14",
  "rustc-hash",
 ]
 
@@ -1659,7 +1716,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.14",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -1794,7 +1851,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "tracing",
 ]
@@ -1969,7 +2026,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -2006,6 +2063,12 @@ dependencies = [
  "smallvec",
  "url",
 ]
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-hash"
@@ -2055,7 +2118,7 @@ checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
- "serde",
+ "serde 1.0.133",
  "serde_json",
 ]
 
@@ -2108,11 +2171,29 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -2122,7 +2203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2155,7 +2236,7 @@ checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2167,7 +2248,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 0.4.7",
  "ryu",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2178,7 +2259,7 @@ checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
 dependencies = [
  "dtoa",
  "linked-hash-map",
- "serde",
+ "serde 1.0.133",
  "yaml-rust",
 ]
 
@@ -2263,7 +2344,7 @@ dependencies = [
  "protocol",
  "regex",
  "schemars",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -2271,6 +2352,12 @@ dependencies = [
  "url",
  "yaml-merge-keys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stats_alloc"
@@ -2397,7 +2484,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
+ "serde 1.0.133",
  "serde_json",
 ]
 
@@ -2476,7 +2563,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2587,7 +2674,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
- "serde",
+ "serde 1.0.133",
  "tracing-core",
 ]
 
@@ -2602,7 +2689,7 @@ dependencies = [
  "lazy_static",
  "matchers 0.0.1",
  "regex",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -2712,7 +2799,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2721,7 +2808,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "serde",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -2742,7 +2829,7 @@ dependencies = [
  "protocol",
  "regex",
  "rusqlite",
- "serde",
+ "serde 1.0.133",
  "serde_json",
  "serde_yaml",
  "sources",
@@ -2763,7 +2850,7 @@ dependencies = [
  "idna",
  "lazy_static",
  "regex",
- "serde",
+ "serde 1.0.133",
  "serde_derive",
  "serde_json",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,22 @@
 resolver = "2"
 members = [ "crates/*"]
 
+default-members = [
+  "crates/allocator",
+  "crates/bindings",
+  "crates/build",
+  # Deliberately exclude the `control` crate from top level cargo commands.
+  "crates/derive",
+  "crates/doc",
+  "crates/json",
+  "crates/librocks-exp",
+  "crates/models",
+  "crates/protocol",
+  "crates/sources",
+  "crates/tuple",
+  "crates/validation"
+]
+
 [profile.release]
 incremental = true
 debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.

--- a/control.Dockerfile
+++ b/control.Dockerfile
@@ -1,0 +1,54 @@
+# Build Stage
+################################################################################
+FROM rust:1.54-slim-buster as builder
+
+RUN rustup component add clippy
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates pkg-config libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY crates/control/Cargo.toml ./Cargo.lock ./
+
+# Avoid having to install/build all dependencies by copying the Cargo files and
+# making a dummy src/main.rs and empty lib.rs files.
+RUN mkdir ./src \
+  && echo "fn main() {}" > src/main.rs \
+  && touch src/lib.rs \
+  # TODO: figure out if there's a way to use `--locked` with these commands.
+  # There seems to be an issue with building only this single Cargo.toml, but
+  # pulling in the workspace Cargo.lock file.
+  && cargo test \
+  && cargo build --release \
+  && rm -r src
+
+COPY crates/control/src ./src
+
+# This touch prevents Docker from using a cached empty main.rs file.
+RUN touch src/main.rs \
+  && touch src/lib.rs \
+  && cargo test --locked --offline \
+  && cargo clippy --locked --offline \
+  && cargo install --path . --locked --offline
+
+
+# Runtime Stage
+################################################################################
+FROM gcr.io/distroless/cc-debian10
+
+WORKDIR /app
+ENV PATH="/app:$PATH"
+
+# Copy in the connector artifact.
+COPY --from=builder /usr/local/cargo/bin/control ./control-plane-server
+
+# Avoid running the connector as root.
+USER nonroot:nonroot
+
+# We can remove this eventually, but for now this is super useful to just set uniformly.
+# * tower_http=debug gives us access logs.
+ENV RUST_LOG=info,tower_http=debug
+
+ENTRYPOINT ["/app/control-plane-server"]

--- a/control.Dockerfile
+++ b/control.Dockerfile
@@ -25,6 +25,7 @@ RUN mkdir ./src \
   && rm -r src
 
 COPY crates/control/src ./src
+COPY crates/control/config ./config
 
 # This touch prevents Docker from using a cached empty main.rs file.
 RUN touch src/main.rs \
@@ -43,6 +44,7 @@ ENV PATH="/app:$PATH"
 
 # Copy in the connector artifact.
 COPY --from=builder /usr/local/cargo/bin/control ./control-plane-server
+COPY --from=builder /app/config ./config
 
 # Avoid running the connector as root.
 USER nonroot:nonroot

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "control"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -24,6 +24,8 @@ once_cell = "1.9.0"
 reqwest = { version = "0.11.9", features = ["json"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
+serde_with = { version = "1.11.0", features = ["chrono"] }
+sqlx = { version = "0.5.10", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
 tokio = { version = "1.15.0", features = ["full"] }
 tower = { version = "0.4.11", features = ["limit"] }
 tower-http = { version = "0.2.0", features = ["trace"] }

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+ctor = "0.1.21"
 insta = "1.10.0"
 
 [features]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2018"
 anyhow = "1.0.52"
 axum = "0.4.3"
 chrono = "0.4.19"
+config = "0.11.0"
 hyper = { version = "0.14.16", features = ["full"] }
+once_cell = "1.9.0"
 reqwest = { version = "0.11.9", features = ["json"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -6,9 +6,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.52"
 axum = "0.4.3"
+chrono = "0.4.19"
+hyper = { version = "0.14.16", features = ["full"] }
+reqwest = "0.11.9"
 tokio = { version = "1.15.0", features = ["full"] }
 tower = { version = "0.4.11", features = ["limit"] }
 tower-http = { version = "0.2.0", features = ["trace"] }
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[features]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -2,8 +2,17 @@
 name = "control"
 version = "0.1.0"
 edition = "2018"
+default-run = "control"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "control"
+
+[[bin]]
+name = "db_url"
+test = false
+bench = false
 
 [dependencies]
 anyhow = "1.0.52"

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -10,11 +10,16 @@ anyhow = "1.0.52"
 axum = "0.4.3"
 chrono = "0.4.19"
 hyper = { version = "0.14.16", features = ["full"] }
-reqwest = "0.11.9"
+reqwest = { version = "0.11.9", features = ["json"] }
+serde = { version = "1.0.133", features = ["derive"] }
+serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }
 tower = { version = "0.4.11", features = ["limit"] }
 tower-http = { version = "0.2.0", features = ["trace"] }
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+insta = "1.10.0"
 
 [features]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum = "0.4.3"
+tokio = { version = "1.15.0", features = ["full"] }
+tower = { version = "0.4.11", features = ["limit"] }
+tower-http = { version = "0.2.0", features = ["trace"] }
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/control/README.md
+++ b/crates/control/README.md
@@ -1,0 +1,22 @@
+# Control Plane
+
+The Control Plane orchestrates actions taken by API users against the Data Plane.
+
+## Local Development
+
+To run on the local machine, you can just use Cargo from the `control` directory.
+
+```bash
+$ cargo test
+$ cargo run
+```
+
+## Docker
+
+The `control` crate is part of the larger Flow workspace. This means we must use the Flow workspace root as the Docker context to access the `Cargo.lock` file.
+
+```bash
+$ cd ../.. # to flow's root dir
+$ docker build . --file control.Dockerfile -t control:dev
+$ docker run --rm -it -p 3000:3000 control:dev
+```

--- a/crates/control/config/base.toml
+++ b/crates/control/config/base.toml
@@ -1,0 +1,3 @@
+[application]
+host = "127.0.0.1"
+port = 3000

--- a/crates/control/config/base.toml
+++ b/crates/control/config/base.toml
@@ -1,3 +1,10 @@
 [application]
 host = "127.0.0.1"
 port = 3000
+
+[database]
+host = "127.0.0.1"
+port = 5432
+username = "flow"
+password = "flow"
+# `db_name` must be overridden per environment

--- a/crates/control/config/development.toml
+++ b/crates/control/config/development.toml
@@ -1,0 +1,1 @@
+# development env settings

--- a/crates/control/config/development.toml
+++ b/crates/control/config/development.toml
@@ -1,1 +1,5 @@
 # development env settings
+[application]
+
+[database]
+db_name = "control_development"

--- a/crates/control/config/production.toml
+++ b/crates/control/config/production.toml
@@ -1,0 +1,4 @@
+# production env settings
+
+[application]
+host = "0.0.0.0"

--- a/crates/control/config/production.toml
+++ b/crates/control/config/production.toml
@@ -2,3 +2,11 @@
 
 [application]
 host = "0.0.0.0"
+
+# Production database config should be provided through environment variables.
+[database]
+host = ""
+port = 0
+username = "set by production env vars"
+password = "deliberately invalid"
+db_name = "control_production"

--- a/crates/control/config/test.toml
+++ b/crates/control/config/test.toml
@@ -1,0 +1,4 @@
+# test env settings
+
+[application]
+port = 0 # servers launch on a random port in test mode

--- a/crates/control/config/test.toml
+++ b/crates/control/config/test.toml
@@ -2,3 +2,6 @@
 
 [application]
 port = 0 # servers launch on a random port in test mode
+
+[database]
+db_name = "control_test"

--- a/crates/control/src/bin/db_url.rs
+++ b/crates/control/src/bin/db_url.rs
@@ -1,0 +1,10 @@
+/// Prints the database url gathered from the config settings files.
+///
+/// Useful for:
+/// - export DATABASE_URL=$(cargo run --bin db_url)
+/// or
+/// - sqlx database setup --database-url $(cargo run --bin db_url)
+fn main() {
+    let settings = control::config::settings();
+    print!("{}", settings.database.url());
+}

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -8,6 +8,7 @@ pub use app_env::app_env;
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub application: ApplicationSettings,
+    pub database: DatabaseSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -19,6 +20,24 @@ pub struct ApplicationSettings {
 impl ApplicationSettings {
     pub fn address(&self) -> String {
         format!("{}:{}", self.host, self.port)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DatabaseSettings {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub db_name: String,
+}
+
+impl DatabaseSettings {
+    pub fn url(&self) -> String {
+        format!(
+            "postgres://{}:{}@{}:{}/{}",
+            self.username, self.password, self.host, self.port, self.db_name
+        )
     }
 }
 

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 
-mod app_env;
+pub mod app_env;
 
 pub use app_env::app_env;
 

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -61,7 +61,7 @@ fn load_settings() -> Result<Settings, config::ConfigError> {
     config.merge(config::File::from(config_dir.join(app_env().as_str())).required(true))?;
 
     // Load settings from ENV_VARs
-    config.merge(config::Environment::with_prefix("CONTROL"))?;
+    config.merge(config::Environment::with_prefix("CONTROL").separator("_"))?;
 
     config.try_into()
 }

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -1,0 +1,48 @@
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+
+mod app_env;
+
+pub use app_env::app_env;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub application: ApplicationSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApplicationSettings {
+    pub host: String,
+    pub port: u16,
+}
+
+impl ApplicationSettings {
+    pub fn address(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+pub fn settings() -> &'static Settings {
+    static SETTINGS: OnceCell<Settings> = OnceCell::new();
+
+    SETTINGS.get_or_init(|| load_settings().expect("Failed to load settings"))
+}
+
+fn load_settings() -> Result<Settings, config::ConfigError> {
+    let mut config = config::Config::default();
+
+    // TODO: Allow passing a configuration directory as a CLI arg
+    let current_dir = std::env::current_dir().expect("The current directory to be available");
+    let config_dir = current_dir.join("config");
+
+    // Load base settings
+    config.merge(config::File::from(config_dir.join("base")).required(true))?;
+
+    // Load app_env-specific settings
+    config.merge(config::File::from(config_dir.join(app_env().as_str())).required(true))?;
+
+    // Load settings from ENV_VARs
+    config.merge(config::Environment::with_prefix("CONTROL"))?;
+
+    config.try_into()
+}

--- a/crates/control/src/config/app_env.rs
+++ b/crates/control/src/config/app_env.rs
@@ -1,0 +1,44 @@
+use std::convert::{TryFrom, TryInto};
+
+use once_cell::sync::OnceCell;
+
+pub fn app_env() -> &'static AppEnv {
+    static APP_ENV: OnceCell<AppEnv> = OnceCell::new();
+
+    APP_ENV.get_or_init(|| {
+        std::env::var("APP_ENV")
+            .unwrap_or_else(|_| "development".into())
+            .try_into()
+            .expect("To parse APP_ENV")
+    })
+}
+
+#[derive(Debug)]
+pub enum AppEnv {
+    Development,
+    Production,
+    Test,
+}
+
+impl AppEnv {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            &AppEnv::Development => "development",
+            &AppEnv::Production => "production",
+            &AppEnv::Test => "test",
+        }
+    }
+}
+
+impl TryFrom<String> for AppEnv {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "development" => Ok(Self::Development),
+            "production" => Ok(Self::Production),
+            "test" => Ok(Self::Test),
+            otherwise => Err(format!("{} is not a known environment", otherwise)),
+        }
+    }
+}

--- a/crates/control/src/config/app_env.rs
+++ b/crates/control/src/config/app_env.rs
@@ -6,10 +6,10 @@ static APP_ENV: OnceCell<AppEnv> = OnceCell::new();
 
 pub fn app_env() -> &'static AppEnv {
     APP_ENV.get_or_init(|| {
-        std::env::var("APP_ENV")
+        std::env::var("CONTROL_APP_ENV")
             .unwrap_or_else(|_| "development".into())
             .try_into()
-            .expect("To parse APP_ENV")
+            .expect("To parse CONTROL_APP_ENV")
     })
 }
 

--- a/crates/control/src/config/app_env.rs
+++ b/crates/control/src/config/app_env.rs
@@ -2,15 +2,19 @@ use std::convert::{TryFrom, TryInto};
 
 use once_cell::sync::OnceCell;
 
-pub fn app_env() -> &'static AppEnv {
-    static APP_ENV: OnceCell<AppEnv> = OnceCell::new();
+static APP_ENV: OnceCell<AppEnv> = OnceCell::new();
 
+pub fn app_env() -> &'static AppEnv {
     APP_ENV.get_or_init(|| {
         std::env::var("APP_ENV")
             .unwrap_or_else(|_| "development".into())
             .try_into()
             .expect("To parse APP_ENV")
     })
+}
+
+pub fn force_env(target: AppEnv) {
+    APP_ENV.set(target).expect("app_env to be unset")
 }
 
 #[derive(Debug)]

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_with;
+
 pub mod config;
 mod routes;
 mod shutdown;

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -1,18 +1,20 @@
+use std::fmt::Debug;
 use std::future::Future;
 use std::net::TcpListener;
 
+use axum::Json;
 use axum::{routing::get, Router};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
 use tower_http::trace::TraceLayer;
 
 pub fn run(
     listener: TcpListener,
 ) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
-    tracing_subscriber::fmt::init();
-
     let app = Router::new()
         .route("/health_check", get(health_check))
+        .route("/connectors", get(list_connectors))
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
@@ -26,4 +28,34 @@ pub fn run(
 
 async fn health_check() -> String {
     format!("{}", Utc::now())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ConnectorType {
+    Source,
+    Materialization,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Connector {
+    description: String,
+    image: String,
+    name: String,
+    owner: String,
+    r#type: ConnectorType,
+    tags: Vec<String>,
+}
+
+async fn list_connectors() -> Json<Vec<Connector>> {
+    let connectors = vec![Connector {
+        description: "A flood of greetings.".to_owned(),
+        image: "ghcr.io/estuary/source-hello-world".to_owned(),
+        name: "source-hello-world".to_owned(),
+        owner: "Estuary".to_owned(),
+        r#type: ConnectorType::Source,
+        tags: vec!["dev".to_owned()],
+    }];
+
+    Json(connectors)
 }

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -1,30 +1,4 @@
-use std::fmt::Debug;
-use std::future::Future;
-use std::net::TcpListener;
-
-use axum::{routing::get, Router};
-use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
-use tower_http::trace::TraceLayer;
-
 pub mod config;
 mod routes;
 mod shutdown;
-
-pub fn run(
-    listener: TcpListener,
-) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
-    let app = Router::new()
-        .route("/health_check", get(routes::health_check))
-        .route("/connectors", get(routes::list_connectors))
-        .layer(
-            ServiceBuilder::new()
-                .layer(TraceLayer::new_for_http())
-                .layer(ConcurrencyLimitLayer::new(64)),
-        );
-
-    let server = axum::Server::from_tcp(listener)?
-        .serve(app.into_make_service())
-        .with_graceful_shutdown(shutdown::signal());
-
-    Ok(server)
-}
+pub mod startup;

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -1,0 +1,29 @@
+use std::future::Future;
+use std::net::TcpListener;
+
+use axum::{routing::get, Router};
+use chrono::Utc;
+use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
+use tower_http::trace::TraceLayer;
+
+pub fn run(
+    listener: TcpListener,
+) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
+    tracing_subscriber::fmt::init();
+
+    let app = Router::new()
+        .route("/health_check", get(health_check))
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(ConcurrencyLimitLayer::new(64)),
+        );
+
+    let server = axum::Server::from_tcp(listener)?.serve(app.into_make_service());
+
+    Ok(server)
+}
+
+async fn health_check() -> String {
+    format!("{}", Utc::now())
+}

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -8,16 +8,13 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
 use tower_http::trace::TraceLayer;
-use tracing::info;
 
+pub mod config;
 mod shutdown;
 
 pub fn run(
     listener: TcpListener,
 ) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
-    let addr = listener.local_addr()?;
-    let address = format!("http://{}:{}", addr.ip(), addr.port());
-
     let app = Router::new()
         .route("/health_check", get(health_check))
         .route("/connectors", get(list_connectors))
@@ -30,8 +27,6 @@ pub fn run(
     let server = axum::Server::from_tcp(listener)?
         .serve(app.into_make_service())
         .with_graceful_shutdown(shutdown::signal());
-
-    info!("Listening on {}", address);
 
     Ok(server)
 }

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -2,22 +2,20 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::net::TcpListener;
 
-use axum::Json;
 use axum::{routing::get, Router};
-use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
 use tower_http::trace::TraceLayer;
 
 pub mod config;
+mod routes;
 mod shutdown;
 
 pub fn run(
     listener: TcpListener,
 ) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
     let app = Router::new()
-        .route("/health_check", get(health_check))
-        .route("/connectors", get(list_connectors))
+        .route("/health_check", get(routes::health_check))
+        .route("/connectors", get(routes::list_connectors))
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
@@ -29,38 +27,4 @@ pub fn run(
         .with_graceful_shutdown(shutdown::signal());
 
     Ok(server)
-}
-
-async fn health_check() -> String {
-    format!("{}", Utc::now())
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum ConnectorType {
-    Source,
-    Materialization,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Connector {
-    description: String,
-    image: String,
-    name: String,
-    owner: String,
-    r#type: ConnectorType,
-    tags: Vec<String>,
-}
-
-async fn list_connectors() -> Json<Vec<Connector>> {
-    let connectors = vec![Connector {
-        description: "A flood of greetings.".to_owned(),
-        image: "ghcr.io/estuary/source-hello-world".to_owned(),
-        name: "source-hello-world".to_owned(),
-        owner: "Estuary".to_owned(),
-        r#type: ConnectorType::Source,
-        tags: vec!["dev".to_owned()],
-    }];
-
-    Json(connectors)
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -1,9 +1,21 @@
 use std::net::TcpListener;
 
+use tracing::info;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let listener = TcpListener::bind("0.0.0.0:3000")?;
-    Ok(control::run(listener)?.await?)
+    info!("Running in {} mode", control::config::app_env().as_str());
+
+    let settings = control::config::settings();
+    let listener = TcpListener::bind(settings.application.address())?;
+    let server = control::run(listener)?;
+
+    info!("Listening on http://{}", settings.application.address());
+
+    // The server runs until it receives a shutdown signal.
+    server.await?;
+
+    Ok(())
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -1,23 +1,7 @@
-use axum::{routing::get, Router};
-use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
-use tower_http::trace::TraceLayer;
-
-async fn hello_world() -> &'static str {
-    "Hello World"
-}
+use std::net::TcpListener;
 
 #[tokio::main]
-async fn main() {
-    tracing_subscriber::fmt::init();
-
-    let app = Router::new().route("/", get(hello_world)).layer(
-        ServiceBuilder::new()
-            .layer(TraceLayer::new_for_http())
-            .layer(ConcurrencyLimitLayer::new(64)),
-    );
-
-    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+async fn main() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("0.0.0.0:3000")?;
+    Ok(control::run(listener)?.await?)
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -2,15 +2,18 @@ use std::net::TcpListener;
 
 use tracing::info;
 
+use control::config;
+use control::startup;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    info!("Running in {} mode", control::config::app_env().as_str());
+    info!("Running in {} mode", config::app_env().as_str());
 
-    let settings = control::config::settings();
+    let settings = config::settings();
     let listener = TcpListener::bind(settings.application.address())?;
-    let server = control::run(listener)?;
+    let server = startup::run(listener)?;
 
     info!("Listening on http://{}", settings.application.address());
 

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -1,3 +1,23 @@
-fn main() {
-    println!("Hello, world!");
+use axum::{routing::get, Router};
+use tower::{limit::ConcurrencyLimitLayer, ServiceBuilder};
+use tower_http::trace::TraceLayer;
+
+async fn hello_world() -> &'static str {
+    "Hello World"
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let app = Router::new().route("/", get(hello_world)).layer(
+        ServiceBuilder::new()
+            .layer(TraceLayer::new_for_http())
+            .layer(ConcurrencyLimitLayer::new(64)),
+    );
+
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -2,6 +2,8 @@ use std::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let listener = TcpListener::bind("0.0.0.0:3000")?;
     Ok(control::run(listener)?.await?)
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -13,7 +13,8 @@ async fn main() -> anyhow::Result<()> {
 
     let settings = config::settings();
     let listener = TcpListener::bind(settings.application.address())?;
-    let server = startup::run(listener)?;
+    let db = startup::connect_to_postgres().await;
+    let server = startup::run(listener, db)?;
 
     info!("Listening on http://{}", settings.application.address());
 

--- a/crates/control/src/routes.rs
+++ b/crates/control/src/routes.rs
@@ -1,0 +1,37 @@
+use axum::Json;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+pub async fn health_check() -> String {
+    format!("{}", Utc::now())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorType {
+    Source,
+    Materialization,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Connector {
+    description: String,
+    image: String,
+    name: String,
+    owner: String,
+    r#type: ConnectorType,
+    tags: Vec<String>,
+}
+
+pub async fn list_connectors() -> Json<Vec<Connector>> {
+    let connectors = vec![Connector {
+        description: "A flood of greetings.".to_owned(),
+        image: "ghcr.io/estuary/source-hello-world".to_owned(),
+        name: "source-hello-world".to_owned(),
+        owner: "Estuary".to_owned(),
+        r#type: ConnectorType::Source,
+        tags: vec!["dev".to_owned()],
+    }];
+
+    Json(connectors)
+}

--- a/crates/control/src/shutdown.rs
+++ b/crates/control/src/shutdown.rs
@@ -1,0 +1,27 @@
+use tracing::info;
+
+/// Sets up a termination signal handlers. The Future returned by this async
+/// function will resolve when one of these handlers is triggered.
+pub(crate) async fn signal() {
+    use tokio::signal;
+
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("Shutdown signal received, starting graceful shutdown");
+}

--- a/crates/control/src/startup.rs
+++ b/crates/control/src/startup.rs
@@ -1,0 +1,30 @@
+use std::future::Future;
+use std::net::TcpListener;
+
+use axum::routing::get;
+use axum::Router;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::ServiceBuilder;
+use tower_http::trace::TraceLayer;
+
+use crate::routes;
+use crate::shutdown;
+
+pub fn run(
+    listener: TcpListener,
+) -> anyhow::Result<impl Future<Output = Result<(), hyper::Error>>> {
+    let app = Router::new()
+        .route("/health_check", get(routes::health_check))
+        .route("/connectors", get(routes::list_connectors))
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(ConcurrencyLimitLayer::new(64)),
+        );
+
+    let server = axum::Server::from_tcp(listener)?
+        .serve(app.into_make_service())
+        .with_graceful_shutdown(shutdown::signal());
+
+    Ok(server)
+}

--- a/crates/control/tests/it/connectors.rs
+++ b/crates/control/tests/it/connectors.rs
@@ -1,0 +1,18 @@
+use crate::support::spawn_app;
+
+use serde_json::Value as JsonValue;
+
+#[tokio::test]
+async fn list_connectors_works() {
+    let server_address = spawn_app().await.expect("Failed to spawn our app.");
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("http://{}/connectors", server_address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert!(response.status().is_success());
+    assert_json_snapshot!(response.json::<JsonValue>().await.unwrap())
+}

--- a/crates/control/tests/it/health_check.rs
+++ b/crates/control/tests/it/health_check.rs
@@ -1,0 +1,15 @@
+use crate::support::spawn_app;
+
+#[tokio::test]
+async fn health_check_works() {
+    let server_address = spawn_app().await.expect("Failed to spawn our app.");
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("http://{}/health_check", server_address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert!(response.status().is_success());
+}

--- a/crates/control/tests/it/main.rs
+++ b/crates/control/tests/it/main.rs
@@ -1,6 +1,23 @@
+use control::config::app_env::{self, AppEnv};
+
+#[macro_use]
+extern crate ctor;
+
 #[macro_use]
 extern crate insta;
 
 mod connectors;
 mod health_check;
 mod support;
+
+/// Setup runs exactly once before any tests run. This allows the test suite to
+/// perform any one-time setup.
+#[ctor]
+fn setup() {
+    app_env::force_env(AppEnv::Test);
+}
+
+/// Teardown runs exactly once after all tests have run. This allows the test
+/// suite to perform any one-time cleanup.
+#[dtor]
+fn teardown() {}

--- a/crates/control/tests/it/main.rs
+++ b/crates/control/tests/it/main.rs
@@ -1,0 +1,2 @@
+mod health_check;
+mod support;

--- a/crates/control/tests/it/main.rs
+++ b/crates/control/tests/it/main.rs
@@ -1,2 +1,6 @@
+#[macro_use]
+extern crate insta;
+
+mod connectors;
 mod health_check;
 mod support;

--- a/crates/control/tests/it/main.rs
+++ b/crates/control/tests/it/main.rs
@@ -15,6 +15,14 @@ mod support;
 #[ctor]
 fn setup() {
     app_env::force_env(AppEnv::Test);
+
+    let test_db = support::TestDatabase::new();
+
+    // Dropping the database may not be possible, as it may not yet exist, but this is okay.
+    let _ = test_db.drop();
+
+    // Setup will create the database and run all migrations.
+    test_db.setup().expect("To setup the database");
 }
 
 /// Teardown runs exactly once after all tests have run. This allows the test

--- a/crates/control/tests/it/snapshots/it__connectors__list_connectors_works.snap
+++ b/crates/control/tests/it/snapshots/it__connectors__list_connectors_works.snap
@@ -1,0 +1,18 @@
+---
+source: crates/control/tests/it/connectors.rs
+assertion_line: 17
+expression: "response.json::<JsonValue>().await.unwrap()"
+
+---
+[
+  {
+    "description": "A flood of greetings.",
+    "image": "ghcr.io/estuary/source-hello-world",
+    "name": "source-hello-world",
+    "owner": "Estuary",
+    "tags": [
+      "dev"
+    ],
+    "type": "source"
+  }
+]

--- a/crates/control/tests/it/support.rs
+++ b/crates/control/tests/it/support.rs
@@ -1,0 +1,11 @@
+use std::net::TcpListener;
+
+pub async fn spawn_app() -> anyhow::Result<String> {
+    // Binding to port 0 will automatically assign a free random port.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("No random port available");
+    let addr = listener.local_addr()?.to_string();
+    let server = control::run(listener)?;
+    // Tokio runs an executor for each test, so this server will shut down at the end of the test.
+    let _ = tokio::spawn(server);
+    Ok(addr)
+}

--- a/crates/control/tests/it/support.rs
+++ b/crates/control/tests/it/support.rs
@@ -1,11 +1,15 @@
 use std::net::TcpListener;
 
+use control::startup;
+
 pub async fn spawn_app() -> anyhow::Result<String> {
     // Binding to port 0 will automatically assign a free random port.
     let listener = TcpListener::bind("127.0.0.1:0").expect("No random port available");
     let addr = listener.local_addr()?.to_string();
-    let server = control::run(listener)?;
+
     // Tokio runs an executor for each test, so this server will shut down at the end of the test.
+    let server = startup::run(listener)?;
     let _ = tokio::spawn(server);
+
     Ok(addr)
 }

--- a/crates/control/tests/it/support.rs
+++ b/crates/control/tests/it/support.rs
@@ -1,5 +1,8 @@
+use std::io::Error as IoError;
 use std::net::TcpListener;
+use std::process::{Command, Output as ProcessOutput};
 
+use control::config;
 use control::startup;
 
 pub async fn spawn_app() -> anyhow::Result<String> {
@@ -7,9 +10,37 @@ pub async fn spawn_app() -> anyhow::Result<String> {
     let listener = TcpListener::bind("127.0.0.1:0").expect("No random port available");
     let addr = listener.local_addr()?.to_string();
 
+    let db = startup::connect_to_postgres().await;
+
     // Tokio runs an executor for each test, so this server will shut down at the end of the test.
-    let server = startup::run(listener)?;
+    let server = startup::run(listener, db)?;
     let _ = tokio::spawn(server);
 
     Ok(addr)
+}
+
+/// Easily invoke sqlx cli commands to help managed the test database.
+pub(crate) struct TestDatabase {
+    url: String,
+}
+
+impl TestDatabase {
+    pub(crate) fn new() -> Self {
+        TestDatabase {
+            url: config::settings().database.url(),
+        }
+    }
+
+    pub(crate) fn drop(&self) -> Result<ProcessOutput, IoError> {
+        self.run_sqlx(&["database", "drop"])
+    }
+
+    pub(crate) fn setup(&self) -> Result<ProcessOutput, IoError> {
+        self.run_sqlx(&["database", "setup"])
+    }
+
+    fn run_sqlx(&self, args: &[&str]) -> Result<ProcessOutput, IoError> {
+        let cmd_args = [args, &["--database-url", &self.url]].concat();
+        Command::new("sqlx").args(cmd_args).output()
+    }
 }


### PR DESCRIPTION
closes #339 

**Description:**

Just a small step, but we have to start somewhere. Adds a `control` crate to the Flow repo. This houses a web server that will be the Control Plane API. There's currently a simple server, some rudimentary tests, and a system for basic application configuration.

**Workflow steps:**

If you want to try it locally, I'd recommend either:

```bash
$ cargo run
# next terminal
$ curl localhost:3000/health_check
$ curl localhost:3000/connectors
```

**Documentation links affected:**

No user facing impact yet

**Notes for reviewers:**

I recommend walking through commit by commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/345)
<!-- Reviewable:end -->
