### PR TITLE
passing primary keys to source connector

### DIFF
--- a/go/capture/driver/airbyte/driver.go
+++ b/go/capture/driver/airbyte/driver.go
@@ -359,10 +359,20 @@ func (d driver) Pull(stream pc.Driver_PullServer) error {
 			projections[p.Field] = p.Ptr
 		}
 
+		var primaryKey = make([][]string, 0, len(binding.Collection.KeyPtrs))
+		for _, key := range binding.Collection.KeyPtrs {
+			if ptr, err := jsonpointer.New(key); err != nil {
+				return fmt.Errorf("parsing json pointer: %w", err)
+			} else {
+				primaryKey = append(primaryKey, ptr.DecodedTokens())
+			}
+		}
+
 		catalog.Streams = append(catalog.Streams,
 			airbyte.ConfiguredStream{
 				SyncMode:            resource.SyncMode,
 				DestinationSyncMode: airbyte.DestinationSyncModeAppend,
+				PrimaryKey:          primaryKey,
 				Stream: airbyte.Stream{
 					Name:               resource.Stream,
 					Namespace:          resource.Namespace,


### PR DESCRIPTION
**Description:**

Parse `KeyPtrs`  as a list of segments, and pass it to the source DB connector.
This enables overriding the DB primary key if the keys specified for catalog collections differ from the DB primary keys, and in that case the catalog collection keys wins, according to [this logic](https://github.com/estuary/connectors/blob/main/sqlcapture/capture.go#L186-L195) 

**Workflow steps:**
To enable the key overriding, specify the key in the catalog capture collections. E.g. the following specification enables <user_id, created> to be the primary keys for storing data captured from a psql table `search_phrases`, which has no primary key specified in the DB.
```
collections:
  deepsync/search_phrases:   # Table has no primary key
    schema: search_phrases.schema.yaml
    key: [/user_id, /created] # This specifies the <user_id, created> to be the keys used internally for processing data from the table search_phrases.
```

**Documentation links affected:**
The primary use case for the change is for some corner cases - to capture a DB tables without primary keys. I am unaware of any existing docs that is related to it. 

(We could later created some documentation that related to how to capture DB tables without primary keys, which could be in a separate doc, and not related to this PR.)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/359)
<!-- Reviewable:end -->
