### PR TITLE
Simplified SSH Forwarding Configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "futures",
  "openssl",
  "openssl-sys",
+ "rand 0.8.5",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
+ "insta",
  "libc",
  "network-tunnel",
  "prost",

--- a/crates/connector_proxy/Cargo.toml
+++ b/crates/connector_proxy/Cargo.toml
@@ -35,3 +35,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "*", features = ["io"] }
 tracing = "*"
 validator = { version = "*", features = ["derive"] }
+
+[dev-dependencies]
+insta = "*"

--- a/crates/connector_proxy/src/libs/network_tunnel.rs
+++ b/crates/connector_proxy/src/libs/network_tunnel.rs
@@ -137,4 +137,49 @@ mod test {
 
         assert_eq!(result.get(), json!({"x": true}).to_string());
     }
+
+    #[test]
+    fn test_extended_endpoint_schema() {
+        let schema = serde_json::from_value(json!({
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "title": "Generic Database Connection Spec",
+            "required": ["address", "credentials"],
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "title": "Server Address",
+                    "description": "The host or host:port at which the database can be reached.",
+                },
+                "credentials": {
+                  "type": "string",
+                  "description": "Some login credentials or something.",
+                  "secret": true,
+                },
+            }
+        }))
+        .unwrap();
+        insta::assert_json_snapshot!(NetworkTunnel::extend_endpoint_schema(schema).unwrap());
+
+        let schema = serde_json::from_value(json!({
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "title": "Generic Database Connection Spec",
+            "required": ["credentials", "hostname"],
+            "properties": {
+                "credentials": {
+                  "type": "string",
+                  "description": "Some login credentials or something.",
+                  "secret": true,
+                },
+                "hostname": {
+                    "type": "string",
+                    "title": "Server Hostname",
+                    "description": "The hostname at which the server can be reached.",
+                },
+            }
+        }))
+        .unwrap();
+        insta::assert_json_snapshot!(NetworkTunnel::extend_endpoint_schema(schema).unwrap());
+    }
 }

