### PR TITLE
Replace 'host' with 'address' for materialize-postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,10 @@ materializations:
           # Try this by standing up a local PostgreSQL database.
           # docker run --rm -e POSTGRES_PASSWORD=password -p 5432:5432 postgres -c log_statement=all
           # (Use host: host.docker.internal when running Docker for Windows/Mac).
-          host: localhost
+          address: localhost:5432
           password: password
           database: postgres
           user: postgres
-          port: 5432
     bindings:
       # Flow creates a 'citi_rides' table for us and keeps it up to date.
       - source: examples/citi-bike/rides

--- a/examples/acmeBank.flow.yaml
+++ b/examples/acmeBank.flow.yaml
@@ -55,11 +55,10 @@ collections:
 #          # Try this by standing up a local PostgreSQL database.
 #          # docker run --rm -e POSTGRES_PASSWORD=password -p 5432:5432 postgres -c log_statement=all
 #          # (Use host: host.docker.internal when running Docker for Windows/Mac).
-#          host: localhost
+#          address: localhost:5432
 #          password: password
 #          database: postgres
 #          user: postgres
-#          port: 5432
 #    bindings:
 #      # Create and materialize into table `account_balances`.
 #      - resource:

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -93,11 +93,10 @@ materializations:
         image: ghcr.io/estuary/materialize-postgres:dev
         # 2: Provide endpoint configuration that the connector requires.
         config:
-          host: localhost
+          address: localhost:5432
           password: password
           database: postgres
           user: postgres
-          port: 5432
     bindings:
       - source: acmeCo/products/anvils
         # 3: Provide resource configuration for the binding between the Flow
@@ -138,11 +137,10 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          host: localhost
+          address: localhost:5432
           password: password
           database: postgres
           user: postgres
-          port: 5432
       bindings: []
 ```
 
@@ -160,11 +158,10 @@ materializations:
 ```
 
 ```yaml title="my.config.yaml"
-host: localhost
+address: localhost:5432
 password: password
 database: postgres
 user: postgres
-port: 5432
 ```
 
 </TabItem>

--- a/tests/citi-bike-success/flow.yaml
+++ b/tests/citi-bike-success/flow.yaml
@@ -10,8 +10,7 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          host: localhost
-          port: 2345
+          address: localhost:2345
           user: flow
           password: flow
           database: flow

--- a/tests/materialize-logs.flow.yaml
+++ b/tests/materialize-logs.flow.yaml
@@ -7,8 +7,7 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          host: localhost
-          port: 2345
+          address: localhost:2345
           user: flow
           password: flow
           database: flow

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -1,5 +1,4 @@
-host: localhost
-port: 16666
+address: localhost:16666
 user: flow
 password: flow
 database: flow


### PR DESCRIPTION
**Description:**

This is a followon to https://github.com/estuary/connectors/pull/297 which replaced the 'host' and 'port' properties with 'address'. This commit modifies the test configurations to use 'address', and also a couple of other places where a 'host' property was mentioned in the context of `materialize-postgres`

**Workflow steps:**

The test changes ought to fix CI builds for the flow repository.

**Documentation links affected:**

None, the main docs changes were actually done slightly before the `address` change landed, and this just fixes a handful of tests and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/601)
<!-- Reviewable:end -->
