### PR TITLE
Allow enabling delta updates on materializations

### DIFF
--- a/go/protocols/materialize/sql/driver.go
+++ b/go/protocols/materialize/sql/driver.go
@@ -111,9 +111,16 @@ func (d *Driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.Val
 			return nil, err
 		}
 
-		if current != nil && current.DeltaUpdates != resource.DeltaUpdates() {
+		// There's no particular reason why we _need_ to constrain this, but it seems smart to only
+		// relax it if we need to. We previously disallowed all changes to the delta_updates
+		// configuration, and relaxed it because we wanted to enable delta_updates for an existing
+		// binding, and couldn't think of why it would hurt anything. But disabling delta_updates
+		// for an existing binding might not be as simple, since Load implementations may not be
+		// prepared to deal with the potential for duplicate primary keys. So I'm leaving this
+		// validation in place for now, since there's no need to relax it further at the moment.
+		if current != nil && current.DeltaUpdates && !resource.DeltaUpdates() {
 			return nil, fmt.Errorf(
-				"cannot alter delta-updates mode of existing target %s", target)
+				"cannot disable delta-updates mode of existing target %s", target)
 		}
 
 		resp.Bindings = append(resp.Bindings,


### PR DESCRIPTION
**Description:**

We were previously raising a validation error when `delta_updates` was
altered for an existing materialization binding. That was done based on
the general principle that it's easier to relax restrictions than to
introduce new ones, not to address some specific correctness issue. Now
we have an actual use case where it's desirable to change an existing
binding from regular to delta-updates mode, and so this relaxes that
validation to allow it. This preserves the restriction on changing
`delta_updates` from `true` to `false`, since that seems to guard
against a greater potential for problems.

**Workflow steps:**

For an existing SQL materialization binding (one that has been applied), the `delta_updates` property can now be changed from `false` to `true` (but not the other way around).

**Documentation links affected:** n/a

**Notes for reviewers:** nope

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/415)
<!-- Reviewable:end -->
