### PR TITLE
connector-proxy: exit after underlying connector exits

### DIFF
--- a/crates/connector_proxy/src/connector_runner.rs
+++ b/crates/connector_proxy/src/connector_runner.rs
@@ -35,9 +35,10 @@ pub async fn run_flow_capture_connector(
     let exit_status_task =
         async move { check_exit_status("flow capture connector:", child.wait().await) };
 
-    tokio::try_join!(streaming_all_task, exit_status_task)?;
-
-    Ok(())
+    tokio::select! {
+        Err(e) = streaming_all_task => Err(e),
+        resp = exit_status_task => resp,
+    }
 }
 
 pub async fn run_flow_materialize_connector(
@@ -60,9 +61,10 @@ pub async fn run_flow_materialize_connector(
     let exit_status_task =
         async move { check_exit_status("flow materialize connector:", child.wait().await) };
 
-    tokio::try_join!(streaming_all_task, exit_status_task)?;
-
-    Ok(())
+    tokio::select! {
+        Err(e) = streaming_all_task => Err(e),
+        resp = exit_status_task => resp,
+    }
 }
 
 pub async fn run_airbyte_source_connector(


### PR DESCRIPTION
**Description:**

- Do not wait for `streaming_all` to finish if the connector has already exit.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/763)
<!-- Reviewable:end -->
