### PR TITLE
Use setup-protoc action with authentication in CI

### DIFF
--- a/.github/workflows/flowctl-release.yaml
+++ b/.github/workflows/flowctl-release.yaml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Linux build steps:
       # Linux builds need the non-default musl target.

--- a/.github/workflows/flowctl-test.yaml
+++ b/.github/workflows/flowctl-test.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
@@ -93,6 +98,11 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
 
       - run: make extra-ci-runner-setup
       - run: make print-versions
@@ -137,8 +147,10 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Install protobuf compiler (it's not already included in CI runner)
-        run: sudo apt install -y libprotobuf-dev protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # We require a minimal Go version of 1.17.
       - uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -268,15 +268,13 @@ ${PKGDIR}/bin/agent: ${RUSTBIN}/agent | ${PKGDIR}
 ##########################################################################
 # Make targets used by CI:
 
-# We use LLVM for faster linking. See .cargo/config.
+# We use LLVM for faster linking. See RUSTFLAGS in .github/workflows/main.yml
 .PHONY: extra-ci-runner-setup
 extra-ci-runner-setup:
 	sudo apt install -y \
-		libprotobuf-dev \
 		libssl-dev \
 		musl-tools \
-		pkg-config \
-		protobuf-compiler
+		pkg-config
 	sudo ln --force --symbolic /usr/bin/ld.lld-12 /usr/bin/ld.lld
 
 .PHONY: print-versions


### PR DESCRIPTION
**Description:**

Previously, flow builds would install protoc using `apt`, while `flowctl` builds would use the `setup-prococ` action. This standardizes on the `setup-protoc` action because it supports multiple platforms.

Further, the `setup-protoc` action was previously failing due to rate limit errors from the GH API (it uses the API in order to fetch release versions). This commit adds the `repo-token` variable, which allows for a much higher rate limit, since the request is authenticated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/700)
<!-- Reviewable:end -->
