### PR TITLE
ci: deploy supabase functions on 'master' branch

### DIFF
--- a/.github/workflows/control-ci-cd.yaml
+++ b/.github/workflows/control-ci-cd.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: supabase/setup-cli@v1
 
       - name: Deploy Supabase Edge Functions
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         id: deploy-supabase-fn
         run: |
           echo ${{ secrets.SUPABASE_ACCESS_TOKEN }} | supabase login


### PR DESCRIPTION
**Description:**

- deploy supabase functions on `master` branch instead of `main`, this broke during migration

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/734)
<!-- Reviewable:end -->
