### PR TITLE
Enable edge functions to work on newer local Supabase Versions

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -1,113 +1,114 @@
-import { serve } from "https://deno.land/std@0.131.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js";
-import Handlebars from "https://esm.sh/handlebars";
-import jsonpointer from "https://esm.sh/jsonpointer.js";
-import { returnPostgresError, handlebarsHelpers } from "../_shared/helpers.ts";
-import { corsHeaders } from "../_shared/cors.ts";
-import { supabaseClient } from "../_shared/supabaseClient.ts";
+import { serve } from 'https://deno.land/std@0.131.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js';
+import HandlebarsJS from 'https://dev.jspm.io/handlebars@4.7.6';
+import jsonpointer from 'https://esm.sh/jsonpointer.js';
+import { returnPostgresError, handlebarsHelpers } from '../_shared/helpers.ts';
+import { corsHeaders } from '../_shared/cors.ts';
+import { supabaseClient } from '../_shared/supabaseClient.ts';
 
 interface OauthSettings {
-  oauth2_client_id: string,
-  oauth2_client_secret: string,
-  oauth2_injected_values: any,
-  oauth2_spec: any
+    oauth2_client_id: string;
+    oauth2_client_secret: string;
+    oauth2_injected_values: any;
+    oauth2_spec: any;
 }
 
 export async function accessToken(req: Record<string, any>) {
-  const { state, config, redirect_uri, ...params } = req;
-  Handlebars.registerHelper(handlebarsHelpers);
+    const { state, config, redirect_uri, ...params } = req;
+    (HandlebarsJS as any).registerHelper(handlebarsHelpers);
 
-  const decodedState = JSON.parse(atob(state));
-  const { connector_id } = decodedState;
+    const decodedState = JSON.parse(atob(state));
+    const { connector_id } = decodedState;
 
-  const { data, error }: { data: OauthSettings | null, error: any } = await supabaseClient
-    .from("connectors")
-    .select("oauth2_client_id,oauth2_client_secret,oauth2_injected_values,oauth2_spec")
-    .eq("id", connector_id)
-    .single();
+    const { data, error }: { data: OauthSettings | null; error: any } = await supabaseClient
+        .from('connectors')
+        .select('oauth2_client_id,oauth2_client_secret,oauth2_injected_values,oauth2_spec')
+        .eq('id', connector_id)
+        .single();
 
-  if (error != null) {
-    returnPostgresError(error);
-  } 
-  // TODO - check for empty data
+    if (error != null) {
+        returnPostgresError(error);
+    }
+    // TODO - check for empty data
 
-  const { oauth2_spec, oauth2_client_id, oauth2_injected_values, oauth2_client_secret } = data as OauthSettings;
+    const { oauth2_spec, oauth2_client_id, oauth2_injected_values, oauth2_client_secret } = data as OauthSettings;
 
-  const urlTemplate = Handlebars.compile(oauth2_spec.accessTokenUrlTemplate);
-  const url = urlTemplate({
-    redirect_uri: redirect_uri ?? "https://dashboard.estuary.dev/oauth",
-    client_id: oauth2_client_id,
-    client_secret: oauth2_client_secret,
-    config,
-    ...oauth2_injected_values,
-    ...params,
-  });
-
-  let body = null;
-  if (oauth2_spec.accessTokenBody) {
-    const bodyTemplate = Handlebars.compile(
-      oauth2_spec.accessTokenBody
-    );
-    body = bodyTemplate({
-      redirect_uri,
-      client_id: oauth2_client_id,
-      client_secret: oauth2_client_secret,
-      config,
-      ...oauth2_injected_values,
-      ...params,
-    });
-  }
-
-  let headers = {};
-  if (oauth2_spec.accessTokenHeaders) {
-    const headersTemplate = Handlebars.compile(
-      JSON.stringify(oauth2_spec.accessTokenHeaders)
-    );
-    headers = JSON.parse(
-      headersTemplate({
-        redirect_uri,
+    const urlTemplate = (HandlebarsJS as any).compile(oauth2_spec.accessTokenUrlTemplate);
+    const url = urlTemplate({
+        redirect_uri: redirect_uri ?? 'https://dashboard.estuary.dev/oauth',
         client_id: oauth2_client_id,
         client_secret: oauth2_client_secret,
         config,
         ...oauth2_injected_values,
         ...params,
-      })
-    );
-  }
+    });
 
-  const response = await fetch(url, {
-    method: "POST",
-    body: body,
-    headers: {
-      accept: "application/json",
-      "content-type": "application/json",
-      ...corsHeaders,
-      ...headers,
-    },
-  });
+    let body = null;
+    if (oauth2_spec.accessTokenBody) {
+        const bodyTemplate = (HandlebarsJS as any).compile(oauth2_spec.accessTokenBody);
+        body = bodyTemplate({
+            redirect_uri,
+            client_id: oauth2_client_id,
+            client_secret: oauth2_client_secret,
+            config,
+            ...oauth2_injected_values,
+            ...params,
+        });
+    }
 
-  const accessTokenResponseMap = oauth2_spec.accessTokenResponseMap || {};
+    let headers = {};
+    if (oauth2_spec.accessTokenHeaders) {
+        const headersTemplate = (HandlebarsJS as any).compile(JSON.stringify(oauth2_spec.accessTokenHeaders));
+        headers = JSON.parse(
+            headersTemplate({
+                redirect_uri,
+                client_id: oauth2_client_id,
+                client_secret: oauth2_client_secret,
+                config,
+                ...oauth2_injected_values,
+                ...params,
+            }),
+        );
+    }
 
-  const responseText = await response.text();
+    const response = await fetch(url, {
+        method: 'POST',
+        body: body,
+        headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+            ...corsHeaders,
+            ...headers,
+        },
+    });
 
