### PR TITLE
network-tunnel: switch to using openssh for tunnel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,20 +40,7 @@ jobs:
       - run: make extra-ci-runner-setup
       - run: make print-versions
 
-      - name: Cache/Restore Rust dependencies.
-        uses: actions/cache@v2
-        with:
-          # See: https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-          # TODO: Try https://github.com/Swatinem/rust-cache
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-glibc-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-glibc-cargo-
+      - uses: Swatinem/rust-cache@v1
 
       - name: Cache/Restore Go dependencies.
         uses: actions/cache@v2
@@ -80,16 +67,6 @@ jobs:
           path: |
             .build/package/bin/*
 
-      # Use to the cached version of cargo-cache if it exists. Saves minutes installing it.
-      - run: |
-          if [[ $(cargo cache --version) != "cargo-cache $CARGO_CACHE_VERSION" ]]; then
-            cargo install --force cargo-cache --version="$CARGO_CACHE_VERSION"
-          fi
-        shell: bash
-
-      # Cleanup in preparation for populating the build cache.
-      - run: cargo cache --autoclean
-
   musl:
     runs-on: ubuntu-20.04
 
@@ -102,18 +79,7 @@ jobs:
       - run: make extra-ci-runner-setup
       - run: make print-versions
 
-      - name: Cache/Restore Rust dependencies.
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-musl-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-musl-cargo-
+      - uses: Swatinem/rust-cache@v1
 
       # Build and test all the things.
       - run: go mod download
@@ -126,16 +92,6 @@ jobs:
           name: musl_binaries
           path: |
             .build/package/bin/*
-
-      # Use to the cached version of cargo-cache if it exists. Saves minutes installing it.
-      - run: |
-          if [[ $(cargo cache --version) != "cargo-cache $CARGO_CACHE_VERSION" ]]; then
-            cargo install --force cargo-cache --version="$CARGO_CACHE_VERSION"
-          fi
-        shell: bash
-
-      # Cleanup in preparation for populating the build cache.
-      - run: cargo cache --autoclean
 
   assembly:
     runs-on: ubuntu-20.04
@@ -177,20 +133,7 @@ jobs:
       - name: Install rust toolchain
         run: rustup show
 
-      - name: Cache/Restore Rust dependencies.
-        uses: actions/cache@v2
-        with:
-          # See: https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-          # TODO: Try https://github.com/Swatinem/rust-cache
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-glibc-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-glibc-cargo-
+      - uses: Swatinem/rust-cache@v1
 
       - name: Cache/Restore Go dependencies.
         uses: actions/cache@v2
@@ -285,16 +228,6 @@ jobs:
           -o /home/runner/work/flow/flow/.build/package/bin/flow-schemalate \
           -o /home/runner/work/flow/flow/.build/package/bin/gazette \
           -o /home/runner/work/flow/flow/.build/package/bin/sops
-
-      # Use to the cached version of cargo-cache if it exists. Saves minutes installing it.
-      - run: |
-          if [[ $(cargo cache --version) != "cargo-cache $CARGO_CACHE_VERSION" ]]; then
-            cargo install --force cargo-cache --version="$CARGO_CACHE_VERSION"
-          fi
-        shell: bash
-
-      # Cleanup in preparation for populating the build cache.
-      - run: cargo cache --autoclean
 
       # Package and push images.
       - run: make docker-image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,6 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "ctr",
  "opaque-debug 0.3.0",
 ]
 
@@ -242,19 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
-name = "bcrypt-pbkdf"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c38c03b9506bd92bf1ef50665a81eda156f615438f7654bffba58907e6149d7"
-dependencies = [
- "blowfish",
- "crypto-mac",
- "pbkdf2 0.8.0",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,19 +319,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -358,39 +335,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding 0.2.1",
- "cipher",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blowfish"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
-dependencies = [
- "byteorder",
- "cipher",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -864,26 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
-name = "cryptovec"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc7fa13a6bbb2322d325292c57f4c8e7291595506f8289968a0eb61c3130bdf"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,21 +834,6 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive"
@@ -983,26 +898,6 @@ dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1428,16 +1323,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
@@ -1789,18 +1674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "walkdir",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,12 +1735,6 @@ name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1979,8 +1846,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "thrussh",
- "thrussh-keys",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2202,17 +2067,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
-dependencies = [
- "base64ct",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
@@ -2295,27 +2149,14 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
-dependencies = [
- "base64ct",
- "crypto-mac",
- "hmac 0.11.0",
- "password-hash 0.2.3",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
  "digest 0.10.3",
- "hmac 0.12.1",
- "password-hash 0.3.2",
- "sha2 0.10.2",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -2817,17 +2658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.6",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,19 +3003,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
@@ -3515,75 +3332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "thrussh"
-version = "0.33.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6540238a9adf83df6e66541c182a52acf892ab335595ca965c229ade8536f8"
-dependencies = [
- "bitflags",
- "byteorder",
- "cryptovec",
- "digest 0.9.0",
- "flate2",
- "futures",
- "generic-array 0.14.5",
- "log",
- "openssl",
- "rand 0.8.5",
- "sha2 0.9.9",
- "thiserror",
- "thrussh-keys",
- "thrussh-libsodium",
- "tokio",
-]
-
-[[package]]
-name = "thrussh-keys"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a72cc51a2932b18d92f7289332d8564cec4a5014063722a9d3fdca52c5d8f5ab"
-dependencies = [
- "aes",
- "bcrypt-pbkdf",
- "bit-vec",
- "block-modes",
- "byteorder",
- "cryptovec",
- "data-encoding",
- "dirs",
- "futures",
- "hmac 0.11.0",
- "log",
- "md5",
- "num-bigint 0.4.3",
- "num-integer",
- "openssl",
- "pbkdf2 0.8.0",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "sha2 0.9.9",
- "thiserror",
- "thrussh-libsodium",
- "tokio",
- "tokio-stream",
- "yasna",
-]
-
-[[package]]
-name = "thrussh-libsodium"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe89c70d27b1cb92e13bc8af63493e890d0de46dae4df0e28233f62b4ed9500"
-dependencies = [
- "lazy_static",
- "libc",
- "libsodium-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -4379,16 +4127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yasna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
-dependencies = [
- "bit-vec",
- "num-bigint 0.4.3",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,12 +4148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-
-[[package]]
 name = "zip"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,8 +4160,8 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac 0.12.1",
- "pbkdf2 0.10.1",
+ "hmac",
+ "pbkdf2",
  "sha1",
  "time 0.3.9",
  "zstd",

--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -1,5 +1,5 @@
 use crate::apis::{FlowCaptureOperation, FlowMaterializeOperation, InterceptorStream};
-use crate::errors::{create_custom_error, raise_err, Error};
+use crate::errors::{create_custom_error, Error};
 use crate::interceptors::{
     airbyte_source_interceptor::AirbyteSourceInterceptor,
     network_tunnel_capture_interceptor::NetworkTunnelCaptureInterceptor,

--- a/crates/connector_proxy/src/libs/network_tunnel.rs
+++ b/crates/connector_proxy/src/libs/network_tunnel.rs
@@ -74,6 +74,7 @@ impl NetworkTunnel {
             Some(c) => serde_json::from_value(c)?,
         };
 
+        tracing::info!("starting network tunnel");
         let (mut tx, rx) = oneshot::channel();
         tokio::spawn(Self::start_network_tunnel(network_tunnel_config, rx));
 

--- a/crates/network-tunnel/Cargo.toml
+++ b/crates/network-tunnel/Cargo.toml
@@ -23,7 +23,5 @@ serde_json = "*"
 thiserror = "*"
 tracing = "*"
 tracing-subscriber = {version = "*", features = ["time", "json", "env-filter"]}
-thrussh={version="*", features=["openssl"]}
-thrussh-keys={version="*", features=["openssl"]}
 tokio = { version = "1.15.0", features = ["full"] }
 url = "*"

--- a/crates/network-tunnel/src/errors.rs
+++ b/crates/network-tunnel/src/errors.rs
@@ -2,30 +2,15 @@ use base64::DecodeError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("SSH endpoint is invalid.")]
-    InvalidSshEndpoint,
-
-    #[error("SSH private key is invalid.")]
-    InvalidSshCredential,
-
-    #[error("Local port number of 0 is invalid")]
-    ZeroLocalPort,
-
     #[error("io operation error.")]
     IoError(#[from] std::io::Error),
-
-    #[error("openssl error.")]
-    OpenSslError(#[from] openssl::error::ErrorStack),
-
-    #[error("ssh_endpoint parse error. Expected format: ssh://<host_url_or_ip>[:port]")]
-    UrlParseError(#[from] url::ParseError),
-
-    #[error("IP parse error.")]
-    IpAddrParseError(#[from] std::net::AddrParseError),
 
     #[error("Json serialization error.")]
     JsonError(#[from] serde_json::Error),
 
     #[error("Failed to decode base64 content of OpenSSH key.")]
     DecodeError(#[from] DecodeError),
+
+    #[error("SSH forwarding network tunnel exit with non-zero exit code {0}")]
+    TunnelExitNonZero(String)
 }

--- a/crates/network-tunnel/src/errors.rs
+++ b/crates/network-tunnel/src/errors.rs
@@ -11,9 +11,6 @@ pub enum Error {
     #[error("Local port number of 0 is invalid")]
     ZeroLocalPort,
 
-    #[error("SSH error.")]
-    ThrusshError(#[from] thrussh::Error),
-
     #[error("io operation error.")]
     IoError(#[from] std::io::Error),
 
@@ -28,9 +25,6 @@ pub enum Error {
 
     #[error("Json serialization error.")]
     JsonError(#[from] serde_json::Error),
-
-    #[error("Failed to parse OpenSSH key.")]
-    KeyParsingError(#[from] thrussh_keys::Error),
 
     #[error("Failed to decode base64 content of OpenSSH key.")]
     DecodeError(#[from] DecodeError),

--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -89,6 +89,7 @@ mod test {
             result.unwrap(),
             NetworkTunnelConfig::SshForwarding(SshForwardingConfig {
                 ssh_endpoint: "ssh://flow@localhost:2222".to_string(),
+                user: None,
                 forward_host: "localhost".to_string(),
                 forward_port: 5432,
                 private_key: "".to_string(),

--- a/crates/network-tunnel/src/interface.rs
+++ b/crates/network-tunnel/src/interface.rs
@@ -74,8 +74,7 @@ mod test {
     fn test_network_config_parse_without_tunnel_type() {
         let config = "{
             \"sshForwarding\": {
-                \"sshEndpoint\": \"ssh://localhost:2222\",
-                \"user\": \"flow\",
+                \"sshEndpoint\": \"ssh://flow@localhost:2222\",
                 \"forwardHost\": \"localhost\",
                 \"forwardPort\": 5432,
                 \"privateKey\": \"\",
@@ -89,8 +88,7 @@ mod test {
         assert_eq!(
             result.unwrap(),
             NetworkTunnelConfig::SshForwarding(SshForwardingConfig {
-                ssh_endpoint: "ssh://localhost:2222".to_string(),
-                user: "flow".to_string(),
+                ssh_endpoint: "ssh://flow@localhost:2222".to_string(),
                 forward_host: "localhost".to_string(),
                 forward_port: 5432,
                 private_key: "".to_string(),

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -139,7 +139,7 @@ impl NetworkTunnel for SshForwarding {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        // Read stderr of SSH until we find "Local forwarding listening", which means
+        // Read stderr of SSH until we find a signal message that
         // the ports are open and we are ready to serve requests
         let mut stderr = child.stderr.take().unwrap();
         let mut last_line = String::new();

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -159,7 +159,9 @@ impl NetworkTunnel for SshForwarding {
             last_line.push_str(read_str);
             tracing::debug!("ssh stderr: {}", &last_line);
 
-            if last_line.contains("Local forwarding listening") {
+            // OpenSSH will enter interactive session after tunnelling has been
+            // successful
+            if last_line.contains("Entering interactive session.") {
                 tracing::debug!("ssh tunnel is listening & ready for serving requests");
                 break;
             }

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -335,10 +335,8 @@ materializations:
               # tunneling from the SSH server.
               forwardPort: 5432
               # Location of the remote SSH server that supports tunneling.
-              # Formatted as ssh://hostname[:port].
-              sshEndpoint: ssh://198.21.98.1
-              # Username to connect to the SSH server.
-              user: sshUser
+              # Formatted as ssh://user@hostname[:port].
+              sshEndpoint: ssh://sshUser@198.21.98.1
               # Private key to connect to the SSH server, formatted as multiline plaintext.
               # Use the YAML literal block style with the indentation indicator.
               # See https://yaml-multiline.info/ for details.

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -19,10 +19,10 @@ basic configuration options.
 
 2. Referencing the config files and shell output, collect the following information:
 
-   * The **SSH endpoint** for the SSH server, formatted as `ssh://hostname[:port]`. This may look like the any of following:
-     * `ssh://ec2-198-21-98-1.compute-1.amazonaws.com`
-     * `ssh://198.21.98.1`
-     * `ssh://198.21.98.1:22`
+   * The **SSH endpoint** for the SSH server, formatted as `ssh://user@hostname[:port]`. This may look like the any of following:
+     * `ssh://sshuser@ec2-198-21-98-1.compute-1.amazonaws.com`
+     * `ssh://sshuser@198.21.98.1`
+     * `ssh://sshuser@198.21.98.1:22`
    * The SSH **user**, which will be used to log into the SSH server, for example, `sshuser`. You may choose to create a new
   user for this workflow.
 
@@ -162,9 +162,8 @@ note that instructions for other database engines may be different.
 
 After you've completed the prerequisites, you should have the following parameters:
 
-* **SSH Endpoint** / `sshEndpoint`: the SSH server's hostname, or public IP address, formatted as `ssh://hostname[:port]`
+* **SSH Endpoint** / `sshEndpoint`: the SSH server's hostname, or public IP address, formatted as `ssh://user@hostname[:port]`
 * **Private Key** / `privateKey`: the contents of the PEM file
-* **User** / `user`: the username used to connect to the SSH server.
 * **Forward Host** / `forwardHost`: the capture or materialization endpoint's host
 * **Forward Port** / `forwardPort`: the capture or materialization endpoint's port
 * **Local Port** / `localPort`: the port on the localhost used to connect to the SSH server

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -3,14 +3,14 @@
 # fail fast
 set -e
 
+echo "running source-test-no-state"
+./run-end-to-end.sh source-test-no-state
+echo
 echo "running citi-bike-success"
 ./run-end-to-end.sh citi-bike-success
 echo
 echo "running source-test-exit-status"
 ./run-end-to-end.sh source-test-exit-status
-echo
-echo "running source-test-no-state"
-./run-end-to-end.sh source-test-no-state
 echo
 echo "running push-capture"
 ./run-end-to-end.sh push-capture

--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -70,6 +70,7 @@ flowctl temp-data-plane \
     --sigterm \
     --tempdir ${TESTDIR} \
     --unix-sockets \
+    --log.level=debug \
     1>$TESTDIR/data-plane.stdout \
     2>$TESTDIR/data-plane.stderr \
     &
@@ -97,6 +98,7 @@ flowctl api build \
     --build-id ${BUILD_ID} \
     --source ${TEST_ROOT}/flow.yaml \
     --ts-package \
+    --log.level=debug \
     1>>$TESTDIR/build.stdout \
     2>>$TESTDIR/build.stderr \
     || bail "Catalog build failed."
@@ -108,7 +110,7 @@ touch $TESTDIR/activate.stderr
 tail -f $TESTDIR/activate.stdout &
 tail -f $TESTDIR/activate.stderr &
 # Activate the catalog.
-flowctl api activate --build-id ${BUILD_ID} --all 1>>$TESTDIR/activate.stdout 2>>$TESTDIR/activate.stderr || bail "Activate failed."
+flowctl api activate --log.level=debug --build-id ${BUILD_ID} --all 1>>$TESTDIR/activate.stdout 2>>$TESTDIR/activate.stderr || bail "Activate failed."
 
 # allow writing tests for failure cases
 set +e

--- a/tests/source-test-no-state/flow.yaml
+++ b/tests/source-test-no-state/flow.yaml
@@ -30,6 +30,8 @@ captures:
           stream: greetings
           syncMode: incremental
         target: examples/greetings-no-state
+    shards:
+      logLevel: debug
 
 materializations:
   test/hello-world/ssh-postgresl:

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -8,8 +8,7 @@ networkTunnel:
     localPort: 16666
     forwardHost: localhost
     forwardPort: 2345
-    sshEndpoint: ssh://localhost:2222
-    user: flowssh
+    sshEndpoint: ssh://flowssh@localhost:2222
     privateKey: |2
       -----BEGIN OPENSSH PRIVATE KEY-----
       b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn


### PR DESCRIPTION
Reverts estuary/flow#532
Is re-deployment of #528 

- Switches from using `thrussh` to shelling out to OpenSSH binaries (`ssh`) for creating a network tunnel
- This means it is now necessary for connectors to have OpenSSH installed. This is done in https://github.com/estuary/connectors/pull/258.
- This changes the config spec, since now the user is part of the `ssh_endpoint` instead of being a separate key. Updates docs to mention the change in `ssh_endpoint`
- Also added a new cache action which reduces the total build time by about 40-50%, from ~45m to ~28m.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/535)
<!-- Reviewable:end -->
