### PR TITLE
cargo: remove clap:2 and structopt, replace with clap:3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,12 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
@@ -458,7 +461,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6d248e3ca02f3fbfabcb9284464c596baec223a26d91bbf44a5a62ddb0d900"
 dependencies = [
- "clap 3.2.5",
+ "clap",
  "heck 0.4.0",
  "indexmap",
  "log",
@@ -535,6 +538,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,21 +573,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -572,9 +587,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -616,7 +631,7 @@ dependencies = [
  "bytelines",
  "byteorder",
  "bytes",
- "clap 3.2.5",
+ "clap",
  "doc",
  "flow_cli_common",
  "futures",
@@ -630,7 +645,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "structopt",
  "strum 0.24.1",
  "strum_macros 0.24.1",
  "tempfile",
@@ -690,15 +704,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -707,7 +722,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -716,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -970,7 +984,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap 3.2.5",
+ "clap",
  "tracing",
  "tracing-subscriber",
 ]
@@ -984,7 +998,7 @@ dependencies = [
  "assert_cmd",
  "build",
  "bytes",
- "clap 3.2.5",
+ "clap",
  "derive",
  "doc",
  "flow_cli_common",
@@ -1988,6 +2002,7 @@ dependencies = [
  "caseless",
  "chardetng",
  "chrono",
+ "clap",
  "csv",
  "doc",
  "encoding_rs",
@@ -2004,7 +2019,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "structopt",
  "strum 0.24.1",
  "tempdir",
  "tempfile",
@@ -2764,15 +2778,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,7 +2813,7 @@ name = "schema-inference"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.5",
+ "clap",
  "doc",
  "insta",
  "itertools",
@@ -2824,7 +2829,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 3.2.5",
+ "clap",
  "doc",
  "flow_cli_common",
  "indexmap",
@@ -2896,12 +2901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
-
-[[package]]
 name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,16 +2915,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -3088,39 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -3272,15 +3231,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -3724,12 +3674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,7 +3734,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sources",
- "strsim 0.10.0",
+ "strsim",
  "superslice",
  "tables",
  "thiserror",
@@ -3851,12 +3795,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/crates/connector_proxy/Cargo.toml
+++ b/crates/connector_proxy/Cargo.toml
@@ -26,7 +26,6 @@ prost = "*"
 schemars = "*"
 serde = { version = "*", features = ["derive"]}
 serde_json = { version = "*", features = ["raw_value"]}
-structopt = "*"
 strum = "*"
 strum_macros = "*"
 tempfile = "*"

--- a/crates/flow_cli_common/Cargo.toml
+++ b/crates/flow_cli_common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "*"
-clap = {version = "*", features = ["derive"]}
+clap = {version = "^3", features = ["derive"]}
 atty = "*"
 tracing = "*"
 tracing-subscriber = {version = "*", features = ["json", "env-filter", "fmt", "time"]}

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -33,8 +33,8 @@ protobuf-parse = "*"
 schemars = "*"
 serde = {version = "*", features=["derive"]}
 serde_json = {version = "*", features = ["raw_value"]}
-structopt = "*"
 tempfile = "*"
+clap = { version = "^3", features=["derive", "env"]}
 thiserror = "*"
 tracing = "*"
 tracing-subscriber = {version = "*", features = ["time", "json", "env-filter"]}

--- a/crates/parser/src/main.rs
+++ b/crates/parser/src/main.rs
@@ -4,20 +4,20 @@ use std::io;
 use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 use std::os::unix::io::FromRawFd;
-use structopt::StructOpt;
+use clap::Parser;
 
 /// parser is a program that parses a variety of formats and emits records in jsonl format.
 /// Data can be passed either as a
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Args {
-    #[structopt(long, global = true, default_value = "warn", env = "PARSER_LOG")]
+    #[clap(long, global = true, default_value = "warn", env = "PARSER_LOG")]
     pub log: String,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Parse the given `--file` (stdin by default) and print the parsed records in jsonl format.
     Parse(ParseArgs),
@@ -25,11 +25,11 @@ pub enum Command {
     Spec,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct ParseArgs {
     /// Path to the configuration file to use for the parse operation. Run the `spec` subcommand to
     /// see the JSON schema of the config file, which includes descriptions of all the fields.
-    #[structopt(long = "config-file", env = "PARSE_CONFIG_FILE")]
+    #[clap(long = "config-file", env = "PARSE_CONFIG_FILE")]
     pub config_file: Option<String>,
 
     /// Path to a file with the data to parse. Defaults to '-', which represents stdin.
@@ -38,12 +38,12 @@ pub struct ParseArgs {
     /// able to seek around the file. This option enables those files to be passed as files, which
     /// allows the parser to avoid duplicating the work of writing the stream to a temporary file.
     /// Note that that's not actually implemented yet, but that's the intent of this option.
-    #[structopt(long = "file", default_value = "-")]
+    #[clap(long = "file", default_value = "-")]
     pub file: String,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     // Logs are written to stderr in jsonl format. This format is very compatible with Flow's log
     // parsing, which means that they will get forwarded with the proper level and will retain the


### PR DESCRIPTION
**Description:**

- I tried to use `flow_cli_common` in another project (airbyte-to-flow), but Cargo got confused about the two versions of clap we have in our `Cargo.lock` in this repository, turns out we had some packages still using clap:2 with structopt, which is now part of clap:3 as derive. I just migrated the code to use clap:3 and removed clap:2.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/680)
<!-- Reviewable:end -->
