### PR TITLE
Fix conflicting schemalate typescript arg

### DIFF
--- a/crates/schemalate/src/typescript/mod.rs
+++ b/crates/schemalate/src/typescript/mod.rs
@@ -16,7 +16,7 @@ pub struct Args {
     name: String,
 
     /// Hoist definitions of the root schema into their own types?
-    #[clap(short, long)]
+    #[clap(long)]
     hoist_definitions: bool,
 }
 


### PR DESCRIPTION
**Description:**

The short option for `--hoist-definitions` was `-h`, which conflicts
with the builtin `-h` for `--help`. The result was that
`--hoist-definitions` could not be used at all. This commit removes the
short option altogether, since `--hoist-definitions` is more readable
anyway.

**Workflow steps:**

No change. You already had to use the full `--hoist-definitions` argument with `flowctl schemalate typescript`, since `-h` conflicted. The only difference seems to be that something (presumably a recent version of `clap`) now causes the conflict error to be raised even when using the long form of the argument.

**Documentation links affected:** nope

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/428)
<!-- Reviewable:end -->
