### PR TITLE
Phil/schema updates

### DIFF
--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -688,6 +688,7 @@ impl Shape {
                     // here as new annotations are added.
                     Annotation::Secret(b) => shape.secret = Some(*b),
                     Annotation::Multiline(_) => {}
+                    Annotation::Advanced(_) => {}
                     Annotation::Order(_) => {}
                     Annotation::X(_) => {}
                 },

--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -4,14 +4,29 @@ use super::sshforwarding::{SshForwarding, SshForwardingConfig};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[schemars(
-    title = "Network Tunneling",
-    description = "Connect to systems on a private network using tunneling."
-)]
 pub enum NetworkTunnelConfig {
     SshForwarding(SshForwardingConfig),
+}
+
+// manually implement JsonSchema so that we can add the 'advanced' annotation, which causes this
+// configuration form to be collapsed by default in the UI.
+impl JsonSchema for NetworkTunnelConfig {
+    fn schema_name() -> String {
+        "NetworkTunnelConfig".to_owned()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let ssh_forwarding = gen.subschema_for::<SshForwardingConfig>();
+        serde_json::from_value(serde_json::json!({
+            "title": "Network Tunneling",
+            "description": "Setup a network tunnel to access systems on a private network",
+            "advanced": true,
+            "oneOf": [ssh_forwarding],
+        }))
+        .unwrap()
+    }
 }
 
 impl NetworkTunnelConfig {
@@ -25,6 +40,26 @@ impl NetworkTunnelConfig {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn network_tunnel_config_has_advanced_annotation() {
+        let schema = schemars::schema_for!(NetworkTunnelConfig);
+        // assert on the serialized form of the schema, to prove that it's actually serialized
+        let as_json = serde_json::to_value(schema.clone()).unwrap();
+        assert_eq!(
+            Some(&serde_json::Value::Bool(true)),
+            as_json.pointer("/advanced"),
+            "actual: {}",
+            as_json,
+        );
+
+        assert!(as_json.pointer("/oneOf").is_some());
+        assert!(as_json.pointer("/oneOf").unwrap().is_array());
+        assert_eq!(
+            as_json.pointer("/oneOf").unwrap().as_array().unwrap().len(),
+            1
+        );
+    }
 
     #[test]
     fn test_network_config_parse_without_tunnel_type() {

--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[schemars(
+    title = "Network Tunneling",
+    description = "Connect to systems on a private network using tunneling."
+)]
 pub enum NetworkTunnelConfig {
     SshForwarding(SshForwardingConfig),
 }

--- a/crates/parser/src/config/mod.rs
+++ b/crates/parser/src/config/mod.rs
@@ -319,6 +319,10 @@ impl schemars::JsonSchema for ErrorThreshold {
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[schemars(
+    title = "Parser Configuration",
+    description = "Configures how files are parsed"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ParseConfig {
     /// format forces the use of the given parser and disables automatic format detection. If

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -1,11 +1,11 @@
 ---
-source: src/config/mod.rs
+source: crates/parser/src/config/mod.rs
 expression: schema
-
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ParseConfig",
+  "title": "Parser Configuration",
+  "description": "Configures how files are parsed",
   "type": "object",
   "properties": {
     "addRecordOffset": {

--- a/crates/parser/src/main.rs
+++ b/crates/parser/src/main.rs
@@ -117,6 +117,12 @@ fn do_spec() {
     } else {
         unreachable!("schema should always have metadata");
     }
+    // Add the "advanced" annotation to the schema, so that the configuration UI will collaps this
+    // by default.
+    schema
+        .schema
+        .extensions
+        .insert("advanced".to_string(), true.into());
     serde_json::to_writer_pretty(io::stdout(), &schema).or_bail("failed to write schema");
 }
 


### PR DESCRIPTION
**Description:**

The main change here is the addition of the `advanced` JSON schema annotation. This is intended to mark schema locations that should be hidden or collapsed by default. The `advanced` annotation is then applied to both the network tunneling and the parser configuration schemas.

This also rolls up a few fixes to the network tunnel schema.

**Workflow steps:**

No user-facing usage here. For developers, if you add `"advanced": true` to your json schema, then the section will be collapsed by default in the UI.

**Documentation links affected:** n/a
**Notes for reviewers:** n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/477)
<!-- Reviewable:end -->
