### PR TITLE
network-tunnel: remove `tunnelType` from network tunnel config

### DIFF
--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -2,28 +2,12 @@ use super::networktunnel::NetworkTunnel;
 use super::sshforwarding::{SshForwarding, SshForwardingConfig};
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields, remote = "Self")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum NetworkTunnelConfig {
     SshForwarding(SshForwardingConfig),
-}
-
-// There is a useless "tunnelType" field in the JSON representation of this enum
-// This deserialize implementation gets rid of that field without
-// complicating the data structure. See https://github.com/serde-rs/serde/issues/1343
-impl<'de> Deserialize<'de> for NetworkTunnelConfig {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        struct Wrapper {
-            #[serde(rename = "tunnelType")]
-            _ignore: Option<String>,
-            #[serde(flatten, with = "NetworkTunnelConfig")]
-            inner: NetworkTunnelConfig,
-        }
-        Wrapper::deserialize(deserializer).map(|w| w.inner)
-    }
 }
 
 impl NetworkTunnelConfig {
@@ -37,36 +21,6 @@ impl NetworkTunnelConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn test_network_config_parse_with_tunnel_type() {
-        let config = "{
-            \"tunnelType\": \"sshForwarding\",
-            \"sshForwarding\": {
-                \"sshEndpoint\": \"ssh://localhost:2222\",
-                \"user\": \"flow\",
-                \"forwardHost\": \"localhost\",
-                \"forwardPort\": 5432,
-                \"privateKey\": \"\",
-                \"localPort\": 5432
-            }
-        }";
-
-        let result: Result<NetworkTunnelConfig, _> = serde_json::from_str(config);
-
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            NetworkTunnelConfig::SshForwarding(SshForwardingConfig {
-                ssh_endpoint: "ssh://localhost:2222".to_string(),
-                user: "flow".to_string(),
-                forward_host: "localhost".to_string(),
-                forward_port: 5432,
-                private_key: "".to_string(),
-                local_port: 5432
-            })
-        );
-    }
 
     #[test]
     fn test_network_config_parse_without_tunnel_type() {


### PR DESCRIPTION
**Description:**

- Remove `tunnelType` since it's unnecessary for parsing of network tunnel config

**Workflow steps:**

N/A

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/453)
<!-- Reviewable:end -->
