### PR TITLE
network-tunnel: mark ssh private key as secret field

### DIFF
--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -48,6 +48,7 @@ fn private_key_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::sc
         "type": "string",
         // This annotation is interpreted by the UI to render this as a multiline input.
         "multiline": true,
+        "secret": true
     }))
     .unwrap()
 }


### PR DESCRIPTION
**Description:**

- Mark private key field as `secret`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/546)
<!-- Reviewable:end -->
