### PR TITLE
sqlDriver: Do not reference fields when generating JSONSchema

### DIFF
--- a/go/protocols/materialize/sql/driver.go
+++ b/go/protocols/materialize/sql/driver.go
@@ -57,6 +57,7 @@ func (d *Driver) Spec(ctx context.Context, req *pm.SpecRequest) (*pm.SpecRespons
 
 	// Use reflection to build JSON Schemas from endpoint and resource configuration types.
 	var reflector = jsonschema.Reflector{
+		DoNotReference: true,
 		ExpandedStruct: true,
 	}
 	endpointSchema, err := reflector.Reflect(d.EndpointSpecType).MarshalJSON()


### PR DESCRIPTION
jsonSchema has the ability to toggle the ability to reference properties
so they aren't embedded in the properties field.

For fields that are defined in go struct's annotation, these are
automatically inlined and never referenced. However, a custom type can
be created and will be, by default, referenced.

So this flag seems to be application, for the most part, only affecting
custom types.

In practice, by enabling the `DoNotReference` flag, the custom type gets rendered differently. With the flag disabled:

```json
"properties": {
  "credentials_json": {
    "$schema": "http://json-schema.org/draft-04/schema#",
    "$ref": "#/definitions/Credential",
  }
},
"additionalProperties": false,
"type": "object",
"definitions": {
  "Credential": {
    "type": "string",
    "title": "Credentials",
    "description": "Google Cloud Service Account JSON credentials in base64 format.",
    "secret": true
  }
}
```
With the flag enabled:
```json
"properties": {
  "credentials_json": {
    "type": "string",
    "title": "Credentials",
    "description": "Google Cloud Service Account JSON credentials in base64 format.",
    "secret": true
  }
}
```

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/496)
<!-- Reviewable:end -->
