### PR TITLE
fix serialization of tail and range

### DIFF
--- a/crates/connector_proxy/src/libs/airbyte_catalog.rs
+++ b/crates/connector_proxy/src/libs/airbyte_catalog.rs
@@ -98,8 +98,8 @@ impl Serialize for Range {
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Range", 2)?;
-        state.serialize_field("begin", &format!("{:x}", self.begin))?;
-        state.serialize_field("end", &format!("{:x}", self.end))?;
+        state.serialize_field("begin", &format!("{:08x}", self.begin))?;
+        state.serialize_field("end", &format!("{:08x}", self.end))?;
         state.end()
     }
 }
@@ -112,10 +112,10 @@ pub struct ConfiguredCatalog {
     #[validate]
     pub streams: Vec<ConfiguredStream>,
 
-    #[serde(alias = "estuary.dev/tail")]
+    #[serde(rename = "estuary.dev/tail")]
     pub tail: bool,
 
-    #[serde(alias = "estuary.dev/range")]
+    #[serde(rename = "estuary.dev/range")]
     #[validate]
     pub range: Range,
 }


### PR DESCRIPTION
Closes https://github.com/estuary/connectors/issues/316

**Description:**

This fixes the `estuary.dev/tail` and `estuary.dev/range` `ConfiguredCatalog` field serialization. `alias` is only for [deserialization](https://serde.rs/field-attrs.html#alias), where as `rename` works for serialization as well. This matches up with the expected values in the protocol [go structs](https://github.com/estuary/flow/blob/02070f5ffee5a6583d1ced2bb7fdd7bd182c9c4b/go/protocols/airbyte/catalog.go#L107-L111) and also the [Rust Kafka connector](https://github.com/estuary/connectors/blob/89a0b84f68e22a3bea0111136afb631d7520c05c/source-kafka/src/catalog.rs#L27-L48).

It also fixes the formatting for values of `range`, which need to be [0-padded and 8 digits long](https://github.com/estuary/flow/blob/02070f5ffee5a6583d1ced2bb7fdd7bd182c9c4b/go/protocols/airbyte/partition_range.go#L38-L39).

**Workflow steps:**

Run a connector that should tail (like the Kafka connector) and observe that it now tails correctly instead of shutting down when all messages have been ready. I also tested that the postgres connector still works properly with this change.

**Documentation links affected:**

N/A

**Notes for reviewers:**

I couldn't come up with any meaningful test additions or changes, since this is basically relying on functionality provided by serde, so it didn't seem worthwhile to test _that_. So I did quite a bit of manual testing - open to suggestions if there are any tests that we should update or add though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/645)
<!-- Reviewable:end -->
