### PR TITLE
Phil/parse config discriminator

### DIFF
--- a/crates/doc/src/annotation.rs
+++ b/crates/doc/src/annotation.rs
@@ -26,6 +26,9 @@ pub enum Annotation {
     /// It has become a sort of convention in JSONSchema and OpenAPI to use X- prefixed fields
     /// for custom behaviour. We parse these fields to avoid breaking on such custom fields.
     X(Value),
+    /// Discriminator is an annotation from the [openapi spec](https://spec.openapis.org/oas/latest.html#discriminator-object),
+    /// which is used by the Estuary UI when rendering forms containing `oneOf`s.
+    Discriminator(Value),
 }
 
 impl schema::Annotation for Annotation {
@@ -40,7 +43,8 @@ impl schema::Annotation for Annotation {
 impl schema::build::AnnotationBuilder for Annotation {
     fn uses_keyword(keyword: &str) -> bool {
         match keyword {
-            "reduce" | "secret" | "airbyte_secret" | "multiline" | "advanced" | "order" => true,
+            "reduce" | "secret" | "airbyte_secret" | "multiline" | "advanced" | "order"
+            | "discriminator" => true,
             key if key.starts_with("x-") => true,
             _ => schema::CoreAnnotation::uses_keyword(keyword),
         }
@@ -74,6 +78,7 @@ impl schema::build::AnnotationBuilder for Annotation {
                 Err(e) => Err(AnnotationErr(Box::new(e))),
                 Ok(b) => Ok(Annotation::Advanced(b)),
             },
+            "discriminator" => Ok(Annotation::Discriminator(value.clone())),
             key if key.starts_with("x-") => match serde_json::to_value(value) {
                 Ok(v) => Ok(Annotation::X(v)),
                 Err(e) => Err(AnnotationErr(Box::new(e))),

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -691,6 +691,7 @@ impl Shape {
                     Annotation::Advanced(_) => {}
                     Annotation::Order(_) => {}
                     Annotation::X(_) => {}
+                    Annotation::Discriminator(_) => {}
                 },
 
                 // Array constraints.

--- a/crates/parser/src/config/mod.rs
+++ b/crates/parser/src/config/mod.rs
@@ -342,6 +342,15 @@ impl Format {
             _ => Some(self.clone()),
         }
     }
+
+    fn schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema = gen.subschema_for::<Format>().into_object();
+        schema.extensions.insert(
+            "discriminator".to_string(),
+            serde_json::json!({"propertyName": "name"}),
+        );
+        schema.into()
+    }
 }
 
 /// This value is always an empty JSON object.
@@ -516,6 +525,7 @@ pub struct ParseConfig {
     /// Determines how to parse the contents. The default, 'Auto', will try to determine the format
     /// automatically based on the file extension or MIME type, if available.
     #[serde(default)]
+    #[schemars(schema_with = "Format::schema")]
     pub format: Format,
 
     /// Determines how to decompress the contents. The default, 'Auto', will try to determine the

--- a/crates/parser/src/config/mod.rs
+++ b/crates/parser/src/config/mod.rs
@@ -699,7 +699,7 @@ mod test {
         // the `config` property will suddently fail to deserialize. This test is here to fail in
         // the case that someone adds a config object to a variant that currently has none.
         // If you're here because this is failing, fear not. There's a way to fix it. Add a custom
-        // `Deserialize` impl for `Format` that deserializes the `config` using two passes. One the
+        // `Deserialize` impl for `Format` that deserializes the `config` using two passes. On the
         // first pass, deserialize it into a `Value` or `RawValue`. Then, once the target variant
         // (and thus the target type of `config`) is known, deserialize that as the typed value.
         let types = ["json", "auto", "avro", "w3cExtendedLog"];

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -499,7 +499,10 @@ expression: schema
             }
           }
         }
-      ]
+      ],
+      "discriminator": {
+        "propertyName": "name"
+      }
     }
   }
 }

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -43,8 +43,7 @@ expression: schema
     "format": {
       "description": "Determines how to parse the contents. The default, 'Auto', will try to determine the format automatically based on the file extension or MIME type, if available.",
       "default": {
-        "config": {},
-        "name": "auto"
+        "type": "auto"
       },
       "oneOf": [
         {
@@ -52,17 +51,11 @@ expression: schema
           "description": "Attempt to determine the format automatically, based on the file extension or associated content-type.",
           "type": "object",
           "required": [
-            "config",
-            "name"
+            "type"
           ],
           "properties": {
-            "config": {
-              "default": {},
-              "type": "object"
-            },
-            "name": {
+            "type": {
               "default": "auto",
-              "type": "string",
               "const": "auto"
             }
           }
@@ -72,17 +65,11 @@ expression: schema
           "description": "Avro object container files, as defined by the [avro spec](https://avro.apache.org/docs/current/spec.html#Object+Container+Files)",
           "type": "object",
           "required": [
-            "config",
-            "name"
+            "type"
           ],
           "properties": {
-            "config": {
-              "default": {},
-              "type": "object"
-            },
-            "name": {
+            "type": {
               "default": "avro",
-              "type": "string",
               "const": "avro"
             }
           }
@@ -92,17 +79,11 @@ expression: schema
           "description": "JSON objects separated by whitespace, typically a single newline. This format works for JSONL (a.k.a. JSON-newline), but also for any stream of JSON objects, as long as they have at least one character of whitespace between them.",
           "type": "object",
           "required": [
-            "config",
-            "name"
+            "type"
           ],
           "properties": {
-            "config": {
-              "default": {},
-              "type": "object"
-            },
-            "name": {
+            "type": {
               "default": "json",
-              "type": "string",
               "const": "json"
             }
           }
@@ -113,7 +94,7 @@ expression: schema
           "type": "object",
           "required": [
             "config",
-            "name"
+            "type"
           ],
           "properties": {
             "config": {
@@ -472,9 +453,8 @@ expression: schema
                 }
               }
             },
-            "name": {
+            "type": {
               "default": "csv",
-              "type": "string",
               "const": "csv"
             }
           }
@@ -484,24 +464,21 @@ expression: schema
           "description": "A W3C Extended Log file, as defined by the working group draft at: https://www.w3.org/TR/WD-logfile.html",
           "type": "object",
           "required": [
-            "config",
-            "name"
+            "type"
           ],
           "properties": {
-            "config": {
-              "default": {},
-              "type": "object"
-            },
-            "name": {
+            "type": {
               "default": "w3cExtendedLog",
-              "type": "string",
               "const": "w3cExtendedLog"
             }
           }
         }
       ],
+      "required": [
+        "type"
+      ],
       "discriminator": {
-        "propertyName": "name"
+        "propertyName": "type"
       }
     }
   }

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -15,22 +15,27 @@ expression: schema
       "oneOf": [
         {
           "title": "GZip",
+          "default": "gzip",
           "const": "gzip"
         },
         {
           "title": "Zip Archive",
+          "default": "zip",
           "const": "zip"
         },
         {
           "title": "Zstandard",
+          "default": "zstd",
           "const": "zstd"
         },
         {
           "title": "None",
+          "default": "none",
           "const": "none"
         },
         {
           "title": "Auto",
+          "default": null,
           "const": null
         }
       ]
@@ -38,7 +43,8 @@ expression: schema
     "format": {
       "description": "Determines how to parse the contents. The default, 'Auto', will try to determine the format automatically based on the file extension or MIME type, if available.",
       "default": {
-        "auto": {}
+        "config": {},
+        "name": "auto"
       },
       "oneOf": [
         {
@@ -46,55 +52,71 @@ expression: schema
           "description": "Attempt to determine the format automatically, based on the file extension or associated content-type.",
           "type": "object",
           "required": [
-            "auto"
+            "config",
+            "name"
           ],
           "properties": {
-            "auto": {
+            "config": {
               "default": {},
               "type": "object"
+            },
+            "name": {
+              "default": "auto",
+              "type": "string",
+              "const": "auto"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "title": "Avro",
           "description": "Avro object container files, as defined by the [avro spec](https://avro.apache.org/docs/current/spec.html#Object+Container+Files)",
           "type": "object",
           "required": [
-            "avro"
+            "config",
+            "name"
           ],
           "properties": {
-            "avro": {
+            "config": {
               "default": {},
               "type": "object"
+            },
+            "name": {
+              "default": "avro",
+              "type": "string",
+              "const": "avro"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "title": "JSON",
           "description": "JSON objects separated by whitespace, typically a single newline. This format works for JSONL (a.k.a. JSON-newline), but also for any stream of JSON objects, as long as they have at least one character of whitespace between them.",
           "type": "object",
           "required": [
-            "json"
+            "config",
+            "name"
           ],
           "properties": {
-            "json": {
+            "config": {
               "default": {},
               "type": "object"
+            },
+            "name": {
+              "default": "json",
+              "type": "string",
+              "const": "json"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "title": "CSV",
           "description": "Character Separated Values, such as comma-separated, tab-separated, etc.",
           "type": "object",
           "required": [
-            "csv"
+            "config",
+            "name"
           ],
           "properties": {
-            "csv": {
+            "config": {
               "type": "object",
               "properties": {
                 "delimiter": {
@@ -104,38 +126,47 @@ expression: schema
                   "oneOf": [
                     {
                       "title": "Comma (,)",
+                      "default": ",",
                       "const": ","
                     },
                     {
                       "title": "Pipe (|)",
+                      "default": "|",
                       "const": "|"
                     },
                     {
                       "title": "Space (0x20)",
+                      "default": " ",
                       "const": " "
                     },
                     {
                       "title": "Semicolon (;)",
+                      "default": ";",
                       "const": ";"
                     },
                     {
                       "title": "Tab (0x09)",
+                      "default": "\t",
                       "const": "\t"
                     },
                     {
                       "title": "Vertical Tab (0x0B)",
+                      "default": "\u000b",
                       "const": "\u000b"
                     },
                     {
                       "title": "Unit Separator (0x1F)",
+                      "default": "\u001f",
                       "const": "\u001f"
                     },
                     {
                       "title": "SOH (0x01)",
+                      "default": "\u0001",
                       "const": "\u0001"
                     },
                     {
                       "title": "Auto",
+                      "default": null,
                       "const": null
                     }
                   ]
@@ -147,158 +178,197 @@ expression: schema
                   "oneOf": [
                     {
                       "title": "UTF-8",
+                      "default": "UTF-8",
                       "const": "UTF-8"
                     },
                     {
                       "title": "UTF-16LE",
+                      "default": "UTF-16LE",
                       "const": "UTF-16LE"
                     },
                     {
                       "title": "UTF-16BE",
+                      "default": "UTF-16BE",
                       "const": "UTF-16BE"
                     },
                     {
                       "title": "IBM866",
+                      "default": "IBM866",
                       "const": "IBM866"
                     },
                     {
                       "title": "ISO-8859-2",
+                      "default": "ISO-8859-2",
                       "const": "ISO-8859-2"
                     },
                     {
                       "title": "ISO-8859-3",
+                      "default": "ISO-8859-3",
                       "const": "ISO-8859-3"
                     },
                     {
                       "title": "ISO-8859-4",
+                      "default": "ISO-8859-4",
                       "const": "ISO-8859-4"
                     },
                     {
                       "title": "ISO-8859-5",
+                      "default": "ISO-8859-5",
                       "const": "ISO-8859-5"
                     },
                     {
                       "title": "ISO-8859-6",
+                      "default": "ISO-8859-6",
                       "const": "ISO-8859-6"
                     },
                     {
                       "title": "ISO-8859-7",
+                      "default": "ISO-8859-7",
                       "const": "ISO-8859-7"
                     },
                     {
                       "title": "ISO-8859-8",
+                      "default": "ISO-8859-8",
                       "const": "ISO-8859-8"
                     },
                     {
                       "title": "ISO-8859-8-I",
+                      "default": "ISO-8859-8-I",
                       "const": "ISO-8859-8-I"
                     },
                     {
                       "title": "ISO-8859-10",
+                      "default": "ISO-8859-10",
                       "const": "ISO-8859-10"
                     },
                     {
                       "title": "ISO-8859-13",
+                      "default": "ISO-8859-13",
                       "const": "ISO-8859-13"
                     },
                     {
                       "title": "ISO-8859-14",
+                      "default": "ISO-8859-14",
                       "const": "ISO-8859-14"
                     },
                     {
                       "title": "ISO-8859-15",
+                      "default": "ISO-8859-15",
                       "const": "ISO-8859-15"
                     },
                     {
                       "title": "ISO-8859-16",
+                      "default": "ISO-8859-16",
                       "const": "ISO-8859-16"
                     },
                     {
                       "title": "KOI8-R",
+                      "default": "KOI8-R",
                       "const": "KOI8-R"
                     },
                     {
                       "title": "KOI8-U",
+                      "default": "KOI8-U",
                       "const": "KOI8-U"
                     },
                     {
                       "title": "macintosh",
+                      "default": "macintosh",
                       "const": "macintosh"
                     },
                     {
                       "title": "windows-874",
+                      "default": "windows-874",
                       "const": "windows-874"
                     },
                     {
                       "title": "windows-1250",
+                      "default": "windows-1250",
                       "const": "windows-1250"
                     },
                     {
                       "title": "windows-1251",
+                      "default": "windows-1251",
                       "const": "windows-1251"
                     },
                     {
                       "title": "windows-1252",
+                      "default": "windows-1252",
                       "const": "windows-1252"
                     },
                     {
                       "title": "windows-1253",
+                      "default": "windows-1253",
                       "const": "windows-1253"
                     },
                     {
                       "title": "windows-1254",
+                      "default": "windows-1254",
                       "const": "windows-1254"
                     },
                     {
                       "title": "windows-1255",
+                      "default": "windows-1255",
                       "const": "windows-1255"
                     },
                     {
                       "title": "windows-1256",
+                      "default": "windows-1256",
                       "const": "windows-1256"
                     },
                     {
                       "title": "windows-1257",
+                      "default": "windows-1257",
                       "const": "windows-1257"
                     },
                     {
                       "title": "windows-1258",
+                      "default": "windows-1258",
                       "const": "windows-1258"
                     },
                     {
                       "title": "x-mac-cyrillic",
+                      "default": "x-mac-cyrillic",
                       "const": "x-mac-cyrillic"
                     },
                     {
                       "title": "GBK",
+                      "default": "GBK",
                       "const": "GBK"
                     },
                     {
                       "title": "gb18030",
+                      "default": "gb18030",
                       "const": "gb18030"
                     },
                     {
                       "title": "Big5",
+                      "default": "Big5",
                       "const": "Big5"
                     },
                     {
                       "title": "EUC-JP",
+                      "default": "EUC-JP",
                       "const": "EUC-JP"
                     },
                     {
                       "title": "ISO-2022-JP",
+                      "default": "ISO-2022-JP",
                       "const": "ISO-2022-JP"
                     },
                     {
                       "title": "Shift_JIS",
+                      "default": "Shift_JIS",
                       "const": "Shift_JIS"
                     },
                     {
                       "title": "EUC-KR",
+                      "default": "EUC-KR",
                       "const": "EUC-KR"
                     },
                     {
                       "title": "Auto",
+                      "default": null,
                       "const": null
                     }
                   ]
@@ -318,14 +388,17 @@ expression: schema
                   "oneOf": [
                     {
                       "title": "Backslash (\\)",
+                      "default": "\\",
                       "const": "\\"
                     },
                     {
                       "title": "Disable Escapes",
+                      "default": "",
                       "const": ""
                     },
                     {
                       "title": "Auto",
+                      "default": null,
                       "const": null
                     }
                   ]
@@ -345,22 +418,27 @@ expression: schema
                   "oneOf": [
                     {
                       "title": "CRLF (\\r\\n) (Windows)",
+                      "default": "\r\n",
                       "const": "\r\n"
                     },
                     {
                       "title": "CR (\\r)",
+                      "default": "\r",
                       "const": "\r"
                     },
                     {
                       "title": "LF (\\n)",
+                      "default": "\n",
                       "const": "\n"
                     },
                     {
                       "title": "Record Separator (0x1E)",
+                      "default": "\u001e",
                       "const": "\u001e"
                     },
                     {
                       "title": "Auto",
+                      "default": null,
                       "const": null
                     }
                   ]
@@ -372,41 +450,54 @@ expression: schema
                   "oneOf": [
                     {
                       "title": "Double Quote (\")",
+                      "default": "\"",
                       "const": "\""
                     },
                     {
                       "title": "Single Quote (')",
+                      "default": "'",
                       "const": "'"
                     },
                     {
                       "title": "Disable Quoting",
+                      "default": "",
                       "const": ""
                     },
                     {
                       "title": "Auto",
+                      "default": null,
                       "const": null
                     }
                   ]
                 }
               }
+            },
+            "name": {
+              "default": "csv",
+              "type": "string",
+              "const": "csv"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "title": "W3C Extended Log",
           "description": "A W3C Extended Log file, as defined by the working group draft at: https://www.w3.org/TR/WD-logfile.html",
           "type": "object",
           "required": [
-            "w3cExtendedLog"
+            "config",
+            "name"
           ],
           "properties": {
-            "w3cExtendedLog": {
+            "config": {
               "default": {},
               "type": "object"
+            },
+            "name": {
+              "default": "w3cExtendedLog",
+              "type": "string",
+              "const": "w3cExtendedLog"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     }

--- a/crates/parser/src/format/mod.rs
+++ b/crates/parser/src/format/mod.rs
@@ -109,11 +109,11 @@ pub fn parse(
 
 fn parser_for(format: Format) -> Box<dyn Parser> {
     match format {
-        Format::Auto(_) => character_separated::new_csv_parser(Default::default()),
-        Format::Json(_) => json::new_parser(),
+        Format::Auto => character_separated::new_csv_parser(Default::default()),
+        Format::Json => json::new_parser(),
         Format::Csv(csv_config) => character_separated::new_csv_parser(csv_config),
-        Format::W3cExtendedLog(_) => character_separated::new_w3c_extended_log_parser(),
-        Format::Avro(_) => avro::new_parser(),
+        Format::W3cExtendedLog => character_separated::new_w3c_extended_log_parser(),
+        Format::Avro => avro::new_parser(),
     }
 }
 
@@ -189,8 +189,8 @@ fn determine_format(config: &ParseConfig) -> Option<Format> {
 
 fn format_for_content_type(content_type: &str) -> Option<Format> {
     match content_type {
-        "application/json" => Some(Format::Json(Default::default())),
-        "text/json" => Some(Format::Json(Default::default())),
+        "application/json" => Some(Format::Json),
+        "text/json" => Some(Format::Json),
         "text/csv" => Some(Format::Csv(Default::default())),
         "text/tab-separated-values" => Some(Format::Csv(Default::default())),
         _ => None,
@@ -199,10 +199,10 @@ fn format_for_content_type(content_type: &str) -> Option<Format> {
 
 fn format_for_file_extension(extension: &str) -> Option<Format> {
     match extension {
-        "jsonl" | "json" => Some(Format::Json(Default::default())),
+        "jsonl" | "json" => Some(Format::Json),
         "csv" => Some(Format::Csv(Default::default())),
         "tsv" => Some(Format::Csv(Default::default())),
-        "avro" => Some(Format::Avro(Default::default())),
+        "avro" => Some(Format::Avro),
         _ => None,
     }
 }
@@ -333,7 +333,7 @@ mod test {
             content_type: Some("xml or something lol".to_string()),
             ..Default::default()
         };
-        assert_format_eq(Some(Format::Json(Default::default())), &conf);
+        assert_format_eq(Some(Format::Json), &conf);
         conf.filename = Some("nope.jason".to_string());
         assert_format_eq(None, &conf);
     }
@@ -345,9 +345,9 @@ mod test {
             content_type: Some("application/json".to_string()),
             ..Default::default()
         };
-        assert_format_eq(Some(Format::Json(Default::default())), &conf);
+        assert_format_eq(Some(Format::Json), &conf);
         conf.content_type = Some("text/json".to_string());
-        assert_format_eq(Some(Format::Json(Default::default())), &conf);
+        assert_format_eq(Some(Format::Json), &conf);
         conf.content_type = Some("wat".to_string());
         assert_format_eq(None, &conf);
     }

--- a/crates/parser/tests/happy_path_test.rs
+++ b/crates/parser/tests/happy_path_test.rs
@@ -23,7 +23,7 @@ fn w3c_extended_log_file_is_parsed() {
     let config = ParseConfig {
         // Explicit format is required, since there's no file extension that's associated with
         // this format.
-        format: Format::W3cExtendedLog(Default::default()).into(),
+        format: Format::W3cExtendedLog.into(),
         ..Default::default()
     };
     let input = input_for_file("tests/examples/w3c-extended-log");


### PR DESCRIPTION
**Description:**

Changes the parser configuration again, in an effort to make it work better in the UI. With this, it finally works well end to end!

**Workflow steps:**

1. Use the S3 or GCS capture connectors.
2. Be amazed at how the parser config form renders all beautifully in the UI.

**Documentation links affected:**

- [S3](https://docs.estuary.dev/reference/Connectors/capture-connectors/amazon-s3/)
- [GCS](https://docs.estuary.dev/reference/Connectors/capture-connectors/gcs/)

**Notes for reviewers:**

Recommend going commit by commit. Here's how it looks as part of the source-s3 connector:

![image](https://user-images.githubusercontent.com/4495829/180562935-fef72d51-2ded-406c-a2c2-a13a5de136b5.png)

![image](https://user-images.githubusercontent.com/4495829/180566285-554d0fd3-b72c-4c33-9598-bcc08d235da3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/591)
<!-- Reviewable:end -->
