### PR TITLE
supabase/db: live_specs needs index on spec_type

### DIFF
--- a/supabase/migrations/09_publications.sql
+++ b/supabase/migrations/09_publications.sql
@@ -64,6 +64,11 @@ alter table live_specs enable row level security;
 create unique index idx_live_specs_catalog_name on live_specs
   (catalog_name text_pattern_ops);
 
+create index idx_live_specs_spec_type on live_specs
+  (spec_type);
+
+create index idx_live_specs_updated_at on live_specs (updated_at desc nulls last);
+
 create policy "Users must be read-authorized to the specification catalog name"
   on live_specs as permissive for select
   using (auth_catalog(catalog_name, 'read'));


### PR DESCRIPTION
**Description:**

- I checked stats for our queries on `live_specs_ext` and found that all offending queries have a filter on `spec_type` which does not have an index, and they order by `updated_at DESC NULL LAST` which also does not have an index. With these changes, I can see an improvement from 3.6-4s down to 1.9-2.2s.
- To get statistics, I used:
```
SELECT query, mean_exec_time, total_exec_time, min_exec_time, max_exec_time FROM pg_stat_statements WHERE query LIKE '%live_specs_ext%';
```
- This is still relatively slow for 10 documents, and that's becaues apparently our authentication policy on `live_specs` table runs before any other quals (i.e. before filtering by `spec_type`). I did some research trying to find a way to optimise this, and basically ask postgres: can you please filter by `spec_type` first? I see a few relevant options such as `security_barrier` views and `leakproof` functions, but I couldn't make them work for our use case where the table itself has a policy on it. So I have posted this question with more details on [stackoverflow](https://stackoverflow.com/questions/74183521/postgres-optimisation-run-view-query-before-policy) for now.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/733)
<!-- Reviewable:end -->
