### PR TITLE
network-tunnel: "Disabled" variant for Network Tunnel JSONSchema

### DIFF
--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -25,9 +25,13 @@ impl JsonSchema for NetworkTunnelConfig {
             "advanced": true,
             "oneOf": [{
                 "type": "object",
+                "title": "SSH Forwarding",
                 "properties": {
                     "sshForwarding": ssh_forwarding
                 }
+            }, {
+                "type": "null",
+                "title": "Disabled"
             }],
         }))
         .unwrap()
@@ -62,7 +66,7 @@ mod test {
         assert!(as_json.pointer("/oneOf").unwrap().is_array());
         assert_eq!(
             as_json.pointer("/oneOf").unwrap().as_array().unwrap().len(),
-            1
+            2
         );
     }
 


### PR DESCRIPTION
**Description:**

- The new JSONSchema for NetworkTunnel is:
```
{
  "title": "Network Tunneling",
  "description": "Setup a network tunnel to access systems on a private network",
  "advanced": true,
  "oneOf": [
    {
      "type": "object",
      "title": "SSH Forwarding",
      "properties": {
        "sshForwarding": {}
      }
    },
    {
      "type": "null",
      "title": "Disabled"
    }
  ]
}
```
- Resolves https://github.com/estuary/connectors/issues/231

**Workflow steps:**

Go to Network Tunnel tab in connector configuration page, you will see two variants: SSH Forwarding and Disabled. If you accidentally hit SSH Forwarding, you can select Disabled to be able to proceed.

**Documentation links affected:**

Not that I'm aware of

**Notes for reviewers:**

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/2807772/172638019-17973a74-cd86-48c5-b8a6-6c2310753cba.png">

Thanks a lot to @travjenkins for https://github.com/estuary/ui/pull/199, it's very useful!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/522)
<!-- Reviewable:end -->
