### PR TITLE
Add reserved words to Firebolt connector docs

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
@@ -105,3 +105,53 @@ The Firebolt connector operates only in [delta updates](../../../concepts/materi
 Firebolt stores all deltas — the unmerged collection documents — directly.
 
 In some cases, this will affect how materialized views look in Firebolt compared to other systems that use standard updates.
+
+## Reserved words
+
+Firebolt has a list of reserved words, which my not be used in identifiers.
+Collections with field names that include a reserved word may not be materialized to Firebolt.
+
+|Reserved words| | |
+|---|---|---|
+| all |	false |	or |
+| alter |	fetch |	order |
+| and |	first |	outer |
+| array |	float |	over |
+| between |	from |	partition |
+| bigint |	full |	precision |
+| bool |	generate |	prepare |
+| boolean |	group |	primary |
+| both |	having |	quarter |
+| case |	if |	right |
+| cast |	ilike |	row |
+| char |	in |	rows |
+| concat |	inner |	sample |
+| copy |	insert |	select |
+| create |	int |	set |
+| cross |	integer |	show |
+| current_date |	intersect |	text |
+| current_timestamp |	interval |	time |
+| database |	is |	timestamp |
+| date |	isnull |	top |
+| datetime |	join |	trailing |
+| decimal |	join_type |	trim |
+| delete |	leading |	true |
+| describe |	left |	truncate |
+| distinct |	like |	union |
+| double |	limit |	unknown_char |
+| doublecolon |	limit_distinct |	unnest |
+| dow |	localtimestamp |	unterminated_string |
+| doy |	long |	update |
+| drop |	natural |	using |
+| empty_identifier |	next |	varchar |
+| epoch |	not |	week |
+| except |	null |	when |
+| execute |	numeric |	where |
+| exists |	offset |	with |
+| explain |	on | |
+| extract |	only | |
+
+
+
+
+


### PR DESCRIPTION
**Description:**

Adds a table from list in #480 

**Notes for reviewers:*

Basically just want to make sure these are expressly forbidden, vs some other systems' reserved words which are permissible when they're quoted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/495)
<!-- Reviewable:end -->
