### PR TITLE
Phil/schemalate code quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "doc 0.0.0",
  "flow_cli_common",
  "indexmap",
+ "itertools",
  "json 0.0.0",
  "lazy_static",
  "regex",

--- a/crates/schemalate/Cargo.toml
+++ b/crates/schemalate/Cargo.toml
@@ -16,6 +16,7 @@ flow_cli_common = { path = "../flow_cli_common" }
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 indexmap = { version = "*", features = ["serde"]}
+itertools = "*"
 lazy_static = "*"
 regex = "*"
 serde = { version = "*", features = ["derive"] }

--- a/crates/schemalate/src/main.rs
+++ b/crates/schemalate/src/main.rs
@@ -21,7 +21,7 @@ enum Subcommand {
     /// schema.
     Typescript(schemalate::typescript::Args),
     /// Generates Markdown documentation of the fields in a schema.
-    Markdown,
+    Markdown(schemalate::markdown::Args),
     /// Generates an Elasticsearch schema
     ElasticsearchSchema(schemalate::elasticsearch::Args),
 }
@@ -37,7 +37,7 @@ fn main() -> Result<(), anyhow::Error> {
 
 fn run_subcommand(subcommand: Subcommand) -> Result<(), anyhow::Error> {
     let result = match subcommand {
-        Subcommand::Markdown => schemalate::markdown::run(),
+        Subcommand::Markdown(md_args) => schemalate::markdown::run(md_args),
         Subcommand::Typescript(ts_args) => schemalate::typescript::run(ts_args),
         Subcommand::ElasticsearchSchema(es_args) => schemalate::elasticsearch::run(es_args),
     };


### PR DESCRIPTION
**Description:**

Fixes #369 

**Workflow steps:**

Here's an example of a command that I ran, and the table that it generated:

```shell
flowctl api spec --image ghcr.io/estuary/source-kinesis:dev | jq '.endpointSpecSchema' | flowctl schemalate markdown --exclude ''
```

Generated table:

| Property | Title | Description | Type | Required/Default |
|---|---|---|---|---|
| **`/awsAccessKeyId`** | AWS Access Key ID | Part of the AWS credentials that will be used to connect to Kinesis | string | Required, `"example-aws-access-key-id"` |
| **`/awsSecretAccessKey`** | AWS Secret Access Key | Part of the AWS credentials that will be used to connect to Kinesis | string | Required, `"example-aws-secret-access-key"` |
| `/endpoint` | AWS Endpoint | The AWS endpoint URI to connect to, useful if you&#x27;re capturing from a kinesis-compatible API that isn&#x27;t provided by AWS | string |  |
| **`/region`** | AWS Region | The name of the AWS region where the Kinesis stream is located | string | Required, `"us-east-1"` |


**Documentation links affected:**

We might want to try using this updated version to re-generate the tables in the connector docs, so they're all consistent, but no impact apart from that.

**Notes for reviewers:**

I tried to make the output look more like what we have currently in the docs, since that's the main use case we're targeting with this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/401)
<!-- Reviewable:end -->
