### PR TITLE
SchemaGenerator: Refactor the logic to use Shape

### DIFF
--- a/crates/parser/src/schema_generator/properties.rs
+++ b/crates/parser/src/schema_generator/properties.rs
@@ -1,0 +1,64 @@
+use doc::inference::*;
+use json::schema::types;
+use serde_json::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PropertyError {
+    #[error("failed to parse the value: {0}")]
+    InvalidValueType(serde_json::Value),
+}
+
+pub fn build<'a>(
+    property: &'a mut ObjProperty,
+    data: &Value,
+) -> Result<&'a ObjProperty, PropertyError> {
+    match data {
+        Value::Bool(_) => property.shape.type_ = types::BOOLEAN,
+        Value::Number(_) => property.shape.type_ = types::INT_OR_FRAC,
+        Value::String(_) => property.shape.type_ = types::STRING,
+        Value::Null => {
+            property.is_required = false;
+            property.shape = Shape {
+                type_: types::NULL,
+                ..property.shape.to_owned()
+            };
+        }
+        e => {
+            return Err(PropertyError::InvalidValueType(e.to_owned()));
+        }
+    };
+
+    return Ok(property);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use doc::inference::ObjProperty;
+    use json::schema::types;
+    use serde_json::json;
+
+    #[test]
+    fn test_different_types() {
+        let mut property = ObjProperty {
+            name: "test".to_string(),
+            is_required: false,
+            shape: Shape::default(),
+        };
+
+        build(&mut property, &json!(true)).expect("expected a valid value");
+        assert_eq!(property.shape.type_.is_single_scalar_type(), true);
+        assert_eq!(property.shape.type_.overlaps(types::BOOLEAN), true);
+
+        build(&mut property, &json!("string".to_string())).expect("expected a valid value");
+        assert_eq!(property.shape.type_.is_single_scalar_type(), true);
+        assert_eq!(property.shape.type_.overlaps(types::STRING), true);
+
+        build(&mut property, &json!(123)).expect("expected a valid value");
+        assert_eq!(property.shape.type_.is_single_scalar_type(), true);
+        assert_eq!(property.shape.type_.overlaps(types::INT_OR_FRAC), true);
+
+        build(&mut property, &json!(null)).expect("expected a valid value");
+        assert_eq!(property.shape.type_.overlaps(types::NULL), true);
+    }
+}

--- a/crates/parser/src/schema_generator/snapshots/parser__schema_generator__test__generator_with_multiple_values.snap
+++ b/crates/parser/src/schema_generator/snapshots/parser__schema_generator__test__generator_with_multiple_values.snap
@@ -1,23 +1,6 @@
 ---
 source: crates/parser/src/schema_generator/mod.rs
-assertion_line: 179
-expression: "&schema.root"
+assertion_line: 146
+expression: schema.to_json().unwrap()
 ---
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "a_null_value": {
-      "type": "null"
-    },
-    "boolean": {
-      "type": "boolean"
-    },
-    "number": {
-      "type": "number"
-    },
-    "string": {
-      "type": "string"
-    }
-  }
-}
+"{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"$id\":\"342ac041-7e3c-42ca-8311-c248284cd034\",\"type\":\"object\",\"properties\":{\"a_null_value\":{\"type\":\"null\"},\"boolean\":{\"type\":\"boolean\"},\"number\":{\"type\":\"number\"},\"string\":{\"type\":\"string\"}}}"

--- a/crates/parser/src/schema_generator/validations.rs
+++ b/crates/parser/src/schema_generator/validations.rs
@@ -1,0 +1,84 @@
+use doc::inference::{ObjProperty, Shape};
+use schemars::schema::*;
+
+pub fn property<'a>(prop: &ObjProperty) -> Schema {
+    let mut schema = SchemaObject {
+        metadata: Some(Box::new(Metadata::default())),
+        ..SchemaObject::default()
+    };
+
+    for value in prop.shape.type_.iter().collect::<Vec<&'static str>>() {
+        match value {
+            "string" => {
+                schema.instance_type = Some(SingleOrVec::Single(Box::new(InstanceType::String)))
+            }
+            "boolean" => {
+                schema.instance_type = Some(SingleOrVec::Single(Box::new(InstanceType::Boolean)))
+            }
+            "number" => {
+                schema.instance_type = Some(SingleOrVec::Single(Box::new(InstanceType::Number)))
+            }
+            "null" => {
+                schema.instance_type = Some(SingleOrVec::Single(Box::new(InstanceType::Null)))
+            }
+            // If the value is not matched, the schema returns is a "failed validation" where it
+            // will always fail the schema validation. This could eventually be changed to be open by
+            // default, but this is only a temporary measure until more data types gets implemented.
+            _ => {
+                return Schema::Bool(false);
+            }
+        }
+    }
+
+    return Schema::Object(schema);
+}
+
+pub fn object(shape: &Shape) -> Option<Box<ObjectValidation>> {
+    let mut validation = ObjectValidation::default();
+    shape.object.properties.iter().for_each(|prop| {
+        validation
+            .properties
+            .insert(prop.name.clone(), property(&prop));
+    });
+    return Some(Box::new(validation));
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use doc::inference::ObjShape;
+    use json::schema::types;
+
+    #[test]
+    fn test_object_includes_all_properties() {
+        let properties = vec![
+            ObjProperty {
+                name: "property1".to_string(),
+                is_required: true,
+                shape: Shape {
+                    type_: types::STRING,
+                    ..Shape::default()
+                },
+            },
+            ObjProperty {
+                name: "property2".to_string(),
+                is_required: true,
+                shape: Shape {
+                    type_: types::BOOLEAN,
+                    ..Shape::default()
+                },
+            },
+        ];
+
+        let result = object(&Shape {
+            object: ObjShape {
+                properties: properties,
+                ..ObjShape::default()
+            },
+            ..Shape::default()
+        });
+
+        let validation = *result.expect("expected to generate a boxed objectValidation");
+        assert_eq!(validation.properties.len(), 2)
+    }
+}


### PR DESCRIPTION
Because we'll eventually need to merge JSONSchema together, it's better
if the generator uses the doc's create and the Shape struct provided by
that crate. Some of the logic is similar to what schemars is using but
it allows set operations on shape which is something that doesn't exists
currently with schemars.

So, the flow for this changes a little bit where initially, the JSON
payload still has to be parsed into a `serde_json::Value` and be passed
to the generator. Then, it will convert the payload into a Shape that is
effectively a tree of multiple shapes which builds the structure of a
JSONSchema.

When the schema is parsed and ready to be rendered as a JSON Value, the
generator will create a `schemars::RootSchema` and convert all shapes
into this schema. This is because the logic of rendering the Shape into
JSON doesn't exist and schemars supports rendering an in-memory schema
into a JSON payload. It might not be the fastest path to render, but
it's at least consistent and the logic flows smoothly, which I think I
prefer over making things fast first.

*This is still a WIP and the code is not accessible currently. It needs to be moved into it's own binary.*

**Notes for reviewers:**
This is my attempt at using Shape and also trying my hand with a few different rust concept. There might be things that could be done more efficiently or use some library to make things nicer. I'd love to hear or learn alternative that would improve the code quality.

The code also lacks documentation. It's not on purpose, but I'm still figuring out some of the API so I didn't want to spend time writing a lot of documentation as I'm not sure if everything will stay the same. As the code stabilize, I will add more comments.

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/503)
<!-- Reviewable:end -->
