### PR TITLE
Use docker --init for connector signal propagation

### DIFF
--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -80,6 +80,12 @@ func Run(
 	var imageArgs = []string{
 		"docker",
 		"run",
+		// --init is needed in order to ensure that connector processes actually all stop when we
+		// send them a SIGTERM. Without this, the (potentially numerous) child processes within a
+		// container may never actually be stopped.
+		"--init",
+		// I'm honestly not sure why, but --interactive is required in order for (at least some)
+		// connectors to startup properly.
 		"--interactive",
 		"--rm",
 		// Tell docker not to persist any container stdout/stderr output.
@@ -273,7 +279,13 @@ func runCommand(
 	// and wait for exit or for its shutdown timeout to elapse (10s default).
 	go func(signal func(os.Signal) error) {
 		<-ctx.Done()
-		_ = signal(syscall.SIGTERM)
+		logger.Log(logrus.DebugLevel, nil, "sending termination signal to connector")
+		if sigErr := signal(syscall.SIGTERM); sigErr != nil {
+			// I haven't seen any evidence that sending the signal ever fails for any other reason
+			// than the child has already exited. But this is here just to help track down any
+			// potential issues with cleaning up connector processes.
+			logger.Log(logrus.WarnLevel, logrus.Fields{"error": sigErr}, "failed to send signal to container process")
+		}
 	}(cmd.Process.Signal)
 
 	err = cmd.Wait()


### PR DESCRIPTION
**Description:**

Fixes #467 

Connector containers were not always stopping in response to SIGTERM.
This changes how we handle signal propagation for connectors to rely on
docker's built-in 'tinyinit' process, which is enabled by passing the
`--init` argument to `docker run`. This removes the signal handling from
connector-proxy, since it's no longer required and would likely just be
confusing to readers.

**Workflow steps:**

Have a capture shard that fails for just about any reason, apart from the connector itself exiting non-0. In this case, the connector container used to stay running, even after the shard was unassigned. With this change, the connector is now stopped when the shard is unassigned or if the shard spec changes.

**Documentation links affected:** n/a

**Notes for reviewers:**

I'm not certain whether this is the best long-term approach, versus putting more robust signal handling logic into the connector proxy. I think it makes sense to use `--init` for now, but that's something we can potentially revisit if/when we move away from docker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/485)
<!-- Reviewable:end -->
