### PR TITLE
Better Generated Go Schemas

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -1,5 +1,5 @@
 use crate::apis::{FlowCaptureOperation, FlowMaterializeOperation, InterceptorStream};
-use crate::errors::{create_custom_error, raise_err, Error};
+use crate::errors::{create_custom_error, Error};
 use crate::interceptors::{
     airbyte_source_interceptor::AirbyteSourceInterceptor,
     network_tunnel_capture_interceptor::NetworkTunnelCaptureInterceptor,

--- a/go/materialize/driver/sqlite/.snapshots/TestSpecification
+++ b/go/materialize/driver/sqlite/.snapshots/TestSpecification
@@ -9,8 +9,8 @@
         "type": "string"
       }
     },
-    "additionalProperties": false,
-    "type": "object"
+    "type": "object",
+    "title": "SQL Connection"
   },
   "resource_spec_schema_json": {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -22,8 +22,8 @@
         "type": "string"
       }
     },
-    "additionalProperties": false,
-    "type": "object"
+    "type": "object",
+    "title": "SQL Table"
   },
   "documentation_url": "https://docs.estuary.dev/#FIXME"
 }

--- a/go/protocols/materialize/go-schema-gen/generate.go
+++ b/go/protocols/materialize/go-schema-gen/generate.go
@@ -1,0 +1,55 @@
+package schemagen
+
+import (
+	"reflect"
+
+	"github.com/alecthomas/jsonschema"
+)
+
+/// WARNING: This file is copied from github.com/estuary/connectors/go-schema-gen/generate.go.
+///
+/// We have a few schema generation fixes that we need to be applied to our
+/// connector schemas. However, sql-based materialization connectors delegate to
+/// the sql/driver package to generate it schema. Until we move sql/driver out
+/// of the flow repo (planned), we'll need to copy this behavior here so that we
+/// can properly mark schema fields as `secret`/`advanced`.
+
+func GenerateSchema(title string, configObject interface{}) *jsonschema.Schema {
+	// By default, the library generates schemas with a top-level $ref that references a definition.
+	// That breaks UI code that tries to generate forms from the schemas, and is just weird and
+	// silly anyway. While we're at it, we just disable references altogether, since they tend to
+	// hurt readability more than they help for these schemas.
+	var reflector = jsonschema.Reflector{
+		ExpandedStruct: true,
+		DoNotReference: true,
+	}
+	var schema = reflector.ReflectFromType(reflect.TypeOf(configObject))
+	schema.AdditionalProperties = nil // Unset means additional properties are permitted on the root object, as they should be
+	schema.Definitions = nil          // Since no references are used, these definitions are just noise
+	schema.Title = title
+	fixSchemaFlagBools(schema.Type, "secret", "advanced", "multiline")
+	return schema
+}
+
+func fixSchemaFlagBools(t *jsonschema.Type, flagKeys ...string) {
+	if t.Properties != nil {
+		for _, key := range t.Properties.Keys() {
+			if p, ok := t.Properties.Get(key); ok {
+				if p, ok := p.(*jsonschema.Type); ok {
+					fixSchemaFlagBools(p, flagKeys...)
+				}
+			}
+		}
+	}
+	for key, val := range t.Extras {
+		for _, flag := range flagKeys {
+			if key != flag {
+				continue
+			} else if val == "true" {
+				t.Extras[key] = true
+			} else if val == "false" {
+				t.Extras[key] = false
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Description:**

There are a few materialization connectors that currently aren't marking their secret fields as `secret`.

Unfortunately this wasn't as simple as adding `secret: true` to their schemas. The connectors which use the `sql/driver` package rely on it to generate their spec schemas. This package was missing the fixes for boolean schemas we already have in the connectors repo. While we'd like to eventually move the `sql/driver` package over to the connectors repo, there's a bit more untangling to do for that. In the meantime, we'll just copy these two functions over to `flow` so that we can correctly serialize the schemas in the materialization connectors.

**Workflow steps:**

1. Merge this PR
2. Bump the flow dependency in the connectors repo
3. Rebuild the affected images
4. `flowctl-go api spec --image=ghcr.io/estuary/materialize-snowflake | jq .endpointSpecSchema.properties.password'`

**Documentation links affected:**

N/A

**Notes for reviewers:**

I've tested this change out locally, but the connectors change needs to contain the version bump.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/553)
<!-- Reviewable:end -->
