### PR TITLE
connector/run: increase timeout for connecting to TCP socket

### DIFF
--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -231,7 +231,7 @@ func runCommand(
 		// Routine dialing a connection to connector
 		go func() {
 			// Try to connect to the connector with a retry mechanism
-			var connectDeadline = time.Now().Add(time.Second * 5)
+			var connectDeadline = time.Now().Add(time.Second * 10)
 			var err error
 			for {
 				conn, err = net.Dial("tcp", localAddress)


### PR DESCRIPTION
**Description:**

- There are still intermittently errors about connecting to the socket, not sure why it would be slow but increasing this for now to allow the rollout of airbyte-to-flow

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/716)
<!-- Reviewable:end -->
