### PR TITLE
go/connector/run: pass --log.level to connector proxy

### DIFF
--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -81,7 +81,7 @@ where
         match self {
             Ok(t) => t,
             Err(e) => {
-                tracing::debug!(error_details = ?e);
+                tracing::error!(error_details = ?e);
                 std::process::exit(1);
             }
         }

--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -135,6 +135,7 @@ func Run(
 
 	args = append([]string{
 		fmt.Sprintf("--image-inspect-json-path=/tmp/%s", imageInspectJsonFileName),
+		fmt.Sprintf("--log.level=%s", logger.Level().String()),
 		protocol.proxyCommand(),
 	}, args...)
 


### PR DESCRIPTION
**Description:**

- Pass `--log.level` in connector runner to connector proxy

**Workflow steps:**

Pass `--log.level` to flowctl and see it being passed to connector proxy.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/461)
<!-- Reviewable:end -->
