### PR TITLE
Docs - SSH for materializations

### DIFF
--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -524,6 +524,7 @@ captures:
               # connect via tunneling from the SSH server
               forwardHost: 127.0.0.1
               # Location of the remote SSH server that supports tunneling.
+              # Formatted as ssh://hostname[:port].
               sshEndpoint: ssh://198.21.98.1
               # Username to connect to the SSH server.
               user: sshUser
@@ -578,6 +579,7 @@ materializations:
               # tunneling from the SSH server.
               forwardPort: 5432
               # Location of the remote SSH server that supports tunneling.
+              # Formatted as ssh://hostname[:port].
               sshEndpoint: ssh://198.21.98.1
               # Username to connect to the SSH server.
               user: sshUser


### PR DESCRIPTION
**Description:**

Adds config details for SSH on materialization connectors, per https://github.com/estuary/flow/pull/379

YAML samples are now provided for both the current capture connectors (ie, just postgres for now) and all materializations. I'm assuming in the future this will be consistent and we'll just have one standard config. 

**Notes for reviewers:**

Initially, I was going to just commit this directly and skip the PR, but it seemed worthwhile to make sure that _both_ configs are accurate. 

FYI, related doc changes per https://github.com/estuary/connectors/pull/143 were [already covered here](https://github.com/estuary/flow/commit/910925a97fe4fa2735fa9b56738153bbd08d1f1e). In hindsight, I probably should've included those on this PR too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/402)
<!-- Reviewable:end -->
