### PR TITLE
agent-sql: fix flow expansion to captures & materializations

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -244,7 +244,7 @@ pub async fn resolve_expanded_rows(
         -- Expand seed collections to include bound captures & materializations.
         -- The "on" clause ensures we only expand if the seed spec is itself a collection.
         -- The "union" is included here to retain the seed spec if it is a capture or materialization already.
-        -- This has the side effect of including the seed spec if is a collection as well, so the seed spec does
+        -- This has the side effect of including the seed spec if it is a collection, so the seed spec does
         -- not need to be union'd into the pass_two selection subquery.
         -- This pass is non-recursive: The "union" does not involve pass_one_b recursively.
         pass_one_b(id) as (

--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -241,20 +241,21 @@ pub async fn resolve_expanded_rows(
             from seeds s join live_spec_flows e
             on s.id = e.source_id and e.flow_type = 'collection'
         ),
-        -- Expand seed collections, captures, and materializations through
-        -- edges that connect captures and materializations to their bound
-        -- collections:
-        --   * A seed capture expands to all bound collections.
-        --   * A seed materialization expands to all bound collections.
-        --   * A seed collection expands to captures or materializations which bind it,
-        --      and from there to all of its other bound collections.
+        -- Expand seed collections to bound captures & materializations.
+        -- This pass is non-recursive.
         pass_one_b(id) as (
-            select id from seeds
-          union
+            select case when s.id = e.source_id then e.target_id else e.source_id end
+              from seeds as s join live_spec_flows as e
+              on s.id = e.source_id and e.flow_type = 'materialization' or s.id = e.target_id and e.flow_type = 'capture'
+            union
+              select * from seeds
+        ),
+        -- Further expand the resulting captures & materializations to their bound collections.
+        -- This pass is non-recursive.
+        pass_one_c(id) as (
             select case when p.id = e.source_id then e.target_id else e.source_id end
-            from pass_one_b as p join live_spec_flows as e
-            on p.id = e.source_id or p.id = e.target_id
-            where e.flow_type in ('capture', 'materialization')
+              from (select id from pass_one_b) as p join live_spec_flows as e
+              on p.id = e.source_id or p.id = e.target_id
         ),
         -- Second pass recursively walks backwards along data-flow edges to
         -- expand derivations and tests:
@@ -262,7 +263,7 @@ pub async fn resolve_expanded_rows(
         --   * A collection or derivation is expanded to tests which write (ingest) into it.
         --   * A test is expanded to collections or derivations it reads (verifies).
         pass_two(id) as (
-            (select id from pass_one_a union select id from pass_one_b)
+            (select id from pass_one_a union select id from pass_one_b union select id from pass_one_c)
           union
             select e.source_id
             from pass_two as p join live_spec_flows as e

--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -241,8 +241,12 @@ pub async fn resolve_expanded_rows(
             from seeds s join live_spec_flows e
             on s.id = e.source_id and e.flow_type = 'collection'
         ),
-        -- Expand seed collections to bound captures & materializations.
-        -- This pass is non-recursive.
+        -- Expand seed collections to include bound captures & materializations.
+        -- The "on" clause ensures we only expand if the seed spec is itself a collection.
+        -- The "union" is included here to retain the seed spec if it is a capture or materialization already.
+        -- This has the side effect of including the seed spec if is a collection as well, so the seed spec does
+        -- not need to be union'd into the pass_two selection subquery.
+        -- This pass is non-recursive: The "union" does not involve pass_one_b recursively.
         pass_one_b(id) as (
             select case when s.id = e.source_id then e.target_id else e.source_id end
               from seeds as s join live_spec_flows as e


### PR DESCRIPTION
Closes https://github.com/estuary/flow/issues/655

**Description:**

Modifies the the flow expansion behavior when doing a build to not include unneeded captures or materializations. This prevents cases where (for example) an existing materialization failing to validate will prevent any new materializations being created from a shared collection. It may also provide a benefit to how long it takes to do a build in certain cases.

As far as I can tell this matches the intent of the original expansion, per the comments in existing the code.

**Workflow steps:**

In addition to the new unit tests, I ran a scenario locally where I:
- Made a single collection
- Create a Postgres materialization from that collection
- Allowed that materialization to successfully start & run, but then deleted the database so the materialization would fail subsequent validation checks
- Verified that with the existing code, a _new_ materialization from that collection could not be created, since the existing one fails to validate
- Verified that with the new code, a new materialization _could_ be created from that same collection, even with the existing materialization not being able to validate (since it isn't included in the build).

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/692)
<!-- Reviewable:end -->
