### PR TITLE
network-tunnel: hide tunnel config if there is no `address` field

### DIFF
--- a/crates/connector_proxy/src/libs/network_tunnel.rs
+++ b/crates/connector_proxy/src/libs/network_tunnel.rs
@@ -2,8 +2,7 @@ use crate::errors::Error;
 use crate::libs::json::{create_root_schema, remove_subobject};
 use network_tunnel::interface::NetworkTunnelConfig;
 
-use schemars::schema::{RootSchema, Schema, SchemaObject};
-use schemars::visit::{visit_root_schema, visit_schema_object, Visitor};
+use schemars::schema::{RootSchema, Schema};
 use serde_json::value::RawValue;
 use tokio::sync::oneshot::{self, Receiver};
 use tokio::time::timeout;
@@ -12,35 +11,11 @@ pub struct NetworkTunnel {}
 pub const NETWORK_TUNNEL_KEY: &str = "networkTunnel";
 pub const ENDPOINT_ADDRESS_KEY: &str = "address";
 
-// The RemoveForwardHost visitor is used to conditionally remove some of
-// the SSH Forwarding config properties if (and only if) we detect that the
-// underlying connector has an 'address' property which makes them redundant.
-//
-// There are very few ways of *conditionally* including/excluding a struct
-// field from the generated JSON schemas, so using a visitor to remove them
-// after the fact was the best way of accomplishing this.
-#[derive(Debug, Clone)]
-pub struct RemoveSSHForwardHost;
-impl Visitor for RemoveSSHForwardHost {
-    fn visit_schema_object(&mut self, schema: &mut SchemaObject) {
-        if let Some(metadata) = &schema.metadata {
-            if metadata.title == Some("SSH Tunnel".to_string()) {
-                if let Some(obj) = &mut schema.object {
-                    obj.properties.remove("forwardHost");
-                    obj.properties.remove("forwardPort");
-                    obj.properties.remove("localPort");
-                }
-            }
-        }
-        visit_schema_object(self, schema);
-    }
-}
-
 impl NetworkTunnel {
     pub fn extend_endpoint_schema(
         endpoint_spec_schema: Box<RawValue>,
     ) -> Result<Box<RawValue>, Error> {
-        let mut network_tunnel_schema = create_root_schema::<NetworkTunnelConfig>();
+        let network_tunnel_schema = create_root_schema::<NetworkTunnelConfig>();
         let mut modified_schema: RootSchema = serde_json::from_str(endpoint_spec_schema.get())?;
         if let Some(ref mut o) = &mut modified_schema.schema.object {
             if o.as_ref().properties.contains_key(NETWORK_TUNNEL_KEY) {
@@ -48,13 +23,11 @@ impl NetworkTunnel {
             }
 
             if o.as_ref().properties.contains_key(ENDPOINT_ADDRESS_KEY) {
-                visit_root_schema(&mut RemoveSSHForwardHost, &mut network_tunnel_schema);
+                o.as_mut().properties.insert(
+                    NETWORK_TUNNEL_KEY.to_string(),
+                    Schema::Object(network_tunnel_schema.schema),
+                );
             }
-
-            o.as_mut().properties.insert(
-                NETWORK_TUNNEL_KEY.to_string(),
-                Schema::Object(network_tunnel_schema.schema),
-            );
         }
 
         let json = serde_json::to_string_pretty(&modified_schema)?;

--- a/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema-2.snap
+++ b/crates/connector_proxy/src/libs/snapshots/flow_connector_proxy__libs__network_tunnel__test__extended_endpoint_schema-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/connector_proxy/src/libs/network_tunnel.rs
-assertion_line: 181
+assertion_line: 156
 expression: "NetworkTunnel::extend_endpoint_schema(schema).unwrap()"
 ---
 {
@@ -21,66 +21,6 @@ expression: "NetworkTunnel::extend_endpoint_schema(schema).unwrap()"
       "title": "Server Hostname",
       "description": "The hostname at which the server can be reached.",
       "type": "string"
-    },
-    "networkTunnel": {
-      "title": "Network Tunneling",
-      "description": "Setup a network tunnel to access systems on a private network",
-      "oneOf": [
-        {
-          "title": "SSH Forwarding",
-          "type": "object",
-          "properties": {
-            "sshForwarding": {
-              "title": "SSH Tunnel",
-              "description": "Connect to your system through an SSH server that acts as a bastion host for your network.",
-              "type": "object",
-              "required": [
-                "privateKey",
-                "sshEndpoint"
-              ],
-              "properties": {
-                "forwardHost": {
-                  "description": "The hostname of the remote destination (e.g. the database server).",
-                  "default": "",
-                  "type": "string"
-                },
-                "forwardPort": {
-                  "title": "Forward Port",
-                  "description": "The port of the remote destination (e.g. the database server).",
-                  "default": 0,
-                  "type": "integer",
-                  "maximum": 65535.0,
-                  "minimum": 1.0
-                },
-                "localPort": {
-                  "title": "Local Port",
-                  "description": "The local port which will be connected to the remote host/port over an SSH tunnel. This should match the port that's used in your basic connector configuration.",
-                  "default": 0,
-                  "type": "integer",
-                  "maximum": 65535.0,
-                  "minimum": 1.0
-                },
-                "privateKey": {
-                  "title": "SSH Private Key",
-                  "description": "Private key to connect to the remote SSH server.",
-                  "type": "string",
-                  "multiline": true,
-                  "secret": true
-                },
-                "sshEndpoint": {
-                  "description": "Endpoint of the remote SSH server that supports tunneling, in the form of ssh://user@hostname[:port]",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Disabled",
-          "type": "null"
-        }
-      ],
-      "advanced": true
     }
   }
 }

--- a/crates/network-tunnel/src/sshforwarding.rs
+++ b/crates/network-tunnel/src/sshforwarding.rs
@@ -36,15 +36,16 @@ pub struct SshForwardingConfig {
     pub private_key: String,
     /// The hostname of the remote destination (e.g. the database server).
     #[serde(default)]
+    #[schemars(skip)]
     pub forward_host: String,
     /// The port of the remote destination (e.g. the database server).
     #[serde(default)]
-    #[schemars(schema_with = "forward_port_schema")]
+    #[schemars(skip)]
     pub forward_port: u16,
     /// The local port which will be connected to the remote host/port over an SSH tunnel.
     /// This should match the port that's used in your basic connector configuration.
     #[serde(default)]
-    #[schemars(schema_with = "local_port_schema")]
+    #[schemars(skip)]
     pub local_port: u16,
 }
 
@@ -56,28 +57,6 @@ fn private_key_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::sc
         // This annotation is interpreted by the UI to render this as a multiline input.
         "multiline": true,
         "secret": true
-    }))
-    .unwrap()
-}
-
-fn forward_port_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    port_schema(
-        "Forward Port",
-        "The port of the remote destination (e.g. the database server)",
-    )
-}
-
-fn local_port_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    port_schema("Local Port", "The local port number to use for the tunnel, which should match the port that's used in your base connector configuration")
-}
-
-fn port_schema(title: &str, description: &str) -> schemars::schema::Schema {
-    serde_json::from_value(serde_json::json!({
-        "title": title,
-        "description": description,
-        "type": "integer",
-        "minimum": 1_i32,
-        "maximum": 65535_i32
     }))
     .unwrap()
 }


### PR DESCRIPTION
**Description:**

- Hide network tunnel config for connectors that do not have an `address` configuration
- Do not expose `forward_host`, `forward_port` and `local_port` as Network Tunnel configuration fields for user
- Still needs to wait until we are done with adding `address` to `materialize-postgres` as @willdonnelly mentioned [here](https://github.com/estuary/flow/issues/513#issuecomment-1189360127)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/583)
<!-- Reviewable:end -->
