### PR TITLE
Log npm package errors as build errors

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -58,8 +58,11 @@ where
     let db = rusqlite::Connection::open(&output_path).context("failed to open catalog database")?;
 
     if config.typescript_generate || config.typescript_compile || config.typescript_package {
-        generate_npm_package(&all_tables, &directory)
-            .context("failed to generate TypeScript package")?;
+        if let Err(err) = generate_npm_package(&all_tables, &directory)
+            .context("failed to generate TypeScript package")
+        {
+            all_tables.errors.insert_row(&root_url, err);
+        }
     }
 
     if !all_tables.errors.is_empty() {


### PR DESCRIPTION
**Description:**

Bailing out early here causes the generated build database to be empty.
This ends up crashing the agent which expects a well-populated build
database.

**Workflow steps:**

1. Create a flow.yaml with a json schema which does not parse.
2. Run `flowctl api build` against it.
3. Inspect the generated build database and notice the complete lack of tables.
4. Checkout this branch.
5. Remove the old build database (they are additive, so old build errors stick around)
6. Rerun the build
7. Inspect the generated build database and see the npm packaging error in the `errors` table.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/586)
<!-- Reviewable:end -->
