### PR TITLE
Use logger instead of `fmt.Printf`

### DIFF
--- a/go/flow/js_worker.go
+++ b/go/flow/js_worker.go
@@ -38,6 +38,7 @@ func NewJSWorker(packageTgz []byte) (*JSWorker, error) {
 	// Bootstrap a Node package with the installed pack.
 	var cmd = exec.Command("npm", "install", packagePath)
 	cmd.Dir = tempdir
+	// TODO: Should we be directly piping npm outputs to the OS? Should these go to ops/ logs and/or logrus logs instead?
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM}
@@ -93,6 +94,7 @@ func StartCmdAndReadReady(dir, socketPath string, setpgid bool, args ...string) 
 
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "SOCKET_PATH="+socketPath)
+	// TODO: Should we be directly piping npm outputs to the OS? Should these go to ops/ logs and/or logrus logs instead?
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &readyWriter{delegate: os.Stderr, ch: readyCh}
 

--- a/go/flowctl-go/cmd-api-activate.go
+++ b/go/flowctl-go/cmd-api-activate.go
@@ -100,11 +100,7 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 			return fmt.Errorf("applying capture %q: %w", spec.Capture, err)
 		}
 
-		if response.ActionDescription != "" {
-			fmt.Println("Applying capture ", spec.Capture, ":")
-			fmt.Println(response.ActionDescription)
-		}
-		log.WithFields(log.Fields{"name": spec.Capture}).
+		log.WithFields(log.Fields{"name": spec.Capture, "actionDescription": response.ActionDescription}).
 			Info("applied capture to endpoint")
 	}
 
@@ -131,11 +127,7 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 			return fmt.Errorf("applying materialization %q: %w", spec.Materialization, err)
 		}
 
-		if response.ActionDescription != "" {
-			fmt.Println("Applying materialization ", spec.Materialization, ":")
-			fmt.Println(response.ActionDescription)
-		}
-		log.WithFields(log.Fields{"name": spec.Materialization}).
+		log.WithFields(log.Fields{"name": spec.Materialization, "actionDescription": response.ActionDescription}).
 			Info("applied materialization to endpoint")
 	}
 

--- a/go/flowctl-go/cmd-api-build.go
+++ b/go/flowctl-go/cmd-api-build.go
@@ -83,8 +83,7 @@ func (cmd apiBuild) execute(ctx context.Context) error {
 
 	for _, be := range errors {
 		var path, ptr = scopeToPathAndPtr(args.Directory, be.Scope)
-		fmt.Println(yellow(path), "error at", red(ptr), ":")
-		fmt.Println(be.Error)
+		log.WithFields(log.Fields{"path": path, "ptr": ptr}).Error(be.Error)
 	}
 	if len(errors) != 0 {
 		return fmt.Errorf("%d build errors", len(errors))

--- a/go/flowctl-go/cmd-api-delete.go
+++ b/go/flowctl-go/cmd-api-delete.go
@@ -99,12 +99,7 @@ func (cmd apiDelete) execute(ctx context.Context) error {
 			return fmt.Errorf("deleting capture %q: %w", spec.Capture, err)
 		}
 
-		if response.ActionDescription != "" {
-			fmt.Println("Deleting capture ", spec.Capture, ":")
-			fmt.Println(response.ActionDescription)
-		}
-
-		log.WithFields(log.Fields{"name": spec.Capture}).
+		log.WithFields(log.Fields{"name": spec.Capture, "actionDescription": response.ActionDescription}).
 			Info("deleted capture from endpoint")
 	}
 
@@ -131,12 +126,7 @@ func (cmd apiDelete) execute(ctx context.Context) error {
 			return fmt.Errorf("deleting materialization %q: %w", spec.Materialization, err)
 		}
 
-		if response.ActionDescription != "" {
-			fmt.Println("Deleting materialization ", spec.Materialization, ":")
-			fmt.Println(response.ActionDescription)
-		}
-
-		log.WithFields(log.Fields{"name": spec.Materialization}).
+		log.WithFields(log.Fields{"name": spec.Materialization, "actionDescription": response.ActionDescription}).
 			Info("deleted materialization from endpoint")
 	}
 

--- a/go/flowctl-go/cmd-deploy.go
+++ b/go/flowctl-go/cmd-deploy.go
@@ -92,9 +92,9 @@ func (cmd cmdDeploy) Execute(_ []string) (retErr error) {
 	var sigCh = make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
-	fmt.Println("Deployment done. Waiting for Ctrl-C to clean up and exit.")
+	log.Warn("Deployment done. Waiting for Ctrl-C to clean up and exit.")
 	<-sigCh
-	fmt.Println("Signaled to exit. Cleaning up deployment.")
+	log.Warn("Signaled to exit. Cleaning up deployment.")
 
 	// Delete derivations and collections from the local dataplane.
 	var delete = apiDelete{
@@ -108,6 +108,6 @@ func (cmd cmdDeploy) Execute(_ []string) (retErr error) {
 		return err
 	}
 
-	fmt.Println("All done.")
+	log.Warn("All done.")
 	return nil
 }

--- a/go/flowctl-go/cmd-temp-data-plane.go
+++ b/go/flowctl-go/cmd-temp-data-plane.go
@@ -61,16 +61,16 @@ func (cmd cmdTempDataPlane) Execute(_ []string) error {
 		return fmt.Errorf("starting data plane: %w", err)
 	}
 
-	fmt.Printf("export BROKER_ADDRESS=%s\n", brokerAddr)
-	fmt.Printf("export CONSUMER_ADDRESS=%s\n", consumerAddr)
+	log.Info("export BROKER_ADDRESS=", brokerAddr)
+	log.Info("export CONSUMER_ADDRESS=", consumerAddr)
 
 	<-sigCh
-	fmt.Println("Stopping the temp-data-plane.")
+	log.Info("Stopping the temp-data-plane.")
 
 	if cmd.Sigterm {
 		time.AfterFunc(time.Second, func() {
-			fmt.Println("The data plane is taking a while to stop after SIGTERM.")
-			fmt.Println("Ctrl-C again to SIGKILL.")
+			log.Warn("The data plane is taking a while to stop after SIGTERM.")
+			log.Warn("Ctrl-C again to SIGKILL.")
 
 			<-sigCh
 			cmd.kill()


### PR DESCRIPTION
**Description:**

When testing out some [json log formatting scenarios](https://github.com/estuary/flow/issues/537), I noticed there were quite a few things that were being directly output to the console, rather than going through the logger. This doesn't play nicely with parsing the logs as jsonl.

The fix was simply replace `fmt.Printf` with appropriate log statements.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

I'm curious what we should be doing with the output from the node processes. This still bypasses the logger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/538)
<!-- Reviewable:end -->
