### PR TITLE
schemalate/firebolt: quote reserved words and weird fields instead of rejecting

### DIFF
--- a/crates/schemalate/src/firebolt/firebolt_projections.rs
+++ b/crates/schemalate/src/firebolt/firebolt_projections.rs
@@ -2,18 +2,10 @@ use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 use json::schema::types;
-use lazy_static::lazy_static;
 use protocol::flow::{inference::Exists, materialization_spec, FieldSelection};
 use protocol::materialize::{constraint, validate_request, Constraint};
-use regex::Regex;
 
 use crate::firebolt::errors::BindingConstraintError;
-
-use super::reserved_words::RESERVED_WORDS;
-
-lazy_static! {
-    static ref VALID_FIELD_REGEX: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
-}
 
 // Can we make this a method on FieldSelection itself?
 fn all_fields(fs: FieldSelection) -> Vec<String> {
@@ -108,19 +100,6 @@ pub fn validate_new_projection(
                         reason:
                             "The root document is usually not necessary in delta-update connectors."
                                 .to_string(),
-                    }
-                } else if !VALID_FIELD_REGEX.is_match(&projection.field) {
-                    Constraint {
-                        r#type: constraint::Type::FieldForbidden.into(),
-                        reason: format!(
-                            "Firebolt requires that field names must match the regex {}.",
-                            VALID_FIELD_REGEX.as_str()
-                        ),
-                    }
-                } else if RESERVED_WORDS.contains(&projection.field.to_lowercase()) {
-                    Constraint {
-                        r#type: constraint::Type::FieldForbidden.into(),
-                        reason: "This field name is a reserved word in Firebolt.".to_string(),
                     }
                 } else {
                     let types = types::Set::from_iter(infer.types.iter());
@@ -587,66 +566,6 @@ mod tests {
             Constraint {
                 r#type: constraint::Type::FieldForbidden.into(),
                 reason: "Cannot materialize field with multiple or no types.".to_string(),
-            },
-        );
-
-        check_validate_new_projection(
-            Projection {
-                field: "root/name".to_string(),
-                ptr: "/root/name".to_string(),
-                inference: Some(Inference {
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            Constraint {
-                r#type: constraint::Type::FieldForbidden.into(),
-                reason: "Firebolt requires that field names must match the regex ^[a-zA-Z_][a-zA-Z0-9_]*$.".to_string(),
-            },
-        );
-
-        check_validate_new_projection(
-            Projection {
-                field: "2name".to_string(),
-                ptr: "name".to_string(),
-                inference: Some(Inference {
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            Constraint {
-                r#type: constraint::Type::FieldForbidden.into(),
-                reason: "Firebolt requires that field names must match the regex ^[a-zA-Z_][a-zA-Z0-9_]*$.".to_string(),
-            },
-        );
-
-        check_validate_new_projection(
-            Projection {
-                field: "💥".to_string(),
-                ptr: "name".to_string(),
-                inference: Some(Inference {
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            Constraint {
-                r#type: constraint::Type::FieldForbidden.into(),
-                reason: "Firebolt requires that field names must match the regex ^[a-zA-Z_][a-zA-Z0-9_]*$.".to_string(),
-            },
-        );
-
-        check_validate_new_projection(
-            Projection {
-                field: "date".to_string(),
-                ptr: "date".to_string(),
-                inference: Some(Inference {
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            Constraint {
-                r#type: constraint::Type::FieldForbidden.into(),
-                reason: "This field name is a reserved word in Firebolt.".to_string(),
             },
         );
     }


### PR DESCRIPTION
**Description:**

- We rejected fields that were reserved words or had illegal characters
- This PR changes the behaviour to quote those fields instead

**Workflow steps:**

- Use a field which is a reserved word or does not meet the [identifier requirements](https://docs.firebolt.io/general-reference/identifier-requirements.html)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/499)
<!-- Reviewable:end -->
