### PR TITLE
Preserve order of JSON fields in sources crate to avoid sops MAC mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,7 @@ dependencies = [
  "doc 0.0.0",
  "futures",
  "humantime-serde",
+ "indexmap",
  "insta",
  "json 0.0.0",
  "lazy_static",

--- a/crates/sources/Cargo.toml
+++ b/crates/sources/Cargo.toml
@@ -18,7 +18,8 @@ lazy_static = "*"
 regex = "*"
 schemars = "*"
 serde = { version = "*", features = ["derive"] }
-serde_json = { version =  "*", features = ["raw_value"] }
+indexmap = "*"
+serde_json = { version =  "*", features = ["raw_value", "preserve_order"] }
 serde_yaml = "*"
 thiserror = "*"
 tracing = "*"

--- a/crates/sources/src/loader.rs
+++ b/crates/sources/src/loader.rs
@@ -1,12 +1,12 @@
 use super::Scope;
 use doc::Schema as CompiledSchema;
 use futures::future::{FutureExt, LocalBoxFuture};
+use indexmap::map::IndexMap;
 use json::schema::{build::build_schema, Application, Keyword};
 use models::{self, tables};
 use protocol::flow::test_spec::step::Type as TestStepType;
 use regex::Regex;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use url::Url;
 
 #[derive(thiserror::Error, Debug)]
@@ -81,7 +81,7 @@ pub trait Fetcher {
 /// tracking of location context.
 pub struct Loader<F: Fetcher> {
     // Inlined resource definitions which have been observed, but not loaded.
-    inlined: RefCell<BTreeMap<Url, models::ResourceDef>>,
+    inlined: RefCell<IndexMap<Url, models::ResourceDef>>,
     // Tables loaded by the build process.
     tables: RefCell<Tables>,
     // Fetcher for retrieving discovered, unvisited resources.
@@ -92,7 +92,7 @@ impl<F: Fetcher> Loader<F> {
     /// Build and return a new Loader.
     pub fn new(tables: Tables, fetcher: F) -> Loader<F> {
         Loader {
-            inlined: RefCell::new(BTreeMap::new()),
+            inlined: RefCell::new(IndexMap::new()),
             tables: RefCell::new(tables),
             fetcher,
         }
@@ -185,7 +185,7 @@ impl<F: Fetcher> Loader<F> {
         // If an inline definition of a resource is already available, then use it.
         // Otherwise delegate to the Fetcher.
         // TODO(johnny): Sanity check expected vs actual content-types.
-        let inlined = self.inlined.borrow_mut().remove(&resource); // Don't hold guard.
+        let inlined = self.inlined.borrow_mut().remove(resource); // Don't hold guard.
         let content = if let Some(resource) = inlined {
             Ok(resource.content.clone())
         } else {

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -430,12 +430,6 @@ flow-258@helpful-kingdom-273219.iam.gserviceaccount.com
 ```
 :::
 
-:::warning
-Due to a known issue within `sops` and Flow,
-you must currently order your configuration files in their natural key-sorted order.
-See https://github.com/estuary/flow/issues/303
-:::
-
 #### Example: Protect portions of a configuration
 
 Endpoint configurations are typically a mix of sensitive and non-sensitive values.


### PR DESCRIPTION
**Description:**

Enable `preserve_order` feature of `serde_json` on sources crate to conserve ordering of fields when reading catalog files. This avoids an issue where the MAC of sops encrypted files mismatch after reading and writing of the file during the catalog build. Resolves #303.

**Workflow steps:**

- Clone https://github.com/mdibaiee/hello-flow and checkout to [cb4dea5](https://github.com/mdibaiee/hello-flow/commit/cb4dea545604dd6aa4f41ab7a477ae4a4db18d4b)
- Note that the sops file for this project [is not ordered](https://github.com/mdibaiee/hello-flow/blob/main/acmeCo/source-gcs.config.yaml#L3-L6)
- You will actually need to create your own encrypted config, similar to the original file, since this one is encrypted using a personal key I have.
- Run the flow using this branch, and using master
```
flowctl deploy --source flow.yaml --wait-and-cleanup --log.level=debug
```

**Documentation links affected:**

- https://docs.estuary.dev/concepts/connectors/ : removed warning that mentioned #303 as an issue and the requirement to order keys manually

**Notes for reviewers:**

I'm not completely aware of any potential issues this might cause elsewhere. Let me know if you think this might have some blast radius outside of this crate. My simple test on a simple flow worked fine.

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/388)
<!-- Reviewable:end -->
