### PR TITLE
Docs: bigquery caveat, shards, transactions, plus flowctl

### DIFF
--- a/site/docs/concepts/advanced/_category_.json
+++ b/site/docs/concepts/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced concepts",
-    "position": 9
+    "position": 10
 }

--- a/site/docs/concepts/advanced/shards.md
+++ b/site/docs/concepts/advanced/shards.md
@@ -17,11 +17,12 @@ https://gazette.readthedocs.io/en/latest/consumers-concepts.html#shards).
 
 When a task is first created, it is initialized with a single shard.
 Later and as required, shards may be split into two shards.
-This is done automatically for you depending on the size of your task.
+This is done by the service operator on your behalf, depending on the size of your task.
 Shard splitting doesn't require downtime; your task will continue to run as normal
 on the old shard until the split occurs and then shift seamlessly to the new, split shards.
 
-Flow repeats this process as needed until your required throughput is achieved.
+This process can be repeated as needed until your required throughput is achieved.
+If you have questions about how shards are split for your tasks, contact your Estuary account representative.
 
 ## Transactions
 

--- a/site/docs/concepts/advanced/shards.md
+++ b/site/docs/concepts/advanced/shards.md
@@ -21,7 +21,7 @@ This is done automatically for you depending on the size of your task.
 Shard splitting doesn't require downtime; your task will continue to run as normal
 on the old shard until the split occurs and then shift seamlessly to the new, split shards.
 
-This process is repeated as needed until your required throughput is achieved.
+Flow repeats this process as needed until your required throughput is achieved.
 
 ## Transactions
 

--- a/site/docs/concepts/captures.md
+++ b/site/docs/concepts/captures.md
@@ -77,8 +77,16 @@ If you see a connector you'd like to prioritize for access in the Flow web app, 
 
 ### Discovery
 
