### PR TITLE
materialize/sql: reserved words in validation logic

### DIFF
--- a/go/materialize/driver/sqlite/validate_test.go
+++ b/go/materialize/driver/sqlite/validate_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestValidations(t *testing.T) {
+	var driver = &sqlDriver.Driver{}
 	var args = bindings.BuildArgs{
 		Context:  context.Background(),
 		FileRoot: "./testdata",
@@ -38,7 +39,7 @@ func TestValidations(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("NewSQLProjections-%s", path.Base(spec.Collection.String())),
 			func(t *testing.T) {
-				constraints := sqlDriver.ValidateNewSQLProjections(spec, false)
+				constraints := driver.ValidateNewSQLProjections(spec, false)
 				cupaloy.SnapshotT(t, constraints)
 			})
 	}
@@ -74,7 +75,8 @@ func testMatchesExisting(t *testing.T, collection *pf.CollectionSpec) {
 	var stringProjection = proposed.GetProjection("string")
 	stringProjection.Inference.Exists = pf.Inference_MUST
 
-	var constraints = sqlDriver.ValidateMatchesExisting(&existingSpec, &proposed)
+	var driver = &sqlDriver.Driver{}
+	var constraints = driver.ValidateMatchesExisting(&existingSpec, &proposed)
 	var req = []string{"theKey", "string", "bool", "flow_document"}
 	for _, field := range req {
 		var constraint, ok = constraints[field]
@@ -93,6 +95,6 @@ func testMatchesExisting(t *testing.T, collection *pf.CollectionSpec) {
 		Collection:     proposed,
 		FieldSelection: *existingFields,
 	}
-	var constraintsError = sqlDriver.ValidateSelectedFields(constraints, &proposedSpec)
+	var constraintsError = driver.ValidateSelectedFields(constraints, &proposedSpec)
 	require.Error(t, constraintsError)
 }

--- a/go/protocols/materialize/sql/spec_mapping.go
+++ b/go/protocols/materialize/sql/spec_mapping.go
@@ -83,20 +83,20 @@ func commentForProjection(projection *pf.Projection) string {
 	return fmt.Sprintf("%s projection of JSON at: %s with inferred types: [%s]", source, projection.Ptr, types)
 }
 
-func generateApplyStatements(
+func (d *Driver) generateApplyStatements(
 	endpoint Endpoint,
 	existing map[string]*pf.MaterializationSpec_Binding,
 	spec *pf.MaterializationSpec_Binding,
 ) ([]string, error) {
 	var target = ResourcePath(spec.ResourcePath).Join()
 
-	current, constraints, err := loadConstraints(target, spec.DeltaUpdates, &spec.Collection, existing)
+	current, constraints, err := d.loadConstraints(target, spec.DeltaUpdates, &spec.Collection, existing)
 	if err != nil {
 		return nil, err
 	}
 
 	// Validate the request binding is a valid solution for its own constraints.
-	if err = ValidateSelectedFields(constraints, spec); err != nil {
+	if err = d.ValidateSelectedFields(constraints, spec); err != nil {
 		return nil, fmt.Errorf("re-validating materialization: %w", err)
 	}
 


### PR DESCRIPTION
**Description:**

- Allows SQL materializations to specify a set of reserved words that will be used in validating projections

**Workflow steps:**

- Specify `ReservedWords` when creating a SQL materialization using our materialize SQL library

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/443)
<!-- Reviewable:end -->
