### PR TITLE
process  $ref when modifying json schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.5",
  "once_cell",
+ "serde 1.0.136",
  "version_check",
 ]
 
@@ -455,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +675,7 @@ dependencies = [
  "flow_cli_common",
  "futures-core",
  "futures-util",
+ "jsonschema",
  "network-proxy",
  "prost",
  "protocol",
@@ -1095,7 +1103,7 @@ dependencies = [
 name = "doc"
 version = "0.0.0"
 dependencies = [
- "fancy-regex",
+ "fancy-regex 0.8.0",
  "insta",
  "itertools",
  "json 0.0.0",
@@ -1116,7 +1124,7 @@ name = "doc"
 version = "0.0.0"
 source = "git+https://github.com/estuary/flow#d8c3be35fc8ac0657e0c4aa2e5e7ef4b3eb72905"
 dependencies = [
- "fancy-regex",
+ "fancy-regex 0.8.0",
  "itertools",
  "json 0.0.0 (git+https://github.com/estuary/flow)",
  "lazy_static",
@@ -1199,6 +1207,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -1304,6 +1322,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba3510011eee8825018be07f08d9643421de007eaf62a3bde58d89b058abfa7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1790,6 +1818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
+name = "iso8601"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a59a3f2be6271b2a844cd0dd13bf8ccc88a9540482d872c7ce58ab1c4db9fab"
+dependencies = [
+ "nom 7.1.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,7 +1903,7 @@ version = "0.0.0"
 dependencies = [
  "bitvec",
  "criterion",
- "fancy-regex",
+ "fancy-regex 0.8.0",
  "fxhash",
  "glob",
  "itertools",
@@ -1885,7 +1922,7 @@ version = "0.0.0"
 source = "git+https://github.com/estuary/flow#d8c3be35fc8ac0657e0c4aa2e5e7ef4b3eb72905"
 dependencies = [
  "bitvec",
- "fancy-regex",
+ "fancy-regex 0.8.0",
  "fxhash",
  "itertools",
  "percent-encoding",
@@ -1906,6 +1943,35 @@ dependencies = [
  "serde 1.0.136",
  "serde_json",
  "treediff",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be404426c47c9b868fc9b6ddda07f84e2885d12b17066036717db2cd4e5d77"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "fancy-regex 0.7.1",
+ "fraction",
+ "iso8601",
+ "itoa 1.0.1",
+ "lazy_static",
+ "memchr",
+ "num-cmp",
+ "parking_lot 0.12.0",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde 1.0.136",
+ "serde_json",
+ "structopt",
+ "time 0.3.7",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2255,6 +2321,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,12 +2357,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
+ "num-integer",
  "num-traits 0.2.14",
 ]
 

--- a/crates/connector_proxy/Cargo.toml
+++ b/crates/connector_proxy/Cargo.toml
@@ -20,6 +20,7 @@ byteorder="*"
 clap = { version = "^3", features = ["derive"] }
 futures-core = "*"
 futures-util="*"
+jsonschema="*"
 prost = "*"
 schemars = "*"
 serde = { version = "*", features = ["derive"]}

--- a/crates/connector_proxy/src/libs/json.rs
+++ b/crates/connector_proxy/src/libs/json.rs
@@ -1,5 +1,9 @@
-use schemars::{schema::RootSchema, JsonSchema};
-use serde_json::Value;
+use crate::errors::Error;
+use schemars::{
+    schema::{ObjectValidation, RootSchema, Schema, SchemaObject, SubschemaValidation},
+    JsonSchema,
+};
+use serde_json::{value::RawValue, Value};
 
 // Create the RootSchema given datatype T.
 pub fn create_root_schema<T: JsonSchema>() -> RootSchema {
@@ -18,4 +22,154 @@ pub fn remove_subobject(mut v: Value, key: &str) -> (Option<Value>, Value) {
     }
 
     (sub_object, v)
+}
+
+// Extend the endpoint schema (of a connector) with the interceptor schema. The resulting schema allows the connector configuration JSON
+// object to accept an additional subobject in the field specified by interceptor_object_field, in addition to all the other configs of the connector.
+pub fn extend_endpoint_schema(
+    endpoint_spec_schema: Box<RawValue>,
+    interceptor_object_field: String,
+    interceptor_schema: RootSchema,
+) -> Result<Box<RawValue>, Error> {
+    let mut interceptor_schema_object_validation = ObjectValidation::default();
+    interceptor_schema_object_validation.properties.insert(
+        interceptor_object_field,
+        Schema::Object(interceptor_schema.schema),
+    );
+
+    let mut interceptor_schema_object = SchemaObject::default();
+    // interceptor_schema_object validates a JSON object that contains a subobject of
+    // { interceptor_object_field: { interceptor config object } }
+    interceptor_schema_object.object = Some(Box::new(interceptor_schema_object_validation));
+
+    // If the endpoint schema is already in `all_of` structure, just append the interceptor shcema object into the list.
+    let mut extended_schema: RootSchema = serde_json::from_str(endpoint_spec_schema.get())?;
+    if let Some(ref mut subschemas) = extended_schema.schema.subschemas {
+        if let Some(ref mut all_of) = subschemas.all_of {
+            all_of.push(Schema::Object(interceptor_schema_object));
+            return RawValue::from_string(serde_json::to_string_pretty(&extended_schema)?)
+                .map_err(Into::into);
+        }
+    }
+
+    // Construct a new schema object with "all_of" structure.
+    let connector_schema_object = extended_schema.schema;
+    let all_of = vec![
+        Schema::Object(connector_schema_object),
+        Schema::Object(interceptor_schema_object),
+    ];
+    let mut subschema_validation = SubschemaValidation::default();
+    subschema_validation.all_of = Some(all_of);
+
+    extended_schema.schema = SchemaObject::default();
+    extended_schema.schema.subschemas = Some(Box::new(subschema_validation));
+
+    RawValue::from_string(serde_json::to_string_pretty(&extended_schema)?).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    pub struct TestInterceptorConfigA {
+        #[allow(dead_code)]
+        interceptor_name_a: String,
+    }
+
+    #[derive(Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    pub struct TestInterceptorConfigB {
+        #[allow(dead_code)]
+        interceptor_name_b: String,
+    }
+
+    fn verify_extended_endpoint_schema(endpoint_schema: String) {
+        let interceptor_schema_a = create_root_schema::<TestInterceptorConfigA>();
+        let interceptor_schema_b = create_root_schema::<TestInterceptorConfigB>();
+
+        let valid_config_instance_1 = json!({
+            "connector_name": "connector",
+            "interceptor_config_a": {
+                "interceptor_name_a": "interceptor_a"
+            },
+            "interceptor_config_b": {
+                "interceptor_name_b": "interceptor_b"
+            }
+        });
+
+        let valid_config_instance_2 = json!({
+            "connector_name": "connector"
+        });
+
+        let config_instance_bad_connector_config = json!({
+            "connector_name_bad": "connector"
+        });
+
+        let config_instance_bad_interceptor_config = json!({
+            "connector_name": "connector",
+            "interceptor_config_a": {
+                "interceptor_name_bad": "interceptor"
+            }
+        });
+
+        let extended_schema_json = extend_endpoint_schema(
+            extend_endpoint_schema(
+                RawValue::from_string(endpoint_schema).unwrap(),
+                "interceptor_config_a".to_string(),
+                interceptor_schema_a,
+            )
+            .unwrap(),
+            "interceptor_config_b".to_string(),
+            interceptor_schema_b,
+        )
+        .unwrap()
+        .to_string();
+
+        let compiled_schema = jsonschema::JSONSchema::options()
+            .compile(&serde_json::from_str(&extended_schema_json).unwrap())
+            .unwrap();
+
+        assert!(compiled_schema.validate(&valid_config_instance_1).is_ok());
+        assert!(compiled_schema.validate(&valid_config_instance_2).is_ok());
+        assert!(compiled_schema
+            .validate(&config_instance_bad_connector_config)
+            .is_err());
+        assert!(compiled_schema
+            .validate(&config_instance_bad_interceptor_config)
+            .is_err());
+    }
+
+    #[test]
+    fn test_extend_endpoint_schema() {
+        let endpoint_schema_a = json!({
+            "type": "object",
+            "required": ["connector_name"],
+            "properties": {
+                "connector_name": {"type": "string"}
+            },
+        })
+        .to_string();
+
+        verify_extended_endpoint_schema(endpoint_schema_a);
+
+        let endpoint_schema_b = json!({
+            "$ref": "#/definitions/nested",
+            "definitions": {
+              "nested": {
+                  "type": "object",
+                  "required": ["connector_name"],
+                  "properties": {
+                      "connector_name": {"type": "string"}
+                  },
+              }
+            }
+        })
+        .to_string();
+
+        verify_extended_endpoint_schema(endpoint_schema_b);
+    }
 }

--- a/crates/connector_proxy/src/libs/network_proxy.rs
+++ b/crates/connector_proxy/src/libs/network_proxy.rs
@@ -1,34 +1,24 @@
 use crate::errors::Error;
-use crate::libs::json::{create_root_schema, remove_subobject};
+use crate::libs::json::{create_root_schema, extend_endpoint_schema, remove_subobject};
 use network_proxy::interface::NetworkProxyConfig;
 
-use schemars::schema::{RootSchema, Schema};
 use serde_json::value::RawValue;
 use tokio::sync::oneshot::{self, Receiver};
 use tokio::time::timeout;
 
 pub struct NetworkProxy {}
-pub const NETWORK_PROXY_KEY: &str = "networkProxy";
+pub const NETWORK_PROXY_KEY: &str = "flowNetworkProxy";
 
 impl NetworkProxy {
     pub fn extend_endpoint_schema(
         endpoint_spec_schema: Box<RawValue>,
     ) -> Result<Box<RawValue>, Error> {
         let network_proxy_schema = create_root_schema::<NetworkProxyConfig>();
-
-        let mut modified_schema: RootSchema = serde_json::from_str(endpoint_spec_schema.get())?;
-        if let Some(ref mut o) = &mut modified_schema.schema.object {
-            if o.as_ref().properties.contains_key(NETWORK_PROXY_KEY) {
-                return Err(Error::DuplicatedKeyError(NETWORK_PROXY_KEY));
-            }
-            o.as_mut().properties.insert(
-                NETWORK_PROXY_KEY.to_string(),
-                Schema::Object(network_proxy_schema.schema),
-            );
-        }
-
-        let json = serde_json::to_string_pretty(&modified_schema)?;
-        RawValue::from_string(json).map_err(Into::into)
+        extend_endpoint_schema(
+            endpoint_spec_schema,
+            NETWORK_PROXY_KEY.to_string(),
+            network_proxy_schema,
+        )
     }
 
     // Start the network proxy. The receiver rx will be dropped to indicate the network proxy

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -3,7 +3,7 @@ port: 16666
 user: flow
 password: flow
 database: flow
-networkProxy:
+flowNetworkProxy:
   sshForwarding:
     localPort: 16666
     forwardHost: localhost


### PR DESCRIPTION
**Description:**

The network proxy intercept needs to manipulate the endpoint config schemas from `spec` responses of the connectors to inject the network-proxy config schema.

The current logic works if the endpoint config schema is a direct schema object, but it missed the cases in which the config schema is embedded in a `$ref` [tag](https://json-schema.org/understanding-json-schema/structuring.html#ref) referring to "$def" fields. 
 This makes some connectors (e.g. `materialize-elasticsearch`) missed the network proxy config.

The fix will now combine `the endpoint config schema` and `network proxy schema` (interceptor schema in general) using [all_of](https://json-schema.org/understanding-json-schema/reference/combining.html#allof) validation.
E.g. the logic will convert the following endpoint schema  
```
{
            "type": "object",
            "required": ["connector_name"],
            "properties": {
                "connector_name": {"type": "string"}
            },
 } 
 ```
into
```
{
    `all_of` : [
        { "flowNetworkProxy": <the network proxy schema> },
        { "interceptorB": <the schema of another interceptor> },
        {
            "type": "object",
            "required": ["connector_name"],
            "properties": {
                "connector_name": {"type": "string"}
            },
         }
    ]
} 
```

and it will translate the `$ref`-based schema
```
{
     "$ref": "#/$defs/connector_schema",
     "$defs": {
        "connector_schema": {
            "type": "object",
            "required": ["connector_name"],
            "properties": {
                "connector_name": {"type": "string"}
            }
        } 
    }
 } 
 ```
into
```
{
     "all_of": [
         { "$ref": "#/$defs/connector_schema" },
         { "flowNetworkProxy": <the network proxy schema> },
         { "interceptorB": <the schema of another interceptor> },
     ],
     "$defs": {
        "connector_schema": {
            "type": "object",
            "required": ["connector_name"],
            "properties": {
                "connector_name": {"type": "string"}
            }
        } 
    }
 } 
 ``````
**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**
The field name of the network proxy config in the connector config is changed from `networkProxy` into `flowNetworkProxy`.

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/413)
<!-- Reviewable:end -->