-  if (response.status >= 400) {
-    console.log("access token request failed");
-    console.log("request: POST ", url);
-    console.log("response: ", response.status, response.statusText, "headers: ", response.headers, "response body:", responseText);
-  }
+    const accessTokenResponseMap = oauth2_spec.accessTokenResponseMap || {};
 
-  let responseData = JSON.parse(responseText);
+    const responseText = await response.text();
 
-  let mappedData: Record<string, any> = {};
-  for (const key in accessTokenResponseMap) {
-    mappedData[key] = jsonpointer.get(
-      responseData,
-      accessTokenResponseMap[key]
-    );
-  }
+    if (response.status >= 400) {
+        console.log('access token request failed');
+        console.log('request: POST ', url);
+        console.log(
+            'response: ',
+            response.status,
+            response.statusText,
+            'headers: ',
+            response.headers,
+            'response body:',
+            responseText,
+        );
+    }
 
-  return new Response(JSON.stringify(mappedData), {
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-    status: response.status,
-  });
+    let responseData = JSON.parse(responseText);
+
+    let mappedData: Record<string, any> = {};
+    for (const key in accessTokenResponseMap) {
+        mappedData[key] = jsonpointer.get(responseData, accessTokenResponseMap[key]);
+    }
+
+    return new Response(JSON.stringify(mappedData), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: response.status,
+    });
 }

--- a/supabase/functions/oauth/auth-url.ts
+++ b/supabase/functions/oauth/auth-url.ts
@@ -1,67 +1,59 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js";
-import Handlebars from "https://esm.sh/handlebars";
-import { corsHeaders } from "../_shared/cors.ts";
-import { returnPostgresError, handlebarsHelpers } from "../_shared/helpers.ts";
-import { supabaseClient } from "../_shared/supabaseClient.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js';
+import HandlebarsJS from 'https://dev.jspm.io/handlebars@4.7.6';
+import { corsHeaders } from '../_shared/cors.ts';
+import { returnPostgresError, handlebarsHelpers } from '../_shared/helpers.ts';
+import { supabaseClient } from '../_shared/supabaseClient.ts';
 
 const generateUniqueRandomKey = () => {
-  const validChars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let array = new Uint8Array(40) as any;
-  window.crypto.getRandomValues(array);
-  array = array.map((x: number) =>
-    validChars.codePointAt(x % validChars.length)
-  );
-  return String.fromCharCode.apply(null, array);
+    const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let array = new Uint8Array(40) as any;
+    window.crypto.getRandomValues(array);
+    array = array.map((x: number) => validChars.codePointAt(x % validChars.length));
+    return String.fromCharCode.apply(null, array);
 };
 
 interface OauthSettings {
-  oauth2_client_id: string,
-  oauth2_spec: any,
+    oauth2_client_id: string;
+    oauth2_spec: any;
 }
 
