### PR TITLE
SQL materializations CREATE TABLE IF NOT EXISTS

### DIFF
--- a/go/protocols/materialize/sql/spec_mapping.go
+++ b/go/protocols/materialize/sql/spec_mapping.go
@@ -12,10 +12,11 @@ import (
 // ensure that each projection has exactly one type besides "null".
 func TableForMaterialization(name string, comment string, identifierRenderer *Renderer, spec *pf.MaterializationSpec_Binding) *Table {
 	return &Table{
-		Name:       name,
-		Identifier: identifierRenderer.Render(name),
-		Comment:    comment,
-		Columns:    columnsForMaterialization(spec, identifierRenderer),
+		Name:        name,
+		Identifier:  identifierRenderer.Render(name),
+		Comment:     comment,
+		Columns:     columnsForMaterialization(spec, identifierRenderer),
+		IfNotExists: true,
 	}
 }
 


### PR DESCRIPTION
**Description:**

Changes the SQL generation for materialization tables to add `IF NOT
EXISTS`. This allows for manual creation of the target tables without
needing to also create and insert into `flow_materializations_v2`. A
newly supported workflow is to manually create the target tables, and
then apply the materialization.

**Workflow steps:**

- use `psql`, for example, to create the tables that you want to materialize into
- _then_ run `flowctl api activate` to apply the materialization
- The materialization should now use the tables you created manually

**Documentation links affected:**

I'm thinking we should leave this undocumented for now, since I'm not really sure if this should be a blessed path for customizing the generated tables.

**Notes for reviewers:**

This was motivated by the materialization of stats into the control plane database. The tables into which stats are materialized are created in a migration script, and the desire is for the materialization to use those. But it doesn't seem appropriate to put the entire materialization spec into that migration, so this allows that migration to only define the target tables and not have to mess with `flow_materializations_v2` or anything like that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/433)
<!-- Reviewable:end -->
