### PR TITLE
Docs: new flowctl and authentication

### DIFF
--- a/site/docs/concepts/README.md
+++ b/site/docs/concepts/README.md
@@ -350,6 +350,7 @@ Storage mappings define how Flow maps your various collections into your storage
 ## flowctl
 
 flowctl is Flow's command-line interface.
-It can be used to develop and test Flow catalogs, and to deploy them into a Flow runtime.
+With flowctl, developers can work directly on active catalogs and drafts created in the Flow webapp.
+They can develop locally, test more flexibly, and collaboratively refine catalogs.
 
 [Learn more about flowctl](flowctl.md)

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -3,30 +3,40 @@ sidebar_position: 5
 ---
 # flowctl
 
-The `flowctl` command-line interface is used to test, develop, and deploy Flow catalogs.
-It is the only Flow binary that you need to work with,
+There are two ways to work with Flow: through the web app, and using the flowctl command-line interface.
+With flowctl, you can work on drafts and active catalogs created in the webapp with a
+higher degree of control.
+You can also authenticate Flow users and roles and generate Typescript modules to customize [derivations](derivations.md).
+
+flowctl is the only Flow binary that you need to work with,
 so distribution and upgrades are all simple.
 
-`flowctl` includes a number of important sub-commands, including:
+## Installation
 
-* `discover` auto-creates a catalog specification given a connector and endpoint configuration.
-  It’s an assisted way to configure an endpoint capture and scaffold a Flow project.
+:::info Beta
+Simplified installation is coming soon.
 
