### PR TITLE
Firebolt: support objects

### DIFF
--- a/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
+++ b/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
@@ -80,7 +80,7 @@ pub fn build_firebolt_schema(binding: &Binding) -> Result<TableSchema, Error> {
         })?;
 
         columns.push(Column {
-            key: projection.field.clone(),
+            key: projection.field.clone().replace("/", "_"),
             r#type: fb_type,
             nullable: !exists.must() || shape.type_.overlaps(types::NULL),
             is_key,
@@ -169,6 +169,10 @@ fn projection_type_to_firebolt_type(shape: &Shape) -> Option<FireboltType> {
         Some(FireboltType::Double)
     } else if shape.type_.overlaps(types::INTEGER) {
         Some(FireboltType::Int)
+
+    // We store objects as stringified JSON objects
+    } else if shape.type_.overlaps(types::OBJECT) {
+        Some(FireboltType::Text)
     } else {
         None
     }
@@ -438,6 +442,92 @@ mod tests {
                 columns: vec![Column {
                     key: "test".to_string(),
                     r#type: FireboltType::Array(Box::new(FireboltType::Text)),
+                    nullable: false,
+                    is_key: true,
+                }],
+            },
+        );
+
+        assert_eq!(
+            build_firebolt_schema(&Binding {
+                field_selection: Some(FieldSelection {
+                    keys: vec!["obj/name".to_string()],
+                    ..Default::default()
+                }),
+                collection: Some(CollectionSpec {
+                    schema_json: json!({
+                        "properties": {
+                            "obj": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name"]
+                            },
+                        },
+                        "type": "object",
+                        "required": ["obj"]
+                    })
+                    .to_string(),
+                    projections: vec![Projection {
+                        field: "obj/name".to_string(),
+                        ptr: "/obj/name".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .unwrap(),
+            TableSchema {
+                columns: vec![Column {
+                    key: "obj_name".to_string(),
+                    r#type: FireboltType::Text,
+                    nullable: false,
+                    is_key: true,
+                }],
+            },
+        );
+
+        assert_eq!(
+            build_firebolt_schema(&Binding {
+                field_selection: Some(FieldSelection {
+                    keys: vec!["obj".to_string()],
+                    ..Default::default()
+                }),
+                collection: Some(CollectionSpec {
+                    schema_json: json!({
+                        "properties": {
+                            "obj": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name"]
+                            },
+                        },
+                        "type": "object",
+                        "required": ["obj"]
+                    })
+                    .to_string(),
+                    projections: vec![Projection {
+                        field: "obj".to_string(),
+                        ptr: "/obj".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .unwrap(),
+            TableSchema {
+                columns: vec![Column {
+                    key: "obj".to_string(),
+                    r#type: FireboltType::Text,
                     nullable: false,
                     is_key: true,
                 }],


### PR DESCRIPTION
**Description:**

- Allows for nested document keys which have `/` by replacing them with `_` to be compatible with Firebolt
- Uses TEXT type to store JSON objects
- This PR is a companion to https://github.com/estuary/connectors/pull/158

**Workflow steps:**

Add an object field and include it in the fields for materialize-firebolt:

```
        obj:
          type: object
          description: random object for testing
          properties:
            name:
              type: string
              description: name
```

```materializations:
  acmeCo/firebolt/materialize-file-sizes:
    endpoint:
      flowSink:
        image: docker.io/library/materialize-firebolt:local
        config: acmeCo/materialize-firebolt.config.yaml
    bindings:
      - resource:
          table: files
          table_type: fact
        source: acmeCo/file-sizes
        fields:
          recommended: true
          include: { obj: {} }
```

This is what it looks like on Firebolt:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/2807772/160369796-3ebe4317-0424-4a0e-ac94-aa6038ef75df.png">

**Documentation links affected:**
N/A

**Notes for reviewers:**

- See the other PR on the materialize-firebolt connector: https://github.com/estuary/connectors/pull/158
- This branch is based on https://github.com/estuary/flow/pull/421

