### PR TITLE
docs: notion, surveymonkey, tiktok, gsc, amazon ads

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 7
 ---
 
 This is a change data capture (CDC) connector that captures change events from a MySQL database via the [Binary Log](https://dev.mysql.com/doc/refman/8.0/en/binary-log.html).

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 8
 ---
 This connector uses change data capture (CDC) to continuously capture updates in a PostgreSQL database into one or more Flow collections.
 

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -1,12 +1,18 @@
 # Capture connectors
 
-Estuary's available capture connectors are listed in this section. Each connector has a unique configuration you must follow in your [catalog specification](concepts/README.md#specifications); these will be linked below the connector name.
+Estuary's available capture connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.
 
-Also listed are links to the most recent Docker image, which you'll need for certain configuration methods.
+Also listed are links to the most recent Docker images for each connector. You'll need these to write Flow specifications manually (if you're [developing locally](../../../concepts/flowctl.md)). If you're using the Flow web app, they aren't necessary.
 
 Estuary is actively developing new connectors, so check back regularly for the latest additions. We’re prioritizing the development of high-scale technological systems, as well as client needs.
 
 ## Available capture connectors
+
+### Estuary connectors
+
+These connectors are created by Estuary. We prioritize high-scale technology systems for development.
+
+All Estuary connectors capture data in real time, as it appears in the source system
 
 * Amazon Kinesis
   * [Configuration](./amazon-kinesis.md)
@@ -14,12 +20,40 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * Amazon S3
   * [Configuration](./amazon-s3.md)
   * Package — ghcr.io/estuary/source-s3:dev
-* Amplitude
-  * [Configuration](./amplitude.md)
-  * Package - ghcr.io/estuary/source-amplitude:dev
 * Apache Kafka
   * [Configuration](./apache-kafka.md)
   * Package — ghcr.io/estuary/source-kafka:dev
