### PR TITLE
connector-proxy: fix log printing in delayed execution

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -8,6 +8,7 @@ use crate::interceptors::{
 use crate::libs::command::{
     check_exit_status, invoke_connector_delayed, invoke_connector_direct, parse_child,
 };
+use flow_cli_common::LogArgs;
 use tokio::io::copy;
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio_util::io::{ReaderStream, StreamReader};
@@ -59,6 +60,7 @@ pub async fn run_flow_materialize_connector(
 pub async fn run_airbyte_source_connector(
     op: &FlowCaptureOperation,
     entrypoint: Vec<String>,
+    log_args: LogArgs,
 ) -> Result<(), Error> {
     let mut airbyte_interceptor = AirbyteSourceInterceptor::new();
 
@@ -66,7 +68,7 @@ pub async fn run_airbyte_source_connector(
     let args = airbyte_interceptor.adapt_command_args(op, args)?;
 
     let (mut child, child_stdin, child_stdout) =
-        parse_child(invoke_connector_delayed(entrypoint, args).await?)?;
+        parse_child(invoke_connector_delayed(entrypoint, args, log_args)?)?;
 
     let adapted_request_stream = airbyte_interceptor.adapt_request_stream(
         op,

--- a/crates/connector_proxy/src/libs/airbyte_catalog.rs
+++ b/crates/connector_proxy/src/libs/airbyte_catalog.rs
@@ -163,11 +163,11 @@ pub struct Log {
 impl Log {
     pub fn log(&self) {
         match self.level {
-            LogLevel::Trace => tracing::trace!(?self.message),
-            LogLevel::Debug => tracing::debug!(?self.message),
-            LogLevel::Info => tracing::info!(?self.message),
-            LogLevel::Warn => tracing::warn!(?self.message),
-            LogLevel::Error | LogLevel::Fatal => tracing::error!(?self.message),
+            LogLevel::Trace => tracing::trace!("{}", self.message),
+            LogLevel::Debug => tracing::debug!("{}", self.message),
+            LogLevel::Info => tracing::info!("{}", self.message),
+            LogLevel::Warn => tracing::warn!("{}", self.message),
+            LogLevel::Error | LogLevel::Fatal => tracing::error!("{}", self.message),
         }
     }
 }

--- a/crates/connector_proxy/src/libs/command.rs
+++ b/crates/connector_proxy/src/libs/command.rs
@@ -1,5 +1,6 @@
 use crate::errors::Error;
 
+use flow_cli_common::LogArgs;
 use serde::{Deserialize, Serialize};
 use std::process::{ExitStatus, Stdio};
 use tempfile::NamedTempFile;
@@ -55,9 +56,10 @@ pub struct CommandConfig {
 // start the real connector after reading a "READY" string from Stdin. Two actions are involved,
 // The caller of `invoke_connector_delayed` is responsible of sending "READY" to the Stdin of the returned Child process,
 // before sending anything else.
-pub async fn invoke_connector_delayed(
+pub fn invoke_connector_delayed(
     entrypoint: String,
     args: Vec<String>,
+    log_args: LogArgs,
 ) -> Result<Child, Error> {
     tracing::info!("invoke delayed connector {}, {:?}", entrypoint, args);
 
@@ -84,7 +86,12 @@ pub async fn invoke_connector_delayed(
         Stdio::piped(),
         Stdio::inherit(),
         bouncer_process_entrypoint,
-        &vec!["delayed-execute".to_string(), config_file_path.to_string()],
+        &vec![
+            "--log.level".to_string(),
+            log_args.level,
+            "delayed-execute".to_string(),
+            config_file_path.to_string(),
+        ],
     )
 }
 

--- a/crates/connector_proxy/src/main.rs
+++ b/crates/connector_proxy/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> std::io::Result<()> {
     } = Args::parse();
     init_logging(&log_args);
 
-    let result = async_main(image_inspect_json_path, proxy_command).await;
+    let result = async_main(image_inspect_json_path, proxy_command, log_args).await;
     if let Err(err) = result.as_ref() {
         tracing::error!(error = ?err, "connector proxy execution failed.");
         std::process::exit(1);
@@ -121,9 +121,12 @@ async fn sigterm_handler() {
 async fn async_main(
     image_inspect_json_path: Option<String>,
     proxy_command: ProxyCommand,
+    log_args: LogArgs,
 ) -> Result<(), Error> {
     match proxy_command {
-        ProxyCommand::ProxyFlowCapture(c) => proxy_flow_capture(c, image_inspect_json_path).await,
+        ProxyCommand::ProxyFlowCapture(c) => {
+            proxy_flow_capture(c, image_inspect_json_path, log_args).await
+        }
         ProxyCommand::ProxyFlowMaterialize(m) => {
             proxy_flow_materialize(m, image_inspect_json_path).await
         }
@@ -134,6 +137,7 @@ async fn async_main(
 async fn proxy_flow_capture(
     c: ProxyFlowCapture,
     image_inspect_json_path: Option<String>,
+    log_args: LogArgs,
 ) -> Result<(), Error> {
     let image_inspect = ImageInspect::parse_from_json_file(image_inspect_json_path)?;
     if image_inspect.infer_runtime_protocol() != FlowRuntimeProtocol::Capture {
@@ -149,7 +153,7 @@ async fn proxy_flow_capture(
             run_flow_capture_connector(&c.operation, entrypoint).await
         }
         CaptureConnectorProtocol::Airbyte => {
-            run_airbyte_source_connector(&c.operation, entrypoint).await
+            run_airbyte_source_connector(&c.operation, entrypoint, log_args).await
         }
     }
 }
@@ -166,11 +170,9 @@ async fn proxy_flow_materialize(
         return Err(Error::MismatchingRuntimeProtocol);
     }
 
-    run_flow_materialize_connector(
-        &m.operation,
-        image_inspect.get_entrypoint(vec![DEFAULT_CONNECTOR_ENTRYPOINT.to_string()]),
-    )
-    .await
+    let entrypoint = image_inspect.get_entrypoint(vec![DEFAULT_CONNECTOR_ENTRYPOINT.to_string()]);
+
+    run_flow_materialize_connector(&m.operation, entrypoint).await
 }
 
 async fn delayed_execute(command_config_path: String) -> Result<(), Error> {


### PR DESCRIPTION
**Description:**

- Delayed execution was not passing the `--log.level` and so a good chunk of logs were lost and made debugging harder
- The `tracing` macro calls were not actually printing the message for some reason, an empty log was being printed. I changed it to use `"{}"` as a format string and now it works.

**Workflow steps:**

- Log stuff from Airbyte connectors and pass `--log.level`

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/471)
<!-- Reviewable:end -->
