### PR TITLE
connector-proxy: replace or_bail usages with map_err to custom err

### DIFF
--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -60,9 +60,6 @@ pub enum Error {
     #[error("The operation of '{0}' is not expected for the given protocol.")]
     UnexpectedOperation(String),
 }
-/*<std::io::Error as From<Elapsed>>
-<std::io::Error as From<EncodeError>>
-<std::io::Error as From<IntoInnerError<W>>>*/
 
 pub fn raise_err<T>(message: &str) -> Result<T, std::io::Error> {
     Err(create_custom_error(message))
@@ -72,7 +69,6 @@ pub fn create_custom_error(message: &str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, message)
 }
 
-// TODO: refactor to remove or_bail usages
 pub trait Must<T> {
     fn or_bail(self) -> T;
 }


### PR DESCRIPTION
**Description:**

- Refactor usages of or_bail and replace them with mapping the error to a custom error in customer-proxy

**Workflow steps:**

- N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/448)
<!-- Reviewable:end -->
