### PR TITLE
connector-proxy: fix logging issues

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -120,8 +120,14 @@ async fn streaming_all(
     });
 
     let (a, b) = tokio::try_join!(request_stream_copy, response_stream_copy)?;
+    let req_stream_bytes = a?;
+    let resp_stream_bytes = b?;
 
-    tracing::info!(req_stream = a?, resp_stream = b?, "Done streaming");
+    tracing::info!(
+        req_stream = req_stream_bytes,
+        resp_stream = resp_stream_bytes,
+        message = "Done streaming"
+    );
     Ok(())
 }
 
@@ -138,12 +144,6 @@ mod test {
         input: Vec<T>,
     ) -> Pin<Box<impl TryStream<Item = std::io::Result<T>, Ok = T, Error = std::io::Error>>> {
         Box::pin(stream::iter(input.into_iter().map(Ok::<T, std::io::Error>)))
-    }
-
-    fn create_cycled_stream<T: std::clone::Clone>(
-        input: Vec<T>,
-    ) -> Pin<Box<impl TryStream<Item = std::io::Result<T>, Ok = T, Error = std::io::Error>>> {
-        Box::pin(stream::iter(input.into_iter().map(Ok::<T, std::io::Error>)).cycle())
     }
 
     #[tokio::test]

--- a/crates/connector_proxy/src/libs/command.rs
+++ b/crates/connector_proxy/src/libs/command.rs
@@ -88,7 +88,7 @@ pub fn invoke_connector_delayed(
         bouncer_process_entrypoint,
         &vec![
             "--log.level".to_string(),
-            log_args.level,
+            log_args.level.to_string(),
             "delayed-execute".to_string(),
             config_file_path.to_string(),
         ],

--- a/crates/connector_proxy/src/main.rs
+++ b/crates/connector_proxy/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> std::io::Result<()> {
 
     let result = async_main(image_inspect_json_path, proxy_command, log_args).await;
     if let Err(err) = result.as_ref() {
-        tracing::error!(error = ?err, "connector proxy execution failed.");
+        tracing::error!(error = ?err, message = "connector proxy execution failed.");
         std::process::exit(1);
     }
     Ok(())

--- a/crates/flow_cli_common/src/lib.rs
+++ b/crates/flow_cli_common/src/lib.rs
@@ -3,7 +3,7 @@ mod logging;
 
 use clap::AppSettings::NoAutoHelp;
 
-pub use logging::{init_logging, LogArgs, LogFormat};
+pub use logging::{init_logging, LogArgs, LogFormat, LogLevel};
 
 /// An arguments container that accepts all arguments verbatim. This is used by external
 /// subcommands to allow all their argument parsing to be handled by the external binary.

--- a/crates/flow_cli_common/src/logging.rs
+++ b/crates/flow_cli_common/src/logging.rs
@@ -7,13 +7,37 @@ pub struct LogArgs {
     /// The log verbosity. Can be one of trace|debug|info|warn|error|off
     #[clap(
         long = "log.level",
-        default_value = "warn",
+        default_value_t = LogLevel::Warn,
         group = "logging",
+        ignore_case(true),
+        arg_enum,
         global = true
     )]
-    pub level: String,
+    pub level: LogLevel,
     #[clap(long = "log.format", arg_enum, group = "logging", global = true)]
     pub format: Option<LogFormat>,
+}
+
+#[derive(Debug, clap::ArgEnum, Clone, Copy)]
+pub enum LogLevel {
+    Tracing,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl ToString for LogLevel {
+    fn to_string(&self) -> String {
+        match self {
+            LogLevel::Tracing => "tracing",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+        .to_string()
+    }
 }
 
 /// The format for logs.
@@ -43,7 +67,7 @@ fn default_log_format() -> LogFormat {
 pub fn init_logging(args: &LogArgs) {
     let builder = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(&args.level)
+        .with_env_filter(&args.level.to_string())
         .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
         // Using CLOSE span events seems like the best balance between helpfulness and verbosity.
         // Any Spans that are created will only be logged once they're done with (i.e. once a

--- a/crates/network-tunnel/src/main.rs
+++ b/crates/network-tunnel/src/main.rs
@@ -4,7 +4,7 @@ pub mod networktunnel;
 pub mod sshforwarding;
 
 use errors::Error;
-use flow_cli_common::{init_logging, LogArgs, LogFormat};
+use flow_cli_common::{init_logging, LogArgs, LogFormat, LogLevel};
 use std::io::{self};
 
 use interface::NetworkTunnelConfig;
@@ -12,7 +12,7 @@ use interface::NetworkTunnelConfig;
 #[tokio::main]
 async fn main() -> io::Result<()> {
     init_logging(&LogArgs {
-        level: "info".to_string(),
+        level: LogLevel::Info,
         format: Some(LogFormat::Json),
     });
     if let Err(err) = run().await.as_ref() {

--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -135,7 +135,7 @@ func Run(
 
 	args = append([]string{
 		fmt.Sprintf("--image-inspect-json-path=/tmp/%s", imageInspectJsonFileName),
-		fmt.Sprintf("--log.level=%s", logger.Level().String()),
+		fmt.Sprintf("--log.level=%s", ops.LogrusToFlowLevel(logger.Level()).String()),
 		protocol.proxyCommand(),
 	}, args...)
 


### PR DESCRIPTION
**Description:**

- Move Try `?` calls outside of the tracing macro: the macro's expression was not being evaluated unless the log level was greater than or equal to info.
- Convert logrus log level to flow log level, because Logrus was outputting `warning` instead of `warn` for the log level.
- To avoid this issue ^ from happening again, I made the LogLevel an enum so that we get errors if a wrong value is being passed to connector proxy or any of our Rust components.

**Workflow steps:**

- Pass any log level you want (specifically `warn` and `error` that had issues) and see them outputting the error as expected.

**Documentation links affected:**
N/A

**Notes for reviewers:**

N/A

