### PR TITLE
Doc updates for SSH, postgres, mysql

### DIFF
--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -19,12 +19,18 @@ basic configuration options.
 
 2. Referencing the config files and shell output, collect the following information:
 
-   * The **SSH endpoint** for the SSH server, formatted as `ssh://user@hostname[:port]`. This may look like the any of following:
+  * The SSH **user**, which will be used to log into the SSH server, for example, `sshuser`. You may choose to create a new
+  user for this workflow.
+  * The **SSH endpoint** for the SSH server, formatted as `ssh://user@hostname[:port]`. This may look like the any of following:
      * `ssh://sshuser@ec2-198-21-98-1.compute-1.amazonaws.com`
      * `ssh://sshuser@198.21.98.1`
      * `ssh://sshuser@198.21.98.1:22`
-   * The SSH **user**, which will be used to log into the SSH server, for example, `sshuser`. You may choose to create a new
-  user for this workflow.
+     :::info Hint
+     The [SSH default port is 22](https://www.ssh.com/academy/ssh/port).
+     Depending on where your server is hosted, you may not be required to specify a port,
+     but we recommend specifying `:22` in all cases to ensure a connection can be made.
+     :::
+
 
 3. In the `.ssh` subdirectory of your user home directory,
    look for the PEM file that contains the private SSH key. Check that it starts with `-----BEGIN RSA PRIVATE KEY-----`,
@@ -116,7 +122,7 @@ Note the generated address.
 6. Find and note the host and port for your capture or materialization endpoint.
   :::tip
   For database instances hosted in Google Cloud SQL, you can find the host in the Cloud Console as Public IP Address.
-  Use `5432` as the port.
+  Use `5432` as the port for PostgreSQL, and `3306` for MySQL.
   :::
 
 7. Choose an open port on your localhost from which you'll connect to the SSH server.
@@ -153,7 +159,7 @@ note that instructions for other database engines may be different.
 
 4. Find and note the host and port for your capture or materialization endpoint.
   :::tip
-  For database instances hosted in Azure, you can find the host as Server Name, and the port under Connection Strings (usually `5432`).
+  For database instances hosted in Azure, you can find the host as Server Name, and the port under Connection Strings (`5432` for PostgreSQL and `3306` for MySql).
   :::
 
 5. Choose an open port on your localhost from which you'll connect to the SSH server.
@@ -163,6 +169,11 @@ note that instructions for other database engines may be different.
 After you've completed the prerequisites, you should have the following parameters:
 
 * **SSH Endpoint** / `sshEndpoint`: the SSH server's hostname, or public IP address, formatted as `ssh://user@hostname[:port]`
+     :::info Hint
+     The [SSH default port is 22](https://www.ssh.com/academy/ssh/port).
+     Depending on where your server is hosted, you may not be required to specify a port,
+     but we recommend specifying `:22` in all cases to ensure a connection can be made.
+     :::
 * **Private Key** / `privateKey`: the contents of the PEM file
 * **Forward Host** / `forwardHost`: the capture or materialization endpoint's host
 * **Forward Port** / `forwardPort`: the capture or materialization endpoint's port


### PR DESCRIPTION
**Description:**

Per feedback from @dyaffe, these updates include:

SSH setup guide
- Instruct user to specify port 22 for ssh_endpoint
- Correct misleading notes referring to port 5432 - elaborate that 5432 is Postgres and 3306 is mysql

Source-postgres
- correct azure setup steps
- ensure that user connects to the correct instance before performing queries
- distinguish Postgres v14 queries from previous versions for cloud platforms (see note below)

Source-mysql
- Add setup steps for azure
- Add setup steps for google cloud

**Notes for reviewers:**

Regarding v14 vs previous version queries for postgres:

As a non-sql-expert, I had some trouble parsing out which queries, exactly, in the pre-v-14 versions for Google Cloud and Amazon steps would be replaced by `GRANT pg_read_all_data `. So, that change was not made there. 

I'm under the impression that `pg_read_all_data` is a new, convenient and pre-defined role, so those old-version commands should still work for all versions, anyway (?). Regardless, the queries could probably use a good review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/558)
<!-- Reviewable:end -->
