### PR TITLE
network-tunnel: fix JSONSchema of network tunnel

### DIFF
--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -23,7 +23,12 @@ impl JsonSchema for NetworkTunnelConfig {
             "title": "Network Tunneling",
             "description": "Setup a network tunnel to access systems on a private network",
             "advanced": true,
-            "oneOf": [ssh_forwarding],
+            "oneOf": [{
+                "type": "object",
+                "properties": {
+                    "sshForwarding": ssh_forwarding
+                }
+            }],
         }))
         .unwrap()
     }


### PR DESCRIPTION
**Description:**

sshForwarding should have its own key under networkTunnel

**Workflow steps:**

- Use `flowctl discover` on a connector

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/508)
<!-- Reviewable:end -->
