### PR TITLE
models: allow inline resource contents to be JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,6 @@ name = "models"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
  "bytes",
  "caseless",
  "doc 0.0.0",

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -10,7 +10,6 @@ doc = { path = "../doc", version = "0.0.0" }
 protocol = { path = "../protocol", version = "0.0.0" }
 
 anyhow = "*"
-base64 = "*"
 bytes = "*"
 humantime-serde = "*"
 lazy_static = "*"

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -35,7 +35,7 @@ pub use references::{
     Capture, Collection, CompositeKey, Field, JsonPointer, Materialization, PartitionField, Prefix,
     RelativeUrl, Test, Transform,
 };
-pub use resources::{ContentType, Import, ResourceDef};
+pub use resources::{ContentType, Import, ResourceContent, ResourceDef};
 pub use schemas::Schema;
 pub use shards::ShardTemplate;
 pub use shuffles::{Lambda, PartitionSelector, Shuffle};

--- a/crates/sources/Cargo.toml
+++ b/crates/sources/Cargo.toml
@@ -11,6 +11,7 @@ models = { path = "../models", version = "0.0.0" }
 protocol = { path = "../protocol", version = "0.0.0" }
 
 anyhow = "*"
+base64 = "*"
 bytes = "*"
 futures = "*"
 humantime-serde = "*"
@@ -18,8 +19,8 @@ lazy_static = "*"
 regex = "*"
 schemars = "*"
 serde = { version = "*", features = ["derive"] }
-serde_json = { version =  "*", features = ["raw_value"] }
 serde-transcode = "*"
+serde_json = { version =  "*", features = ["raw_value"] }
 serde_yaml = "*"
 thiserror = "*"
 tracing = "*"

--- a/crates/sources/src/scenarios/mod.rs
+++ b/crates/sources/src/scenarios/mod.rs
@@ -59,13 +59,26 @@ mod test {
             "import": [
                 "https://absolute/path/to/c.yaml"
             ],
+            "collections": {
+                "foo": {
+                    "schema": "subpath/json-schema.yaml",
+                    "key": ["/ptr"]
+                },
+                "bar": {
+                    "schema": "subpath/wrong-content-type.yaml",
+                    "key": ["/ptr"]
+                },
+                "baz": {
+                    "schema": "subpath/invalid-base64",
+                    "key": ["/ptr"]
+                }
+            },
             "storageMappings": {
                 "B/": {
                     "stores": [{ "provider": "S3", "bucket": "s3-bucket" }]
                 }
             }
         });
