### PR TITLE
make: default target can include linux-binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ GO_BUILD_DEPS = \
 # Build rules:
 
 .PHONY: default
-default: package
+default: linux-binaries package
 
 # Rules for protocols
 .PHONY: protoc-gen-gogo


### PR DESCRIPTION
**Description:**

- default target can include linux-binaries

**Workflow steps:**

`make`

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/706)
<!-- Reviewable:end -->
