### PR TITLE
Elasticsearch and S3-parquet connector docs

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
@@ -28,9 +28,11 @@ If you haven't yet captured your data from its external source, start at the beg
 To use this connector, begin with data in one or more Flow collections.
 Use the below properties to configure an Elasticsearch materialization, which will direct the contents of these Flow collections into Elasticsearch indices.
 
-You must indicate the desired Elasticsearch field type for each field in your Flow collection.
-You configure this in the `field_overrides` array for each binding.
-To do so, provide a JSON pointer to the field in the collection schema, choose the output field type, and specify additional properties, if necessary.
+By default, the connector attempts to map each field in the Flow collection to the most appropriate Elasticsearch [field type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html).
+However, because each JSON field type can map to multiple Elasticsearch field types,
+you may want to override the defaults.
+You can configure this by adding `field_overrides` to the collection's [binding](#bindings) in the materialization specification.
+To do so, provide a JSON pointer to the field in the collection schema, choose the output field type, and specify additional properties, if necessary. 
 
 ### Properties
 

--- a/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
@@ -13,7 +13,7 @@ This connector materializes Flow collections into indices in an Elasticsearch cl
 To use this connector, you'll need:
 
 * An Elastic cluster with a known [endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html#send-requests-to-elasticsearch)
-  * If the cluster is on the Elastic Cloud, you'll need an Elastic user with a role that grants all privileges on indices in the cluster.
+  * If the cluster is on the Elastic Cloud, you'll need an Elastic user with a role that grants all privileges on indices you plan to materialize to within the cluster.
     See Elastic's documentation on [defining roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-indices-priv) and
     [security privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#privileges-list-indices).
 * At least one Flow collection
@@ -32,7 +32,7 @@ By default, the connector attempts to map each field in the Flow collection to t
 However, because each JSON field type can map to multiple Elasticsearch field types,
 you may want to override the defaults.
 You can configure this by adding `field_overrides` to the collection's [binding](#bindings) in the materialization specification.
-To do so, provide a JSON pointer to the field in the collection schema, choose the output field type, and specify additional properties, if necessary. 
+To do so, provide a JSON pointer to the field in the collection schema, choose the output field type, and specify additional properties, if necessary.
 
 ### Properties
 
@@ -59,7 +59,7 @@ To do so, provide a JSON pointer to the field in the collection schema, choose t
 | _`/field_overrides/-/es_type/text_spec`_ | Text specifications | Configuration for the text field, effective if field&#x5F;type is &#x27;text&#x27;. | object |  |
 | _`/field_overrides/-/es_type/text_spec/dual_keyword`_ | Dual keyword | Whether or not to specify the field as text&#x2F;keyword dual field. | boolean |  |
 | _`/field_overrides/-/es_type/text_spec/keyword_ignore_above`_ | Ignore above | Effective only if Dual Keyword is enabled. Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html). | integer |  |
-| _`/field_overrides/-/pointer`_ | Pointer | A &#x27;&#x2F;&#x27;-delimitated json pointer to the location of the overridden field. | string |  |
+| _`/field_overrides/-/pointer`_ | Pointer | A &#x27;&#x2F;&#x27;-delimited json pointer to the location of the overridden field. | string |  |
 | **`/index`** | index | Name of the ElasticSearch index to store the materialization results. | string | Required |
 | `/number_of_replicas` | Number of replicas | The number of replicas in ElasticSearch index. If not set, default to be 0. For single-node clusters, make sure this field is 0, because the Elastic search needs to allocate replicas on different nodes. | integer | `0` |
 | `/number_of_shards` | Number of shards | The number of shards in ElasticSearch index. Must set to be greater than 0. | integer | `1` |

--- a/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
@@ -1,16 +1,21 @@
+---
+sidebar_position: 2
+---
+
 # Elasticsearch
 
-This connector materializes Flow collections into indices in Elasticsearch.
+This connector materializes Flow collections into indices in an Elasticsearch cluster.
 
-TODO: other high-level details about credentials used, mechanism, etc
-
-[`ghcr.io/estuary/materialize-<ENDPOINT-NAME>:dev`](https://ghcr.io/estuary/materialize-<ENDPOINT-NAME>:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+[`ghcr.io/estuary/materialize-elasticsearch:dev`](https://ghcr.io/estuary/materialize-elasticsearch:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
 
 ## Prerequisites
 
 To use this connector, you'll need:
 
-TODO: additional?
+* An Elastic cluster with a known [endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html#send-requests-to-elasticsearch)
+  * If the cluster is on the Elastic Cloud, you'll need an Elastic user with a role that grants all privileges on indices in the cluster.
+    See Elastic's documentation on [defining roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-indices-priv) and
+    [security privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#privileges-list-indices).
 * At least one Flow collection
 
 :::tip
@@ -21,11 +26,11 @@ If you haven't yet captured your data from its external source, start at the beg
 ## Configuration
 
 To use this connector, begin with data in one or more Flow collections.
-Use the below properties to configure a Elasticsearch materialization, which will direct one or more of your Flow collections to your desired Elasticsearch indices.
+Use the below properties to configure an Elasticsearch materialization, which will direct the contents of these Flow collections into Elasticsearch indices.
 
 You must indicate the desired Elasticsearch field type for each field in your Flow collection.
 You configure this in the `field_overrides` array for each binding.
-To do so, provide a JSON pointer to the field in the collection schema and choose the output field type.
+To do so, provide a JSON pointer to the field in the collection schema, choose the output field type, and specify additional properties, if necessary.
 
 ### Properties
 
@@ -33,34 +38,59 @@ To do so, provide a JSON pointer to the field in the collection schema and choos
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/endpoint`** |  |  | string | Required |
-| `/password` |  |  | string |  |
-| `/username` |  |  | string |  |
+| **`/endpoint`** | Endpoint | Endpoint host or URL. If using Elastic Cloud, this follows the format `https://CLUSTER_ID.REGION.CLOUD_PLATFORM.DOMAIN:PORT`. | string | Required |
+| `/password` | Password | Password to connect to the endpoint. | string |  |
+| `/username` | Username | User to connect to the endpoint. | string |  |
 
 #### Bindings
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/delta_updates`** |  |  | boolean | Required |
-| **`/field_overrides`** |  |  | array | Required |
-| _`/field_overrides/-`_ |  |  | object |  |
-| _`/field_overrides/-/es_type`_ |  | The overriding Elasticsearch data type of the field. | object |  |
-| _`/field_overrides/-/es_type/date_spec`_ |  | Spec of the date field, effective if field&#x5F;type is &#x27;date&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html). | object |  |
-| _`/field_overrides/-/es_type/date_spec/format`_ |  | Format of the date. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html.). | string |  |
-| _`/field_overrides/-/es_type/field_type`_ |  | The Elasticsearch field data types. Supported types include: boolean, date, double, geo&#x5F;point, geo&#x5F;shape, keyword, long, null, text. | string |  |
-| _`/field_overrides/-/es_type/keyword_spec`_ |  | Spec of the keyword field, effective if field&#x5F;type is &#x27;keyword&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html) | object |  |
-| _`/field_overrides/-/es_type/keyword_spec/ignore_above`_ |  | Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) | integer |  |
-| _`/field_overrides/-/es_type/text_spec`_ |  | Spec of the text field, effective if field&#x5F;type is &#x27;text&#x27;. | object |  |
-| _`/field_overrides/-/es_type/text_spec/dual_keyword`_ |  | Whether or not to specify the field as text&#x2F;keyword dual field. | boolean |  |
-| _`/field_overrides/-/es_type/text_spec/keyword_ignore_above`_ |  | Effective only if DualKeyword is enabled. Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) | integer |  |
-| _`/field_overrides/-/pointer`_ |  | A &#x27;&#x2F;&#x27;-delimitated json pointer to the location of the overridden field. | string |  |
-| **`/index`** |  | Name of the ElasticSearch index to store the materialization results. | string | Required |
-| `/number_of_replicas` |  | The number of replicas in ElasticSearch index. If not set, default to be 0. For single-node clusters, make sure this field is 0, because the Elastic search needs to allocate replicas on different nodes. | integer |  |
-| `/number_of_shards` |  | The number of shards in ElasticSearch index. Must set to be greater than 0. | integer | `1` |
+| **`/delta_updates`** | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean | Required |
+| **`/field_overrides`** | Field overrides | Assign Elastic field type to each collection field. | array | Required |
+| _`/field_overrides/-/es_type`_ | Elasticsearch type | The overriding Elasticsearch data type of the field. | object |  |
+| _`/field_overrides/-/es_type/date_spec`_ | Date specifications | Configuration for the date field, effective if field&#x5F;type is &#x27;date&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html). | object |  |
+| _`/field_overrides/-/es_type/date_spec/format`_ | Date format | Format of the date. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html). | string |  |
+| _`/field_overrides/-/es_type/field_type`_ | Field type | The Elasticsearch field data types. Supported types include: boolean, date, double, geo&#x5F;point, geo&#x5F;shape, keyword, long, null, text. | string |  |
+| _`/field_overrides/-/es_type/keyword_spec`_ | Keyword specifications | Configuration for the keyword field, effective if field&#x5F;type is &#x27;keyword&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html) | object |  |
+| _`/field_overrides/-/es_type/keyword_spec/ignore_above`_ | Ignore above | Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) | integer |  |
+| _`/field_overrides/-/es_type/text_spec`_ | Text specifications | Configuration for the text field, effective if field&#x5F;type is &#x27;text&#x27;. | object |  |
+| _`/field_overrides/-/es_type/text_spec/dual_keyword`_ | Dual keyword | Whether or not to specify the field as text&#x2F;keyword dual field. | boolean |  |
+| _`/field_overrides/-/es_type/text_spec/keyword_ignore_above`_ | Ignore above | Effective only if Dual Keyword is enabled. Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html). | integer |  |
+| _`/field_overrides/-/pointer`_ | Pointer | A &#x27;&#x2F;&#x27;-delimitated json pointer to the location of the overridden field. | string |  |
+| **`/index`** | index | Name of the ElasticSearch index to store the materialization results. | string | Required |
+| `/number_of_replicas` | Number of replicas | The number of replicas in ElasticSearch index. If not set, default to be 0. For single-node clusters, make sure this field is 0, because the Elastic search needs to allocate replicas on different nodes. | integer | `0` |
+| `/number_of_shards` | Number of shards | The number of shards in ElasticSearch index. Must set to be greater than 0. | integer | `1` |
 
 ### Sample
-TODO use https://github.com/estuary/demos-ais-vessels/blob/f474b4aa8ff764589e727e447c808fb636effd99/visualizations/vessels.flow.yaml for ref
 
+```yaml
+materializations:
+  tenant/mat_name:
+    endpoint:
+      connector:
+         # Path to the latest version of the connector, provided as a Docker image
+        image: ghcr.io/estuary/materialize-elasticsearch:dev
+        config:
+          endpoint: https://ec47fc4d2c53414e1307e85726d4b9bb.us-east-1.aws.found.io:9243
+          username: flow_user
+          password: secret
+  	# If you have multiple collections you need to materialize, add a binding for each one
+    # to ensure complete data flow-through
+        bindings:
+          - resource:
+              index: last-updated
+              delta_updates: false
+              field_overrides:
+                  - pointer: /updated-date
+                    es_type:
+                      field_type: date
+                        date_spec:
+                          format: yyyy-MM-dd
+            source: tenant/source_collection
+```
 ## Delta updates
 
-TODO Add this section if the connector supports delta updates or both standard and delta. Omit if just standard.
+This connector supports both standard and delta updates. You must choose an option for each binding.
+
+[Learn more about delta updates](../../../concepts/materialization.md#delta-updates) and the implications of using each update type.

--- a/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
@@ -1,0 +1,66 @@
+# Elasticsearch
+
+This connector materializes Flow collections into indices in Elasticsearch.
+
+TODO: other high-level details about credentials used, mechanism, etc
+
+[`ghcr.io/estuary/materialize-<ENDPOINT-NAME>:dev`](https://ghcr.io/estuary/materialize-<ENDPOINT-NAME>:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+TODO: additional?
+* At least one Flow collection
+
+:::tip
+If you haven't yet captured your data from its external source, start at the beginning of the [guide to create a dataflow](../../../guides/create-dataflow.md). You'll be referred back to this connector-specific documentation at the appropriate steps.
+:::
+
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a Elasticsearch materialization, which will direct one or more of your Flow collections to your desired Elasticsearch indices.
+
+You must indicate the desired Elasticsearch field type for each field in your Flow collection.
+You configure this in the `field_overrides` array for each binding.
+To do so, provide a JSON pointer to the field in the collection schema and choose the output field type.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/endpoint`** |  |  | string | Required |
+| `/password` |  |  | string |  |
+| `/username` |  |  | string |  |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/delta_updates`** |  |  | boolean | Required |
+| **`/field_overrides`** |  |  | array | Required |
+| _`/field_overrides/-`_ |  |  | object |  |
+| _`/field_overrides/-/es_type`_ |  | The overriding Elasticsearch data type of the field. | object |  |
+| _`/field_overrides/-/es_type/date_spec`_ |  | Spec of the date field, effective if field&#x5F;type is &#x27;date&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html). | object |  |
+| _`/field_overrides/-/es_type/date_spec/format`_ |  | Format of the date. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html.). | string |  |
+| _`/field_overrides/-/es_type/field_type`_ |  | The Elasticsearch field data types. Supported types include: boolean, date, double, geo&#x5F;point, geo&#x5F;shape, keyword, long, null, text. | string |  |
+| _`/field_overrides/-/es_type/keyword_spec`_ |  | Spec of the keyword field, effective if field&#x5F;type is &#x27;keyword&#x27;. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html) | object |  |
+| _`/field_overrides/-/es_type/keyword_spec/ignore_above`_ |  | Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) | integer |  |
+| _`/field_overrides/-/es_type/text_spec`_ |  | Spec of the text field, effective if field&#x5F;type is &#x27;text&#x27;. | object |  |
+| _`/field_overrides/-/es_type/text_spec/dual_keyword`_ |  | Whether or not to specify the field as text&#x2F;keyword dual field. | boolean |  |
+| _`/field_overrides/-/es_type/text_spec/keyword_ignore_above`_ |  | Effective only if DualKeyword is enabled. Strings longer than the ignore&#x5F;above setting will not be indexed or stored. See [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) | integer |  |
+| _`/field_overrides/-/pointer`_ |  | A &#x27;&#x2F;&#x27;-delimitated json pointer to the location of the overridden field. | string |  |
+| **`/index`** |  | Name of the ElasticSearch index to store the materialization results. | string | Required |
+| `/number_of_replicas` |  | The number of replicas in ElasticSearch index. If not set, default to be 0. For single-node clusters, make sure this field is 0, because the Elastic search needs to allocate replicas on different nodes. | integer |  |
+| `/number_of_shards` |  | The number of shards in ElasticSearch index. Must set to be greater than 0. | integer | `1` |
+
+### Sample
+TODO use https://github.com/estuary/demos-ais-vessels/blob/f474b4aa8ff764589e727e447c808fb636effd99/visualizations/vessels.flow.yaml for ref
+
+## Delta updates
+
+TODO Add this section if the connector supports delta updates or both standard and delta. Omit if just standard.

--- a/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Firebolt
 
 This Flow connector materializes [delta updates](../../../concepts/materialization.md#delta-updates) of Flow collections into Firebolt `FACT` or `DIMENSION` tables.

--- a/site/docs/reference/Connectors/materialization-connectors/Parquet.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Parquet.md
@@ -1,0 +1,77 @@
+# Apache Parquet in S3
+
+This connector materializes Flow [delta updates](#delta-updates) of collections into an S3 bucket in the Apache Parquet format.
+
+The delta updates are batched within Flow, converted to Parquet files, and the pushed to the S3 bucket at a time interval that you set.
+
+[`ghcr.io/estuary/materialize-s3-parquet:dev`](https://ghcr.io/estuary/materialize-s3-parquet:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* An AWS root or IAM user with access to the S3 bucket. For this user, you'll need the **access key** and **secret access key**.
+  See the [AWS blog](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/) for help finding these credentials.
+* At least one Flow collection
+
+:::tip
+If you haven't yet captured your data from its external source, start at the beginning of the [guide to create a dataflow](../../../guides/create-dataflow.md). You'll be referred back to this connector-specific documentation at the appropriate steps.
+:::
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a  materialization, which will direct one or more of your Flow collections to Parquet files in S3.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/awsAccessKeyId`** | AWS Access Key ID | AWS credential used to connect to S3 | string | Required |
+| **`/awsSecretAccessKey`** | AWS Secret Access Key | AWS credential used to connect to S3 | string | Required |
+| **`/bucket`** | Bucket | Name of the S3 bucket | string | Required |
+| `/endpoint` | AWS Endpoint | The AWS endpoint URI to connect to, useful if you&#x27;re capturing from a S3-compatible API that isn&#x27;t provided by AWS | string |  |
+| `/region` |  AWS Region | The name of the AWS region where the S3 bucket is located. &quot;us-east-1&quot; is a popular default you can try, if you&#x27;re unsure what to put here. | string |  |
+| **`/uploadIntervalInSeconds`** | Upload Interval in Seconds | Time interval, in seconds, at which to upload data from Flow to S3. | integer | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| `/compressionType` | Compression type | The method used to compress data in Parquet. | string |  |
+| **`/pathPrefix`** | Path prefix | The desired Parquet file path within the bucket as determined by an S3 [prefix](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html) | string | Required |
+
+The following compression types are supported:
+
+* `snappy`
+* `gzip`
+* `lz4`
+* `zstd`
+
+### Sample
+```yaml
+materializations:
+  ${tenant}/${mat_name}:
+	  endpoint:
+        connector:
+          config:
+            awsAccessKeyId: AKIAIOSFODNN7EXAMPLE
+            awsSecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRET
+            bucket: my-bucket
+            uploadIntervalInSeconds: 10
+          # Path to the latest version of the connector, provided as a Docker image
+          image: ghcr.io/estuary/materialize-s3-parquet:dev
+	# If you have multiple collections you need to materialize, add a binding for each one
+    # to ensure complete data flow-through
+    bindings:
+      - resource:
+          pathPrefix: /my-prefix
+      source: ${tenant}/${source_collection}
+```
+
+## Delta updates
+
+This connector uses only [delta updates](../../../concepts/materialization.md#delta-updates) mode.
+Collection documents are converted to Parquet format and stored in their unmerged state.

--- a/site/docs/reference/Connectors/materialization-connectors/Parquet.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Parquet.md
@@ -64,7 +64,7 @@ materializations:
             awsAccessKeyId: AKIAIOSFODNN7EXAMPLE
             awsSecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRET
             bucket: my-bucket
-            uploadIntervalInSeconds: 10
+            uploadIntervalInSeconds: 300
           # Path to the latest version of the connector, provided as a Docker image
           image: ghcr.io/estuary/materialize-s3-parquet:dev
 	# If you have multiple collections you need to materialize, add a binding for each one

--- a/site/docs/reference/Connectors/materialization-connectors/Parquet.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Parquet.md
@@ -1,6 +1,10 @@
+---
+sidebar_position: 1
+---
+
 # Apache Parquet in S3
 
-This connector materializes Flow [delta updates](#delta-updates) of collections into an S3 bucket in the Apache Parquet format.
+This connector materializes [delta updates](#delta-updates) of Flow collections into an S3 bucket in the Apache Parquet format.
 
 The delta updates are batched within Flow, converted to Parquet files, and the pushed to the S3 bucket at a time interval that you set.
 
@@ -21,7 +25,7 @@ If you haven't yet captured your data from its external source, start at the beg
 ## Configuration
 
 To use this connector, begin with data in one or more Flow collections.
-Use the below properties to configure a  materialization, which will direct one or more of your Flow collections to Parquet files in S3.
+Use the below properties to configure a  materialization, which will direct the contents of these Flow collections to Parquet files in S3.
 
 ### Properties
 
@@ -29,10 +33,10 @@ Use the below properties to configure a  materialization, which will direct one 
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/awsAccessKeyId`** | AWS Access Key ID | AWS credential used to connect to S3 | string | Required |
-| **`/awsSecretAccessKey`** | AWS Secret Access Key | AWS credential used to connect to S3 | string | Required |
-| **`/bucket`** | Bucket | Name of the S3 bucket | string | Required |
-| `/endpoint` | AWS Endpoint | The AWS endpoint URI to connect to, useful if you&#x27;re capturing from a S3-compatible API that isn&#x27;t provided by AWS | string |  |
+| **`/awsAccessKeyId`** | AWS Access Key ID | AWS credential used to connect to S3. | string | Required |
+| **`/awsSecretAccessKey`** | AWS Secret Access Key | AWS credential used to connect to S3. | string | Required |
+| **`/bucket`** | Bucket | Name of the S3 bucket. | string | Required |
+| `/endpoint` | AWS Endpoint | The AWS endpoint URI to connect to, useful if you&#x27;re capturing from a S3-compatible API that isn&#x27;t provided by AWS | string. |  |
 | `/region` |  AWS Region | The name of the AWS region where the S3 bucket is located. &quot;us-east-1&quot; is a popular default you can try, if you&#x27;re unsure what to put here. | string |  |
 | **`/uploadIntervalInSeconds`** | Upload Interval in Seconds | Time interval, in seconds, at which to upload data from Flow to S3. | integer | Required |
 
@@ -41,7 +45,7 @@ Use the below properties to configure a  materialization, which will direct one 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
 | `/compressionType` | Compression type | The method used to compress data in Parquet. | string |  |
-| **`/pathPrefix`** | Path prefix | The desired Parquet file path within the bucket as determined by an S3 [prefix](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html) | string | Required |
+| **`/pathPrefix`** | Path prefix | The desired Parquet file path within the bucket as determined by an S3 [prefix](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html). | string | Required |
 
 The following compression types are supported:
 
@@ -53,7 +57,7 @@ The following compression types are supported:
 ### Sample
 ```yaml
 materializations:
-  ${tenant}/${mat_name}:
+  tenant/mat_name:
 	  endpoint:
         connector:
           config:
@@ -68,7 +72,7 @@ materializations:
     bindings:
       - resource:
           pathPrefix: /my-prefix
-      source: ${tenant}/${source_collection}
+      source: tenant/source_collection
 ```
 
 ## Delta updates

--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -10,11 +10,11 @@ Also listed are links to the most recent Docker image, which you'll need for cer
 Estuary is actively developing new connectors, so check back regularly for the latest additions. We’re prioritizing the development of high-scale technological systems, as well as client needs.
 
 ## Available materialization connectors
-* Apache Parquet
-  * Configuration
+* Apache Parquet in S3
+  * [Configuration](./Parquet.md)
   * Package — ghcr.io/estuary/materialize-s3-parquet:dev
 * Elasticsearch
-  * Configuration
+  * [Configuration](./Elasticsearch.md)
   * Package — ghcr.io/estuary/materialize-elasticsearch:dev
 * Firebolt
   * [Configuration](./Firebolt.md)


### PR DESCRIPTION
**Description:**

Adds docs for `materialize-s3-parquet` and `materialize-elasticsearch`. This catches us up on connector docs. 

**Notes for reviewers:**

With the exception of most of the `field_overrides` in elasticsearch, I wrote the property descriptions - they're either not present in the config or I wasn't able to find them.

Some outstanding questions because the original developer isn't here and there are no READMEs. Specifically, with Elastic, I used up my free trial a while ago and wasn't able to test, so this needs review from someone familiar with that platform. 
* Prerequisites and permissions for elastic - are these correct?
* Is there anything worth mentioning in the intro for the mechanism of this connector that'd be pertinent to the user?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/432)
<!-- Reviewable:end -->
