### PR TITLE
connector-proxy: inherit stderr for child and parallelize streaming of I/O

### DIFF
--- a/crates/connector_proxy/src/libs/command.rs
+++ b/crates/connector_proxy/src/libs/command.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::process::{ExitStatus, Stdio};
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::timeout;
 
 pub const READY: &[u8] = "READY".as_bytes();

--- a/crates/connector_proxy/src/libs/command.rs
+++ b/crates/connector_proxy/src/libs/command.rs
@@ -82,7 +82,7 @@ pub async fn invoke_connector_delayed(
     invoke_connector(
         Stdio::piped(),
         Stdio::piped(),
-        Stdio::piped(),
+        Stdio::inherit(),
         bouncer_process_entrypoint,
         &vec!["delayed-execute".to_string(), config_file_path.to_string()],
     )

--- a/crates/connector_proxy/src/libs/command.rs
+++ b/crates/connector_proxy/src/libs/command.rs
@@ -14,7 +14,7 @@ pub fn invoke_connector_direct(entrypoint: String, args: Vec<String>) -> Result<
     invoke_connector(
         Stdio::piped(),
         Stdio::piped(),
-        Stdio::piped(),
+        Stdio::inherit(),
         &entrypoint,
         &args,
     )
@@ -128,12 +128,9 @@ pub fn invoke_connector(
         .map_err(|e| e.into())
 }
 
-pub fn parse_child(
-    mut child: Child,
-) -> Result<(Child, ChildStdin, ChildStdout, ChildStderr), Error> {
+pub fn parse_child(mut child: Child) -> Result<(Child, ChildStdin, ChildStdout), Error> {
     let stdout = child.stdout.take().ok_or(Error::MissingIOPipe)?;
     let stdin = child.stdin.take().ok_or(Error::MissingIOPipe)?;
-    let stderr = child.stderr.take().ok_or(Error::MissingIOPipe)?;
 
-    Ok((child, stdin, stdout, stderr))
+    Ok((child, stdin, stdout))
 }

--- a/crates/connector_proxy/src/main.rs
+++ b/crates/connector_proxy/src/main.rs
@@ -7,10 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use clap::{ArgEnum, Parser, Subcommand};
-use tokio::{
-    io::AsyncReadExt,
-    signal::unix::{signal, SignalKind},
-};
+use tokio::signal::unix::{signal, SignalKind};
 
 use apis::{FlowCaptureOperation, FlowMaterializeOperation, FlowRuntimeProtocol};
 

--- a/crates/network-tunnel/src/main.rs
+++ b/crates/network-tunnel/src/main.rs
@@ -1,17 +1,20 @@
-pub mod interface;
-pub mod sshforwarding;
 pub mod errors;
+pub mod interface;
 pub mod networktunnel;
+pub mod sshforwarding;
 
 use errors::Error;
 use flow_cli_common::{init_logging, LogArgs, LogFormat};
-use std::io::{self, Write};
+use std::io::{self};
 
 use interface::NetworkTunnelConfig;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    init_logging(&LogArgs{level: "info".to_string(), format: Some(LogFormat::Json)});
+    init_logging(&LogArgs {
+        level: "info".to_string(),
+        format: Some(LogFormat::Json),
+    });
     if let Err(err) = run().await.as_ref() {
         tracing::error!(error = ?err, "network tunnel failed.");
         std::process::exit(1);


### PR DESCRIPTION
**Description:**

- Use `Stdio::inherit()` for stderr of child process in connector-proxy, this simplifies the logic and removes the need for a manual copy in of stderr. We don't process anything of the stderr anyway.
- Because we used to join our stdin/stdout streams concurrently, rather than in parallel, if one of them was stuck, it would block all the others from working as well. So I changed that to use a parallel copy which allows the stdin to reach the process.
- Added a test with `tail -f` (which will not terminate its stdout until an EOF in stdin is received) to test this: with the concurrent approach, this gets blocked forever, with the parallel approach and stderr being inherited, this allows the EOF in stdin to reach the process without being blocked by the stdout and exits as soon as EOF is reached in stdin.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

My main concern with this PR is use of `tail -f` which is available on most Linux and BSD machines through coreutils, but I don't know if there is any guarantee of that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/458)
<!-- Reviewable:end -->