+* Google Cloud Storage
+  * [Configuration](./gcs.md)
+  * Package — ghcr.io/estuary/source-gcs:dev
+* Google Firestore
+  * [Configuration](./google-firestore.md)
+  * Package - ghcr.io/estuary/source-firestore:dev
+* HTTP file
+  * [Configuration](./http-file.md)
+  * Package - ghcr.io/estuary/source-http-file:dev
+* MySQL
+  * [Configuration](./MySQL.md)
+  * Package - ghcr.io/estuary/source-mysql:dev
+* PostgreSQL
+  * [Configuration](./PostgreSQL.md)
+  * Package — ghcr.io/estuary/source-postgres:dev
+
+
+### Third party connectors
+
+Estuary supports open-source connectors from third parties. These connectors operate in a **batch** fashion,
+capturing data in increments. When you run these connectors in Flow, you'll get as close to real time as possible
+within the limitations set by the connector itself.
+
+Typically, we enable SaaS connectors from third parties to allow more diverse data flows.
+
+All the third-party connectors available currently were created by [Airbyte](https://airbyte.com/connectors).
+The versions made available in Flow have been adapted for compatibility.
+
+* Amplitude
+  * [Configuration](./amplitude.md)
+  * Package - ghcr.io/estuary/source-amplitude:dev
 * Exchange Rates API
   * [Configuration](./exchange-rates.md)
   * Package - ghcr.io/estuary/source-exchange-rates:dev
@@ -35,18 +69,9 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * Google Analytics
   * [Configuration](./google-analytics.md)
   * Package - ghcr.io/estuary/source-google-analytics-v4:dev
-* Google Cloud Storage
-  * [Configuration](./gcs.md)
-  * Package — ghcr.io/estuary/source-gcs:dev
-* Google Firestore
-  * [Configuration](./google-firestore.md)
-  * Package - ghcr.io/estuary/source-firestore:dev
 * Google Sheets
   * [Configuration](./google-sheets.md)
   * Package - ghcr.io/estuary/source-google-sheets:dev
-* HTTP file
-  * [Configuration](./http-file.md)
-  * Package - ghcr.io/estuary/source-http-file:dev
 * Hubspot
   * [Configuration](./hubspot.md)
   * Package - ghcr.io/estuary/source-hubspot:dev
@@ -59,15 +84,15 @@ Estuary is actively developing new connectors, so check back regularly for the l
 * Mailchimp
   * [Configuration](./mailchimp.md)
   * Package - ghcr.io/estuary/source-mailchimp:dev
-* MySQL
-  * [Configuration](./MySQL.md)
-  * Package - ghcr.io/estuary/source-mysql:dev
-* PostgreSQL
-  * [Configuration](./PostgreSQL.md)
-  * Package — ghcr.io/estuary/source-postgres:dev
+* Notion
+  * [Configuration](./notion.md)
+  * Package - ghcr.io/estuary/source-notion:dev
 * Stripe
   * [Configuration](./stripe.md)
   * Package - ghcr.io/estuary/source-stripe:dev
+* SurveyMonkey
+  * [Configuration](./survey-monkey.md)
+  * Package - ghcr.io/estuary/source-surveymonkey:dev
 * Zendesk Support
   * [Configuration](./zendesk-support.md)
   * Package - ghcr.io/estuary/source-zendesk-support:dev

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -51,6 +51,9 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 All the third-party connectors available currently were created by [Airbyte](https://airbyte.com/connectors).
 The versions made available in Flow have been adapted for compatibility.
 
+* Amazon Ads
+  * [Configuration](./amazon-ads.md)
+  * Package - ghrc.io/estuary/source-amazon-ads.dev
 * Amplitude
   * [Configuration](./amplitude.md)
   * Package - ghcr.io/estuary/source-amplitude:dev
@@ -69,6 +72,9 @@ The versions made available in Flow have been adapted for compatibility.
 * Google Analytics
   * [Configuration](./google-analytics.md)
   * Package - ghcr.io/estuary/source-google-analytics-v4:dev
+* Google Search Console
+  * [Configuration](./google-search-console.md)
+  * Package - ghcr.io/estuary/source-google-search-console:dev
 * Google Sheets
   * [Configuration](./google-sheets.md)
   * Package - ghcr.io/estuary/source-google-sheets:dev

--- a/site/docs/reference/Connectors/capture-connectors/amazon-ads.md
+++ b/site/docs/reference/Connectors/capture-connectors/amazon-ads.md
@@ -1,0 +1,143 @@
+# Amazon Ads
+
+This connector captures data from Amazon Ads into Flow collections via the [Amazon Ads API](https://advertising.amazon.com/API/docs/en-us).
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-amazon-ads:dev`](https://ghcr.io/estuary/source-amazon-ads:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/amazon-ads/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported:
+
+* [Profiles](https://advertising.amazon.com/API/docs/en-us/reference/2/profiles#/Profiles)
+* [Sponsored brands ad groups](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Ad%20groups)
+* [Sponsored brands campaigns](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Campaigns)
+* [Sponsored brands keywords](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Keywords)
+* [Sponsored brands report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Reports)
+* [Sponsored brands video report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Reports)
+* [Sponsored display ad groups](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Ad%20groups)
+* [Sponsored display ad campaigns](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Campaigns)
+* [Sponsored display product ads](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Product%20ads)
+* [ Sponsored display report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Reports)
+* [Sponsored display targetings](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Targeting)
+* [Sponsored product ad groups](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Ad%20groups)
+* [Sponsored product ads](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Product%20ads)
+* [Sponsored product campaigns](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Campaigns)
+* [Sponsored product keywords](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Keywords)
+* [Sponsored product negative keywords](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Negative%20keywords)
+* [Sponsored product targetings](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Product%20targeting)
+* [Sponsored product report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Reports)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+This connector uses OAuth2 to authenticate with Amazon. You can do this in the Flow web app, or configure manually if you're using the flowctl CLI.
+
+### Using OAuth2 to authenticate with Amazon in the Flow web app
+
+You'll need an Amazon user account with [access](https://advertising.amazon.com/help?ref_=a20m_us_blg#GDQVHVQMY9F88PCA) to the [Amazon Ads account](https://advertising.amazon.com/register) from which you wish to capture data.
+
+You'll use these credentials to sign in.
+
+### Authenticating manually using the CLI
+
+When you configure this connector manually, you provide the same credentials that OAuth2 would automatically
+fetch if you used the web app. These are:
+
+* **Client ID**
+* **Client secret**
+* **Refresh token**
+
+To obtain these credentials:
+
+1. Complete the [Amazon Ads API onboarding process](https://advertising.amazon.com/API/docs/en-us/onboarding/overview).
+
+2. [Retrieve your client ID and client secret](https://advertising.amazon.com/API/docs/en-us/getting-started/retrieve-access-token#retrieve-your-client-id-and-client-secret).
+
+3. [Retrieve a refresh token](https://advertising.amazon.com/API/docs/en-us/getting-started/retrieve-access-token#call-the-authorization-url-to-request-access-and-refresh-tokens).
+
+## Selecting data region and profiles
+
+When you [configure the endpoint](#endpoint) for this connector, you must choose an Amazon region from which to capture data.
+Optionally, you may also select profiles from which to capture data.
+
+The **region** must be one of:
+
+* NA (North America)
+* EU (European Union)
+* FE (Far East)
+
+These represent the three URL endpoints provided by Amazon through which you can access the marketing API.
+Each region encompasses multiple Amazon marketplaces, which are broken down by country.
+See the [Amazon docs](https://advertising.amazon.com/API/docs/en-us/info/api-overview#api-endpoints) for details.
+
+If you run your Amazon ads in multiple marketplaces, you may have separate [profiles](https://advertising.amazon.com/API/docs/en-us/concepts/authorization/profiles) for each.
+If this is the case, you can specify the profiles from which you wish to capture data
+by supplying their [profile IDs](https://advertising.amazon.com/API/docs/en-us/concepts/authorization/profiles#retrieving-profiles-2).
+Be sure to specify only profiles that correspond to marketplaces within the region you chose.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Amazon Ads source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties in the table below reflect the manual authentication method.
+If you're working in the Flow web app, you'll use [OAuth2](#using-oauth2-to-authenticate-with-amazon-in-the-flow-web-app),
+so many of these properties aren't required.
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials`** |  |  | object | Required |
+| `/credentials/auth_type` | Auth Type | Set to `oauth2.0` for manual integration (in this method, you're re-creating the same credentials of the OAuth user interface, but doing so manually) | string |  |
+| **`/credentials/client_id`** | Client ID | The client ID of your Amazon Ads developer application. | string | Required |
+| **`/credentials/client_secret`** | Client Secret | The client secret of your Amazon Ads developer application. | string | Required |
+| **`/credentials/refresh_token`** | Refresh Token | Amazon Ads refresh token. | string | Required |
+| `/profiles` | Profile IDs (Optional) | [Profile IDs](#selecting-data-region-and-profiles) you want to fetch data for.  | array |  |
+| `/region` | Region &#x2A; | [Region](#selecting-data-region-and-profiles) to pull data from (EU&#x2F;NA&#x2F;FE). | string | `"NA"` |
+| `/report_generation_max_retries` | Report Generation Maximum Retries &#x2A; | Maximum retries the connector will attempt for fetching report data. | integer | `5` |
+| `/report_wait_timeout` | Report Wait Timeout &#x2A; | Timeout duration in minutes for reports. | integer | `60` |
+| `/start_date` | Start Date (Optional) | The start date for collecting reports, in YYYY-MM-DD format. This should not be more than 60 days in the past. | string |  |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Amazon Ads resource from which a collection is captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+This sample specification reflects the manual authentication method.
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-amazon-ads:dev
+          config:
+            credentials:
+              auth_type: oauth2.0
+              client_id: amzn1.application-oa2-client.XXXXXXXXX
+              client_secret: <secret>
+              refresh_token: Atzr|XXXXXXXXXXXX
+            region: NA
+            report_generation_max_retries: 5
+            report_wait_timeout: 60
+            start_date: 2022-03-01
+
+      bindings:
+        - resource:
+            stream: profiles
+            syncMode: full_refresh
+          target: ${PREFIX}/profiles
+       {}
+```

--- a/site/docs/reference/Connectors/capture-connectors/amplitude.md
+++ b/site/docs/reference/Connectors/capture-connectors/amplitude.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 3
----
-
 # Amplitude
 
 This connector captures data from Amplitude into Flow collections.

--- a/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
+++ b/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 # Apache Kafka
 

--- a/site/docs/reference/Connectors/capture-connectors/exchange-rates.md
+++ b/site/docs/reference/Connectors/capture-connectors/exchange-rates.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 5
----
-
 # Exchange Rates API
 
 This connector captures data from the [Exchange Rates API](https://exchangeratesapi.io/).

--- a/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
+++ b/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 6
----
-
 # Facebook Marketing
 
 This connector captures data from the Facebook Marketing API into Flow collections.

--- a/site/docs/reference/Connectors/capture-connectors/gcs.md
+++ b/site/docs/reference/Connectors/capture-connectors/gcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 ---
 # Google Cloud Storage
 

--- a/site/docs/reference/Connectors/capture-connectors/github.md
+++ b/site/docs/reference/Connectors/capture-connectors/github.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 6
----
 # GitHub
 
 This connector captures data from GitHub repositories and organizations into Flow collections via GitHub's REST API.

--- a/site/docs/reference/Connectors/capture-connectors/google-ads.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-ads.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 7
----
-
 # Google Ads
 
 This connector captures data from [resources](https://developers.google.com/google-ads/api/fields/v11/overview) in one or more Google Ads accounts into Flow collections via the Google Ads API.
@@ -109,7 +105,7 @@ so many of these properties aren't required.
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/stream`** | Stream | Google Ad resource from which a collections is captured. | string | Required |
+| **`/stream`** | Stream | Google Ad resource from which a collection is captured. | string | Required |
 | **`/syncMode`** | Sync Mode | Connection method. | string | Required |
 
 ### Sample

--- a/site/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 8
----
-
 # Google Analytics
 
 This connector captures data from a view in Google Analytics.

--- a/site/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -47,7 +47,7 @@ You can find this using Google's [Account Explorer](https://ga-dev-tools.web.app
 
 * Your Google account username and password.
 
-### Configuring the connector specification manually
+### Authenticating manually with a service account key
 
 * The View ID for your Google Analytics account.
 You can find this using Google's [Account Explorer](https://ga-dev-tools.web.app/account-explorer/) tool.

--- a/site/docs/reference/Connectors/capture-connectors/google-firestore.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-firestore.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 5
 ---
 
 # Google Firestore

--- a/site/docs/reference/Connectors/capture-connectors/google-search-console.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-search-console.md
@@ -1,0 +1,124 @@
+# Google Search Console
+
+This connector captures data from Google Search Console into Flow collections via the [Google Search Console API](https://developers.google.com/webmaster-tools/v1/api_reference_index).
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-google-search-console:dev`](https://ghcr.io/estuary/source-google-search-console:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/google-search-console/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported:
+
+* [Search analytics: all fields](https://developers.google.com/webmaster-tools/v1/searchanalytics)
+    * This resource contains all data in for your search analytics, and can be large. The following five collections come from queries applied to this dataset.
+* Search analytics by country
+* Search analytics by date
+* Search analytics by device
+* Search analytics by page
+* Search analytics by query
+* [Sitemaps](https://developers.google.com/webmaster-tools/v1/sitemaps)
+* [Sites](https://developers.google.com/webmaster-tools/v1/sites)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+### Custom reports
+
+In addition to the resources listed above, you can add custom reports created with the [Google Analytics Search Console integration](https://support.google.com/analytics/topic/1308589?hl=en&ref_topic=3125765).
+You add these to the [endpoint configuration](#endpoint) in the format `{"name": "<report-name>", "dimensions": ["<dimension-name>", ...]}`.
+Each report is mapped to an additional Flow collection.
+
+:::caution
+Custom reports involve an integration with Google Universal Analytics, which Google will deprecate in July 2023.
+:::
+
+## Prerequisites
+
+There are two ways to authenticate with Google when capturing data from Google Search Console: using OAuth2, and manually, by generating a service account key.
+Their prerequisites differ.
+
+OAuth2 is recommended for simplicity in the Flow web app;
+the service account key method is the only supported method using the command line.
+
+### Using OAuth2 to authenticate with Google in the Flow web app
+
+You'll need:
+
+* Google credentials with [Owner access](https://support.google.com/webmasters/answer/7687615?hl=en) on the Google Search Console property. This can be a user account or a [service account](https://cloud.google.com/iam/docs/service-accounts).
+
+You'll use these credentials to log in to Google in the Flow web app.
+
+### Authenticating manually with a service account key
+
+You'll need:
+
+* A Google service account with:
+  * A JSON key generated.
+  * Access to the Google Search Console view through the API.
+
+Follow the steps below to meet these prerequisites:
+
+1. Create a [service account and generate a JSON key](https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount)
+You'll copy the contents of the downloaded key file into the Service Account Credentials parameter when you configure the connector.
+
+2. [Set up domain-wide delegation for the service account](https://developers.google.com/workspace/guides/create-credentials#optional_set_up_domain-wide_delegation_for_a_service_account).
+   1. During this process, grant the `https://www.googleapis.com/auth/webmasters.readonly` OAuth scope.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Google Search Console source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties in the table below reflect the manual authentication method.
+If you're working in the Flow web app, you'll use [OAuth2](#using-oauth2-to-authenticate-with-google-in-the-flow-web-app),
+so many of these properties aren't required.
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials`** | Authentication |  | object | Required |
+| **`/credentials/auth_type`** | Authentication Type | Set to `Service` for manual authentication | string | Required |
+| **`/credentials/service_account_info`** | Service Account JSON Key | The JSON key of the service account to use for authorization. | Required
+| **`/credentials/email`** | Admin Email | The email of your [Google Workspace administrator](https://support.google.com/a/answer/182076?hl=en). This is likely the account used during setup.  |
+| `/custom_reports` | Custom Reports (Optional) | A JSON array describing the [custom reports](#custom-reports) you want to sync from Google Search Console.  | string |  |
+| `/end_date` | End Date | UTC date in the format 2017-01-25. Any data after this date will not be replicated. Must be greater or equal to the start date field. | string |  |
+| **`/site_urls`** | Website URL | The [URLs of the website properties](https://support.google.com/webmasters/answer/34592?hl=en) attached to your GSC account. | array | Required |
+| **`/start_date`** | Start Date | UTC date in the format 2017-01-25. Any data before this date will not be replicated. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Google Search Consol resource from which a collection is captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+This sample specification reflects the manual authentication method.
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-google-search-console:dev
+          config:
+            credentials:
+              auth_type: Service
+              service_account_info: <secret>
+              email: admin@yourdomain.com
+            site_urls: https://yourdomain.com
+            start_date: 2022-03-01
+
+      bindings:
+        - resource:
+            stream: sites
+            syncMode: full_refresh
+          target: ${PREFIX}/sites
+       {}
+```

--- a/site/docs/reference/Connectors/capture-connectors/google-sheets.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-sheets.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 11
----
-
 # Google Sheets
 
 This connector captures data from a Google Sheets spreadsheet.

--- a/site/docs/reference/Connectors/capture-connectors/http-file.md
+++ b/site/docs/reference/Connectors/capture-connectors/http-file.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 6
 ---
 # HTTP file
 

--- a/site/docs/reference/Connectors/capture-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/capture-connectors/hubspot.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 13
----
-
 # Hubspot
 
 This connector captures data from a Hubspot account.

--- a/site/docs/reference/Connectors/capture-connectors/intercom.md
+++ b/site/docs/reference/Connectors/capture-connectors/intercom.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 14
----
-
 # Intercom
 
 This connector captures data from Intercom into Flow collections.

--- a/site/docs/reference/Connectors/capture-connectors/linkedin-ads.md
+++ b/site/docs/reference/Connectors/capture-connectors/linkedin-ads.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 15
----
-
 # LinkedIn Ads
 
 This connector captures data from LinkedIn Ads into Flow collections through the LinkedIn Marketing API.

--- a/site/docs/reference/Connectors/capture-connectors/mailchimp.md
+++ b/site/docs/reference/Connectors/capture-connectors/mailchimp.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 16
----
-
 # Mailchimp
 
 This connector captures data from a Mailchimp account.

--- a/site/docs/reference/Connectors/capture-connectors/notion.md
+++ b/site/docs/reference/Connectors/capture-connectors/notion.md
@@ -1,0 +1,96 @@
+# Notion
+
+This connector captures data from Notion into Flow collections via the [Notion API](https://developers.notion.com/reference/intro).
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-notion:dev`](https://ghcr.io/estuary/source-notion:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/notion/),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported:
+
+* [Blocks](https://developers.notion.com/reference/retrieve-a-block)
+* [Databases](https://developers.notion.com/reference/retrieve-a-database)
+* [Pages](https://developers.notion.com/reference/retrieve-a-page)
+* [Users](https://developers.notion.com/reference/get-user)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+To use this connector, you'll need a Notion account with an [integration](https://developers.notion.com/docs/authorization) created to connect with Flow.
+
+Before you create your integration, choose how you'll authenticate with Notion.
+There are two ways: using OAuth to sign in directly in the web app,
+or manually, using an access token.
+OAuth is recommended in the web app; only manual configuration is supported when using the CLI.
+
+### Setup for OAuth authentication
+
+1. Go to [your integrations page](https://www.notion.so/my-integrations) and create a new integration.
+
+2. On the new integration's **Secrets** page, change the integration type to **Public**. Fill in the required fields.
+
+   * Redirect URIs: http://dashboard.estuary.dev
+   * Website homepage: http://dashboard.estuary.dev
+   * Privacy policy: https://www.estuary.dev/privacy-policy/
+   * Terms of use: https://www.estuary.dev/terms/
+
+### Setup for manual authentication
+
+1. Go to [your integrations page](https://www.notion.so/my-integrations) and create a new [internal integration](https://developers.notion.com/docs/authorization#integration-types). Notion integrations are internal by default.
+
+2. Copy the generated token for use in the connector configuration.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Notion source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties in the table below reflect the manual authentication method.
+If you're working in the Flow web app, you'll use [OAuth2](#setup-for-oauth-authentication),
+so many of these properties aren't required.
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials`** | Authenticate using | Pick an authentication method. | object | Required |
+| **`/credentials/auth_type`** | Authentication type | Set to `token` for manual authentication | string | Required |
+| `/credentials/token` | Access Token | Notion API access token | string | |
+| **`/start_date`** | Start Date | UTC date and time in the format 2017-01-25T00:00:00.000Z. Any data before this date will not be replicated. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Notion resource from which a collection is captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+This sample specification reflects the manual authentication method.
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-notion:dev
+        config:
+          credentials:
+            auth_type: token
+            token: {secret}
+          start_date: 2021-01-25T00:00:00Z
+    bindings:
+      - resource:
+          stream: blocks
+          syncMode: incremental
+        target: ${PREFIX}/blocks
+      {...}
+```

--- a/site/docs/reference/Connectors/capture-connectors/survey-monkey.md
+++ b/site/docs/reference/Connectors/capture-connectors/survey-monkey.md
@@ -1,0 +1,103 @@
+# Survey Monkey
+
+This connector captures data from SurveyMonkey surveys into Flow collections via the SurveyMonkey API.
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-surveymonkey:dev`](https://ghcr.io/estuary/source-surveymonkey:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/surveymonkey),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported:
+
+* [Surveys](https://developer.surveymonkey.com/api/v3/#api-endpoints-get-surveys)
+* [Survey pages](https://developer.surveymonkey.com/api/v3/#api-endpoints-get-surveys-id-pages)
+* [Survey questions](https://developer.surveymonkey.com/api/v3/#api-endpoints-get-surveys-survey_id-pages-page_id-questions)
+* [Survey responses](https://developer.surveymonkey.com/api/v3/#api-endpoints-survey-responses)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+You'll need to configure a SurveyMonkey private app to integrate with Flow.
+
+### Setup
+
+1. Go to your your [SurveyMonkey apps page](https://developer.surveymonkey.com/apps) and create a new private app.
+2. Set the following required [scopes](https://developer.surveymonkey.com/api/v3/#scopes):
+   * View surveys
+   * View responses
+3. Deploy the app. This requires a paid SurveyMonkey plan; otherwise, [the app will be deleted in 90 days](https://developer.surveymonkey.com/api/v3/#deploying-an-app).
+
+Once the app is set up, there are two ways to authenticate SurveyMonkey in Flow: using OAuth in the web app, or using an access token with the flowctl CLI.
+
+#### OAuth authentication in the web app
+
+You'll need the username and password of a SurveyMonkey user that is part of the [team](https://help.surveymonkey.com/en/billing/teams/)
+for which the private app was created.
+
+#### Manual authentication with flowctl
+
+Note the client ID, secret, and access token for the private app you created. You'll use these in the connector configuration.
+
+## Performance considerations
+
+The SurveyMonkey API imposes [call limits](https://developer.surveymonkey.com/api/v3/#request-and-response-limits) of 500 per day
+and 120 per minute.
+
+This connector uses caching to avoid exceeding these limits.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the SurveyMonkey source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties in the table below reflect the manual authentication method.
+If you're working in the Flow web app, you'll use [OAuth2](#oauth-authentication-in-the-web-app),
+so many of these properties aren't required.
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials`** | Credentials | Credentials for the service | object | Required |
+| **`/credentials/access_token`** | Access Token | Access Token for your SurveyMonkey private app. | string | Required |
+| **`/credentials/client_id`** | Client ID | Client ID associated with your SurveyMonkey private app. | string | Required |
+| **`/credentials/client_secret`** | Client Secret | Client secret associated with your SurveyMonkey private app. | string | Required |
+| **`/start_date`** | Start Date | UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated. | string | Required |
+| `/survey_ids` | Survey Monkey survey IDs | IDs of the surveys from which you&#x27;d like to replicate data. If left empty, data from all boards to which you have access will be replicated. | array |  |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | SurveyMonkey resource from which a collection is captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+This sample specification reflects the manual authentication method.
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-surveymonkey:dev
+        config:
+          credentials:
+            access_token: {secret}
+            client_id: XXXXXXXXXXXXXXXX
+            client_secret: {secret}
+          start_date: 2021-01-25T00:00:00Z
+    bindings:
+      - resource:
+          stream: surveys
+          syncMode: incremental
+        target: ${PREFIX}/surveys
+      {...}
+```

--- a/site/docs/reference/Connectors/capture-connectors/tiktok.md
+++ b/site/docs/reference/Connectors/capture-connectors/tiktok.md
@@ -1,0 +1,134 @@
+# TikTok Marketing
+
+This connector captures data from TikTok marketing campaigns and ads into Flow collections via the [TikTok API for Business](https://ads.tiktok.com/marketing_api/docs). It supports production as well as [sandbox](https://ads.tiktok.com/marketing_api/docs?id=1738855331457026) accounts.
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-tiktok-marketing:dev`](https://ghcr.io/estuary/source-tiktok-marketing:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+You can find their documentation [here](https://docs.airbyte.com/integrations/sources/tiktok-marketing),
+but keep in mind that the two versions may be significantly different.
+
+## Supported data resources
+
+The following data resources are supported:
+
+| Resource | Production | Sandbox |
+|---|---|---|
+| Advertisers | X | X |
+| Ad Groups | X | X |
+| Ads | X | X |
+| Campaigns | X | X |
+| Ads Reports Hourly | X | X |
+| Ads Reports Daily | X | X |
+| Ads Reports Lifetime | X | X |
+| Advertisers Reports Hourly | X | |
+| Advertisers Reports Daily | X | |
+| Advertisers Reports Lifetime | X | |
+| Ad Groups Reports Hourly | X | X |
+| Ad Groups Reports Daily | X | X |
+| Ad Groups Reports Lifetime | X | X |
+| Campaigns Reports Hourly | X | X |
+| Campaigns Reports Daily | X | X |
+| Campaigns Reports Lifetime | X | X |
+| Advertisers Audience Reports Hourly | X | |
+| Advertisers Audience Reports Daily | X | |
+| Advertisers Audience Reports Lifetime | X | |
+| Ad Group Audience Reports Hourly | X | X |
+| Ad Group Audience Reports Daily | X | X |
+| Ads Audience Reports Hourly | X | X |
+| Ads Audience Reports Daily | X | X |
+| Campaigns Audience Reports By Country Hourly | X | X |
+| Campaigns Audience Reports By Country Daily | X | X |
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+Prerequisites differ depending on whether you have a production or [sandbox](https://ads.tiktok.com/marketing_api/docs?id=1738855331457026)
+TikTok for Business account, and on whether you'll use the Flow web app or the flowctl CLI.
+
+### OAuth authentication in the web app (production accounts)
+
+If you have a TikTok marketing account in production and will use the Flow web app, you'll be able to quickly log in using OAuth.
+
+You'll need:
+
+* A [TikTok for Business account](https://ads.tiktok.com/marketing_api/docs?rid=fgvgaumno25&id=1702715936951297) with one or more active campaigns.
+
+   * Note the username and password used to sign into this account
+
+### Sandbox access token authentication in the web app or CLI
+
+If you're working in a Sandbox TikTok for Business account, you'll authenticate with an access token in both the web app and CLI.
+
+You'll need:
+
+* A [TikTok for Business account](https://ads.tiktok.com/marketing_api/docs?rid=fgvgaumno25&id=1702715936951297).
+
+* A [Sandbox account](https://ads.tiktok.com/marketing_api/docs?rid=fgvgaumno25&id=1701890920013825) created under an existing
+ [developer application](https://ads.tiktok.com/marketing_api/docs?rid=fgvgaumno25&id=1702716474845185).
+
+   * Generate an access token and note the advertiser ID for the Sandbox.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the TikTok Marketing source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties in the table below reflect the manual authentication method for Sandbox accounts.
+If you're using a production account, you'll use [OAuth2](#oauth-authentication-in-the-web-app-production-accounts) to authenticate in the Flow web app,
+so many of these properties aren't required.
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials`** | Authentication Method | Authentication method | object | Required |
+| **`/credentials/auth_type`** | Authentication type | Set to `sandbox_access_token` to manually authenticate a Sandbox. | string | Required |
+| `/credentials/advertiser_id` | Advertiser ID | The Advertiser ID generated for the developer's Sandbox application. | string | |
+| `/credentials/access_token` | Access Token | The long-term authorized access token. | string | |
+| `/end_date` | End Date | The date until which you'd like to replicate data for all incremental streams, in the format YYYY-MM-DD. All data generated between `start_date` and this date will be replicated. Not setting this option will result in always syncing the data till the current date. | string | |
+| `/report_granularity` | Report Aggregation Granularity | The granularity used for [aggregating performance data in reports](#report-aggregation). Choose `DAY`, `LIFETIME`, or `HOUR`.| string | |
+| `/start_date` | Start Date | Replication Start Date | The Start Date in format: YYYY-MM-DD. Any data before this date will not be replicated. If this parameter is not set, all data will be replicated. | string | |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | TikTok resource from which a collection is captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+This sample specification reflects the access token method for Sandbox accounts.
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-tiktok-marketing:dev
+        config:
+          credentials:
+            auth_type: sandbox_access_token
+            access_token: {secret}
+            advertiser_id: {secret}
+          end_date: 2022-01-01
+          report_granularity: DAY
+          start_date: 2020-01-01
+    bindings:
+      - resource:
+          stream: campaigns
+          syncMode: incremental
+        target: ${PREFIX}/campaigns
+      {...}
+```
+
+## Report aggregation
+
+Many of the [resources](#supported-data-resources) this connector supports are reports.
+Data in these reports is aggregated into rows based on the granularity you select in the [configuration](#endpoint).
+
+You can choose hourly, daily, or lifetime granularity. For example, if you choose daily granularity, the report will contain one row for each day.

--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -1,12 +1,16 @@
 # Materialization connectors
 
-Estuary's available materialization connectors are listed in this section. Each connector has a unique configuration you must follow as you create your Flow catalog.
+Estuary's available materialization connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.
 
-Also listed are links to the most recent Docker image, which you'll need for certain configuration methods.
+Also listed are links to the most recent Docker images for each connector. You'll need these to write Flow specifications manually (if you're [developing locally](../../../concepts/flowctl.md)). If you're using the Flow web app, they aren't necessary.
 
 Estuary is actively developing new connectors, so check back regularly for the latest additions. We’re prioritizing the development of high-scale technological systems, as well as client needs.
 
+At this time, all the available materialization connectors are created by Estuary.
+In the future, other open-source materialization connectors from third parties could be supported.
+
 ## Available materialization connectors
+
 * Apache Parquet in S3
   * [Configuration](./Parquet.md)
   * Package — ghcr.io/estuary/materialize-s3-parquet:dev


### PR DESCRIPTION
**Description:**

Add docs for:
* source-notion
* source-survey-monkey
* source-tiktok-marketing
* source-google-search-console
* source-amazon-ads

Also, re-orders connectors to emphasize ours over airbyte's, and better explain how we integrate with 3rd parties. 


**Documentation links affected:**

https://go.estuary.dev/fdKumB - GSC
https://go.estuary.dev/Y8iqCr - SurveyMonkey
https://go.estuary.dev/byfCts - TikTok
https://go.estuary.dev/VyWQ7h - TikTok
https://go.estuary.dev/EkkKXD - GSC
https://go.estuary.dev/9iXgpB - Notion
https://go.estuary.dev/rzNWCe - Amazon ads

...all need to be updated to point to our docs after merge.

**Notes for reviewers:**

Self-reviewed. We can tweak these more later if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/712)
<!-- Reviewable:end -->
