### PR TITLE
doc/pointer: from_vec and Display implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,6 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "json-pointer",
  "libc",
  "network-tunnel",
  "prost",
@@ -1717,15 +1716,6 @@ dependencies = [
  "serde",
  "serde_json",
  "treediff",
-]
-
-[[package]]
-name = "json-pointer"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe841b94e719a482213cee19dd04927cf412f26d8dc84c5a446c081e49c2997"
-dependencies = [
- "serde_json",
 ]
 
 [[package]]

--- a/crates/connector_proxy/Cargo.toml
+++ b/crates/connector_proxy/Cargo.toml
@@ -21,7 +21,6 @@ clap = { version = "^3", features = ["derive"] }
 futures = "*"
 futures-core = "*"
 futures-util = "*"
-json-pointer = "*"
 libc = "*"
 prost = "*"
 schemars = "*"

--- a/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
@@ -22,7 +22,6 @@ use tokio::sync::Mutex;
 use validator::Validate;
 
 use futures::{stream, StreamExt, TryStreamExt};
-use json_pointer::JsonPointer;
 use serde_json::value::RawValue;
 use std::fs::File;
 use std::io::Write;
@@ -114,11 +113,9 @@ impl AirbyteSourceInterceptor {
 
                 let key_ptrs = match stream.source_defined_primary_key {
                     None => Vec::new(),
-                    // TODO: use doc::Pointer, and if necessary implement creation of new json pointers
-                    // in that module. What about the existing tokenize_jsonpointer function?
                     Some(keys) => keys
                         .iter()
-                        .map(|k| JsonPointer::new(k).to_string())
+                        .map(|k| doc::Pointer::from_vec(k).to_string())
                         .collect(),
                 };
                 let recommended_name = stream_to_recommended_name(&stream.name);


### PR DESCRIPTION
**Description:**

use `doc::Pointer(vec).to_string()` in connector-proxy for translating primary key lists to JSON pointers. Removes our dependency on `json-pointers` crate (3rd party)

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/517)
<!-- Reviewable:end -->
