### PR TITLE
supabase/oauth: when encryption fails, log the response from enc service

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -35,17 +35,20 @@ export async function accessToken(req: Record<string, any>) {
     ...params,
   });
 
-  const bodyTemplate = Handlebars.compile(
-    oauth2_spec.accessTokenBody
-  );
-  const body = bodyTemplate({
-    redirect_uri,
-    client_id: oauth2_client_id,
-    client_secret: oauth2_client_secret,
-    config,
-    ...oauth2_injected_values,
-    ...params,
-  });
+  let body = null;
+  if (oauth2_spec.accessTokenBody) {
+    const bodyTemplate = Handlebars.compile(
+      oauth2_spec.accessTokenBody
+    );
+    body = bodyTemplate({
+      redirect_uri,
+      client_id: oauth2_client_id,
+      client_secret: oauth2_client_secret,
+      config,
+      ...oauth2_injected_values,
+      ...params,
+    });
+  }
 
   let headers = {};
   if (oauth2_spec.accessTokenHeaders) {

--- a/supabase/functions/oauth/encrypt-config.ts
+++ b/supabase/functions/oauth/encrypt-config.ts
@@ -60,6 +60,8 @@ export async function encryptConfig(req: Record<string, any>) {
   });
 
   if (response.status >= 400) {
+    console.error(await response.text());
+
     return new Response(
       JSON.stringify({
         error: {


### PR DESCRIPTION
**Description:**

- Log the response from encryption service when encryption fails to allow for troubleshooting

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/705)
<!-- Reviewable:end -->
