### PR TITLE
schemalate/firebolt: quote table name identifiers if necessary

### DIFF
--- a/crates/schemalate/src/firebolt/firebolt_types.rs
+++ b/crates/schemalate/src/firebolt/firebolt_types.rs
@@ -99,7 +99,7 @@ lazy_static! {
 
 // non-lower-case keys, reserved words, and fields not conforming to the regex must
 // be quoted. see https://docs.firebolt.io/general-reference/identifier-requirements.html
-pub fn column_quote(s: &str) -> String {
+pub fn identifier_quote(s: &str) -> String {
     if !VALID_FIELD_REGEX.is_match(s)
         || RESERVED_WORDS.contains(&s.to_lowercase())
         || s != s.to_lowercase()
@@ -115,7 +115,7 @@ impl Display for Column {
         write!(
             f,
             "{} {}{}",
-            column_quote(&self.key),
+            identifier_quote(&self.key),
             self.r#type,
             if self.nullable { " NULL" } else { "" }
         )


### PR DESCRIPTION
**Description:**

- We were only quoting column identifiers, but table names must also conform to the same identifier requirements

**Workflow steps:**

- Create a table with a special character such as `-`

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/623)
<!-- Reviewable:end -->
