### PR TITLE
ci: Remove extra logging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,8 +151,6 @@ jobs:
 
       # Use to the cached version of cargo-cache if it exists. Saves minutes installing it.
       - run: |
-          cargo cache --version
-          echo "$CARGO_CACHE_VERSION"
           if [[ $(cargo cache --version) != "cargo-cache $CARGO_CACHE_VERSION" ]]; then
             cargo install --force cargo-cache --version="$CARGO_CACHE_VERSION"
           fi


### PR DESCRIPTION
**Description:**

This causes CI to fail when there is no `cargo-cache` binary in the cache.

**Notes for reviewers:**

This was helpful when I was working on the CI stuff on my branch, but it got left in accidentally in one place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/381)
<!-- Reviewable:end -->
