### PR TITLE
docs: flowctl updates, logs and stats

### DIFF
--- a/site/docs/concepts/advanced/logs-stats.md
+++ b/site/docs/concepts/advanced/logs-stats.md
@@ -2,10 +2,6 @@
 
 Flow collects logs and statistics of catalog tasks to aid in debugging and refinement of your workflows.
 
-:::caution
-Access to statistics is still a work in progress. For now, this documentation deals strictly with logs.
-:::
-
 ## Logs
 
 Each organization that uses Flow has a `logs` collection under the global `ops` prefix.
@@ -15,10 +11,10 @@ These can be thought of as standard application logs:
 they store information about events that occur at runtime.
 They’re distinct from [recovery logs](./shards.md#recovery-logs), which track the state of various task shards.
 
-Regardless of how many Flow catalogs your organization has, all logs are stored in the same collection,
+Regardless of how many Data Flows your organization has, all logs are stored in the same collection,
 which is read-only and [logically partitioned](./projections.md#logical-partitions) on [tasks](../README.md#tasks).
 Logs are collected from events that occur within the Flow runtime,
-as well as the capture and materialization [connectors](../connectors.md) your catalog is using.
+as well as the capture and materialization [connectors](../connectors.md) your Data Flow is using.
 
 ### Log level
 
@@ -41,6 +37,27 @@ materializations:
     endpoint:
         {}
 ```
+## Statistics
 
-To learn more about working with logs and statistics,
-see their [reference documentation](../../../reference/working-logs-stats/).
+Each organization that uses Flow has a `stats` collection under the global `ops` prefix.
+For the organization Acme Co, it would have the name `ops/acmeCo/stats`.
+
+Regardless of how many Data Flows your organization has, all stats are stored in the same collection,
+which is read-only and [logically partitioned](./projections.md#logical-partitions) on [tasks](../README.md#tasks).
+
+A new document is published to the `stats` collection for each task transaction.
+Each document includes information about the time and quantity of data inputs and outputs.
+Statistics vary by task type (capture, materialization, or derivation).
+
+Use stats to:
+
+* Evaluate the data throughput of a task; for example, a derivation.
+* Compare a data throughput of a task between platforms; for example, compare reported data capture by Flow to detected change rate in a source system.
+* Access the same information used by Estuary for billing.
+* Optimize your tasks for increased efficiency.
+
+[See a detailed table of the properties included in `stats` documents.](../../reference/working-logs-stats.md#available-statistics)
+
+## Working with logs and statistics
+
+[Learn more about working with logs and statistics](../../reference/working-logs-stats.md)

--- a/site/docs/concepts/collections.md
+++ b/site/docs/concepts/collections.md
@@ -40,10 +40,10 @@ Use `flowctl collections read --help` to see documentation for all options.
 :::info Beta
 While in beta, this command currently has the following limitations. They will be removed in a later release:
 
-* The `--uncommitted` flag is required. This means that all collection documents are read, regardless of whether they were successfully committed or if they part of a [transaction](../concepts/advanced/shards.md#transactions) that was rolled back or uncommitted.
+* The `--uncommitted` flag is required. This means that all collection documents are read, regardless of whether they were successfully committed or not.
 In the future, reads of committed documents will be the default.
 
-* Only collections comprising a single [journal](../concepts/advanced/journals.md) can be read.
+* Only reads of a single [partition](../concepts/advanced/projections.md#logical-partitions) are supported. If you need to read from a partitioned collection, use `--include-partition` or `--exclude-partition` to narrow down to a single partition.
 
 * The `--output` flag is not usable for this command. Only JSON data can be read from collections.
 :::

--- a/site/docs/concepts/collections.md
+++ b/site/docs/concepts/collections.md
@@ -15,6 +15,39 @@ you define one or more new collections as part of that process.
 Every collection has a key and an associated [schema](#schemas)
 that its documents must validate against.
 
+## Viewing collection data
+
+In many cases, it's not necessary to view your collection data — you're able to materialize it directly to a destination in the correct shape using a [connector](../concepts/README.md#connectors).
+
+However, it can be helpful to view collection data to confirm the source data was captured as expected, or verify a schema change.
+
+#### In the web application
+
+Sign into the Flow web application and click the **Collections** tab. The collections to which you have access are listed.
+Click the **Details** drop down to show a sample of collection data as well as the collection [specification](#specification).
+
+The collection documents are displayed by key. Click the desired key to preview it in its native JSON format.
+
+#### Using the flowctl CLI
+
+In your [authenticated flowctl session](../reference/authentication.md#authenticating-flow-using-the-cli), issue the command `flowctl collections read --collection <full/collection-name> --uncommitted`. For example, `flowctl collections read --collection acmeCo/inventory/anvils --uncommitted`.
+
+Options are available to read a subset of data from collections.
+For example, `--since` allows you to specify an approximate start time from which to read data, and
+`--include-partition` allows you to read only data from a specified [logical partition](../concepts/advanced/projections.md#logical-partitions).
+Use `flowctl collections read --help` to see documentation for all options.
+
+:::info Beta
+While in beta, this command currently has the following limitations. They will be removed in a later release:
+
+* The `--uncommitted` flag is required. This means that all collection documents are read, regardless of whether they were successfully committed or if they part of a [transaction](../concepts/advanced/shards.md#transactions) that was rolled back or uncommitted.
+In the future, reads of committed documents will be the default.
+
+* Only collections comprising a single [journal](../concepts/advanced/journals.md) can be read.
+
+* The `--output` flag is not usable for this command. Only JSON data can be read from collections.
+:::
+
 ## Specification
 
 Collections are defined in Flow specification files per the following format:

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -43,7 +43,9 @@ Important top-level flowctl subcommands are described below.
 It's also how you provision Flow roles and users. Learn more about [authentication](../reference/authentication.md).
 
 * `catalog` allows you to work with your organization's current active catalog entities. You can investigate the current Data Flows,
- or add their specification files to a **draft**, where you can develop them further.
+ or add their specification files to a **draft**, where you can develop them further.f
+
+* `collections` allows you to work with your Flow collections. You can read the data from the collection and output it to stdout, or list the [journals](../concepts/advanced/journals.md) or journal fragments that comprise the collection. [Learn more about reading collections with flowctl](../concepts/collections.md#using-the-flowctl-cli).
 
 * `draft` allows you to work with drafts. You can create, test, develop locally, and then **publish**, or deploy, them to the catalog.
 
@@ -65,7 +67,6 @@ With `draft`, you:
 * Develop the draft locally.
 * Author your local changes to the draft. This is equivalent to syncing changes.
 * Test and publish the draft to publish to the catalog.
-
 
 <Mermaid chart={`
 	graph LR;

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -40,6 +40,21 @@ To install, copy and paste the appropriate script below into your terminal. This
 
 Alternatively, you can find the source files on GitHub [here](https://go.estuary.dev/flowctl).
 
+Once you've installed flowctl and are ready to begin working, authenticate your session using an access token.
+
+1. Sign into the Flow web application.
+
+2. Click the **Admin** tab.
+
+3. On the Admin page, click the **CLI-API** tab. Copy the token from the **Access Token** box.
+
+4. In the terminal of your local development environment, run:
+   ``` console
+   flowctl auth token --token=<copied-token>
+   ```
+
+The token will expire after a predetermined duration. Generate a new token using the web application and re-authenticate.
+
 [Learn more about using flowctl.](../concepts/flowctl.md)
 
 ## Self-hosting Flow

--- a/site/docs/reference/authentication.md
+++ b/site/docs/reference/authentication.md
@@ -59,13 +59,15 @@ To authenticate a local development session using the CLI, do the following:
 
 1. Sign into the Flow web application.
 
-2. Click the **Admin** tab, scroll to the **Access Token** box, and copy the token.
+2. Click the **Admin** tab.
 
-3. In the terminal of your local development environment, run:
+3. On the Admin page, click the **CLI-API** tab. Copy the token from the **Access Token** box.
+
+4. In the terminal of your local development environment, run:
    ``` console
    flowctl auth token --token=<copied-token>
    ```
-
+   
 The token will expire after a predetermined duration. Generate a new token using the web application and re-authenticate.
 
 ## Provisioning capabilities

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -44,7 +44,7 @@ Additional options for `flowctl logs` and `flowctl stats` can be accessed throug
 
 You can materialize your `logs` or `stats` collections to an external system.
 This is typically the preferred method if you’d like to continuously work with or monitor logs or statistics.
-It's easiest to materialize the whole collection, but you can use a [partition selector](../../concepts/materialization/#partition-selectors) to only materialize specific tasks, as the `logs` and `stats` collections are partitioned on tasks.
+You can materialize the logs or statistics for all tasks, or select a subset of tasks using a [partition selector](../../concepts/materialization/#partition-selectors) (the `logs` and `stats` collections are partitioned on tasks).
 
 :::caution
 Be sure to add a partition selector to exclude the logs and statistics of the materialization
@@ -79,7 +79,8 @@ A thorough knowledge of Flow's [advanced concepts](../concepts/README.md#advance
 
 ### Shard information
 
-Each `stats` document begin with data about the shard processing the transaction.
+A `stats` document begins with data about the shard processing the transaction.
+Each processing shard is uniquely identified by the combination of its `name`, `keyBegin`, and `rClockBegin`.
 This information is important for tasks with multiple shards: it allows you to determine whether data throughput is
 evenly distributed amongst those shards.
 
@@ -102,13 +103,13 @@ and that the amount of data processed matches your expectations.
 |---|---|---|---|
 | `/ts` | Timestamp corresponding to the start of the transaction, rounded to the nearest minute | string | All |
 | `/openSecondsTotal` | Total time that the transaction was open before starting to commit | number | All |
-| `/txnCount` | Total number of transactions represented by this stats document. Used for reduction; will always be `1`. | integer | All |
+| `/txnCount` | Total number of transactions represented by this stats document. Used for reduction. | integer | All |
 | `/capture` | Capture stats, organized by collection | object | Capture |
 | `/materialize` | Materialization stats, organized by collection | object | Materialization |
 | `/derive` | Derivation statistics | object | Derivation |
-| `/<task-type>/right/`| Input documents from a the task's source | object | Capture, materialization |
-| `/<task-type>/left/`| Input documents from an external destination; used for [reduced updates](../concepts/materialization.md#how-continuous-materialization-works) in materializations | object | Materialization |
-| `/<task-type>/out/`| Output documents from the transaction | object | All |
+| `/<task-type>/<collection-name>/right/`| Input documents from a the task's source | object | Capture, materialization |
+| `/<task-type>/<collection-name>/left/`| Input documents from an external destination; used for [reduced updates](../concepts/materialization.md#how-continuous-materialization-works) in materializations | object | Materialization |
+| `/<task-type>/<collection-name>/out/`| Output documents from the transaction | object | All |
 | `/<task-type>/{}/docsTotal` | Total number of documents| integer| All |
 | `/<task-type>/{}/bytesTotal` | Total number of bytes representing the JSON encoded documents | integer | All |
 | `/derivations/transforms/transformStats` | Stats for a specific transform of a derivation, which will have an update, publish, or both | object | Derivation |

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -6,65 +6,50 @@ sidebar_position: 3
 Your [`logs` and `stats` collections](../concepts/advanced/logs-stats.md)
 are useful for debugging and monitoring catalog tasks.
 
-:::info Beta
-Access to statistics is still a work in progress. For now, this documentation deals strictly with logs.
-:::
+## Accessing logs and statistics
 
-## Accessing logs
+You can access logs and statistics by materializing them to an external endpoint, or from the command line.
 
-You can access logs by materializing them to an external endpoint, or from the command line.
+### Accessing logs and statistics from the command line
 
-### Accessing logs from the command line
-
-:::caution Beta
-The `flowctl logs` subcommand is not currently available due to ongoing development.
-Command line support will be added back soon.
-Contact [Estuary Support](mailto:support@estuary.dev) for more information.
-
-For now, use a [materialization](#accessing-logs-by-materialization) to view logs.
-:::
-
-The `flowctl logs` subcommand allows you to print logs from the command line.
+The `flowctl logs` and `flowctl stats` subcommands allow you to print logs and stats, respectively, from the command line.
 This method allows more flexibility and is ideal for debugging.
 
-You can retrieve logs for any task that is part of a catalog that is currently deployed.
-
-#### Printing logs for a specific task
-
-You can print logs for a given deployed task using the flag `--task` followed by the task name.
+You can retrieve logs and stats for any published Flow task. For example:
 
 ```console
 flowctl logs --task acmeCo/anvils/capture-one
+
+flowctl stats --task acmeCo/anvils/capture-one --uncommitted
 ```
 
-#### Printing all logs for a prefix
+:::info Beta
+The `--uncommitted` flag is currently required for `flowctl stats`. This means that all statistics are read, regardless of whether they are about a successfully committed [transaction](../concepts/advanced/shards.md#transactions), or a transaction that was rolled back or uncommitted.
+In the future, committed reads will be the default.
+:::
 
-You can print all logs for currently deployed catalogs of a given prefix using the flag `--tenant`.
+#### Printing logs or stats since a specific time
 
-```console
-flowctl logs --tenant acmeCo
+To limit output, you can retrieve logs are stats starting at a specific time in the past. For example:
+
+```
+flowctl stats --task acmeCo/anvils/materialization-one --since 1h
 ```
 
-This is the same as printing the entire contents of the collection `ops/acmeCo/logs`.
+...will retrieve stats from approximately the last hour. The actual start time will always be at the previous [fragment](../concepts/advanced/journals.md#fragment-files) boundary, so it can be significantly before the requested time period.
 
-#### Printing logs by task type
+Additional options for `flowctl logs` and `flowctl stats` can be accessed through command-line help.
 
-Within a given prefix, you can print logs for all deployed tasks of a given type using the flag `--task-type` followed by one of `capture`, `derivation`, or `materialization`.
+### Accessing logs or stats by materialization
 
-```console
-flowctl logs --tenant acmeCo --task-type capture
-```
-
-### Accessing logs by materialization
-
-You can materialize your `logs` collection to an external system.
-This is typically the preferred method if you’d like to continuously work with or monitor logs.
-It's easiest to materialize the whole collection, but you can use a [partition selector](../../concepts/materialization/#partition-selectors) to only materialize specific tasks, as the `logs` collection is partitioned on tasks.
+You can materialize your `logs` or `stats` collections to an external system.
+This is typically the preferred method if you’d like to continuously work with or monitor logs or statistics.
+It's easiest to materialize the whole collection, but you can use a [partition selector](../../concepts/materialization/#partition-selectors) to only materialize specific tasks, as the `logs` and `stats` collections are partitioned on tasks.
 
 :::caution
-Be sure to add a partition selector to exclude the logs of the materialization
+Be sure to add a partition selector to exclude the logs and statistics of the materialization
 itself. Otherwise, you could trigger an infinite loop in which the connector
-materializes its own logs, logs that event, and so on.
+materializes its own logs and statistics, collects logs and statistic on that event, and so on.
 :::
 
 ```yaml
@@ -83,3 +68,51 @@ acmeCo/anvils/logs:
         exclude:
           name: ['acmeCo/anvils/logs']
 ```
+
+## Available statistics
+
+Available statistics include information about the amount of data in inputs and outputs of each transaction. They also include temporal information about the transaction. Statistics vary by task type (capture, materialization, or derivation).
+
+A thorough knowledge of Flow's [advanced concepts](../concepts/README.md#advanced-concepts) is necessary to effectively leverage these statistics.
+
+`stats` collection documents include the following properties.
+
+### Shard information
+
+Each `stats` document begin with data about the shard processing the transaction.
+This information is important for tasks with multiple shards: it allows you to determine whether data throughput is
+evenly distributed amongst those shards.
+
+| Property | Description | Data Type | Applicable Task Type |
+|---|---|---|---|
+| `/shard` | Flow shard information| object | All |
+| `/shard/kind` | The type of catalog task. One of `"capture"`, `"derivation"`, or `"materialization"` | string | All |
+| `/shard/name` | The name of the catalog task (without the task type prefix) | string | All |
+| `/shard/keyBegin` | With `rClockBegin`, this comprises the shard ID. The inclusive beginning of the shard's assigned key range.  | string | All |
+| `/shard/rClockBegin` | With `keyBegin`, this comprises the shard ID. The inclusive beginning of the shard's assigned rClock range.  | string | All |
+
+### Transaction information
+
+`stats` documents include information about a transaction: its inputs and outputs,
+the amount of data processed, and the time taken.
+You can use this information to ensure that your Flow tasks are running efficiently,
+and that the amount of data processed matches your expectations.
+
+| Property | Description | Data Type | Applicable Task Type |
+|---|---|---|---|
+| `/ts` | Timestamp corresponding to the start of the transaction, rounded to the nearest minute | string | All |
+| `/openSecondsTotal` | Total time that the transaction was open before starting to commit | number | All |
+| `/txnCount` | Total number of transactions represented by this stats document. Used for reduction; will always be `1`. | integer | All |
+| `/capture` | Capture stats, organized by collection | object | Capture |
+| `/materialize` | Materialization stats, organized by collection | object | Materialization |
+| `/derive` | Derivation statistics | object | Derivation |
+| `/<task-type>/right/`| Input documents from a the task's source | object | Capture, materialization |
+| `/<task-type>/left/`| Input documents from an external destination; used for [reduced updates](../concepts/materialization.md#how-continuous-materialization-works) in materializations | object | Materialization |
+| `/<task-type>/out/`| Output documents from the transaction | object | All |
+| `/<task-type>/{}/docsTotal` | Total number of documents| integer| All |
+| `/<task-type>/{}/bytesTotal` | Total number of bytes representing the JSON encoded documents | integer | All |
+| `/derivations/transforms/transformStats` | Stats for a specific transform of a derivation, which will have an update, publish, or both | object | Derivation |
+| `/derivations/transforms/transformStats/input` | The input documents that were fed into this transform | object | Derivation |
+| `/derivations/transforms/transformStats/update` | The outputs from update lambda invocations, which were combined into registers | object | Derivation |
+| `/derivations/transforms/transformStats/publish` | The outputs from publish lambda invocations. | object | Derivation |
+| `/derivations/registers/createdTotal` | The total number of new register keys that were created | integer | Derivation |


### PR DESCRIPTION
**Description:**

Docs updates per #707, including

- Updates to flowctl docs to reflect new commands
- Updates to collections docs (on flowctl access)
- Updates to the concept and reference pages on logs and statistics, including full docs of stats, which were omitted prior
- A few random tweaks to installation and auth docs

**Documentation links affected:**

don't think there are any shortlinks. 

**Notes for reviewers:**

I decided to handle stats properties (sort of) like connector config properties. I'm very curious to hear feedback on this. It's the sort of thing that I don't expect people to use all the time, but needs to be somewhere. Note the table _is_ simplified, but I didn't think exhaustively detailing the whole stats schema would be necessary or even helpful here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/728)
<!-- Reviewable:end -->
