### PR TITLE
Don't use host network by default

### DIFF
--- a/go/flowctl-go/cmd-api-activate.go
+++ b/go/flowctl-go/cmd-api-activate.go
@@ -37,7 +37,7 @@ type apiActivate struct {
 	DryRun         bool                  `long:"dry-run" description:"Print actions that would be taken, but don't actually take them"`
 	InitialSplits  int                   `long:"initial-splits" default:"1" description:"When creating new tasks, the number of initial key splits to use"`
 	Names          []string              `long:"name" description:"Name of task or collection to activate. May be repeated many times"`
-	Network        string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network        string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	NoWait         bool                  `long:"no-wait" description:"Don't wait for all activated shards to become ready (PRIMARY)"`
 	Log            mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics    mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`

--- a/go/flowctl-go/cmd-api-build.go
+++ b/go/flowctl-go/cmd-api-build.go
@@ -22,7 +22,7 @@ type apiBuild struct {
 	BuildID     string                `long:"build-id" required:"true" description:"ID of this build"`
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
 	FileRoot    string                `long:"fs-root" default:"/" description:"Filesystem root of fetched file:// resources"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	SourceType  string                `long:"source-type" default:"catalog" choice:"catalog" choice:"jsonSchema" description:"Type of the source to build."`
 	TSCompile   bool                  `long:"ts-compile" description:"Should TypeScript modules be compiled and linted? Implies generation."`

--- a/go/flowctl-go/cmd-api-delete.go
+++ b/go/flowctl-go/cmd-api-delete.go
@@ -27,7 +27,7 @@ type apiDelete struct {
 	Consumer       mbp.ClientConfig      `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
 	DryRun         bool                  `long:"dry-run" description:"Print actions that would be taken, but don't actually take them"`
 	Names          []string              `long:"name" description:"Name of task or collection to activate. May be repeated many times"`
-	Network        string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network        string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Log            mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics    mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 }

--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -21,7 +21,7 @@ type apiDiscover struct {
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 	Image       string                `long:"image" required:"true" description:"Docker image of the connector to use"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Config      string                `long:"config" description:"Path to the connector endpoint configuration"`
 	Output      string                `long:"output" choice:"json" choice:"proto" default:"json"`
 }

--- a/go/flowctl-go/cmd-api-spec.go
+++ b/go/flowctl-go/cmd-api-spec.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
-	"fmt"
 
-	"github.com/estuary/flow/go/connector"
 	"github.com/estuary/flow/go/capture"
+	"github.com/estuary/flow/go/connector"
 	"github.com/estuary/flow/go/flow/ops"
 	"github.com/estuary/flow/go/materialize"
 	pc "github.com/estuary/flow/go/protocols/capture"
@@ -30,7 +30,7 @@ type apiSpec struct {
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 	Image       string                `long:"image" required:"true" description:"Docker image of the connector to use"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 }
 
 type imageConfig struct {
@@ -58,7 +58,7 @@ func (cmd apiSpec) execute(ctx context.Context) (specResponse, error) {
 	err = connector.PullRemoteImage(ctx, cmd.Image, ops.StdLogger())
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
-			"error":    err,
+			"error": err,
 		}).Info("pull remote image does not succeed.")
 	}
 	inspectOutput, err := connector.InspectImage(ctx, cmd.Image)

--- a/go/flowctl-go/cmd-check.go
+++ b/go/flowctl-go/cmd-check.go
@@ -13,7 +13,7 @@ import (
 
 type cmdCheck struct {
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`

--- a/go/flowctl-go/cmd-combine.go
+++ b/go/flowctl-go/cmd-combine.go
@@ -22,7 +22,7 @@ import (
 
 type cmdCombine struct {
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	Collection  string                `long:"collection" required:"true" description:"The name of the collection from which to take the schema and key"`
 	MaxDocs     uint64                `long:"max-docs" default:"0" description:"Maximum number of documents to add to the combiner before draining it. If 0, then there is no maximum"`

--- a/go/flowctl-go/cmd-deploy.go
+++ b/go/flowctl-go/cmd-deploy.go
@@ -18,7 +18,7 @@ type cmdDeploy struct {
 	Broker      mbp.ClientConfig      `group:"Broker" namespace:"broker" env-namespace:"BROKER"`
 	Consumer    mbp.ClientConfig      `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	Cleanup     bool                  `long:"wait-and-cleanup" description:"Keep running after deploy until Ctrl-C. Then, delete the deployment from the dataplane."`
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`

--- a/go/flowctl-go/cmd-discover.go
+++ b/go/flowctl-go/cmd-discover.go
@@ -27,7 +27,7 @@ type cmdDiscover struct {
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`
 	Diagnostics mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 	Image       string                `long:"image" required:"true" description:"Docker image of the connector to use"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Prefix      string                `long:"prefix" default:"acmeCo" description:"Prefix of generated catalog entities. For example, an organization or company name."`
 	Directory   string                `long:"directory" description:"Output directory for catalog source files. Defaults to --prefix"`
 }

--- a/go/flowctl-go/cmd-temp-data-plane.go
+++ b/go/flowctl-go/cmd-temp-data-plane.go
@@ -20,7 +20,7 @@ import (
 type cmdTempDataPlane struct {
 	BrokerPort   uint16                `long:"broker-port" default:"8080" description:"Port bound by Gazette broker"`
 	ConsumerPort uint16                `long:"consumer-port" default:"9000" description:"Port bound by Flow consumer"`
-	Network      string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network      string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Poll         bool                  `long:"poll" description:"Poll connectors, rather than running them continuously. Required in order to use 'flowctl api poll'"`
 	Sigterm      bool                  `long:"sigterm" hidden:"true" description:"Send SIGTERM rather than SIGKILL on exit"`
 	Tempdir      string                `long:"tempdir" description:"Directory for data plane files. If not set, a temporary directory is created and then deleted upon exit"`
@@ -197,13 +197,15 @@ func (cmd cmdTempDataPlane) consumerCmd(ctx context.Context, tempdir, buildsRoot
 		"--consumer.watch-delay", "0ms", // Speed test execution.
 		"--etcd.address", etcdAddr,
 		"--flow.builds-root", buildsRoot,
-		"--flow.network", cmd.Network,
 		"--flow.test-apis",
 		"--log.format", cmd.Log.Format,
 		"--log.level", cmd.Log.Level,
 	}
 	if cmd.Poll {
 		args = append(args, "--flow.poll")
+	}
+	if cmd.Network != "" {
+		args = append(args, "--flow.network", cmd.Network)
 	}
 
 	var out = exec.CommandContext(ctx, args[0], args[1:]...)

--- a/go/flowctl-go/cmd-test.go
+++ b/go/flowctl-go/cmd-test.go
@@ -17,7 +17,7 @@ import (
 
 type cmdTest struct {
 	Directory   string                `long:"directory" default:"." description:"Build directory"`
-	Network     string                `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+	Network     string                `long:"network" description:"The Docker network that connector containers are given access to."`
 	Source      string                `long:"source" required:"true" description:"Catalog source file or URL to build"`
 	Snapshot    string                `long:"snapshot" description:"When set, failed test verifications produce snapshots into the given base directory"`
 	Log         mbp.LogConfig         `group:"Logging" namespace:"log" env-namespace:"LOG"`

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -29,7 +29,7 @@ type FlowConsumerConfig struct {
 	Flow struct {
 		BuildsRoot string `long:"builds-root" required:"true" env:"BUILDS_ROOT" description:"Base URL for fetching Flow catalog builds"`
 		BrokerRoot string `long:"broker-root" required:"true" env:"BROKER_ROOT" default:"/gazette/cluster" description:"Broker Etcd base prefix"`
-		Network    string `long:"network" default:"host" description:"The Docker network that connector containers are given access to."`
+		Network    string `long:"network" description:"The Docker network that connector containers are given access to, defaults to the bridge network"`
 		TestAPIs   bool   `long:"test-apis" description:"Enable APIs exclusively used while running catalog tests"`
 		Poll       bool   `long:"poll" description:"Poll connectors, rather than running them continuously"`
 	} `group:"flow" namespace:"flow" env-namespace:"FLOW"`

--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -71,6 +71,7 @@ flowctl temp-data-plane \
     --sigterm \
     --tempdir ${TESTDIR} \
     --unix-sockets \
+    --network=host \
     1>$TESTDIR/data-plane.stdout \
     2>$TESTDIR/data-plane.stderr \
     &
@@ -98,6 +99,7 @@ tail -f $TESTDIR/build.stderr &
 # Build the catalog. Arrange for it to be removed on exit.
 flowctl api build \
     --directory ${TESTDIR}/catalog-build \
+    --network=host \
     --build-id ${BUILD_ID} \
     --source ${TEST_ROOT}/flow.yaml \
     --ts-package \
@@ -112,7 +114,7 @@ touch $TESTDIR/activate.stderr
 tail -f $TESTDIR/activate.stdout &
 tail -f $TESTDIR/activate.stderr &
 # Activate the catalog.
-flowctl api activate --log.level=debug --build-id ${BUILD_ID} --all 1>>$TESTDIR/activate.stdout 2>>$TESTDIR/activate.stderr || bail "Activate failed."
+flowctl api activate --network=host --log.level=debug --build-id ${BUILD_ID} --all 1>>$TESTDIR/activate.stdout 2>>$TESTDIR/activate.stderr || bail "Activate failed."
 
 # allow writing tests for failure cases
 set +e
@@ -205,7 +207,7 @@ done
 
 echo "running flowctl api delete"
 ## Clean up the activated catalog.
-flowctl api delete --build-id ${BUILD_ID} --all || bail "Delete failed."
+flowctl api delete --network=host --build-id ${BUILD_ID} --all || bail "Delete failed."
 
 # Setting this to true will cause TESTDIR to be cleaned up on exit
 TESTS_PASSED=true


### PR DESCRIPTION
**Description:**

Changes the default value of the --network argument to flowctl serve
consumer to be empty so that the host network will not be used by
default. This also removes the default from `temp-data-plane`, so
users who use that for running locally may want to pass `--network=host`
in order to connect to services running on localhost.

Using the host network in production would be bad because tasks that use ssh forwarding could end up using conflicting ports. This PR is primarily to address that issue.

**Workflow steps:**

If you run temp-data-plane locally, you'll probably want to add the `--network host` argument. Otherwise, no change.

**Documentation links affected:**

No user-facing docs changes, since temp-data-plane isn't really a user-facing subcommand anymore.

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/566)
<!-- Reviewable:end -->
