### PR TITLE
runtime: fix five bugs

### DIFF
--- a/crates/protocol/src/consumer.rs
+++ b/crates/protocol/src/consumer.rs
@@ -424,6 +424,21 @@ pub mod get_hints_response {
         pub hints: ::core::option::Option<super::super::recoverylog::FsmHints>,
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnassignRequest {
+    /// Shards to unassign.
+    #[prost(string, repeated, tag="1")]
+    pub shards: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Only unassign shards which have a primary in FAILED status.
+    #[prost(bool, tag="2")]
+    pub only_failed: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnassignResponse {
+    /// Status of the Unassign RPC.
+    #[prost(enumeration="Status", tag="1")]
+    pub status: i32,
+}
 /// Status is a response status code, used across Gazette Consumer RPC APIs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20211118163301-f0ff6cd8fce4
+	go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20211118163301-f0ff6cd8fce4 h1:pgGLbrM/TiKVrEhuzh+S9LNL4OjfDRDHaV8VEGth2q4=
-go.gazette.dev/core v0.89.1-0.20211118163301-f0ff6cd8fce4/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
+go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e h1:iS3yKckWyKO6FeZf1TgffcmcXgR4T2pMnhKp7ywXstc=
+go.gazette.dev/core v0.89.1-0.20220202052436-0087160ef15e/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go/flow/converge_test.go
+++ b/go/flow/converge_test.go
@@ -485,3 +485,6 @@ func (sc *mockShards) Apply(ctx context.Context, in *pc.ApplyRequest, opts ...gr
 func (sc *mockShards) GetHints(ctx context.Context, in *pc.GetHintsRequest, opts ...grpc.CallOption) (*pc.GetHintsResponse, error) {
 	panic("not implemented")
 }
+func (sc *mockShards) Unassign(ctx context.Context, in *pc.UnassignRequest, opts ...grpc.CallOption) (*pc.UnassignResponse, error) {
+	panic("not implemented")
+}

--- a/go/protocols/capture/pull_client.go
+++ b/go/protocols/capture/pull_client.go
@@ -89,6 +89,7 @@ func OpenPull(
 // Serve will call into startCommitFn with a non-nil error exactly once,
 // as its very last invocation.
 func (c *PullClient) Serve(startCommitFn func(error)) {
+	defer c.rpc.CloseSend()
 	var respCh = PullResponseChannel(c.rpc)
 
 	c.loop(startCommitFn,

--- a/go/shuffle/reader_test.go
+++ b/go/shuffle/reader_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
 	"github.com/estuary/flow/go/labels"
-	flowLabels "github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -110,9 +109,9 @@ func TestConsumerIntegration(t *testing.T) {
 			Name: name,
 			LabelSet: pb.MustLabelSet(
 				gazLabels.ContentType, gazLabels.ContentType_JSONLines,
-				flowLabels.Collection, "a/collection",
-				flowLabels.KeyBegin, flowLabels.KeyBeginMin,
-				flowLabels.KeyEnd, flowLabels.KeyEndMax,
+				labels.Collection, "a/collection",
+				labels.KeyBegin, labels.KeyBeginMin,
+				labels.KeyEnd, labels.KeyEndMax,
 			),
 		}))
 	}
@@ -191,7 +190,7 @@ func TestConsumerIntegration(t *testing.T) {
 			HintPrefix:        "/hints",
 			HintBackups:       1,
 			MaxTxnDuration:    time.Second,
-			LabelSet: flowLabels.EncodeRange(pf.RangeSpec{
+			LabelSet: labels.EncodeRange(pf.RangeSpec{
 				KeyBegin:    uint32((math.MaxUint32 / len(shards)) * i),
 				KeyEnd:      uint32((math.MaxUint32/len(shards))*(i+1) - 1),
 				RClockBegin: 0,
@@ -302,11 +301,12 @@ func (a testApp) NewStore(shard consumer.Shard, recorder *recoverylog.Recorder) 
 	}
 
 	readBuilder, err := NewReadBuilder(
-		a.service,
+		a.buildID,
+		make(<-chan struct{}),
 		a.journals,
+		a.service,
 		shard.Spec().Id,
 		a.shuffles,
-		a.buildID,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See individual commits for fixes to #350 & #352. No behavior or documentation changes.

See also the related gazette fix: https://github.com/gazette/core/pull/315

Testing:
 * #352 is a challenging / timing dependent reproduction, but I'm pretty confident this is the underlying cause. New unit tests are added.
 * #350 and gazette/core#314 were manually confirmed by running a catalog that mixed a polled & streaming capture, along with a materialization, and excercising:
   * Multiple timed polling intervals.
   * Multiple deployments of the same catalog tasks, such that their specs were updated.
   * Multiple unassignments of the running materialization to re-create the conditions of assigning to the same reactor & slot, to confirm the "delete and re-create" semantics were honored.
  
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/354)
<!-- Reviewable:end -->
