### PR TITLE
connector-proxy: let delayed process inherit stderr

### DIFF
--- a/crates/connector_proxy/src/main.rs
+++ b/crates/connector_proxy/src/main.rs
@@ -188,26 +188,14 @@ async fn delayed_execute(command_config_path: String) -> Result<(), Error> {
     let mut child = invoke_connector(
         Stdio::inherit(),
         Stdio::inherit(),
-        Stdio::piped(),
+        Stdio::inherit(),
         &command_config.entrypoint,
         &command_config.args,
     )?;
 
     match check_exit_status("delayed process", child.wait().await) {
         Err(e) => {
-            let mut buf = Vec::new();
-            child
-                .stderr
-                .take()
-                .ok_or(Error::MissingIOPipe)?
-                .read_to_end(&mut buf)
-                .await?;
-
-            tracing::error!(
-                "connector failed. command_config: {:?}. stderr from connector: {}",
-                &command_config,
-                std::str::from_utf8(&buf).expect("error when decoding stderr")
-            );
+            tracing::error!("connector failed. command_config: {:?}.", &command_config);
             Err(e)
         }
         _ => Ok(()),


### PR DESCRIPTION
**Description:**

- We used to eat up stderr of connector and only output it in case of error. With this change it's just forwarded to the parent stderr.

Solves #455 

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/456)
<!-- Reviewable:end -->
