### PR TITLE
json/schema: fix the 64 field limit

### DIFF
--- a/crates/doc/tests/reduce_annotations_test.rs
+++ b/crates/doc/tests/reduce_annotations_test.rs
@@ -141,6 +141,7 @@ fn test_validate_then_reduce() {
             .unwrap()
             .ok()
             .unwrap();
+
         let reduced = reduce::reduce(lhs, rhs, true).unwrap();
         assert_eq!(&reduced, &expect);
         lhs = Some(reduced);

--- a/crates/doc/tests/reduce_annotations_test.rs
+++ b/crates/doc/tests/reduce_annotations_test.rs
@@ -141,7 +141,6 @@ fn test_validate_then_reduce() {
             .unwrap()
             .ok()
             .unwrap();
-
         let reduced = reduce::reduce(lhs, rhs, true).unwrap();
         assert_eq!(&reduced, &expect);
         lhs = Some(reduced);

--- a/crates/json/src/schema/intern.rs
+++ b/crates/json/src/schema/intern.rs
@@ -75,4 +75,4 @@ mod test {
     }
 }
 
-const MAX_TABLE_SIZE: usize = std::mem::size_of::<Set>() * 8;
+pub const MAX_TABLE_SIZE: usize = std::mem::size_of::<Set>() * 8;

--- a/crates/json/src/schema/mod.rs
+++ b/crates/json/src/schema/mod.rs
@@ -130,6 +130,7 @@ pub enum Application {
     },
     AdditionalItems,
     UnevaluatedItems,
+    Inline,
 }
 
 impl Application {
@@ -164,6 +165,10 @@ impl Application {
             Items { .. } => parent.push_prop(keywords::ITEMS),
             AdditionalItems => parent.push_prop(keywords::ADDITIONAL_ITEMS),
             UnevaluatedItems => parent.push_prop(keywords::UNEVALUATED_ITEMS),
+
+            // Inline is a special application that does not in itself have a location
+            // and is only useful for wrapping other applications to work around the intern table limit
+            Inline => *parent,
         }
     }
 
@@ -198,7 +203,7 @@ impl Application {
             Contains => *parent,
             Items { index: None } => *parent,
             Items { index: Some(i) } => parent.push_item(*i),
-            AdditionalItems | UnevaluatedItems => *parent,
+            AdditionalItems | UnevaluatedItems | Inline => *parent,
         }
     }
 

--- a/crates/json/src/validator.rs
+++ b/crates/json/src/validator.rs
@@ -850,7 +850,8 @@ where
             | App::Items { .. }
             | App::Properties { .. }
             | App::PropertyNames
-            | App::AdditionalItems => RequiredChild,
+            | App::AdditionalItems
+            | App::Inline => RequiredChild,
 
             // Speculative "unevaluated" child applications.
             App::UnevaluatedProperties => UnevaluatedChild,
@@ -908,7 +909,7 @@ where
 
     fn expand_scope<'a>(&mut self, index: usize, span: &Span, loc: &'a Location<'a>) {
         use Application::{
-            AllOf, AnyOf, DependentSchema, Else, If, Not, OneOf, RecursiveRef, Ref, Then,
+            AllOf, AnyOf, DependentSchema, Else, If, Inline, Not, OneOf, RecursiveRef, Ref, Then,
         };
 
         //println!("expand_scope '{}' '{}'", self.scopes[index].keyword_location(&self.scopes), self.scopes[index].schema.curi);
@@ -952,7 +953,8 @@ where
                 | If
                 | Then
                 | Else
-                | DependentSchema { .. } => (schema, None),
+                | DependentSchema { .. }
+                | Inline => (schema, None),
 
                 _ => continue, // Not an in-place application.
             };

