### PR TITLE
connector_proxy: bubble up exit status errors from airbyte connectors

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -175,7 +175,7 @@ pub async fn run_airbyte_source_connector(
             if tp_receiver.await.unwrap() {
                 // We generate a synthetic commit now, and the empty checkpoint means the assumed behavior
                 // of the next invocation will be "full refresh".
-                tracing::warn!("connector exited without writing a final state checkpoint, flushing the driver checkpoint.");
+                tracing::warn!("connector exited without writing a final state checkpoint, writing an empty object {{}} merge patch driver checkpoint.");
                 let mut resp = PullResponse::default();
                 resp.checkpoint = Some(DriverCheckpoint {
                     driver_checkpoint_json: b"{}".to_vec(),

--- a/tests/end-to-end.expected
+++ b/tests/end-to-end.expected
@@ -723,7 +723,7 @@ examples/hello-world/views
 examples/source-hello-world
 examples/source-hello-world-no-state
 no_state_driver_checkpoint_flush:
-examples/source-hello-world-no-state|warn|connector exited without writing a final state checkpoint, flushing the driver checkpoint.
+examples/source-hello-world-no-state|warn|connector exited without writing a final state checkpoint, writing an empty object {} merge patch driver checkpoint.
 flow_stats:
 capture|examples/citi-bike/rides-from-s3
 capture|examples/source-hello-world


### PR DESCRIPTION
**Description:**

- Bubble up exit status errors from Airbyte connectors
- Regression from #512 🤦🏽 

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/540)
<!-- Reviewable:end -->
