### PR TITLE
control: add build API and builder daemon service

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,14 +8,24 @@
 		// Integrate the empty docker-compose database into VSCode.
 		"sqltools.connections": [
 			{
-				"name": "Container database",
+				"database": "flow",
 				"driver": "PostgreSQL",
+				"name": "Test DB",
+				"password": "flow",
+				"port": 5432,
 				"previewLimit": 50,
 				"server": "localhost",
+				"username": "flow"
+			},
+			{
+				"database": "control_development",
+				"driver": "PostgreSQL",
+				"name": "Control DB",
+				"password": "flow",
 				"port": 5432,
-				"database": "flow",
-				"username": "flow",
-				"password": "flow"
+				"previewLimit": 50,
+				"server": "localhost",
+				"username": "flow"
 			}
 		],
 		// Add extra CGO configuration required for the vscode-go extension to build

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -18,9 +18,14 @@ services:
       # work on Github Codespaces (but works fine in VSCode Remote Containers).
       - /var/tmp:/var/tmp
 
-    # Use /var/tmp as the default temporary directory, rather than /tmp.
     environment:
+      # Use /var/tmp as the default temporary directory, rather than /tmp.
       TMPDIR: /var/tmp
+      # Enable SQLX online introspection of the control-plane database.
+      # TODO(johnny): We don't want this on-by-default, so if you're working
+      # on control-plane APIs, unfortunatley you must uncomment this and
+      # rebuild your devcontainer.
+      # SQLX_OFFLINE: "false"
 
     # Wrap in an init process that reaps defunct child processes.
     init: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "once_cell",
  "version_check",
 ]
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avro-rs"
@@ -162,7 +162,7 @@ dependencies = [
  "libflate",
  "num-bigint 0.2.6",
  "rand 0.7.3",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "snap",
  "strum 0.18.0",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157d3c6bef9a248ecf0492f05bb91019ced3c5b0f4cd9ec09b16d06596e1e743"
+checksum = "c9f346c92c1e9a71d14fe4aaf7c2a5d9932cc4e5e48d8fb6641524416eb79ddd"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -193,7 +193,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca6c0b218388a7ed6a8d25e94f7dea5498daaa4fd8c711fb3ff166041b06fda"
+checksum = "6dbcda393bef9c87572779cb8ef916f12d77750b27535dd6819fa86591627a51"
 dependencies = [
  "async-trait",
  "bytes",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4154d2d850312d05205dc501ceadf3638cf1945496d7699a1bf24866367a49c6"
+checksum = "c5b2a9133b2658e684c8ea04157a8bd48dac7906a2eb884ffebfb051af123394"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.0"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2ce639ee22f41a6ea0a3061e9bea9f690cf0c6ffc1ada0a3a599778f99ccba"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -287,11 +287,11 @@ dependencies = [
  "derive",
  "prost",
  "protocol",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
  "tracing",
- "tracing-subscriber 0.2.19",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -317,9 +317,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
 dependencies = [
  "funty",
  "radium",
@@ -395,14 +395,14 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "rusqlite",
  "schemalate",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "sources",
@@ -444,9 +444,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-tools"
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38728c31b994e4b849cf59feefb4a8bf26acd299ee0b92c9fb35bd14ad4b8dfa"
+checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
 dependencies = [
  "clap 2.34.0",
  "heck 0.3.3",
@@ -518,7 +518,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "syn",
  "tempfile",
@@ -527,20 +527,20 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 6.1.2",
+ "nom 7.1.0",
 ]
 
 [[package]]
@@ -569,8 +569,8 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.133",
- "time 0.1.43",
+ "serde 1.0.136",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.13"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -623,14 +623,14 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.12"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -648,7 +648,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -663,7 +663,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "clap 3.0.13",
+ "clap 3.1.6",
  "doc 0.0.0",
  "flow_cli_common",
  "futures-core",
@@ -672,14 +672,14 @@ dependencies = [
  "prost",
  "protocol",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "strum 0.24.0",
  "strum_macros 0.24.0",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.0",
  "tracing",
 ]
 
@@ -706,7 +706,7 @@ dependencies = [
  "axum-macros",
  "base64",
  "chrono",
- "clap 3.0.13",
+ "clap 3.1.6",
  "config",
  "ctor",
  "flow_cli_common",
@@ -717,10 +717,10 @@ dependencies = [
  "mime",
  "models",
  "once_cell",
- "rand 0.8.4",
+ "rand 0.8.5",
  "reqwest",
  "rusqlite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_with",
  "sha2 0.10.2",
@@ -732,16 +732,16 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber 0.3.9",
  "url",
  "validator",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -813,7 +813,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -923,9 +923,9 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa 0.4.7",
+ "itoa 0.4.8",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1015,8 +1015,7 @@ dependencies = [
  "prost",
  "protocol",
  "rocksdb",
- "rusqlite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "stats_alloc",
  "tempfile",
@@ -1103,7 +1102,7 @@ dependencies = [
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1115,13 +1114,13 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1eec92640928b3ba33ce809f2fb139be3bbf0c59"
+source = "git+https://github.com/estuary/flow#d8c3be35fc8ac0657e0c4aa2e5e7ef4b3eb72905"
 dependencies = [
  "fancy-regex",
  "itertools",
  "json 0.0.0 (git+https://github.com/estuary/flow)",
  "lazy_static",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1143,12 +1142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,7 +1153,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1176,7 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1209,9 +1202,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
 dependencies = [
  "bit-set",
  "regex",
@@ -1228,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
@@ -1250,9 +1243,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap 3.0.13",
+ "clap 3.1.6",
  "tracing",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -1263,7 +1256,7 @@ dependencies = [
  "assert_cmd",
  "build",
  "bytes",
- "clap 3.0.13",
+ "clap 3.1.6",
  "control",
  "derive",
  "doc 0.0.0",
@@ -1333,9 +1326,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1348,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1358,15 +1351,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1381,20 +1374,20 @@ checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1403,21 +1396,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1472,13 +1465,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1489,9 +1482,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1502,15 +1495,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -1634,9 +1627,9 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1657,14 +1650,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1675,7 +1668,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.7",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1692,7 +1685,7 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "tokio",
  "tokio-rustls 0.23.2",
 ]
@@ -1747,30 +1740,29 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "insta"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3cb858fc306825b542b1311d5fd536e4483680528f303a17a1d6803b0f6ce17"
+checksum = "30a7e1911532a662f6b08b68f884080850f2fd9544963c3ab23a5af42bda1eac"
 dependencies = [
  "console",
- "lazy_static",
+ "once_cell",
  "pest",
  "pest_derive",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "similar",
- "uuid",
 ]
 
 [[package]]
@@ -1783,25 +1775,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.3.1"
+name = "integer-sqrt"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1843,18 +1844,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1870,7 +1871,7 @@ dependencies = [
  "glob",
  "itertools",
  "percent-encoding",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1881,14 +1882,14 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1eec92640928b3ba33ce809f2fb139be3bbf0c59"
+source = "git+https://github.com/estuary/flow#d8c3be35fc8ac0657e0c4aa2e5e7ef4b3eb72905"
 dependencies = [
  "bitvec",
  "fancy-regex",
  "fxhash",
  "itertools",
  "percent-encoding",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -1902,7 +1903,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "treediff",
 ]
@@ -1934,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libflate"
@@ -1960,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -2000,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "cb644c388dfaefa18035c12614156d285364769e818893da0dda9030c80ad2ba"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2017,9 +2018,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -2059,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
@@ -2094,9 +2095,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -2125,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -2166,7 +2167,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "superslice",
@@ -2211,14 +2212,14 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
  "thrussh",
  "thrussh-keys",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber 0.3.9",
  "url",
 ]
 
@@ -2229,18 +2230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
  "memchr",
  "version_check",
 ]
@@ -2258,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -2317,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -2336,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "oorandom"
@@ -2418,7 +2407,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2433,6 +2432,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2455,14 +2467,14 @@ dependencies = [
  "mime",
  "num-bigint 0.4.3",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "tempdir",
  "tempfile",
  "thiserror",
  "tracing",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber 0.3.9",
  "unicode-bom",
  "unicode-normalization",
  "url",
@@ -2508,21 +2520,23 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pathfinding"
-version = "2.1.6"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77091b83a48831a1e8d03f6b5def4047070b4e2dbee06c134daaf35ca20b979d"
+checksum = "ae0f81e2934f5e80cf0fa7a3ee971b9b37df69ac111f20772e4dd33ff379d740"
 dependencies = [
  "fixedbitset",
  "indexmap",
+ "integer-sqrt",
  "itertools",
  "num-traits 0.2.14",
  "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -2605,18 +2619,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2625,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -2637,9 +2651,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plotters"
@@ -2671,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
@@ -2805,7 +2819,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "tonic",
  "tonic-build",
@@ -2821,7 +2835,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2873,19 +2887,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2938,7 +2951,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -2948,15 +2961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2995,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -3008,15 +3012,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3072,9 +3076,9 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "rustls-pemfile",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3120,11 +3124,13 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
+ "chrono",
+ "csv",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3132,7 +3138,9 @@ dependencies = [
  "memchr",
  "serde_json",
  "smallvec",
+ "time 0.3.7",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3171,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
@@ -3198,9 +3206,9 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -3226,7 +3234,7 @@ name = "schemalate"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 3.0.13",
+ "clap 3.1.6",
  "doc 0.0.0",
  "flow_cli_common",
  "indexmap",
@@ -3234,7 +3242,7 @@ dependencies = [
  "json 0.0.0",
  "lazy_static",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
  "tracing",
@@ -3243,21 +3251,21 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
+checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9ea2a613fe4cd7118b2bb101a25d8ae6192e1975179b67b2f17afd11e70ac8"
+checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3293,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3306,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3316,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -3328,9 +3336,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -3353,7 +3361,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3363,14 +3371,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3390,37 +3398,37 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.7",
+ "itoa 1.0.1",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "base64",
  "chrono",
  "rustversion",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_with_macros",
 ]
 
@@ -3438,13 +3446,13 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
- "linked-hash-map",
- "serde 1.0.133",
+ "indexmap",
+ "ryu",
+ "serde 1.0.136",
  "yaml-rust",
 ]
 
@@ -3510,18 +3518,18 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3540,9 +3548,9 @@ checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -3562,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -3587,7 +3595,7 @@ dependencies = [
  "protocol",
  "regex",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-transcode",
  "serde_json",
  "serde_yaml",
@@ -3657,9 +3665,9 @@ dependencies = [
  "once_cell",
  "paste 1.0.6",
  "percent-encoding",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rustls 0.19.1",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "sha-1 0.9.8",
  "sha2 0.9.9",
@@ -3688,7 +3696,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "sha2 0.9.9",
  "sqlx-core",
@@ -3879,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -3913,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3939,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -3961,7 +3969,7 @@ dependencies = [
  "generic-array 0.14.5",
  "log",
  "openssl",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha2 0.9.9",
  "thiserror",
  "thrussh-keys",
@@ -3991,8 +3999,8 @@ dependencies = [
  "num-integer",
  "openssl",
  "pbkdf2",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_derive",
  "sha2 0.9.9",
  "thiserror",
@@ -4017,11 +4025,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -4034,7 +4043,14 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinytemplate"
@@ -4042,15 +4058,15 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4063,9 +4079,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -4073,9 +4089,10 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -4128,7 +4145,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -4159,12 +4176,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -4190,7 +4221,7 @@ dependencies = [
  "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4223,20 +4254,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4244,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb284cac1883d54083a0edbdc9cabf931dfed87455f8c7266c01ece6394a43a"
+checksum = "90c125fdea84614a4368fd35786b51d0682ab8d42705e061e92f0b955dea40fb"
 dependencies = [
  "bitflags",
  "bytes",
@@ -4276,9 +4306,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "log",
@@ -4289,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4300,11 +4330,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -4330,26 +4361,26 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
  "matchers 0.0.1",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -4362,15 +4393,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
  "matchers 0.1.0",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -4418,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -4430,12 +4461,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-bom"
@@ -4454,15 +4482,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -4492,7 +4520,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -4501,8 +4529,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
- "serde 1.0.133",
+ "getrandom 0.2.5",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -4522,7 +4550,7 @@ dependencies = [
  "protocol",
  "regex",
  "rusqlite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "sources",
@@ -4542,7 +4570,7 @@ dependencies = [
  "idna",
  "lazy_static",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "url",
@@ -4577,6 +4605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4590,9 +4624,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -4632,15 +4666,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4648,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4663,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4675,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4685,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4698,15 +4732,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4752,11 +4786,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.1.0"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
 ]
 
@@ -4802,6 +4837,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,9 +4896,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-merge-keys"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd236a7dc9bb598f349fe4a8754f49181fee50284daa15cd1ba652d722280004"
+checksum = "af47d205071caaef70ebce5e04e1d88eba944833f8a6626dacdda700f86c285a"
 dependencies = [
  "lazy_static",
  "serde_yaml",
@@ -4885,5 +4963,5 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time 0.1.43",
+ "time 0.1.44",
 ]

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,10 @@ GO_MODULE_PATH = $(shell go list -f '{{ .Dir }}' -m $(module))
 ##########################################################################
 # Configure Go build & test behaviors.
 
-# Enable the sqlite3 JSON extension.
-GO_BUILD_TAGS += json1
+# Tell the go-sqlite3 package to link against a pre-built library
+# rather than statically compiling in its own definition.
+# This will use the static library definitions provided by libbindings.a.
+GO_BUILD_TAGS += libsqlite3
 
 # Targets which Go targets rely on in order to build.
 GO_BUILD_DEPS = \

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "*"
 pathdiff = "*"
 prost = "*"
 regex = "*"
-rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
+rusqlite = { version = "*", features = ["bundled-full"] }
 schemars = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = { version =  "*", features = ["raw_value"] }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -57,10 +57,8 @@ where
 
     // Output database path is implied from the configured directory and ID.
     let output_path = directory.join(&config.build_id);
-    // Create or truncate the output database.
-    std::fs::write(&output_path, &[]).context("failed to create catalog database")?;
-
     let db = rusqlite::Connection::open(&output_path).context("failed to open catalog database")?;
+
     tables::persist_tables(&db, &all_tables.as_tables())
         .context("failed to persist catalog tables")?;
     tracing::info!(?output_path, "wrote build database");

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -23,7 +23,7 @@ hmac = "0.12.1"
 hyper = { version = "0.14.16", features = ["full"] }
 once_cell = "1.9.0"
 rand = "0.8.4"
-rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
+rusqlite = { version = "*", features = ["bundled-full"] }
 reqwest = { version = "0.11.9", features = ["json"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }

--- a/crates/control/docker-compose.yaml
+++ b/crates/control/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: flow
       POSTGRES_PASSWORD: flow
       POSTGRES_DB: control_development
-    network_mode: host
+    ports: ['5432:5432']
 
 volumes:
   postgres_data: {}

--- a/crates/control/migrations/20220303214925_create_builds.down.sql
+++ b/crates/control/migrations/20220303214925_create_builds.down.sql
@@ -1,3 +1,5 @@
 DROP INDEX builds_id_where_queued;
 
+DROP INDEX builds_account_id;
+
 DROP TABLE builds;

--- a/crates/control/migrations/20220303214925_create_builds.down.sql
+++ b/crates/control/migrations/20220303214925_create_builds.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX builds_id_where_queued;
+
+DROP TABLE builds;

--- a/crates/control/migrations/20220303214925_create_builds.up.sql
+++ b/crates/control/migrations/20220303214925_create_builds.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE builds (
+  "account_id" BIGINT NOT NULL REFERENCES accounts(id),
+  "catalog" JSON NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL,
+  "id" BIGINT PRIMARY KEY NOT NULL DEFAULT id_generator(),
+  "state" JSONB NOT NULL,
+  "updated_at" TIMESTAMPTZ NOT NULL
+);
+
+-- Index for efficiently identifying builds that are queued,
+-- which is a small subset of the overall builds that exist.
+CREATE UNIQUE INDEX builds_id_where_queued ON builds USING BTREE (id)
+WHERE state->>'type' = 'queued';

--- a/crates/control/migrations/20220303214925_create_builds.up.sql
+++ b/crates/control/migrations/20220303214925_create_builds.up.sql
@@ -7,6 +7,9 @@ CREATE TABLE builds (
   "updated_at" TIMESTAMPTZ NOT NULL
 );
 
+-- Index for identifying builds of a given account.
+CREATE INDEX builds_account_id ON builds USING BTREE (account_id);
+
 -- Index for efficiently identifying builds that are queued,
 -- which is a small subset of the overall builds that exist.
 CREATE UNIQUE INDEX builds_id_where_queued ON builds USING BTREE (id)

--- a/crates/control/sqlx-data.json
+++ b/crates/control/sqlx-data.json
@@ -1,48 +1,44 @@
 {
   "db": "PostgreSQL",
   "0cb8f1b604bdbfc3c6cd06cb7d63374f03dd8df9f9d3669c7d18181118611fa6": {
-    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Account>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "email",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "name!: CatalogName",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "unique_name!: UniqueName",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
@@ -51,18 +47,24 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    "
   },
   "2ee6f173845e15f5f1229d18e1040be2850c0a716699831235485d420e356bbe": {
-    "query": "\n    INSERT INTO credentials(\n        account_id,\n        expires_at,\n        issuer,\n        last_authorized_at,\n        session_token,\n        subject,\n        created_at,\n        updated_at\n    )\n    VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())\n    RETURNING id as \"id!: Id<Credential>\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Credential>",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -73,57 +75,49 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    INSERT INTO credentials(\n        account_id,\n        expires_at,\n        issuer,\n        last_authorized_at,\n        session_token,\n        subject,\n        created_at,\n        updated_at\n    )\n    VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())\n    RETURNING id as \"id!: Id<Credential>\"\n    "
   },
   "2ef2f367656030ea9cadc848e7a586f2c11282c5c26ecc69c0258e7b42ff720e": {
-    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    WHERE name = $1\n    LIMIT 1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Account>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "email",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "name!: CatalogName",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "unique_name!: UniqueName",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -132,54 +126,54 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    WHERE name = $1\n    LIMIT 1\n    "
   },
   "3130a9642afcbf07a7e8b0e7441428447b70bacf57589cac8cdd79a2d5492b52": {
-    "query": "\n    SELECT id as \"id!: Id<Connector>\", description, name, maintainer, type as \"type!: ConnectorType\", created_at, updated_at\n    FROM connectors\n    WHERE id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Connector>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "description",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "maintainer",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "type!: ConnectorType",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -188,52 +182,102 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Connector>\", description, name, maintainer, type as \"type!: ConnectorType\", created_at, updated_at\n    FROM connectors\n    WHERE id = $1\n    "
+  },
+  "313ded554111cc7d36f9b1760e64a1a9b53438d60b6d070d2bf4045b3512bf62": {
+    "describe": {
+      "columns": [
+        {
+          "name": "account_id: Id<Account>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "catalog: Option<Json<models::Catalog>>",
+          "ordinal": 1,
+          "type_info": "Json"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "id: Id<Build>",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "state: Json<State>",
+          "ordinal": 4,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n    SELECT\n        account_id as \"account_id: Id<Account>\",\n        catalog as \"catalog: Option<Json<models::Catalog>>\",\n        created_at,\n        id as \"id: Id<Build>\",\n        state as \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE state->>'type' = 'queued' AND\n        pg_try_advisory_xact_lock(id)\n    ORDER BY id ASC\n    LIMIT 1\n    "
   },
   "40eb0abd64861d5312663b9d2c80b2681950a48283d6cb34ede4e7d92757bbfc": {
-    "query": "\n    SELECT id as \"id!: Id<Connector>\", description, name, maintainer, type as \"type!: ConnectorType\", created_at, updated_at\n    FROM connectors\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Connector>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "description",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "maintainer",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "type!: ConnectorType",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
@@ -242,18 +286,24 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Connector>\", description, name, maintainer, type as \"type!: ConnectorType\", created_at, updated_at\n    FROM connectors\n    "
   },
   "484eee5e70b9a382601916323bf5ba89b22112caae7fac46d13e53cecbcdc0b8": {
-    "query": "\n    INSERT INTO connectors(description, name, maintainer, type, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<Connector>\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Connector>",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -262,21 +312,21 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    INSERT INTO connectors(description, name, maintainer, type, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<Connector>\"\n    "
   },
   "59f9a43507b96057a17e471eac43c8541c4eef7b4a2a3cd6b0ee62dc9ccc6150": {
-    "query": "\n    INSERT INTO connector_images(connector_id, name, digest, tag, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<ConnectorImage>\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<ConnectorImage>",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -285,67 +335,59 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    INSERT INTO connector_images(connector_id, name, digest, tag, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<ConnectorImage>\"\n    "
   },
   "62b2424aaf1539ac6900db3a299fe05448ab56597398d8ac8575ccb4529e52ce": {
-    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE account_id = $1\n    LIMIT 1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Credential>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "account_id!: Id<Account>",
+          "ordinal": 1,
           "type_info": "Int8"
         },
         {
-          "ordinal": 2,
           "name": "expires_at",
+          "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 3,
           "name": "issuer",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "last_authorized_at",
+          "ordinal": 4,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 5,
           "name": "session_token",
+          "ordinal": 5,
           "type_info": "Text"
         },
         {
-          "ordinal": 6,
           "name": "subject",
+          "ordinal": 6,
           "type_info": "Text"
         },
         {
-          "ordinal": 7,
           "name": "created_at",
+          "ordinal": 7,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 8,
           "name": "updated_at",
+          "ordinal": 8,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -356,123 +398,267 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE account_id = $1\n    LIMIT 1\n    "
   },
-  "b514524b7f8225168c0fb0d8b2cfb812a07a7b72b7375dc76eed95a2bc98f0ef": {
-    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE account_id = $1 AND session_token = $2\n    LIMIT 1\n    ",
+  "88550c22dc35c54a04af228fffdaf3031ed77fb7b331d7e0089998884c6ade66": {
     "describe": {
       "columns": [
         {
+          "name": "account_id: Id<Account>",
           "ordinal": 0,
-          "name": "id!: Id<Credential>",
           "type_info": "Int8"
         },
         {
+          "name": "catalog: Option<Json<models::Catalog>>",
           "ordinal": 1,
-          "name": "account_id!: Id<Account>",
+          "type_info": "Json"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "id: Id<Build>",
+          "ordinal": 3,
           "type_info": "Int8"
         },
         {
-          "ordinal": 2,
-          "name": "expires_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "issuer",
-          "type_info": "Text"
-        },
-        {
+          "name": "state: Json<State>",
           "ordinal": 4,
-          "name": "last_authorized_at",
-          "type_info": "Timestamptz"
+          "type_info": "Jsonb"
         },
         {
-          "ordinal": 5,
-          "name": "session_token",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "subject",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
           "name": "updated_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT\n        account_id AS \"account_id: Id<Account>\",\n        catalog AS \"catalog: Option<Json<models::Catalog>>\",\n        created_at,\n        id AS \"id: Id<Build>\",\n        state AS \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE id = $1 AND account_id = $2\n    "
+  },
+  "b514524b7f8225168c0fb0d8b2cfb812a07a7b72b7375dc76eed95a2bc98f0ef": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: Id<Credential>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "account_id!: Id<Account>",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "expires_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "issuer",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "last_authorized_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "session_token",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "subject",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Int8",
           "Text"
         ]
-      },
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE account_id = $1 AND session_token = $2\n    LIMIT 1\n    "
+  },
+  "b64320e37bd93edf271b6987b1dce085ed2609ef8c2ad3131684e38ff4abb657": {
+    "describe": {
+      "columns": [
+        {
+          "name": "account_id: Id<Account>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "catalog: Json<models::Catalog>",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "id: Id<Build>",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "state: Json<State>",
+          "ordinal": 4,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        }
+      ],
       "nullable": [
         false,
-        false,
-        false,
-        false,
-        false,
+        null,
         false,
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT\n        account_id AS \"account_id: Id<Account>\",\n        NULL AS \"catalog: Json<models::Catalog>\", -- Skip catalog JSON in index listing.\n        created_at,\n        id AS \"id: Id<Build>\",\n        state AS \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE account_id = $1\n    "
+  },
+  "c32c26847d7fc19b3b8aba9058c7c577eaf98f0a13ca0b1c1b86714d28dff33c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "r",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Jsonb"
+        ]
+      }
+    },
+    "query": "\n    UPDATE builds SET\n        state = $2,\n        updated_at = NOW()\n    WHERE id = $1\n    RETURNING\n        true AS \"r\"\n    "
+  },
+  "c334b909172fd7fe443f1474076ba71d7bb88a3ef4803d2bec45d0e3671cd688": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: Id<Build>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Json",
+          "Jsonb"
+        ]
+      }
+    },
+    "query": "\n    INSERT INTO builds(account_id, catalog, state, created_at, updated_at)\n    VALUES ($1, $2, $3, NOW(), NOW())\n    RETURNING\n        id as \"id!: Id<Build>\"\n    "
   },
   "d9f2506c62e6f8321d372f50aaa14df78ce25dc5333ab0e5c61b0ce7945e394d": {
-    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    WHERE id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Account>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "display_name",
+          "ordinal": 1,
           "type_info": "Text"
         },
         {
-          "ordinal": 2,
           "name": "email",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "name!: CatalogName",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "unique_name!: UniqueName",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -481,54 +667,54 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Account>\", display_name, email, name as \"name!: CatalogName\", unique_name as \"unique_name!: UniqueName\", created_at, updated_at\n    FROM accounts\n    WHERE id = $1\n    "
   },
   "e7a5e36825585adf822633ca2a09a60f67926102959eb6a6bf54697b24e37795": {
-    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    WHERE id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<ConnectorImage>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "connector_id!: Id<Connector>",
+          "ordinal": 1,
           "type_info": "Int8"
         },
         {
-          "ordinal": 2,
           "name": "name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "digest",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "tag",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
       ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
       "nullable": [
         false,
         false,
@@ -537,72 +723,80 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    WHERE id = $1\n    "
   },
   "e80822fdeb3678a96f3ca3708ebc68449eed437937f2b66aaade0ff11ce5199f": {
-    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<ConnectorImage>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "connector_id!: Id<Connector>",
+          "ordinal": 1,
           "type_info": "Int8"
         },
         {
-          "ordinal": 2,
           "name": "name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "digest",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "tag",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    "
   },
   "eb3beba1620e27fd782269f9d87616d32e55d2c62a86ac9e4f16424658c6faf3": {
-    "query": "\n    INSERT INTO accounts(display_name, email, name, unique_name, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<Account>\"\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<Account>",
+          "ordinal": 0,
           "type_info": "Int8"
         }
+      ],
+      "nullable": [
+        false
       ],
       "parameters": {
         "Left": [
@@ -611,57 +805,115 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    INSERT INTO accounts(display_name, email, name, unique_name, created_at, updated_at)\n    VALUES ($1, $2, $3, $4, NOW(), NOW())\n    RETURNING id as \"id!: Id<Account>\"\n    "
   },
   "f2650529688140a9ce20356a8857e7a0f5b5e0af5b154f836f60cd297d0f898e": {
-    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    WHERE connector_id = $1\n    ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id!: Id<ConnectorImage>",
+          "ordinal": 0,
           "type_info": "Int8"
         },
         {
-          "ordinal": 1,
           "name": "connector_id!: Id<Connector>",
+          "ordinal": 1,
           "type_info": "Int8"
         },
         {
-          "ordinal": 2,
           "name": "name",
+          "ordinal": 2,
           "type_info": "Text"
         },
         {
-          "ordinal": 3,
           "name": "digest",
+          "ordinal": 3,
           "type_info": "Text"
         },
         {
-          "ordinal": 4,
           "name": "tag",
+          "ordinal": 4,
           "type_info": "Text"
         },
         {
-          "ordinal": 5,
           "name": "created_at",
+          "ordinal": 5,
           "type_info": "Timestamptz"
         },
         {
-          "ordinal": 6,
           "name": "updated_at",
+          "ordinal": 6,
           "type_info": "Timestamptz"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
           "Int8"
         ]
-      },
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<ConnectorImage>\", connector_id as \"connector_id!: Id<Connector>\", name, digest, tag, created_at, updated_at\n    FROM connector_images\n    WHERE connector_id = $1\n    "
+  },
+  "f87d932c6871310b077ff7515ed727f998532e87ca0bad505e7c443579acbd32": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: Id<Credential>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "account_id!: Id<Account>",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "expires_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "issuer",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "last_authorized_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "session_token",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "subject",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        }
+      ],
       "nullable": [
         false,
         false,
@@ -669,63 +921,65 @@
         false,
         false,
         false,
+        false,
+        false,
         false
-      ]
-    }
-  },
-  "f87d932c6871310b077ff7515ed727f998532e87ca0bad505e7c443579acbd32": {
-    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: Id<Credential>",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "account_id!: Id<Account>",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 2,
-          "name": "expires_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "issuer",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "last_authorized_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "session_token",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "subject",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        }
       ],
       "parameters": {
         "Left": []
-      },
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    "
+  },
+  "fb3510b76904e7b36feca665d4a7927bfc38d7b3719835a6cce8681fa151544e": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!: Id<Credential>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "account_id!: Id<Account>",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "expires_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "issuer",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "last_authorized_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "session_token",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "subject",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        }
+      ],
       "nullable": [
         false,
         false,
@@ -736,75 +990,13 @@
         false,
         false,
         false
-      ]
-    }
-  },
-  "fb3510b76904e7b36feca665d4a7927bfc38d7b3719835a6cce8681fa151544e": {
-    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE id = $1\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id!: Id<Credential>",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "account_id!: Id<Account>",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 2,
-          "name": "expires_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 3,
-          "name": "issuer",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "last_authorized_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "session_token",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "subject",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "updated_at",
-          "type_info": "Timestamptz"
-        }
       ],
       "parameters": {
         "Left": [
           "Int8"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "\n    SELECT id as \"id!: Id<Credential>\",\n           account_id as \"account_id!: Id<Account>\",\n           expires_at,\n           issuer,\n           last_authorized_at,\n           session_token,\n           subject,\n           created_at,\n           updated_at\n    FROM credentials\n    WHERE id = $1\n    "
   }
 }

--- a/crates/control/sqlx-data.json
+++ b/crates/control/sqlx-data.json
@@ -191,54 +191,6 @@
     },
     "query": "\n    SELECT id as \"id!: Id<Connector>\", description, name, maintainer, type as \"type!: ConnectorType\", created_at, updated_at\n    FROM connectors\n    WHERE id = $1\n    "
   },
-  "313ded554111cc7d36f9b1760e64a1a9b53438d60b6d070d2bf4045b3512bf62": {
-    "describe": {
-      "columns": [
-        {
-          "name": "account_id: Id<Account>",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "catalog: Option<Json<models::Catalog>>",
-          "ordinal": 1,
-          "type_info": "Json"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 2,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "id: Id<Build>",
-          "ordinal": 3,
-          "type_info": "Int8"
-        },
-        {
-          "name": "state: Json<State>",
-          "ordinal": 4,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "updated_at",
-          "ordinal": 5,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "\n    SELECT\n        account_id as \"account_id: Id<Account>\",\n        catalog as \"catalog: Option<Json<models::Catalog>>\",\n        created_at,\n        id as \"id: Id<Build>\",\n        state as \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE state->>'type' = 'queued' AND\n        pg_try_advisory_xact_lock(id)\n    ORDER BY id ASC\n    LIMIT 1\n    "
-  },
   "40eb0abd64861d5312663b9d2c80b2681950a48283d6cb34ede4e7d92757bbfc": {
     "describe": {
       "columns": [
@@ -457,6 +409,54 @@
       }
     },
     "query": "\n    SELECT\n        account_id AS \"account_id: Id<Account>\",\n        catalog AS \"catalog: Option<Json<models::Catalog>>\",\n        created_at,\n        id AS \"id: Id<Build>\",\n        state AS \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE id = $1 AND account_id = $2\n    "
+  },
+  "ad999cf9b68926b6f897cb66f44fe8f0a2b34bdf26c04d5284abc1c957155901": {
+    "describe": {
+      "columns": [
+        {
+          "name": "account_id: Id<Account>",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "catalog: Option<Json<models::Catalog>>",
+          "ordinal": 1,
+          "type_info": "Json"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "id: Id<Build>",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "state: Json<State>",
+          "ordinal": 4,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 5,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n    SELECT\n        account_id as \"account_id: Id<Account>\",\n        catalog as \"catalog: Option<Json<models::Catalog>>\",\n        created_at,\n        id as \"id: Id<Build>\",\n        state as \"state: Json<State>\",\n        updated_at\n    FROM builds\n    WHERE state->>'type' = 'queued'\n    ORDER BY id ASC\n    LIMIT 1\n    FOR UPDATE SKIP LOCKED\n    "
   },
   "b514524b7f8225168c0fb0d8b2cfb812a07a7b72b7375dc76eed95a2bc98f0ef": {
     "describe": {

--- a/crates/control/src/controllers/builds.rs
+++ b/crates/control/src/controllers/builds.rs
@@ -16,9 +16,7 @@ pub async fn index(
     Extension(ctx): Extension<AppContext>,
     CurrentAccount(account): CurrentAccount,
 ) -> Result<impl IntoResponse, AppError> {
-    tracing::debug!(?account.id, "entered index");
     let builds = builds_repo::fetch_for_account(ctx.db(), account.id).await?;
-
     Ok((StatusCode::OK, view::index(builds)))
 }
 
@@ -28,7 +26,6 @@ pub async fn create(
     Json(catalog): Json<models::Catalog>,
 ) -> Result<impl IntoResponse, AppError> {
     let build = builds_repo::insert(ctx.db(), catalog, account.id).await?;
-
     Ok((StatusCode::CREATED, view::create(build)))
 }
 

--- a/crates/control/src/controllers/builds.rs
+++ b/crates/control/src/controllers/builds.rs
@@ -1,0 +1,42 @@
+use axum::extract::{Extension, Path};
+use axum::response::IntoResponse;
+use axum::Json;
+use hyper::StatusCode;
+
+use crate::context::AppContext;
+use crate::error::AppError;
+use crate::middleware::sessions::CurrentAccount;
+use crate::models::{builds::Build, id::Id};
+use crate::repo::builds as builds_repo;
+
+pub mod routes;
+mod view;
+
+pub async fn index(
+    Extension(ctx): Extension<AppContext>,
+    CurrentAccount(account): CurrentAccount,
+) -> Result<impl IntoResponse, AppError> {
+    tracing::debug!(?account.id, "entered index");
+    let builds = builds_repo::fetch_for_account(ctx.db(), account.id).await?;
+
+    Ok((StatusCode::OK, view::index(builds)))
+}
+
+pub async fn create(
+    Extension(ctx): Extension<AppContext>,
+    CurrentAccount(account): CurrentAccount,
+    Json(catalog): Json<models::Catalog>,
+) -> Result<impl IntoResponse, AppError> {
+    let build = builds_repo::insert(ctx.db(), catalog, account.id).await?;
+
+    Ok((StatusCode::CREATED, view::create(build)))
+}
+
+pub async fn show(
+    Extension(ctx): Extension<AppContext>,
+    CurrentAccount(account): CurrentAccount,
+    Path(build_id): Path<Id<Build>>,
+) -> Result<impl IntoResponse, AppError> {
+    let image = builds_repo::fetch_one(ctx.db(), build_id, account.id).await?;
+    Ok((StatusCode::OK, view::show(image)))
+}

--- a/crates/control/src/controllers/builds/routes.rs
+++ b/crates/control/src/controllers/builds/routes.rs
@@ -1,14 +1,10 @@
-use crate::config::settings;
+use crate::controllers::url_for;
 use crate::models::{builds::Build, id::Id};
 
 pub fn index() -> String {
-    prefixed("/builds")
+    url_for("/builds")
 }
 
 pub fn show(build_id: Id<Build>) -> String {
-    prefixed(format!("/builds/{}", build_id.to_string()))
-}
-
-fn prefixed(path: impl Into<String>) -> String {
-    format!("http://{}{}", settings().application.address(), path.into())
+    url_for(format!("/builds/{}", build_id.to_string()))
 }

--- a/crates/control/src/controllers/builds/routes.rs
+++ b/crates/control/src/controllers/builds/routes.rs
@@ -1,0 +1,14 @@
+use crate::config::settings;
+use crate::models::{builds::Build, id::Id};
+
+pub fn index() -> String {
+    prefixed("/builds")
+}
+
+pub fn show(build_id: Id<Build>) -> String {
+    prefixed(format!("/builds/{}", build_id.to_string()))
+}
+
+fn prefixed(path: impl Into<String>) -> String {
+    format!("http://{}{}", settings().application.address(), path.into())
+}

--- a/crates/control/src/controllers/builds/view.rs
+++ b/crates/control/src/controllers/builds/view.rs
@@ -1,0 +1,34 @@
+use axum::Json;
+
+use crate::controllers::builds::routes;
+use crate::controllers::json_api::{DocumentData, Links, Many, One, Resource};
+use crate::models::builds::Build;
+
+pub fn index(builds: Vec<Build>) -> Json<Many<Build>> {
+    let resources = builds.into_iter().map(Resource::from).collect();
+    let links = Links::default().put("self", routes::index());
+    Json(DocumentData::new(resources, links))
+}
+
+pub fn create(build: Build) -> Json<One<Build>> {
+    let resource = DocumentData::new(Resource::from(build), Links::default());
+    Json(resource)
+}
+
+pub fn show(build: Build) -> Json<One<Build>> {
+    let resource = DocumentData::new(Resource::from(build), Links::default());
+    Json(resource)
+}
+
+impl From<Build> for Resource<Build> {
+    fn from(build: Build) -> Self {
+        let links = Links::default().put("self", routes::show(build.id));
+
+        Resource {
+            id: build.id,
+            r#type: "build",
+            attributes: build,
+            links,
+        }
+    }
+}

--- a/crates/control/src/controllers/mod.rs
+++ b/crates/control/src/controllers/mod.rs
@@ -1,4 +1,5 @@
 pub mod accounts;
+pub mod builds;
 pub mod connector_images;
 pub mod connectors;
 pub mod health_check;

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -8,9 +8,9 @@ pub mod middleware;
 pub mod models;
 pub mod repo;
 pub mod services;
+pub mod shutdown;
 pub mod startup;
 
 mod controllers;
 mod error;
 mod routes;
-mod shutdown;

--- a/crates/control/src/models/builds.rs
+++ b/crates/control/src/models/builds.rs
@@ -1,0 +1,49 @@
+use chrono::{DateTime, Utc};
+use models;
+use serde::{Deserialize, Serialize};
+use sqlx::{types::Json, FromRow};
+use std::fmt;
+
+use crate::models::accounts;
+use crate::models::id::Id;
+
+/// Status of the Build.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum State {
+    Queued,
+    Done,
+    BuildFailed { code: Option<i32> },
+    TestFailed { code: Option<i32> },
+}
+
+#[derive(Deserialize, FromRow, Serialize)]
+pub struct Build {
+    /// Account which owns this Build.
+    pub account_id: Id<accounts::Account>,
+    /// Root catalog built by this build, which may inline additional resources.
+    /// The catalog may not be retrieved in all contexts.
+    pub catalog: Option<Json<models::Catalog>>,
+    /// When this record was created.
+    pub created_at: DateTime<Utc>,
+    /// Primary key for this record.
+    pub id: Id<Build>,
+    /// Connectors must be either a source or materialization.
+    pub state: Json<State>,
+    /// When this record was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+// TODO(johnny) impl Debug for Build is required by query_as!, but I'm not sure why.
+impl fmt::Debug for Build {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Build")
+            .field("account_id", &self.account_id)
+            // catalog is omitted.
+            .field("created_at", &self.created_at)
+            .field("id", &self.id)
+            .field("state", &self.state)
+            .field("updated_at", &self.updated_at)
+            .finish()
+    }
+}

--- a/crates/control/src/models/builds.rs
+++ b/crates/control/src/models/builds.rs
@@ -12,7 +12,7 @@ use crate::models::id::Id;
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum State {
     Queued,
-    Done,
+    Success,
     BuildFailed { code: Option<i32> },
     TestFailed { code: Option<i32> },
 }
@@ -39,7 +39,7 @@ impl fmt::Debug for Build {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Build")
             .field("account_id", &self.account_id)
-            // catalog is omitted.
+            .field("catalog", &"<omitted>".to_string())
             .field("created_at", &self.created_at)
             .field("id", &self.id)
             .field("state", &self.state)

--- a/crates/control/src/models/mod.rs
+++ b/crates/control/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod accounts;
+pub mod builds;
 pub mod connector_images;
 pub mod connectors;
 pub mod credentials;

--- a/crates/control/src/repo/builds.rs
+++ b/crates/control/src/repo/builds.rs
@@ -1,0 +1,156 @@
+use crate::models::id::Id;
+use crate::models::{
+    accounts::Account,
+    builds::{Build, State},
+};
+use futures::TryFutureExt;
+use sqlx::{types::Json, PgPool, Postgres, Transaction};
+
+pub async fn fetch_for_account<'e>(
+    db: &PgPool,
+    account_id: Id<Account>,
+) -> Result<Vec<Build>, sqlx::Error> {
+    sqlx::query_as!(
+        Build,
+        r#"
+    SELECT
+        account_id AS "account_id: Id<Account>",
+        NULL AS "catalog: Json<models::Catalog>", -- Skip catalog JSON in index listing.
+        created_at,
+        id AS "id: Id<Build>",
+        state AS "state: Json<State>",
+        updated_at
+    FROM builds
+    WHERE account_id = $1
+    "#,
+        account_id as Id<Account>,
+    )
+    .fetch_all(db)
+    .await
+}
+
+pub async fn fetch_one(
+    db: &PgPool,
+    build_id: Id<Build>,
+    account_id: Id<Account>,
+) -> Result<Build, sqlx::Error> {
+    sqlx::query_as!(
+        Build,
+        r#"
+    SELECT
+        account_id AS "account_id: Id<Account>",
+        catalog AS "catalog: Option<Json<models::Catalog>>",
+        created_at,
+        id AS "id: Id<Build>",
+        state AS "state: Json<State>",
+        updated_at
+    FROM builds
+    WHERE id = $1 AND account_id = $2
+    "#,
+        build_id as Id<Build>,
+        account_id as Id<Account>,
+    )
+    .fetch_one(db)
+    .await
+}
+
+pub async fn insert(
+    db: &PgPool,
+    catalog: models::Catalog,
+    account_id: Id<Account>,
+) -> Result<Build, sqlx::Error> {
+    sqlx::query!(
+        r#"
+    INSERT INTO builds(account_id, catalog, state, created_at, updated_at)
+    VALUES ($1, $2, $3, NOW(), NOW())
+    RETURNING
+        id as "id!: Id<Build>"
+    "#,
+        account_id as Id<Account>,
+        Json(catalog) as Json<models::Catalog>,
+        Json(State::Queued) as Json<State>,
+    )
+    .fetch_one(db)
+    .and_then(|row| fetch_one(db, row.id, account_id))
+    .await
+}
+
+// dequeue_build returns a queued Build to build, or None if the queue is empty.
+// If a Some(Build) is returned, it's guaranteed that no parallel invocation of
+// dequeue_build will return that same Build so long as the argument Transaction
+// is alive.
+//
+// The query leverages PostgreSQL's advisory lock mechanism to obtain a
+// transaction-scoped exclusive lock on the `id` of its returned row.
+// `pg_try_advisory_xact_lock(id)` returns true if it obtains a lock on `id`,
+// or false if it's locked already.
+//
+// It's therefore important that the query plan call `pg_try_advisory_xact_lock`
+// on as few actual `id`'s as possible, as extra locking reduces parallelism.
+// For this query, we're capitalizing on the index `builds_id_where_queued`.
+// The optimizer uses it in an Index Scan to try successive increasing `id`'s
+// until one is found which is lock-able.
+//
+// This index also means that the common case (there are no queued builds) is
+// very cheap to poll, even if the total number of builds is large.
+//
+// If the query plan were to change on us then `pg_try_advisory_xact_lock(id)`
+// could lock additional non-returned `id`'s, which would reduce the potential
+// parallelism but would not be a correctness issue.
+//
+// All obtained locks are automatically released on transaction close.
+// If a builder fails its lock is automatically removed, making the Build
+// eligible again for dequeue by other workers.
+//
+/*
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+Limit  (cost=0.13..6.18 rows=1 width=68)
+->  Index Scan using builds_id_where_queued on builds  (cost=0.13..12.22 rows=2 width=68)
+        Filter: pg_try_advisory_xact_lock(id)
+*/
+pub async fn dequeue_build<'c>(
+    txn: &mut Transaction<'c, Postgres>,
+) -> Result<Option<Build>, sqlx::Error> {
+    sqlx::query_as!(
+        Build,
+        r#"
+    SELECT
+        account_id as "account_id: Id<Account>",
+        catalog as "catalog: Option<Json<models::Catalog>>",
+        created_at,
+        id as "id: Id<Build>",
+        state as "state: Json<State>",
+        updated_at
+    FROM builds
+    WHERE state->>'type' = 'queued' AND
+        pg_try_advisory_xact_lock(id)
+    ORDER BY id ASC
+    LIMIT 1
+    "#,
+    )
+    .fetch_optional(txn)
+    .await
+}
+
+pub async fn update_build_state<'c>(
+    txn: &mut Transaction<'c, Postgres>,
+    build_id: Id<Build>,
+    state: State,
+) -> Result<(), sqlx::Error> {
+    let _ = sqlx::query!(
+        r#"
+    UPDATE builds SET
+        state = $2,
+        updated_at = NOW()
+    WHERE id = $1
+    RETURNING
+        true AS "r"
+    "#,
+        build_id as Id<Build>,
+        Json(state) as Json<State>,
+    )
+    .fetch_one(txn)
+    .await?;
+    Ok(())
+}

--- a/crates/control/src/repo/mod.rs
+++ b/crates/control/src/repo/mod.rs
@@ -1,4 +1,5 @@
 pub mod accounts;
+pub mod builds;
 pub mod connector_images;
 pub mod connectors;
 pub mod credentials;

--- a/crates/control/src/routes.rs
+++ b/crates/control/src/routes.rs
@@ -6,6 +6,7 @@ use axum::Router;
 pub fn routes() -> Router {
     Router::new()
         .merge(accounts_routes())
+        .merge(builds_routes())
         .merge(connectors_routes())
         .merge(connector_images_routes())
         .layer(axum::middleware::from_fn(validate_authentication_token))
@@ -20,6 +21,15 @@ fn accounts_routes() -> Router {
             get(controllers::accounts::index).post(controllers::accounts::create),
         )
         .route("/accounts/:id", get(controllers::accounts::show))
+}
+
+fn builds_routes() -> Router {
+    Router::new()
+        .route(
+            "/builds",
+            get(controllers::builds::index).post(controllers::builds::create),
+        )
+        .route("/builds/:id", get(controllers::builds::show))
 }
 
 fn connectors_routes() -> Router {

--- a/crates/control/src/services/builder/mod.rs
+++ b/crates/control/src/services/builder/mod.rs
@@ -1,0 +1,310 @@
+use crate::context::AppContext;
+use crate::models::{
+    builds::{Build, State},
+    id::Id,
+};
+use crate::repo::builds::{dequeue_build, update_build_state};
+
+use futures::{pin_mut, select, FutureExt};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+use tokio::io::AsyncBufReadExt;
+use tracing::{debug, error, info};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to create temporary build directory")]
+    CreateDir(#[source] std::io::Error),
+    #[error("failed to create source catalog file")]
+    CreateSource(#[source] std::io::Error),
+    #[error("processing task {task:?} failed")]
+    Task {
+        task: String,
+        #[source]
+        err: std::io::Error,
+    },
+    #[error("failed to persist build {id}")]
+    PersistBuild {
+        id: Id<Build>,
+        #[source]
+        src: crate::services::builds_root::BuildsRootError,
+    },
+    #[error("sqlite database error")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("control plane database error")]
+    SqlxError(#[from] sqlx::Error),
+}
+
+pub async fn serve_builds<F>(ctx: AppContext, shutdown: F) -> Result<(), Error>
+where
+    F: std::future::Future<Output = ()>,
+{
+    let shutdown = shutdown.fuse();
+    pin_mut!(shutdown);
+
+    let mut backoff = std::time::Duration::ZERO;
+
+    loop {
+        let sleep = tokio::time::sleep(backoff).fuse();
+        pin_mut!(sleep);
+
+        select! {
+            _ = shutdown => {
+                return Ok(())
+            }
+            _ = &mut sleep => (),
+        };
+
+        // Begin a |txn| which will scope a held advisory lock on `Build.id`.
+        let mut txn = ctx.db().begin().await?;
+
+        if let Some(build) = dequeue_build(&mut txn).await? {
+            let Build {
+                id,
+                account_id,
+                catalog,
+                created_at,
+                state: _,
+                updated_at,
+            } = build;
+
+            let tmpdir = tempfile::TempDir::new().map_err(|e| Error::CreateDir(e))?;
+            info!(%id, %account_id, tmpdir=?tmpdir.path(), %created_at, %updated_at, "processing dequeued build");
+
+            let (state, db_path) = process_build(id, catalog.unwrap().0, tmpdir.path()).await?;
+            info!(?state, "processed build");
+
+            ctx.put_builds()
+                .put_build(id, &db_path)
+                .await
+                .map_err(|src| Error::PersistBuild { id, src })?;
+            info!(%id, "put build");
+
+            update_build_state(&mut txn, id, state).await?;
+            txn.commit().await?;
+
+            backoff = std::time::Duration::ZERO;
+        } else {
+            debug!("serve_builds found no build to dequeue. Sleeping...");
+            backoff = std::time::Duration::from_secs(5);
+        }
+    }
+}
+
+async fn process_build(
+    id: Id<Build>,
+    catalog: models::Catalog,
+    tmp_dir: &Path,
+) -> Result<(State, PathBuf), Error> {
+    // We perform the build under a ./builds/ subdirectory, which is a
+    // specific sub-path expected by temp-data-plane underneath its
+    // working temporary directory. This lets temp-data-plane use the
+    // build database in-place.
+    let builds_dir = tmp_dir.join("builds");
+    std::fs::create_dir(&builds_dir).map_err(|err| Error::CreateDir(err))?;
+
+    // Write our catalog source file within the build directory.
+    std::fs::File::create(&builds_dir.join(&format!("{}.flow.yaml", id)))
+        .and_then(|mut f| {
+            f.write_all(
+                serde_json::to_string_pretty(&catalog)
+                    .expect("to always serialize a models::Catalog")
+                    .as_bytes(),
+            )
+        })
+        .map_err(|e| Error::CreateSource(e))?;
+
+    let db_name = format!("{}", id);
+    let db_path = builds_dir.join(&db_name);
+    let db = rusqlite::Connection::open(&db_path)?;
+
+    enable_wal_mode(&db)?;
+    create_task_logs_table(&db)?;
+
+    let build_task = run_task(
+        tokio::process::Command::new("flowctl")
+            .arg("api")
+            .arg("build")
+            .arg("--build-id")
+            .arg(&db_name)
+            .arg("--directory")
+            .arg(&builds_dir)
+            .arg("--fs-root")
+            .arg(&builds_dir)
+            .arg("--network")
+            .arg(&crate::config::settings().application.connector_network)
+            .arg("--source")
+            .arg(format!("file:///{}.flow.yaml", id))
+            .arg("--source-type")
+            .arg("catalog")
+            .arg("--ts-package")
+            .arg("--log.level=info")
+            .arg("--log.format=color")
+            .current_dir(tmp_dir),
+        &db,
+        "build",
+    )
+    .await
+    .map_err(|err| Error::Task {
+        task: "build".to_string(),
+        err,
+    })?;
+
+    if !build_task.success() {
+        return Ok((
+            State::BuildFailed {
+                code: build_task.code(),
+            },
+            db_path,
+        ));
+    }
+
+    // Start a data-plane. It will use ${tmp_dir}/builds as its builds-root,
+    // which we also used as the build directory, meaning the build database
+    // is already in-place.
+    let mut data_plane_task = tokio::process::Command::new("flowctl");
+    let data_plane_task = run_task(
+        data_plane_task
+            .arg("temp-data-plane")
+            .arg("--network")
+            .arg(&crate::config::settings().application.connector_network)
+            .arg("--tempdir")
+            .arg(tmp_dir)
+            .arg("--unix-sockets")
+            .arg("--log.level=info")
+            .arg("--log.format=color")
+            .current_dir(tmp_dir),
+        &db,
+        "temp-data-plane",
+    )
+    .fuse();
+
+    // Start the test runner.
+    let mut test_task = tokio::process::Command::new("flowctl");
+    let test_task = run_task(
+        test_task
+            .arg("api")
+            .arg("test")
+            .arg("--build-id")
+            .arg(&db_name)
+            .arg("--broker.address")
+            .arg(&format!(
+                "unix://localhost/{}/gazette.sock",
+                tmp_dir.as_os_str().to_string_lossy()
+            ))
+            .arg("--consumer.address")
+            .arg(&format!(
+                "unix://localhost/{}/consumer.sock",
+                tmp_dir.as_os_str().to_string_lossy()
+            ))
+            .arg("--log.level=info")
+            .arg("--log.format=color")
+            .current_dir(tmp_dir),
+        &db,
+        "test",
+    )
+    .fuse();
+
+    // Drive the data-plane and test tasks, until tests complete.
+    pin_mut!(data_plane_task, test_task);
+    let test_task = select! {
+        r = data_plane_task => {
+            tracing::error!(?r, "test data-plane exited unexpectedly");
+            test_task.await // Wait for the test task to finish.
+        }
+        r = test_task => r,
+    }
+    .map_err(|err| Error::Task {
+        task: "test".to_string(),
+        err,
+    })?;
+
+    if !test_task.success() {
+        return Ok((
+            State::TestFailed {
+                code: test_task.code(),
+            },
+            db_path,
+        ));
+    }
+
+    Ok((State::Done, db_path))
+}
+
+// run_task spawns the provided Command, capturing its stdout and stderr
+// into the provided logs database identified by |task|.
+async fn run_task(
+    cmd: &mut tokio::process::Command,
+    logs_db: &rusqlite::Connection,
+    task: &str,
+) -> Result<std::process::ExitStatus, std::io::Error> {
+    cmd
+        // Pass through PATH, but remove all other environment variables.
+        .env_clear()
+        .envs(std::env::vars().filter(|&(ref k, _)| k == "PATH"))
+        .kill_on_drop(true)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+
+    let stdout = capture_task_logs(logs_db, task, 0, child.stdout.take().unwrap());
+    let stderr = capture_task_logs(logs_db, task, 1, child.stderr.take().unwrap());
+
+    let (_, _, exit) = futures::try_join!(stdout, stderr, child.wait())?;
+    Ok(exit)
+}
+
+fn enable_wal_mode(db: &rusqlite::Connection) -> rusqlite::Result<()> {
+    let mode: String = db.pragma_update_and_check(None, "journal_mode", "wal", |row| row.get(0))?;
+    if mode != "wal" {
+        Err(rusqlite::Error::UserFunctionError(
+            format!("expected journal_mode to be wal, not {}", mode).into(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn create_task_logs_table(db: &rusqlite::Connection) -> rusqlite::Result<()> {
+    db.execute_batch(
+        r#"
+    CREATE TABLE IF NOT EXISTS task_logs (
+        task TEXT NOT NULL,
+        source INTEGER NOT NULL, -- 0 is stdout; 1 is stderr.
+        timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        line TEXT NOT NULL
+    );
+    "#,
+    )?;
+
+    Ok(())
+}
+
+// capture_task_logs consumes lines from the AsyncRead and adds each as a log
+// entry to a well-known `task_logs` table within the given SQLite database.
+// Each entry is identified by its task and source.
+// By convention, stdout is source=0 and stderr is source=1.
+async fn capture_task_logs<R>(
+    db: &rusqlite::Connection,
+    task: &str,
+    source: i32,
+    r: R,
+) -> Result<(), std::io::Error>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut splits = tokio::io::BufReader::new(r).split(b'\n');
+    while let Some(split) = splits.next_segment().await? {
+        db.execute(
+            "INSERT INTO task_logs (task, source, line) VALUES (?, ?, ?);",
+            rusqlite::params![task, source, split],
+        )
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+    }
+
+    Ok(())
+}

--- a/crates/control/src/services/builds_root/mod.rs
+++ b/crates/control/src/services/builds_root/mod.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::error::SubprocessError;
-use crate::models::id::Id;
+use crate::models::{builds::Build, id::Id};
+
 use async_trait::async_trait;
 use rusqlite::{Connection, OpenFlags};
 use std::collections::BTreeMap;
@@ -13,19 +14,17 @@ use tokio::sync::Mutex;
 mod gcs;
 mod local;
 
-// TEMPORARY: I needed something to parameterize `Id` with. This should be
-// replaced with a real `Build` type soon.
-#[derive(Debug)]
-pub struct Build;
-
 /// Allows uploading builds to the builds root.
 #[derive(Debug, Clone)]
 pub struct PutBuilds(Arc<dyn BuildsRootService>);
 
 impl PutBuilds {
     /// Uploads the given `build_db` to the builds root so that it is accessible to the data plane.
-    #[allow(dead_code)]
-    async fn put_build(&self, build_id: Id<Build>, build_db: &Path) -> Result<(), BuildsRootError> {
+    pub async fn put_build(
+        &self,
+        build_id: Id<Build>,
+        build_db: &Path,
+    ) -> Result<(), BuildsRootError> {
         self.0.put_build(build_id, build_db).await
     }
 }

--- a/crates/control/src/services/mod.rs
+++ b/crates/control/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod builds_root;
 pub mod connectors;
 pub mod sessions;

--- a/crates/control/src/shutdown.rs
+++ b/crates/control/src/shutdown.rs
@@ -2,7 +2,7 @@ use tracing::info;
 
 /// Sets up a termination signal handlers. The Future returned by this async
 /// function will resolve when one of these handlers is triggered.
-pub(crate) async fn signal() {
+pub async fn signal() {
     use tokio::signal;
 
     let ctrl_c = async {

--- a/crates/control/src/startup.rs
+++ b/crates/control/src/startup.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::net::TcpListener;
 
-use axum::{AddExtensionLayer, Router};
+use axum::Router;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use tower::limit::ConcurrencyLimitLayer;
@@ -40,7 +40,7 @@ pub fn app(ctx: AppContext) -> Router {
         .layer(cors::cors_layer())
         .layer(TraceLayer::new_for_http())
         .layer(ConcurrencyLimitLayer::new(64))
-        .layer(AddExtensionLayer::new(ctx))
+        .layer(axum::extract::Extension(ctx))
 }
 
 pub async fn connect_to_postgres(db_settings: &DatabaseSettings) -> PgPool {

--- a/crates/control/tests/it/builds.rs
+++ b/crates/control/tests/it/builds.rs
@@ -1,0 +1,134 @@
+use crate::support::{self, factory, redactor, test_context};
+
+use control::models::builds::{Build, State};
+use control::repo::builds::{dequeue_build, fetch_for_account, update_build_state};
+
+#[tokio::test]
+async fn index_test() {
+    let mut t = test_context!();
+    let batman = factory::BatmanAccount.create(t.db()).await;
+    let joker = factory::JokerAccount.create(t.db()).await;
+    let build_batman = factory::AcmeBuild.create(t.db(), batman.id).await;
+    let build_joker = factory::AcmeBuild.create(t.db(), joker.id).await;
+
+    let redactor = redactor::Redactor::default()
+        .redact(batman.id, "account<batman>")
+        .redact(joker.id, "account<joker>")
+        .redact(build_batman.id, "build<batman>")
+        .redact(build_joker.id, "build<joker>");
+
+    // Batman views their build.
+    t.login(batman.clone());
+    let mut response = t.get("/builds").await;
+
+    // Assert we get Batman's build (only).
+    assert!(response.status().is_success());
+    assert_json_snapshot!(redactor.response_json(&mut response).await.unwrap(), {
+        ".data.*.attributes.created_at" => "[datetime]",
+        ".data.*.attributes.updated_at" => "[datetime]",
+    });
+}
+
+#[tokio::test]
+async fn create_test() {
+    let mut t = test_context!();
+    let account = factory::BatmanAccount.create(t.db()).await;
+    t.login(account.clone());
+    let catalog = factory::AcmeBuild.attrs();
+
+    let mut response = t.post("/builds", &catalog).await;
+
+    // Expect build was created.
+    let builds = fetch_for_account(t.db(), account.id)
+        .await
+        .expect("to insert test data");
+    assert_eq!(1, builds.len());
+
+    // Expect build was returned in the response.
+    assert_eq!(201, response.status().as_u16());
+    let redactor = redactor::Redactor::default()
+        .redact(account.id, "a1")
+        .redact(builds[0].id, "b1");
+    assert_json_snapshot!(redactor.response_json(&mut response).await.unwrap(), {
+        ".data.attributes.created_at" => "[datetime]",
+        ".data.attributes.updated_at" => "[datetime]",
+    });
+}
+
+#[tokio::test]
+async fn show_test() {
+    let mut t = test_context!();
+    let batman = factory::BatmanAccount.create(t.db()).await;
+    let joker = factory::JokerAccount.create(t.db()).await;
+    let build = factory::AcmeBuild.create(t.db(), batman.id).await;
+
+    let build_url = format!("/builds/{}", build.id);
+    let redactor = redactor::Redactor::default()
+        .redact(batman.id, "account<batman>")
+        .redact(build.id, "build<batman>");
+
+    // Joker attempts to view Batman's build, but it 404's.
+    t.login(joker.clone());
+    let response = t.get(&build_url).await;
+    assert_eq!(response.status().canonical_reason(), Some("Not Found"));
+
+    // Batman can view their own build.
+    t.login(batman.clone());
+    let mut response = t.get(&build_url).await;
+
+    assert!(response.status().is_success());
+    assert_json_snapshot!(redactor.response_json(&mut response).await.unwrap(), {
+        ".data.attributes.created_at" => "[datetime]",
+        ".data.attributes.updated_at" => "[datetime]",
+    });
+}
+
+#[tokio::test]
+async fn dequeue_builds_test() {
+    let t = test_context!();
+    let batman = factory::BatmanAccount.create(t.db()).await;
+    let build_1 = factory::AcmeBuild.create(t.db(), batman.id).await;
+
+    // First dequeue obtains build_1 and holds its transaction open.
+    let mut txn_1 = t.db().begin().await.unwrap();
+    let build = dequeue_build(&mut txn_1).await.unwrap();
+    assert!(matches!(build, Some(Build { id, .. }) if id == build_1.id));
+
+    // Second build is added, and a parallel transaction dequeues it.
+    let build_2 = factory::AcmeBuild.create(t.db(), batman.id).await;
+
+    let mut txn_2 = t.db().begin().await.unwrap();
+    let build = dequeue_build(&mut txn_2).await.unwrap();
+    assert!(matches!(build, Some(Build { id, .. }) if id == build_2.id));
+
+    // Third dequeue is attempted, but doesn't obtain a build as both are locked.
+    let mut txn_3 = t.db().begin().await.unwrap();
+    let build = dequeue_build(&mut txn_3).await.unwrap();
+    assert!(matches!(build, None));
+    std::mem::drop(txn_3);
+
+    // Second transaction updates its build and commits.
+    update_build_state(&mut txn_2, build_2.id, State::Done)
+        .await
+        .unwrap();
+    txn_2.commit().await.unwrap();
+
+    // First transaction aborts.
+    std::mem::drop(txn_1);
+
+    // First build is now eligible for dequeue again.
+    let mut txn_4 = t.db().begin().await.unwrap();
+    let build = dequeue_build(&mut txn_4).await.unwrap();
+    assert!(matches!(build, Some(Build { id, .. }) if id == build_1.id));
+
+    // It's completed.
+    update_build_state(&mut txn_4, build_1.id, State::TestFailed { code: None })
+        .await
+        .unwrap();
+    txn_4.commit().await.unwrap();
+
+    // No further builds are queued.
+    let mut txn_5 = t.db().begin().await.unwrap();
+    let build = dequeue_build(&mut txn_5).await.unwrap();
+    assert!(matches!(build, None));
+}

--- a/crates/control/tests/it/builds.rs
+++ b/crates/control/tests/it/builds.rs
@@ -108,7 +108,7 @@ async fn dequeue_builds_test() {
     std::mem::drop(txn_3);
 
     // Second transaction updates its build and commits.
-    update_build_state(&mut txn_2, build_2.id, State::Done)
+    update_build_state(&mut txn_2, build_2.id, State::Success)
         .await
         .unwrap();
     txn_2.commit().await.unwrap();

--- a/crates/control/tests/it/main.rs
+++ b/crates/control/tests/it/main.rs
@@ -7,6 +7,7 @@ extern crate insta;
 extern crate sqlx;
 
 mod accounts;
+mod builds;
 mod connector_images;
 mod connectors;
 mod health_check;

--- a/crates/control/tests/it/snapshots/it__builds__create_test.snap
+++ b/crates/control/tests/it/snapshots/it__builds__create_test.snap
@@ -1,0 +1,54 @@
+---
+source: crates/control/tests/it/builds.rs
+assertion_line: 51
+expression: redactor.response_json(&mut response).await.unwrap()
+---
+{
+  "data": {
+    "attributes": {
+      "account_id": "[a1]",
+      "catalog": {
+        "$schema": null,
+        "captures": {},
+        "collections": {
+          "acmeCo/collection": {
+            "derivation": null,
+            "journals": {
+              "fragments": {}
+            },
+            "key": [
+              "/key"
+            ],
+            "projections": {},
+            "schema": {
+              "properties": {
+                "key": {
+                  "type": "integer"
+                }
+              },
+              "required": "key",
+              "type": "object"
+            }
+          }
+        },
+        "import": [],
+        "materializations": {},
+        "npmDependencies": {},
+        "resources": {},
+        "storageMappings": {},
+        "tests": {}
+      },
+      "created_at": "[datetime]",
+      "id": "[b1]",
+      "state": {
+        "type": "queued"
+      },
+      "updated_at": "[datetime]"
+    },
+    "id": "[b1]",
+    "links": {
+      "self": "http://127.0.0.1:0/builds/[b1]"
+    },
+    "type": "build"
+  }
+}

--- a/crates/control/tests/it/snapshots/it__builds__index_test.snap
+++ b/crates/control/tests/it/snapshots/it__builds__index_test.snap
@@ -1,0 +1,29 @@
+---
+source: crates/control/tests/it/builds.rs
+assertion_line: 25
+expression: redactor.response_json(&mut response).await.unwrap()
+---
+{
+  "data": [
+    {
+      "attributes": {
+        "account_id": "[account<batman>]",
+        "catalog": null,
+        "created_at": "[datetime]",
+        "id": "[build<batman>]",
+        "state": {
+          "type": "queued"
+        },
+        "updated_at": "[datetime]"
+      },
+      "id": "[build<batman>]",
+      "links": {
+        "self": "http://127.0.0.1:0/builds/[build<batman>]"
+      },
+      "type": "build"
+    }
+  ],
+  "links": {
+    "self": "http://127.0.0.1:0/builds"
+  }
+}

--- a/crates/control/tests/it/snapshots/it__builds__show_test.snap
+++ b/crates/control/tests/it/snapshots/it__builds__show_test.snap
@@ -1,0 +1,54 @@
+---
+source: crates/control/tests/it/builds.rs
+assertion_line: 79
+expression: redactor.response_json(&mut response).await.unwrap()
+---
+{
+  "data": {
+    "attributes": {
+      "account_id": "[account<batman>]",
+      "catalog": {
+        "$schema": null,
+        "captures": {},
+        "collections": {
+          "acmeCo/collection": {
+            "derivation": null,
+            "journals": {
+              "fragments": {}
+            },
+            "key": [
+              "/key"
+            ],
+            "projections": {},
+            "schema": {
+              "properties": {
+                "key": {
+                  "type": "integer"
+                }
+              },
+              "required": "key",
+              "type": "object"
+            }
+          }
+        },
+        "import": [],
+        "materializations": {},
+        "npmDependencies": {},
+        "resources": {},
+        "storageMappings": {},
+        "tests": {}
+      },
+      "created_at": "[datetime]",
+      "id": "[build<batman>]",
+      "state": {
+        "type": "queued"
+      },
+      "updated_at": "[datetime]"
+    },
+    "id": "[build<batman>]",
+    "links": {
+      "self": "http://127.0.0.1:0/builds/[build<batman>]"
+    },
+    "type": "build"
+  }
+}

--- a/crates/control/tests/it/support.rs
+++ b/crates/control/tests/it/support.rs
@@ -3,7 +3,7 @@ use std::net::TcpListener;
 use axum::body::Body;
 use axum::http::{header, Request};
 use axum::response::Response;
-use axum::{AddExtensionLayer, Router};
+use axum::Router;
 use serde::Serialize;
 use sqlx::PgPool;
 use tower::ServiceExt;
@@ -31,7 +31,7 @@ pub struct TestContext {
     pub test_name: &'static str,
     db: PgPool,
     app: Router,
-    auth: Option<AddExtensionLayer<CurrentAccount>>,
+    auth: Option<axum::extract::Extension<CurrentAccount>>,
 }
 
 impl TestContext {
@@ -52,7 +52,7 @@ impl TestContext {
     }
 
     pub fn login(&mut self, account: Account) {
-        self.auth = Some(AddExtensionLayer::new(CurrentAccount(account)));
+        self.auth = Some(axum::extract::Extension(CurrentAccount(account)));
     }
 
     // pub fn logout(&mut self) {

--- a/crates/control/tests/it/support/factory.rs
+++ b/crates/control/tests/it/support/factory.rs
@@ -1,9 +1,12 @@
 use sqlx::PgPool;
 
 use control::models::accounts::{Account, NewAccount};
+use control::models::builds::Build;
 use control::models::connector_images::{ConnectorImage, NewConnectorImage};
 use control::models::connectors::{Connector, ConnectorType, NewConnector};
+use control::models::id::Id;
 use control::repo::accounts::insert as insert_account;
+use control::repo::builds::insert as insert_build;
 use control::repo::connector_images::insert as insert_image;
 use control::repo::connectors::insert as insert_connector;
 
@@ -132,6 +135,34 @@ impl JokerAccount {
 
     pub async fn create(&self, db: &PgPool) -> Account {
         insert_account(db, self.attrs())
+            .await
+            .expect("to insert test data")
+    }
+}
+
+pub struct AcmeBuild;
+
+impl AcmeBuild {
+    pub fn attrs(&self) -> models::Catalog {
+        serde_json::from_value(serde_json::json!({
+            "collections": {
+                "acmeCo/collection": {
+                    "key": ["/key"],
+                    "schema": {
+                        "type": "object",
+                        "required": "key",
+                        "properties": {
+                            "key": {"type": "integer"}
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    pub async fn create(&self, db: &PgPool, account_id: Id<Account>) -> Build {
+        insert_build(db, self.attrs(), account_id)
             .await
             .expect("to insert test data")
     }

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -20,7 +20,6 @@ librocksdb-sys = { version = "*", default-features = false, features = ["snappy"
 pin-utils = "*"
 prost = "*"
 rocksdb = { version = "*", default-features = false, features = ["snappy", "rtti"] }
-rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
 serde = { version = "*", features = ["derive"] }
 serde_json = { version =  "*"}
 stats_alloc = "*"

--- a/crates/derive/src/combine_api.rs
+++ b/crates/derive/src/combine_api.rs
@@ -27,9 +27,6 @@ pub enum Error {
     #[error(transparent)]
     #[serde(serialize_with = "crate::serialize_as_display")]
     UTF8Error(#[from] std::str::Utf8Error),
-    #[error(transparent)]
-    #[serde(serialize_with = "crate::serialize_as_display")]
-    Rusqlite(#[from] rusqlite::Error),
     #[error("combined key cannot be empty")]
     EmptyKey,
     #[error("protocol error (invalid state or invocation)")]

--- a/crates/flow_cli_common/src/lib.rs
+++ b/crates/flow_cli_common/src/lib.rs
@@ -1,16 +1,16 @@
 //! Contains helpers and things that are used by all Flow rust executables.
 mod logging;
 
-// These settings are applied to ExternalArgs to prevent clap from automatically using its own help
-// handling, so that --help and -h are simply forwarded to the external subcommand.
-use clap::AppSettings::{AllowHyphenValues, DisableHelpFlag, NoAutoHelp};
+use clap::AppSettings::NoAutoHelp;
 
 pub use logging::{init_logging, LogArgs, LogFormat};
 
 /// An arguments container that accepts all arguments verbatim. This is used by external
 /// subcommands to allow all their argument parsing to be handled by the external binary.
+// These settings prevent clap from automatically using its own help
+// handling, so that --help and -h are simply forwarded to the external subcommand.
 #[derive(Debug, clap::Args)]
-#[clap(setting = NoAutoHelp | DisableHelpFlag | AllowHyphenValues)]
+#[clap(setting = NoAutoHelp, disable_help_flag = true, allow_hyphen_values = true)]
 pub struct ExternalArgs {
     pub args: Vec<String>,
 }

--- a/crates/flowctl/src/logs.rs
+++ b/crates/flowctl/src/logs.rs
@@ -4,7 +4,7 @@ use models::build::encode_resource_path;
 use protocol::labels;
 
 #[derive(clap::Args, Debug)]
-#[clap(global_setting(clap::AppSettings::TrailingVarArg))]
+#[clap(trailing_var_arg = true)]
 pub struct Args {
     #[clap(flatten)]
     pub task: TaskSelector,

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -18,7 +18,7 @@ pathfinding = "*"
 percent-encoding = "*"
 prost = "*"
 regex = "*"
-rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
+rusqlite = { version = "*", features = ["bundled-full"] }
 schemars = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = { version =  "*", features = ["raw_value"] }

--- a/crates/models/src/tables/macros.rs
+++ b/crates/models/src/tables/macros.rs
@@ -98,7 +98,7 @@ impl<T: SQLType> SQLType for Option<T> {
 /// Persist a dynamic set of tables to the database, creating their table schema
 /// if they don't yet exist, and writing all row records.
 pub fn persist_tables(db: &rusqlite::Connection, tables: &[&dyn TableObj]) -> rusqlite::Result<()> {
-    db.execute_batch("BEGIN;")?;
+    db.execute_batch("BEGIN IMMEDIATE;")?;
     for table in tables {
         db.execute_batch(&table.create_table_sql())?;
         table.persist_all(db)?;

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -28,7 +28,7 @@ url = "*"
 sources = { path = "../sources", version = "0.0.0" }
 
 insta = "*"
-rusqlite = { version = "*", features = ["bundled", "collation", "column_decltype", "functions", "serde_json", "url"] }
+rusqlite = { version = "*", features = ["bundled-full"] }
 serde = "*"
 serde_yaml = "*"
 

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -49,12 +49,13 @@ fn test_database_round_trip() {
 
 #[test]
 fn test_golden_error() {
-    run_test_errors(&GOLDEN, "{}");
+    let errors = run_test_errors(&GOLDEN, "{}");
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_collection_names_prefixes_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -80,11 +81,12 @@ test://example/catalog.yaml:
     testing/Int-Halve: *spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_partition_names_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -108,11 +110,12 @@ test://example/int-string:
         str: /int
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_transform_names_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-reverse:
@@ -135,11 +138,12 @@ test://example/int-reverse:
           reVeRsEIntString: *spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_capture_names_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -173,11 +177,12 @@ test://example/captures:
     testing/SoMe-source: *spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_materialization_names_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -211,11 +216,12 @@ test://example/materializations:
     testing/SoMe-target: *spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_test_names_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -241,11 +247,12 @@ test://example/catalog.yaml:
     testing/TeSt: *spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_cross_entity_name_prefixes_and_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -291,11 +298,12 @@ test://example/catalog.yaml:
     testing/b/4/suffix: *test_spec
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_transform_source_not_found() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-halve:
@@ -309,11 +317,12 @@ test://example/int-halve:
             source: { name: wildly/off/name }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_capture_target_not_found() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-captures:
@@ -326,11 +335,12 @@ test://example/int-string-captures:
           resource: { stream: v2-stream }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_capture_target_is_missing_imports() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-captures:
@@ -344,11 +354,12 @@ test://example/int-string-captures:
           resource: { }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_capture_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-captures:
@@ -375,11 +386,12 @@ driver:
         - resourcePath: [target, two]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_duplicates() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/db-views:
@@ -409,11 +421,12 @@ driver:
           resourcePath: [target, two]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_use_without_import() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -426,11 +439,12 @@ test://example/webhook-deliveries:
   import: [] # Clear.
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_schema_fragment_not_found() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -454,11 +468,12 @@ test://example/int-halve:
               schema: test://example/int-string-len.schema#/not/found
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_keyed_location_wrong_type() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string.schema:
@@ -466,11 +481,12 @@ test://example/int-string.schema:
     int: { type: [number, object] }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_unknown_locations() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -490,11 +506,12 @@ test://example/int-halve:
               key: [/len, /int, /unknown/shuffle]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_shuffle_key_length_mismatch() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-halve:
@@ -510,11 +527,12 @@ test://example/int-halve:
               key: [/len, /int]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_shuffle_key_types_mismatch() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-halve:
@@ -530,11 +548,12 @@ test://example/int-halve:
               key: [/str, /int]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_shuffle_key_relaxed() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-reverse:
@@ -553,11 +572,12 @@ test://example/int-reverse:
             publish: { lambda: typescript }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_collection_key_empty() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -566,11 +586,12 @@ test://example/int-string:
       key: []
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_shuffle_key_empty() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-reverse:
@@ -582,11 +603,12 @@ test://example/int-reverse:
             shuffle: {key: []}
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_partition_selections() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-halve:
@@ -607,11 +629,12 @@ test://example/int-halve:
                   AlsoUnknown: ["whoops"]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_redundant_source_schema_and_shuffle() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-reverse:
@@ -627,11 +650,12 @@ test://example/int-reverse:
               key: [/int]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_must_have_update_or_publish() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-reverse:
@@ -644,11 +668,12 @@ test://example/int-reverse:
             update: null
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_initial_register() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-halve:
@@ -659,11 +684,12 @@ test://example/int-halve:
           initial: "should be an integer"
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_shape_inspections() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-len.schema:
@@ -674,22 +700,24 @@ test://example/int-string-len.schema:
       reduce: { strategy: sum }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_schema_reference_verification() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-len.schema:
   $ref: test://example/int-string.schema#/whoops
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_source_not_found() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/db-views:
@@ -702,11 +730,12 @@ test://example/db-views:
           resource: { table: other_table }
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_field_errors() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/webhook-deliveries:
@@ -731,11 +760,12 @@ test://example/webhook-deliveries:
             recommended: false
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_capture_driver_returns_error() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 driver:
@@ -744,11 +774,12 @@ driver:
       error: "A driver error!"
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_driver_returns_error() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 driver:
@@ -758,11 +789,12 @@ driver:
       error: "A driver error!"
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_driver_unknown_constraint() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 driver:
@@ -779,11 +811,12 @@ driver:
           resourcePath: [tar!get, two]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_driver_conflicts() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 
@@ -815,11 +848,12 @@ driver:
           resourcePath: [tar!get]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_test_step_unknown_collection() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-tests:
@@ -833,11 +867,12 @@ test://example/int-string-tests:
           documents: []
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_test_step_ingest_schema_error() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-tests:
@@ -850,11 +885,12 @@ test://example/int-string-tests:
             - {int: 52, str_whoops: "string B", bit: true}
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_test_step_verify_key_order() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-tests:
@@ -865,11 +901,12 @@ test://example/int-string-tests:
           documents: [{int: 52}, {int: 62}, {int: 42}]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_test_step_verify_selector() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string-tests:
@@ -889,11 +926,12 @@ test://example/int-string-tests:
               AlsoUnknown: ["whoops"]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_materialization_selector() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/db-views:
@@ -913,11 +951,12 @@ test://example/db-views:
               AlsoUnknown: ["whoops"]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_duplicate_named_schema() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 # Repeat a named anchor, in a different schema.
@@ -928,11 +967,12 @@ test://example/int-string-len.schema:
       type: string
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_incompatible_npm_packages() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -948,11 +988,12 @@ test://example/int-string:
     pkg-three: "3"
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_invalid_and_duplicate_storage_mappings() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/int-string:
@@ -975,11 +1016,12 @@ test://example/int-string:
     "/leading/Slash/": {stores: *stores}
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_storage_mappings_not_imported() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -993,11 +1035,12 @@ test://example/array-key:
       stores: [{provider: GCS, bucket: recovery-bucket, prefix: some/ }]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_storage_mappings_not_found() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -1013,22 +1056,24 @@ test://example/int-string:
       stores: [{provider: GCS, bucket: recovery-bucket, prefix: some/ }]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_no_storage_mappings_defined() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
   storageMappings: null
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_storage_mappings_without_prefix() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -1038,11 +1083,12 @@ test://example/catalog.yaml:
       stores: [{provider: S3, bucket: a-bucket}]
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[test]
 fn test_collection_schema_string() {
-    run_test_errors(
+    let errors = run_test_errors(
         &GOLDEN,
         r#"
 test://example/catalog.yaml:
@@ -1055,6 +1101,7 @@ test://example/string-schema:
       key: ['']
 "#,
     );
+    insta::assert_debug_snapshot!(errors);
 }
 
 #[derive(serde::Deserialize)]
@@ -1286,7 +1333,8 @@ fn run_test(mut fixture: Value, config: &flow::build_api::Config) -> tables::All
     }
 }
 
-fn run_test_errors(fixture: &Value, patch: &str) {
+#[must_use]
+fn run_test_errors(fixture: &Value, patch: &str) -> tables::Errors {
     let mut fixture = fixture.clone();
     let patch: Value = serde_yaml::from_str(patch).unwrap();
     json_patch::merge(&mut fixture, &patch);
@@ -1298,5 +1346,5 @@ fn run_test_errors(fixture: &Value, patch: &str) {
             ..Default::default()
         },
     );
-    insta::assert_debug_snapshot!(errors);
+    errors
 }

--- a/go/flowctl-go/cmd-temp-data-plane.go
+++ b/go/flowctl-go/cmd-temp-data-plane.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -84,7 +85,7 @@ func (cmd cmdTempDataPlane) Execute(_ []string) error {
 
 func (cmd *cmdTempDataPlane) start(ctx context.Context, tempdir string) (etcdAddr, brokerAddr, consumerAddr string, _ error) {
 	var buildsRoot = filepath.Join(tempdir, "builds")
-	if err := os.Mkdir(buildsRoot, 0700); err != nil {
+	if err := os.Mkdir(buildsRoot, 0700); err != nil && !errors.Is(err, os.ErrExist) {
 		return "", "", "", fmt.Errorf("creating builds dir: %w", err)
 	}
 	buildsRoot = "file://" + buildsRoot + "/"


### PR DESCRIPTION
**Description:**

This PR introduces new `/builds` endpoints:

  * `GET /builds` lists all builds which you're permitted to see (currently: owned by your account).
  * `GET /builds/:build_id` fetches a specific build, including its catalog definition
  * `POST /builds` takes a JSON `models::Catalog`, and creates a new queued build.
  
There's also now a builder daemon which will look for queued builds and attempt to build them.
The status of a build is updated and retrievable through `/builds` etc,
and the build database itself is put to the builds root and contains all related task logs of the build process.

**Workflow steps:**

Migrate your CP DB.

<details><summary>Here's a test catalog you can post to `/builds`.</summary>
<p>

```json
{
	"$schema": "https://raw.githubusercontent.com/estuary/flow/master/flow.schema.json",
	"collections": {
		"acmeCo/collection": {
			"key": [
				"/key"
			],
			"schema": {
				"type": "object",
				"required": [
					"key"
				],
				"properties": {
					"key": {
						"type": "string"
					}
				}
			}
		}
	},
	"storageMappings": {
		"": {
			"stores": [
				{
					"bucket": "my-bucket",
					"provider": "S3"
				}
			]
		}
	},
	"tests": {
		"acmeCo/conversions/test": [
			{
				"ingest": {
					"collection": "acmeCo/collection",
					"description": "Description of the ingestion.",
					"documents": [
						{
							"key": "one"
						},
						{
							"key": "two"
						}
					]
				}
			},
			{
				"verify": {
					"collection": "acmeCo/collection",
					"description": "Description of the verification.",
					"documents": [
						{
							"key": "one"
						},
						{
							"key": "two"
						}
					]
				}
			}
		]
	}
}

```

</p>
</details>

```console
$ curl -s -H "Authorization: Basic $AUTH" -H "Content-Type: application/json" --data-binary @/home/johnny/test_catalog.flow.json http://127.0.0.1:3000/builds | jq .
```
When a build completes, you'll see it under `/var/tmp/flow-builds`.
```console
/var/tmp/flow-builds$ sqlite3 * 'select * from task_logs';
```

**Documentation links affected:**

None yet.

**Notes for reviewers:**

Recommend reviewing commit by commit.
There are also some commits for dependency updates and other minor fixups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/408)
<!-- Reviewable:end -->
