### PR TITLE
support x- fields in JSONSchema

### DIFF
--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -689,6 +689,7 @@ impl Shape {
                     Annotation::Secret(b) => shape.secret = Some(*b),
                     Annotation::Multiline(_) => {}
                     Annotation::Order(_) => {}
+                    Annotation::X(_) => {}
                 },
 
                 // Array constraints.


### PR DESCRIPTION
resolves #439

**Description:**

- Supports `x-` prefixed fields in JSONSchema. This is a kind of convention to use these kinds of fields for custom behaviour. For example it is used here: https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/schemas/shared/addressMergeSegment.json#L9

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/441)
<!-- Reviewable:end -->
