### PR TITLE
Phil/airbyte keywords

### DIFF
--- a/crates/doc/src/annotation.rs
+++ b/crates/doc/src/annotation.rs
@@ -12,6 +12,12 @@ pub enum Annotation {
     Reduce(reduce::Strategy),
     /// "secret" or "airbyte_secret" annotation keyword.
     Secret(bool),
+    /// "multiline" annotation keyword marks fields that should have a multiline text input in the
+    /// UI. This is from the airbyte spec.
+    Multiline(bool),
+    /// "order" annotation keyword, indicates the desired presentation order of fields in the UI.
+    /// This is from the airbyte spec.
+    Order(i32),
 }
 
 impl schema::Annotation for Annotation {
@@ -26,7 +32,7 @@ impl schema::Annotation for Annotation {
 impl schema::build::AnnotationBuilder for Annotation {
     fn uses_keyword(keyword: &str) -> bool {
         match keyword {
-            "reduce" | "secret" | "airbyte_secret" => true,
+            "reduce" | "secret" | "airbyte_secret" | "multiline" | "order" => true,
             _ => schema::CoreAnnotation::uses_keyword(keyword),
         }
     }
@@ -43,9 +49,17 @@ impl schema::build::AnnotationBuilder for Annotation {
                 Err(e) => Err(AnnotationErr(Box::new(e))),
                 Ok(r) => Ok(Annotation::Reduce(r)),
             },
+            "order" => match i32::deserialize(value) {
+                Err(e) => Err(AnnotationErr(Box::new(e))),
+                Ok(i) => Ok(Annotation::Order(i)),
+            },
             "secret" | "airbyte_secret" => match bool::deserialize(value) {
                 Err(e) => Err(AnnotationErr(Box::new(e))),
                 Ok(b) => Ok(Annotation::Secret(b)),
+            },
+            "multiline" => match bool::deserialize(value) {
+                Err(e) => Err(AnnotationErr(Box::new(e))),
+                Ok(b) => Ok(Annotation::Multiline(b)),
             },
             _ => Ok(Annotation::Core(Core::from_keyword(keyword, value)?)),
         }

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -626,7 +626,6 @@ impl Shape {
                     Annotation::Core(CoreAnnotation::Default(value)) => {
                         shape.default = Some(value.clone());
                     }
-                    Annotation::Secret(b) => shape.secret = Some(*b),
 
                     // String constraints.
                     Annotation::Core(CoreAnnotation::ContentEncoding(enc)) => {
@@ -639,6 +638,13 @@ impl Shape {
                         shape.string.format = Some(format.clone());
                     }
                     Annotation::Core(_) => {} // Other CoreAnnotations are no-ops.
+
+                    // These annotations mostly just influence the UI. Most are ignored for now,
+                    // but explicitly mentioned so that a compiler error will force us to check
+                    // here as new annotations are added.
+                    Annotation::Secret(b) => shape.secret = Some(*b),
+                    Annotation::Multiline(_) => {}
+                    Annotation::Order(_) => {}
                 },
 
                 // Array constraints.

--- a/go/protocols/airbyte/catalog.go
+++ b/go/protocols/airbyte/catalog.go
@@ -233,8 +233,11 @@ type Spec struct {
 	// connectors
 	SupportsDBT bool `json:"supportsDBT,omitempty"`
 	// AuthSpecification is not currently used or supported by Flow or estuary-developed
-	// connectors
+	// connectors, and it is deprecated in the airbyte spec.
 	AuthSpecification json.RawMessage `json:"authSpecification,omitempty"`
+	// AdvancedAuth is not currently used or supported by Flow or estuary-developed
+	// connectors.
+	AdvancedAuth json.RawMessage `json:"advanced_auth,omitempty"`
 }
 
 type MessageType string


### PR DESCRIPTION
**Description:**

Fixes estuary/connectors#88 and estuary/connectors#89 by simply permitting those keywords to be present, without actually doing anything with them.

**Workflow steps:** no change

**Documentation links affected:** none

**Notes for reviewers:**

Originally, I'd started by creating a separate `AirbyteAnnotation` type so that we could eventually move to a model where we only conditionally allow the extra keywords. But the keywords themselves actually seem to be generally reasonable and useful for generating UI form inputs, so I decided to keep them all in our existing `Annotation` enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/351)
<!-- Reviewable:end -->
