### PR TITLE
validation: add user-friendly validation checks over JSON pointers

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -59,6 +59,10 @@ pub enum Error {
     CollectionKeyEmpty { collection: String },
     #[error("collection {collection} schema must be an object")]
     CollectionSchemaNotObject { collection: String },
+    #[error("{ptr} is not a valid JSON pointer (missing leading '/' slash)")]
+    KeyMissingLeadingSlash { ptr: String },
+    #[error("{ptr} is not a valid JSON pointer ({unmatched:?} is invalid)")]
+    KeyRegex { ptr: String, unmatched: String },
     #[error("keyed location {ptr} must be required to exist by schema {schema} (https://go.estuary.dev/KUYbal)")]
     KeyMayNotExist { ptr: String, schema: Url },
     #[error(

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -510,6 +510,25 @@ test://example/int-halve:
 }
 
 #[test]
+fn test_keyed_location_pointer_is_malformed() {
+    let errors = run_test_errors(
+        &GOLDEN,
+        r#"
+test://example/int-string:
+  collections:
+    testing/int-string:
+      key: [int]
+      projections:
+        Int: int
+        DoubleSlash: /double//slash
+        InvalidEscape: /an/esc~ape
+        ValidRootField: ""
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
 fn test_keyed_location_wrong_type() {
     let errors = run_test_errors(
         &GOLDEN,

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_pointer_is_malformed.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_pointer_is_malformed.snap
@@ -1,0 +1,22 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string,
+        error: int is not a valid JSON pointer (missing leading '/' slash),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/projections/DoubleSlash,
+        error: /double//slash is not a valid JSON pointer ("//slash" is invalid),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/projections/Int,
+        error: int is not a valid JSON pointer (missing leading '/' slash),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/projections/InvalidEscape,
+        error: /an/esc~ape is not a valid JSON pointer ("~ape" is invalid),
+    },
+]


### PR DESCRIPTION

**Description:**

Add explicit validation over JSON pointer locations within the catalog.

Special case the "you missed the leading slash" condition from the more
obtuse "something else is invalid about your JSON pointer".

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/652)
<!-- Reviewable:end -->
