### PR TITLE
fix: e2e tests failing because of conflicting ports

### DIFF
--- a/crates/network-tunnel/src/networktunnel.rs
+++ b/crates/network-tunnel/src/networktunnel.rs
@@ -6,21 +6,22 @@ use async_trait::async_trait;
 
 #[async_trait]
 pub trait NetworkTunnel: Send + Sync {
-    // Inspect and/or modify the endpoint spec for which this network tunnel is created.
-    // This takes place before the tunnel is started, and may also modify tunnel config
-    // if appropriate.
+    /// Inspect and/or modify the endpoint spec for which this network tunnel is created.
+    ///
+    /// This takes place before the tunnel is started, and may also modify tunnel config
+    /// if appropriate.
     fn adjust_endpoint_spec(
         &mut self,
         endpoint_spec: serde_json::Value,
     ) -> Result<serde_json::Value, Error>;
-    // Setup the network proxy server. Network proxy should be able to listen and accept requests after `prepare` is performed.
+    /// Setup the network proxy server. Network proxy should be able to listen and accept requests after `prepare` is performed.
     async fn prepare(&mut self) -> Result<(), Error>;
-    // Start a long-running task that serves and processes all proxy requests from clients.
+    /// Start a long-running task that serves and processes all proxy requests from clients.
     async fn start_serve(&mut self) -> Result<(), Error>;
-    // Cleanup the child process. This is called in cases of failure to make sure the child process
-    // is properly killed.
+    /// Cleanup the child process. This is called in cases of failure to make sure the child process
+    /// is properly killed.
     async fn cleanup(&mut self) -> Result<(), Error>;
 
-    // This is only used for testing purposes
+    /// This is only used for testing purposes
     fn as_any(&self) -> &dyn Any;
 }

--- a/tests/citi-bike-success/flow.yaml
+++ b/tests/citi-bike-success/flow.yaml
@@ -10,7 +10,7 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          address: localhost:2345
+          address: postgres:5432
           user: flow
           password: flow
           database: flow

--- a/tests/materialize-logs.flow.yaml
+++ b/tests/materialize-logs.flow.yaml
@@ -7,7 +7,7 @@ materializations:
       connector:
         image: ghcr.io/estuary/materialize-postgres:dev
         config:
-          address: localhost:2345
+          address: postgres:5432
           user: flow
           password: flow
           database: flow

--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -53,7 +53,7 @@ ${FLOWCTL} api build \
     --build-id ${BUILD_ID} \
     --directory ${TESTDIR}/builds \
     --log.level info \
-    --network tunnel \
+    --network flow-test-network \
     --source ${TEST_ROOT}/flow.yaml \
     --ts-package \
     1>$TESTDIR/build.out 2>&1
@@ -84,7 +84,7 @@ export CONSUMER_ADDRESS=unix://localhost${TESTDIR}/consumer.sock
 # --unix-sockets to create UDS socket files in TESTDIR in well-known locations.
 ${FLOWCTL} temp-data-plane \
     --log.level info \
-    --network tunnel \
+    --network flow-test-network \
     --poll \
     --sigterm \
     --tempdir ${TESTDIR} \
@@ -110,7 +110,7 @@ ${FLOWCTL} api activate \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
-    --network tunnel \
+    --network flow-test-network \
     1>$TESTDIR/activate.out 2>&1
 
 if [ $? -ne 0 ]; then
@@ -237,7 +237,7 @@ ${FLOWCTL} api delete \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
-    --network tunnel \
+    --network flow-test-network \
     1>$TESTDIR/delete.out 2>&1
 
 if [ $? -ne 0 ]; then

--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -53,6 +53,7 @@ ${FLOWCTL} api build \
     --build-id ${BUILD_ID} \
     --directory ${TESTDIR}/builds \
     --log.level info \
+    --network tunnel \
     --source ${TEST_ROOT}/flow.yaml \
     --ts-package \
     1>$TESTDIR/build.out 2>&1
@@ -83,6 +84,7 @@ export CONSUMER_ADDRESS=unix://localhost${TESTDIR}/consumer.sock
 # --unix-sockets to create UDS socket files in TESTDIR in well-known locations.
 ${FLOWCTL} temp-data-plane \
     --log.level info \
+    --network tunnel \
     --poll \
     --sigterm \
     --tempdir ${TESTDIR} \
@@ -108,6 +110,7 @@ ${FLOWCTL} api activate \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
+    --network tunnel \
     1>$TESTDIR/activate.out 2>&1
 
 if [ $? -ne 0 ]; then
@@ -234,6 +237,7 @@ ${FLOWCTL} api delete \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
+    --network tunnel \
     1>$TESTDIR/delete.out 2>&1
 
 if [ $? -ne 0 ]; then

--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -53,7 +53,6 @@ ${FLOWCTL} api build \
     --build-id ${BUILD_ID} \
     --directory ${TESTDIR}/builds \
     --log.level info \
-    --network host \
     --source ${TEST_ROOT}/flow.yaml \
     --ts-package \
     1>$TESTDIR/build.out 2>&1
@@ -84,7 +83,6 @@ export CONSUMER_ADDRESS=unix://localhost${TESTDIR}/consumer.sock
 # --unix-sockets to create UDS socket files in TESTDIR in well-known locations.
 ${FLOWCTL} temp-data-plane \
     --log.level info \
-    --network host \
     --poll \
     --sigterm \
     --tempdir ${TESTDIR} \
