### PR TITLE
cli + connector_proxy: support labels for materialization images + backward-compatibility hack

### DIFF
--- a/crates/connector_proxy/src/libs/image_inspect.rs
+++ b/crates/connector_proxy/src/libs/image_inspect.rs
@@ -62,6 +62,15 @@ impl ImageInspect {
             }
         }
 
+        // For backward compatibility with old images that do not have the label
+        if let Some(repo_tags) = &self.repo_tags {
+            for tag in repo_tags {
+                if tag.starts_with("ghcr.io/estuary/materialize-") {
+                    return FlowRuntimeProtocol::Materialize;
+                }
+            }
+        }
+
         return FlowRuntimeProtocol::Capture;
     }
 

--- a/crates/connector_proxy/src/libs/image_inspect.rs
+++ b/crates/connector_proxy/src/libs/image_inspect.rs
@@ -62,16 +62,6 @@ impl ImageInspect {
             }
         }
 
-        // TODO: change this to allow arbitrary docker images to be recognized
-        // as a materialization
-        if let Some(repo_tags) = &self.repo_tags {
-            for tag in repo_tags {
-                if tag.starts_with("ghcr.io/estuary/materialize-") {
-                    return FlowRuntimeProtocol::Materialize;
-                }
-            }
-        }
-
         return FlowRuntimeProtocol::Capture;
     }
 

--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -119,7 +119,7 @@ func Run(
 		)
 	}
 
-	if err := pullRemoteImage(ctx, image, logger); err != nil {
+	if err := PullRemoteImage(ctx, image, logger); err != nil {
 		// This might be a local image. Log an error and keep going.
 		// If the image does not exist locally, the inspectImage will return an error and terminate the workflow.
 		logger.Log(logrus.InfoLevel, logrus.Fields{
@@ -127,7 +127,7 @@ func Run(
 		}, "pull remote image does not succeed.")
 	}
 
-	if inspectOutput, err := inspectImage(ctx, image); err != nil {
+	if inspectOutput, err := InspectImage(ctx, image); err != nil {
 		return fmt.Errorf("inspect image: %w", err)
 	} else {
 		if jsonFiles == nil {
@@ -568,7 +568,7 @@ func (fe *firstError) unwrap() error {
 const maxStderrBytes = 4096
 const maxMessageSize = 1 << 23 // 8 MB.
 
-func pullRemoteImage(ctx context.Context, image string, logger ops.Logger) error {
+func PullRemoteImage(ctx context.Context, image string, logger ops.Logger) error {
 	var combinedOutput, err = exec.CommandContext(ctx, "docker", "pull", image).CombinedOutput()
 	logger.Log(logrus.TraceLevel, nil, fmt.Sprintf("output from docker pull: %s", combinedOutput))
 	if err != nil {
@@ -577,7 +577,7 @@ func pullRemoteImage(ctx context.Context, image string, logger ops.Logger) error
 	return nil
 }
 
-func inspectImage(ctx context.Context, image string) (json.RawMessage, error) {
+func InspectImage(ctx context.Context, image string) (json.RawMessage, error) {
 	if output, err := exec.CommandContext(ctx, "docker", "inspect", image).Output(); err != nil {
 		return nil, fmt.Errorf("inspect image: %w", err)
 	} else {


### PR DESCRIPTION
This reverts commit 4d246d8641806e964c5535ec2737f465f5838dd8.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/524)
<!-- Reviewable:end -->
