### PR TITLE
connector_proxy: handle channel send error gracefully

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -1,5 +1,5 @@
 use crate::apis::{FlowCaptureOperation, FlowMaterializeOperation, InterceptorStream};
-use crate::errors::Error;
+use crate::errors::{create_custom_error, raise_err, Error};
 use crate::interceptors::{
     airbyte_source_interceptor::AirbyteSourceInterceptor,
     network_tunnel_capture_interceptor::NetworkTunnelCaptureInterceptor,
@@ -141,7 +141,9 @@ pub async fn run_airbyte_source_connector(
                         (msg, bytes)
                     }
                     None => {
-                        sender.send(transaction_pending).unwrap();
+                        sender.send(transaction_pending).map_err(|_|
+                            create_custom_error("Could not send signal for Airbyte connector's pending checkpoint. This can happen if the connector exits abruptly.")
+                        )?;
                         return Ok(None);
                     }
                 };


### PR DESCRIPTION
**Description:**

- We saw this `unwrap` in alerts channel, it happens if the connector exits abruptly and the receiver of the channel is dropped.
- Add a better error message to avoid confusions.

Resolves #530 

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/531)
<!-- Reviewable:end -->
