### PR TITLE
Bubble up errors returned from parser consumer

### DIFF
--- a/go/parser/run.go
+++ b/go/parser/run.go
@@ -113,7 +113,8 @@ func (r *parserStdout) Write(p []byte) (int, error) {
 		p = p[pivot+1:]
 	}
 
-	if err := r.onLines(lines); err != nil {
+	err := r.onLines(lines)
+	if err != nil {
 		r.onError(err)
 	}
 
@@ -122,5 +123,7 @@ func (r *parserStdout) Write(p []byte) (int, error) {
 	r.rem = append(r.rem, p...)
 	r.scratch = lines[:0]
 
-	return n, nil
+	// Returns the err value from onLines. This may not be nil, but we want to
+	// adjust the rem/scratch before bailing.
+	return n, err
 }


### PR DESCRIPTION
**Description:**

This allows the caller to signal that we should halt parsing. Without this change, the parser will continue to read documents from the source until it reaches the end of data even if the caller has encountered an error (or would for its own reasons prefer to stop).

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

Used by the latest changes to https://github.com/estuary/connectors/pull/278.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/579)
<!-- Reviewable:end -->
