### PR TITLE
Docs - materialize-postgres

### DIFF
--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -69,11 +69,11 @@ To allow SSH tunneling to a database instance hosted on AWS, you'll need to crea
 
 2. [Import your SSH key into AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws).
 
-3. [Launch a new instance in EC2](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/LaunchingAndUsingInstances.html). During setup:
+3. [Launch a new instance in EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html). During setup:
    * Configure the security group to allow SSH connection from anywhere.
    * When selecting a key pair, choose the key you just imported.
 
-4. [Connect to the instance](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/connecting_to_windows_instance.html),
+4. [Connect to the instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html),
 setting the user name to `ec2-user`.
 
 5. Find and note the [instance's public DNS](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-viewing). This will be formatted like: `ec2-198-21-98-1.compute-1.amazonaws.com`.
@@ -101,9 +101,9 @@ To allow SSH tunneling to a database instance hosted on Google Cloud, you must s
    ```console
       ssh-keygen -p -N "" -m pem -f /path/to/key
       ```
-   * If your Google login differs from your local username, add your Gmail or organizational Google email address as a comment:
+   * If your Google login differs from your local username, generate a key that includes your Google email address as a comment:
    ```console
-      ssh-keygen -p -N "" -m pem -f /path/to/key -C user@domain.com
+      ssh-keygen -m PEM -t rsa -C user@domain.com
       ```
 
 2. [Create and start a new VM in GCP](https://cloud.google.com/compute/docs/instances/create-start-instance), [choosing an image that supports OS Login](https://cloud.google.com/compute/docs/images/os-details#user-space-features).

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -101,6 +101,10 @@ To allow SSH tunneling to a database instance hosted on Google Cloud, you must s
    ```console
       ssh-keygen -p -N "" -m pem -f /path/to/key
       ```
+   * If your Google login differs from your local username, add your Gmail or organizational Google email address as a comment:
+   ```console
+      ssh-keygen -p -N "" -m pem -f /path/to/key -C user@domain.com
+      ```
 
 2. [Create and start a new VM in GCP](https://cloud.google.com/compute/docs/instances/create-start-instance), [choosing an image that supports OS Login](https://cloud.google.com/compute/docs/images/os-details#user-space-features).
 
@@ -162,7 +166,7 @@ After you've completed the prerequisites, you should have the following paramete
 
 * `sshEndpoint`: the SSH server's hostname, or public IP address, formatted as `ssh://hostname[:port]`
 * `privateKey`: the contents of the PEM file
-* `user`: the username used to connect to the SSH server
+* `user`: the username used to connect to the SSH server.
 * `forwardHost`: the capture or materialization endpoint's host
 * `forwardPort`: the capture or materialization endpoint's port
 * `localPort`: the port on the localhost used to connect to the SSH server, step 7

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
@@ -76,6 +76,6 @@ for additional details and a sample.
 :::tip
 You can find the values for `forwardHost` and `forwardPort` in the following locations in each platform's console:
 * Amazon RDS: `forwardHost` as Endpoint; `forwardPort` as Port.
-* Google Cloud SQL: `forwardHost` as Public IP Address; `forwardPort` is always `5432`.
+* Google Cloud SQL: `forwardHost` as Private IP Address; `forwardPort` is always `5432`. You may need to [configure private IP](https://cloud.google.com/sql/docs/postgres/configure-private-ip) on your database.
 * Azure Database: `forwardHost` as Server Name; `forwardPort` under Connection Strings (usually `5432`).
 :::

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
@@ -9,7 +9,7 @@ To use this connector, you'll need:
 
 * An existing catalog spec that includes at least one collection.
 * A Postgres database to which to materialize, and user credentials.
-  Optionally, you can choose existing tables to materialize to; otherwise, the tables you specify will be created by the connector.
+  The connector will create new tables in the database per your specification. Tables created manually in advance are not supported.
 
 ## Configuration
 
@@ -33,7 +33,7 @@ Follow the basic [materialization setup](../../../concepts/materialization.md#sp
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/table`** | Table | Table name to materialize to. If it doesn't exist, it will be created. | string | Required |
+| **`/table`** | Table | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string | Required |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
@@ -1,0 +1,81 @@
+
+This connector materializes Flow collections into tables in a PostgreSQL database.
+
+[`ghcr.io/estuary/materialize-postgres:dev`](https://ghcr.io/estuary/materialize-postgres:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* An existing catalog spec that includes at least one collection.
+* A Postgres database to which to materialize, and user credentials.
+  Optionally, you can choose existing tables to materialize to; otherwise, the tables you specify will be created by the connector.
+
+## Configuration
+
+To use this connector, begin with a Flow catalog that has at least one collection.
+You'll add a Postgres materialization, which will direct one or more of your Flow collections to your desired tables, or views, in the database.
+Follow the basic [materialization setup](../../../concepts/materialization.md#specification) and add the required Postgres configuration values per the table below.
+
+### Values
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| `/database` | Database | Name of the logical database to materialize to. | string |  |
+| **`/host`** | Host | Host name of the database to connect to. | string | Required |
+| **`/password`** | Password | User password configured within the database. | string | Required |
+| `/port` | Port | Port on which to connect to the database. | integer |  |
+| **`/user`** | User | Database user to use. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/table`** | Table | Table name to materialize to. If it doesn't exist, it will be created. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${tenant}/${mat_name}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-postgres:dev
+        config:
+          database: flow
+          host: localhost
+          password: flow
+          port: 5432
+          user: flow
+    bindings:
+      - resource:
+          table: ${TABLE_NAME}
+        source: ${TENANT}/${COLLECTION_NAME}
+```
+
+## PostgreSQL on managed cloud platforms
+
+In addition to standard PostgreSQL, this connector supports cloud-based PostgreSQL instances.
+To connect securely, you must use an SSH tunnel.
+
+Google Cloud Platform, Amazon Web Service, and Microsoft Azure are currently supported.
+You may use other cloud platforms, but Estuary doesn't guarantee performance.
+
+
+### Setup
+
+1. Refer to the [guide](../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+
+2. Configure your connector as described in the [configuration](#configuration) section above,
+with the additional of the `networkProxy` stanza to enable the SSH tunnel, if using.
+See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+for additional details and a sample.
+
+:::tip
+You can find the values for `forwardHost` and `forwardPort` in the following locations in each platform's console:
+* Amazon RDS: `forwardHost` as Endpoint; `forwardPort` as Port.
+* Google Cloud SQL: `forwardHost` as Public IP Address; `forwardPort` is always `5432`.
+* Azure Database: `forwardHost` as Server Name; `forwardPort` under Connection Strings (usually `5432`).
+:::

--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -20,7 +20,7 @@ Estuary is actively developing new connectors, so check back regularly for the l
   * [Configuration](./BigQuery.md)
   * Package — ghcr.io/estuary/materialize-bigquery:dev
 * PostgreSQL
-  * Configuration
+  * [Configuration](./PostgreSQL.md)
   * Package — ghcr.io/estuary/materialize-postgres:dev
 * Rockset
   * [Configuration](./Rockset.md)


### PR DESCRIPTION
**Description:**

Adds docs for materialize-postgres. 

Tested the connector via SSH to a Google Cloud database, and added docs to cover a few gotcha's there. I intend to test in AWS and Azure too, but don't have time immediately and want to get the essentials pushed out. 

**Notes for reviewers:**

- Config descriptions and titles were added by me, referencing source-postgres, because none were provided by this connector. Similarly, there was no README, which I would otherwise reference.
- The fields that are flagged as required seemed a bit odd to me - I feel like they should _all_ be. But this is what came out of the schemalate markdown generator, so...
-  Another thing that we found during testing that strikes me as odd: SSH to a hosted DB on Gcloud required that the DB use a _private_ IP, while source-postgres uses a public IP. This is probably tangential but noting just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/414)
<!-- Reviewable:end -->
