### PR TITLE
connector_proxy: use explicit shutdown_background of tokio::Runtime

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -1,5 +1,7 @@
 use crate::apis::{FlowCaptureOperation, FlowMaterializeOperation, InterceptorStream};
-use crate::errors::{Error, self, io_stream_to_interceptor_stream, interceptor_stream_to_io_stream};
+use crate::errors::{
+    self, interceptor_stream_to_io_stream, io_stream_to_interceptor_stream, Error,
+};
 use crate::interceptors::{
     airbyte_source_interceptor::AirbyteSourceInterceptor,
     network_tunnel_capture_interceptor::NetworkTunnelCaptureInterceptor,
@@ -15,18 +17,7 @@ use proto_flow::capture::PullResponse;
 use proto_flow::flow::DriverCheckpoint;
 use tokio::io::copy;
 use tokio::process::{ChildStdin, ChildStdout};
-use tokio::task::JoinHandle;
 use tokio_util::io::{ReaderStream, StreamReader};
-
-async fn flatten_join_handle<T, E: std::convert::From<tokio::task::JoinError>>(
-    handle: JoinHandle<Result<T, E>>,
-) -> Result<T, E> {
-    match handle.await {
-        Ok(Ok(result)) => Ok(result),
-        Ok(Err(err)) => Err(err),
-        Err(err) => Err(err.into()),
-    }
-}
 
 pub async fn run_flow_capture_connector(
     op: &FlowCaptureOperation,
@@ -44,21 +35,13 @@ pub async fn run_flow_capture_connector(
     let adapted_response_stream =
         NetworkTunnelCaptureInterceptor::adapt_response_stream(op, response_stream(child_stdout))?;
 
-    let streaming_all_task = tokio::spawn(streaming_all(
-        child_stdin,
-        adapted_request_stream,
-        adapted_response_stream,
-    ));
+    let streaming_all_task =
+        streaming_all(child_stdin, adapted_request_stream, adapted_response_stream);
 
     let exit_status_task =
-        tokio::spawn(
-            async move { check_exit_status("flow capture connector:", child.wait().await) },
-        );
+        async move { check_exit_status("flow capture connector:", child.wait().await) };
 
-    tokio::try_join!(
-        flatten_join_handle(streaming_all_task),
-        flatten_join_handle(exit_status_task)
-    )?;
+    tokio::try_join!(streaming_all_task, exit_status_task)?;
 
     Ok(())
 }
@@ -81,20 +64,13 @@ pub async fn run_flow_materialize_connector(
         response_stream(child_stdout),
     )?;
 
-    let streaming_all_task = tokio::spawn(streaming_all(
-        child_stdin,
-        adapted_request_stream,
-        adapted_response_stream,
-    ));
+    let streaming_all_task =
+        streaming_all(child_stdin, adapted_request_stream, adapted_response_stream);
 
-    let exit_status_task = tokio::spawn(async move {
-        check_exit_status("flow materialize connector:", child.wait().await)
-    });
+    let exit_status_task =
+        async move { check_exit_status("flow materialize connector:", child.wait().await) };
 
-    tokio::try_join!(
-        flatten_join_handle(streaming_all_task),
-        flatten_join_handle(exit_status_task)
-    )?;
+    tokio::try_join!(streaming_all_task, exit_status_task)?;
 
     Ok(())
 }
@@ -139,7 +115,9 @@ pub async fn run_airbyte_source_connector(
                         (msg, bytes)
                     }
                     None => {
-                        sender.send(transaction_pending).map_err(|_| errors::Error::AirbyteCheckpointPending)?;
+                        sender
+                            .send(transaction_pending)
+                            .map_err(|_| errors::Error::AirbyteCheckpointPending)?;
                         return Ok(None);
                     }
                 };
