### PR TITLE
Docs: whitelisting IPs + various odds and ends

### DIFF
--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -276,7 +276,7 @@ sops:
     version: 3.7.1
 ```
 
-You then use this `config.yaml` within your Flowc specification.
+You then use this `config.yaml` within your Flow specification.
 Flow looks for and understands the `encrypted_suffix`,
 and will remove this suffix from configuration keys before passing them to the connector.
 
@@ -284,6 +284,12 @@ and will remove this suffix from configuration keys before passing them to the c
 
 In some cases, your source or destination endpoint may be within a secure network, and you may not be able
 to allow direct access to its port due to your organization's security policy.
+
+:::tip
+If permitted by your organization, a quicker solution is to whitelist the Estuary IP address, `34.121.207.128`.
+For help completing this task on different cloud hosting platforms,
+see the documentation for the [connector](../reference/Connectors/README.md) you're using.
+:::
 
 [SHH tunneling](https://www.ssh.com/academy/ssh/tunneling/example#local-forwarding), or port forwarding,
 provides a means for Flow to access the port indirectly through an SSH server.

--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -5,6 +5,12 @@ For added security, you can configure [SSH tunneling](https://www.ssh.com/academ
 You configure this in the `networkTunnel` section of applicable capture or materialization definitions, but
 before you can do so, you need a properly configured SSH server on your internal network or cloud hosting platform.
 
+:::tip
+If permitted by your organization, a quicker way to connect to a secure database is to whitelist the Estuary IP address, `34.121.207.128`.
+For help completing this task on different cloud hosting platforms,
+see the documentation for the [connector](../reference/Connectors/README.md) you're using.
+:::
+
 This guide includes setup steps for popular cloud platforms,
 as well as generalized setup that provides a basic roadmap for on-premise servers or other cloud platforms.
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL.md
@@ -129,9 +129,21 @@ You're able to apply the connector directly to the primary instance if you'd lik
 
 #### Setup
 
-1. You'll need to configure secure access to the database to enable the Flow capture.
-  Estuary recommends SSH tunneling to allow this.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+1. Allow connections to the database from the Estuary Flow IP address.
+
+   1. Edit the VPC security group associated with your database, or create a new VPC security group and associate it with the database.
+      Refer to the [steps in the Amazon documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.RDSSecurityGroups.html#Overview.RDSSecurityGroups.Create).
+
+   2. Create a new inbound rule and a new outbound rule that allow all traffic from the IP address `34.121.207.128`.
+
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. Create a RDS parameter group to enable replication in MySQL.
 
@@ -188,9 +200,19 @@ You can use this connector for MySQL instances on Google Cloud SQL using the fol
 
 #### Setup
 
-1. You'll need to configure secure access to the database to enable the Flow capture.
-  Estuary recommends SSH tunneling to allow this.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+1. Allow connections to the database from the Estuary Flow IP address.
+
+   1. [Enable public IP on your database](https://cloud.google.com/sql/docs/mysql/configure-ip#add) and add
+      `34.121.207.128` as an authorized IP address.
+
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. Set the instance's `binlog_expire_logs_seconds` [flag](https://cloud.google.com/sql/docs/mysql/flags?_ga=2.8077298.-1359189752.1655241239&_gac=1.226418280.1655849730.Cj0KCQjw2MWVBhCQARIsAIjbwoOczKklaVaykkUiCMZ4n3_jVtsInpmlugWN92zx6rL5i7zTxm3AALIaAv6nEALw_wcB)
 to `2592000`.
@@ -222,9 +244,19 @@ You can use this connector for MySQL instances on Azure Database for MySQL using
 
 #### Setup
 
-1. You'll need to configure secure access to the database to enable the Flow capture.
-  Estuary recommends SSH tunneling to allow this.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+1. Allow connections to the database from the Estuary Flow IP address.
+
+   1. Create a new [firewall rule](https://docs.microsoft.com/en-us/azure/mysql/flexible-server/how-to-manage-firewall-portal#create-a-firewall-rule-after-server-is-created)
+   that grants access to the IP address `34.121.207.128`.
+
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. Set the `binlog_expire_logs_seconds` [server perameter](https://docs.microsoft.com/en-us/azure/mysql/single-server/concepts-server-parameters#configurable-server-parameters)
 to `2592000`.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -14,6 +14,8 @@ You'll need a PostgreSQL database setup with the following:
 * [User role](https://www.postgresql.org/docs/current/sql-createrole.html) with `REPLICATION` attribute
 * A [replication slot](https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS). This represents a “cursor” into the PostgreSQL write-ahead log from which change events can be read.
     * Optional; if none exist, one will be created by the connector.
+    * If you wish to run multiple captures from the same database, each must have its own slot.
+    You can create these slots yourself, or by specifying a name other than the default in the advanced [configuration](#configuration).
 * A [publication](https://www.postgresql.org/docs/current/sql-createpublication.html). This represents the set of tables for which change events will be reported.
     * In more restricted setups, this must be created manually, but can be created automatically if the connector has suitable permissions.
 * A watermarks table. The watermarks table is a small “scratch space” to which the connector occasionally writes a small amount of data to ensure accuracy when backfilling preexisting table contents.
@@ -100,7 +102,7 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 | **`/password`** | Password | Password for the specified database user. | string | Required |
 | `/advanced/publicationName` | Publication name | The name of the PostgreSQL publication to replicate from. | string | `"flow_publication"` |
 | `/advanced/skip_backfills` | Skip Backfills | A comma-separated list of fully-qualified table names which should not be backfilled. | string |  |
-| `/advanced/slotName` | Slot name | The name of the PostgreSQL replication slot to replicate from. | string | `"flow_slot"` |
+| `/advanced/slotName` | Slot name | The name of the PostgreSQL replication slot to replicate from. A slot can only support one capture at a time. | string | `"flow_slot"` |
 | `/advanced/watermarksTable` | Watermarks table | The name of the table used for watermark writes during backfills. Must be fully-qualified in `<schema>.<table>` form. | string | `"public.flow_watermarks"` |
 
 
@@ -148,9 +150,21 @@ You can use this connector for PostgreSQL instances on Amazon RDS using the foll
 
 #### Setup
 
-1. You'll need to configure secure access to the database to enable the Flow capture.
-  This is currently supported through SSH tunneling.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+1. Allow connections to the database from the Estuary Flow IP address.
+
+   1. Edit the VPC security group associated with your database, or create a new VPC security group and associate it with the database.
+      Refer to the [steps in the Amazon documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.RDSSecurityGroups.html#Overview.RDSSecurityGroups.Create).
+
+   2. Create a new inbound rule and a new outbound rule that allow all traffic from the IP address `34.121.207.128`.
+
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. Enable logical replication on your RDS PostgreSQL instance.
 
@@ -179,28 +193,25 @@ and set up the watermarks table and publication.
 
 6. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
 
-4. Configure your connector as described in the [configuration](#configuration) section above,
-including the additional `networkTunnel` configuration to enable the SSH tunnel.
-See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
-for additional details and a sample.
-
 ### Google Cloud SQL
 
 You can use this connector for PostgreSQL instances on Google Cloud SQL using the following setup instructions.
 
 #### Setup
 
-1. Allow the connector to access your PostgreSQL instance using one of the following methods:
+1. Allow connections to the database from the Estuary Flow IP address.
 
-   1. Configure secure access. This is currently supported through SSH tunneling.
-   Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
-   You'll need to set up a Google Cloud Virtual Machine to act as a proxy;
-   be sure to follow the prerequisites outlined in the [Google Cloud section](../../../../guides/connect-network#setup-for-google-cloud)
-   section of the guide.
+   1. [Enable public IP on your database](https://cloud.google.com/sql/docs/mysql/configure-ip#add) and add
+      `34.121.207.128` as an authorized IP address.
 
-   2. Configure the instance to allow unsecured connections.
-   In your Cloud SQL settings, [disable the requirement for SSL/TLS](https://cloud.google.com/sql/docs/mysql/configure-ssl-instance#enforcing-ssl)
-   and [enable public IP access](https://cloud.google.com/sql/docs/mysql/configure-ip#add), if necessary.
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. Set [the `cloudsql.logical_decoding` flag to `on`](https://cloud.google.com/sql/docs/postgres/flags) to enable logical replication on your loud SQL PostgreSQL instance.
 
@@ -220,20 +231,25 @@ and set up the watermarks table and publication.
 4. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `5432`.
 Together, you'll use the host:port as the `address` property when you configure the connector.
 
-5. Configure your connector as described in the [configuration](#configuration) section above,
-including the additional `networkTunnel` configuration to enable the SSH tunnel, if using.
-See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
-for additional details and a sample.
-
 ### Azure Database for PostgreSQL
 
 You can use this connector for instances on Azure Database for PostgreSQL using the following setup instructions.
 
 #### Setup
 
-1. You'll need to configure secure access to the database to enable the Flow capture.
-  This is currently supported through SSH tunneling.
-  Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/).
+1. Allow connections to the database from the Estuary Flow IP address.
+
+   1. Create a new [firewall rule](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-firewall-portal#create-a-firewall-rule-after-server-is-created)
+   that grants access to the IP address `34.121.207.128`.
+
+   :::info
+   Alternatively, you can allow secure connections via SSH tunneling. To do so:
+     * Follow the guide to [configure an SSH server for tunneling](../../../../guides/connect-network/)
+     * When you configure your connector as described in the [configuration](#configuration) section above,
+        including the additional `networkTunnel` configuration to enable the SSH tunnel.
+        See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
+        for additional details and a sample.
+   :::
 
 2. In your Azure PostgreSQL instance's support parameters, [set replication to logical](https://docs.microsoft.com/en-us/azure/postgresql/single-server/concepts-logical#set-up-your-server) to enable logical replication.
 
@@ -242,29 +258,29 @@ You can use this connector for instances on Azure Database for PostgreSQL using 
 ```sql
 CREATE USER flow_capture WITH PASSWORD 'secret' REPLICATION;
 ```
-   1. If using PostgreSQL v14 or later:
 
-   ```sql
-   GRANT pg_read_all_data TO flow_capture;
-   ```
+  * If using PostgreSQL v14 or later:
 
-   2. If using an earlier version:
+```sql
+GRANT pg_read_all_data TO flow_capture;
+```
 
-   ```sql
-   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES to flow_capture;
-       GRANT SELECT ON ALL TABLES IN SCHEMA public, <others> TO flow_capture;
-      GRANT SELECT ON ALL TABLES IN SCHEMA information_schema, pg_catalog TO flow_capture;
+  * If using an earlier version:
 
