### PR TITLE
Minor POSIX-compatibility fix to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ go-protobufs: $(GO_PROTO_TARGETS)
 ${PKGDIR}/bin/etcd:
 	# For Apple M1 we are currently using an unofficial built binary. Once the official binary for
 	# M1 is released we should switch to use that: https://github.com/etcd-io/etcd/issues/14001
-	if [ "$(UNAME)" == "Darwin arm" ]; then \
+	if [ "$(UNAME)" = "Darwin arm" ]; then \
 		curl -L -o /tmp/etcd.tgz \
 										https://github.com/UniversalShipping/etcd/releases/download/${ETCD_VERSION}/etcd-binaries-darwin-arm64.tar.gz \
 						&& tar --extract \
@@ -116,7 +116,7 @@ ${PKGDIR}/bin/etcd:
 						&& rm -r /tmp/bin/ \
 						&& rm /tmp/etcd.tgz \
 						&& $@ --version; \
-	elif [ "$(UNAME)" == "Darwin i386" ]; then \
+	elif [ "$(UNAME)" = "Darwin i386" ]; then \
 		curl -L -o /tmp/etcd.zip \
 										https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-darwin-amd64.zip \
 						&& echo "${ETCD_DARWIN_AMD64_SHA256} /tmp/etcd.zip" | sha256sum -c - \


### PR DESCRIPTION
**Description:**

The standard `test` (`[`) binary uses the syntax `[ foo = bar ]` for string equality comparison rather than `[ foo == bar ]`. This is easy to miss because many shells (like bash for instance) use their own builtin replacement which *does* accept `==`, but for whatever reason my setup was having trouble with that in the context of Makefile command execution.

For obvious reasons I have not tested this on a Mac, but in general I'd expect this change to be more likely to work in odd places, so hopefully it's fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/600)
<!-- Reviewable:end -->
