### PR TITLE
Connector Proxy stream refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
     "cSpell.words": [
+        "airbyte",
         "Firebolt",
         "schemalate"
     ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "clap 3.1.6",
  "doc 0.0.0",
  "flow_cli_common",
+ "futures",
  "futures-core",
  "futures-util",
  "json-pointer",

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ docker-image:
 		--file .devcontainer/release.Dockerfile \
 		--tag ghcr.io/estuary/flow:${FLOW_VERSION} \
 		--tag ghcr.io/estuary/flow:dev \
+		--tag mdibaiee/flow:dev \
 		${PKGDIR}/
 
 .PHONY: docker-push
@@ -278,3 +279,7 @@ docker-push:
 .PHONY: docker-push-dev
 docker-push-dev:
 	docker push ghcr.io/estuary/flow:dev
+
+.PHONY: docker-push-dev
+docker-push-mahdi: rust-binaries musl-binaries docker-image
+	docker push mdibaiee/flow:dev

--- a/Makefile
+++ b/Makefile
@@ -283,3 +283,5 @@ docker-push-dev:
 .PHONY: docker-push-dev
 docker-push-mahdi: rust-binaries musl-binaries docker-image
 	docker push mdibaiee/flow:dev
+	docker tag mdibaiee/flow:dev mdibaiee/flow:deepsync-stream
+	docker push mdibaiee/flow:deepsync-stream

--- a/crates/connector_proxy/Cargo.toml
+++ b/crates/connector_proxy/Cargo.toml
@@ -20,6 +20,7 @@ byteorder="*"
 clap = { version = "^3", features = ["derive"] }
 futures-core = "*"
 futures-util="*"
+futures="*"
 json-pointer="*"
 libc="*"
 prost = "*"

--- a/crates/connector_proxy/src/apis.rs
+++ b/crates/connector_proxy/src/apis.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use clap::ArgEnum;
+use futures::TryStream;
 use futures_core::stream::Stream;
 use std::pin::Pin;
 
@@ -42,4 +43,10 @@ pub enum FlowMaterializeOperation {
 
 // An interceptor modifies the request/response streams between Flow runtime and the connector.
 // InterceptorStream defines the type of input and output streams handled by interceptors.
-pub type InterceptorStream = Pin<Box<dyn Stream<Item = std::io::Result<Bytes>> + Send + Sync>>;
+pub type InterceptorStream = Pin<
+    Box<
+        dyn TryStream<Ok = Bytes, Error = std::io::Error, Item = std::io::Result<Bytes>>
+            + Send
+            + Sync,
+    >,
+>;

--- a/crates/connector_proxy/src/apis.rs
+++ b/crates/connector_proxy/src/apis.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
 use clap::ArgEnum;
 use futures::TryStream;
-use futures_core::stream::Stream;
 use std::pin::Pin;
 
 // The protocol used by FlowRuntime to speak with connector-proxy.

--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -61,7 +61,7 @@ pub enum Error {
     UnexpectedOperation(String),
 }
 
-pub fn raise_custom_error<T>(message: &str) -> Result<T, std::io::Error> {
+pub fn raise_err<T>(message: &str) -> Result<T, std::io::Error> {
     Err(create_custom_error(message))
 }
 

--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -61,7 +61,7 @@ pub enum Error {
     UnexpectedOperation(String),
 }
 
-pub fn raise_custom_error(message: &str) -> Result<(), std::io::Error> {
+pub fn raise_custom_error<T>(message: &str) -> Result<T, std::io::Error> {
     Err(create_custom_error(message))
 }
 

--- a/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
@@ -22,8 +22,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use validator::Validate;
 
-use futures::{stream, TryStreamExt};
-use futures_util::StreamExt;
+use futures::{stream, StreamExt, TryStreamExt};
 use json_pointer::JsonPointer;
 use serde_json::value::RawValue;
 use std::fs::File;

--- a/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
@@ -113,14 +113,15 @@ impl NetworkProxyCaptureInterceptor {
         in_stream: InterceptorStream,
     ) -> Result<InterceptorStream, Error> {
         Ok(match op {
-            FlowCaptureOperation::Spec => Box::pin(stream! {
-                let mut reader = StreamReader::new(in_stream);
-                let mut response = decode_message::<SpecResponse, _>(&mut reader).await.or_bail().expect("No expected response received.");
+            FlowCaptureOperation::Spec => Box::pin(stream::once(async move {
+                let mut response = get_decoded_message::<SpecResponse>(in_stream).await?;
                 response.endpoint_spec_schema_json = NetworkProxy::extend_endpoint_schema(
                     RawValue::from_string(response.endpoint_spec_schema_json)?,
-                ).or_bail().to_string();
-                yield encode_message(&response);
-            }),
+                )
+                .or_bail()
+                .to_string();
+                encode_message(&response)
+            })),
             _ => in_stream,
         })
     }

--- a/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
@@ -3,13 +3,12 @@ use crate::errors::{Error, Must};
 use crate::libs::network_proxy::NetworkProxy;
 use crate::libs::protobuf::{decode_message, encode_message};
 use crate::libs::stream::stream_all_bytes;
-use futures::{future, stream, TryStreamExt};
+use futures::{future, stream, StreamExt, TryStreamExt};
 use protocol::capture::{
     ApplyRequest, DiscoverRequest, PullRequest, SpecResponse, ValidateRequest,
 };
 
 use async_stream::stream;
-use futures_util::StreamExt;
 use serde_json::value::RawValue;
 use tokio_util::io::StreamReader;
 

--- a/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_proxy_capture_interceptor.rs
@@ -3,13 +3,12 @@ use crate::errors::{Error, Must};
 use crate::libs::network_proxy::NetworkProxy;
 use crate::libs::protobuf::{decode_message, encode_message};
 use crate::libs::stream::stream_all_bytes;
-use futures::stream;
+use futures::{future, stream, TryStreamExt};
 use protocol::capture::{
     ApplyRequest, DiscoverRequest, PullRequest, SpecResponse, ValidateRequest,
 };
 
 use async_stream::stream;
-use futures_util::pin_mut;
 use futures_util::StreamExt;
 use serde_json::value::RawValue;
 use tokio_util::io::StreamReader;
@@ -71,24 +70,32 @@ impl NetworkProxyCaptureInterceptor {
     }
 
     fn adapt_pull_request_stream(in_stream: InterceptorStream) -> InterceptorStream {
-        Box::pin(stream! {
-            let mut reader = StreamReader::new(in_stream);
-            let mut request = decode_message::<PullRequest, _>(&mut reader).await.or_bail().expect("expected request is not received.");
-            if let Some(ref mut o) = request.open {
-                if let Some(ref mut c) = o.capture {
-                    c.endpoint_spec_json = NetworkProxy::consume_network_proxy_config(
-                        RawValue::from_string(c.endpoint_spec_json.clone())?,
-                    ).await.or_bail().to_string();
+        Box::pin(
+            stream::once(async {
+                let mut reader = StreamReader::new(in_stream);
+                let mut request = decode_message::<PullRequest, _>(&mut reader)
+                    .await
+                    .or_bail()
+                    .expect("expected request is not received.");
+                if let Some(ref mut o) = request.open {
+                    if let Some(ref mut c) = o.capture {
+                        c.endpoint_spec_json = NetworkProxy::consume_network_proxy_config(
+                            RawValue::from_string(c.endpoint_spec_json.clone())?,
+                        )
+                        .await
+                        .or_bail()
+                        .to_string();
+                    }
                 }
-            }
-            yield encode_message(&request);
-            // deliver the rest messages in the stream.
-            let s = stream_all_bytes(reader);
-            pin_mut!(s);
-            while let Some(value) = s.next().await {
-                yield value;
-            }
-        })
+
+                let first = stream::once(future::ready(encode_message(&request)));
+                let rest = stream_all_bytes(reader);
+
+                // We need to set explicit error type, see https://github.com/rust-lang/rust/issues/63502
+                Ok::<_, std::io::Error>(first.chain(rest))
+            })
+            .try_flatten(),
+        )
     }
 }
 

--- a/crates/connector_proxy/src/interceptors/network_proxy_materialize_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_proxy_materialize_interceptor.rs
@@ -4,11 +4,10 @@ use crate::libs::network_proxy::NetworkProxy;
 use crate::libs::protobuf::{decode_message, encode_message};
 use crate::libs::stream::stream_all_bytes;
 
-use futures::{future, stream, TryStreamExt};
+use futures::{future, stream, StreamExt, TryStreamExt};
 use protocol::materialize::{ApplyRequest, SpecResponse, TransactionRequest, ValidateRequest};
 
 use async_stream::stream;
-use futures_util::StreamExt;
 use serde_json::value::RawValue;
 use tokio_util::io::StreamReader;
 

--- a/crates/connector_proxy/src/libs/stream.rs
+++ b/crates/connector_proxy/src/libs/stream.rs
@@ -4,7 +4,7 @@ use crate::libs::airbyte_catalog::Message;
 use crate::errors::raise_custom_error;
 use async_stream::try_stream;
 use bytes::{Buf, Bytes, BytesMut};
-use futures::stream;
+use futures::{stream, Stream};
 use futures_core::TryStream;
 use futures_util::{StreamExt, TryStreamExt};
 use serde_json::{Deserializer, Value};
@@ -31,10 +31,10 @@ pub fn stream_all_bytes<R: 'static + AsyncRead + std::marker::Unpin>(
 pub fn stream_all_airbyte_messages(
     mut in_stream: InterceptorStream,
 ) -> impl TryStream<Item = std::io::Result<Message>> {
-    stream::try_unfold(in_stream, |mut istream| async {
+    try_stream! {
         let mut buf = BytesMut::new();
 
-        let items = istream.flat_map(|bytes| {
+        while let Some(bytes) = in_stream.next().await {
             match bytes {
                 Ok(b) => {
                     buf.extend_from_slice(b.chunk());
@@ -49,54 +49,38 @@ pub fn stream_all_airbyte_messages(
 
             // Deserialize to Value first, instead of Message, to avoid missing 'is_eof' signals in error.
             let mut value_stream = deserializer.into_iter::<Value>();
-            let values = value_stream
-                .map(|value| match value {
+            while let Some(value) = value_stream.next() {
+                match value {
                     Ok(v) => {
                         let message: Message = serde_json::from_value(v).unwrap();
                         if let Err(e) = message.validate() {
                             raise_custom_error(&format!(
-                                "error in validating message: {:?}, {:?}",
-                                e,
-                                std::str::from_utf8(&chunk[value_stream.byte_offset()..])
-                            ))?;
-                        };
+                            "error in validating message: {:?}, {:?}",
+                             e, std::str::from_utf8(&chunk[value_stream.byte_offset()..])))?;
+                        }
                         tracing::debug!("read message:: {:?}", &message);
-                        return Ok(Some(message));
+                        yield message;
                     }
                     Err(e) => {
                         if e.is_eof() {
-                            return Ok(None);
+                            break;
                         }
 
-                        Err(raise_custom_error(&format!(
+                        raise_custom_error(&format!(
                             "error in decoding message: {:?}, {:?}",
-                            e,
-                            std::str::from_utf8(&chunk[value_stream.byte_offset()..])
-                        ))
-                        .unwrap_err())
+                             e, std::str::from_utf8(&chunk[value_stream.byte_offset()..])))?;
                     }
-                })
-                .try_fold(Vec::new(), |vec, item| match item {
-                    Ok(None) => Ok(vec),
-                    Ok(Some(v)) => {
-                        vec.push(v);
-                        Ok(vec)
-                    }
-                    Err(e) => Err(e),
-                });
+                }
+            }
 
             let byte_offset = value_stream.byte_offset();
             drop(buf.split_to(byte_offset));
-
-            values
-        });
+        }
 
         if buf.len() > 0 {
             raise_custom_error("unconsumed content in stream found.")?;
         }
 
         tracing::info!("done reading all in_stream.");
-
-        Ok(Some((items, istream)))
-    })
+    }
 }

--- a/crates/connector_proxy/src/libs/stream.rs
+++ b/crates/connector_proxy/src/libs/stream.rs
@@ -1,12 +1,15 @@
-use crate::apis::InterceptorStream;
 use crate::libs::airbyte_catalog::Message;
+use crate::{apis::InterceptorStream, errors::create_custom_error};
 
-use crate::errors::raise_custom_error;
+use crate::errors::raise_err;
 use bytes::{Buf, Bytes, BytesMut};
-use futures::{stream, StreamExt, TryStream, TryStreamExt};
+use futures::{stream, StreamExt, TryFuture, TryStream, TryStreamExt};
 use serde_json::{Deserializer, Value};
 use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_util::io::StreamReader;
 use validator::Validate;
+
+use super::protobuf::decode_message;
 
 pub fn stream_all_bytes<R: 'static + AsyncRead + std::marker::Unpin>(
     reader: R,
@@ -18,36 +21,36 @@ pub fn stream_all_bytes<R: 'static + AsyncRead + std::marker::Unpin>(
         match r.read_buf(&mut buf).await {
             Ok(0) => Ok(None),
             Ok(_) => Ok(Some((Bytes::from(buf), r))),
-            Err(e) => raise_custom_error(&format!("error during streaming {:?}.", e)),
+            Err(e) => raise_err(&format!("error during streaming {:?}.", e)),
         }
     })
 }
 
