### PR TITLE
Phil/logging fixes

### DIFF
--- a/crates/flow_cli_common/src/logging.rs
+++ b/crates/flow_cli_common/src/logging.rs
@@ -20,7 +20,7 @@ pub struct LogArgs {
 
 #[derive(Debug, clap::ArgEnum, Clone, Copy)]
 pub enum LogLevel {
-    Tracing,
+    Trace,
     Debug,
     Info,
     Warn,
@@ -30,7 +30,7 @@ pub enum LogLevel {
 impl ToString for LogLevel {
     fn to_string(&self) -> String {
         match self {
-            LogLevel::Tracing => "tracing",
+            LogLevel::Trace => "trace",
             LogLevel::Debug => "debug",
             LogLevel::Info => "info",
             LogLevel::Warn => "warn",

--- a/go/runtime/ops.go
+++ b/go/runtime/ops.go
@@ -183,6 +183,12 @@ func (p *LogPublisher) Log(level logrus.Level, fields logrus.Fields, message str
 	if p.level < level {
 		return nil
 	}
+	// It's common practice to treat `nil` and an empty map equivalently. But that doesn't work when
+	// you pass a `nil` of type `logrus.Fields` to `doLog`, which accepts `fields interface{}`.
+	// See: https://stackoverflow.com/questions/44320960/omitempty-doesnt-omit-interface-nil-values-in-json
+	if fields == nil {
+		fields = logrus.Fields{}
+	}
 	var err = p.doLog(level, time.Now().UTC(), fields, message)
 	if err == nil && logrus.IsLevelEnabled(level) {
 		ops.StdLogger().Log(level, fields, message)
@@ -195,6 +201,12 @@ func (p *LogPublisher) Log(level logrus.Level, fields logrus.Fields, message str
 func (p *LogPublisher) LogForwarded(ts time.Time, level logrus.Level, fields map[string]json.RawMessage, message string) error {
 	if p.level < level {
 		return nil
+	}
+	// It's common practice to treat `nil` and an empty map equivalently. But that doesn't work when
+	// you pass a `nil` of type `map[string]json.RawMessage` to `doLog`, which accepts `fields interface{}`.
+	// See: https://stackoverflow.com/questions/44320960/omitempty-doesnt-omit-interface-nil-values-in-json
+	if fields == nil {
+		fields = map[string]json.RawMessage{}
 	}
 	var err = p.doLog(level, time.Now().UTC(), fields, message)
 	if err == nil && logrus.IsLevelEnabled(level) {


### PR DESCRIPTION
**Description:**

During the course of debugging, I discovered a couple of bugs related to logging.

First: The `"trace"` logging level was incorrectly called `"tracing"` in `flow_cli_common`, which results in a connector-proxy error when the `shards.logLevel` is set to `trace`.

Second: There are some places where callers pass `nil` instead of an empty `logrus.Fields{}` map, which resulted in a literal `null` value for the `fields` in the serialized JSON (despite the presence of `omitempty`), which is not valid against the JSON schema of the `ops/<prefix>/logs` collection. I'll try to resist the urge to rant about this one...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/622)
<!-- Reviewable:end -->