-Flow offers a CLI tool `flowctl discover --image connector/image:tag` which
-provides a guided workflow for creating a correctly configured capture.
+To help you configure new pull captures, Flow offers the guided **discovery** workflow in the Flow web application.
+
+To begin discovery, you tell Flow the connector you'd like to use and basic information about the endpoint.
+Flow automatically stubs out the capture configuration for you. It identifies one or more
+**resources** — tables, data streams, or the equivalent — and generates **bindings** so that each will be mapped to a
+data collection in Flow.
+
+You may then modify the generated configuration as needed before publishing the capture.
+
+For detailed steps, see the [guide to create a dataflow in the web app](../guides/create-dataflow.md#create-a-capture).
 
 ## Push captures
 

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -4,20 +4,18 @@ sidebar_position: 5
 # flowctl
 
 There are two ways to work with Flow: through the web app, and using the flowctl command-line interface.
-With flowctl, you can work on drafts and active catalogs created in the webapp with a
+With flowctl, you can work on drafts and active catalogs created in the web app with a
 higher degree of control.
-You can also authenticate Flow users and roles and generate Typescript modules to write custom transformations for your [derivations](derivations.md).
+You can also authorize Flow users and roles and generate Typescript modules to write custom transformations for your [derivations](derivations.md).
 
 flowctl is the only Flow binary that you need to work with,
 so distribution and upgrades are all simple.
 
 ## Installation
 
-:::info Beta
-Simplified installation is coming soon.
+flowctl binaries for MacOS and Linux can be found [here](https://go.estuary.dev/flowctl).
 
-For now, you can [contact Estuary support](mailto:support@estuary.dev) for access.
-:::
+Download the correct binary, make it executable, and add it to your `PATH`.
 
 ## flowctl subcommands
 

--- a/site/docs/reference/Configuring-task-shards.md
+++ b/site/docs/reference/Configuring-task-shards.md
@@ -25,24 +25,24 @@ For more information about these controls and when you might need to use them, s
 ```yaml
 materializations:
   acmeCo/snowflake-materialization:
-	  endpoint:
-  	    connector:
-    	    config:
-              account: acmeCo
-              database: acmeCo_db
-              password: secret
-              cloud_provider: aws
-              region: us-east-1
-              schema: acmeCo_flow_schema
-              user: snowflake_user
-              warehouse: acmeCo_warehouse
-    	    image: ghcr.io/estuary/materialize-snowflake:dev
+    endpoint:
+      connector:
+        config:
+          account: acmeCo
+          database: acmeCo_db
+          password: secret
+          cloud_provider: aws
+          region: us-east-1
+          schema: acmeCo_flow_schema
+          user: snowflake_user
+          warehouse: acmeCo_warehouse
+        image: ghcr.io/estuary/materialize-snowflake:dev
     bindings:
-  	- resource:
-      	table: anvils
+    - resource:
+        table: anvils
       source: acmeCo/anvils
     shards:
       logLevel: debug
       minTxnDuration: 30s
-      maxTxnDuration: 10m
+      maxTxnDuration: 4m
 ```

--- a/site/docs/reference/Configuring-task-shards.md
+++ b/site/docs/reference/Configuring-task-shards.md
@@ -12,7 +12,7 @@ You do this by adding the `shards` configuration to the capture or materializati
 |---|---|---|---|
 | `/disable` | Disable | Disable processing of the task's shards. | Boolean |
 | `/logLevel` | Log level | Log levels may currently be \"error\", \"warn\", \"info\", \"debug\", or \"trace\". If not set, the effective log level is \"info\". | String |
-| `/maxTxnDuration` | Maximum transaction duration | This duration upper-bounds the amount of time during which a transaction may process documents before it must flush and commit. It may run for less time if there aren't additional ready documents for it to process. If not set, the maximum duration defaults to one second. | String |
+| `/maxTxnDuration` | Maximum transaction duration | This duration upper-bounds the amount of time during which a transaction may process documents before it must initiate a commit. Note that it may take some additional time for the commit to complete after it is initiated. The shard may run for less time if there aren't additional ready documents for it to process. If not set, the maximum duration defaults to one second. | String |
 | `/minTxnDuration` | Minimum transaction duration | This duration lower-bounds the amount of time during which a transaction must process documents before it must flush and commit. It may run for more time if additional documents are available. The default value is zero seconds. | String |
 
 For more information about these controls and when you might need to use them, see:

--- a/site/docs/reference/Configuring-task-shards.md
+++ b/site/docs/reference/Configuring-task-shards.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 2
+---
+# Configuring task shards
+
+For some catalog tasks, it's helpful to control the behavior of [shards](../concepts/advanced/shards.md)
+You do this by adding the `shards` configuration to the capture or materialization configuration.
+
+## Properties
+
+| Property | Title | Description | Type |
+|---|---|---|---|
+| `/disable` | Disable | Disable processing of the task's shards. | Boolean |
+| `/logLevel` | Log level | Log levels may currently be \"error\", \"warn\", \"info\", \"debug\", or \"trace\". If not set, the effective log level is \"info\". | String |
+| `/maxTxnDuration` | Maximum transaction duration | This duration upper-bounds the amount of time during which a transaction may process documents before it must flush and commit. It may run for less time if there aren't additional ready documents for it to process. If not set, the maximum duration defaults to one second. | String |
+| `/minTxnDuration` | Minimum transaction duration | This duration lower-bounds the amount of time during which a transaction must process documents before it must flush and commit. It may run for more time if additional documents are available. The default value is zero seconds. | String |
+
+For more information about these controls and when you might need to use them, see:
+
+* [Transactions](../concepts/advanced/shards.md#transactions)
+* [Log level](../concepts/advanced/logs-stats.md#log-level)
+
+## Sample
+
+```yaml
+materializations:
+  acmeCo/snowflake-materialization:
+	  endpoint:
+  	    connector:
+    	    config:
+              account: acmeCo
+              database: acmeCo_db
+              password: secret
+              cloud_provider: aws
+              region: us-east-1
+              schema: acmeCo_flow_schema
+              user: snowflake_user
+              warehouse: acmeCo_warehouse
+    	    image: ghcr.io/estuary/materialize-snowflake:dev
+    bindings:
+  	- resource:
+      	table: anvils
+      source: acmeCo/anvils
+    shards:
+      logLevel: debug
+      minTxnDuration: 30s
+      maxTxnDuration: 10m
+```

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -22,7 +22,7 @@ To avoid running up against this limit, you should set the minimum transaction t
 or a minimum value of 1 minute. You do this by configuring the materialization's [task shard](../../Configuring-task-shards.md). This causes an apparent delay in the materialization, but is necessary to prevent error.
 This also makes transactions more efficient, which reduces costs in BigQuery, especially for large datasets.
 
-Instructions to set the minimum transaction time are detailed [below](#shard-configuration)
+Instructions to set the minimum transaction time are detailed [below](#shard-configuration).
 
 ## Prerequisites
 
@@ -99,8 +99,8 @@ To learn more about project billing, [see the BigQuery docs](https://cloud.googl
 ### Shard configuration
 
 :::info Beta
-Controls for this workflow will be added to the Flow web app's UI in the future.
-For now, you must edit the materialization config manually, either in the web app or using the CLI
+UI controls for this workflow will be added to the Flow web app soon.
+For now, you must edit the materialization config manually, either in the web app or using the CLI.
 :::
 
 To avoid exceeding your BigQuery tables' daily operation limits as discussed in [Performance considerations](#performance-considerations),
@@ -110,15 +110,15 @@ complete the following steps when configuring your materialization:
 create a draft materialization. Don't publish it yet.
 
 2. Add the [`shards` configuration](../../Configuring-task-shards.md) to the materialization at the same indentation level as `endpoint` and `resource`.
-Set the `minTxnDuration` property to at least `1m` (we recommend`2m`).
+Set the `minTxnDuration` property to at least `1m` (we recommend `2m`).
 In the web app, you do this in the catalog editor.
 
-```yaml
-shards:
-  minTxnDuration: 2m
-```
+   ```yaml
+   shards:
+     minTxnDuration: 2m
+   ```
 
-A full sample is included [below](#sample).
+   A full sample is included [below](#sample).
 
 3. Continue to test and publish the materialization.
 
@@ -127,18 +127,16 @@ A full sample is included [below](#sample).
 ```yaml
 materializations:
   ${PREFIX}/${mat_name}:
-	  endpoint:
-  	    connector:
-    	    config:
-              project_id: our-bigquery-project
-              dataset: materialized-data
-              region: US
-              bucket: our-gcs-bucket
-              bucket_path: bucket-path/
-              credentials_json: SSBqdXN0IHdhbm5hIHRlbGwgeW91IGhvdyBJJ20gZmVlbGluZwpHb3R0YSBtYWtlIHlvdSB1bmRlcnN0YW5kCk5ldmVyIGdvbm5hIGdpdmUgeW91IHVwCk5ldmVyIGdvbm5hIGxldCB5b3UgZG93bgpOZXZlciBnb25uYSBydW4gYXJvdW5kIGFuZCBkZXNlcnQgeW91Ck5ldmVyIGdvbm5hIG1ha2UgeW91IGNyeQpOZXZlciBnb25uYSBzYXkgZ29vZGJ5ZQpOZXZlciBnb25uYSB0ZWxsIGEgbGllIGFuZCBodXJ0IHlvdQ==
-    	    image: ghcr.io/estuary/materialize-bigquery:dev
-	# If you have multiple collections you need to materialize, add a binding for each one
-    # to ensure complete data flow-through
+    endpoint:
+      connector:
+        config:
+          project_id: our-bigquery-project
+          dataset: materialized-data
+          region: US
+          bucket: our-gcs-bucket
+          bucket_path: bucket-path/
+          credentials_json: SSBqdXN0IHdhbm5hIHRlbGwgeW91IGhvdyBJJ20gZmVlbGluZwpHb3R0YSBtYWtlIHlvdSB1bmRlcnN0YW5kCk5ldmVyIGdvbm5hIGdpdmUgeW91IHVwCk5ldmVyIGdvbm5hIGxldCB5b3UgZG93bgpOZXZlciBnb25uYSBydW4gYXJvdW5kIGFuZCBkZXNlcnQgeW91Ck5ldmVyIGdvbm5hIG1ha2UgeW91IGNyeQpOZXZlciBnb25uYSBzYXkgZ29vZGJ5ZQpOZXZlciBnb25uYSB0ZWxsIGEgbGllIGFuZCBodXJ0IHlvdQ==
+        image: ghcr.io/estuary/materialize-bigquery:dev
     bindings:
   	- resource:
       	table: ${table_name}

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -11,6 +11,19 @@ The tables in the bucket act as a temporary staging area for data storage and re
 
 [`ghcr.io/estuary/materialize-bigquery:dev`](https://github.com/estuary/connectors/pkgs/container/materialize-bigquery) provides the latest connector image. You can also follow the link in your browser to see past image versions.
 
+## Performance considerations
+
+Like other Estuary connectors, this is a real-time connector that materializes documents using continuous [transactions](../../../concepts/advanced/shards.md#transactions).
+However, in practice, there are speed limitations.
+Standard BigQuery tables are [limited to 1500 operations per day](https://cloud.google.com/bigquery/quotas#standard_tables).
+This means that the connector is limited 1500 transactions per day.
+
+To avoid running up against this limit, you should set the minimum transaction time to a recommended value of 2 minutes,
+or a minimum value of 1 minute. You do this by configuring the materialization's [task shard](../../Configuring-task-shards.md). This causes an apparent delay in the materialization, but is necessary to prevent error.
+This also makes transactions more efficient, which reduces costs in BigQuery, especially for large datasets.
+
+Instructions to set the minimum transaction time are detailed [below](#shard-configuration)
+
 ## Prerequisites
 
 To use this connector, you'll need:
@@ -25,7 +38,6 @@ To use this connector, you'll need:
 
     See [Setup](#setup) for detailed steps to set up your service account.
 * At least one Flow collection
-
 
 :::tip
 If you haven't yet captured your data from its external source, start at the beginning of the [guide to create a dataflow](../../../guides/create-dataflow.md). You'll be referred back to this connector-specific documentation at the appropriate steps.
@@ -51,7 +63,6 @@ During account creation:
    ```
 
    You'll use the resulting string when you configure the connector.
-
 
 ## Configuration
 
@@ -85,6 +96,32 @@ To learn more about project billing, [see the BigQuery docs](https://cloud.googl
 | **`/table`** | Table | Table name. | string | Required |
 | `/delta_updates` | Delta updates. | Whether to use standard or [delta updates](#delta-updates) | boolean | false |
 
+### Shard configuration
+
+:::info Beta
+Controls for this workflow will be added to the Flow web app's UI in the future.
+For now, you must edit the materialization config manually, either in the web app or using the CLI
+:::
+
+To avoid exceeding your BigQuery tables' daily operation limits as discussed in [Performance considerations](#performance-considerations),
+complete the following steps when configuring your materialization:
+
+1. Using the [Flow web application](../../../guides/create-dataflow.md#create-a-materialization) or the flowctl CLI,
+create a draft materialization. Don't publish it yet.
+
+2. Add the [`shards` configuration](../../Configuring-task-shards.md) to the materialization at the same indentation level as `endpoint` and `resource`.
+Set the `minTxnDuration` property to at least `1m` (we recommend`2m`).
+In the web app, you do this in the catalog editor.
+
+```yaml
+shards:
+  minTxnDuration: 2m
+```
+
+A full sample is included [below](#sample).
+
+3. Continue to test and publish the materialization.
+
 ### Sample
 
 ```yaml
@@ -105,7 +142,9 @@ materializations:
     bindings:
   	- resource:
       	table: ${table_name}
-    source: ${PREFIX}/${source_collection}
+      source: ${PREFIX}/${source_collection}
+    shards:
+      minTxnDuration: 2m
 ```
 
 ## Delta updates

--- a/site/docs/reference/organizing-catalogs.md
+++ b/site/docs/reference/organizing-catalogs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 # Organizing a Flow catalog
 

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 # Working with logs and statistics
 


### PR DESCRIPTION
**Description:**

users need to set minimum transaction duration to avoid running up against bigquery's table operations limitations. This PR adds this to the docs, along with all the required background information. This includes:

- new performance considerations section in BQ docs, plus step-by-step to change the appropriate setting
- changes to conceptual shards docs to discuss transactions
- Addition of a new reference page for shards config 

Plus some other random updates that aren't entirely related, but are necessary:
- instructions to download new flowctl binaries
- Remove references to some older `flowctl` commands `discover`, `shards split`
- update section about data discovery to discuss it as something that's only available in the UI

**Documentation links affected:**

added a new shortlink for downloading flowctl: 
go.estuary.dev/flowctl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/590)
<!-- Reviewable:end -->