-export async function authURL(req: {
-  connector_id: string;
-  config: object;
-  redirect_uri?: string;
-  state?: object;
-}) {
-  Handlebars.registerHelper(handlebarsHelpers);
+export async function authURL(req: { connector_id: string; config: object; redirect_uri?: string; state?: object }) {
+    (HandlebarsJS as any).registerHelper(handlebarsHelpers);
 
-  const { connector_id, config, redirect_uri, state } = req;
+    const { connector_id, config, redirect_uri, state } = req;
 
-  const { data, error }: { data: OauthSettings | null, error: any } = await supabaseClient
-    .from("connectors")
-    .select("oauth2_client_id,oauth2_spec")
-    .eq("id", connector_id)
-    .single();
+    const { data, error }: { data: OauthSettings | null; error: any } = await supabaseClient
+        .from('connectors')
+        .select('oauth2_client_id,oauth2_spec')
+        .eq('id', connector_id)
+        .single();
 
-  if (error != null) {
-    returnPostgresError(error);
-  }
-  // TODO - check for empty data
+    if (error != null) {
+        returnPostgresError(error);
+    }
+    // TODO - check for empty data
 
-  const { oauth2_spec, oauth2_client_id } = data as OauthSettings;
+    const { oauth2_spec, oauth2_client_id } = data as OauthSettings;
 
-  const finalState = btoa(
-    JSON.stringify({
-      ...(state ?? {}),
-      verification_token: generateUniqueRandomKey(),
-      connector_id,
-    })
-  );
+    const finalState = btoa(
+        JSON.stringify({
+            ...(state ?? {}),
+            verification_token: generateUniqueRandomKey(),
+            connector_id,
+        }),
+    );
 
-  const template = Handlebars.compile(oauth2_spec.authUrlTemplate);
-  const url = template({
-    state: finalState,
-    redirect_uri: redirect_uri ?? "https://dashboard.estuary.dev/oauth",
-    client_id: oauth2_client_id,
-    config,
-  });
+    const template = (HandlebarsJS as any).compile(oauth2_spec.authUrlTemplate);
+    const url = template({
+        state: finalState,
+        redirect_uri: redirect_uri ?? 'https://dashboard.estuary.dev/oauth',
+        client_id: oauth2_client_id,
+        config,
+    });
 
-  return new Response(JSON.stringify({ url: url, state: finalState }), {
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
+    return new Response(JSON.stringify({ url: url, state: finalState }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
 }
 
 // To invoke:


### PR DESCRIPTION
**Description:**
We want to use jspm because when it bundles non-es module libraries it uses Node polyfills instead of esm's use of Deno STD polyfills.

Also - there are some formatting changes because I saved the file and my LSP kicked in.

**Workflow steps:**

Start up edge functions with any recent version of Supabase

**Documentation links affected:**

None

**Notes for reviewers:**

This feels so weird as a fix for the problem and I also still do not know exactly what happened in 1.4.7 that messed stuff up. I looked at the change (https://github.com/supabase/cli/compare/v1.4.6...v1.4.7) and could not see anything that would cause an issue. The version of Deno was already locked so it should not be that.

On version 1.4.6 and before we were good.
On version 1.4.7 we get an error like this:
```
...
...
truncated
...
...
TS2345 [ERROR]: Argument of type '"SOA"' is not assignable to parameter of type 'RecordType'.
    this.#query(name, "SOA").then(({ code, ret }) => {
                      ~~~~~
    at https://deno.land/std@0.153.0/node/internal_binding/cares_wrap.ts:451:23

TS2694 [ERROR]: Namespace 'Deno' has no exported member 'SOARecord'.
          ret[0] as Deno.SOARecord;
                         ~~~~~~~~~
    at https://deno.land/std@0.153.0/node/internal_binding/cares_wrap.ts:456:26

TS2339 [ERROR]: Property 'reason' does not exist on type 'Event'.
          throw event.reason;
                      ~~~~~~
    at https://deno.land/std@0.153.0/node/process.ts:290:23

TS2339 [ERROR]: Property 'reason' does not exist on type 'Event'.
        uncaughtExceptionHandler(event.reason, "unhandledRejection");
                                       ~~~~~~
    at https://deno.land/std@0.153.0/node/process.ts:294:40

TS2339 [ERROR]: Property 'reason' does not exist on type 'Event'.
      process.emit("unhandledRejection", event.reason, event.promise);
                                               ~~~~~~
    at https://deno.land/std@0.153.0/node/process.ts:299:48

TS2339 [ERROR]: Property 'promise' does not exist on type 'Event'.
      process.emit("unhandledRejection", event.reason, event.promise);
                                                             ~~~~~~~
    at https://deno.land/std@0.153.0/node/process.ts:299:62

TS2339 [ERROR]: Property 'error' does not exist on type 'Event'.
      uncaughtExceptionHandler(event.error, "uncaughtException");
                                     ~~~~~
    at https://deno.land/std@0.153.0/node/process.ts:307:38

Found 23 errors.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/732)
<!-- Reviewable:end -->
