### PR TITLE
Add logs documentation, placeholder for stats

### DIFF
--- a/site/docs/concepts/README.md
+++ b/site/docs/concepts/README.md
@@ -121,7 +121,7 @@ and fault tolerance.
 Each shard has an associated **recovery log**, which is a journal into which
 internal checkpoint states are written.
 
-[Learn more about journals](journals.md)
+[Learn more about journals](./advanced/journals.md)
 
 ***
 
@@ -272,7 +272,7 @@ Catalog tasks are created with a single shard,
 which can be repeatedly subdivided at any time — with no downtime — to
 increase the processing capacity of the task.
 
-[Learn more about shards](shards.md)
+[Learn more about shards](./advanced/shards.md)
 
 ***
 

--- a/site/docs/concepts/advanced/logs-stats.md
+++ b/site/docs/concepts/advanced/logs-stats.md
@@ -9,10 +9,10 @@ Access to statistics is still a work in progress. For now, this documentation de
 ## Logs
 
 Each organization, or tenant, that uses Flow has a `logs` collection under the global `ops` prefix.
-For the tenant Acme Co, it would have the name `ops/acmeCo/logs`.
+For the tenant acmeCo, it would have the name `ops/acmeCo/logs`.
 
 These can be thought of as standard application logs:
-they store information about events that occur at catalog build time.
+they store information about events that occur at runtime.
 They’re distinct from [recovery logs](./shards.md#recovery-logs), which track the state of various task shards.
 
 Regardless of how many Flow catalogs your organization has, all logs are stored in the same collection,

--- a/site/docs/concepts/advanced/logs-stats.md
+++ b/site/docs/concepts/advanced/logs-stats.md
@@ -1,5 +1,46 @@
 # Logs and statistics
 
+Flow collects logs and statistics of catalog tasks to aid in debugging and refinement of your workflows.
+
 :::caution
-Page in progress. Check back soon.
+Access to statistics is still a work in progress. For now, this documentation deals strictly with logs.
 :::
+
+## Logs
+
+Each organization, or tenant, that uses Flow has a `logs` collection under the global `ops` prefix.
+For the tenant Acme Co, it would have the name `ops/acmeCo/logs`.
+
+These can be thought of as standard application logs:
+they store information about events that occur at catalog build time.
+They’re distinct from [recovery logs](./shards.md#recovery-logs), which track the state of various task shards.
+
+Regardless of how many Flow catalogs your organization has, all logs are stored in the same collection,
+which is read-only and [logically partitioned](./projections.md#logical-partitions) on [tasks](../README.md#tasks).
+Logs are collected from events that occur within the Flow runtime,
+as well as the capture and materialization [connectors](../connectors.md) your catalog is using.
+
+### Log level
+
+You can set the log level for each catalog task to control the level of detail at which logs are collected for that task.
+The available levels, listed from least to most detailed, are:
+
+* `error`: Non-recoverable errors from the Flow runtime or connector that are critical to know about
+* `warn`: Errors that can be re-tried, but likely require investigation
+* `info`: Task lifecycle events, or information you might want to collect on an ongoing basis
+* `debug`: Details that will help debug an issue with a task
+* `trace`: Maximum level of detail that may yield gigabytes of logs
+
+The default log level is `info`. You can change a task’s log level by adding the `shards` keyword to its definition in the catalog spec:
+
+```yaml
+materializations:
+  acmeCo/debugMaterialization:
+    shards:
+      logLevel: debug
+    endpoint:
+        {}
+```
+
+To learn more about working with logs and statistics,
+see their [reference documentation](../../../reference/working-logs-stats/).

--- a/site/docs/reference/Connectors/_category_.json
+++ b/site/docs/reference/Connectors/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Connectors",
+    "position": 2
+}

--- a/site/docs/reference/organizing-catalogs.md
+++ b/site/docs/reference/organizing-catalogs.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Organizing a Flow catalog
 
 It's not necessary to store the entire catalog spec in one YAML file, and Flow provides the flexibility to reference other files, which can be managed independently. You may want to do so if:

--- a/site/docs/reference/reduction-strategies/_category_.json
+++ b/site/docs/reference/reduction-strategies/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Reduction strategies",
-    "position": 2
+    "position": 3
 }

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -1,0 +1,62 @@
+# Working with logs and statistics
+
+Your [`logs` and `stats` collections](../concepts/advanced/logs-stats.md)
+are useful for debugging and monitoring catalog tasks.
+
+:::caution
+Access to statistics is still a work in progress. For now, this documentation deals strictly with logs.
+:::
+
+## Accessing logs
+
+You can access logs by materializing them to an external endpoint, or from the command line.
+
+For illustrative purposes, the following sections use the word counts example from the [Flow tutorial](../getting-started/flow-tutorials/hello-flow.md).
+
+### Accessing logs from the command line
+
+:::info Beta
+Enhancements to this workflow are coming soon.
+:::
+
+From the command line, you can access logs by printing the journals that comprise them.
+This workflow is ideal if you require logs to debug specific catalog tasks,
+as logs are divided into journals per partition, and each partition maps to a task.
+
+Say you work for Acme Co, and you want to print logs for the materialization `materialize-word-counts`.
+You need to find the name of the correct journal.
+Begin by printing a list of active journals in your environment:
+
+```console
+flowctl journals list
+```
+
+Each task in the catalog will have a journal in the `logs` collection beginning with `ops/acmeCo/logs`.
+Look for the name of the desired task.
+In this case, the journal you’re looking for is: `ops/acmeCo/logs/kind=materialization/name=acmeCo%2Fpostgres%2Fmaterialize-word-counts/pivot=00 `
+
+Print the contents of the journal to view the logs:
+
+```console
+flowctl journals read -l name=ops/acmeCo/logs/kind=materialization/name=acmeCo%2Fpostgres%2Fmaterialize-word-counts/pivot=00
+```
+
+### Accessing logs by materialization
+
+You can materialize your `logs` collection to an external system.
+This is typically the preferred message if you’d like to work with logs for all tasks; in other words, the entire collection.
+
+```yaml
+acmeCo/postgres/logs:
+  endpoint:
+    connector:
+      image: ghcr.io/estuary/materialize-webhook:dev
+      config:
+        address: my.imaginarywebhook.com
+  bindings:
+    - resource:
+        relativePath: /log/wordcount
+      source: ops/acmeCo/logs
+```
+
+If necessary, you can also add [partition selectors](../../concepts/materialization/#partition-selectors) to only materialize logs of specific tasks.

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -3,7 +3,7 @@
 Your [`logs` and `stats` collections](../concepts/advanced/logs-stats.md)
 are useful for debugging and monitoring catalog tasks.
 
-:::caution
+:::info Beta
 Access to statistics is still a work in progress. For now, this documentation deals strictly with logs.
 :::
 
@@ -46,17 +46,25 @@ flowctl journals read -l name=ops/acmeCo/logs/kind=materialization/name=acmeCo%2
 You can materialize your `logs` collection to an external system.
 This is typically the preferred message if you’d like to work with logs for all tasks; in other words, the entire collection.
 
+:::caution
+Be sure to add a [partition selector](../../concepts/materialization/#partition-selectors) to exclude the logs of the materialization
+itself. Otherwise, you could trigger an infinite loop in which the connector
+materializes its own logs, logs that event, and so on.
+:::
+
 ```yaml
 acmeCo/postgres/logs:
   endpoint:
     connector:
       image: ghcr.io/estuary/materialize-webhook:dev
       config:
-        address: my.imaginarywebhook.com
+        address: my.webhook.com
   bindings:
     - resource:
         relativePath: /log/wordcount
       source: ops/acmeCo/logs
+      # Exclude the logs of this materialization to avoid an infinite loop.
+      partitions:
+        exclude:
+          name: ['acmeCo/postgres/logs']
 ```
-
-If necessary, you can also add [partition selectors](../../concepts/materialization/#partition-selectors) to only materialize logs of specific tasks.


### PR DESCRIPTION
**Description:**

We're not quite ready to document stats because they're not as easy to access/work with yet, but documentation for logs  was also missing. 

Two new pages: Added a conceptual page under Advanced concepts. Broke off the section on accessing logs to be a separate doc under Reference, though I'm open to combining the two or moving it elsewhere. 

In the future, the plan is to cover parallel aspects of stats in subsections of these same two docs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

No shortlinks, don't think we need to add any either (?)

**Notes for reviewers:**

YAML samples need particular attention.. especially the example using the webhook connector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/353)
<!-- Reviewable:end -->
