### PR TITLE
connector_proxy: Error wrapping tweaks

### DIFF
--- a/crates/connector_proxy/src/errors.rs
+++ b/crates/connector_proxy/src/errors.rs
@@ -27,7 +27,7 @@ pub enum Error {
     #[error("go.estuary.dev/E007: The connector's protocol does not match the requested protocol. Connector protocol is {0}, requested protocol is {1}")]
     MismatchingRuntimeProtocol(String, &'static str),
 
-    #[error("go.estuary.dev/E008: IO Error")]
+    #[error(transparent)]
     IOError(#[from] std::io::Error),
 
     #[error("go.estuary.dev/E009: Json Error")]
@@ -87,8 +87,10 @@ pub fn create_custom_error(message: &str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, message)
 }
 
-pub fn interceptor_stream_to_io_stream(stream: InterceptorStream) -> impl TryStream<Item = std::io::Result<Bytes>, Ok = Bytes, Error = std::io::Error> {
-    stream.map_err(|e| create_custom_error(&e.to_string()))
+pub fn interceptor_stream_to_io_stream(
+    stream: InterceptorStream,
+) -> impl TryStream<Item = std::io::Result<Bytes>, Ok = Bytes, Error = std::io::Error> {
+    stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }
 
 pub fn io_stream_to_interceptor_stream(stream: impl Stream<Item = std::io::Result<Bytes>> + Send + Sync + 'static) -> InterceptorStream {


### PR DESCRIPTION
**Description:**

This commit tweaks `interceptor_stream_to_io_stream` to no longer stringify the underlying error type, so we get more information about the cause of the error.

In addition it changes `IOError` to be "transparent", meaning that when unwrapping the error details it won't be mentioned, which makes failure messages a lot more concise with (AFAIK) no loss of useful information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/749)
<!-- Reviewable:end -->
