### PR TITLE
Set flowctl version from FLOW_VERSION

### DIFF
--- a/.github/workflows/flowctl-release.yaml
+++ b/.github/workflows/flowctl-release.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       ASSET_NAME: ${{ matrix.config.assetName }}
       # build.rs reads this env variable and uses to set the value that's printed by flowctl --version
-      FLOWCTL_RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      FLOW_VERSION: ${{ github.event.release.tag_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +31,7 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           target: x86_64-unknown-linux-musl
       - name: Build Linux
         if: matrix.config.os == 'ubuntu-latest'
@@ -46,6 +47,8 @@ jobs:
       - name: Install Rust
         if: matrix.config.os == 'macos-latest'
         uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       # This one mac build should hopefully run on intel or m1 macs
       - name: Build Mac
         if: matrix.config.os == 'macos-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,13 +145,6 @@ jobs:
         with:
           go-version: "1.19"
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2
-
       - name: Cache/Restore Go dependencies.
         uses: actions/cache@v2
         with:

--- a/crates/flowctl/build.rs
+++ b/crates/flowctl/build.rs
@@ -1,8 +1,9 @@
 fn main() {
     // If we set CARGO_PKG_VERSION this way, then it will override the default value, which is
     // taken from the `version` in Cargo.toml.
-    if let Ok(val) = std::env::var("FLOWCTL_RELEASE_VERSION") {
+    if let Ok(val) = std::env::var("FLOW_VERSION") {
         println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
+        eprintln!("using FLOW_VERSION: {}", val);
     }
-    println!("cargo:rerun-if-env-changed=FLOWCTL_RELEASE_VERSION");
+    println!("cargo:rerun-if-env-changed=FLOW_VERSION");
 }


### PR DESCRIPTION
**Description:**

Uses the `FLOW_VERSION` env variable to set the version string used by flowctl. This makes it consistent with the rest of the build, and allows non-release builds to use the version that's determined by the Makefile.

Also specifies the rust toolchain for flowctl release CI jobs.

_In theory_, this should get flowctl releases working, but I'll have to test that after this is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/698)
<!-- Reviewable:end -->
