### PR TITLE
build: tighten outputs and paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,38 +263,38 @@ jobs:
       - name: make catalog-test
         run: |
           make catalog-test \
-          -o .build/package/bin/etcd \
-          -o .build/package/bin/flowctl \
-          -o .build/package/bin/flowctl-go \
-          -o .build/package/bin/flow-network-proxy \
-          -o .build/package/bin/flow-parser \
-          -o .build/package/bin/flow-schemalate \
-          -o .build/package/bin/gazette \
-          -o .build/package/bin/sops
+          -o /home/runner/work/flow/flow/.build/package/bin/etcd \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl-go \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-network-proxy \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-parser \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-schemalate \
+          -o /home/runner/work/flow/flow/.build/package/bin/gazette \
+          -o /home/runner/work/flow/flow/.build/package/bin/sops
 
       - name: make end-to-end-test
         run: |
           make end-to-end-test \
-          -o .build/package/bin/etcd \
-          -o .build/package/bin/flowctl \
-          -o .build/package/bin/flowctl-go \
-          -o .build/package/bin/flow-network-proxy \
-          -o .build/package/bin/flow-parser \
-          -o .build/package/bin/flow-schemalate \
-          -o .build/package/bin/gazette \
-          -o .build/package/bin/sops
+          -o /home/runner/work/flow/flow/.build/package/bin/etcd \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl-go \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-network-proxy \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-parser \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-schemalate \
+          -o /home/runner/work/flow/flow/.build/package/bin/gazette \
+          -o /home/runner/work/flow/flow/.build/package/bin/sops
 
       - name: make package (tar only)
         run: |
-          make .build/package/flow-x86-linux.tar.gz \
-          -o .build/package/bin/etcd \
-          -o .build/package/bin/flowctl \
-          -o .build/package/bin/flowctl-go \
-          -o .build/package/bin/flow-network-proxy \
-          -o .build/package/bin/flow-parser \
-          -o .build/package/bin/flow-schemalate \
-          -o .build/package/bin/gazette \
-          -o .build/package/bin/sops
+          make /home/runner/work/flow/flow/.build/package/flow-x86-linux.tar.gz \
+          -o /home/runner/work/flow/flow/.build/package/bin/etcd \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl \
+          -o /home/runner/work/flow/flow/.build/package/bin/flowctl-go \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-network-proxy \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-parser \
+          -o /home/runner/work/flow/flow/.build/package/bin/flow-schemalate \
+          -o /home/runner/work/flow/flow/.build/package/bin/gazette \
+          -o /home/runner/work/flow/flow/.build/package/bin/sops
 
       - name: Tidy up, and ensure that generated files are unchanged.
         run: |

--- a/crates/flow_cli_common/src/lib.rs
+++ b/crates/flow_cli_common/src/lib.rs
@@ -43,8 +43,17 @@ where
             std::process::exit(code);
         }
         Ok(Success::Exec(external)) => {
-            tracing::debug!(command = ?external, "process will be replaced by command");
-            std::process::Command::new(&external.program)
+            let resolved = std::env::current_exe()
+                .expect("failed to fetch current exec path")
+                .canonicalize()
+                .expect("failed to make the exec path canonical")
+                .parent()
+                .expect("failed to extract exec directory")
+                .join(&external.program);
+
+            tracing::debug!(command = ?external, ?resolved, "process will be replaced by command");
+
+            std::process::Command::new(resolved)
                 .args(&external.args)
                 .exec()
                 .into()

--- a/go/pkgbin/exec.go
+++ b/go/pkgbin/exec.go
@@ -1,0 +1,47 @@
+// pkgbin implements functionality related to Flow's packaging,
+// including finding binaries and artifcats which are part of
+// a packaged Flow release.
+package pkgbin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Locate the full path of a binary by:
+// * Looking first for a binary that exist alongside the currently
+//   executing binary, in a common directory.
+// * Only if that's not found, then attempt to find a binary on the $PATH.
+func Locate(binary string) (string, error) {
+	var execPath, err = os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("fetching path of current executable: %w", err)
+	}
+
+	var path = filepath.Join(filepath.Dir(execPath), binary)
+	if _, err = os.Stat(path); err == nil {
+		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat-ing path %s: %w", path, err)
+	}
+
+	// Fall back to looking for |binary| on the path.
+	return exec.LookPath(binary)
+}
+
+// MustLocate locates the full path of a binary, or panics if it's not found.
+func MustLocate(binary string) string {
+	var path, err = Locate(binary)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"binary": binary,
+			"err":    err,
+		}).Fatal("failed to locate required binary")
+	}
+	return path
+}


### PR DESCRIPTION
**Description:**

`flowctl` now requires that external binaries it invokes are co-located
in its same executable directory. This was already the practice with
`flowctl-go`, so the behavior is now consistent for both.

Similarly require that `sops` be co-located in the current executable
directory.

Remove dependencies on GOPATH from Makefile.
Instead, Go binaries are directly built (using go build -o) into the
desired $PKGDIR location.

export PATH is also removed from the Makefile, to coerce binaries to
rely only on co-location within a package directory and to not shell out
to $PATH and hope for the best, as this is a frequent source of
challenges from unexpected / old / stale binaries.

**Workflow steps:**

None.

**Documentation links affected:**

None.

**Notes for reviewers:**

None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/390)
<!-- Reviewable:end -->
