### PR TITLE
Await TCP copy goroutines in connector.Run

### DIFF
--- a/examples/citi-bike/csv-rides.flow.yaml
+++ b/examples/citi-bike/csv-rides.flow.yaml
@@ -7,7 +7,7 @@ captures:
   examples/citi-bike/rides-from-s3:
     endpoint:
       connector:
-        image: ghcr.io/estuary/source-s3:dev
+        image: ghcr.io/estuary/source-s3:mahdi-test
         config: rides.config.yaml
     bindings:
       - resource:

--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -252,12 +252,14 @@ func runCommand(
 			// Copy |writeLoop| into socket
 			go func() {
 				fe.onError(writeLoop(conn))
+				os.Stderr.WriteString("writeLoop end\n")
 				group.Done()
 			}()
 
 			// Read from socket connection and delegate to output through the error interceptor
 			go func() {
 				var _, err = io.Copy(outputInterceptor, conn)
+				os.Stderr.WriteString("outputInterceptor write end\n")
 				fe.onError(err)
 				group.Done()
 			}()
@@ -310,10 +312,14 @@ func runCommand(
 			fe.onError(ctx.Err())
 		}
 	}
+	os.Stderr.WriteString("cmd.Wait done\n")
 	// Wait for any TCP copy operations to finish. This must be done after the process exits.
 	group.Wait()
+	os.Stderr.WriteString("group.Wait done\n")
 	_ = stderrForwarder.Close()
+	os.Stderr.WriteString("stderrForwarder closed\n")
 	_ = output.Close()
+	os.Stderr.WriteString("output closed\n")
 
 	if port != "" && conn != nil {
 		var closeErr = conn.Close()

--- a/go/protocols/materialize/client.go
+++ b/go/protocols/materialize/client.go
@@ -419,9 +419,16 @@ func (f *TxnClient) readLoop() (__out error) {
 
 		// These can never succeed, since we're no longer looping.
 		if f.rx.commitOps.DriverCommitted != nil {
+			// TODO: For now I'm just logging this to see if the err is ever nil in practice
+			if __out == nil {
+				logrus.Warn("readLoop completed with nil err, but DriverCommitted was not done")
+			}
 			f.rx.commitOps.DriverCommitted.Resolve(__out)
 		}
 		if f.rx.commitOps.Acknowledged != nil {
+			if __out == nil {
+				logrus.Warn("readLoop completed with nil err, but Acknowledged was not done")
+			}
 			f.rx.commitOps.Acknowledged.Resolve(__out)
 		}
 	}()


### PR DESCRIPTION
**Description:**

When running connectors using the TCP mode, it was possible that the goroutines copying data between the socket and the "adapter" wrapper would still be running after the call to `Run` returned. This caused a panic in the capture runtime, due to the wrapper attempting to send a deserialized message on a channel that's already been closed.

The short term (hope springs eternal) fix that's implemented in this PR will await the completion of those goroutines before returning from the `runCommand` function. A better factoring, once we no longer need to support stdin/out connectors, would be to simply eliminate the wrapper altogether, and have the runtime dial the connector as you would any normal gRPC service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/724)
<!-- Reviewable:end -->