--- a/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema-2.snap
+++ b/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema-2.snap
@@ -1,0 +1,86 @@
+---
+source: crates/connector_proxy/src/libs/network_tunnel.rs
+assertion_line: 181
+expression: "NetworkTunnel::extend_endpoint_schema(schema).unwrap()"
+---
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Generic Database Connection Spec",
+  "type": "object",
+  "required": [
+    "credentials",
+    "hostname"
+  ],
+  "properties": {
+    "credentials": {
+      "description": "Some login credentials or something.",
+      "type": "string",
+      "secret": true
+    },
+    "hostname": {
+      "title": "Server Hostname",
+      "description": "The hostname at which the server can be reached.",
+      "type": "string"
+    },
+    "networkTunnel": {
+      "title": "Network Tunneling",
+      "description": "Setup a network tunnel to access systems on a private network",
+      "oneOf": [
+        {
+          "title": "SSH Forwarding",
+          "type": "object",
+          "properties": {
+            "sshForwarding": {
+              "title": "SSH Tunnel",
+              "description": "Connect to your system through an SSH server that acts as a bastion host for your network.",
+              "type": "object",
+              "required": [
+                "privateKey",
+                "sshEndpoint"
+              ],
+              "properties": {
+                "forwardHost": {
+                  "description": "The hostname of the remote destination (e.g. the database server).",
+                  "default": "",
+                  "type": "string"
+                },
+                "forwardPort": {
+                  "title": "Forward Port",
+                  "description": "The port of the remote destination (e.g. the database server).",
+                  "default": 0,
+                  "type": "integer",
+                  "maximum": 65535.0,
+                  "minimum": 1.0
+                },
+                "localPort": {
+                  "title": "Local Port",
+                  "description": "The local port which will be connected to the remote host/port over an SSH tunnel. This should match the port that's used in your basic connector configuration.",
+                  "default": 0,
+                  "type": "integer",
+                  "maximum": 65535.0,
+                  "minimum": 1.0
+                },
+                "privateKey": {
+                  "title": "SSH Private Key",
+                  "description": "Private key to connect to the remote SSH server.",
+                  "type": "string",
+                  "multiline": true,
+                  "secret": true
+                },
+                "sshEndpoint": {
+                  "description": "Endpoint of the remote SSH server that supports tunneling, in the form of ssh://user@hostname[:port]",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Disabled",
+          "type": "null"
+        }
+      ],
+      "advanced": true
+    }
+  }
+}

--- a/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema.snap
+++ b/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema.snap
@@ -1,0 +1,65 @@
+---
+source: crates/connector_proxy/src/libs/network_tunnel.rs
+assertion_line: 160
+expression: "NetworkTunnel::extend_endpoint_schema(schema).unwrap()"
+---
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Generic Database Connection Spec",
+  "type": "object",
+  "required": [
+    "address",
+    "credentials"
+  ],
+  "properties": {
+    "address": {
+      "title": "Server Address",
+      "description": "The host or host:port at which the database can be reached.",
+      "type": "string"
+    },
+    "credentials": {
+      "description": "Some login credentials or something.",
+      "type": "string",
+      "secret": true
+    },
+    "networkTunnel": {
+      "title": "Network Tunneling",
+      "description": "Setup a network tunnel to access systems on a private network",
+      "oneOf": [
+        {
+          "title": "SSH Forwarding",
+          "type": "object",
+          "properties": {
+            "sshForwarding": {
+              "title": "SSH Tunnel",
+              "description": "Connect to your system through an SSH server that acts as a bastion host for your network.",
+              "type": "object",
+              "required": [
+                "privateKey",
+                "sshEndpoint"
+              ],
+              "properties": {
+                "privateKey": {
+                  "title": "SSH Private Key",
+                  "description": "Private key to connect to the remote SSH server.",
+                  "type": "string",
+                  "multiline": true,
+                  "secret": true
+                },
+                "sshEndpoint": {
+                  "description": "Endpoint of the remote SSH server that supports tunneling, in the form of ssh://user@hostname[:port]",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Disabled",
+          "type": "null"
+        }
+      ],
+      "advanced": true
+    }
+  }
+}

--- a/crates/network-tunnel/Cargo.toml
+++ b/crates/network-tunnel/Cargo.toml
@@ -17,6 +17,7 @@ base64="*"
 futures="*"
 openssl-sys = { version = "*", features = ['vendored'] }
 openssl="*"
+rand = "*"
 schemars = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"

--- a/crates/network-tunnel/src/errors.rs
+++ b/crates/network-tunnel/src/errors.rs
@@ -12,5 +12,11 @@ pub enum Error {
     DecodeError(#[from] DecodeError),
 
     #[error("SSH forwarding network tunnel exit with non-zero exit code {0}")]
-    TunnelExitNonZero(String)
+    TunnelExitNonZero(String),
+
+    #[error("network tunnel requested, but no destination address was found in the endpoint configuration")]
+    MissingDestinationAddress,
+
+    #[error("malformed destination address {0}")]
+    BadDestinationAddress(String),
 }

--- a/crates/network-tunnel/src/networktunnel.rs
+++ b/crates/network-tunnel/src/networktunnel.rs
@@ -3,10 +3,16 @@ use super::errors::Error;
 use async_trait::async_trait;
 
 #[async_trait]
-pub trait NetworkTunnel: Send {
+pub trait NetworkTunnel: Send + Sync {
+    // Inspect and/or modify the endpoint spec for which this network tunnel is created.
+    // This takes place before the tunnel is started, and may also modify tunnel config
+    // if appropriate.
+    fn adjust_endpoint_spec(
+        &mut self,
+        endpoint_spec: serde_json::Value,
+    ) -> Result<serde_json::Value, Error>;
     // Setup the network proxy server. Network proxy should be able to listen and accept requests after `prepare` is performed.
     async fn prepare(&mut self) -> Result<(), Error>;
     // Start a long-running task that serves and processes all proxy requests from clients.
     async fn start_serve(&mut self) -> Result<(), Error>;
 }
-

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 pub const ENDPOINT_ADDRESS_KEY: &str = "address";
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[schemars(
     title = "SSH Tunnel",
     description = "Connect to your system through an SSH server that acts as a bastion host for your network."

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -34,12 +34,16 @@ pub struct SshForwardingConfig {
     /// Private key to connect to the remote SSH server.
     #[schemars(schema_with = "private_key_schema")]
     pub private_key: String,
-    /// Host name to connect from the remote SSH server to the remote destination (e.g. DB) via internal network.
+    /// The hostname of the remote destination (e.g. the database server).
+    #[serde(default)]
     pub forward_host: String,
-    /// Port of the remote destination.
+    /// The port of the remote destination (e.g. the database server).
+    #[serde(default)]
     #[schemars(schema_with = "forward_port_schema")]
     pub forward_port: u16,
-    /// Local port to start the SSH tunnel.
+    /// The local port which will be connected to the remote host/port over an SSH tunnel.
+    /// This should match the port that's used in your basic connector configuration.
+    #[serde(default)]
     #[schemars(schema_with = "local_port_schema")]
     pub local_port: u16,
 }
@@ -59,7 +63,7 @@ fn private_key_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::sc
 fn forward_port_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
     port_schema(
         "Forward Port",
-        "The port number that the data source is listening on",
+        "The port of the remote destination (e.g. the database server)",
     )
 }
 

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -77,7 +77,7 @@ fn port_schema(title: &str, description: &str) -> schemars::schema::Schema {
         "description": description,
         "type": "integer",
         "minimum": 1_i32,
-        "maximum": 65536_i32
+        "maximum": 65535_i32
     }))
     .unwrap()
 }


### PR DESCRIPTION
**Description:**

This is an attempt to implement the mechanism I described in https://github.com/estuary/flow/issues/513, which allows a top-level endpoint config property named `address` to serve as the `forwardHost/forwardPort` values for SSH tunneling (and replaces the `address` property with `127.0.0.1:$RANDOM_LOCAL_PORT` before invoking the connector).

It includes some additional logic which does a similar job when asked for the endpoint config spec, and omits the `forwardHost`, `forwardPort`, and `localPort` properties from the SSH config portion of the resulting schema IFF the main endpoint config schema contains a top-level `address` property.

It should be noted that the new logic is backwards-compatible in two ways:

- First, any existing captures/materializations which explicitly specify `forwardHost` / `forwardPort` / `localPort` should continue to operate as normal. This means that we can choose to migrate existing uses of `source-postgres` and other connectors whenever it's convenient.
- Second, any connectors which do not have a top-level `address` property will continue to provide the "full" version of the SSH config spec, which includes `forwardHost` and friends. This means that we can choose to modify additional connectors (such as `materialize-postgres`) to use the specific `address` configuration whenever it's convenient.

This whole PR still feels really hacky because of the reliance on a specific endpoint property `address`, but I believe it should work well in practice and I couldn't justify using a more complicated mechanism at this time. The main issues are:

1. To opt in to this behavior, connectors will need to be modified. For instance `materialize-postgres` will need to replace its current `host` and `port` properties with `address`, which is itself a potentially-breaking change that needs some care (either keeping things backwards-compatible or pinning-then-upgrading the live materializations) to not break existing uses.
2. There could theoretically be some connectors out there with a top-level `address` property which does not have the expected semantics, and we would do the wrong thing with those. However I have checked and I do not believe any of our current officially supported connectors have this issue, and it's a bit unlikely anyway.

**Workflow steps:**

Configuration for some connectors (currently `source-postgres` and `source-mysql`) will no longer require `forwardHost` and related properties to be specified. Instead the primary `address` field should always describe the target database, and the fact that it's not directly reachable but goes through an SSH bastion host is only represented by the presence of `sshEndpoint` and `privateKey` configuration.

**Documentation links affected:**

Probably https://docs.estuary.dev/guides/connect-network/, and it looks like https://docs.estuary.dev/reference/Connectors/capture-connectors/PostgreSQL/#amazon-rds directly mentions `forwardHost` so that should be changed too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/563)
<!-- Reviewable:end -->
