### PR TITLE
Update sops to 3.7.3 for WIF support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ${PKGDIR}/bin/flowctl-go: $(GO_BUILD_DEPS) $(GO_PROTO_TARGETS) go-install/github
 
 # `sops` is used for encrypt/decrypt of connector configurations.
 ${PKGDIR}/bin/sops:
-	go install go.mozilla.org/sops/v3/cmd/sops@v3.7.1
+	go install go.mozilla.org/sops/v3/cmd/sops@v3.7.3
 	cp $(shell go env GOPATH)/bin/sops $@
 
 ########################################################################


### PR DESCRIPTION
**Description:**

Sops 3.7.3 is the first version to support using GCP KMS with workload
identity federation tokens. This updates our sops version so that we can
run sops in CI using WIF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/483)
<!-- Reviewable:end -->