-        let b = base64::encode(serde_json::to_vec(&b).unwrap());
 
         let fixture = json!({
             "test://example/catalog.yaml": {
@@ -73,7 +86,19 @@ mod test {
                     "test://example/B.yaml": {
                         "content": b,
                         "contentType": "CATALOG",
-                    }
+                    },
+                    "test://example/subpath/json-schema.yaml": {
+                        "content": {"const": 42},
+                        "contentType": "JSON_SCHEMA",
+                    },
+                    "test://example/subpath/wrong-content-type.yaml": {
+                        "content": {},
+                        "contentType": "CATALOG",
+                    },
+                    "test://example/subpath/invalid-base64": {
+                        "content": "this should be base64",
+                        "contentType": "JSON_SCHEMA",
+                    },
                 },
                 "import": [
                     "B.yaml"

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__inline_nested_catalogs.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__inline_nested_catalogs.snap
@@ -1,15 +1,52 @@
 ---
 source: crates/sources/src/scenarios/mod.rs
-assertion_line: 90
+assertion_line: 115
 expression: tables
-
 ---
 Tables {
     capture_bindings: [],
     captures: [],
-    collections: [],
+    collections: [
+        Collection {
+            scope: test://example/B.yaml#/collections/bar,
+            collection: bar,
+            schema: test://example/subpath/wrong-content-type.yaml,
+            key: ["/ptr"],
+            journals: {"fragments":{}},
+        },
+        Collection {
+            scope: test://example/B.yaml#/collections/baz,
+            collection: baz,
+            schema: test://example/subpath/invalid-base64,
+            key: ["/ptr"],
+            journals: {"fragments":{}},
+        },
+        Collection {
+            scope: test://example/B.yaml#/collections/foo,
+            collection: foo,
+            schema: test://example/subpath/json-schema.yaml,
+            key: ["/ptr"],
+            journals: {"fragments":{}},
+        },
+    ],
     derivations: [],
-    errors: [],
+    errors: [
+        Error {
+            scope: test://example/B.yaml#/collections/bar/schema,
+            error: failed to fetch resource test://example/subpath/wrong-content-type.yaml
+            
+            Caused by:
+                inline resource has content-type Catalog, not the requested JsonSchema,
+        },
+        Error {
+            scope: test://example/B.yaml#/collections/baz/schema,
+            error: failed to fetch resource test://example/subpath/invalid-base64
+            
+            Caused by:
+                0: base64-decode of inline resource failed
+                1: Encoded text cannot have a 6-bit remainder.,
+        },
+    ],
     fetches: [
         Fetch {
             depth: 1,
@@ -32,6 +69,18 @@ Tables {
             resource: test://example/B.ts,
         },
         Fetch {
+            depth: 3,
+            resource: test://example/subpath/invalid-base64,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/subpath/json-schema.yaml,
+        },
+        Fetch {
+            depth: 3,
+            resource: test://example/subpath/wrong-content-type.yaml,
+        },
+        Fetch {
             depth: 4,
             resource: https://absolute/path/to/c.ts,
         },
@@ -51,6 +100,21 @@ Tables {
             scope: test://example/B.yaml,
             from_resource: test://example/B.yaml,
             to_resource: test://example/B.ts,
+        },
+        Import {
+            scope: test://example/B.yaml#/collections/baz/schema,
+            from_resource: test://example/B.yaml,
+            to_resource: test://example/subpath/invalid-base64,
+        },
+        Import {
+            scope: test://example/B.yaml#/collections/foo/schema,
+            from_resource: test://example/B.yaml,
+            to_resource: test://example/subpath/json-schema.yaml,
+        },
+        Import {
+            scope: test://example/B.yaml#/collections/bar/schema,
+            from_resource: test://example/B.yaml,
+            to_resource: test://example/subpath/wrong-content-type.yaml,
         },
         Import {
             scope: test://example/catalog.yaml#/import/0,
@@ -84,8 +148,18 @@ Tables {
             content_type: "CATALOG",
             content: ".. binary ..",
         },
+        Resource {
+            resource: test://example/subpath/json-schema.yaml,
+            content_type: "JSON_SCHEMA",
+            content: ".. binary ..",
+        },
     ],
-    schema_docs: [],
+    schema_docs: [
+        SchemaDoc {
+            schema: test://example/subpath/json-schema.yaml,
+            dom: {"const":42},
+        },
+    ],
     storage_mappings: [
         StorageMapping {
             scope: test://example/catalog.yaml#/storageMappings/A~1,

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/sources/tests/schema_generation.rs
+assertion_line: 4
 expression: "&schema"
-
 ---
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -999,8 +999,26 @@ expression: "&schema"
       "type": "string",
       "pattern": "^[^ ]+$"
     },
+    "ResourceContent": {
+      "examples": [
+        "aGVsbG8sIHdvcmxk",
+        {
+          "hello": "world"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
     "ResourceDef": {
-      "description": "A Resource is binary content with an associated ContentType.",
+      "description": "A Resource is content with an associated ContentType.",
       "type": "object",
       "required": [
         "content",
@@ -1008,9 +1026,8 @@ expression: "&schema"
       ],
       "properties": {
         "content": {
-          "title": "Byte content of the Resource.",
-          "type": "string",
-          "contentEncoding": "base64"
+          "title": "Content of the Resource.",
+          "$ref": "#/definitions/ResourceContent"
         },
         "contentType": {
           "title": "Content type of the Resource.",

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -994,8 +994,26 @@
       "type": "string",
       "pattern": "^[^ ]+$"
     },
+    "ResourceContent": {
+      "examples": [
+        "aGVsbG8sIHdvcmxk",
+        {
+          "hello": "world"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
     "ResourceDef": {
-      "description": "A Resource is binary content with an associated ContentType.",
+      "description": "A Resource is content with an associated ContentType.",
       "type": "object",
       "required": [
         "content",
@@ -1003,9 +1021,8 @@
       ],
       "properties": {
         "content": {
-          "title": "Byte content of the Resource.",
-          "type": "string",
-          "contentEncoding": "base64"
+          "title": "Content of the Resource.",
+          "$ref": "#/definitions/ResourceContent"
         },
         "contentType": {
           "title": "Content type of the Resource.",


### PR DESCRIPTION

In addition to base64 values. This is more ergonomic in some cases,
as inner JSON documents can be directly contained in the catalog without
being obfuscated through base64 encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/430)
<!-- Reviewable:end -->
