### PR TITLE
connector_proxy: pass through cursorField in Airbyte connectors

### DIFF
--- a/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
@@ -111,6 +111,7 @@ impl AirbyteSourceInterceptor {
                     stream: stream.name.clone(),
                     namespace: stream.namespace,
                     sync_mode: mode,
+                    cursor_field: stream.default_cursor_field,
                 };
 
                 let key_ptrs = match stream.source_defined_primary_key {
@@ -246,7 +247,7 @@ impl AirbyteSourceInterceptor {
                                 catalog.streams.push(ConfiguredStream {
                                     sync_mode: resource.sync_mode.clone(),
                                     destination_sync_mode: DestinationSyncMode::Append,
-                                    cursor_field: None,
+                                    cursor_field: resource.cursor_field,
                                     primary_key: Some(primary_key),
                                     stream: airbyte_catalog::Stream {
                                         name: resource.stream,

--- a/crates/connector_proxy/src/libs/airbyte_catalog.rs
+++ b/crates/connector_proxy/src/libs/airbyte_catalog.rs
@@ -244,4 +244,6 @@ pub struct ResourceSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     pub sync_mode: SyncMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor_field: Option<Vec<String>>,
 }


### PR DESCRIPTION
**Description:**

- Connector proxy now passes through `cursorField` from Airbyte spec of streams. This allows us to specify a cursor field for each stream (useful for source-firestore).

**Workflow steps:**

- Pass `cursorField` to a binding resource_spec, it's an optional array of strings

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/616)
<!-- Reviewable:end -->
