### PR TITLE
captures: separate driver checkpoint update from log commit

### DIFF
--- a/go/protocols/capture/pull_client_test.go
+++ b/go/protocols/capture/pull_client_test.go
@@ -48,12 +48,14 @@ func TestPullClientLifecycle(t *testing.T) {
 	// It models the caller's expected behavior of producing captured documents
 	// into a collection upon notification.
 	var drain = func() string {
-		var combiner = rpc.Combiners()[0].(*pf.MockCombiner)
+		var combiners, checkpoint = rpc.PopTransaction()
+
+		var combiner = combiners[0].(*pf.MockCombiner)
 		var n = len(combiner.Combined)
 		captured = append(captured, combiner.Combined...)
 		combiner.Combined = nil
 
-		require.NoError(t, reducedCheckpoint.Reduce(rpc.DriverCheckpoint()))
+		require.NoError(t, reducedCheckpoint.Reduce(checkpoint))
 		return fmt.Sprintf("%d => %s", n, string(reducedCheckpoint.DriverCheckpointJson))
 	}
 

--- a/go/protocols/capture/push_server_test.go
+++ b/go/protocols/capture/push_server_test.go
@@ -37,11 +37,13 @@ func TestPushServerLifecycle(t *testing.T) {
 	// drain takes Combined documents from the MockCombiner, appending them into
 	// |captured|, and reduces the driver checkpoint into |reducedCheckpoint|.
 	var drain = func() {
-		var combiner = push.Combiners()[0].(*pf.MockCombiner)
+		var combiners, checkpoint = push.PopTransaction()
+
+		var combiner = combiners[0].(*pf.MockCombiner)
 		captured = append(captured, combiner.Combined...)
 		combiner.Combined = nil
 
-		require.NoError(t, reducedCheckpoint.Reduce(push.DriverCheckpoint()))
+		require.NoError(t, reducedCheckpoint.Reduce(checkpoint))
 	}
 
 	// Start Serve() delivering into |startCommitCh|.

--- a/go/runtime/connector_store_test.go
+++ b/go/runtime/connector_store_test.go
@@ -12,41 +12,45 @@ import (
 	"go.gazette.dev/core/broker/client"
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/brokertest"
+	"go.gazette.dev/core/consumer"
 	"go.gazette.dev/core/consumer/recoverylog"
 	"go.gazette.dev/core/etcdtest"
 )
 
 func TestConnectorInitializationAndStateUpdates(t *testing.T) {
-	testWithConnectorStore(t, nil, func(t *testing.T, cs connectorStore) {
+	testWithConnectorStore(t, nil, func(t *testing.T, cs *consumer.JSONFileStore) {
 
 		// A new connector store initializes with an empty state.
-		require.Equal(t, json.RawMessage(nil), cs.delegate.State.(*storeState).DriverCheckpoint)
-		require.Equal(t, json.RawMessage("{}"), cs.driverCheckpoint())
+		require.Equal(t, json.RawMessage(nil), cs.State.(*storeState).DriverCheckpoint)
+		require.Equal(t, json.RawMessage("{}"), loadDriverCheckpoint(cs))
 
-		var cp, err = cs.restoreCheckpoint(nil)
+		var cp, err = cs.RestoreCheckpoint(nil)
 		require.NoError(t, err)
 		require.Empty(t, cp.Sources)
 
 		// Patch and commit the state.
-		require.NoError(t, cs.startCommit(nil, cp, pf.DriverCheckpoint{
+		require.NoError(t, updateDriverCheckpoint(cs, pf.DriverCheckpoint{
 			DriverCheckpointJson: []byte(`{"k1":"v1","n":null}`),
 			Rfc7396MergePatch:    true,
-		}, nil).Err())
-		require.Equal(t, `{"k1":"v1"}`, string(cs.driverCheckpoint()))
+		}))
+		require.NoError(t, cs.StartCommit(nil, cp, nil).Err())
+		require.Equal(t, `{"k1":"v1"}`, string(loadDriverCheckpoint(cs)))
 
 		// A non-merged patch replaces the current checkpoint.
-		require.NoError(t, cs.startCommit(nil, cp, pf.DriverCheckpoint{
+		require.NoError(t, updateDriverCheckpoint(cs, pf.DriverCheckpoint{
 			DriverCheckpointJson: []byte(`{"expect":"k1-is-dropped"}`),
 			Rfc7396MergePatch:    false,
-		}, nil).Err())
-		require.Equal(t, `{"expect":"k1-is-dropped"}`, string(cs.driverCheckpoint()))
+		}))
+		require.NoError(t, cs.StartCommit(nil, cp, nil).Err())
+		require.Equal(t, `{"expect":"k1-is-dropped"}`, string(loadDriverCheckpoint(cs)))
 
 		// Empty non-patch update clears a current state.
-		require.NoError(t, cs.startCommit(nil, cp, pf.DriverCheckpoint{
+		require.NoError(t, updateDriverCheckpoint(cs, pf.DriverCheckpoint{
 			DriverCheckpointJson: nil,
 			Rfc7396MergePatch:    false,
-		}, nil).Err())
-		require.Equal(t, json.RawMessage(`{}`), cs.driverCheckpoint())
+		}))
+		require.NoError(t, cs.StartCommit(nil, cp, nil).Err())
+		require.Equal(t, `{}`, string(loadDriverCheckpoint(cs)))
 	})
 }
 
@@ -54,10 +58,10 @@ func TestConnectorWithNilStateFixture(t *testing.T) {
 	// Offsets, followed by state, followed by checkpoint. See NewJSONFileStore.
 	var fixture = "{}\n{\"driverCheckpoint\":null}\n{}\n"
 
-	testWithConnectorStore(t, []byte(fixture), func(t *testing.T, cs connectorStore) {
+	testWithConnectorStore(t, []byte(fixture), func(t *testing.T, cs *consumer.JSONFileStore) {
 		// Expect nil-ness of the driver checkpoint was restored.
-		require.Equal(t, json.RawMessage(nil), cs.delegate.State.(*storeState).DriverCheckpoint)
-		require.Equal(t, json.RawMessage("{}"), cs.driverCheckpoint())
+		require.Equal(t, json.RawMessage(nil), cs.State.(*storeState).DriverCheckpoint)
+		require.Equal(t, `{}`, string(loadDriverCheckpoint(cs)))
 	})
 }
 
@@ -65,12 +69,12 @@ func TestConnectorWithNonNilStateFixture(t *testing.T) {
 	// Offsets, followed by state, followed by checkpoint. See NewJSONFileStore.
 	var fixture = "{}\n{\"driverCheckpoint\":{\"foo\":42}}\n{}\n"
 
-	testWithConnectorStore(t, []byte(fixture), func(t *testing.T, cs connectorStore) {
-		require.Equal(t, json.RawMessage(`{"foo":42}`), cs.driverCheckpoint())
+	testWithConnectorStore(t, []byte(fixture), func(t *testing.T, cs *consumer.JSONFileStore) {
+		require.Equal(t, `{"foo":42}`, string(loadDriverCheckpoint(cs)))
 	})
 }
 
-func testWithConnectorStore(t *testing.T, fixture []byte, fn func(*testing.T, connectorStore)) {
+func testWithConnectorStore(t *testing.T, fixture []byte, fn func(*testing.T, *consumer.JSONFileStore)) {
 	var etcd = etcdtest.TestClient()
 	defer etcdtest.Cleanup()
 


### PR DESCRIPTION
Not all recovery log commits necessarily imply an updated driver
checkpoint. Refactor the capture runtime to update driver checkpoints
within ConsumeMessage, rather than StartCommit.

Update the capture protocol to make these semantics clearer and harder
to mis-use.

Manually tested with a capture that exits EOF without writing a
checkpoint.

Fixes #541

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/542)
<!-- Reviewable:end -->
