### PR TITLE
Change parser errorThreshold default to 0

### DIFF
--- a/crates/parser/src/config/character_separated.rs
+++ b/crates/parser/src/config/character_separated.rs
@@ -36,7 +36,7 @@ pub struct AdvancedCsvConfig {
     /// Allows a percentage of errors to be ignored without failing the entire
     /// parsing process. When this limit is exceeded, parsing halts.
     #[serde(default)]
-    pub error_threshold: Option<ErrorThreshold>,
+    pub error_threshold: ErrorThreshold,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, EnumIter, IntoStaticStr)]

--- a/crates/parser/src/config/mod.rs
+++ b/crates/parser/src/config/mod.rs
@@ -444,6 +444,10 @@ impl ErrorThreshold {
         }
     }
 
+    pub fn is_zero(&self) -> bool {
+        self.max_percent == 0
+    }
+
     pub fn exceeded(&self, test_percent: u8) -> bool {
         test_percent >= self.max_percent
     }
@@ -489,7 +493,6 @@ impl schemars::JsonSchema for ErrorThreshold {
         serde_json::from_value(serde_json::json!({
             "type": "integer",
             "title": "Error Threshold",
-            "description": "The percentage of malformed rows which can be encountered without halting the parsing process. Only the most recent 1000 rows are used to calculate the error rate.",
             "default": 0,
             "minimum": 0,
             "maximum": 100,
@@ -644,7 +647,7 @@ mod test {
                 escape: Escape::Backslash.into(),
                 encoding: EncodingRef("windows-1252").into(),
                 headers: Vec::new(),
-                error_threshold: None,
+                error_threshold: Default::default(),
             })
             .into(),
             compression: Compression::ZipArchive.into(),

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -306,7 +306,7 @@ expression: schema
                 "errorThreshold": {
                   "title": "Error Threshold",
                   "description": "Allows a percentage of errors to be ignored without failing the entire parsing process. When this limit is exceeded, parsing halts.",
-                  "default": null,
+                  "default": 0,
                   "type": "integer",
                   "maximum": 100.0,
                   "minimum": 0.0

--- a/crates/parser/src/format/character_separated/mod.rs
+++ b/crates/parser/src/format/character_separated/mod.rs
@@ -192,8 +192,11 @@ impl Parser for CsvParser {
         let columns = resolve_headers(headers, CSV_NULLS);
 
         let csv_output = CsvOutput::new(columns, reader);
-        let iterator = if let Some(threshold) = self.config.error_threshold {
-            Box::new(ParseErrorBuffer::new(csv_output, threshold)) as Output
+        let iterator = if !self.config.error_threshold.is_zero() {
+            Box::new(ParseErrorBuffer::new(
+                csv_output,
+                self.config.error_threshold,
+            )) as Output
         } else {
             Box::new(csv_output) as Output
         };

--- a/crates/parser/tests/csv_error_absorption_test.rs
+++ b/crates/parser/tests/csv_error_absorption_test.rs
@@ -8,7 +8,7 @@ use testutil::run_test;
 #[test]
 fn no_tolerance_for_errors_test() {
     let mut csv = EphemeralCsv::default();
-    let config = csv.parse_config(None);
+    let config = csv.parse_config(Default::default());
 
     csv.write_rows(1, &|_i| "n,n_squared".to_owned());
     csv.write_rows(500, &|i| format!("{},{}", i, i * i));
@@ -23,7 +23,7 @@ fn no_tolerance_for_errors_test() {
 #[test]
 fn smaller_than_window_test() {
     let mut csv = EphemeralCsv::default();
-    let config = csv.parse_config(ErrorThreshold::new(10).unwrap().into());
+    let config = csv.parse_config(ErrorThreshold::new(10).unwrap());
 
     csv.write_rows(1, &|_i| "n,n_squared".to_owned());
     csv.write_rows(500, &|i| format!("{},{}", i, i * i));
@@ -111,7 +111,7 @@ impl EphemeralCsv {
         }
     }
 
-    fn parse_config(&self, error_threshold: Option<ErrorThreshold>) -> ParseConfig {
+    fn parse_config(&self, error_threshold: ErrorThreshold) -> ParseConfig {
         ParseConfig {
             filename: Some("data.csv".to_owned()),
             format: Format::Csv(character_separated::AdvancedCsvConfig {


### PR DESCRIPTION
**Description:**

Previously, the `errorThreshold` field was represented as an
`Option<ErrorThreshold>`, which meant that the default value was always
`null`. This changes the representation so that it no longer uses an
`Option` and instead uses the number 0 as the default. This is more
clear and user friendly, and renders better in the UI.

**Workflow steps:**

`null` is no longer a valid value for `errorThreshold` in the parser config. Use `0` instead. I don't think there's any endpoint configs that actually specified `null` though.

**Documentation links affected:** None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/573)
<!-- Reviewable:end -->