@@ -154,14 +132,11 @@ pub async fn run_airbyte_source_connector(
     let adapted_response_stream =
         NetworkTunnelCaptureInterceptor::adapt_response_stream(op, res_stream)?;
 
-    let streaming_all_task = tokio::spawn(streaming_all(
-        child_stdin,
-        adapted_request_stream,
-        adapted_response_stream,
-    ));
+    let streaming_all_task =
+        streaming_all(child_stdin, adapted_request_stream, adapted_response_stream);
 
     let cloned_op = op.clone();
-    let exit_status_task = tokio::spawn(async move {
+    let exit_status_task = async move {
         let exit_status_result = check_exit_status("airbyte source connector:", child.wait().await);
 
         // There are some Airbyte connectors that write records, and exit successfully, without ever writing
@@ -197,12 +172,9 @@ pub async fn run_airbyte_source_connector(
         }
 
         exit_status_result
-    });
+    };
 
-    tokio::try_join!(
-        flatten_join_handle(streaming_all_task),
-        flatten_join_handle(exit_status_task)
-    )?;
+    tokio::try_join!(streaming_all_task, exit_status_task)?;
 
     Ok(())
 }
@@ -216,11 +188,15 @@ fn parse_entrypoint(entrypoint: &Vec<String>) -> Result<(String, Vec<String>), E
 }
 
 fn request_stream() -> InterceptorStream {
-    Box::pin(io_stream_to_interceptor_stream(ReaderStream::new(tokio::io::stdin())))
+    Box::pin(io_stream_to_interceptor_stream(ReaderStream::new(
+        tokio::io::stdin(),
+    )))
 }
 
 fn response_stream(child_stdout: ChildStdout) -> InterceptorStream {
-    Box::pin(io_stream_to_interceptor_stream(ReaderStream::new(child_stdout)))
+    Box::pin(io_stream_to_interceptor_stream(ReaderStream::new(
+        child_stdout,
+    )))
 }
 
 async fn streaming_all(
@@ -228,23 +204,20 @@ async fn streaming_all(
     request_stream: InterceptorStream,
     response_stream: InterceptorStream,
 ) -> Result<(), Error> {
-    let mut request_stream_reader = StreamReader::new(interceptor_stream_to_io_stream(request_stream));
-    let mut response_stream_reader = StreamReader::new(interceptor_stream_to_io_stream(response_stream));
+    let mut request_stream_reader =
+        StreamReader::new(interceptor_stream_to_io_stream(request_stream));
+    let mut response_stream_reader =
+        StreamReader::new(interceptor_stream_to_io_stream(response_stream));
     let mut response_stream_writer = tokio::io::stdout();
 
     let request_stream_copy =
-        tokio::spawn(
-            async move { copy(&mut request_stream_reader, &mut request_stream_writer).await },
-        );
+        async move { copy(&mut request_stream_reader, &mut request_stream_writer).await };
 
-    let response_stream_copy = tokio::spawn(async move {
-        copy(&mut response_stream_reader, &mut response_stream_writer).await
-    });
+    let response_stream_copy =
+        async move { copy(&mut response_stream_reader, &mut response_stream_writer).await };
 
-    let (req_stream_bytes, resp_stream_bytes) = tokio::try_join!(
-        flatten_join_handle(request_stream_copy),
-        flatten_join_handle(response_stream_copy)
-    )?;
+    let (req_stream_bytes, resp_stream_bytes) =
+        tokio::try_join!(request_stream_copy, response_stream_copy)?;
 
     tracing::debug!(
         req_stream = req_stream_bytes,

--- a/crates/connector_proxy/src/main.rs
+++ b/crates/connector_proxy/src/main.rs
@@ -1,18 +1,18 @@
+use anyhow::Context;
+use apis::{FlowCaptureOperation, FlowMaterializeOperation, FlowRuntimeProtocol};
 use clap::Parser;
+use connector_runner::{
+    run_airbyte_source_connector, run_flow_capture_connector, run_flow_materialize_connector,
+};
+use errors::Error;
 use flow_cli_common::{init_logging, LogArgs};
+use libs::image_inspect::ImageInspect;
 
 pub mod apis;
 pub mod connector_runner;
 pub mod errors;
 pub mod interceptors;
 pub mod libs;
-
-use apis::{FlowCaptureOperation, FlowMaterializeOperation, FlowRuntimeProtocol};
-use connector_runner::{
-    run_airbyte_source_connector, run_flow_capture_connector, run_flow_materialize_connector,
-};
-use errors::Error;
-use libs::image_inspect::ImageInspect;
 
 #[derive(Debug, clap::ArgEnum, Clone)]
 pub enum CaptureConnectorProtocol {
@@ -74,8 +74,7 @@ static DEFAULT_CONNECTOR_ENTRYPOINT: &str = "/connector/connector";
 //    network proxy specs, and starts the network proxy for the rest commands. See apis.rs for details.nd allows additional
 //    functionalities to be triggered during the communications.
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let Args {
         image_inspect_json_path,
         proxy_command,
@@ -83,12 +82,22 @@ async fn main() -> anyhow::Result<()> {
     } = Args::parse();
     init_logging(&log_args);
 
-    let result = async_main(image_inspect_json_path, proxy_command).await;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+
+    let result = runtime.block_on(async_main(image_inspect_json_path, proxy_command));
+
+    // Explicitly call Runtime::shutdown_background as an alternative to calling Runtime::Drop.
+    // This shuts down the runtime without waiting for blocking background tasks to complete,
+    // which is good because they likely never will. Consider a blocking call to read from stdin,
+    // where the sender is itself waiting for us to exit or write to our stdout.
+    // (Note that tokio::io maps AsyncRead of file descriptors to blocking tasks under the hood).
+    runtime.shutdown_background();
 
     match result {
-        Err(err) => {
-            Err(err.into())
-        }
+        Err(err) => Err(err.into()),
         Ok(()) => {
             tracing::info!(message = "connector-proxy exiting");
             Ok(())
@@ -115,7 +124,10 @@ async fn proxy_flow_capture(
     let image_inspect = ImageInspect::parse_from_json_file(image_inspect_json_path)?;
     let connector_protocol = image_inspect.infer_runtime_protocol();
     if connector_protocol != FlowRuntimeProtocol::Capture {
-        return Err(Error::MismatchingRuntimeProtocol(connector_protocol.to_string(), "capture"));
+        return Err(Error::MismatchingRuntimeProtocol(
+            connector_protocol.to_string(),
+            "capture",
+        ));
     }
 
     let entrypoint = image_inspect.get_entrypoint(vec![DEFAULT_CONNECTOR_ENTRYPOINT.to_string()]);
@@ -139,7 +151,10 @@ async fn proxy_flow_materialize(
     let image_inspect = ImageInspect::parse_from_json_file(image_inspect_json_path)?;
     let connector_protocol = image_inspect.infer_runtime_protocol();
     if connector_protocol != FlowRuntimeProtocol::Materialize {
-        return Err(Error::MismatchingRuntimeProtocol(connector_protocol.to_string(), "materialize"));
+        return Err(Error::MismatchingRuntimeProtocol(
+            connector_protocol.to_string(),
+            "materialize",
+        ));
     }
 
     let entrypoint = image_inspect.get_entrypoint(vec![DEFAULT_CONNECTOR_ENTRYPOINT.to_string()]);


### PR DESCRIPTION
**Description:**

Our use of tokio::io to read from stdin will actually map those reads into regular, synchronous reads on a blocking thread pool of the tokio::Runtime.

Sometimes those reads will run forever, since stdin is never closed by the parent process without our first exiting or closing our stdout.

However, the Drop behavior of a Runtime is to block forever awaiting all tasks to stop running, which means we can deadlock. Use shutdown_background instead to explicitly and immediately leak blocking tasks which cannot be cancelled.

Tested locally with a reproduction case using a capture connector that deliberately fails.
Before this patch I confirmed that the connector-proxy was attempting to exit but not actually doing so, because it was sitting in Runtime::Drop awaiting a blocking read of stdin.

After this patch, the connector-proxy exits as expected.

I'm still unclear why our existing E2E test isn't actually tickling this behavior. It may be due to differences in polling mode but that's not confirmed.

**Workflow steps:**

connector-proxy no longer silently fails but prevents the shard from being marked as FAILED.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/750)
<!-- Reviewable:end -->