--- a/crates/json/tests/schema-fixtures/2019-09-additional-props-inline.json
+++ b/crates/json/tests/schema-fixtures/2019-09-additional-props-inline.json
@@ -1,0 +1,241 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/additional-props-inline",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+    "title": "Inlining of `allOf` beside additonalProperties",
+    "allOf": [
+        {
+            "$ref": "meta/core"
+        },
+        {
+            "$ref": "meta/applicator"
+        },
+        {
+            "$ref": "meta/validation"
+        },
+        {
+            "$ref": "meta/meta-data"
+        },
+        {
+            "$ref": "meta/format"
+        },
+        {
+            "$ref": "meta/content"
+        }
+    ],
+    "properties": {
+        "0": {
+            "const": "0"
+        },
+        "1": {
+            "const": "1"
+        },
+        "2": {
+            "const": "2"
+        },
+        "3": {
+            "const": "3"
+        },
+        "4": {
+            "const": "4"
+        },
+        "5": {
+            "const": "5"
+        },
+        "6": {
+            "const": "6"
+        },
+        "7": {
+            "const": "7"
+        },
+        "8": {
+            "const": "8"
+        },
+        "9": {
+            "const": "9"
+        },
+        "10": {
+            "const": "10"
+        },
+        "11": {
+            "const": "11"
+        },
+        "12": {
+            "const": "12"
+        },
+        "13": {
+            "const": "13"
+        },
+        "14": {
+            "const": "14"
+        },
+        "15": {
+            "const": "15"
+        },
+        "16": {
+            "const": "16"
+        },
+        "17": {
+            "const": "17"
+        },
+        "18": {
+            "const": "18"
+        },
+        "19": {
+            "const": "19"
+        },
+        "20": {
+            "const": "20"
+        },
+        "21": {
+            "const": "21"
+        },
+        "22": {
+            "const": "22"
+        },
+        "23": {
+            "const": "23"
+        },
+        "24": {
+            "const": "24"
+        },
+        "25": {
+            "const": "25"
+        },
+        "26": {
+            "const": "26"
+        },
+        "27": {
+            "const": "27"
+        },
+        "28": {
+            "const": "28"
+        },
+        "29": {
+            "const": "29"
+        },
+        "30": {
+            "const": "30"
+        },
+        "31": {
+            "const": "31"
+        },
+        "32": {
+            "const": "32"
+        },
+        "33": {
+            "const": "33"
+        },
+        "34": {
+            "const": "34"
+        },
+        "35": {
+            "const": "35"
+        },
+        "36": {
+            "const": "36"
+        },
+        "37": {
+            "const": "37"
+        },
+        "38": {
+            "const": "38"
+        },
+        "39": {
+            "const": "39"
+        },
+        "40": {
+            "const": "40"
+        },
+        "41": {
+            "const": "41"
+        },
+        "42": {
+            "const": "42"
+        },
+        "43": {
+            "const": "43"
+        },
+        "44": {
+            "const": "44"
+        },
+        "45": {
+            "const": "45"
+        },
+        "46": {
+            "const": "46"
+        },
+        "47": {
+            "const": "47"
+        },
+        "48": {
+            "const": "48"
+        },
+        "49": {
+            "const": "49"
+        },
+        "50": {
+            "const": "50"
+        },
+        "51": {
+            "const": "51"
+        },
+        "52": {
+            "const": "52"
+        },
+        "53": {
+            "const": "53"
+        },
+        "54": {
+            "const": "54"
+        },
+        "55": {
+            "const": "55"
+        },
+        "56": {
+            "const": "56"
+        },
+        "57": {
+            "const": "57"
+        },
+        "58": {
+            "const": "58"
+        },
+        "59": {
+            "const": "59"
+        },
+        "60": {
+            "const": "60"
+        },
+        "61": {
+            "const": "61"
+        },
+        "62": {
+            "const": "62"
+        },
+        "63": {
+            "const": "63"
+        },
+        "64": {
+            "const": "64"
+        },
+        "65": {
+            "const": "65"
+        }
+    },
+    "additionalProperties": {
+        "const": "additional-prop"
+    },
+    "type": [
+        "object",
+        "boolean"
+    ]
+}


### PR DESCRIPTION
**Description:**

- Introduce a new `Inline` variant to JSONSchema build to work around the 64 intern table limit for `properties`

solves #315 

**Workflow steps:**

- Try a schema with more than 64 fields under a `properties` keyword

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/465)
<!-- Reviewable:end -->
