### PR TITLE
connector_proxy: Include reason when 'check' subcommand fails

### DIFF
--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -60,8 +60,8 @@ pub enum Error {
     #[error("go.estuary.dev/E017: Could not find expected message in stream: {0}")]
     MessageNotFound(&'static str),
 
-    #[error("go.estuary.dev/E018: Connector's connection status is not successful")]
-    ConnectionStatusUnsuccessful,
+    #[error("go.estuary.dev/E018: Connection failed: {0}")]
+    ConnectionStatusUnsuccessful(String),
 
     #[error("go.estuary.dev/E019: Validation request is missing")]
     MissingValidateRequest,

--- a/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
+++ b/crates/connector_proxy/src/interceptors/airbyte_source_interceptor.rs
@@ -163,7 +163,7 @@ impl AirbyteSourceInterceptor {
             let connection_status = message.connection_status.unwrap();
 
             if connection_status.status != Status::Succeeded {
-                return Err(Error::ConnectionStatusUnsuccessful)
+                return Err(Error::ConnectionStatusUnsuccessful(connection_status.message.unwrap_or_default()))
             }
 
             let req = validate_request.lock().await;


### PR DESCRIPTION
**Description:**

An Airbyte connector returning a well-formed connection status [1] of 'FAILED' currently turns into an unhelpful error like:

    {"timestamp":"2022-09-21T21:36:40.118112447Z","level":"ERROR","message":"Check failed"}
    Error: go.estuary.dev/E008: IO Error
    Caused by:
        go.estuary.dev/E018: Connector's connection status is not successful

This commit makes that description a little bit more helpful and also includes the 'message' text that the connector provides, so the error might instead look something like:

    {"timestamp":"2022-09-21T21:36:40.118112447Z","level":"ERROR","message":"Check failed"}
    Error: go.estuary.dev/E008: IO Error
    Caused by:
        go.estuary.dev/E018: Connection failed: User 'wgd' not authorized

(Where the "User 'wgd' not authorized" bit is a hypothetical message that might come from the underlying connector which would tell the user what's actually gone wrong)

It would be nice to additionally remove the whole 'IO Error' wrapping thing, but the plumbing for that is a bit complicated so I figured that I ought to just tackle the easy part here.

[1] https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#airbyteconnectionstatus-message