-   ```
-   where `<others>` lists all schemas that will be captured from.
+    ```sql
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES to flow_capture;
+        GRANT SELECT ON ALL TABLES IN SCHEMA public, <others> TO flow_capture;
+        GRANT SELECT ON ALL TABLES IN SCHEMA information_schema, pg_catalog TO flow_capture;
+    ```
+    where `<others>` lists all schemas that will be captured from.
+
     :::info
     If an even more restricted set of permissions is desired, you can also grant SELECT on
-    just the specific table(s) which should be captured from. The ‘information_schema’ and
-    ‘pg_catalog’ access is required for stream auto-discovery, but not for capturing already
+    just the specific table(s) which should be captured from. The ‘information_schema’ and      ‘pg_catalog’ access is required for stream auto-discovery, but not for capturing already
     configured streams.
     :::
 
-3. Set up the watermarks table and publication.
+4. Set up the watermarks table and publication.
 
 ```sql
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES to flow_capture;
@@ -275,13 +291,10 @@ GRANT ALL PRIVILEGES ON TABLE public.flow_watermarks TO flow_capture;
 CREATE PUBLICATION flow_publication FOR TABLE schema.table1, schema.table2;
 ```
 
-4. Note the instance's host under Server name, and the port under Connection Strings (usually `5432`).
-Together, you'll use the host:port as the `address` property when you configure the connector.
+5. Note the following important items for configuration:
 
-5. Configure your connector as described in the [configuration](#configuration) section above,
-including the additional `networkTunnel` configuration to enable the SSH tunnel.
-See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
-for additional details and a sample.
+   * Find the instance's host under Server Name, and the port under Connection Strings (usually `5432`). Together, you'll use the host:port as the `address` property when you configure the connector.
+   * Format `user` as `username@databasename`; for example, `flow_capture@myazuredb`.
 
 ## TOASTed values
 

--- a/site/docs/reference/Connectors/capture-connectors/google-firestore.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-firestore.md
@@ -35,8 +35,7 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/stream`** | Stream | Firestore collection from which a Flow collection is captured. | string | Required |
-| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+| **`/path`** | Path to Collection | Firestore collection from which a Flow collection is captured. Supports parent&#x2F;&#x2A;&#x2F;nested to capture all nested collections of parent&#x27;s children | string | Required |
 
 ### Sample
 
