### PR TITLE
flowctl-go/discover: mkdir for nested collection paths

### DIFF
--- a/go/flowctl-go/cmd-discover.go
+++ b/go/flowctl-go/cmd-discover.go
@@ -118,6 +118,12 @@ Edit and update this file, and then run this command again.
 	for _, b := range discovered.Bindings {
 		var collection = path.Join(cmd.Prefix, b.RecommendedName.String())
 		var schemaName = fmt.Sprintf("%s.schema.yaml", b.RecommendedName)
+		var outputPath = filepath.Join(cmd.Directory, schemaName)
+		var outputDir = path.Dir(outputPath)
+
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("creating output directory: %w", err)
+		}
 
 		var schema, resource interface{}
 		if err := json.Unmarshal(b.DocumentSchemaJson, &schema); err != nil {


### PR DESCRIPTION
**Description:**

- If you have a collection with slash in its name, discover fails because the directory doesn't exist, this PR resolves that issue.

**Workflow steps:**

- `flowctl-admin discover` on a connector with nested collections (e.g. firestore)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/636)
<!-- Reviewable:end -->
