### PR TITLE
Docs: updated network tunnel config

### DIFF
--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -316,27 +316,15 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          # When using a proxy like SSH tunneling, set to localhost
-          host: localhost
-          # Specify an open port on your local machine to connect to the proxy.
-          port: 15432
+          address: 127.0.0.1:5432
           database: flow
           user: flow_user
           password: secret
           networkTunnel:
             sshForwarding:
-              # Port on the local machine from which you'll connect to the SSH server.
-              # If a port is specified elsewhere in the connector configuration, it must match.
-              localPort: 15432
-              # Host or IP address of the final endpoint to which you’ll
-              # connect via tunneling from the SSH server
-              forwardHost: 127.0.0.1
-              # Port of the final endpoint to which you’ll connect via
-              # tunneling from the SSH server.
-              forwardPort: 5432
               # Location of the remote SSH server that supports tunneling.
               # Formatted as ssh://user@hostname[:port].
-              sshEndpoint: ssh://sshUser@198.21.98.1
+              sshEndpoint: ssh://sshUser@198.21.98.1:22
               # Private key to connect to the SSH server, formatted as multiline plaintext.
               # Use the YAML literal block style with the indentation indicator.
               # See https://yaml-multiline.info/ for details.

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -309,12 +309,12 @@ or add the `networkTunnel` stanza directly to the YAML, as shown below.
 
 #### Sample
 
-```yaml title="materialize-postgres-ssh-tunnel.flow.yaml"
-materializations:
-  acmeCo/postgres-materialize-ssh:
+```yaml title="source-postgres-ssh-tunnel.flow.yaml"
+captures:
+  acmeCo/postgres-capture-ssh:
     endpoint:
       connector:
-        image: ghcr.io/estuary/materialize-postgres:dev
+        image: ghcr.io/estuary/source-postgres:dev
         config:
           address: 127.0.0.1:5432
           database: flow

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -1,7 +1,7 @@
 # Configure connections with SSH tunneling
 
 Flow connects to certain types of endpoints — generally databases — using their IP address and port.
