### PR TITLE
sql/validate: don't allow field names >63 bytes in length

### DIFF
--- a/go/protocols/materialize/sql/validate.go
+++ b/go/protocols/materialize/sql/validate.go
@@ -55,6 +55,9 @@ func ValidateNewSQLProjections(proposed *pf.CollectionSpec, deltaUpdates bool) m
 	for _, projection := range proposed.Projections {
 		var constraint = new(pm.Constraint)
 		switch {
+		case len(projection.Field) > 63:
+			constraint.Type = pm.Constraint_FIELD_FORBIDDEN
+			constraint.Reason = "Field names must be less than 63 bytes in length."
 		case projection.IsPrimaryKey:
 			constraint.Type = pm.Constraint_LOCATION_REQUIRED
 			constraint.Reason = "All Locations that are part of the collections key are required"


### PR DESCRIPTION
**Description:**

- Field names over 63 bytes are not allowed in Postgres and will get truncated
- If there are multiple fields with such long names and they share a prefix that's 63 bytes long, they will become duplicate column names
- This PR introduces a limit of 63 bytes for all SQL materializations as a general rule

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

Also see: https://estuary-dev.slack.com/archives/C01G7CFNA8K/p1649772559301679

Solves https://github.com/estuary/connectors/issues/166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/440)
<!-- Reviewable:end -->
