### PR TITLE
Use a process-scoped Context for ops logs appender

### DIFF
--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -55,6 +55,10 @@ type FlowConsumer struct {
 		Now *flow.Timepoint
 		Mu  sync.Mutex
 	}
+	// LogAppendService is used to append log messages to the ops logs collections. It's important
+	// that we use an AppendService with a context that's scoped to the life of the process, rather
+	// than the lives of individual shards.
+	LogAppendService *client.AppendService
 }
 
 var _ consumer.Application = (*FlowConsumer)(nil)
@@ -184,6 +188,7 @@ func (f *FlowConsumer) InitApplication(args runconsumer.InitArgs) error {
 		return flow.ShardStat(ctx, svc, req, journals)
 	}
 
+	f.LogAppendService = client.NewAppendService(args.Context, args.Service.Journals)
 	f.Config = &config
 	f.Service = args.Service
 	f.Builds = builds

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -89,7 +89,7 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 	if t.LogPublisher, err = NewLogPublisher(
 		t.labels,
 		logsCollectionSpec,
-		shard.JournalClient(),
+		host.LogAppendService,
 		flow.NewMapper(shard.Context(), host.Service.Etcd, host.Journals, shard.FQN()),
 	); err != nil {
 		return fmt.Errorf("creating log publisher: %w", err)


### PR DESCRIPTION
**Description:**

The ops logs appender previously used the `Context` of the shard, which
caused log messages to be silently dropped as soon as the shard was
unassigned. This caused us to miss logs related to connector shutdown
because we generally shutdown connectors only after the shard context is
cancelled.

This change introduces a global `AppendService`, which is used by all
`LogAppender`s. This uses a context that will never be cancelled, and
thus should capture logs during the teardown of shards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/629)
<!-- Reviewable:end -->
