### PR TITLE
Revert "connector_proxy: remove docker image url hack for flow protocol inference"

### DIFF
--- a/crates/connector_proxy/src/libs/image_inspect.rs
+++ b/crates/connector_proxy/src/libs/image_inspect.rs
@@ -62,6 +62,16 @@ impl ImageInspect {
             }
         }
 
+        // TODO: change this to allow arbitrary docker images to be recognized
+        // as a materialization
+        if let Some(repo_tags) = &self.repo_tags {
+            for tag in repo_tags {
+                if tag.starts_with("ghcr.io/estuary/materialize-") {
+                    return FlowRuntimeProtocol::Materialize;
+                }
+            }
+        }
+
         return FlowRuntimeProtocol::Capture;
     }
 


### PR DESCRIPTION
Reverts estuary/flow#518

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/523)
<!-- Reviewable:end -->
