### PR TITLE
small fixes for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
 		// Go language support.
 		"golang.go",
 		// Rust language support.
-		"matklad.rust-analyzer",
+		"rust-lang.rust-analyzer",
 		// SQL support.
 		"mtxr.sqltools",
 		// Driver for attached, docker compose database.

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: postgres:latest
+    image: postgres:14
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
**Description:**

This pins Postgres to 14 in the devcontainer setup as well as fixes a location for vscode extension for Rust support. `postgres:latest` is currently PG15 which doesn't work with this setup. 

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/731)
<!-- Reviewable:end -->
