### PR TITLE
connector: use tcp socket for communicating with connectors

### DIFF
--- a/go/flowctl-go/cmd-api-spec.go
+++ b/go/flowctl-go/cmd-api-spec.go
@@ -58,7 +58,7 @@ func (cmd apiSpec) execute(ctx context.Context) (specResponse, error) {
 
 	if err = connector.PullImage(ctx, cmd.Image); err != nil {
 		return specResponse{}, err
-	} else if o, err := connector.InspectImage(ctx, cmd.Image); err != nil {
+	} else if o, err := connector.DockerInspect(ctx, cmd.Image); err != nil {
 		return specResponse{}, err
 	} else if err = json.Unmarshal(o, &imageMeta); err != nil {
 		return specResponse{}, fmt.Errorf("parsing inspect image %w", err)


### PR DESCRIPTION
**Description:**

- use a tcp socket for communicating with connectors
- I could not test UDS due to https://github.com/docker/for-mac/issues/483, but adding it should not be too hard if necessary
- We need a way to migrate our existing deployments to this new method without disruption in service, so I may have to change this code so that it supports both methods somehow, open to suggestions on that
- At the moment this pull-request means network-tunnel doesn't work anymore since I'm bypassing connector-proxy completely. Moving network-tunnel to an independent binary should also be worked before we can fully migrate.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/682)
<!-- Reviewable:end -->