@@ -61,7 +60,15 @@ captures:
           scan_interval: "24h"
     bindings:
       - resource:
-          stream: my_firestore_collection
-          syncMode: incremental
-        target: ${PREFIX}/my_firestore_collection
+          path: orgs/*/runs/*/runResults/*/queryResults
+        target: ${PREFIX}/orgs_runs_runResults_queryResults
+      - resource:
+          path: orgs/*/runs/*/runResults
+        target: ${PREFIX}/orgs_runs_runResults
+      - resource:
+          path: orgs/*/runs
+        target: ${PREFIX}/orgs_runs
+      - resource:
+          path: orgs
+        target: ${PREFIX}/orgs
 ```

--- a/site/docs/reference/Connectors/capture-connectors/http-file.md
+++ b/site/docs/reference/Connectors/capture-connectors/http-file.md
@@ -55,6 +55,10 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 | `/credentials` | Credentials | User credentials, if required to access the data at the HTTP URL. | object |  |
 | `/credentials/password` | Password | Password, if required to access the HTTP endpoint. | string |  |
 | `/credentials/user` | User | Username, if required to access the HTTP endpoint. | string |  |
+| `/headers` | Headers |  | object |  |
+| `/headers/items` | Additional HTTP Headers | Additional HTTP headers when requesting the file. These are uncommon. | array |  |
+| _`/headers/items/-/key`_ | Header Key |  | string |  |
+| _`/headers/items/-/value`_ | Header Value |  | string |  |
 | `/parser` | Parser Configuration | Configures how files are parsed | object |  |
 | `/parser/compression` | Compression | Determines how to decompress the contents. The default, &#x27;Auto&#x27;, will try to determine the compression automatically. | null, string | `null` |
 | `/parser/format` | Format | Determines how to parse the contents. The default, &#x27;Auto&#x27;, will try to determine the format automatically based on the file extension or MIME type, if available. | object | `{"type":"auto"}` |
@@ -175,3 +179,8 @@ but you may need to specify for unusual datasets. These properties are:
   * Auto
 
 The sample specification [above](#sample) includes these fields.
+
+### Advanced: Using HTTP headers
+
+For real-time streams of unbounded size, you may need to send [headers as part of your HTTP request](https://developer.mozilla.org/en-US/docs/Glossary/Request_header).
+This is uncommon, and is supported by the optional **Headers** configuration.

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL.md
@@ -63,6 +63,19 @@ You may use other cloud platforms, but Estuary doesn't guarantee performance.
 
 ### Setup
 
+You must configure your database to allow connections from Estuary.
+The recommended method is to whitelist Estuary Flow's IP address.
+
+* **Amazon RDS**: Edit the VPC security group associated with your database, or create a new VPC security group and associate it with the database.
+ Refer to the [steps in the Amazon documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.RDSSecurityGroups.html#Overview.RDSSecurityGroups.Create).
+ Create a new inbound rule and a new outbound rule that allow all traffic from the IP address `34.121.207.128`.
+
+* **Google Cloud SQL**: [Enable public IP on your database](https://cloud.google.com/sql/docs/mysql/configure-ip#add) and add `34.121.207.128` as an authorized IP address.
+
+* **Azure Database For PostgreSQL**: Create a new [firewall rule](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-firewall-portal#create-a-firewall-rule-after-server-is-created) that grants access to the IP address `34.121.207.128`.
+
+Alternatively, you can allow secure connections via SSH tunneling. To do so:
+
 1. Refer to the [guide](../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
 
 2. Configure your connector as described in the [configuration](#configuration) section above,
@@ -70,7 +83,7 @@ with the additional of the `networkTunnel` stanza to enable the SSH tunnel, if u
 See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks)
 for additional details and a sample.
 
-:::tip
+:::tip SSH Configuration Tip
 You can find the values for `forwardHost` and `forwardPort` in the following locations in each platform's console:
 * Amazon RDS: `forwardHost` as Endpoint; `forwardPort` as Port.
 * Google Cloud SQL: `forwardHost` as Private IP Address; `forwardPort` is always `5432`. You may need to [configure private IP](https://cloud.google.com/sql/docs/postgres/configure-private-ip) on your database.


### PR DESCRIPTION
**Description:**

Adds documentation for:

- Whitelisting the Estuary IP for source-postgres, source-mysql, materialize-postgres
- Fixing format issues found this week
- Messaging around slots for source-postgres (https://github.com/estuary/connectors/pull/331)
- Updates to source-firestore resource config (https://github.com/estuary/connectors/pull/319)
- Headers for source-http file (https://github.com/estuary/connectors/pull/321) - plan to follow up on this one so I can add more detail to the docs because I don't 100% get how this works 

**Notes for reviewers:**

Self-review for this one

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/657)
<!-- Reviewable:end -->
