### PR TITLE
network-tunnel: better error when consuming config fails

### DIFF
--- a/crates/connector_proxy/src/interceptors/network_tunnel_capture_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_tunnel_capture_interceptor.rs
@@ -23,7 +23,7 @@ impl NetworkTunnelCaptureInterceptor {
             )
             .await
             .map_err(|err| {
-                create_custom_error(&format!("error consuming tunnel configuration {:?}", err))
+                create_custom_error(&format!("error starting network tunnel {:?}", err))
             })?
             .to_string();
 
@@ -40,7 +40,7 @@ impl NetworkTunnelCaptureInterceptor {
             )
             .await
             .map_err(|err| {
-                create_custom_error(&format!("error consuming tunnel configuration {:?}", err))
+                create_custom_error(&format!("error starting network tunnel {:?}", err))
             })?
             .to_string();
 
@@ -58,7 +58,7 @@ impl NetworkTunnelCaptureInterceptor {
                 )
                 .await
                 .map_err(|err| {
-                    create_custom_error(&format!("error consuming tunnel configuration {:?}", err))
+                    create_custom_error(&format!("error starting network tunnel {:?}", err))
                 })?
                 .to_string();
             }
@@ -85,7 +85,7 @@ impl NetworkTunnelCaptureInterceptor {
                         .await
                         .map_err(|err| {
                             create_custom_error(&format!(
-                                "error consuming tunnel configuration {:?}",
+                                "error starting network tunnel {:?}",
                                 err
                             ))
                         })?

--- a/crates/connector_proxy/src/interceptors/network_tunnel_materialize_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/network_tunnel_materialize_interceptor.rs
@@ -21,7 +21,9 @@ impl NetworkTunnelMaterializeInterceptor {
                 RawValue::from_string(request.endpoint_spec_json)?,
             )
             .await
-            .expect("failed to start network tunnel")
+            .map_err(|err| {
+                create_custom_error(&format!("error starting network tunnel {:?}", err))
+            })?
             .to_string();
             encode_message(&request)
         }))
@@ -37,7 +39,7 @@ impl NetworkTunnelMaterializeInterceptor {
                 )
                 .await
                 .map_err(|err| {
-                    create_custom_error(&format!("error consuming tunnel configuration {:?}", err))
+                    create_custom_error(&format!("error starting network tunnel {:?}", err))
                 })?
                 .to_string();
             }
@@ -67,7 +69,7 @@ impl NetworkTunnelMaterializeInterceptor {
                         .await
                         .map_err(|err| {
                             create_custom_error(&format!(
-                                "error consuming tunnel configuration {:?}",
+                                "error starting network tunnel {:?}",
                                 err
                             ))
                         })?


### PR DESCRIPTION
**Description:**

- Resolves #648 by replacing the `.expect` with a proper `Result::Err`

**Workflow steps:**

- wrongly-configured network tunnel for a materialization

**Documentation links affected:**
N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/664)
<!-- Reviewable:end -->
