### PR TITLE
airbyte: allow explicit specification of recommended_name for streams

### DIFF
--- a/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
@@ -121,7 +121,10 @@ impl AirbyteSourceInterceptor {
                         .map(|k| doc::Pointer::from_vec(k).to_string())
                         .collect(),
                 };
-                let recommended_name = stream_to_recommended_name(&stream.name);
+                let recommended_name = match stream.recommended_name {
+                    Some(s) if !s.is_empty() => s,
+                    _ => stream_to_recommended_name(&stream.name)
+                };
 
                 resp.bindings.push(discover_response::Binding {
                     recommended_name,
@@ -256,6 +259,7 @@ impl AirbyteSourceInterceptor {
                                     primary_key: Some(primary_key),
                                     stream: airbyte_catalog::Stream {
                                         name: resource.stream,
+                                        recommended_name: None,
                                         namespace: resource.namespace,
                                         json_schema: RawValue::from_string(
                                             collection.schema_json.clone(),

--- a/crates/connector_proxy/src/libs/airbyte_catalog.rs
+++ b/crates/connector_proxy/src/libs/airbyte_catalog.rs
@@ -17,6 +17,7 @@ pub enum SyncMode {
 #[serde(rename_all = "snake_case")]
 pub struct Stream {
     pub name: String,
+    pub recommended_name: Option<String>,
     pub json_schema: Box<RawValue>,
     // supported_sync_modes is planned to be made required soon
     // see https://is.gd/RqAhTO

--- a/crates/schema-inference/src/main.rs
+++ b/crates/schema-inference/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-use schema_inference::analyze::{self};
+use schema_inference::analyze;
 
 /// Reads JSON documents and infers a basic schema from its structure.
 #[derive(Debug, clap::Parser)]

--- a/go/protocols/airbyte/catalog.go
+++ b/go/protocols/airbyte/catalog.go
@@ -16,6 +16,7 @@ var AllSyncModes = []SyncMode{SyncModeIncremental, SyncModeFullRefresh}
 
 type Stream struct {
 	Name                    string          `json:"name"`
+	RecommendedName         string          `json:"recommended_name"`
 	JSONSchema              json.RawMessage `json:"json_schema"`
 	SupportedSyncModes      []SyncMode      `json:"supported_sync_modes"`
 	SourceDefinedCursor     bool            `json:"source_defined_cursor,omitempty"`


### PR DESCRIPTION
**Description:**

- Allow explicitly specifying `recommended_name` for a stream from Airbyte protocol

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/638)
<!-- Reviewable:end -->
