### PR TITLE
Allow catalogs to define ops collections

### DIFF
--- a/crates/assemble/src/ops/snapshots/assemble__ops__test__ops_collections_are_generated.snap
+++ b/crates/assemble/src/ops/snapshots/assemble__ops__test__ops_collections_are_generated.snap
@@ -36,18 +36,15 @@ Sources {
     ],
     collections: [
         Collection {
-            scope: builtin://flow/ops/generated/collections,
+            scope: test://foo.bar/collection,
             collection: ops/acmeCo/logs,
             spec: {
-              "schema": false,
+              "schema": true,
               "key": [
-                "/shard/name",
-                "/shard/keyBegin",
-                "/shard/rClockBegin",
-                "/ts"
+                "/not/a/real/key"
               ]
             },
-            schema: builtin://flow/ops-log-schema.json,
+            schema: test://foo.bar/schema,
         },
         Collection {
             scope: builtin://flow/ops/generated/collections,
@@ -201,24 +198,6 @@ Sources {
     ],
     npm_dependencies: [],
     projections: [
-        Projection {
-            scope: builtin://flow/ops/generated/collections,
-            collection: ops/acmeCo/logs,
-            field: kind,
-            spec: {
-              "location": "/shard/kind",
-              "partition": true
-            },
-        },
-        Projection {
-            scope: builtin://flow/ops/generated/collections,
-            collection: ops/acmeCo/logs,
-            field: name,
-            spec: {
-              "location": "/shard/name",
-              "partition": true
-            },
-        },
         Projection {
             scope: builtin://flow/ops/generated/collections,
             collection: ops/acmeCo/stats,


### PR DESCRIPTION
**Description:**

Changes the generation of ops collections to only generate them when
they're not already defined in the sources. This allows a catalog source
yaml to include definitions of ops collections, and thus permits
migration to having them generated by the control plane agent instead of
flowctl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/516)
<!-- Reviewable:end -->
