### PR TITLE
crates/build: don't generate TS package if there are validation failures

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -181,8 +181,8 @@ pub enum Error {
         rhs_scope: Url,
     },
 
-    #[error(transparent)]
-    SchemaBuild(#[from] json::schema::build::Error),
+    #[error("one or more JSON schemas has errors which prevent further validation checks")]
+    SchemaBuild,
     #[error(transparent)]
     SchemaIndex(#[from] json::schema::index::Error),
     #[error(transparent)]

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -57,8 +57,8 @@ pub async fn validate<D: Drivers>(
 
     let compiled_schemas = match tables::Resource::compile_all_json_schemas(resources) {
         Ok(c) => c,
-        Err(err) => {
-            Error::from(err).push(root_scope, &mut errors);
+        Err(_) => {
+            Error::SchemaBuild.push(root_scope, &mut errors);
 
             return tables::Validations {
                 errors,


### PR DESCRIPTION
Generating TypeScript types can fail if there are user schema errors.
Only proceed if validation is successful.

Tested manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/560)
<!-- Reviewable:end -->
