### PR TITLE
Docs: amplitude, intercom, stripe, zendesk support

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
 ---
 
 This is a change data capture (CDC) connector that captures change events from a MySQL database via the [Binary Log](https://dev.mysql.com/doc/refman/8.0/en/binary-log.html).

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 ---
 This connector uses change data capture (CDC) to continuously capture updates in a PostgreSQL database into one or more Flow collections.
 
@@ -41,7 +41,7 @@ CREATE USER flow_capture WITH PASSWORD 'secret' REPLICATION;
 ```
 2. Assign the appropriate role.
     1. If using PostgreSQL v14 or later:
-    
+
     ```sql
     GRANT pg_read_all_data TO flow_capture;
     ```

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -14,6 +14,9 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * Amazon S3
   * [Configuration](./amazon-s3.md)
   * Package — ghcr.io/estuary/source-s3:dev
+* Amplitude
+  * [Configuration](./amplitude.md)
+  * Package - ghcr.io/estuary/airbyte-source-amplitude:dev
 * Apache Kafka
   * [Configuration](./apache-kafka.md)
   * Package — ghcr.io/estuary/source-kafka:dev
@@ -35,6 +38,9 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * Hubspot
   * [Configuration](./hubspot.md)
   * Package - ghcr.io/estuary/airbyte-source-hubspot:dev
+* Intercom
+  * [Configuration](./intercom.md)
+  * Package - ghcr.io/estuary/airbyte-source-intercom:dev
 * Mailchimp
   * [Configuration](./mailchimp.md)
   * Package - ghcr.io/estuary/airbyte-source-mailchimp:dev
@@ -44,3 +50,9 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * PostgreSQL
   * [Configuration](./PostgreSQL.md)
   * Package — ghcr.io/estuary/source-postgres:dev
+* Stripe
+  * [Configuration](./stripe.md)
+  * Package - ghcr.io/estuary/airbyte-source-stripe:dev
+* Zendesk Support
+  * [Configuration](./zendesk-support.md)
+  * Package - ghcr.io/estuary/airbyte-source-zendesk-support:dev

--- a/site/docs/reference/Connectors/capture-connectors/amplitude.md
+++ b/site/docs/reference/Connectors/capture-connectors/amplitude.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 3
+---
+
+# Amplitude
+
+This connector captures data from Amplitude into Flow collections.
+
+[`ghcr.io/estuary/airbyte-source-amplitude:dev`](https://ghcr.io/estuary/airbyte-source-amplitude:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/amplitude/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported through the Amplitude APIs:
+
+* [Active User Counts](https://developers.amplitude.com/docs/dashboard-rest-api#active-and-new-user-counts)
+* [Annotations](https://developers.amplitude.com/docs/chart-annotations-api#get-all-annotations)
+* [Average Session Length](https://developers.amplitude.com/docs/dashboard-rest-api#average-session-length)
+* [Cohorts](https://developers.amplitude.com/docs/behavioral-cohorts-api#listing-all-cohorts)
+* [Events](https://developers.amplitude.com/docs/export-api#export-api---export-your-projects-event-data)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+* An Amplitude project with an [API Key and Secret Key](https://help.amplitude.com/hc/en-us/articles/360058073772-Create-and-manage-organizations-and-projects)
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog spec YAML.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and YAML sample below provide configuration details specific to the Facebook Marketing source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/api_key`** | API Key | Amplitude API Key. | string | Required |
+| **`/secret_key`** | Secret Key | Amplitude Secret Key. | string | Required |
+| **`/start_date`** | Replication Start Date | UTC date and time in the format 2021-01-25T00:00:00Z. Any data before this date will not be replicated. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Resource of your Amplitude project from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+```yaml
+
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/airbyte-source-amplitude:dev
+        config:
+            api_key: <secret>
+            secret_key: <secret>
+            start_date: 2022-06-18T00:00:00Z
+    bindings:
+      - resource:
+          stream: cohorts
+          syncMode: full_refresh
+        target: ${PREFIX}/cohorts
+      - resource:
+          stream: annotations
+          syncMode: full_refresh
+        target: ${PREFIX}/annotations
+      - resource:
+          stream: events
+          syncMode: incremental
+        target: ${PREFIX}/events
+      - resource:
+          stream: active_users
+          syncMode: incremental
+        target: ${PREFIX}/activeusers
+      - resource:
+          stream: average_session_length
+          syncMode: incremental
+        target: ${PREFIX}/averagesessionlength
+```

--- a/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
+++ b/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 # Apache Kafka
 

--- a/site/docs/reference/Connectors/capture-connectors/exchange-rates.md
+++ b/site/docs/reference/Connectors/capture-connectors/exchange-rates.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Exchange Rates API

--- a/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
+++ b/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Facebook Marketing

--- a/site/docs/reference/Connectors/capture-connectors/gcs.md
+++ b/site/docs/reference/Connectors/capture-connectors/gcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 # Google Cloud Storage
 

--- a/site/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Google Analytics

--- a/site/docs/reference/Connectors/capture-connectors/google-sheets.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-sheets.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Google Sheets

--- a/site/docs/reference/Connectors/capture-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/capture-connectors/hubspot.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Hubspot

--- a/site/docs/reference/Connectors/capture-connectors/intercom.md
+++ b/site/docs/reference/Connectors/capture-connectors/intercom.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 11
+---
+
+# Intercom
+
+This connector captures data from Intercom into Flow collections.
+
+[`ghcr.io/estuary/airbyte-source-intercom:dev`](https://ghcr.io/estuary/airbyte-source-intercom:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/intercom/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported through the Intercom API:
+
+* [Admins](https://developers.intercom.com/intercom-api-reference/reference/list-admins)
+* [Companies](https://developers.intercom.com/intercom-api-reference/reference/list-companies)
+* [Company attributes](https://developers.intercom.com/intercom-api-reference/reference/list-data-attributes)
+* [Company segments](https://developers.intercom.com/intercom-api-reference/reference/list-attached-segments-1)
+* [Contacts](https://developers.intercom.com/intercom-api-reference/reference/list-contacts)
+* [Contact attributes](https://developers.intercom.com/intercom-api-reference/reference/list-data-attributes)
+* [Conversations](https://developers.intercom.com/intercom-api-reference/reference/list-conversations)
+* [Conversation parts](https://developers.intercom.com/intercom-api-reference/reference/retrieve-a-conversation)
+* [Segments](https://developers.intercom.com/intercom-api-reference/reference/list-segments)
+* [Tags](https://developers.intercom.com/intercom-api-reference/reference/list-tags-for-an-app)
+* [Teams](https://developers.intercom.com/intercom-api-reference/reference/list-teams)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+* The [access token](https://developers.intercom.com/building-apps/docs/authentication-types#section-how-to-get-your-access-token) for you Intercom account.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog spec YAML.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and YAML sample below provide configuration details specific to the Facebook Marketing source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/access_token`** | Access token | Access token for making authenticated requests. | string | Required |
+| **`/start_date`** | Start date | UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Resource from Intercom from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/airbyte-source-intercom:dev
+        config:
+            access_token: <secret>
+            start_date: 2022-06-18T00:00:00Z
+    bindings:
+      - resource:
+          stream: admins
+          syncMode: full_refresh
+        target: ${PREFIX}/admins
+      - resource:
+          stream: companies
+          syncMode: incremental
+        target: ${PREFIX}/companies
+      - resource:
+          stream: company_segments
+          syncMode: incremental
+        target: ${PREFIX}/companysegments
+      - resource:
+          stream: conversations
+          syncMode: incremental
+        target: ${PREFIX}/conversations
+      - resource:
+          stream: conversation_parts
+          syncMode: incremental
+        target: ${PREFIX}/conversationparts
+      - resource:
+          stream: contacts
+          syncMode: incremental
+        target: ${PREFIX}/contacts
+      - resource:
+          stream: company_attributes
+          syncMode: full_refresh
+        target: ${PREFIX}/companyattributes
+      - resource:
+          stream: contact_attributes
+          syncMode: full_refresh
+        target: ${PREFIX}/contactattributes
+      - resource:
+          stream: segments
+          syncMode: incremental
+        target: ${PREFIX}/segments
+      - resource:
+          stream: tags
+          syncMode: full_refresh
+        target: ${PREFIX}/tags
+      - resource:
+          stream: teams
+          syncMode: full_refresh
+        target: ${PREFIX}/teams
+```

--- a/site/docs/reference/Connectors/capture-connectors/mailchimp.md
+++ b/site/docs/reference/Connectors/capture-connectors/mailchimp.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 ---
 
 # Mailchimp

--- a/site/docs/reference/Connectors/capture-connectors/stripe.md
+++ b/site/docs/reference/Connectors/capture-connectors/stripe.md
@@ -1,0 +1,182 @@
+# Stripe
+
+This connector captures data from Stripe into Flow collections.
+
+[`ghcr.io/estuary/airbyte-source-stripe:dev`](https://ghcr.io/estuary/airbyte-source-stripe:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/stripe/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported through the Stripe API:
+
+* [Balance transactions](https://stripe.com/docs/api/balance_transactions/list)
+* [Bank accounts](https://stripe.com/docs/api/customer_bank_accounts/list)
+* [Charges](https://stripe.com/docs/api/charges/list)
+* [Checkout sessions](https://stripe.com/docs/api/checkout/sessions/list)
+* [Checkout sessions line items](https://stripe.com/docs/api/checkout/sessions/line_items)
+* [Coupons](https://stripe.com/docs/api/coupons/list)
+* [Customer balance transactions](https://stripe.com/docs/api/customer_balance_transactions/list)
+* [Customers](https://stripe.com/docs/api/customers/list)
+* [Disputes](https://stripe.com/docs/api/disputes/list)
+* [Events](https://stripe.com/docs/api/events/list)
+* [Invoice items](https://stripe.com/docs/api/invoiceitems/list)
+* [Invoice line items](https://stripe.com/docs/api/invoices/invoice_lines)
+* [Invoices](https://stripe.com/docs/api/invoices/list)
+* [Payment intents](https://stripe.com/docs/api/payment_intents/list)
+* [Payouts](https://stripe.com/docs/api/payouts/list)
+* [Plans](https://stripe.com/docs/api/plans/list)
+* [Products](https://stripe.com/docs/api/products/list)
+* [Promotion codes](https://stripe.com/docs/api/promotion_codes/list)
+* [Refunds](https://stripe.com/docs/api/refunds/list)
+* [Subscription items](https://stripe.com/docs/api/subscription_items/list)
+* [Subscriptions](https://stripe.com/docs/api/subscriptions/list)
+* [Transfers](https://stripe.com/docs/api/transfers/list)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+* [Account ID](https://stripe.com/docs/dashboard#find-account-id) of your Stripe account.
+* [Secret key](https://stripe.com/docs/keys#obtain-api-keys) for the Stripe API.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog spec YAML.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and YAML sample below provide configuration details specific to the Facebook Marketing source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/account_id`** | Account ID | Your Stripe account ID (starts with &#x27;acct&#x5F;&#x27;, find yours here https:&#x2F;&#x2F;dashboard.stripe.com&#x2F;settings&#x2F;account | string | Required |
+| **`/client_secret`** | Secret Key | Stripe API key (usually starts with &#x27;sk&#x5F;live&#x5F;&#x27;; find yours here https:&#x2F;&#x2F;dashboard.stripe.com&#x2F;apikeys | string | Required |
+| `/lookback_window_days` | Lookback Window in days (Optional) | When set, the connector will always re-export data from the past N days, where N is the value set here. This is useful if your data is frequently updated after creation. | integer | `0` |
+| **`/start_date`** | Replication start date | UTC date and time in the format 2017-01-25T00:00:00Z. Only data generated after this date will be replicated. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Resource from Stripe from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+
+### Choosing your start date and lookback window
+
+The connector will continually capture data beginning on the **Replication start date** you choose.
+
+However, some data from the Stripe API is mutable; for example, [a draft invoice can be completed](https://stripe.com/docs/billing/migration/invoice-states) at a later date than it was created.
+To account for this, it's useful to set the **Lookback Window**. When this is set, at a given point in time, the connector will not only look for new data;
+it will also capture changes made to data within the window.
+
+For example, if you start the connector with the start date of `2022-06-06T00:00:00Z` (June 6) and the lookback window of `3`, the connector will begin to capture data starting from June 3.
+As time goes on while the capture remains active, the lookback window rolls forward along with the current timestamp.
+On June 10, the connector will continue to monitor data starting from June 7 and capture any changes to that data, and so on.
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/airbyte-source-stripe:dev
+        config:
+            account_id: 00000000
+            client_secret: <secret>
+            start_date: 2022-06-18T00:00:00Z
+    bindings:
+      - resource:
+          stream: balance_transactions
+          syncMode: incremental
+        target: ${PREFIX}/balancetransactions
+      - resource:
+          stream: bank_accounts
+          syncMode: full_refresh
+        target: ${PREFIX}/bankaccounts
+      - resource:
+          stream: charges
+          syncMode: incremental
+        target: ${PREFIX}/charges
+      - resource:
+          stream: checkout_sessions
+          syncMode: incremental
+        target: ${PREFIX}/checkoutsessions
+      - resource:
+          stream: checkout_sessions_line_items
+          syncMode: incremental
+        target: ${PREFIX}/checkoutsessionslineitems
+      - resource:
+          stream: coupons
+          syncMode: incremental
+        target: ${PREFIX}/coupons
+      - resource:
+          stream: customer_balance_transactions
+          syncMode: full_refresh
+        target: ${PREFIX}/customerbalancetransactions
+      - resource:
+          stream: customers
+          syncMode: incremental
+        target: ${PREFIX}/customers
+      - resource:
+          stream: disputes
+          syncMode: incremental
+        target: ${PREFIX}/disputes
+      - resource:
+          stream: events
+          syncMode: incremental
+        target: ${PREFIX}/events
+      - resource:
+          stream: invoice_items
+          syncMode: incremental
+        target: ${PREFIX}/invoice_items
+      - resource:
+          stream: invoice_line_items
+          syncMode: full_refresh
+        target: ${PREFIX}/invoicelineitems
+      - resource:
+          stream: invoices
+          syncMode: incremental
+        target: ${PREFIX}/invoices
+      - resource:
+          stream: payment_intents
+          syncMode: incremental
+        target: ${PREFIX}/paymentintents
+      - resource:
+          stream: payouts
+          syncMode: incremental
+        target: ${PREFIX}/payouts
+      - resource:
+          stream: plans
+          syncMode: incremental
+        target: ${PREFIX}/plans
+      - resource:
+          stream: products
+          syncMode: incremental
+        target: ${PREFIX}/products
+      - resource:
+          stream: promotion_codes
+          syncMode: incremental
+        target: ${PREFIX}/promotioncodes
+      - resource:
+          stream: refunds
+          syncMode: incremental
+        target: ${PREFIX}/refunds
+      - resource:
+          stream: subscription_items
+          syncMode: full_refresh
+        target: ${PREFIX}/subscriptionitems
+      - resource:
+          stream: subscriptions
+          syncMode: incremental
+        target: ${PREFIX}/subscriptions
+      - resource:
+          stream: transfers
+          syncMode: incremental
+        target: ${PREFIX}/transfers
+```

--- a/site/docs/reference/Connectors/capture-connectors/zendesk-support.md
+++ b/site/docs/reference/Connectors/capture-connectors/zendesk-support.md
@@ -1,0 +1,154 @@
+# Zendesk Support
+
+This connector captures data from Zendesk into Flow collections.
+
+[`ghcr.io/estuary/airbyte-source-zendesk-support:dev`](https://ghcr.io/estuary/airbyte-source-zendesk-support:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/zendesk-support/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported through the Zendesk API:
+
+* [Brands](https://developer.zendesk.com/api-reference/ticketing/account-configuration/brands/)
+* [Custom roles](https://developer.zendesk.com/api-reference/ticketing/account-configuration/custom_roles/)
+* [Group memberships](https://developer.zendesk.com/api-reference/ticketing/groups/group_memberships/)
+* [Groups](https://developer.zendesk.com/api-reference/ticketing/groups/groups/)
+* [Macros](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/)
+* [Organizations](https://developer.zendesk.com/api-reference/ticketing/organizations/organizations/)
+* [Satisfaction ratings](https://developer.zendesk.com/api-reference/ticketing/ticket-management/satisfaction_ratings/)
+* [Schedules](https://developer.zendesk.com/api-reference/ticketing/ticket-management/schedules/)
+* [SLA policies](https://developer.zendesk.com/api-reference/ticketing/business-rules/sla_policies/)
+* [Tags](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/)
+* [Ticket audits](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_audits/)
+* [Ticket comments](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/)
+* [Ticket fields](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_fields/)
+* [Ticket forms](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_forms/)
+* [Ticket metrics](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metrics/)
+* [Ticket metric events](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metric_events/)
+* [Tickets](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-export-time-based)
+* [Users](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-user-export)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+* Subdomain of your Zendesk URL. In the URL `https://MY_SUBDOMAIN.zendesk.com/`, `MY_SUBDOMAIN` is the subdomain.
+* Email address associated with your Zendesk account.
+* A Zendesk API token. See the [Zendesk docs](https://support.zendesk.com/hc/en-us/articles/4408889192858-Generating-a-new-API-token) to enable tokens and generate a new token.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog spec YAML.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and YAML sample below provide configuration details specific to the Facebook Marketing source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| `/credentials/api_token` | API Token | The value of the API token generated. | string |  |
+| `/credentials/credentials` | Credentials method | Type of credentials used. Set to `api-token` | string |  |
+| `/credentials/email` | Email | The user email for your Zendesk account. | string |  |
+| **`/start_date`** | Start Date | The date from which you&#x27;d like to replicate data for Zendesk Support API, in the format YYYY-MM-DDT00:00:00Z. All data generated after this date will be replicated. | string | Required |
+| **`/subdomain`** | Subdomain | This is your Zendesk subdomain that can be found in your account URL. For example, in https:&#x2F;&#x2F;{MY&#x5F;SUBDOMAIN}.zendesk.com&#x2F;, where MY&#x5F;SUBDOMAIN is the value of your subdomain. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Resource in Zendesk from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/airbyte-source-zendesk-support:dev
+        config:
+            credentials:
+              api_token: <secret>
+              credentials: api_token
+              email: user@domain.com
+            start_date: 2022-03-01T00:00:00Z
+            subdomain: my_subdomain
+    bindings:
+      - resource:
+          stream: group_memberships
+          syncMode: incremental
+        target: ${PREFIX}/groupmemberships
+      - resource:
+          stream: groups
+          syncMode: incremental
+        target: ${PREFIX}/groups
+      - resource:
+          stream: macros
+          syncMode: incremental
+        target: ${PREFIX}/macros
+      - resource:
+          stream: organizations
+          syncMode: incremental
+        target: ${PREFIX}/organizations
+      - resource:
+          stream: satisfaction_ratings
+          syncMode: incremental
+        target: ${PREFIX}/satisfactionratings
+      - resource:
+          stream: sla_policies
+          syncMode: full_refresh
+        target: ${PREFIX}/slapoliciies
+      - resource:
+          stream: tags
+          syncMode: full_refresh
+        target: ${PREFIX}/tags
+      - resource:
+          stream: ticket_audits
+          syncMode: incremental
+        target: ${PREFIX}/ticketaudits
+      - resource:
+          stream: ticket_comments
+          syncMode: incremental
+        target: ${PREFIX}/ticketcomments
+      - resource:
+          stream: ticket_fields
+          syncMode: incremental
+        target: ${PREFIX}/ticketfields
+      - resource:
+          stream: ticket_forms
+          syncMode: incremental
+        target: ${PREFIX}/ticketforms
+      - resource:
+          stream: ticket_metrics
+          syncMode: incremental
+        target: ${PREFIX}/ticketmetrics
+      - resource:
+          stream: ticket_metric_events
+          syncMode: incremental
+        target: ${PREFIX}/ticketmetricevents
+      - resource:
+          stream: tickets
+          syncMode: incremental
+        target: ${PREFIX}/tickets
+      - resource:
+          stream: users
+          syncMode: incremental
+        target: ${PREFIX}/users
+      - resource:
+          stream: brands
+          syncMode: full_refresh
+        target: ${PREFIX}/brands
+      - resource:
+          stream: custom_roles
+          syncMode: full_refresh
+        target: ${PREFIX}/customroles
+      - resource:
+          stream: schedules
+          syncMode: full_refresh
+        target: ${PREFIX}/schedules
+```


### PR DESCRIPTION
**Description:**

Adds connector docs for the following newly added sources

- amplitude
- intercom
- stripe
- zendesk support

**Documentation links affected:**

I will update these shortlinks after merging:

Zendesk:
https://go.estuary.dev/9riGqC
https://go.estuary.dev/VHDFYJ

Stripe:
https://go.estuary.dev/k392Zj
https://go.estuary.dev/OhUbgL

Amplitude:
https://go.estuary.dev/94rlKl
https://go.estuary.dev/CTEm20

Intercom:
https://go.estuary.dev/3L0sGJ

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/561)
<!-- Reviewable:end -->
