### PR TITLE
json: remove the 64-property limit in schemas

### DIFF
--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -811,7 +811,7 @@ impl Shape {
 
                     shape = Shape::intersect(shape, referent);
                 }
-                Keyword::Application(Application::AllOf { .. }, schema) => {
+                Keyword::Application(Application::AllOf { .. } | Application::Inline, schema) => {
                     shape = Shape::intersect(shape, Shape::infer_inner(schema, index, visited));
                 }
                 Keyword::Application(Application::OneOf { .. }, schema) => {
@@ -2569,6 +2569,24 @@ mod test {
                 ..Default::default()
             }
         );
+    }
+
+    #[test]
+    fn test_inline_required_is_transparent() {
+        let fill_to = json::schema::intern::MAX_TABLE_SIZE + 7;
+        let required: Vec<_> = (0..fill_to).map(|i| i.to_string()).collect();
+
+        let shape = shape_from(
+            &json!({
+                "required": required,
+                "properties": {
+                    "9": {"const": "value"} // Overlaps with `required`.
+                }
+            })
+            .to_string(),
+        );
+        assert_eq!(shape.object.properties.len(), fill_to);
+        assert!(shape.object.properties.iter().all(|p| p.is_required));
     }
 
     fn shape_from(case: &str) -> Shape {

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -21,11 +21,9 @@ url = {version = "*", features = ["serde"]}
 criterion = "*"
 glob = "*"
 
-# TODO(johnny): This benchmark is disabled because it
-# overflows our maximum intern table size.
-# [[bench]]
-# name = "github_events"
-# harness = false
+[[bench]]
+name = "github_events"
+harness = false
 
 [[bench]]
 name = "citi_rides"

--- a/crates/json/benches/github_events.rs
+++ b/crates/json/benches/github_events.rs
@@ -37,11 +37,10 @@ pub fn github_events(c: &mut Criterion) {
         c.bench_function(&format!("scrape{}", s), |b| {
             let mut val = Validator::<CoreAnnotation, SpanContext>::new(&index);
             b.iter(|| {
-                for (n, doc) in scrape.iter().enumerate() {
+                for (_n, doc) in scrape.iter().enumerate() {
                     val.prepare(&schema.curi).unwrap();
                     let _ = de::walk(doc, &mut val).expect("validation error");
-
-                    println!("scrape {} outcomes {}: {:?}", s, n, val.outcomes());
+                    //println!("scrape {} errors {}: {:?}", s, _n, errors);
                     assert!(!val.invalid());
                 }
             })

--- a/crates/json/benches/testdata/github-event.schema.json
+++ b/crates/json/benches/testdata/github-event.schema.json
@@ -161,7 +161,10 @@
               "example": "Found a bug"
             },
             "body": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "example": "I'm having a problem with this."
             },
             "user": {
@@ -2744,7 +2747,6 @@
             "id",
             "node_id",
             "html_url",
-            "issue_url",
             "author_association",
             "user",
             "url",

--- a/crates/json/src/schema/index.rs
+++ b/crates/json/src/schema/index.rs
@@ -41,6 +41,10 @@ where
 
         for kw in &schema.kw {
             match kw {
+                // We skip Inline applications for indexing.
+                // They share the canonical URI of their parent, and we use them only
+                // for the `required` keywords which has no sub-schemas.
+                Keyword::Application(Application::Inline, _) => {}
                 // Recurse to index a subordinate schema application.
                 Keyword::Application(_, child) => self.add(child)?,
                 // Index an alternative, anchor-form canonical URI.

--- a/crates/json/src/schema/intern.rs
+++ b/crates/json/src/schema/intern.rs
@@ -23,6 +23,13 @@ impl Table {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.m.len()
+    }
+    pub fn remaining(&self) -> usize {
+        MAX_TABLE_SIZE - self.m.len()
+    }
+
     /// Intern a str into a corresponding Set having exactly one bit set.
     /// After the first intern of a str, all future interns will return
     /// the same Set value.
@@ -75,4 +82,4 @@ mod test {
     }
 }
 
-const MAX_TABLE_SIZE: usize = std::mem::size_of::<Set>() * 8;
+pub const MAX_TABLE_SIZE: usize = std::mem::size_of::<Set>() * 8;

--- a/crates/json/src/schema/mod.rs
+++ b/crates/json/src/schema/mod.rs
@@ -115,7 +115,6 @@ pub enum Application {
     PropertyNames,
     Properties {
         name: String,
-        name_interned: intern::Set,
     },
     PatternProperties {
         re: fancy_regex::Regex,
@@ -130,6 +129,7 @@ pub enum Application {
     },
     AdditionalItems,
     UnevaluatedItems,
+    Inline,
 }
 
 impl Application {
@@ -164,6 +164,10 @@ impl Application {
             Items { .. } => parent.push_prop(keywords::ITEMS),
             AdditionalItems => parent.push_prop(keywords::ADDITIONAL_ITEMS),
             UnevaluatedItems => parent.push_prop(keywords::UNEVALUATED_ITEMS),
+
+            // Inline is a special application that does not in itself have a location
+            // and is only useful for wrapping other applications to work around the intern table limit
+            Inline => *parent,
         }
     }
 
@@ -198,7 +202,7 @@ impl Application {
             Contains => *parent,
             Items { index: None } => *parent,
             Items { index: Some(i) } => parent.push_item(*i),
-            AdditionalItems | UnevaluatedItems => *parent,
+            AdditionalItems | UnevaluatedItems | Inline => *parent,
         }
     }
 


### PR DESCRIPTION
For the `properties` and `required` keywords, by:

1) Having Application::Properties use direct string comparison rather
than interning. Interning is not fundamentally required for properties
as the keyword has no look-back requirement (where we must check
if the property was seen long after we've processed it). This lets
schemas scale to an arbitrary number of properties.

2) Adding Application::Inline as an in-place application has no schema
keyword. `required` properties of a schema may be pushed down into
Inline applications on an as-needed basis. This is done by deferring
processing of `required` keywords until the intern table size is known,
and then overflowing extra entries into Inline sub-schemas.

This is still correct because `required` is an embarrisingly-parallel
keyword to evaluate. The same technique could also be applied to
dependentRequired and dependentSchemas if needed.

Enable a GitHub benchmark which had been created but was disabled due to
the 64-field limitation. This surfaced some issues in GitHub's own
schema, which are fixed here. Note that the GitHub schema has more
than 64 `required` properties, which validation is now able to handle.

This patch has no impact on performance:

```
rides1x                 time:   [10.827 ms 10.945 ms 11.077 ms]
                        change: [-1.6814% +0.1011% +1.9073%] (p = 0.91 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

Benchmarking rides4x: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.5s, or reduce sample count to 90.
rides4x                 time:   [54.702 ms 54.993 ms 55.370 ms]
                        change: [-1.1690% +0.0567% +1.0967%] (p = 0.93 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
```

Credit to @mdibaiee, this is derived from patches in #465 

**Workflow steps:**

Start using schemas with lots of `properties` & `required` properties.

**Documentation links affected:**

None I know of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/469)
<!-- Reviewable:end -->