-To keep this connection secure, you can configure [SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding.
+For added security, you can configure [SSH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), also known as port forwarding.
 You configure this in the `networkTunnel` section of applicable capture or materialization definitions, but
 before you can do so, you need a properly configured SSH server on your internal network or cloud hosting platform.
 
@@ -150,7 +150,7 @@ After you've completed the prerequisites, you should have the following paramete
      Depending on where your server is hosted, you may not be required to specify a port,
      but we recommend specifying `:22` in all cases to ensure a connection can be made.
 
-* **Private Key** / `privateKey`: the contents of the PEM file
+* **Private Key** / `privateKey`: the contents of the SSH private key file
 
 Use these to add SSH tunneling to your capture or materialization definition, either by filling in the corresponding fields
 in the web app, or by working with the YAML directly. Reference the [Connectors](../../concepts/connectors/#connecting-to-endpoints-on-secure-networks) page for a YAML sample.

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -1,8 +1,9 @@
 # Configure connections with SSH tunneling
 
-Depending on your enterprise network security, you may need to use [SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding, to allow Flow
-to securely access your endpoint. This is configured within a capture or materialization definition, but
-before you can do this, you'll need a properly configured SSH server on your internal network or cloud hosting platform.
+Flow connects to certain types of endpoints — generally databases — using their IP address and port.
+To keep this connection secure, you can configure [SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding.
+You configure this in the `networkTunnel` section of applicable capture or materialization definitions, but
+before you can do so, you need a properly configured SSH server on your internal network or cloud hosting platform.
 
 This guide includes setup steps for popular cloud platforms,
 as well as generalized setup that provides a basic roadmap for on-premise servers or other cloud platforms.
@@ -48,13 +49,10 @@ basic configuration options.
   They'll allow the connector to do the same.
 
 5. Configure your internal network to allow the SSH server to access your capture or materialization endpoint.
-  Note the internal **host** and **port**; these are necessary to open the connection.
 
 6. Configure your network to expose the SSH server endpoint to external traffic. The method you use
    depends on your organization's IT policies. Currently, Estuary doesn't provide a list of static IPs for
    whitelisting purposes, but if you require one, [contact Estuary support](mailto:support@estuary.dev).
-
-7. Choose an open port on your localhost from which you'll connect to the SSH server.
 
 ## Setup for AWS
 
@@ -84,13 +82,6 @@ setting the user name to `ec2-user`.
 
 5. Find and note the [instance's public DNS](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-viewing). This will be formatted like: `ec2-198-21-98-1.compute-1.amazonaws.com`.
 
-6. Find and note the host and port for your capture or materialization endpoint.
-  :::tip
-  For database instances hosted in Amazon RDS, you can find these in the RDS console as Endpoint and Port.
-  :::
-
-7. Choose an open port on your localhost from which you'll connect to the SSH server.
-
 ## Setup for Google Cloud
 
 To allow SSH tunneling to a database instance hosted on Google Cloud, you must set up a virtual machine (VM).
@@ -118,14 +109,6 @@ To allow SSH tunneling to a database instance hosted on Google Cloud, you must s
 
 5. [Reserve an external IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) and connect it to the VM during setup.
 Note the generated address.
-
-6. Find and note the host and port for your capture or materialization endpoint.
-  :::tip
-  For database instances hosted in Google Cloud SQL, you can find the host in the Cloud Console as Public IP Address.
-  Use `5432` as the port for PostgreSQL, and `3306` for MySQL.
-  :::
-
-7. Choose an open port on your localhost from which you'll connect to the SSH server.
 
 ## Setup for Azure
 
@@ -157,34 +140,17 @@ To allow SSH tunneling to a database instance hosted on Azure, you'll need to cr
 Instructions for Azure Database For PostgreSQL can be found [here](https://docs.microsoft.com/en-us/azure/postgresql/howto-manage-vnet-using-portal);
 note that instructions for other database engines may be different.
 
-4. Find and note the host and port for your capture or materialization endpoint.
-  :::tip
-  For database instances hosted in Azure, you can find the host as Server Name, and the port under Connection Strings (`5432` for PostgreSQL and `3306` for MySql).
-  :::
-
-5. Choose an open port on your localhost from which you'll connect to the SSH server.
-
 ## Configuration
 
 After you've completed the prerequisites, you should have the following parameters:
 
-* **SSH Endpoint** / `sshEndpoint`: the SSH server's hostname, or public IP address, formatted as `ssh://user@hostname[:port]`
-     :::info Hint
+* **SSH Endpoint** / `sshEndpoint`: the remote SSH server's hostname, or public IP address, formatted as `ssh://user@hostname[:port]`
+
      The [SSH default port is 22](https://www.ssh.com/academy/ssh/port).
      Depending on where your server is hosted, you may not be required to specify a port,
      but we recommend specifying `:22` in all cases to ensure a connection can be made.
-     :::
+
 * **Private Key** / `privateKey`: the contents of the PEM file
-* **Forward Host** / `forwardHost`: the capture or materialization endpoint's host
-* **Forward Port** / `forwardPort`: the capture or materialization endpoint's port
-* **Local Port** / `localPort`: the port on the localhost used to connect to the SSH server
 
-1. Use these to add SSH tunneling to your capture or materialization definition, either by filling in the corresponding fields
-  in a web app, or by working with the YAML directly. Reference the [Connectors](../../concepts/connectors/#connecting-to-endpoints-on-secure-networks) page for a YAML sample.
-
-2. Proxies like SSH are always run on an open port on your localhost,
-so you'll need to re-configure other fields in your capture or materialization definition.
-
-   1. Set the connector's host property to match `localhost` in the SSH configuration.
-
-   2. If the connector has a `port` property, set it to the same value as `localPort` in the SSH configuration.
+Use these to add SSH tunneling to your capture or materialization definition, either by filling in the corresponding fields
+in the web app, or by working with the YAML directly. Reference the [Connectors](../../concepts/connectors/#connecting-to-endpoints-on-secure-networks) page for a YAML sample.

--- a/site/docs/reference/Connectors/capture-connectors/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL.md
@@ -181,6 +181,8 @@ GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
 CALL mysql.rds_set_configuration('binlog retention hours', 168);
 ```
 
+6. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+
 ### Google Cloud SQL
 
 You can use this connector for MySQL instances on Google Cloud SQL using the following setup instructions.
@@ -212,9 +214,10 @@ GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
 GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
 ```
+5. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `3306`.
+Together, you'll use the host:port as the `address` property when you configure the connector.
 
 ### Azure Database for MySQL
-
 
 You can use this connector for MySQL instances on Azure Database for MySQL using the following setup instructions.
 
@@ -250,6 +253,9 @@ GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
 GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
 ```
+
+4. Note the instance's host under Server name, and the port under Connection Strings (usually `3306`).
+Together, you'll use the host:port as the `address` property when you configure the connector.
 
 ## Troubleshooting Capture Errors
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -177,11 +177,12 @@ and set up the watermarks table and publication.
   CREATE PUBLICATION flow_publication FOR ALL TABLES;
   ```
 
+6. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+
 4. Configure your connector as described in the [configuration](#configuration) section above,
-with the additional of the `proxy` stanza to enable the SSH tunnel.
+including the additional `networkTunnel` configuration to enable the SSH tunnel.
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
-You can find the SSH `forwardHost` and `forwardPort` in the [RDS console](https://console.aws.amazon.com/rds/) as the Endpoint and Port, respectively.
 
 ### Google Cloud SQL
 
@@ -216,16 +217,17 @@ and set up the watermarks table and publication.
   CREATE PUBLICATION flow_publication FOR ALL TABLES;
   ```
 
-4. Configure your connector as described in the [configuration](#configuration) section above,
-with the additional of the `proxy` stanza to enable the SSH tunnel, if using.
+4. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `5432`.
+Together, you'll use the host:port as the `address` property when you configure the connector.
+
+5. Configure your connector as described in the [configuration](#configuration) section above,
+including the additional `networkTunnel` configuration to enable the SSH tunnel, if using.
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
-You can find the `forwardHost` under Public IP Address.
-The `forwardPort` is always `5432`.
 
 ### Azure Database for PostgreSQL
 
-You can use this connector for  instances on Azure Database for PostgreSQL using the following setup instructions.
+You can use this connector for instances on Azure Database for PostgreSQL using the following setup instructions.
 
 #### Setup
 
@@ -273,11 +275,13 @@ GRANT ALL PRIVILEGES ON TABLE public.flow_watermarks TO flow_capture;
 CREATE PUBLICATION flow_publication FOR TABLE schema.table1, schema.table2;
 ```
 
-4. Configure your connector as described in the [configuration](#configuration) section above,
-with the additional of the `proxy` stanza to enable the SSH tunnel.
+4. Note the instance's host under Server name, and the port under Connection Strings (usually `5432`).
+Together, you'll use the host:port as the `address` property when you configure the connector.
+
+5. Configure your connector as described in the [configuration](#configuration) section above,
+including the additional `networkTunnel` configuration to enable the SSH tunnel.
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
-You can find the host as Server Name, and the port under Connection Strings (usually `5432`).
 
 ## TOASTed values
 


### PR DESCRIPTION
**Description:**

Updates documentation to reflect the new network tunnel config per https://github.com/estuary/flow/pull/563

Eliminated reference to older config, even though it's backward-compatible, because it's not expected to be pertinent to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/580)
<!-- Reviewable:end -->
