### PR TITLE
Allow disabling captures and materializations when the external systems are unreachable

### DIFF
--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -21,6 +21,45 @@ fn test_golden_all_visits() {
 }
 
 #[test]
+fn connector_validation_is_skipped_when_shards_are_disabled() {
+    let fixture =
+        serde_yaml::from_slice(include_bytes!("validation_skipped_when_disabled.yaml")).unwrap();
+    let tables = run_test(
+        fixture,
+        &flow::build_api::Config {
+            build_id: "validation-skipped-build-id".to_string(),
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        tables.errors.is_empty(),
+        "expected no errors, got: {:?}",
+        tables.errors
+    );
+    assert!(tables.built_captures.len() == 1);
+    assert_eq!(
+        tables.built_captures[0]
+            .spec
+            .shard_template
+            .as_ref()
+            .unwrap()
+            .disable,
+        true
+    );
+    assert!(tables.built_materializations.len() == 1);
+    assert_eq!(
+        tables.built_materializations[0]
+            .spec
+            .shard_template
+            .as_ref()
+            .unwrap()
+            .disable,
+        true
+    );
+}
+
+#[test]
 fn test_database_round_trip() {
     let tables = run_test(
         GOLDEN.clone(),

--- a/crates/validation/tests/validation_skipped_when_disabled.yaml
+++ b/crates/validation/tests/validation_skipped_when_disabled.yaml
@@ -1,0 +1,64 @@
+test://example/catalog.yaml:
+  collections:
+    acmeCo/foo:
+      schema:
+        type: object
+        properties:
+          id: {type: integer}
+          val: {type: string}
+        required: [id, val]
+      key: [/id]
+  captures:
+    acmeCo/testCapture:
+      shards:
+        disable: true
+      endpoint:
+        connector:
+          image: someSourceImage
+          config:
+            any: thing
+      bindings:
+        - resource: { whatever: 'and ever' }
+          target: acmeCo/foo
+  materializations:
+    acmeCo/testMaterialization:
+      shards:
+        disable: true
+      endpoint:
+        connector:
+          image: someMaterializationImage
+          config:
+            any: thing
+      bindings:
+        - resource: { whatever: 'and ever' }
+          source: acmeCo/foo
+  storageMappings:
+    acmeCo/:
+      stores: [{ provider: S3, bucket: data-bucket }]
+    recovery/acmeCo/:
+      stores: [{ provider: S3, bucket: data-bucket }]
+
+driver:
+  materializations:
+    acmeCo/testMaterialization:
+      endpoint: FLOW_SINK
+      spec:
+        image: someMaterializationImage
+        config: { any: thing }
+      deltaUpdates: true
+      error: Validate should never be called
+      bindings:
+        - constraints:
+            id: {type: 0, reason: 'field required'}
+            val: {type: 0, reason: 'field required'}
+          resourcePath: [mockPath]
+
+  captures:
+    acmeCo/testCapture:
+      endpoint: AIRBYTE_SOURCE
+      error: Validate should never be called
+      spec:
+        image: someCaptureImage
+        config: { any: thing }
+      bindings:
+        - resourcePath: [mockPath]

--- a/go/flowctl-go/cmd-api-activate.go
+++ b/go/flowctl-go/cmd-api-activate.go
@@ -84,6 +84,11 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 		if !ok {
 			continue
 		}
+		if spec.ShardTemplate.Disable {
+			log.WithField("capture", spec.Capture.String()).
+				Info("Will skip applying capture because it's shards are disabled")
+			continue
+		}
 
 		driver, err := capture.NewDriver(ctx,
 			spec.EndpointType, json.RawMessage(spec.EndpointSpecJson), cmd.Network, ops.StdLogger())
@@ -113,6 +118,11 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 	for _, t := range tasks {
 		var spec, ok = t.(*pf.MaterializationSpec)
 		if !ok {
+			continue
+		}
+		if spec.ShardTemplate.Disable {
+			log.WithField("capture", spec.Materialization.String()).
+				Info("Will skip applying materialization because it's shards are disabled")
 			continue
 		}
 

--- a/go/flowctl-go/cmd-api-activate.go
+++ b/go/flowctl-go/cmd-api-activate.go
@@ -121,7 +121,7 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 			continue
 		}
 		if spec.ShardTemplate.Disable {
-			log.WithField("capture", spec.Materialization.String()).
+			log.WithField("materialization", spec.Materialization.String()).
 				Info("Will skip applying materialization because it's shards are disabled")
 			continue
 		}

--- a/go/flowctl-go/cmd-api-activate.go
+++ b/go/flowctl-go/cmd-api-activate.go
@@ -163,7 +163,7 @@ func (cmd apiActivate) execute(ctx context.Context) error {
 	for _, task := range tasks {
 
 		if task.TaskShardTemplate().Disable {
-			log.WithField("task", task.TaskName()).Warn("task is disabled")
+			log.WithField("task", task.TaskName()).Info("task is disabled")
 			continue
 		}
 

--- a/go/flowctl-go/cmd-api-delete.go
+++ b/go/flowctl-go/cmd-api-delete.go
@@ -83,6 +83,11 @@ func (cmd apiDelete) execute(ctx context.Context) error {
 		if !ok {
 			continue
 		}
+		if spec.ShardTemplate.Disable {
+			log.WithField("capture", spec.Capture.String()).
+				Info("Will skip un-applying capture because it's disabled")
+			continue
+		}
 
 		driver, err := capture.NewDriver(ctx,
 			spec.EndpointType, json.RawMessage(spec.EndpointSpecJson), cmd.Network, ops.StdLogger())
@@ -113,6 +118,11 @@ func (cmd apiDelete) execute(ctx context.Context) error {
 	for _, t := range tasks {
 		var spec, ok = t.(*pf.MaterializationSpec)
 		if !ok {
+			continue
+		}
+		if spec.ShardTemplate.Disable {
+			log.WithField("materialization", spec.Materialization.String()).
+				Info("Will skip un-applying materialization because it's disabled")
 			continue
 		}
 

--- a/tests/citi-bike-success/flow.yaml
+++ b/tests/citi-bike-success/flow.yaml
@@ -20,5 +20,40 @@ materializations:
       - source: examples/citi-bike/last-seen
         resource: { table: citi_last_seen }
 
+  # This materialization exists to document and exercise the expectation that disabled tasks
+  # do not need to connect to the target system as part of build and activation.
+  examples/citi-bike/disabled-materialization:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-postgres:dev
+        config:
+          address: not-a-real-domain.test:5432
+          user: not-a-real-user
+          password: not-a-real-password
+          database: not-a-real-database
+    bindings:
+      - source: examples/citi-bike/stations
+        resource: { table: citi_stations }
+
+captures:
+  # This capture exists to document and exercise the expectation that disabled tasks
+  # do not need to connect to the source system as part of build and activation.
+  examples/citi-bike/disabled-capture:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-postgres:dev
+        config:
+          address: not-a-real-domain.test:5432
+          user: not-a-real-user
+          password: not-a-real-password
+          database: not-a-real-database
+    bindings:
+      - resource: { table: not_a_real_table }
+        target: examples/citi-bike/rides
+
 storageMappings:
   "": { stores: [{ provider: S3, bucket: a-bucket }] }


### PR DESCRIPTION
**Description:**

The problem that we observed is this. Say you have a capture or a materialization, and the system you're connecting to becomes unreachable in some way. It could be that someone changed the credentials, deleted the database, or anything else. In Flow, we often want to just disable these tasks so that we can reduce the noise of alerts, and then they can be resumed when the system comes back online. This was not possible because Flow would call into the connectors to `Validate` the specs when changing `/shards/disabled` from `false` to `true`. I also discovered that `flowctl api activate` would also call into the connector to `ApplyUpsert` disabled shards.

This PR updates the build step to skip the call to `Validate`, and also the activate step to skip the call to `ApplyUpsert`.

There's an argument to be made for still calling `ApplyUpsert` on disabled tasks, and just ignoring errors on those. It seems potentially useful for a connector to know when a task becomes disabled. But there's no clear use case for this at the moment, and I thought it simpler to just always skip the calls for now.

**Workflow steps:**

Use either the UI or CLI to disable a capture or a materialization. This should now succeed, even when the external system is unreachable.

**Documentation links affected:**

The previous behavior wasn't documented, and it's probably not necessary to document the new behavior, either, since it's probably what users would expect anyway.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/608)
<!-- Reviewable:end -->
