### PR TITLE
go-schema-gen: use integers for ordering values

### DIFF
--- a/go/protocols/materialize/go-schema-gen/.snapshots/TestGenerateSchema
+++ b/go/protocols/materialize/go-schema-gen/.snapshots/TestGenerateSchema
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/estuary/flow/go/protocols/materialize/go-schema-gen/test-config",
+  "properties": {
+    "password": {
+      "type": "string",
+      "title": "Password",
+      "description": "Secret password.",
+      "order": 1,
+      "secret": true
+    },
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "Test user.",
+      "order": 0
+    },
+    "advanced": {
+      "properties": {
+        "long_advanced": {
+          "type": "string",
+          "title": "Example",
+          "description": "Some long description.",
+          "multiline": true
+        },
+        "secret_advanced": {
+          "type": "string",
+          "title": "Secret Advanced",
+          "description": "Some secret advanced config with ordering.",
+          "order": 0,
+          "secret": true
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "advanced": true
+    }
+  },
+  "type": "object",
+  "required": [
+    "password",
+    "username"
+  ],
+  "title": "Test Schema"
+}

--- a/go/protocols/materialize/go-schema-gen/generate_test.go
+++ b/go/protocols/materialize/go-schema-gen/generate_test.go
@@ -1,0 +1,25 @@
+package schemagen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/require"
+)
+
+type testConfig struct {
+	Password string `json:"password" jsonschema:"title=Password,description=Secret password." jsonschema_extras:"secret=true,order=1"`
+	Username string `json:"username" jsonschema:"title=Username,description=Test user." jsonschema_extras:"order=0"`
+	Advanced struct {
+		LongAdvanced          string `json:"long_advanced,omitempty" jsonschema:"title=Example,description=Some long description." jsonschema_extras:"multiline=true"`
+		SecretOrderedAdvanced string `json:"secret_advanced,omitempty" jsonschema:"title=Secret Advanced,description=Some secret advanced config with ordering." jsonschema_extras:"secret=true,order=0"`
+	} `json:"advanced,omitempty" jsonschema_extras:"advanced=true"`
+}
+
+func TestGenerateSchema(t *testing.T) {
+	got := GenerateSchema("Test Schema", testConfig{})
+	formatted, err := json.MarshalIndent(got, "", "  ")
+	require.NoError(t, err)
+	cupaloy.SnapshotT(t, formatted)
+}


### PR DESCRIPTION
This is a copy of the changes that were made in the mirrored code in the connectors repo, see https://github.com/estuary/connectors/pull/370

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/711)
<!-- Reviewable:end -->
