### PR TITLE
Add RDS section to Postgres connector docs

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -118,27 +118,29 @@ to allow Flow to connect to databases ports in secure networks.
 
 To set up and configure your SSH server, see the [guide](../../../../guides/connect-network/).
 
-## Setup: PostgreSQL on Amazon RDS
+## PostgreSQL on Amazon RDS
 
 Amazon Relational Database Service (RDS) is a managed web service providing cloud-based instances
 of popular relational databases, including PostgreSQL.
 
+### Setup
+
 You can use this connector for PostgreSQL instances on RDS, but the setup requirements are different.
-Once configured, the connection will behave in the same way as standard PostgreSQL.
 
 1. Create a new RDS PostgreSQL instance for testing. You can
-[reference the instructions from Amazon](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html), but use
-**Standard create mode** to ensure you can access the required settings. Configure the following:
-  * **Engine**: PostgreSQL
-  * **DB instance size**: Dev/Test
-  * Enter a unique **DB instance identifier**, **Master username**, and **Master password** of your choosing.
-  * **DB instance class**: db.t3.micro
-  * **Public access**: Yes
-  * **Enable enhanced monitoring**: False
-2. You'll need to configure secure access to the database to enable the Flow capture.
-  Currently, Estuary supports SSH tunneling to allow this.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
-3. Enable logical replication on the database.
+[reference the instructions from Amazon](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html), but if you're using AWS
+Management Console, be sure to select
+**Standard create mode** so you can access the required settings.
+
+  Configure the following:
+   * **Engine**: PostgreSQL
+   * **DB instance size**: Dev/Test
+   * Enter a unique **DB instance identifier**, **Master username**, and **Master password** of your choosing.
+   * **DB instance class**: db.t3.micro
+   * **Public access**: Yes
+   * **Enable enhanced monitoring**: False
+
+2. Enable logical replication on the database.
 
   a. Create a [parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
   with the following properties:
@@ -152,7 +154,8 @@ Once configured, the connection will behave in the same way as standard PostgreS
   c. [Associate the parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html#USER_WorkingWithParamGroups.Associating) with the database.
 
   d. Reboot the database to allow the new parameter group to take effect.
-4. Run the following commands to create a new user for the capture with appropriate permissions,
+
+3. Run the following commands to create a new user for the capture with appropriate permissions,
 and set up the watermarks table and publication.
   ```sql
   CREATE USER flow_capture WITH PASSWORD '<secret>';
@@ -163,7 +166,15 @@ and set up the watermarks table and publication.
   GRANT ALL PRIVILEGES ON TABLE public.flow_watermarks TO flow_capture;
   CREATE PUBLICATION flow_publication FOR ALL TABLES;
   ```
-5. Configure your connector with the additional `proxy` stanza to enable the SSH tunnel.
+
+4. You'll need to configure secure access to the database to enable the Flow capture.
+  Currently, Estuary supports SSH tunneling to allow this.
+  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+
+5. Configure your connector as you normally would,
+with the additional of the `proxy` stanza to enable the SSH tunnel.
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
-You can find the `remoteHost` and `remotePort`in the [RDS console](https://console.aws.amazon.com/rds/) as the Endpoint and Port, respectively.
+You can find the `remoteHost` and `remotePort` in the [RDS console](https://console.aws.amazon.com/rds/) as the Endpoint and Port, respectively.
+
+Once configured, the connection will behave in the same way as standard PostgreSQL.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -17,6 +17,14 @@ To use this connector, you'll need a PostgreSQL database setup with the followin
 
 ### Setup
 
+:::info
+These setup instructions are PostgreSQL instances you manage yourself. If you use a cloud-based managed service
+for your database, different setup steps are required.
+
+Instructions for setup on Amazon RDS can be found [below](#setup-postgresql-on-amazon-rds). If you use a different managed service,
+contact [Estuary support](mailto:support@estuary.dev).
+:::
+
 The simplest way to meet the above prerequisites is to change the WAL level and have the connector use a database superuser role.
 
 For a more restricted setup, create a new user with just the required permissions as detailed in the following steps:
@@ -109,3 +117,53 @@ The PostgreSQL source connector [supports SSH tunneling](../../../concepts/conne
 to allow Flow to connect to databases ports in secure networks.
 
 To set up and configure your SSH server, see the [guide](../../../../guides/connect-network/).
+
+## Setup: PostgreSQL on Amazon RDS
+
+Amazon Relational Database Service (RDS) is a managed web service providing cloud-based instances
+of popular relational databases, including PostgreSQL.
+
+You can use this connector for PostgreSQL instances on RDS, but the setup requirements are different.
+Once configured, the connection will behave in the same way as standard PostgreSQL.
+
+1. Create a new RDS PostgreSQL instance for testing. You can
+[reference the instructions from Amazon](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html), but use
+**Standard create mode** to ensure you can access the required settings. Configure the following:
+  * **Engine**: PostgreSQL
+  * **DB instance size**: Dev/Test
+  * Enter a unique **DB instance identifier**, **Master username**, and **Master password** of your choosing.
+  * **DB instance class**: db.t3.micro
+  * **Public access**: Yes
+  * **Enable enhanced monitoring**: False
+2. You'll need to configure secure access to the database to enable the Flow capture.
+  Currently, Estuary supports SSH tunneling to allow this.
+  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+3. Enable logical replication on the database.
+
+  a. Create a [parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
+  with the following properties:
+    * **Family**: postgres13
+    * **Type**: DB Parameter group
+    * **Name**: postgres13-logical-replication
+    * **Description**: Database with logical replication enabled
+
+  b. [Modify the new parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html#USER_WorkingWithParamGroups.Modifying) and set `rds.logical_replication=1`.
+
+  c. [Associate the parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html#USER_WorkingWithParamGroups.Associating) with the database.
+
+  d. Reboot the database to allow the new parameter group to take effect.
+4. Run the following commands to create a new user for the capture with appropriate permissions,
+and set up the watermarks table and publication.
+  ```sql
+  CREATE USER flow_capture WITH PASSWORD '<secret>';
+  GRANT rds_replication TO flow_capture;
+  GRANT SELECT ON ALL TABLES IN SCHEMA public TO flow_capture;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO flow_capture;
+  CREATE TABLE IF NOT EXISTS public.flow_watermarks (slot TEXT PRIMARY KEY, watermark TEXT);
+  GRANT ALL PRIVILEGES ON TABLE public.flow_watermarks TO flow_capture;
+  CREATE PUBLICATION flow_publication FOR ALL TABLES;
+  ```
+5. Configure your connector with the additional `proxy` stanza to enable the SSH tunnel.
+See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+for additional details and a sample.
+You can find the `remoteHost` and `remotePort`in the [RDS console](https://console.aws.amazon.com/rds/) as the Endpoint and Port, respectively.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -19,9 +19,10 @@ To use this connector, you'll need a PostgreSQL database setup with the followin
 
 :::info
 These setup instructions are PostgreSQL instances you manage yourself. If you use a cloud-based managed service
-for your database, different setup steps are required.
+for your database, different setup steps may be required.
 
-Instructions for setup on Amazon RDS can be found [below](#setup-postgresql-on-amazon-rds). If you use a different managed service,
+Instructions for setup on Amazon RDS can be found [below](#setup-postgresql-on-amazon-rds). If you use a different managed service
+and the standard steps don't work as expected,
 contact [Estuary support](mailto:support@estuary.dev).
 :::
 
@@ -127,20 +128,11 @@ of popular relational databases, including PostgreSQL.
 
 You can use this connector for PostgreSQL instances on RDS, but the setup requirements are different.
 
-1. Create a new RDS PostgreSQL instance for testing. You can
-[reference the instructions from Amazon](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html), but if you're using AWS
-Management Console, be sure to select
-**Standard create mode** so you can access the required settings.
+1. You'll need to configure secure access to the database to enable the Flow capture.
+  Currently, Estuary supports SSH tunneling to allow this.
+  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
 
-  Configure the following:
-   * **Engine**: PostgreSQL
-   * **DB instance size**: Dev/Test
-   * Enter a unique **DB instance identifier**, **Master username**, and **Master password** of your choosing.
-   * **DB instance class**: db.t3.micro
-   * **Public access**: Yes
-   * **Enable enhanced monitoring**: False
-
-2. Enable logical replication on the database.
+2. Enable logical replication on your existing RDS PostgreSQL instance.
 
   a. Create a [parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
   with the following properties:
@@ -167,14 +159,8 @@ and set up the watermarks table and publication.
   CREATE PUBLICATION flow_publication FOR ALL TABLES;
   ```
 
-4. You'll need to configure secure access to the database to enable the Flow capture.
-  Currently, Estuary supports SSH tunneling to allow this.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
-
-5. Configure your connector as you normally would,
+4. Configure your connector as described in the [configuration](#configuration) section above,
 with the additional of the `proxy` stanza to enable the SSH tunnel.
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
 You can find the `remoteHost` and `remotePort` in the [RDS console](https://console.aws.amazon.com/rds/) as the Endpoint and Port, respectively.
-
-Once configured, the connection will behave in the same way as standard PostgreSQL.


### PR DESCRIPTION
**Description:**

Added instructions from [slack conversation](https://estuaryworkspace.slack.com/archives/C012S5U0WP2/p1643151353092500?thread_ts=1643151253.092400&cid=C012S5U0WP2) to connect to RDS postgres. 

Modified somewhat to instruct user to choose SSH tunneling since that's all we support right now; removed the bit about IP access because we don't have an IP range.

**Workflow steps:**

Nested under Postgres connector docs with the assumption that users that need it will start there. Links to SSH docs included to make it a complete workflow 

I _think_ this should work but might be missing some details needed to get SSH + RDS to work together

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/349)
<!-- Reviewable:end -->
