### PR TITLE
Fix deletion of catalog entities in flowctl

### DIFF
--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -310,7 +310,7 @@ async fn do_draft(
 #[derive(Deserialize, Serialize)]
 pub struct SpecSummaryItem {
     pub catalog_name: String,
-    pub spec_type: String,
+    pub spec_type: Option<String>,
 }
 impl CliOutput for SpecSummaryItem {
     type TableAlt = ();


### PR DESCRIPTION
**Description:**

PR #707 regressed the ability to delete catalog entities using `flowctl catalog draft --delete ...`. This fixes that by allowing the `spec_type` of a `SpecCummaryItem` to be `null`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/754)
<!-- Reviewable:end -->
