### PR TITLE
validation: Add short link to CollectionKeyEmpty error

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -55,7 +55,7 @@ pub enum Error {
     },
     #[error("referenced schema fragment location {schema} does not exist")]
     NoSuchSchema { schema: Url },
-    #[error("collection {collection} key cannot be empty")]
+    #[error("collection {collection} key cannot be empty (https://go.estuary.dev/Zq6zVB)")]
     CollectionKeyEmpty { collection: String },
     #[error("collection {collection} schema must be an object")]
     CollectionSchemaNotObject { collection: String },

--- a/crates/validation/tests/snapshots/scenario_tests__collection_key_empty.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__collection_key_empty.snap
@@ -6,6 +6,6 @@ expression: errors
 [
     Error {
         scope: test://example/int-string#/collections/testing~1int-string,
-        error: collection testing/int-string key cannot be empty,
+        error: collection testing/int-string key cannot be empty (https://go.estuary.dev/Zq6zVB),
     },
 ]


### PR DESCRIPTION
**Description:**

Adds a short link to the `CollectionKeyEmpty` error text. The new short link https://go.estuary.dev/Zq6zVB points at https://docs.estuary.dev/concepts/collections/#empty-keys which should hopefully give the user enough context to understand how to fix things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/547)
<!-- Reviewable:end -->
