### PR TITLE
agent: use bridge as default network

### DIFF
--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -32,7 +32,7 @@ struct Args {
     )]
     consumer_address: url::Url,
     /// Docker network for connector invocations.
-    #[clap(long = "connector-network", default_value = "host")]
+    #[clap(long = "connector-network", default_value = "bridge")]
     connector_network: String,
     /// Path to binaries like `flowctl`.
     #[clap(long = "bin-dir", env = "BIN_DIR")]


### PR DESCRIPTION
**Description:**

- Use `bridge` as the default network when running connectors in agent

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

