### PR TITLE
go/shuffle: audit and update logging, and use ops.Logger

### DIFF
--- a/go/shuffle/api_test.go
+++ b/go/shuffle/api_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/ops"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -97,7 +98,7 @@ func TestAPIIntegrationWithFixtures(t *testing.T) {
 	// Use a resolve() fixture which returns a mocked store with our |coordinator|.
 	var srv = server.MustLoopback()
 	var apiCtx, cancelAPICtx = context.WithCancel(backgroundCtx)
-	var coordinator = NewCoordinator(apiCtx, bk.Client(), builds)
+	var coordinator = NewCoordinator(apiCtx, builds, ops.StdLogger(), bk.Client())
 
 	pf.RegisterShufflerServer(srv.GRPCServer, &API{
 		resolve: func(args consumer.ResolveArgs) (consumer.Resolution, error) {
@@ -147,7 +148,8 @@ func TestAPIIntegrationWithFixtures(t *testing.T) {
 		}, nil
 	}
 	var replayRead = &read{
-		spec: *journalSpec,
+		logger: ops.StdLogger(),
+		spec:   *journalSpec,
 		req: pf.ShuffleRequest{
 			Shuffle:   shuffle,
 			Range:     range_,
@@ -197,7 +199,8 @@ func TestAPIIntegrationWithFixtures(t *testing.T) {
 	badShuffle.SourceSchemaUri += "/does/not/exist"
 
 	var badRead = &read{
-		spec: *journalSpec,
+		logger: ops.StdLogger(),
+		spec:   *journalSpec,
 		req: pf.ShuffleRequest{
 			Shuffle:   badShuffle,
 			Range:     range_,

--- a/go/shuffle/reader_test.go
+++ b/go/shuffle/reader_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/ops"
 	"github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
@@ -304,6 +305,7 @@ func (a testApp) NewStore(shard consumer.Shard, recorder *recoverylog.Recorder) 
 		a.buildID,
 		make(<-chan struct{}),
 		a.journals,
+		ops.StdLogger(),
 		a.service,
 		shard.Spec().Id,
 		a.shuffles,
@@ -312,7 +314,7 @@ func (a testApp) NewStore(shard consumer.Shard, recorder *recoverylog.Recorder) 
 		return nil, err
 	}
 
-	var coordinator = NewCoordinator(shard.Context(), shard.JournalClient(), a.builds)
+	var coordinator = NewCoordinator(shard.Context(), a.builds, ops.StdLogger(), shard.JournalClient())
 
 	return &testStore{
 		JSONFileStore: store,


### PR DESCRIPTION
**Description:**

Shuffled reads now log to the ops.Logger, and are controllable using a
per-shard log level.

Do a comprehensive audit and update of the debug logging
we have in place around journal reads.

Issue #355

**Workflow steps:**

The `shards: {logLevel: debug}` stanza of a catalog task (derivation or materialization) now authors debug logs into the operations log.

**Documentation links affected:**

No documentation impacts, as this simply makes ops logs more functional / comprehensive.

**Notes for reviewers:**

nada

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/362)
<!-- Reviewable:end -->
