### PR TITLE
validation: require unique root document projection field name

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -175,7 +175,7 @@ pub enum Error {
     },
     #[error("derivation's initial register is invalid against its schema: {}", serde_json::to_string_pretty(.0).unwrap())]
     RegisterInitialInvalid(doc::FailedValidation),
-    #[error("collection {collection} requires a unique projection field for the root document")]
+    #[error("collection {collection} requires a unique projection field for the root document, see https://go.estuary.dev/gmedel")]
     UniqueRootProjectionFieldRequired { collection: String },
     #[error("test ingest document is invalid against the collection schema: {}", serde_json::to_string_pretty(.0).unwrap())]
     IngestDocInvalid(doc::FailedValidation),

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -175,6 +175,8 @@ pub enum Error {
     },
     #[error("derivation's initial register is invalid against its schema: {}", serde_json::to_string_pretty(.0).unwrap())]
     RegisterInitialInvalid(doc::FailedValidation),
+    #[error("collection {collection} requires a unique projection field for the root document")]
+    UniqueRootProjectionFieldRequired { collection: String },
     #[error("test ingest document is invalid against the collection schema: {}", serde_json::to_string_pretty(.0).unwrap())]
     IngestDocInvalid(doc::FailedValidation),
     #[error("{entity} {name} bindings duplicate the endpoint resource {resource} at {rhs_scope}")]

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -152,6 +152,52 @@ test://example/int-string:
 }
 
 #[test]
+fn test_no_unique_root_document_projection() {
+    let errors = run_test_errors(
+        &GOLDEN,
+        r#"
+test://example/int-string:
+  collections:
+    testing/int-string:
+      schema:
+        type: object
+        properties:
+          flow_document: {}
+          int: { type: integer }
+          str: { type: string }
+          bit: { type: boolean }
+        required: [int, str, bit]
+      key: [/int]
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_flow_document_field_with_root_projection() {
+    let errors = run_test_errors(
+        &GOLDEN,
+        r#"
+test://example/int-string:
+  collections:
+    testing/int-string:
+      schema:
+        type: object
+        properties:
+          flow_document: {}
+          int: { type: integer }
+          str: { type: string }
+          bit: { type: boolean }
+        required: [int, str, bit]
+      key: [/int]
+      projections:
+        some_other_field: ""
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
 fn test_invalid_transform_names_and_duplicates() {
     let errors = run_test_errors(
         &GOLDEN,

--- a/crates/validation/tests/snapshots/scenario_tests__flow_document_field_with_root_projection.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__flow_document_field_with_root_projection.snap
@@ -1,0 +1,6 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 197
+expression: errors
+---
+[]

--- a/crates/validation/tests/snapshots/scenario_tests__no_unique_root_document_projection.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__no_unique_root_document_projection.snap
@@ -1,0 +1,11 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 173
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string,
+        error: collection testing/int-string requires a unique projection field for the root document,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__no_unique_root_document_projection.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__no_unique_root_document_projection.snap
@@ -6,6 +6,6 @@ expression: errors
 [
     Error {
         scope: test://example/int-string#/collections/testing~1int-string,
-        error: collection testing/int-string requires a unique projection field for the root document,
+        error: collection testing/int-string requires a unique projection field for the root document, see https://go.estuary.dev/gmedel,
     },
 ]


### PR DESCRIPTION
**Description:**

Closes https://github.com/estuary/flow/issues/653

Adds a validation check to verify that the root document has at least one unique projection field name. This will cause a build-time error if a collection schema has an explicit `"flow_document"` field name without a separate unique projection of the root. This a preferred alternative over a run-time error as observed in https://github.com/estuary/flow/issues/661.

**Workflow steps:**

A collection like this will now result in a verification error:
```
collections:
  collection/some-collection:
    schema:
      type: object
      properties:
        id: { type: integer }
        flow_document: {}
      required: [id]
    key: [/id]
```

If allowed to publish, that collection would cause a run-time error when materialized from.

The following collection will not result in a verification error, and also does not result in a run-time error:
```
collections:
  collection/some-collection:
    schema:
      type: object
      properties:
        id: { type: integer }
        flow_document: {}
      required: [id]
    key: [/id]
    projections:
      some_other_thing: ""
```

**Documentation links affected:**

https://go.estuary.dev/gmedel - The error message links here, which will need to document how to create a projection from the "root" document. It is a somewhat strange concept requiring a `""` pointer. I couldn't find anything about this in the existing projections documentation.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/669)
<!-- Reviewable:end -->
