### PR TITLE
relax `api delete` to remove named shards in all cases

### DIFF
--- a/go/flow/.snapshots/TestConvergence-list-partitions-at-build-request
+++ b/go/flow/.snapshots/TestConvergence-list-partitions-at-build-request
@@ -1,1 +1,0 @@
-(protocol.ListRequest) selector:<include:<labels:<name:"estuary.dev/build" value:"bar-build" > labels:<name:"estuary.dev/collection" value:"example/collection" > > exclude:<> > 

--- a/go/flow/.snapshots/TestConvergence-list-recovery-logs-request
+++ b/go/flow/.snapshots/TestConvergence-list-recovery-logs-request
@@ -1,1 +1,1 @@
-(protocol.ListRequest) selector:<include:<labels:<name:"estuary.dev/task-name" value:"example/derivation" > labels:<name:"estuary.dev/task-type" value:"derivation" > > exclude:<> > 
+(protocol.ListRequest) selector:<include:<labels:<name:"content-type" value:"application/x-gazette-recoverylog" > labels:<name:"estuary.dev/task-name" value:"example/derivation" > labels:<name:"estuary.dev/task-type" value:"derivation" > > exclude:<> > 

--- a/go/flow/.snapshots/TestConvergence-list-shards-at-build-request
+++ b/go/flow/.snapshots/TestConvergence-list-shards-at-build-request
@@ -1,1 +1,0 @@
-(protocol.ListRequest) selector:<include:<labels:<name:"estuary.dev/build" value:"foo-build" > labels:<name:"estuary.dev/task-name" value:"example/derivation" > labels:<name:"estuary.dev/task-type" value:"derivation" > > exclude:<> > 

--- a/go/flow/converge.go
+++ b/go/flow/converge.go
@@ -12,6 +12,7 @@ import (
 	pb "go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/consumer"
 	pc "go.gazette.dev/core/consumer/protocol"
+	glabels "go.gazette.dev/core/labels"
 )
 
 // ListShardsRequest builds a ListRequest of the Task's shards.
@@ -26,24 +27,12 @@ func ListShardsRequest(task pf.Task) pc.ListRequest {
 	}
 }
 
