### PR TITLE
docs: s3 to snowflake guide and tutorial

### DIFF
--- a/site/docs/getting-started/tutorials/README.md
+++ b/site/docs/getting-started/tutorials/README.md
@@ -1,0 +1,18 @@
+# Flow tutorials
+
+Flow tutorials are complete learning experiences that help you get to know Flow using sample data.
+
+You'll find these helpful if:
+
+* You're testing out Flow with a trial account.
+
+* You're a new user looking for practice before you implement production Data Flows.
+
+* You'd rather learn the Flow [concepts](../../concepts/README.md) in a hands-on setting.
+
+:::info Beta
+Flow is in private beta. Sign up for a free [discovery call](https://go.estuary.dev/sign-up)
+or email support@estuary.dev for your free trial account.
+:::
+
+If you're looking for more streamlined guidance for your own use case, check out the [user guides](../../guides/).

--- a/site/docs/getting-started/tutorials/_category_.json
+++ b/site/docs/getting-started/tutorials/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Tutorials",
+    "position": 2
+}

--- a/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
+++ b/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
@@ -1,0 +1,245 @@
+# Create your first dataflow with Amazon S3 and Snowflake
+
+In this tutorial, you'll create your first complete **Data Flow** with Estuary Flow using publicly available data.
+
+The dataset you'll use is composed of zipped CSV files in an Amazon S3 cloud storage bucket. You'll transport this data to a table in your own Snowflake data warehouse.
+
+## Prerequisites
+
+You'll need:
+
+* An Estuary Flow trial account (or a full account).
+
+:::info Beta
+Flow is in private beta. Sign up for a free [discovery call](https://go.estuary.dev/sign-up)
+or email support@estuary.dev for your free account.
+:::
+
+* A [Snowflake free trial account](https://signup.snowflake.com/) (or a full account).
+  Snowflake trials are valid for 30 days.
+
+## Introduction
+
+#### The data
+
+New York City hosts the United States' largest bike share program, Citi Bike. [Citi Bike shares ride data](https://ride.citibikenyc.com/system-data) in CSV format with the public, including the starting and ending times and locations for every ride.
+They upload new data monthly to [their Amazon S3 bucket](https://s3.amazonaws.com/tripdata/index.html) as a zipped CSV file.
+
+In this scenario, let's imagine you're interested in urban bike safety, or perhaps you plan to open a bike store and entice Citi Bike renters to buy their own bikes.
+You'd like to access the Citi Bike data in your Snowflake data warehouse.
+From there, you plan to use your data analytics platform of choice to explore the data, and perhaps integrate it with business intelligence apps.
+
+You can use Estuary Flow to build a real-time Data Flow that will capture all the new data from Citi Bike as soon as it appears, convert it to Snowflake's format, and land the data in your warehouse.
+
+#### Estuary Flow
+
+In Estuary Flow, you create Data Flows to connect data **source** and **destination** systems.
+
+The simplest Data Flow comprises three types of entities:
+
+* A data **capture**, which ingests data from the source. In this case, you'll capture from Amazon S3.
+
+* One or more **collections**, which Flow uses to store that data inside a cloud-backed data lake
+
+* A **materialization**, to push the data to an external destination. In this case, you'll materialize to a Snowflake data warehouse.
+
+import Mermaid from '@theme/Mermaid';
+
+<Mermaid chart={`
+	graph LR;
+		Capture-->Collection;
+        Collection-->Materialization;
+`}/>
+
+
+For the capture and materialization to work, they need to integrate with outside systems: in this case, S3 and Snowflake, but many other systems can be used.
+To accomplish this, Flow uses **connectors**.
+Connectors are plug-in components that interface between Flow and an outside system.
+Today, you'll use Flow's S3 capture connector and Snowflake materialization connector.
+
+You'll start by creating your capture.
+
+## Capture Citi Bike data from S3
+
+1. Go to the Flow web app at [dashboard.estuary.dev](http://dashboard.estuary.dev) and sign in using the credentials provided by your Estuary account manager.
+
+2. Click the **Captures** tab and choose **New Capture**
+
+   All of the available capture connectors — representing the possible data sources — appear as tiles.
+
+3. Choose the **Amazon S3** tile.
+
+   A form appears with the properties required for an S3 capture. Every connector requires different properties to configure.
+
+   First, you'll name your capture.
+
+4. Click inside the **Name** box.
+
+  Names of entities in Flow must be unique. They're organized by prefixes, similar to paths in a file system.
+
+  If you're using a Flow trial account, you'll see the `trial/` prefix available to you in the drop-down menu.
+  If you're not a trial user, you'll see one or more prefixes pertaining to your organization.
+  These prefixes represent the **namespaces** of Flow to which you have access.
+
+5. Click `trial/` (or another prefix) from the dropdown and append a unique name after it. For example, `trial/yourname/citibiketutorial`.
+
+6. Next, fill out the required properties for S3.
+
+   * **AWS Access Key ID** and **AWS Secret Access Key**: The bucket is public, so you can leave these fields blank.
+
+   * **AWS Region**: `us-east-1`
+
+   * **Bucket**: `tripdata`
+
+   * **Prefix**: The storage bucket isn't organized by prefixes, so leave this blank.
+
+   * **Match Keys**: `2022`
+
+   The Citi Bike storage bucket has been around for a while. Some of the older datasets have incorrect file extensions or contain data in different formats. By selecting files that contain `2022`, you'll restrict the data to this year only, making things easier to manage for the purposes of this tutorial.
+   (In a real-world use case, you'd likely reconcile the different schemas of the various data formats using a **derivation**.
+   [Derivations](../../concepts/README.md#derivations) are a more advanced Flow skill.)
+
+7. Click **Discover Endpoint**.
+
+   Flow uses the configuration you provided to initiate a connection with S3. It generates a specification with details of the capture,
+   and another that contains details and a schema for the **collection** that will store the captured data in Flow.
+
+   Once this process completes, you can move on to the next step. If there's an error, go back and check your configuration.
+
+
+8. Click **Save and Publish**.
+
+   Flow deploys, or **publishes**, your capture, including your change to the schema. You'll see a notification when the this is complete.
+
+   All data in the Citi Bike tripdata bucket has been captured to a Flow collection. Now, you can materialize that data to Snowflake.
+
+9. Click **Materialize Collections**.
+
+## Prepare Snowflake to use with Flow
+
+Before you can materialize from Flow to Snowflake, you need to complete some setup steps.
+
+1. Leave the Flow web app open. In a new window or tab, go to your Snowflake console.
+
+  If you're a new trial user, you should have received instructions by email. For additional help in this section, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide-getting-started.html).
+
+2. Create a new Snowflake worksheet if you don't have one open.
+
+   This provides an interface where you can run queries.
+
+3. Paste the follow script into the console, changing the value for `estuary_password` from `secret` to a strong password):
+
+```sql
+set database_name = 'ESTUARY_DB';
+set warehouse_name = 'ESTUARY_WH';
+set estuary_role = 'ESTUARY_ROLE';
+set estuary_user = 'ESTUARY_USER';
+set estuary_password = 'secret';
+set estuary_schema = 'ESTUARY_SCHEMA';
+-- create role and schema for Estuary
+create role if not exists identifier($estuary_role);
+grant role identifier($estuary_role) to role SYSADMIN;
+-- Create snowflake DB
+create database if not exists identifier($database_name);
+use database identifier($database_name);
+create schema if not exists identifier($estuary_schema);
+-- create a user for Estuary
+create user if not exists identifier($estuary_user)
+password = $estuary_password
+default_role = $estuary_role
+default_warehouse = $warehouse_name;
+grant role identifier($estuary_role) to user identifier($estuary_user);
+grant all on schema identifier($estuary_schema) to identifier($estuary_role);
+-- create a warehouse for estuary
+create warehouse if not exists identifier($warehouse_name)
+warehouse_size = xsmall
+warehouse_type = standard
+auto_suspend = 60
+auto_resume = true
+initially_suspended = true;
+-- grant Estuary role access to warehouse
+grant USAGE
+on warehouse identifier($warehouse_name)
+to role identifier($estuary_role);
+-- grant Estuary access to database
+grant CREATE SCHEMA, MONITOR, USAGE on database identifier($database_name) to role identifier($estuary_role);
+-- change role to ACCOUNTADMIN for STORAGE INTEGRATION support to Estuary (only needed for Snowflake on GCP)
+use role ACCOUNTADMIN;
+grant CREATE INTEGRATION on account to role identifier($estuary_role);
+use role sysadmin;
+COMMIT;
+```
+
+4. Run all the queries.
+
+   * If you're using the the Snowflake Classic Web Interface, check **All queries** and click **Run**.
+
+   * If you're using the Snowsight interface, highlight the whole script and click the blue run button.
+
+  Snowflake is ready to use with Flow.
+
+5. Return to the Flow web application.
+
+## Materialize your Flow collection to Snowflake
+
+You were directed to the **Materializations** page.
+All of the available materialization connectors — representing the possible data destinations — are shown as tiles.
+
+1. Locate and select the **Snowflake** tile.
+
+   A new form appears with the properties required to materialize to Snowflake.
+
+2. Click inside the **Name** box.
+
+3. Click `trial/` (or another prefix) from the dropdown and append a unique name after it. For example, `trial/yourname/citibiketutorial`.
+
+4. Next, fill out the required properties for Snowflake (most of these come from the script you just ran).
+
+   * **Host URL**: This is the URL you use to log into Snowflake. If you recently signed up for a trial, it should be in your email. Omit the protocol from the beginning. For example, `ACCOUNTID.region.cloudprovider.snowflakecomputing.com` or `orgname-accountname.snowflakecomputing.com`.
+
+      [Learn more about account identifiers and host URLs.](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used)
+
+   * **Account**: Your account identifier. This is part of the Host URL. Using the previous examples, it would be `ACCOUNTID` or `accountname`.
+
+   * **User**: `ESTUARY_USER`
+
+   * **Password**: `secret` (Substitute the password you set in the script.)
+
+   * **Database**: `ESTUARY_DB`
+
+   * **Schema**: `ESTUARY_SCHEMA`
+
+   * **Warehouse**: `ESTUARY_WH`
+
+   * **Role**: `ESTUARY_ROLE`
+
+4. Scroll down to view the **Collection Selector** and fill in the **Table** field with `CitiBikeData` or another name of your choosing.
+
+   The collection you just created was already selected, but you must provide a name for the table to which it'll be materialized in Snowflake.
+
+6. Click **Discover endpoint**.
+
+   Flow uses the configuration you provided to initiate a connection with Snowflake and generate a specification with details of the materialization.
+
+   Once this process completes, you can move on to the next step. If there's an error, go back and check your configuration.
+
+9. Click **Save and Publish**.
+
+   Flow publishes the materialization.
+
+10. Return to the Snowflake console and expand ESTUARY_DB and ESTUARY_SCHEMA.
+You'll find the materialized table there.
+
+## Conclusion
+
+You've created a complete Data Flow that ingests the Citi Bike CSV files from an Amazon S3 bucket and materializes them into your Snowflake database.
+
+When Citi Bike uploads new data, it'll be reflected in Snowflake in near-real-time, so long as you don't disable your capture or materialization.
+
+Data warehouses like Snowflake are designed to power data analytics. From here, you can begin any number of analytical workflows.
+
+#### Want to learn more?
+
+* For more information on the connectors you used today, see the pages on [S3](../../reference/Connectors/capture-connectors/amazon-s3.md) and [Snowflake](../../reference/Connectors/materialization-connectors/Snowflake.md).
+
+* You can create a Data Flow using any combination of supported connectors with a similar process to the one you followed in this tutorial. For a more generalized procedure, see the [guide to create a Data Flow](../../guides/create-dataflow.md).

--- a/site/docs/guides/README.md
+++ b/site/docs/guides/README.md
@@ -1,0 +1,7 @@
+# Flow user guides
+
+In this section, you'll find step-by-step guides that walk you through common Flow tasks.
+
+These guides are designed to help you work with Data Flows in production — we assume you have your own data and are familiar with your source and destination systems. You might be here to [get your data moving with Flow](./create-dataflow.md) as quickly as possible, [reshape your collection with a derivation](./create-derivation.md), or [create a secure connection to your database](./connect-network.md).
+
+If you'd prefer a tailored learning experience with sample data, check out the [Flow tutorials](../getting-started/tutorials/).

--- a/site/docs/guides/create-dataflow.md
+++ b/site/docs/guides/create-dataflow.md
@@ -1,27 +1,27 @@
 ---
 sidebar_position: 1
 ---
-# Create a simple data flow
+# Create a basic Data Flow
 
-This guide walks you through the process of creating an end-to-end data flow in the
+This guide walks you through the process of creating an end-to-end Data Flow in the
 Flow web application.
 
 :::info Beta
-The Flow web application is currently available to users in the Estuary [beta program](https://go.estuary.dev/sign-up).
+The Flow web application is currently available to users in the Estuary beta program. Sign up for a free [discovery call](https://go.estuary.dev/sign-up)
+or email support@estuary.dev for your free account.
 :::
 
 ## Prerequisites
 
 This guide is intended for new Flow users and briefly introduces Flow's key concepts.
 Though it's not required, you may find it helpful to read
-the [high level concepts](../concepts/README.md) documentation for more detail before you begin.
+the [high level concepts](../concepts/README.md#essential-concepts) documentation for more detail before you begin.
 
 ## Introduction
 
-In Estuary Flow, you create data flows to connect data **source** and **destination** systems.
-The set of specifications that defines a data flow is known as a **catalog**, and is made of several important entities.
+In Estuary Flow, you create Data Flows to connect data **source** and **destination** systems.
 
-The simplest Flow catalog comprises three types of entities:
+The simplest Data Flow comprises three types of entities:
 
 * A data **capture**, which ingests data from an external source
 * One or more **collections**, which store that data in a cloud-backed data lake
@@ -29,7 +29,7 @@ The simplest Flow catalog comprises three types of entities:
 
 Almost always, the capture and materialization each rely on a **connector**.
 A connector is a plug-in component that interfaces between Flow and whatever data system you need to connect to.
-Here, we'll walk through how to leverage various connectors, configure them, and deploy your catalog to create an active data flow.
+Here, we'll walk through how to leverage various connectors, configure them, and deploy your Data Flow.
 
 ## Create a capture
 
@@ -41,15 +41,17 @@ credentials provided by your Estuary account manager.
 
 2. Click the **Captures** tab and choose **New capture**.
 
-3. On the **Create Capture** page, choose a name for your capture.
-Your capture name must begin with a [prefix](../concepts/README.md#namespace) to which you [have access](../reference/authentication.md).
-Click inside the **Name** field to generate a drop-down menu of available prefixes, and select your prefix.
-Append a unique capture name after the `/` to create the full name, for example `acmeCo/myFirstCapture`.
-
-4. Use the **Connector** drop down to choose your desired data source.
+3. Choose the appropriate **Connector** for your desired data source.
 
   A form appears with the properties required for that connector.
   More details are on each connector are provided in the [connectors reference](../reference/Connectors/capture-connectors/README.md).
+
+4. Type a name for your capture.
+
+   Your capture name must begin with a [prefix](../concepts/catalogs.md#namespace) to which you [have access](../reference/authentication.md).
+
+    Click inside the **Name** field to generate a drop-down menu of available prefixes, and select your prefix.
+    Append a unique capture name after the `/` to create the full name, for example `acmeCo/myFirstCapture`.
 
 5. Fill out the required properties and click **Discover Endpoint**.
 
@@ -60,12 +62,12 @@ Append a unique capture name after the `/` to create the full name, for example 
 
 6. Look over the generated capture definition and the schema of the resulting Flow **collection(s)**.
 
-  Flow generates catalog specifications as YAML files.
+  Flow generates these specifications as YAML files.
   You can modify it by filling in new values in the form and clicking **Discover Endpoint**,
   or by editing the YAML files directly in the web application.
   (Those who prefer a [command-line interface](../concepts/flowctl.md) can manage and edit YAML in their preferred development environment).
 
-  It's not always necessary to review and edit the YAML — Flow will prevent the publication of invalid catalogs.
+  It's not always necessary to review and edit the YAML — Flow will prevent the publication of invalid specifications.
 
 7. Once you're satisfied with the configuration, click **Save and publish**. You'll see a notification when the capture publishes successfully.
 
@@ -75,32 +77,33 @@ Append a unique capture name after the `/` to create the full name, for example 
 
 Now that you've captured data into one or more collections, you can materialize it to a destination.
 
-The **New Materializations** page is pre-populated with the capture and collection you just created.
 
-1.  Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/myFirstMaterialization`.
+1. Select the **Connector** tile for your desired data destination.
 
-2. Use the **Connector** drop down to choose your desired data destination.
-
-  The rest of the page populates with the properties required for that connector.
+  The page populates with the properties required for that connector.
   More details are on each connector are provided in the [connectors reference](../reference/Connectors/materialization-connectors/README.md).
+
+  Details of the collection you just created are already filled in.
+
+2.  Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/myFirstMaterialization`.
 
 3. Fill out the required properties and click **Discover Endpoint**.
 
-  Flow initiates a connection with the destination system, and creates a binding to map each collection in your catalog to a **resource** in the destination.
+  Flow initiates a connection with the destination system, and creates a binding to map each collection from your capture to a **resource** in the destination.
   Again, these may be tables, data streams, or something else.
-  When you publish the complete catalog, Flow will create these new resources in the destination.
+  When you publish the Data Flow, Flow will create these new resources in the destination.
 
 4. Look over the generated materialization definition and edit it, if you'd like.
 
-5. Click **Save and publish**. You'll see a notification when the full data flow publishes successfully.
+5. Click **Save and publish**. You'll see a notification when the full Data Flow publishes successfully.
 
 ## What's next?
 
-Now that you've deployed your first data flow, you can explore more possibilities.
+Now that you've deployed your first Data Flow, you can explore more possibilities.
 
 * Read the [high level concepts](../concepts/README.md) to better understand how Flow works and what's possible.
 
-* Create more complex data flows by mixing and matching collections in your captures and materializations. For example:
+* Create more complex Data Flows by mixing and matching collections in your captures and materializations. For example:
 
    * Materialize the same collection to multiple destinations.
 

--- a/site/docs/guides/create-derivation.md
+++ b/site/docs/guides/create-derivation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 # Create a derivation with flowctl
 

--- a/site/docs/guides/system-specific-dataflows/README.md
+++ b/site/docs/guides/system-specific-dataflows/README.md
@@ -1,0 +1,7 @@
+# System-specific Data Flows
+
+The guides in this section cover popular Estuary Flow use cases. Each guide walks you through the process of **capturing** data from a specific source system and **materializing** it to a specific destination.
+
+These are supplemental to the [main guide to create a Data Flow](../create-dataflow.md).
+If you don't see your exact Data Flow here, use the main guide and the [connector reference](../../reference/Connectors/)
+to mix and match your required source and destination systems.

--- a/site/docs/guides/system-specific-dataflows/_category_.json
+++ b/site/docs/guides/system-specific-dataflows/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Create a Data Flow for specific systems",
+    "position": 2
+}

--- a/site/docs/guides/system-specific-dataflows/s3-to-snowflake.md
+++ b/site/docs/guides/system-specific-dataflows/s3-to-snowflake.md
@@ -1,0 +1,147 @@
+
+# Amazon S3 to Snowflake
+
+This guide walks you through the process of creating an
+end-to-end real-time Data Flow from Amazon S3 to Snowflake using Estuary Flow.
+
+## Prerequisites
+
+You'll need:
+
+* (Recommended) understanding of the [basic Flow concepts](../../concepts/README.md#essential-concepts).
+
+* Access to the [**Flow web application**](http://dashboard.estuary.dev) through an Estuary account.
+
+:::info Beta
+Flow is in private beta. Sign up for a free [discovery call](https://go.estuary.dev/sign-up)
+or email support@estuary.dev for your free account.
+:::
+
+* An **S3 bucket** that contains the data you'd like to move to Snowflake.
+
+  * For public buckets, verify that the [access policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-overview.html#access-control-resources-manage-permissions-basics) allows anonymous reads.
+
+  * For buckets accessed by a user account, you'll need the AWS **access key** and **secret access key** for the user.
+  See the [AWS blog](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/) for help finding these credentials.
+
+* A Snowflake account with:
+
+  * A target **database**, **schema**, and virtual **warehouse**; and a **user** with a **role** assigned that grants the appropriate access levels to these resources.
+  [You can use a script to quickly create all of these items.](../../reference/Connectors/materialization-connectors/Snowflake.md#setup) Have these details on hand for setup with Flow.
+
+  * The account identifier and host URL noted. The URL is formatted using the [Snowflake account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used). For example, you might have the account identifier `orgname-accountname.snowflakecomputing.com`.
+
+## Introduction
+
+In Estuary Flow, you create **Data Flows** to transfer data from **source** systems to **destination** systems in real time.
+In this use case, your source is an Amazon S3 bucket and your destination is a Snowflake data warehouse.
+
+After following this guide, you'll have a Data Flow that comprises:
+
+* A **capture**, which ingests data from S3
+* A **collection**, a cloud-backed copy of that data in the Flow system
+* A **materialization**, which pushes the data to Snowflake
+
+The capture and materialization rely on plug-in components called **connectors**.
+We'll walk through how to configure the [S3](../../reference/Connectors/capture-connectors/amazon-s3.md) and [Snowflake](../../reference/Connectors/materialization-connectors/Snowflake.md) connectors to integrate these systems with Flow.
+
+## Capture from S3
+
+You'll first create a capture to connect to your S3 bucket, which will yield one or more Flow collections.
+
+1. Go to the Flow web application at [dashboard.estuary.dev](https://dashboard.estuary.dev/) and sign in using the
+credentials provided by your Estuary account manager.
+
+2. Click the **Captures** tab and choose **New Capture**.
+
+3. Click the **Amazon S3** tile.
+
+  A form appears with the properties required for an S3 capture.
+
+4. Type a name for your capture.
+
+    Your capture name must begin with a [prefix](../../concepts/catalogs.md#namespace) to which you [have access](../../reference/authentication.md).
+
+    Click inside the **Name** field to generate a drop-down menu of available prefixes, and select your prefix.
+    Append a unique capture name after the `/` to create the full name, for example `acmeCo/myS3Capture`.
+
+5. Fill out the required properties for S3.
+
+   * [**AWS Access Key ID** and **AWS Secret Access Key**](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/): Required for private buckets.
+
+   * **AWS Region** and **Bucket**: These are listed in your [S3 console](https://s3.console.aws.amazon.com/s3/buckets).
+
+   * **Prefix**: You might organize your S3 bucket using [prefixes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html), which emulate a directory structure. To capture *only* from a specific prefix, add it here.
+
+   * **Match Keys**: Filters to apply to the objects in the S3 bucket. If provided, only data whose absolute path matches the filter will be captured. For example, `*\.json` will only capture JSON file.
+
+   See the S3 connector documentation for information on [advanced fields](../../reference/Connectors/capture-connectors/amazon-s3.md#endpoint) and [parser settings](../../reference/Connectors/capture-connectors/amazon-s3.md#advanced-parsing-cloud-storage-data). (You're unlikely to need these for most use cases.)
+
+6. Click **Discover Endpoint**.
+
+  Flow uses the provided configuration to initiate a connection to S3. It generates a capture specification and details of the collection that it will create, once published.
+
+  You'll be notified if there's an error. In that case, fix the configuration form or your S3 bucket setup as needed and click **Discover Endpoint** to try again.
+
+  :::tip
+  If you'd rather work on the specification files in their native YAML format, you can use the [flowctl](../../concepts/flowctl.md) CLI. flowctl provides a developer-focused path to build full Data Flows in your preferred development environment.
+
+  flowctl also offers access to advanced features — with S3, for instance, you can [map multiple prefixes to different collections within a single capture](../../reference/Connectors/capture-connectors/amazon-s3.md#configuration).
+  :::
+
+7. Click **Save and publish**.
+
+  You'll see a notification when the capture publishes successfully.
+
+  The data currently in your S3 bucket has been captured, and future updates to it will be captured continuously.
+
+8. Click **Materialize Collections** to continue.
+
+## Materialize to Snowflake
+
+Next, you'll add a Snowflake materialization to connect the captured data to its destination: your data warehouse.
+
+1. On the **Create Materialization** page, search for and select the **Snowflake** tile.
+
+  A form appears with the properties required for a Snowflake materialization. 
+
+2.  Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/mySnowflakeMaterialization`.
+
+3. Fill out the required properties for Snowflake (you should have most of these handy from the [prerequisites](#prerequisites)).
+
+   * **Host URL**
+
+   * **Account**
+
+   * **User**
+
+   * **Password**
+
+   * **Database**
+
+   * **Schema**
+
+   * **Warehouse**: optional
+
+   * **Role**: optional
+
+4. Scroll down to view the **Collection Selector** and fill in the **Table** field.
+
+   The collection you just created is already selected, but you must provide a name for the table to which it'll be materialized in Snowflake.
+
+5. Choose whether to [enable delta updates](../../reference/Connectors/materialization-connectors/Snowflake.md#delta-updates).
+
+6. Click **Discover endpoint**.
+
+  Flow uses the provided configuration to initiate a connection to Snowflake. It generates a materialization specification.
+
+  You'll be notified if there's an error. In that case, fix the configuration form or Snowflake setup as needed and click **Discover Endpoint** to try again.
+
+7. Click **Save and Publish**. You'll see a notification when the full Data Flow publishes successfully.
+
+## What's next?
+
+Your Data Flow has been deployed, and will run continuously until it's stopped. Updates in your S3 bucket will be reflected in your Snowflake table as they occur.
+
+You can advance your Data Flow by adding a **derivation**. Derivations are real-time data transformations.
+See the [guide to create a derivation](../create-derivation.md).

--- a/site/docs/reference/Connectors/capture-connectors/amazon-s3.md
+++ b/site/docs/reference/Connectors/capture-connectors/amazon-s3.md
@@ -26,10 +26,10 @@ You might organize your S3 bucket using [prefixes](https://docs.aws.amazon.com/A
 This connector can use prefixes in two ways: first, to perform the [**discovery**](../../../concepts/connectors.md#flowctl-discover) phase of setup, and later, when the capture is running.
 
 * You can specify a prefix in the endpoint configuration to limit the overall scope of data discovery.
-* You're required to specify prefixes on a per-binding basis. This allows you to map each prefix to a distinct Flow collection,
+* If using the flowctl CLI to write your specification locally, you can specify prefixes on a per-binding basis. This allows you to map each prefix to a distinct Flow collection,
 and informs how the capture will behave in production.
 
-To capture the entire bucket, omit `prefix` in the endpoint configuration and set `stream` to the name of the bucket.
+To capture the entire bucket, omit `prefix` in the endpoint configuration and set `stream` to the name of the bucket. (This is the only available method in the web app.)
 :::
 
 ### Properties

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -28,7 +28,11 @@ If you haven't yet captured your data from its external source, start at the beg
 
 ### Setup
 
-To meet the prerequisites, copy and paste the following script into the Snowflake SQL editor, replacing the variable names in the first six lines with whatever you'd like.
+To meet the prerequisites, copy and paste the following script into the Snowflake SQL editor, replacing the variable names in the first six lines.
+
+If you'd like to use an existing database, warehouse, and/or schema, be sure to set
+`database_name`, `warehouse_name`, and `estuary_schema` accordingly. If you specify a new name, the script will create the item for you. You can set `estuary_role`, `estuary_user`, and `estuary_password` to whatever you'd like.
+
 Check the **All Queries** check box, and click **Run**.
 
 ```sql

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -45,6 +45,9 @@ set estuary_schema = 'ESTUARY_SCHEMA';
 -- create role and schema for Estuary
 create role if not exists identifier($estuary_role);
 grant role identifier($estuary_role) to role SYSADMIN;
+-- Create snowflake DB
+create database if not exists identifier($database_name);
+use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
@@ -52,7 +55,7 @@ password = $estuary_password
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);
-grant all on schema identifier($estuary_schema) to identifier($estuary_user);
+grant all on schema identifier($estuary_schema) to identifier($estuary_role);
 -- create a warehouse for estuary
 create warehouse if not exists identifier($warehouse_name)
 warehouse_size = xsmall
@@ -60,8 +63,6 @@ warehouse_type = standard
 auto_suspend = 60
 auto_resume = true
 initially_suspended = true;
--- Create snowflake DB
-create database if not exists identifier($database_name);
 -- grant Estuary role access to warehouse
 grant USAGE
 on warehouse identifier($warehouse_name)


### PR DESCRIPTION
**Description:**

* Introduces distinction between user guide (BYO data; assumes there is an active use case) and tutorials (provides data and exact step-by-step; designed for learning)
* Adds a "system specific guide" section to user guides, which we can populate with popular source-to-destination combinations
* Adds the first system-specific guide for an S3 to Snowflake dataflow
* Adds a thorough tutorial on S3 to snowflake using Citibike data
* Some associated changes to S3 and Snowflake connector docs that I found along the way
* Updates general guide to create a dataflow to new UI

**Notes for reviewers:**

Merging with self-review and will incorporate feedback on the published materials at a later date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/720)
<!-- Reviewable:end -->
