### PR TITLE
connector_proxy: remove docker image url hack for flow protocol inference

### DIFF
--- a/crates/connector_proxy/src/libs/image_inspect.rs
+++ b/crates/connector_proxy/src/libs/image_inspect.rs
@@ -62,16 +62,6 @@ impl ImageInspect {
             }
         }
 
-        // TODO: change this to allow arbitrary docker images to be recognized
-        // as a materialization
-        if let Some(repo_tags) = &self.repo_tags {
-            for tag in repo_tags {
-                if tag.starts_with("ghcr.io/estuary/materialize-") {
-                    return FlowRuntimeProtocol::Materialize;
-                }
-            }
-        }
-
         return FlowRuntimeProtocol::Capture;
     }
 


### PR DESCRIPTION
**Description:**

- I added the protocol label to all our materialization images: https://github.com/estuary/connectors/commit/cf209eb2dc4469365384081461509ebd275f4ae4
- So we do not need this hack anymore.

**Workflow steps:**

Use a materialization image

**Documentation links affected:**

N/A

**Notes for reviewers:**

- I also triggered a re-fetch of these new images on production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/518)
<!-- Reviewable:end -->