-// ListShardsAtBuildRequest builds a ListRequest of the Task's shards which are at the given |buildID|.
-func ListShardsAtBuildRequest(task pf.Task, buildID string) pc.ListRequest {
-	return pc.ListRequest{
-		Selector: pb.LabelSelector{
-			Include: pb.MustLabelSet(
-				labels.Build, buildID,
-				labels.TaskName, task.TaskName(),
-				labels.TaskType, taskType(task),
-			),
-		},
-	}
-}
-
 // ListRecoveryLogsRequest builds a ListRequest of the Tasks's recovery logs.
 func ListRecoveryLogsRequest(task pf.Task) pb.ListRequest {
 	return pb.ListRequest{
 		Selector: pb.LabelSelector{
 			Include: pb.MustLabelSet(
+				glabels.ContentType, glabels.ContentType_RecoveryLog,
 				labels.TaskName, task.TaskName(),
 				labels.TaskType, taskType(task),
 			),
@@ -56,18 +45,6 @@ func ListPartitionsRequest(collection *pf.CollectionSpec) pb.ListRequest {
 	return pb.ListRequest{
 		Selector: pf.LabelSelector{
 			Include: pb.MustLabelSet(labels.Collection, collection.Collection.String()),
-		},
-	}
-}
-
-// ListPartitionsAtBuildRequest builds a ListRequest of the collection's partitions at the given |buildID|.
-func ListPartitionsAtBuildRequest(collection *pf.CollectionSpec, buildID string) pb.ListRequest {
-	return pb.ListRequest{
-		Selector: pf.LabelSelector{
-			Include: pb.MustLabelSet(
-				labels.Build, buildID,
-				labels.Collection, collection.Collection.String(),
-			),
 		},
 	}
 }
@@ -417,15 +394,13 @@ func ActivationChanges(
 
 // DeletionChanges enumerates all shard and journal changes required to bring
 // a current data-plane state into consistency with the deletion of each of the
-// specified collections and tasks, expected to be at |buildID|. If a task ShardSpec
-// or partition JournalSpec isn't at |buildID|, then no deletion change is generated.
+// specified collections and tasks.
 func DeletionChanges(
 	ctx context.Context,
 	jc pb.JournalClient,
 	sc pc.ShardClient,
 	collections []*pf.CollectionSpec,
 	tasks []pf.Task,
-	buildID string,
 ) ([]pc.ApplyRequest_Change, []pb.ApplyRequest_Change, error) {
 
 	var shards []pc.ApplyRequest_Change
@@ -434,7 +409,7 @@ func DeletionChanges(
 	// TODO(johnny): We could parallelize this by scattering / gathering list requests.
 
 	for _, collection := range collections {
-		var resp, err = client.ListAllJournals(ctx, jc, ListPartitionsAtBuildRequest(collection, buildID))
+		var resp, err = client.ListAllJournals(ctx, jc, ListPartitionsRequest(collection))
 		if err != nil {
 			return nil, nil, fmt.Errorf("listing partitions of %s: %w", collection.Collection, err)
 		}
@@ -448,7 +423,7 @@ func DeletionChanges(
 	}
 
 	for _, task := range tasks {
-		var shardsReq = ListShardsAtBuildRequest(task, buildID)
+		var shardsReq = ListShardsRequest(task)
 		var logsReq = ListRecoveryLogsRequest(task)
 
 		shardsResp, err := consumer.ListShards(ctx, sc, &shardsReq)
@@ -460,26 +435,17 @@ func DeletionChanges(
 			return nil, nil, fmt.Errorf("listing recovery logs of %s: %w", task.TaskName(), err)
 		}
 
-		var logsIdx = make(map[pf.Journal]pb.ListResponse_Journal, len(logsResp.Journals))
-		for _, cur := range logsResp.Journals {
-			logsIdx[cur.Spec.Name] = cur
-		}
-
 		for _, cur := range shardsResp.Shards {
 			shards = append(shards, pc.ApplyRequest_Change{
 				Delete:            cur.Spec.Id,
 				ExpectModRevision: cur.ModRevision,
 			})
-			// If we're removing a shard, we remove its recovery log regardless of
-			// whether it's converged to the shard's same build ID. It definitely
-			// *should* be, but we don't allow the recovery log to dangle either way.
-
-			if log, ok := logsIdx[cur.Spec.RecoveryLog()]; ok {
-				journals = append(journals, pb.ApplyRequest_Change{
-					Delete:            log.Spec.Name,
-					ExpectModRevision: log.ModRevision,
-				})
-			}
+		}
+		for _, cur := range logsResp.Journals {
+			journals = append(journals, pb.ApplyRequest_Change{
+				Delete:            cur.Spec.Name,
+				ExpectModRevision: cur.ModRevision,
+			})
 		}
 	}
 	return shards, journals, nil

--- a/go/flow/converge_test.go
+++ b/go/flow/converge_test.go
@@ -124,11 +124,6 @@ func TestConvergence(t *testing.T) {
 		cupaloy.SnapshotT(t, out)
 	})
 
-	t.Run("list-shards-at-build-request", func(t *testing.T) {
-		var out = ListShardsAtBuildRequest(derivation, "foo-build")
-		cupaloy.SnapshotT(t, out)
-	})
-
 	t.Run("list-recovery-logs-request", func(t *testing.T) {
 		var out = ListRecoveryLogsRequest(derivation)
 		cupaloy.SnapshotT(t, out)
@@ -136,11 +131,6 @@ func TestConvergence(t *testing.T) {
 
 	t.Run("list-partitions-request", func(t *testing.T) {
 		var out = ListPartitionsRequest(collection)
-		cupaloy.SnapshotT(t, out)
-	})
-
-	t.Run("list-partitions-at-build-request", func(t *testing.T) {
-		var out = ListPartitionsAtBuildRequest(collection, "bar-build")
 		cupaloy.SnapshotT(t, out)
 	})
 
@@ -362,7 +352,7 @@ func TestConvergence(t *testing.T) {
 		var jc = &mockJournals{}
 		var sc = &mockShards{}
 
-		var shards, journals, err = DeletionChanges(ctx, jc, sc, []*pf.CollectionSpec{collection}, []pf.Task{derivation}, "fixture")
+		var shards, journals, err = DeletionChanges(ctx, jc, sc, []*pf.CollectionSpec{collection}, []pf.Task{derivation})
 		require.NoError(t, err)
 		cupaloy.SnapshotT(t, shards, journals)
 	})
@@ -383,7 +373,7 @@ func TestConvergence(t *testing.T) {
 			},
 		}
 
-		var shards, journals, err = DeletionChanges(ctx, jc, sc, []*pf.CollectionSpec{collection}, []pf.Task{derivation}, "fixture")
+		var shards, journals, err = DeletionChanges(ctx, jc, sc, []*pf.CollectionSpec{collection}, []pf.Task{derivation})
 		require.NoError(t, err)
 		cupaloy.SnapshotT(t, shards, journals)
 	})

--- a/go/flowctl-go/cmd-api-delete.go
+++ b/go/flowctl-go/cmd-api-delete.go
@@ -66,7 +66,7 @@ func (cmd apiDelete) execute(ctx context.Context) error {
 		return fmt.Errorf("extracting from build: %w", err)
 	}
 
-	shards, journals, err := flow.DeletionChanges(ctx, rjc, sc, collections, tasks, cmd.BuildID)
+	shards, journals, err := flow.DeletionChanges(ctx, rjc, sc, collections, tasks)
 	if err != nil {
 		return err
 	}

--- a/go/testing/driver.go
+++ b/go/testing/driver.go
@@ -431,14 +431,13 @@ func CombineDocuments(
 }
 
 // Initialize fetches existing collection offsets from the cluster,
-// models them as completed ingestions, and ensures all downstream dataflows have
+// models each as a completed ingestion, and ensures all downstream data-flows have
 // completed. On its return, the internal write clock of the Graph reflects the
 // current cluster state.
 func Initialize(ctx context.Context, driver *ClusterDriver, graph *Graph) error {
 	for _, collection := range driver.collections {
 		// List journals of the collection.
-		list, err := client.ListAllJournals(ctx, driver.rjc,
-			flow.ListPartitionsAtBuildRequest(collection, driver.buildID))
+		list, err := client.ListAllJournals(ctx, driver.rjc, flow.ListPartitionsRequest(collection))
 		if err != nil {
 			return fmt.Errorf("listing journals of %s: %w", collection.Collection, err)
 		}


### PR DESCRIPTION
**Description:**

Do not explicitly require they match on --build-id,
though we continue to *expect* that this is the case.

We were not explicitly checking build IDs of updated shards, so it seems
a bit silly to do it only for deletions.

In any case this level of transactional checking is now the
responsibility of the control plane. KISS.

Issue estuary/animated-carnival#24

Tested in combination with estuary/animated-carnival#25:
  * Started a local control-plane + data-plane, with a side Postgres DB
  * Create a capture and multiple materializations over a period of time,
    with staggered deletions of materializations while creating others.
  * Deleted all remaining tasks, and verified that all ApplyDelete RPCs
    were run and all shards were removed, leaving an empty data-plane.

**Workflow steps:**

No user-facing changes.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/554)
<!-- Reviewable:end -->
