### PR TITLE
tests/end-to-end: set default PGPASSWORD=flow if not set

### DIFF
--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -20,6 +20,7 @@ function bail() {
 TEST=$1
 # Root of the running test
 TEST_ROOT="${ROOTDIR}/tests/${TEST}"
+PGPASSWORD=${PGPASSWORD:-flow}
 
 # Temporary test directory into which we'll build our test database,
 # and stage temporary data plane files.


### PR DESCRIPTION
**Description:**

- The default `PGPASSWORD` can be set to `flow`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

