### PR TITLE
docs: Document some potential isues when building from scratch on an M1, and their resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,27 @@ Flow mixes a variety of architectural techniques to achieve great throughput wit
 
 ## Building on M1
 
-To cross-compile `musl` binaries from a darwin arm64 (M1) machine, you need to install `musl-cross` and link it:
+* To cross-compile `musl` binaries from a darwin arm64 (M1) machine, you need to install `musl-cross` and link it:
+  ```
+  brew install filosottile/musl-cross/musl-cross
+  sudo ln -s /opt/homebrew/opt/musl-cross/bin/x86_64-linux-musl-gcc /usr/local/bin/musl-gcc
+  ```
 
-```
-brew install filosottile/musl-cross/musl-cross
-sudo ln -s /opt/homebrew/opt/musl-cross/bin/x86_64-linux-musl-gcc /usr/local/bin/musl-gcc
-```
+* If you encounter build errors complaining about missing symbols for x86_64 architecture, try setting the following environment variables:
+  ```
+  export GOARCH=arm64
+  export CGO_ENABLED=1
+  ```
+
+* If you encounter build errors related to openssl, you probably have openssl 3 installed, rather than openssl 1.1:
+  ```
+  $ brew uninstall openssl@3
+  $ brew install openssl@1.1
+  ```
+  Also make sure to follow homebrew's prompt about setting `LDFLAGS` and `CPPFLAGS`
+
+* If you encounter build errors complaining about `invalid linker name in argument '-fuse-ld=lld'`, you probably need to install llvm:
+  ```
+  $ brew install llvm
+  ```
+  Also make sure to follow homebrew's prompt about adding llvm to your PATH


### PR DESCRIPTION
These are condensed from the notes I took when getting Flow to build on my new M1 macbook. I left out a few more obvious issues such as the error you get when `go` or `protobuf` aren't installed, as I felt it was fairly obvious what the fix was.

One thought I had is that these issues may not all be M1-specific, especially openssl and llvm. Maybe it should all be under a "getting started" section? My default was to just keep it simple.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/627)
<!-- Reviewable:end -->
