### PR TITLE
Adds builds_root module to control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.4",
  "reqwest",
+ "rusqlite",
  "serde 1.0.133",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.5",
  "url",
+ "validator",
 ]
 
 [[package]]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3.19"
 hyper = { version = "0.14.16", features = ["full"] }
 once_cell = "1.9.0"
 rand = "0.8.4"
+rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
 reqwest = { version = "0.11.9", features = ["json"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }
@@ -31,7 +32,7 @@ tower = { version = "0.4.11", features = ["limit"] }
 tower-http = { version = "0.2.0", features = ["cors", "trace"] }
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.2.2"
+url = {version = "2.2.2", features = ["serde"]}
 
 [dev-dependencies]
 axum-debug = "0.3.2"

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -33,6 +33,7 @@ tower-http = { version = "0.2.0", features = ["cors", "trace"] }
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = {version = "2.2.2", features = ["serde"]}
+validator = {version = "*", features = ["derive"]}
 
 [dev-dependencies]
 axum-debug = "0.3.2"

--- a/crates/control/README.md
+++ b/crates/control/README.md
@@ -4,19 +4,36 @@ The Control Plane orchestrates actions taken by API users against the Data Plane
 
 ## Local Development
 
+A Postgres instance is required for both compilation and testing, and the connection URL must be
+exported as the environment variable `DATABASE_URL`.
+
+For running integration tests:
+
+```bash
+$ docker run --network host -e POSTGRES_USER=flow -e POSTGRES_PASSWORD=flow --detach postgres:14
+$ export DATABASE_URL=postgres://flow:flow@localhost:5432/postgres
+$ cargo test --all-targets --all-features
+```
+
+The `--all-features` is needed because the integration tests require certain features to be present.
+The features are required so that a `cargo test --all` from the repo root will not try to run
+control plane integration tests.
+
+Postgres will not be required during compilation if the `SQLX_OFFLINE` env variable is `true`. In
+that case, it will rely on the checked-in `sqlx-data.json` for query type checking instead of doing
+it dynamically based on the database schema. When running `cargo build` from the repository root
+(only), the `.cargo/config.toml` will set `SQLX_OFFLINE=true`.
+
+
+### Running locally
+
 To run on the local machine, you can just use Cargo from the `control` directory.
 
 ```bash
-$ cargo test
 $ cargo run
 ```
 
-## Docker
+This uses `crates/control/src/main.rs`, which is exclusively for local dev environments. `main.rs`
+is _not_ used for production. The "official" way to run control plane is to run `flowctl
+control-plane serve`. 
 
-The `control` crate is part of the larger Flow workspace. This means we must use the Flow workspace root as the Docker context to access the `Cargo.lock` file.
-
-```bash
-$ cd ../.. # to flow's root dir
-$ docker build . --file control.Dockerfile -t control:dev
-$ docker run --rm -it -p 3000:3000 control:dev
-```

--- a/crates/control/config/development.toml
+++ b/crates/control/config/development.toml
@@ -20,3 +20,6 @@ port = 5432
 username = "flow"
 password = "flow"
 db_name = "control_development"
+
+[builds_root]
+uri = "file:///var/tmp/flow-builds/"

--- a/crates/control/config/test.toml
+++ b/crates/control/config/test.toml
@@ -11,3 +11,6 @@ allowed_origins = ["*"]
 # test databases are created for each test in the suite. They are derived from
 # the development database. Settings here would not have much meaning. See the
 # development.toml, .env, and tests/it/main.rs for more information.
+
+[builds_root]
+uri = "file:///var/tmp/flow-builds/"

--- a/crates/control/src/cmd/serve.rs
+++ b/crates/control/src/cmd/serve.rs
@@ -24,7 +24,8 @@ pub fn run(args: Args) -> anyhow::Result<()> {
 
 async fn serve(listener: TcpListener) -> anyhow::Result<()> {
     let db = startup::connect_to_postgres(&config::settings().database).await;
-    let server = startup::run(listener, db)?;
+    let (put_builds, fetch_builds) = startup::init_builds_root(&config::settings().builds_root)?;
+    let server = startup::run(listener, db, put_builds, fetch_builds)?;
 
     // The server runs until it receives a shutdown signal.
     server.await?;

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -11,6 +11,15 @@ pub use app_env::app_env;
 pub struct Settings {
     pub application: ApplicationSettings,
     pub database: DatabaseSettings,
+    pub builds_root: BuildsRootSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BuildsRootSettings {
+    /// The URI of the builds root, where build databases will be stored. In production, this will
+    /// always be a `gs://` URI for GCS. When running locally, this may be a `file:///` URI. No
+    /// other URI schemes are currently supported.
+    pub uri: url::Url,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/control/src/config.rs
+++ b/crates/control/src/config.rs
@@ -2,24 +2,51 @@ use std::path::Path;
 
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
+use validator::{Validate, ValidationError, ValidationErrors};
 
 pub mod app_env;
 
 pub use app_env::app_env;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct Settings {
     pub application: ApplicationSettings,
     pub database: DatabaseSettings,
+    #[validate]
     pub builds_root: BuildsRootSettings,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct BuildsRootSettings {
     /// The URI of the builds root, where build databases will be stored. In production, this will
     /// always be a `gs://` URI for GCS. When running locally, this may be a `file:///` URI. No
     /// other URI schemes are currently supported.
+    #[validate(custom = "BuildsRootSettings::validate_uri")]
     pub uri: url::Url,
+}
+
+impl BuildsRootSettings {
+    fn validate_uri(uri: &url::Url) -> Result<(), ValidationError> {
+        let ensure = |ok: bool, msg: &str| {
+            if !ok {
+                let mut err = ValidationError::new("builds_root.uri");
+                err.message = Some(msg.to_owned().into());
+                Err(err)
+            } else {
+                Ok(())
+            }
+        };
+        ensure(!uri.cannot_be_a_base(), "uri cannot be a base")?;
+        ensure(uri.path().ends_with('/'), "uri must end with a '/'")?;
+        match uri.scheme() {
+            "gs" | "file" => { /* all good here */ }
+            other => {
+                let msg = format!("invalid uri scheme: '{}'", other);
+                ensure(false, msg.as_str())?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -72,7 +99,15 @@ pub fn settings() -> &'static Settings {
         .expect("to have initialized SETTINGS via `load_settings`")
 }
 
-pub fn load_settings<P>(config_path: P) -> Result<&'static Settings, ::config::ConfigError>
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("loading config: {0}")]
+    Loading(#[from] ::config::ConfigError),
+    #[error("invalid config: {0}")]
+    Validation(#[from] ValidationErrors),
+}
+
+pub fn load_settings<P>(config_path: P) -> Result<&'static Settings, ConfigError>
 where
     P: AsRef<Path>,
 {
@@ -88,7 +123,9 @@ where
         // Load settings from ENV_VARs
         config.merge(config::Environment::with_prefix("CONTROL").separator("__"))?;
 
-        config.try_into()
+        let settings: Settings = config.try_into()?;
+        settings.validate()?;
+        Ok(settings)
     })
 }
 
@@ -136,4 +173,26 @@ fn merge_database_url(config: &mut config::Config) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn builds_root_uri_validation() {
+        validate_uri("file:///foo/bar/").expect("should pass validation");
+
+        // We probably should eventually make these assertions more specific, but leaving this as
+        // "good enough for now".
+        validate_uri("file:///foo/bar").expect_err("should fail due to missing trailing slash");
+        validate_uri("wut:///foo/bar/").expect_err("should fail due to unsupported scheme");
+        validate_uri("gs:foo/bar/").expect_err("should fail due to cannot be a base");
+    }
+
+    fn validate_uri(uri: &str) -> Result<(), validator::ValidationErrors> {
+        let parsed = url::Url::parse(uri).expect("failed to parse test url");
+        let conf = BuildsRootSettings { uri: parsed };
+        conf.validate()
+    }
 }

--- a/crates/control/src/main.rs
+++ b/crates/control/src/main.rs
@@ -31,7 +31,8 @@ async fn main() -> anyhow::Result<()> {
     let settings = config::load_settings("config/development.toml")?;
     let listener = TcpListener::bind(settings.application.address())?;
     let db = startup::connect_to_postgres(&settings.database).await;
-    let server = startup::run(listener, db)?;
+    let (put_builds, fetch_builds) = startup::init_builds_root(&settings.builds_root)?;
+    let server = startup::run(listener, db, put_builds, fetch_builds)?;
 
     // The server runs until it receives a shutdown signal.
     server.await?;

--- a/crates/control/src/models/mod.rs
+++ b/crates/control/src/models/mod.rs
@@ -40,7 +40,7 @@ static ENCODING_CONFIG: base64::Config = base64::URL_SAFE_NO_PAD;
 pub struct Id(i64);
 
 impl Id {
-    pub fn new(inner: i64) -> Self {
+    pub const fn new(inner: i64) -> Self {
         Self(inner)
     }
 

--- a/crates/control/src/services/builds_root.rs
+++ b/crates/control/src/services/builds_root.rs
@@ -1,0 +1,344 @@
+use crate::config;
+use crate::error::SubprocessError;
+use async_trait::async_trait;
+use rusqlite::{Connection, OpenFlags};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+mod gcs;
+
+/// Allows uploading builds to the builds root.
+#[derive(Debug, Clone)]
+pub struct PutBuilds(Arc<dyn BuildsRootService>);
+
+impl PutBuilds {
+    /// Uploads the given `build_db` to the builds root so that it is accessible to the data plane.
+    async fn put_build(&self, build_id: &str, build_db: &Path) -> Result<(), BuildsRootError> {
+        self.0.put_build(build_id, build_db).await
+    }
+}
+
+/// A sqlite connection to a build database that has been fetched from the builds root.
+/// This type implements `Deref<Target=rusqlite::Connection>`, so you can use it just like you
+/// would a normal sqlite connection. This is an inert wrapper type currently, and exists to allow
+/// for caching in the future.
+#[derive(Debug)]
+pub struct BuildDBRef {
+    connection: Connection,
+}
+
+impl std::ops::Deref for BuildDBRef {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+/// Allows querying build databases by build id. Builds will be fetched automatically from the
+/// builds root, if required.
+#[derive(Debug, Clone)]
+pub struct FetchBuilds {
+    root: Arc<dyn BuildsRootService>,
+    local_builds: Arc<Mutex<BTreeMap<String, LocalBuildState>>>,
+}
+
+impl FetchBuilds {
+    fn new(root: Arc<dyn BuildsRootService>) -> FetchBuilds {
+        FetchBuilds {
+            root,
+            local_builds: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    #[tracing::instrument(level = "debug")]
+    pub async fn get_build(&self, build_id: &str) -> Result<BuildDBRef, BuildsRootError> {
+        let state_lock = self.get_state(build_id).await;
+        let mut build_state = state_lock.0.lock().await;
+
+        // The initial state will be a `LastError` with 0 attempts.
+        // Every time we actually attempt to fetch the build, the `attempts` counter will be
+        // incremented, which is used to apply an incremental backoff to attempts to dowload a
+        // build from cloud storage. The assumption being that requests for a given `build_id` may
+        // be pretty "bursty", and so repeated requests for a build that doesn't exist could
+        // otherwise run afoul of rate limits.
+        if let Some(prior_attempts) = build_state
+            .as_ref()
+            .err()
+            .filter(|e| e.should_fetch())
+            .map(|e| e.attempts)
+        {
+            let s = match self.root.retrieve_build(build_id).await {
+                Ok(build_path) => Ok(LocalBuildDB::new(build_path)),
+                Err(err) => {
+                    tracing::error!(error = ?err, build_id, prior_attempts, "failed to fetch build");
+                    Err(LastError {
+                        attempts: prior_attempts + 1,
+                        last_attempt: Instant::now(),
+                        error: err.to_string(),
+                    })
+                }
+            };
+            let _ = std::mem::replace(&mut *build_state, s);
+        }
+
+        match *build_state {
+            Ok(LocalBuildDB { ref path }) => {
+                let connection =
+                    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+                Ok(BuildDBRef { connection })
+            }
+            Err(LastError { ref error, .. }) => Err(BuildsRootError::PrevError(error.clone())),
+        }
+    }
+
+    async fn get_state(&self, build_id: &str) -> LocalBuildState {
+        let mut locals = self.local_builds.lock().await;
+        if let Some(ours) = locals.get(build_id) {
+            ours.clone()
+        } else {
+            let build_state = LocalBuildState::default();
+            locals.insert(build_id.to_owned(), build_state.clone());
+            build_state
+        }
+    }
+}
+
+/// Creates builds root services from the `BuildsRootSettings`. Returns an error if the
+/// configuration is structurally invalid, but does not attempt to connect to any external
+/// services.
+pub fn init_builds_root(
+    conf: &config::BuildsRootSettings,
+) -> anyhow::Result<(PutBuilds, FetchBuilds)> {
+    if !conf.uri.path().ends_with('/') {
+        anyhow::bail!("invalid uri: '{}', must end with a '/'", conf.uri);
+    }
+
+    let root: Arc<dyn BuildsRootService> = match conf.uri.scheme() {
+        "gs" => Arc::new(gcs::GCSBuildsRoot::new(conf.uri.clone())?),
+        "file" => Arc::new(LocalBuildsRoot::new(conf.uri.path())),
+        other => anyhow::bail!("invalid uri: unsupported scheme: '{}'", other),
+    };
+    Ok((PutBuilds(root.clone()), FetchBuilds::new(root)))
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum BuildsRootError {
+    #[error("build database error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("cloud storage error: {0}")]
+    GsUtil(#[from] SubprocessError),
+
+    #[error("cannot create build URI: {0}")]
+    Url(#[from] url::ParseError),
+    #[error("filesystem error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    PrevError(String),
+}
+
+#[async_trait]
+trait BuildsRootService: Debug + Send + Sync {
+    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError>;
+    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError>;
+}
+
+// A `BuildsRootService` that stores all builds in a local directory.
+#[derive(Debug)]
+struct LocalBuildsRoot {
+    dir: PathBuf,
+}
+
+impl LocalBuildsRoot {
+    fn new(dir: impl AsRef<Path>) -> LocalBuildsRoot {
+        LocalBuildsRoot {
+            dir: dir.as_ref().to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl BuildsRootService for LocalBuildsRoot {
+    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError> {
+        use std::io;
+
+        let dest_path = self.dir.join(build_id);
+        if dest_path.exists() {
+            Err(BuildsRootError::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("the build file: '{}' already exists", dest_path.display()),
+            )))
+        } else {
+            tokio::fs::copy(build, &dest_path).await?;
+            Ok(())
+        }
+    }
+
+    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
+        use std::io;
+
+        let dest_path = self.dir.join(build_id);
+        if dest_path.exists() {
+            Ok(dest_path)
+        } else {
+            Err(BuildsRootError::Io(io::Error::new(
+                io::ErrorKind::NotFound,
+                "no such build exists within the root",
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LastError {
+    attempts: u32,
+    last_attempt: Instant,
+    error: String,
+}
+
+impl Default for LastError {
+    fn default() -> Self {
+        Self {
+            attempts: 0,
+            last_attempt: Instant::now(),
+            error: String::new(),
+        }
+    }
+}
+
+impl LastError {
+    fn should_fetch(&self) -> bool {
+        let wait = match self.attempts {
+            0 => return true,
+            1 => Duration::from_millis(50),
+            2..=5 => Duration::from_millis(250),
+            _ => Duration::from_secs(5),
+        };
+        self.last_attempt.elapsed() > wait
+    }
+}
+
+/// A local copy of a build database, which was fetched from the builds root.
+/// Note that for the local builds root, this will refer to the same file within the builds root,
+/// so it should never be modified.
+#[derive(Debug, Clone)]
+struct LocalBuildDB {
+    path: PathBuf,
+}
+
+impl LocalBuildDB {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LocalBuildState(Arc<Mutex<Result<LocalBuildDB, LastError>>>);
+
+impl std::default::Default for LocalBuildState {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(Err(LastError::default()))))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn local_builds_root_can_get_and_put_a_build_successfully() {
+        let dir = TempDir::new().unwrap();
+        let test_build = make_test_build(dir.path(), "test-1");
+        let build_id = "test-build-1";
+
+        let root_dir = TempDir::new().unwrap();
+
+        let root_uri =
+            url::Url::parse(format!("file://{}/", root_dir.path().display()).as_str()).unwrap();
+        let (put_svc, fetch_svc) = init_builds_root(&config::BuildsRootSettings { uri: root_uri })
+            .expect("init_builds_root failed");
+
+        put_svc
+            .put_build(build_id, &test_build)
+            .await
+            .expect("failed to put build");
+
+        let build = fetch_svc
+            .get_build(build_id)
+            .await
+            .expect("failed to get build");
+        assert_build_ok(&build);
+
+        // Fetching a build that doesn't exist returns an error
+        fetch_svc
+            .get_build("def-doesnt-exist")
+            .await
+            .expect_err("should fail");
+    }
+
+    #[tokio::test]
+    async fn fetch_errors_are_not_retried_immediately() {
+        let root = Arc::new(MockBuildsRoot(AtomicU32::new(0)));
+        let fetch_svc = FetchBuilds::new(root.clone());
+
+        // Make a bunch of calls in a hot loop, where we know that they'll return errors. Then
+        // we'll assert that not all the calls were actually dispatched through to the
+        // MockBuildsRoot. There isn't really a good way to make a precise assertion on what the
+        // number of calls _should_ be because time is involved, but we can at least be certain
+        // that the actual number should be less than 10.
+        for _ in 0..10 {
+            let err = fetch_svc.get_build("foo").await.expect_err("should fail");
+            assert!(matches!(err, BuildsRootError::PrevError(_)));
+        }
+
+        let num_calls = root.0.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(num_calls < 10);
+    }
+
+    #[derive(Debug)]
+    struct MockBuildsRoot(AtomicU32);
+
+    #[async_trait]
+    impl BuildsRootService for MockBuildsRoot {
+        async fn put_build(&self, _: &str, _: &Path) -> Result<(), BuildsRootError> {
+            unimplemented!()
+        }
+
+        async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
+            let call_num = self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(BuildsRootError::PrevError(format!(
+                "test error: {}, build: {}",
+                call_num, build_id
+            )))
+        }
+    }
+
+    fn make_test_build(dir: &Path, id: &str) -> PathBuf {
+        let path = dir.join(id);
+        let conn = Connection::open(&path).expect("failed to create db");
+        conn.execute_batch(
+            r#"CREATE TABLE coal_mine (canary);
+            INSERT INTO coal_mine (canary) VALUES ('tweety');"#,
+        )
+        .expect("failed to exec sql");
+        conn.close().expect("failed to close sqlite connection");
+        assert!(path.exists());
+        path
+    }
+
+    fn assert_build_ok(build: &BuildDBRef) {
+        let canary: String = build
+            .query_row(r#"SELECT canary FROM coal_mine LIMIT 1;"#, [], |row| {
+                row.get(0)
+            })
+            .expect("failed to query row");
+        assert_eq!("tweety", canary);
+    }
+}

--- a/crates/control/src/services/builds_root/gcs.rs
+++ b/crates/control/src/services/builds_root/gcs.rs
@@ -14,12 +14,6 @@ pub struct GCSBuildsRoot {
 
 impl GCSBuildsRoot {
     pub fn new(uri: url::Url) -> Result<GCSBuildsRoot, anyhow::Error> {
-        anyhow::ensure!(!uri.cannot_be_a_base(), "uri cannot be a base");
-        anyhow::ensure!(uri.path().ends_with('/'), "uri must end with a '/'");
-
-        // TODO: either assert that the temp_dir is empty, or scan it an pre-populate local_builds
-        // based on its contents.
-
         let temp_dir = TempDir::new()?;
         Ok(GCSBuildsRoot {
             root: uri,

--- a/crates/control/src/services/builds_root/gcs.rs
+++ b/crates/control/src/services/builds_root/gcs.rs
@@ -1,0 +1,60 @@
+use super::{BuildsRootError, BuildsRootService};
+use crate::services::subprocess::Subprocess;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tokio::process::Command;
+
+#[derive(Debug)]
+pub struct GCSBuildsRoot {
+    root: url::Url,
+    temp_dir: TempDir,
+}
+
+impl GCSBuildsRoot {
+    pub fn new(uri: url::Url) -> Result<GCSBuildsRoot, anyhow::Error> {
+        anyhow::ensure!(!uri.cannot_be_a_base(), "uri cannot be a base");
+        anyhow::ensure!(uri.path().ends_with('/'), "uri must end with a '/'");
+
+        // TODO: either assert that the temp_dir is empty, or scan it an pre-populate local_builds
+        // based on its contents.
+
+        let temp_dir = TempDir::new()?;
+        Ok(GCSBuildsRoot {
+            root: uri,
+            temp_dir,
+        })
+    }
+}
+
+#[async_trait]
+impl BuildsRootService for GCSBuildsRoot {
+    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError> {
+        let dest_url = self.root.join(build_id)?;
+        Command::new("gsutil")
+            .arg("cp")
+            .arg("-n") // -n causes gsutil to fail if the file already exists
+            .arg(build.display().to_string())
+            .arg(dest_url.to_string())
+            .execute()
+            .await?;
+        Ok(())
+    }
+
+    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
+        let dest_file = self.temp_dir.path().join(build_id);
+        let src_key = self.root.join(build_id)?;
+
+        // If we've previously attempted to retrieve this build and failed part way through, then
+        // a file with this name could already exist. We don't use the `-n` flag here, and rely on
+        // gsutil to overwrite the destination file in that case.
+        Command::new("gsutil")
+            .arg("cp")
+            .arg(src_key.to_string())
+            .arg(dest_file.display().to_string())
+            .execute()
+            .await?;
+
+        Ok(dest_file)
+    }
+}

--- a/crates/control/src/services/builds_root/local.rs
+++ b/crates/control/src/services/builds_root/local.rs
@@ -1,4 +1,5 @@
 use super::{BuildsRootError, BuildsRootService};
+use crate::models::Id;
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 
@@ -18,10 +19,10 @@ impl LocalBuildsRoot {
 
 #[async_trait]
 impl BuildsRootService for LocalBuildsRoot {
-    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError> {
+    async fn put_build(&self, build_id: Id, build: &Path) -> Result<(), BuildsRootError> {
         use std::io;
 
-        let dest_path = self.dir.join(build_id);
+        let dest_path = self.dir.join(build_id.to_string());
         if dest_path.exists() {
             Err(BuildsRootError::Io(io::Error::new(
                 io::ErrorKind::Other,
@@ -33,10 +34,10 @@ impl BuildsRootService for LocalBuildsRoot {
         }
     }
 
-    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
+    async fn retrieve_build(&self, build_id: Id) -> Result<PathBuf, BuildsRootError> {
         use std::io;
 
-        let dest_path = self.dir.join(build_id);
+        let dest_path = self.dir.join(build_id.to_string());
         if dest_path.exists() {
             Ok(dest_path)
         } else {

--- a/crates/control/src/services/builds_root/local.rs
+++ b/crates/control/src/services/builds_root/local.rs
@@ -1,0 +1,49 @@
+use super::{BuildsRootError, BuildsRootService};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+// A `BuildsRootService` that stores all builds in a local directory.
+#[derive(Debug)]
+pub struct LocalBuildsRoot {
+    dir: PathBuf,
+}
+
+impl LocalBuildsRoot {
+    pub fn new(dir: impl AsRef<Path>) -> LocalBuildsRoot {
+        LocalBuildsRoot {
+            dir: dir.as_ref().to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl BuildsRootService for LocalBuildsRoot {
+    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError> {
+        use std::io;
+
+        let dest_path = self.dir.join(build_id);
+        if dest_path.exists() {
+            Err(BuildsRootError::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("the build file: '{}' already exists", dest_path.display()),
+            )))
+        } else {
+            tokio::fs::copy(build, &dest_path).await?;
+            Ok(())
+        }
+    }
+
+    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
+        use std::io;
+
+        let dest_path = self.dir.join(build_id);
+        if dest_path.exists() {
+            Ok(dest_path)
+        } else {
+            Err(BuildsRootError::Io(io::Error::new(
+                io::ErrorKind::NotFound,
+                "no such build exists within the root",
+            )))
+        }
+    }
+}

--- a/crates/control/src/services/builds_root/mod.rs
+++ b/crates/control/src/services/builds_root/mod.rs
@@ -117,10 +117,6 @@ impl FetchBuilds {
 pub fn init_builds_root(
     conf: &config::BuildsRootSettings,
 ) -> anyhow::Result<(PutBuilds, FetchBuilds)> {
-    if !conf.uri.path().ends_with('/') {
-        anyhow::bail!("invalid uri: '{}', must end with a '/'", conf.uri);
-    }
-
     let root: Arc<dyn BuildsRootService> = match conf.uri.scheme() {
         "gs" => Arc::new(gcs::GCSBuildsRoot::new(conf.uri.clone())?),
         "file" => Arc::new(local::LocalBuildsRoot::new(conf.uri.path())),

--- a/crates/control/src/services/builds_root/mod.rs
+++ b/crates/control/src/services/builds_root/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 mod gcs;
+mod local;
 
 /// Allows uploading builds to the builds root.
 #[derive(Debug, Clone)]
@@ -120,7 +121,7 @@ pub fn init_builds_root(
 
     let root: Arc<dyn BuildsRootService> = match conf.uri.scheme() {
         "gs" => Arc::new(gcs::GCSBuildsRoot::new(conf.uri.clone())?),
-        "file" => Arc::new(LocalBuildsRoot::new(conf.uri.path())),
+        "file" => Arc::new(local::LocalBuildsRoot::new(conf.uri.path())),
         other => anyhow::bail!("invalid uri: unsupported scheme: '{}'", other),
     };
     Ok((PutBuilds(root.clone()), FetchBuilds::new(root)))
@@ -146,52 +147,6 @@ pub enum BuildsRootError {
 trait BuildsRootService: Debug + Send + Sync {
     async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError>;
     async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError>;
-}
-
-// A `BuildsRootService` that stores all builds in a local directory.
-#[derive(Debug)]
-struct LocalBuildsRoot {
-    dir: PathBuf,
-}
-
-impl LocalBuildsRoot {
-    fn new(dir: impl AsRef<Path>) -> LocalBuildsRoot {
-        LocalBuildsRoot {
-            dir: dir.as_ref().to_owned(),
-        }
-    }
-}
-
-#[async_trait]
-impl BuildsRootService for LocalBuildsRoot {
-    async fn put_build(&self, build_id: &str, build: &Path) -> Result<(), BuildsRootError> {
-        use std::io;
-
-        let dest_path = self.dir.join(build_id);
-        if dest_path.exists() {
-            Err(BuildsRootError::Io(io::Error::new(
-                io::ErrorKind::Other,
-                format!("the build file: '{}' already exists", dest_path.display()),
-            )))
-        } else {
-            tokio::fs::copy(build, &dest_path).await?;
-            Ok(())
-        }
-    }
-
-    async fn retrieve_build(&self, build_id: &str) -> Result<PathBuf, BuildsRootError> {
-        use std::io;
-
-        let dest_path = self.dir.join(build_id);
-        if dest_path.exists() {
-            Ok(dest_path)
-        } else {
-            Err(BuildsRootError::Io(io::Error::new(
-                io::ErrorKind::NotFound,
-                "no such build exists within the root",
-            )))
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/control/src/services/mod.rs
+++ b/crates/control/src/services/mod.rs
@@ -1,2 +1,3 @@
+pub mod builds_root;
 pub mod connectors;
 pub mod subprocess;


### PR DESCRIPTION
**Description:**

Adds `PutBuilds` and `FetchBuilds` services to control plane, for
interacting with the builds root. These services are initialized on
startup and are added as extension layers, so they're available to all
handlers.

**Workflow steps:** n/a

**Documentation links affected:** n/a

**Notes for reviewers:**

The workflow for local development is a little quirky due to the builds root being specified only as a URI. This means that in the config file, you must provide an absolute path to a builds root. It's currently set to `/var/tmp/flow-builds/` in `config/development.toml`. The pain point there is that if you add a build `foo` with one instance of the application, then another instance of the application won't see it, and you won't be able to create a second build with the same name. I'm on the fence about whether we should, A, just allow it to overwrite files in the local builds root (not for GCS), or B, scan the local builds root on startup and be able to work with those same builds. My thought at this point is to wait and see what makes sense after we get a little time working with the builds endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/383)
<!-- Reviewable:end -->
