### PR TITLE
sshforwarding: Even more error message tweaks

### DIFF
--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -175,6 +175,8 @@ impl NetworkTunnel for SshForwarding {
                 tracing::error!("ssh: {}", &line);
             } else if line.contains("Network is unreachable") {
                 tracing::error!("ssh: {}", &line);
+            } else if line.contains("Connection timed out") {
+                tracing::error!("ssh: {}", &line);
             } else {
                 tracing::info!("ssh: {}", &line);
             }
@@ -184,7 +186,7 @@ impl NetworkTunnel for SshForwarding {
         // it's ready to serve traffic. If stderr closes unexpectedly we treat
         // this as a probably-erroneous form of 'success', and rely on the later
         // `start_serve` exit code checking to report a failure.
-        tracing::error!("unexpected end of output from ssh tunnel");
+        tracing::warn!("unexpected end of output from ssh tunnel");
         Ok(())
     }
 


### PR DESCRIPTION
**Description:**

This commit adds a special case so `Connection timed out` errors from the SSH binary are logged as errors (rather than INFO), and demotes the `unexpected end of output` warning from an error to a warning.

Thus in the case of an incorrect SSH bastion IP/port the logging at error level will now look like:

    ERRO[0005] ssh: ssh: connect to host 35.192.214.194 port 1234: Connection timed out
    ERRO[0005] network tunnel ssh exit with non-zero code.

Where previously it was a less helpful:

    ERRO[0005] unexpected end of output from ssh tunnel
    ERRO[0005] network tunnel ssh exit with non-zero code.

I'm not a huge fan of the duplicate `ssh: ssh:` prefix, but we're already on shaky ground looking for specific message strings on stderr, so I'd prefer not to assume the SSH client will always add that prefix for us on this specific error message and not any others.

**Notes for reviewers:**

This commit is basically just "oops, meant to include `Connection timed out` in the special cases from https://github.com/estuary/flow/pull/562" plus "actually that `unexpected end of output` message could be a bit confusing if all the user sees in the UI is ERROR level logs and they hit some unhandled sort of failure".

