### PR TITLE
sshforwarding: Various tweaks to make failures debuggable

### DIFF
--- a/crates/connector_proxy/src/libs/network_tunnel.rs
+++ b/crates/connector_proxy/src/libs/network_tunnel.rs
@@ -80,8 +80,11 @@ impl NetworkTunnel {
 
         // TODO: Refact the network-tunnel and remove the timeout logic here after all connectors are converted to work with connector-proxy.
 
-        // Block for at most 5 seconds for network tunnel to be prepared.
-        if let Err(_) = timeout(std::time::Duration::from_secs(5), tx.closed()).await {
+        // Block for at most 6 seconds for network tunnel to be prepared. This
+        // is one second longer than the SSH client is given, so in the common
+        // case of an unresponsive SSH server the timeout should come from that.
+        if let Err(_) = timeout(std::time::Duration::from_secs(6), tx.closed()).await {
+            tracing::error!("network tunnel timeout expired before startup finished");
             return Err(Error::ChannelTimeoutError);
         };
 


### PR DESCRIPTION
**Description:**

This is a grab-bag of several fixes, basically what I did was try and misconfigure SSH forwarding in various common ways (forgetting to specify a username, inputting the wrong or malformed key data, inputting the wrong SSH server hostname/IP, etc) and tweaked things to try and make the reasons for those failures more obvious.

Concretely, this meant:

  * Replacing the previous logic around detecting the `Entering interactive session` log message with a new mechanism which     uses the tokio `BufReader::lines()` and then looks at each output line individually to decide how to log it.
  * Hard-coded some special cases for logging certain messages from `ssh` at `DEBUG` and `ERROR` levels, with the default being `INFO` for any message not otherwise handled.
  * Explicitly giving the `ssh` invocation `-o ConnectTimeout=5` and bumping the generic "network tunnel startup" timeout to 6. This means that in the common case (SSH server just not reachable) we will see a more verbose failure from `ssh`.

This should go a long way towards fixing https://github.com/estuary/flow/issues/555

**Workflow steps:**

None, ideally it should just be less confusing why your SSH tunnel setup failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/562)
<!-- Reviewable:end -->
