### PR TITLE
bigquery connector docs

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -1,7 +1,8 @@
-This Flow connector materializes Flow collections into Google BigQuery datasets. It allows both standard and [delta updates](../../../concepts/materialization.md#delta-updates).
+This Flow connector materializes Flow collections into tables within a Google BigQuery dataset.
+It allows both standard and [delta updates](../../../concepts/materialization.md#delta-updates).
 
-The connector uses a service account to materialize to BigQuery by way of tables in Google Cloud Storage (GCS).
-These tables act as a temporary staging area for data storage and retrieval.
+The connector uses your Google Cloud service account to materialize to BigQuery tables by way of tables in a Google Cloud Storage (GCS) bucket.
+The tables in the bucket act as a temporary staging area for data storage and retrieval.
 
 `ghcr.io/estuary/materialize-bigquery:dev` provides the latest connector image when using the Flow GitOps environment. You can also follow the link in your browser to see past image versions.
 
@@ -20,22 +21,31 @@ To use this connector, you'll need:
 
 ## Configuration
 
-To use this connector, begin with a Flow catalog that has at least one **collection**. You'll add a BigQuery materialization, which will direct one or more of your Flow collections to your desired BigQuery datasets. Follow the basic [materialization setup](../../../concepts/materialization.md#specification) and add the required BigQuery configuration values per the table below.
+To use this connector, begin with a Flow catalog that has at least one collection.
+You'll add a BigQuery materialization, which will direct one or more of your Flow collections to your desired tables within a BigQuery dataset.
+Follow the basic [materialization setup](../../../concepts/materialization.md#specification) and add the required BigQuery configuration values per the table below.
+
+This configuration assumes a working knowledge of resource organization in BigQuery.
+You can find introductory documentation in the [BigQuery docs](https://cloud.google.com/bigquery/docs/resource-hierarchy).
 
 ### Values
 
 | Value | Name | Type | Required/Default | Details |
 |-------|------|------|---------| --------|
-| `ProjectID`| Project ID | String | Required | The project ID for the Google Cloud Storage bucket and BigQuery dataset|
-| `Dataset` | Dataset | String | Required | ??????|
-| `Region` | Region | String | Required | The GCS region |
-| `Bucket` | Bucket | string | Required | Name of the GCS bucket |
-| `BucketPath` | Bucket Path | String | Required | Base path to the GCS bucket |
-| `CredentialsFile` | Credentials File | String | * | Path to a JSON service account file |
-| `CredentialsJSON` | Credentials JSON | Byte | * | Base64-encoded string of the full service account file |
+| `project_id`| Project ID | String | Required | The project ID for the Google Cloud Storage bucket and BigQuery dataset|
+| `billing_project_id` | Billing project ID | String | Same as `project_id` | The project ID to which these operations are billed in BigQuery* |
+| `dataset` | Dataset | String | Required | Name of the target BigQuery dataset |
+| `region` | Region | String | Required | The GCS region |
+| `bucket` | Bucket | string | Required | Name of the GCS bucket |
+| `bucket_path` | Bucket Path | String | Required | Base path within the GCS bucket |
+| `credentials_file` | Credentials File | String | ** | Path to a JSON service account file |
+| `credentials_json` | Credentials JSON | Byte | ** | Base64-encoded string of the full service account file |
 
-*One of `CredentialsFile` or `CredentialsJSON` is required. If both are provided, the connector will try
-to use `CredentialsFile` first.
+*Typically, you want this to be the same as `project_id` (the default).
+To learn more about project billing, [see the BigQuery docs](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled).
+
+**One of `credentials_file` or `credentials_json` is required. If both are provided, the connector will try
+to use `credentials_file` first.
 
 ### Sample
 
@@ -46,13 +56,17 @@ materializations:
 	  endpoint:
   	    connector:
     	    config:
-               FILL IN HERE!!!!!!!!!!!!!!
+              project_ID: our-bigquery-project
+              dataset: materialized-data
+              region: US
+              bucket: our-gcs-bucket
+              bucket_path: bucket-path/
+              credentials_file: /workspace/secret/credentials.json
     	    image: ghcr.io/estuary/materialize-bigquery:dev
 	# If you have multiple collections you need to materialize, add a binding for each one
     # to ensure complete data flow-through
     bindings:
   	- resource:
-      	workspace: ${namespace_name}
-      	collection: ${table_name}
+      	table: ${table_name}
     source: ${tenant}/${source_collection}
     ```

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -1,0 +1,19 @@
+This Flow connector materializes Flow collections into Google BigQuery datasets. It allows both standard and [delta updates](../../../concepts/materialization.md#delta-updates).
+
+The connector uses a service account to materialize to BigQuery by way of tables in Google Cloud Storage (GCS).
+These tables act as a temporary staging area for data storage and retrieval.
+
+`ghcr.io/estuary/materialize-bigquery:dev` provides the latest connector image when using the Flow GitOps environment. You can also follow the link in your browser to see past image versions.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* An existing catalog spec that includes at least one collection with its schema specified
+* A [new Google Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets) in the same region as the BigQuery destination dataset.
+* A Google Cloud [service account](https://cloud.google.com/docs/authentication/getting-started) with a key file generated and the following roles:
+    * [`roles/bigquery.dataEditor`](https://cloud.google.com/bigquery/docs/access-control#bigquery.dataEditor) on the destination dataset
+    * [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser) on each
+    project with which the BigQuery destination is associated
+    * ['roles/storage.objectAdmin'](https://cloud.google.com/storage/docs/access-control/iam-roles#standard-roles)
+    on the GCS bucket created above

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -1,7 +1,7 @@
 This Flow connector materializes Flow collections into tables within a Google BigQuery dataset.
 It allows both standard and [delta updates](#delta-updates).
 
-The connector uses your Google Cloud service account to materialize to BigQuery tables by way of tables in a Google Cloud Storage (GCS) bucket.
+The connector uses your Google Cloud service account to materialize to BigQuery tables by way of files in a Google Cloud Storage (GCS) bucket.
 The tables in the bucket act as a temporary staging area for data storage and retrieval.
 
 `ghcr.io/estuary/materialize-bigquery:dev` provides the latest connector image when using the Flow GitOps environment. You can also follow the link in your browser to see past image versions.
@@ -10,7 +10,7 @@ The tables in the bucket act as a temporary staging area for data storage and re
 
 To use this connector, you'll need:
 
-* An existing catalog spec that includes at least one collection with its schema specified
+* An existing catalog spec that includes at least one collection
 * A [new Google Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets) in the same region as the BigQuery destination dataset.
 * A Google Cloud [service account](https://cloud.google.com/docs/authentication/getting-started) with a key file generated and the following roles:
     * [`roles/bigquery.dataEditor`](https://cloud.google.com/bigquery/docs/access-control#bigquery.dataEditor) on the destination dataset
@@ -38,14 +38,10 @@ You can find introductory documentation in the [BigQuery docs](https://cloud.goo
 | `region` | Region | String | Required | The GCS region |
 | `bucket` | Bucket | string | Required | Name of the GCS bucket |
 | `bucket_path` | Bucket Path | String | Required | Base path within the GCS bucket |
-| `credentials_file` | Credentials File | String | ** | Path to a JSON service account file |
-| `credentials_json` | Credentials JSON | Byte | ** | Base64-encoded string of the full service account file |
+| `credentials_json` | Credentials JSON | Byte | Required | Base64-encoded string of the full service account file |
 
 *Typically, you want this to be the same as `project_id` (the default).
 To learn more about project billing, [see the BigQuery docs](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled).
-
-**One of `credentials_file` or `credentials_json` is required. If both are provided, the connector will try
-to use `credentials_file` first.
 
 ### Sample
 
@@ -61,7 +57,7 @@ materializations:
               region: US
               bucket: our-gcs-bucket
               bucket_path: bucket-path/
-              credentials_file: /workspace/secret/credentials.json
+              credentials_json: SSBqdXN0IHdhbm5hIHRlbGwgeW91IGhvdyBJJ20gZmVlbGluZwpHb3R0YSBtYWtlIHlvdSB1bmRlcnN0YW5kCk5ldmVyIGdvbm5hIGdpdmUgeW91IHVwCk5ldmVyIGdvbm5hIGxldCB5b3UgZG93bgpOZXZlciBnb25uYSBydW4gYXJvdW5kIGFuZCBkZXNlcnQgeW91Ck5ldmVyIGdvbm5hIG1ha2UgeW91IGNyeQpOZXZlciBnb25uYSBzYXkgZ29vZGJ5ZQpOZXZlciBnb25uYSB0ZWxsIGEgbGllIGFuZCBodXJ0IHlvdQ==
     	    image: ghcr.io/estuary/materialize-bigquery:dev
 	# If you have multiple collections you need to materialize, add a binding for each one
     # to ensure complete data flow-through
@@ -76,8 +72,7 @@ materializations:
 This connector supports both standard (merge) and [delta updates](../../../concepts/materialization.md#delta-updates).
 The default is to use standard updates.
 
-Enabling delta updates can significantly reduce Flow's resource usage, making it a good way to
-reduce cost when materializing extremely large datasets.
+Enabling delta updates will prevent Flow from querying for documents in your BigQuery table, which can reduce latency and costs for large datasets.
 If you're certain that all events will have unique keys, enabling delta updates is a simple way to improve
 performance with no effect on the output.
 However, enabling delta updates is not suitable for all workflows, as the resulting table in BigQuery won't be fully reduced.

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -13,7 +13,46 @@ To use this connector, you'll need:
 * A [new Google Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets) in the same region as the BigQuery destination dataset.
 * A Google Cloud [service account](https://cloud.google.com/docs/authentication/getting-started) with a key file generated and the following roles:
     * [`roles/bigquery.dataEditor`](https://cloud.google.com/bigquery/docs/access-control#bigquery.dataEditor) on the destination dataset
-    * [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser) on each
-    project with which the BigQuery destination is associated
-    * ['roles/storage.objectAdmin'](https://cloud.google.com/storage/docs/access-control/iam-roles#standard-roles)
+    * [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser) on the
+    project with which the BigQuery destination dataset is associated
+    * [`roles/storage.objectAdmin`](https://cloud.google.com/storage/docs/access-control/iam-roles#standard-roles)
     on the GCS bucket created above
+
+## Configuration
+
+To use this connector, begin with a Flow catalog that has at least one **collection**. You'll add a BigQuery materialization, which will direct one or more of your Flow collections to your desired BigQuery datasets. Follow the basic [materialization setup](../../../concepts/materialization.md#specification) and add the required BigQuery configuration values per the table below.
+
+### Values
+
+| Value | Name | Type | Required/Default | Details |
+|-------|------|------|---------| --------|
+| `ProjectID`| Project ID | String | Required | The project ID for the Google Cloud Storage bucket and BigQuery dataset|
+| `Dataset` | Dataset | String | Required | ??????|
+| `Region` | Region | String | Required | The GCS region |
+| `Bucket` | Bucket | string | Required | Name of the GCS bucket |
+| `BucketPath` | Bucket Path | String | Required | Base path to the GCS bucket |
+| `CredentialsFile` | Credentials File | String | * | Path to a JSON service account file |
+| `CredentialsJSON` | Credentials JSON | Byte | * | Base64-encoded string of the full service account file |
+
+*One of `CredentialsFile` or `CredentialsJSON` is required. If both are provided, the connector will try
+to use `CredentialsFile` first.
+
+### Sample
+
+```yaml
+# If this is the first materialization, add the section to your catalog spec
+materializations:
+  ${tenant}/${mat_name}:
+	  endpoint:
+  	    connector:
+    	    config:
+               FILL IN HERE!!!!!!!!!!!!!!
+    	    image: ghcr.io/estuary/materialize-bigquery:dev
+	# If you have multiple collections you need to materialize, add a binding for each one
+    # to ensure complete data flow-through
+    bindings:
+  	- resource:
+      	workspace: ${namespace_name}
+      	collection: ${table_name}
+    source: ${tenant}/${source_collection}
+    ```

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -1,5 +1,5 @@
 This Flow connector materializes Flow collections into tables within a Google BigQuery dataset.
-It allows both standard and [delta updates](../../../concepts/materialization.md#delta-updates).
+It allows both standard and [delta updates](#delta-updates).
 
 The connector uses your Google Cloud service account to materialize to BigQuery tables by way of tables in a Google Cloud Storage (GCS) bucket.
 The tables in the bucket act as a temporary staging area for data storage and retrieval.
@@ -69,4 +69,25 @@ materializations:
   	- resource:
       	table: ${table_name}
     source: ${tenant}/${source_collection}
-    ```
+```
+
+## Delta updates
+
+This connector supports both standard (merge) and [delta updates](../../../concepts/materialization.md#delta-updates).
+The default is to use standard updates.
+
+Enabling delta updates can significantly reduce Flow's resource usage, making it a good way to
+reduce cost when materializing extremely large datasets.
+If you're certain that all events will have unique keys, enabling delta updates is a simple way to improve
+performance with no effect on the output.
+However, enabling delta updates is not suitable for all workflows, as the resulting table in BigQuery won't be fully reduced.
+
+You can enable delta updates on a per-binding basis:
+
+```yaml
+    bindings:
+  	- resource:
+      	table: ${table_name}
+        delta_updates: true
+    source: ${tenant}/${source_collection}
+```

--- a/site/docs/reference/Connectors/materialization-connectors/Rockset.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Rockset.md
@@ -4,7 +4,7 @@ This Flow connector materializes [delta updates](../../../concepts/materializati
 
 ## Prerequisites
 
-To use this connector, you'll need :
+To use this connector, you'll need:
 * An existing catalog spec that includes at least one collection with its schema specified
 * A Rockset account with an [API key generated](https://rockset.com/docs/rest-api/#createapikey) from the web UI
 * A Rockset workspace

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1408,6 +1408,17 @@
         "webpack-dev-server": "^4.5.0",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.0-3"
+      },
+      "dependencies": {
+        "react-loadable": {
+          "version": "npm:@docusaurus/react-loadable@5.5.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+          "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "@docusaurus/cssnano-preset": {
@@ -7577,15 +7588,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-loadable": {
-      "version": "npm:@docusaurus/react-loadable@5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "requires": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
-      }
     },
     "react-loadable-ssr-addon-v5-slorber": {
       "version": "1.0.1",


### PR DESCRIPTION
**Description:**

Add docs for bigquery connector. 

**Documentation links affected:**

created new shortlink for future (verify after merge & deploy)
https://go.estuary.dev/materialize-bigquery

**Notes for reviewers:**

- Roles in the [README](https://github.com/estuary/connectors/tree/main/materialize-bigquery#readme) didn’t align exactly with the names of roles found in the GCS/bigquery help. I went with Google’s version, but this is worth verifying that I picked the right ones.
- In some connector docs (like Postgres) we give step-by-step setup to walk people through meeting the prerequisites. In others (Like Rockset) we don’t. This simply has to do with how intuitive setup would be for users of the particular endpoint. In this case, I didn’t add steps. If anyone has experience to indicate that steps _would_ be warranted, please let me know
- Based on a conversation re: the deepsync POC and some subsequent chatting with @dyaffe, I’m explicitly asking users to create _their own_ service account and storage bucket. If there’s any other implications that came out of the deepsync POC that I’m missing please let me know.
- I have my eye on this PR https://github.com/estuary/connectors/pull/129 and will make changes after it’s merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/367)
<!-- Reviewable:end -->
