### PR TITLE
crates/json: use explicit serde enum and add macaddr8 support

### DIFF
--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "json"
 version = "0.0.0"
 authors = ["Estuary Technologies, Inc"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 addr = {version="0.15.4", features=["idna", "std","psl"]}

--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -3,9 +3,47 @@ use std::{net::IpAddr, str::FromStr};
 use addr::{parse_domain_name, parse_email_address};
 use fancy_regex::Regex;
 use iri_string::spec::{IriSpec, UriSpec};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::validator::ValidationResult;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Format {
+    Date,
+    #[serde(rename = "date-time")]
+    DateTime,
+    Time,
+    Email,
+    Hostname,
+    /// IdnHostname is parsed but is not supported (validation always fails).
+    #[serde(rename = "idn-hostname")]
+    IdnHostname,
+    /// IdnEmail is parsed but is not supported (validation always fails).
+    #[serde(rename = "idn-email")]
+    IdnEmail,
+    Ipv4,
+    Ipv6,
+    Macaddr,
+    Macaddr8,
+    Uuid,
+    Duration,
+    Iri,
+    Uri,
+    #[serde(rename = "uri-reference")]
+    UriReference,
+    #[serde(rename = "iri-reference")]
+    IriReference,
+    #[serde(rename = "uri-template")]
+    UriTemplate,
+    #[serde(rename = "json-pointer")]
+    JsonPointer,
+    #[serde(rename = "regex")]
+    Regex,
+    #[serde(rename = "relative-json-pointer")]
+    RelativeJsonPointer,
+}
 
 // Some are from https://github.com/JamesNK/Newtonsoft.Json.Schema/blob/master/Src/Newtonsoft.Json.Schema/Infrastructure/FormatHelpers.cs
 // Some are artisinally crafted
@@ -22,73 +60,161 @@ lazy_static::lazy_static! {
     static ref ISO_8601_ONLY_WEEKS_RE: Regex = Regex::new(r"^[0-9P|W]*$").expect("Is a valid regex");
     static ref ISO_8601_NO_WEEKS_RE: Regex = Regex::new(r"^[^W]*$").expect("Is a valid regex");
     static ref JSON_POINTER_RE: Regex = Regex::new(r"^(\/([^~]|(~[01]))*)*$").expect("Is a valid regex");
+    static ref MACADDR: Regex = Regex::new(r"^([0-9A-Fa-f]{2}[:-]?){5}[0-9A-Fa-f]{2}$").expect("Is a valid regex");
+    static ref MACADDR8: Regex = Regex::new(r"^([0-9A-Fa-f]{2}[:-]?){7}[0-9A-Fa-f]{2}$").expect("Is a valid regex");
 }
 
-pub fn validate_format(format: &str, val: &str) -> ValidationResult {
-    match format {
-        "date" => {
-            // Padding with zeroes is ignored by the underlying parser. The most efficient
-            // way to check it will be to use a custom parser that won't ignore zeroes,
-            // but this regex will do the trick and costs ~20% extra time in this validator.
-            if !DATE_RE.is_match(val).unwrap_or(false) {
-                return ValidationResult::Invalid(None)
+impl Format {
+    pub fn validate(&self, val: &str) -> ValidationResult {
+        match self {
+            Self::Date => {
+                // Padding with zeroes is ignored by the underlying parser. The most efficient
+                // way to check it will be to use a custom parser that won't ignore zeroes,
+                // but this regex will do the trick and costs ~20% extra time in this validator.
+                if !DATE_RE.is_match(val).unwrap_or(false) {
+                    return ValidationResult::Invalid(None);
+                }
+                ValidationResult::from(time::Date::parse(
+                    val,
+                    &time::macros::format_description!("[year]-[month]-[day]"),
+                ))
             }
-            ValidationResult::from(time::Date::parse(
+            Self::DateTime => ValidationResult::from(time::OffsetDateTime::parse(
                 val,
-                &time::macros::format_description!("[year]-[month]-[day]"),
-            ))
-        }
-        "date-time" => {
-            ValidationResult::from(time::OffsetDateTime::parse(val, &time::format_description::well_known::Rfc3339))
-        }
-        "time" => ValidationResult::from(time::Time::parse(
-            val,
-            &time::macros::format_description!("[hour]:[minute]:[second].[subsecond]Z"),
-        )),
-        "email" => ValidationResult::from(parse_email_address(val)),
-        "hostname" => ValidationResult::from(parse_domain_name(val)),
-        // The rules/test cases for these are absolutely bonkers
-        // If we end up needing this let's revisit (jshearer)
-        "idn-hostname" | "idn-email" => {
-            tracing::warn!("Unsupported string format {}", format);
-            ValidationResult::Invalid(None)
-        }
-        "ipv4" => {
-            if val.starts_with('0') {
-                return ValidationResult::Invalid(None)
+                &time::format_description::well_known::Rfc3339,
+            )),
+            Self::Time => ValidationResult::from(time::Time::parse(
+                val,
+                &time::macros::format_description!("[hour]:[minute]:[second].[subsecond]Z"),
+            )),
+            Self::Email => ValidationResult::from(parse_email_address(val)),
+            Self::Hostname => ValidationResult::from(parse_domain_name(val)),
+            // The rules/test cases for these are absolutely bonkers
+            // If we end up needing this let's revisit (jshearer)
+            Self::IdnHostname | Self::IdnEmail => {
+                ValidationResult::Invalid(Some(format!("{self:?} is not supported")))
             }
-            match IpAddr::from_str(val) {
-                Ok(i) => ValidationResult::from(i.is_ipv4()),
-                Err(e) => ValidationResult::Invalid(Some(e.to_string())),
-            }
-        }
-        "ipv6" => ValidationResult::from(match IpAddr::from_str(val) {
-            Ok(i) => ValidationResult::from(i.is_ipv6()),
-            Err(e) => ValidationResult::Invalid(Some(e.to_string())),
-        }),
-        // uuid crate supports non-hyphenated inputs, jsonschema does not
-        "uuid" if val.len() == 36 => ValidationResult::from(Uuid::parse_str(val)),
-
-        "duration" => ValidationResult::from(match ISO_8601_DURATION_RE.is_match(val) {
-            Ok(true) => {
-                if val.contains("W") {
-                    // If we parse as weeks, ensure that ONLY weeks are provided
-                    ISO_8601_ONLY_WEEKS_RE.is_match(val).unwrap_or(false)
-                } else {
-                    // Otherwise, ensure that NO weeks are provided
-                    ISO_8601_NO_WEEKS_RE.is_match(val).unwrap_or(false)
+            Self::Ipv4 => {
+                if val.starts_with('0') {
+                    return ValidationResult::Invalid(None);
+                }
+                match IpAddr::from_str(val) {
+                    Ok(i) => ValidationResult::from(i.is_ipv4()),
+                    Err(e) => ValidationResult::Invalid(Some(e.to_string())),
                 }
             }
-            _ => false,
-        }),
-        "iri" => ValidationResult::from(iri_string::validate::iri::<IriSpec>(val)),
-        "uri" => ValidationResult::from(iri_string::validate::iri::<UriSpec>(val)),
-        "uri-reference" => ValidationResult::from(iri_string::validate::iri_reference::<UriSpec>(val)),
-        "iri-reference" => ValidationResult::from(iri_string::validate::iri_reference::<IriSpec>(val)),
-        "uri-template" => ValidationResult::from(URI_TEMPLATE_RE.is_match(val).unwrap_or(false)),
-        "json-pointer" => ValidationResult::from(JSON_POINTER_RE.is_match(val).unwrap_or(false)),
-        "regex" => ValidationResult::from(Regex::new(val)),
-        "relative-json-pointer" => ValidationResult::from(RELATIVE_JSON_POINTER_RE.is_match(val).unwrap_or(false)),
-        _ => ValidationResult::Invalid(None),
+            Self::Ipv6 => ValidationResult::from(match IpAddr::from_str(val) {
+                Ok(i) => ValidationResult::from(i.is_ipv6()),
+                Err(e) => ValidationResult::Invalid(Some(e.to_string())),
+            }),
+            Self::Macaddr => ValidationResult::from(MACADDR.is_match(val).unwrap_or(false)),
+            Self::Macaddr8 => ValidationResult::from(MACADDR8.is_match(val).unwrap_or(false)),
+            // uuid crate supports non-hyphenated inputs, jsonschema does not
+            Self::Uuid if val.len() == 36 => ValidationResult::from(Uuid::parse_str(val)),
+            Self::Uuid => ValidationResult::Invalid(Some(format!(
+                "{val} is the wrong length (missing hyphens?)"
+            ))),
+
+            Self::Duration => ValidationResult::from(match ISO_8601_DURATION_RE.is_match(val) {
+                Ok(true) => {
+                    if val.contains("W") {
+                        // If we parse as weeks, ensure that ONLY weeks are provided
+                        ISO_8601_ONLY_WEEKS_RE.is_match(val).unwrap_or(false)
+                    } else {
+                        // Otherwise, ensure that NO weeks are provided
+                        ISO_8601_NO_WEEKS_RE.is_match(val).unwrap_or(false)
+                    }
+                }
+                _ => false,
+            }),
+            Self::Iri => ValidationResult::from(iri_string::validate::iri::<IriSpec>(val)),
+            Self::Uri => ValidationResult::from(iri_string::validate::iri::<UriSpec>(val)),
+            Self::UriReference => {
+                ValidationResult::from(iri_string::validate::iri_reference::<UriSpec>(val))
+            }
+            Self::IriReference => {
+                ValidationResult::from(iri_string::validate::iri_reference::<IriSpec>(val))
+            }
+            Self::UriTemplate => {
+                ValidationResult::from(URI_TEMPLATE_RE.is_match(val).unwrap_or(false))
+            }
+            Self::JsonPointer => {
+                ValidationResult::from(JSON_POINTER_RE.is_match(val).unwrap_or(false))
+            }
+            Self::Regex => ValidationResult::from(Regex::new(val)),
+            Self::RelativeJsonPointer => {
+                ValidationResult::from(RELATIVE_JSON_POINTER_RE.is_match(val).unwrap_or(false))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Format;
+    use crate::validator::ValidationResult;
+
+    #[test]
+    fn test_format_cases() {
+        // Missing format cases:
+        //  * idn-hostname
+        //  * idn-email
+        //  * iri
+        //  * iri-reference
+        for (format, value, expect) in [
+            ("date", "2022-09-11", true),
+            ("date", "2022-09-11T10:31:25.123Z", false),
+            ("date-time", "2022-09-11T10:31:25.123Z", true),
+            ("date-time", "10:31:25.123Z", false),
+            ("time", "10:31:25.123Z", true),
+            ("email", "john@doe.com", true),
+            ("email", "john at doe.com", false),
+            ("hostname", "hostname.com", true),
+            ("hostname", "hostname dot com", false),
+            ("ipv4", "123.45.6.78", true),
+            ("ipv4", "123.45.6.78.9", false),
+            ("ipv4", "0.1.2.3", false),
+            ("ipv6", "2001:0db8:0000:0000:0000:ff00:0042:8329", true),
+            ("ipv6", "2001:db8::ff00:42:8329", true),
+            ("ipv6", "2001 db8  ff00:42:8329", false),
+            ("macaddr", "001B638445E6", true),
+            ("macaddr", "00:1b-63:84-45:e6", true),
+            ("macaddr", "00!1b!63:84!45:e6", false),
+            ("macaddr", "00:1b:63:84:45:e6", true),
+            ("macaddr8", "00:1b:63:84:45:e6", false),
+            ("macaddr8", "00:1b:63:84:45:e6:aa:bb", true),
+            ("macaddr8", "00-1b-638445e6aa:bb", true),
+            ("uuid", "df518555-34f0-446a-8788-7b36f607bbea", true),
+            ("uuid", "DF518555-34F0-446A-8788-7B36F607BBEA", true),
+            ("uuid", "not-a-UUID-7B36F607BBEA", false),
+            ("duration", "P1M3DT30H4S", true),
+            ("duration", "P1W", true),
+            ("duration", "P1W3D", false), // Mixes weeks and days (disallowed).
+            ("duration", "roundtuit", false),
+            ("uri", "http://www.example.org/foo/bar", true),
+            ("uri", "../path/to/bar", false),
+            ("uri-reference", "../path/to/bar", true),
+            ("uri", "http://example.com/~{username}/", false),
+            ("uri-template", "http://example.com/~{username}/", true),
+            ("json-pointer", "/valid/json pointer", true),
+            ("json-pointer", "/invalid/es~cape", false),
+            ("relative-json-pointer", "0/objects", true),
+            ("regex", "^hello$", true),
+            ("regex", "[hello", false),
+        ] {
+            let format: Format =
+                serde_json::from_value(serde_json::Value::String(format.to_string())).unwrap();
+
+            match format.validate(value) {
+                ValidationResult::Valid if expect => {}
+                ValidationResult::Invalid(_) if !expect => {}
+                ValidationResult::Valid => {
+                    panic!("expected {format:?} with {value} to be invalid, but it's valid")
+                }
+                ValidationResult::Invalid(reason) => {
+                    panic!("expected {format:?} with {value} to be valid, but it's invalid with {reason:?}")
+                }
+            }
+        }
     }
 }

--- a/crates/json/src/schema/mod.rs
+++ b/crates/json/src/schema/mod.rs
@@ -3,11 +3,11 @@ use serde_json as sj;
 use std::fmt::Write;
 
 pub mod build;
+pub mod formats;
 pub mod index;
 pub mod intern;
 pub mod keywords;
 pub mod types;
-pub mod formats;
 
 pub use build::Error as BuildError;
 
@@ -237,7 +237,7 @@ pub enum Validation {
     MaxLength(usize),
     MinLength(usize),
     Pattern(fancy_regex::Regex),
-    Format(String),
+    Format(formats::Format),
 
     // Number-specific validations.
     MultipleOf(Number),

--- a/crates/json/tests/validator_test_utils.rs
+++ b/crates/json/tests/validator_test_utils.rs
@@ -9,11 +9,15 @@ use serde_json as sj;
 use std::{env, fs, io, path};
 
 /// Runs tests from the given file within the `draft2019-09/` directory.
+// This is not actually dead code (used by draft2019_tests.rs).
+#[allow(dead_code)]
 pub fn run_draft09_test(target: &str) {
     run_file_test(&["official", "tests", "draft2019-09", target]);
 }
 
 /// Runs tests from the given file within the `draft2019-09/optional/format` directory.
+// This is not actually dead code (used by draft2019_format_tests.rs).
+#[allow(dead_code)]
 pub fn run_draft09_format_test(target: &str) {
     run_file_test(&[
         "official",

--- a/examples/net-trace/schema.yaml
+++ b/examples/net-trace/schema.yaml
@@ -6,7 +6,7 @@ $defs:
   ip-port:
     type: object
     properties:
-      ip: { type: string }
+      ip: { type: string, format: ipv4 }
       port: { type: integer }
     required: [ip, port]
 


### PR DESCRIPTION
**Description:**

Use an explicit Format enum deserialized by serde, so that unsupported formats are a build-time rather than a run-time error.

Add support for macaddr and macaddr8 formats, which are not part of the standard but are sensible and for which we have an internal use case (related to stats materializations).

Add basic test cases for almost all formats, which supplements the official schema test cases.

Tested:
 * New tests cases covering macaddr and others.
 * Manually verified that invalid formats now produce helpful build errors like:

```
examples/net-trace/schema.yaml error at <root> :
failed to build JSON schema

Caused by:
    0: at keyword 'format' of schema 'file:///home/johnny/estuary/flow/examples/net-trace/schema.yaml#/$defs/ip-port/properties/ip': unknown variant `ipv4whoops`, expected one of `date`, `date-time`, `time`, `email`, `hostname`, `idn-hostname`, `idn-email`, `ipv4`, `ipv6`, `macaddr`, `macaddr8`, `uuid`, `duration`, `iri`, `uri`, `uri-reference`, `iri-reference`, `uri-template`, `json-pointer`, `regex`, `relative-json-pointer`
```

Issue estuary/animated-carnival#59


**Workflow steps:**

* Use `format` annotation and notice that invalid formats now become build-time errors.
* Use new `macaddr` and `macaddr8` formats.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/663)
<!-- Reviewable:end -->