-  [Learn more about `flowctl discover`](connectors.md#flowctl-discover)
-
-* `temp-data-plane` starts a local, ephemeral Flow data plane.
-  It runs a complete deployment of the Flow runtime,
-  but shrunk down to your local machine instead of a data center.
-
-* `deploy` builds from catalog sources and deploys into a Flow data plane.
-  It's typically used to deploy to a temporary data plane for local development.
-
-* `test` builds from catalog sources and runs all of your catalog tests.
-
-:::tip
-Additional `flowctl` commands are available for advanced users and development workflows.
-To read a list of all current commands and details in the CLI, run  `flowctl --help`.
+For now, you can [contact Estuary support](mailto:support@estuary.dev) for access.
 :::
+
+## flowctl subcommands
+
+flowctl includes several top-level subcommands representing different functional areas. Each of these include multiple nested subcommands.
+Important top-level flowctl subcommands are described below.
+
+* `auth` allows you to authenticate your development session in your local development environment.
+It's also how you provision Flow roles and users. Learn more about [authentication](../reference/authentication.md).
+
+* `catalog` allows you to work with your organization's current active catalog. You can investigate the current deployment,
+ or add its specification to a **draft**, where you can develop it further.
+
+* `draft` allows you to work with draft catalog specifications. You can create, test, develop locally, and then **publish**, or deploy, them.
+
+You can access full documentation of all flowctl subcommands from the command line by passing the `--help` or `-h` flag, for example:
+
+* `flowctl --help` lists top-level flowctl subcommands
+
+* `flowctl catalog --help` lists subcommands of `catalog`
 
 ## Build directory
 

--- a/site/docs/reference/authentication.md
+++ b/site/docs/reference/authentication.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 1
+---
+
+# Authenticating Flow
+
+Read, write, and admin capabilities over Flow catalogs and the [collections](../concepts/collections.md) that comprise them
+are granted to Flow users through **roles**.
+
+Roles are granted in terms of **prefixes** within the Flow [namespace](../concepts/README.md#namespace).
+By default, each organization, or **tenant**, has a unique high-level prefix.
+For example, if you worked for Acme Co, your assigned tenant prefix would be `acmeCo/`.
+You may further divide your namespace however you'd like; for example `acmeCo/anvils` and `acmeCo/roadrunners`.
+When you name a collection, you can customize the prefix, and roles can be configured at any prefix level.
+This allows you to flexibly control access to your Flow data.
+
+The available roles are:
+
+* **`read`**: Allows the subject to read data from collections of the given prefix.
+
+* **`write`**: Allows the subject to read and write data from collections of the given prefix.
+
+* **`admin`**: Allows the subject to read and write data from collections of the given prefix,
+and to manage storage mappings, catalog specifications, and role grants within the prefix.
+The admin role also inherits roles granted to the prefix, as discussed below.
+
+## Subjects, objects, and inherited roles
+
+The entity to which you grant a role is called the **subject**, and the entity over which access is granted is called the **object**.
+The subject can be either a user or a prefix, and the object is always a prefix. This allows subjects to inherit nested roles,
+so long as they are granted the `admin` role.
+
+For example, user X of Acme Co has admin access to the `acmeCo/` prefix, and user Y has write access.
+A third party has granted `acmeCo/` read access to shared data at `outside-org/acmeCo-share/`.
+User X automatically inherits read access to `outside-org/acmeCo-share/`, but user Y does not.
+
+## Default authentication settings
+
+When you first sign up to use Flow, your organization is provisioned a tenant prefix, and your username is granted admin access to the prefix.
+Your prefix is granted write access to itself and read access to its logs, which are stored in the global `ops/` prefix.
+
+Using the same example, say user X signs up on behalf of their company, AcmeCo. User X is automatically granted `admin` access to the `acmeCo/` prefix.
+`acmeCo/`, in turn, has write access to `acmeCo/` and read access to `ops/acmeCo/`.
+
+As more users and prefixes are added, admins can [provision roles](#provisioning-roles) using the CLI.
+
+## Authenticating Flow in the web app
+
+You must sign in to begin a new session using the Flow web application.
+For the duration of the session, you'll be able to perform actions depending on the roles granted to the user profile.
+
+You can view the roles currently provisioned in your organization on the **Admin** tab.
+
+## Authenticating Flow using the CLI
+
+You can use the [flowctl](../concepts/flowctl.md) CLI to work with your organization's catalogs and drafts in your local development environment.
+
+To authenticate a local development session using the CLI, do the following:
+
+1. Sign into the Flow web application.
+
+2. Click the **Admin** tab, scroll to the **Access Token** box, and copy the token.
+
+3. In the terminal of your local development environment, run:
+   ``` console
+   flowctl auth token --token=<copied-token>
+   ```
+
+The token will expire after a prolonged period of inactivity. Generate a new token using the web application and re-authenticate.
+
+## Provisioning roles
+
+As an admin, you can provision roles using the CLI with the subcommands of `flowctl auth roles`.
+
+For example:
+
+* `flowctl auth roles list` returns a list of all currently provisioned roles
+
+* `flowctl auth roles grant --object-role=acmeCo/ --capability=admin --subject-user-id=userZ` grants user Z admin access to `acmeCo`
+
+* `flowctl auth roles revoke --object-role=outside-org/acmeCo-share/ --capability=read --subject-role=acmeCo/` would be used by an admin of `outside-org`
+to revoke `acmeCo/`'s read access to `outside-org/acmeCo-share/`.
+
+You can find detailed help for all subcommands using the `--help` or `-h` flag.
+

--- a/site/docs/reference/organizing-catalogs.md
+++ b/site/docs/reference/organizing-catalogs.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 1
----
 # Organizing a Flow catalog
 
 It's not necessary to store the entire catalog spec in one YAML file, and Flow provides the flexibility to reference other files, which can be managed independently. You may want to do so if:

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -9,9 +9,19 @@ Access to statistics is still a work in progress. For now, this documentation de
 
 ## Accessing logs
 
-You can access logs by materializing them to an external endpoint, or from the command line.
+You can access logs in the web application, by materializing them to an external endpoint, or from the command line.
+
+### Accessing logs in the web application
+
+The Flow web application displays logs for each running catalog task.
+Navigate to the **Captures** and **Materializations** tabs and select the task of interest.
 
 ### Accessing logs from the command line
+
+:::info Beta
+The `flowctl logs` subcommand is currently under construction.
+Contact [Estuary Support](mailto:support@estuary.dev) for more information.
+:::
 
 The `flowctl logs` subcommand allows you to print logs from the command line.
 This method allows more flexibility and is ideal for debugging.

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1408,17 +1408,6 @@
         "webpack-dev-server": "^4.5.0",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.0-3"
-      },
-      "dependencies": {
-        "react-loadable": {
-          "version": "npm:@docusaurus/react-loadable@5.5.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-          "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-          "requires": {
-            "@types/react": "*",
-            "prop-types": "^15.6.2"
-          }
-        }
       }
     },
     "@docusaurus/cssnano-preset": {
@@ -7784,6 +7773,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-loadable": {
+      "version": "npm:@docusaurus/react-loadable@5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
+      }
     },
     "react-loadable-ssr-addon-v5-slorber": {
       "version": "1.0.1",


### PR DESCRIPTION
**Description:**

Initial pass at documentation to remove (most) reference to old flowctl commands, and provide rudimentary docs of current commands and available workflows. Including:

- Authentication between ui/cli, and provisioning roles
- New flowctl subcommands
- Archive detailed explanations of CLI discovery workflow and point to UI for this
- Mention that `logs` subcommand currently out of commission. 

**Notes for reviewers:**

The other half of this work is in a separate PR - #473 - covering the major changes to derivations and typescript generation. 

Neither of these likely reflects the "final state" of the docs, but since we're about to go live with the UI, I'm trying to get initial docs for the current state of things up and organized. 