### PR TITLE
agent-sql: allow null specs when inserting data-flow edges

### DIFF
--- a/crates/agent-sql/tests/publications.rs
+++ b/crates/agent-sql/tests/publications.rs
@@ -110,12 +110,16 @@ async fn test_publication_data_operations() {
     .unwrap();
 
     // Insert a number of flows between `aliceCo/Test/Fixture` and other specs.
-    // Expect all flows are resolved.
+    // Expect all flows that can be resolved, are resolved. Others are ignored.
     agent_sql::publications::insert_live_spec_flows(
         Id::new([0xcc, 0, 0, 0, 0, 0, 0, 0]),
         &Some(agent_sql::CatalogType::Test),
-        Some(vec!["aliceCo/First/Thing"]),
-        Some(vec!["aliceCo/First/Thing", "aliceCo/Second/Thing"]),
+        Some(vec!["aliceCo/First/Thing", "does/not/exist"]),
+        Some(vec![
+            "aliceCo/First/Thing",
+            "aliceCo/Second/Thing",
+            "also/does/not/exist",
+        ]),
         &mut txn,
     )
     .await


### PR DESCRIPTION
**Description:**

We update spec edges *before* validating the specifications for referential correctness, so we must relax our precondition to allow for referenced specs that don't actually exist.

We'll later surface these missing specs as build errors when checking for referential integrity.

**Workflow steps:**

None. Agent will no longer crash if referenced collections don't actually exist.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/745)
<!-- Reviewable:end -->
