### PR TITLE
connector_proxy: consider null values of networkTunnel

### DIFF
--- a/crates/network-tunnel/src/errors.rs
+++ b/crates/network-tunnel/src/errors.rs
@@ -1,5 +1,3 @@
-use std::array::TryFromSliceError;
-
 use base64::DecodeError;
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use base64::DecodeError;
 use futures::pin_mut;
 use schemars::JsonSchema;
+use std::net::SocketAddr;
 use std::sync::Arc;
-use std::{convert::TryInto, net::SocketAddr};
 use thrussh::{
     client,
     client::{Handle, Session},


### PR DESCRIPTION
**Description:**

- The UI was sending down a `networkTunnel: null` when using the "Disabled" case, and it was throwing an error
- Handling the case where `networkTunnel: null` by removing that key, but not starting a network tunnel

**Workflow steps:**

- Use "Disabled" in UI for network tunnel configuration or pass `networkTunnel: null` manually

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/526)
<!-- Reviewable:end -->