+// Given a stream of bytes, try to deserialize them into Airbyte Messages, validate them
+// and handling Log messages
 pub fn stream_all_airbyte_messages(
     in_stream: InterceptorStream,
-) -> impl TryStream<Item = std::io::Result<Message>> {
+) -> impl TryStream<Item = std::io::Result<Message>, Ok = Message, Error = std::io::Error> {
     stream::once(async {
         let mut buf = BytesMut::new();
         let items = in_stream
             .map(move |bytes| {
-                // Can someone explain to me why do we need this buf, instead of just using `chunk = b.chunk()`?
+                // TODO: Can someone explain to me why do we need this buf, instead of just using `chunk = b.chunk()`?
                 let b = bytes?;
                 buf.extend_from_slice(b.chunk());
                 let chunk = buf.chunk();
-                let deserializer = Deserializer::from_slice(chunk);
 
                 // Deserialize to Value first, instead of Message, to avoid missing 'is_eof' signals in error.
+                let deserializer = Deserializer::from_slice(chunk);
                 let value_stream = deserializer.into_iter::<Value>();
-                //let values = value_stream.try_fold(Vec::new(), |vec, value| match value {
+
+                // Turn Values into Messages and validate them
                 let values: Vec<Result<Message, std::io::Error>> = value_stream
                     .map(|value| match value {
                         Ok(v) => {
                             let message: Message = serde_json::from_value(v).unwrap();
                             if let Err(e) = message.validate() {
-                                raise_custom_error(&format!(
-                                    "error in validating message: {:?}",
-                                    e
-                                ))?;
+                                raise_err(&format!("error in validating message: {:?}", e))?;
                             }
                             tracing::debug!("read message:: {:?}", &message);
                             Ok(Some(message))
@@ -57,13 +60,14 @@ pub fn stream_all_airbyte_messages(
                                 return Ok(None);
                             }
 
-                            raise_custom_error(&format!(
+                            raise_err(&format!(
                                 "error in decoding message: {:?}, {:?}",
                                 e,
                                 std::str::from_utf8(chunk)
                             ))
                         }
                     })
+                    // Flipping the Option and Result to filter out the None values
                     .filter_map(|value| match value {
                         Ok(Some(v)) => Some(Ok(v)),
                         Ok(None) => None,
@@ -71,16 +75,63 @@ pub fn stream_all_airbyte_messages(
                     })
                     .collect();
 
-                // Stream<Result<Message>>
                 Ok::<_, std::io::Error>(stream::iter(values))
             })
-            // Stream<Result<Stream<Result<Message>>>
             .try_flatten();
-
-        tracing::info!("done reading all in_stream.");
 
         // We need to set explicit error type, see https://github.com/rust-lang/rust/issues/63502
         Ok::<_, std::io::Error>(items)
     })
     .try_flatten()
+    // Handle logs here so we don't have to worry about them everywhere else
+    .try_filter_map(|message| async {
+        if let Some(log) = message.log {
+            log.log();
+            Ok(None)
+        } else {
+            Ok(Some(message))
+        }
+    })
+}
+
+/// Read the given stream and try to find a message that matches the predicate
+/// This allows consumers to work with a single message, simplifying the code
+pub fn get_airbyte_message<F: 'static>(
+    in_stream: InterceptorStream,
+    predicate: F,
+) -> impl futures::Future<Output = std::io::Result<Message>>
+where
+    F: Fn(&Message) -> bool,
+{
+    async move {
+        let stream_head = Box::pin(stream_all_airbyte_messages(in_stream))
+            .next()
+            .await;
+
+        let message = match stream_head {
+            Some(m) => m,
+            None => return raise_err("Could not find message in stream"),
+        }?;
+
+        if predicate(&message) {
+            Ok(message)
+        } else {
+            raise_err("Could not find message matching condition")
+        }
+    }
+}
+
+/// Read the given stream of bytes and try to decode it to type <T>
+pub fn get_decoded_message<T>(
+    in_stream: InterceptorStream,
+) -> impl futures::Future<Output = std::io::Result<T>>
+where
+    T: prost::Message + std::default::Default,
+{
+    async move {
+        let mut reader = StreamReader::new(in_stream);
+        decode_message::<T, _>(&mut reader)
+            .await?
+            .ok_or(create_custom_error("missing request"))
+    }
 }

--- a/crates/connector_proxy/src/libs/stream.rs
+++ b/crates/connector_proxy/src/libs/stream.rs
@@ -4,42 +4,37 @@ use crate::libs::airbyte_catalog::Message;
 use crate::errors::raise_custom_error;
 use async_stream::try_stream;
 use bytes::{Buf, Bytes, BytesMut};
-use futures_core::Stream;
-use futures_util::StreamExt;
+use futures::stream;
+use futures_core::TryStream;
+use futures_util::{StreamExt, TryStreamExt};
 use serde_json::{Deserializer, Value};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use validator::Validate;
 
 pub fn stream_all_bytes<R: 'static + AsyncRead + std::marker::Unpin>(
     mut reader: R,
-) -> impl Stream<Item = std::io::Result<Bytes>> {
-    // TODO: can we replace these macros with futures crate StreamExt or TryStreamExt methods?
-    // e.g. futures::stream::unfold() might be useful.
-    try_stream! {
-        loop {
-            // consistent with the default capacity of ReaderStream.
-            // https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/io/reader_stream.rs#L8
-            let mut buf = BytesMut::with_capacity(4096);
-            match reader.read_buf(&mut buf).await {
-                Ok(0) => break,
-                Ok(_) => {
-                    yield buf.into();
-                }
-                Err(e) => {
-                    raise_custom_error(&format!("error during streaming {:?}.", e))?;
-                }
+) -> impl TryStream<Item = std::io::Result<Bytes>> {
+    stream::try_unfold(reader, |mut r| async {
+        // consistent with the default capacity of ReaderStream.
+        // https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/io/reader_stream.rs#L8
+        let mut buf = BytesMut::with_capacity(4096);
+        match r.read_buf(&mut buf).await {
+            Ok(0) => Ok(None),
+            Ok(_) => Ok(Some((Bytes::from(buf), r))),
+            Err(e) => {
+                Err(raise_custom_error(&format!("error during streaming {:?}.", e)).unwrap_err())
             }
         }
-    }
+    })
 }
 
 pub fn stream_all_airbyte_messages(
     mut in_stream: InterceptorStream,
-) -> impl Stream<Item = std::io::Result<Message>> {
-    try_stream! {
+) -> impl TryStream<Item = std::io::Result<Message>> {
+    stream::try_unfold(in_stream, |mut istream| async {
         let mut buf = BytesMut::new();
 
-        while let Some(bytes) = in_stream.next().await {
+        let items = istream.flat_map(|bytes| {
             match bytes {
                 Ok(b) => {
                     buf.extend_from_slice(b.chunk());
@@ -54,38 +49,54 @@ pub fn stream_all_airbyte_messages(
 
             // Deserialize to Value first, instead of Message, to avoid missing 'is_eof' signals in error.
             let mut value_stream = deserializer.into_iter::<Value>();
-            while let Some(value) = value_stream.next() {
-                match value {
+            let values = value_stream
+                .map(|value| match value {
                     Ok(v) => {
                         let message: Message = serde_json::from_value(v).unwrap();
                         if let Err(e) = message.validate() {
                             raise_custom_error(&format!(
-                            "error in validating message: {:?}, {:?}",
-                             e, std::str::from_utf8(&chunk[value_stream.byte_offset()..])))?;
-                        }
+                                "error in validating message: {:?}, {:?}",
+                                e,
+                                std::str::from_utf8(&chunk[value_stream.byte_offset()..])
+                            ))?;
+                        };
                         tracing::debug!("read message:: {:?}", &message);
-                        yield message;
+                        return Ok(Some(message));
                     }
                     Err(e) => {
                         if e.is_eof() {
-                            break;
+                            return Ok(None);
                         }
 
-                        raise_custom_error(&format!(
+                        Err(raise_custom_error(&format!(
                             "error in decoding message: {:?}, {:?}",
-                             e, std::str::from_utf8(&chunk[value_stream.byte_offset()..])))?;
+                            e,
+                            std::str::from_utf8(&chunk[value_stream.byte_offset()..])
+                        ))
+                        .unwrap_err())
                     }
-                }
-            }
+                })
+                .try_fold(Vec::new(), |vec, item| match item {
+                    Ok(None) => Ok(vec),
+                    Ok(Some(v)) => {
+                        vec.push(v);
+                        Ok(vec)
+                    }
+                    Err(e) => Err(e),
+                });
 
             let byte_offset = value_stream.byte_offset();
             drop(buf.split_to(byte_offset));
-        }
+
+            values
+        });
 
         if buf.len() > 0 {
             raise_custom_error("unconsumed content in stream found.")?;
         }
 
         tracing::info!("done reading all in_stream.");
-    }
+
+        Ok(Some((items, istream)))
+    })
 }


### PR DESCRIPTION
**Description:**

- Refactoring stream macros to use `futures` crates StreamExt and TryStreamExt methods instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/435)
<!-- Reviewable:end -->
