### PR TITLE
read & debugging telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42
+	go.gazette.dev/core v0.89.1-0.20220212151322-e7c18c1b78cc
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c
+	go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c h1:Kav7gx3Zy4FRNqBhhEWAvXJaKdPEO8qJKQBCxdGH0HI=
-go.gazette.dev/core v0.89.1-0.20220207160125-861bd211798c/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
+go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42 h1:54cqW1TN7KsOnIU7JqEdDPN9G7ut8zg4Q5OcIehJzGc=
+go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42 h1:54cqW1TN7KsOnIU7JqEdDPN9G7ut8zg4Q5OcIehJzGc=
-go.gazette.dev/core v0.89.1-0.20220211035637-fb71eec18f42/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
+go.gazette.dev/core v0.89.1-0.20220212151322-e7c18c1b78cc h1:GyR68JB114+qvRCqqD4Isnm8wedXq3DTmYkdr9x+9g8=
+go.gazette.dev/core v0.89.1-0.20220212151322-e7c18c1b78cc/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -367,11 +367,11 @@ func (r *read) sendReadResult(resp *pf.ShuffleResponse, err error, wakeCh chan<-
 			// Fall through to send to channel.
 
 		case <-timer.C:
-			if queue > 10 { // Log values > 1s.
+			if queue > 13 { // Log values > 8s.
 				r.log(logrus.DebugLevel,
 					"backpressure timer elapsed on a slow shuffle read",
 					"queue", queue,
-					"backoff", dur,
+					"backoff", dur.Seconds(),
 				)
 			}
 			// Fall through to send to channel.

--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -634,8 +634,8 @@ func pickHRW(h uint32, from []shuffleMember, start, stop int) int {
 }
 
 // readChannelCapacity is sized so that sendReadResult will overflow and
-// cancel the read after ~65 seconds of no progress (1<<15 + 1<<14 + 1<<13 ... millis).
-var readChannelCapacity = 17
+// cancel the read after ~35 minutes of no progress (1<<20 + 1<<19 + 1<<18 ... millis).
+var readChannelCapacity = 22
 
 func backoff(attempt int) time.Duration {
 	// The choices of backoff time reflect that we're usually waiting for the

--- a/go/shuffle/ring.go
+++ b/go/shuffle/ring.go
@@ -154,10 +154,12 @@ func (r *ring) onRead(staged *pf.ShuffleResponse, ok bool, ex *bindings.Extracto
 		// Reader at the top of the read stack has exited.
 		r.readChans = r.readChans[:len(r.readChans)-1]
 
-		r.log(logrus.DebugLevel,
-			"completed catch-up journal read",
-			"reads", len(r.readChans),
-		)
+		if len(r.readChans) != 0 {
+			r.log(logrus.DebugLevel,
+				"completed catch-up journal read",
+				"reads", len(r.readChans),
+			)
+		}
 		return
 	}
 


### PR DESCRIPTION
**Description:**

Substantially increase the read cancellation timeout, from ~65 seconds to ~35 minutes.

Investigation of read amplification highlighted that mixing (relatively) frequent cancellations,
aggressive buffering, and connector transactions that regularly took ~2-3 minutes results
in pretty extravagant numbers of surplus reads from Gazette.

Relaxing this cancellation appears to have wholly resolved the problem.

Otherwise, add more telemetry.
* Support `pprof.Labels` so that we can associate specific shards, builds, and journals to goroutine traces (`debug=1`) and profiles.
* Add a new metric which surfaces the polling state of each ongoing shuffled journal read undertaken by a shard. This is helpful for understanding which specific journal(s) a shard is waiting for data from, which can then in turn be used to track down what the journal's read loop is doing.

**Workflow steps:**

No new user-facing features.

Developers can take profiles `/debug/pprof` and use `/debug/pprof/goroutine?debug=1` to get stack traces which are tightly associated with originating shards & journals. This **massively** simplifies debugging a Flow reactor with lots of things going on.

**Documentation links affected:**

None I'm aware of.

**Notes for reviewers:**

Nada

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/366)
<!-- Reviewable:end -->
