### PR TITLE
schemalate/firebolt: quote column names that are not lowercase

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -198,7 +198,6 @@ mod test {
     use std::pin::Pin;
 
     use bytes::Bytes;
-    use flow_cli_common::LogLevel;
     use futures::{stream, TryStream};
 
     use super::*;

--- a/crates/schemalate/src/firebolt/firebolt_types.rs
+++ b/crates/schemalate/src/firebolt/firebolt_types.rs
@@ -87,12 +87,23 @@ impl Display for FireboltType {
         }
     }
 }
+
+// non-lower-case keys must be quoted.
+// see https://docs.firebolt.io/general-reference/identifier-requirements.html
+pub fn column_quote(s: &str) -> String {
+    if s == s.to_lowercase() {
+        s.to_string()
+    } else {
+        format!("\"{}\"", s)
+    }
+}
+
 impl Display for Column {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {}{}",
-            self.key,
+            column_quote(&self.key),
             self.r#type,
             if self.nullable { " NULL" } else { "" }
         )
@@ -166,11 +177,17 @@ mod tests {
                         r#type: FireboltType::Boolean,
                         nullable: false,
                         is_key: true,
+                    },
+                    Column {
+                        key: "Nonlowercase".to_string(),
+                        r#type: FireboltType::Boolean,
+                        nullable: false,
+                        is_key: true,
                     }
                 ],
             }
             .to_string(),
-            "str TEXT,int INT NULL,num DOUBLE,big BIGINT,float FLOAT,date DATE,timestamp TIMESTAMP,boolean BOOLEAN"
+            "str TEXT,int INT NULL,num DOUBLE,big BIGINT,float FLOAT,date DATE,timestamp TIMESTAMP,boolean BOOLEAN,\"Nonlowercase\" BOOLEAN"
         );
 
         assert_eq!(


### PR DESCRIPTION
**Description:**

- Non-lowercase column names must be quoted, otherwise they are considered to be lowercase, and this causes issues when the flow documents have non-lowercase keys.
- Quote columns that are not lowercase
- Fixes https://github.com/estuary/connectors/issues/196

**Workflow steps:**

- Use a flow document with non-lower-case keys

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/479)
<!-- Reviewable:end -->