@@ -110,7 +108,6 @@ ${FLOWCTL} api activate \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
-    --network host \
     1>$TESTDIR/activate.out 2>&1
 
 if [ $? -ne 0 ]; then
@@ -237,7 +234,6 @@ ${FLOWCTL} api delete \
     --all \
     --build-id ${BUILD_ID} \
     --log.level=info \
-    --network host \
     1>$TESTDIR/delete.out 2>&1
 
 if [ $? -ne 0 ]; then

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -1,12 +1,9 @@
-address: localhost:16666
+address: postgres:5432
 user: flow
 password: flow
 database: flow
 networkTunnel:
   sshForwarding:
-    localPort: 16666
-    forwardHost: postgres
-    forwardPort: 5432
     sshEndpoint: ssh://flowssh@openssh-server:2222
     privateKey: |2
       -----BEGIN OPENSSH PRIVATE KEY-----

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -5,9 +5,9 @@ database: flow
 networkTunnel:
   sshForwarding:
     localPort: 16666
-    forwardHost: localhost
+    forwardHost: openssh-server
     forwardPort: 2345
-    sshEndpoint: ssh://flowssh@localhost:2222
+    sshEndpoint: ssh://flowssh@openssh-server:2222
     privateKey: |2
       -----BEGIN OPENSSH PRIVATE KEY-----
       b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn

--- a/tests/sshforwarding/materialize-postgres.ssh.config.yaml
+++ b/tests/sshforwarding/materialize-postgres.ssh.config.yaml
@@ -5,8 +5,8 @@ database: flow
 networkTunnel:
   sshForwarding:
     localPort: 16666
-    forwardHost: openssh-server
-    forwardPort: 2345
+    forwardHost: postgres
+    forwardPort: 5432
     sshEndpoint: ssh://flowssh@openssh-server:2222
     privateKey: |2
       -----BEGIN OPENSSH PRIVATE KEY-----

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -30,4 +30,5 @@ services:
       - tunnel
 networks:
   tunnel:
+    external: true
     name: tunnel

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -18,10 +18,16 @@ services:
       - SUDO_ACCESS=false
       - PASSWORD_ACCESS=false
       - USER_NAME=flowssh
-    network_mode: "host"
+    networks: 
+      - tunnel
     restart: unless-stopped
   postgres:
     image: 'postgres:latest'
     command: ["postgres"]
     environment: {"POSTGRES_DB": "flow", "POSTGRES_USER": "flow", "POSTGRES_PASSWORD": "flow"}
     ports: ["2345:5432"]
+    networks: 
+      - tunnel
+networks:
+  tunnel:
+    name: tunnel

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -30,5 +30,5 @@ services:
       - tunnel
 networks:
   tunnel:
-    external: true
+    enable_ipv6: true
     name: tunnel

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -19,16 +19,15 @@ services:
       - PASSWORD_ACCESS=false
       - USER_NAME=flowssh
     networks: 
-      - tunnel
+      - flow-test-network
     restart: unless-stopped
   postgres:
     image: 'postgres:latest'
     command: ["postgres"]
     environment: {"POSTGRES_DB": "flow", "POSTGRES_USER": "flow", "POSTGRES_PASSWORD": "flow"}
-    ports: ["2345:5432"]
     networks: 
-      - tunnel
+      - flow-test-network
 networks:
   tunnel:
     driver: bridge
-    name: tunnel
+    name: flow-test-network

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -28,6 +28,6 @@ services:
     networks: 
       - flow-test-network
 networks:
-  tunnel:
+  flow-test-network:
     driver: bridge
     name: flow-test-network

--- a/tests/sshforwarding/sshd-configs/docker-compose.yaml
+++ b/tests/sshforwarding/sshd-configs/docker-compose.yaml
@@ -30,5 +30,5 @@ services:
       - tunnel
 networks:
   tunnel:
-    enable_ipv6: true
+    driver: bridge
     name: tunnel


### PR DESCRIPTION
Okay, so after talking with Johnny and Phil about this earlier, I went on to keep debugging this.
* We figured out the correct hostnames and ports in order to configure the connector’s `sshForwarding` to the postgres container. We got hung up on the fact that the connector binds to port 2222 by [default](https://github.com/estuary/connectors/blob/main/materialize-boilerplate/boilerplate.go#L35), which is _also_ the port that the `openssh-server` container uses. After figuring this out, we moved us on to the next error: 
* `ssh: bind [::1]:16666: Cannot assign requested address`. I found [this blog  post](https://www.electricmonk.nl/log/2014/09/24/ssh-port-forwarding-bind-cannot-assign-requested-address/) which suggested this is actually about ipv6 (note the `[::1]` instead of `127.0.0.1`). I couldn’t figure out an easier way to change this, so I [added](https://github.com/estuary/flow/pull/717/files#diff-dea4484ed61c1ed0c3f3fdf7bd093db8fd240d9caea93844456b67dea1101119R168-R171) `-o AddressFamly inet` to the ssh invocation, which seems to have worked, revealing the next  layer of this onion, which is also where I’m gonna call it for tonight:
* `msg=\"failed to query materialization spec (the table may not be initialized?)\" err=\"ERROR: relation \\\"flow_materializations_v2\\\" does not exist (SQLSTATE 42P01)\" table=flow_materializations_v2"` This seems to have gone away, not sure what caused it
* Needed to change how ssh forwarding is configured, thanks @mdibaiee.

We got a ✅!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/717)
<!-- Reviewable:end -->
