### PR TITLE
refactor: Improve agent test infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ name = "agent-sql"
 version = "0.0.0"
 dependencies = [
  "chrono",
+ "hex",
  "insta",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "crates/*"]
+members = ["crates/*"]
 
 [workspace.package]
 version = "0.0.0"
@@ -13,9 +13,13 @@ repository = "https://github.com/estuary/flow"
 license = "BSL"
 
 [workspace.dependencies]
-addr = {version="0.15.4", features=["idna", "std","psl"]}
+addr = { version = "0.15.4", features = ["idna", "std", "psl"] }
 anyhow = "1.0"
-async-compression = { version = "0.3", features = ["all-algorithms", "tokio", "futures-io"] }
+async-compression = { version = "0.3", features = [
+    "all-algorithms",
+    "tokio",
+    "futures-io",
+] }
 async-trait = "0.1"
 atty = "0.2"
 avro-rs = { version = "0.13", features = ["snappy"] }
@@ -29,12 +33,12 @@ byteorder = "1.4"
 caseless = "0.2"
 chardetng = "0.1"
 chrono = "0.4"
-clap = { version = "3.2", features = ["derive", "env"]}
+clap = { version = "3.2", features = ["derive", "env"] }
 comfy-table = "6.1"
 crossterm = "0.25"
 csv = "1.1"
 dirs = "4.0"
-encoding_rs = {version = "0.8", features = ["serde"]}
+encoding_rs = { version = "0.8", features = ["serde"] }
 exponential-backoff = "1.1.0"
 fancy-regex = "0.10"
 flate2 = "1.0"
@@ -45,14 +49,17 @@ fxhash = "0.2"
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"
-indexmap = { version = "1.8", features = ["serde"]}
+indexmap = { version = "1.8", features = ["serde"] }
 iri-string = "0.6.0"
 jemallocator = "0.3"
 jemalloc-ctl = "0.3"
 json-patch = "0.2"
 lazy_static = "1.4"
 libc = "0.2"
-librocksdb-sys = { version = "6.20", default-features = false, features = ["snappy", "rtti"] }
+librocksdb-sys = { version = "6.20", default-features = false, features = [
+    "snappy",
+    "rtti",
+] }
 mime = "0.3"
 memchr = "2.5"
 num-bigint = "0.4"
@@ -72,38 +79,63 @@ protobuf-json-mapping = "3.1"
 protobuf-parse = "3.1"
 rand = "0.8"
 regex = "1.5"
+hex = "0.4.3"
 
-reqwest = { version = "0.11", default_features = false, features = ["json", "rustls-tls", "stream"] }
-rocksdb = { version = "0.17", default-features = false, features = ["snappy", "rtti"] }
-rusqlite = { version = "0.27", features = ["bundled-full"]}
+reqwest = { version = "0.11", default_features = false, features = [
+    "json",
+    "rustls-tls",
+    "stream",
+] }
+rocksdb = { version = "0.17", default-features = false, features = [
+    "snappy",
+    "rtti",
+] }
+rusqlite = { version = "0.27", features = ["bundled-full"] }
 schemars = "0.8"
 scopeguard = "1.1"
-serde = { version = "1.0", features = ["derive"]}
-serde_json = { version = "1.0.85", features = ["raw_value"]}
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0.85", features = ["raw_value"] }
 serde_yaml = "0.8"
 serde-transcode = "1.1"
 size = "0.4"
 strsim = "0.10"
-strum = {version = "0.24", features = ["derive"]}
+strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 superslice = "1.0"
-sqlx = { version = "0.6", features = [ "chrono", "json", "macros", "postgres", "runtime-tokio-native-tls", "uuid" ] }
+sqlx = { version = "0.6", features = [
+    "chrono",
+    "json",
+    "macros",
+    "postgres",
+    "runtime-tokio-native-tls",
+    "uuid",
+] }
 
 tempfile = "3.3"
 tempdir = "0.3"
 thiserror = "1.0"
-time = { version = "0.3", features = ["serde-well-known", "macros", "formatting", "parsing"] }
-tinyvec = {version = "1.6", features = ["alloc"]}
+time = { version = "0.3", features = [
+    "serde-well-known",
+    "macros",
+    "formatting",
+    "parsing",
+] }
+tinyvec = { version = "1.6", features = ["alloc"] }
 tokio = { version = "1.15", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
-tonic = {version = "0.8", features = [ "tls", "tls-roots"]}
+tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 tower = "0.4"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["time", "json", "env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3", features = [
+    "time",
+    "json",
+    "env-filter",
+    "fmt",
+] }
 
 unicode-bom = "1.1"
 unicode-normalization = "0.1"
-url = {version = "2.2", features = ["serde"]}
+url = { version = "2.2", features = ["serde"] }
 uuid = { version = "1.1", features = ["serde", "v4"] }
 validator = { version = "0.15", features = ["derive"] }
 quickcheck = "1.0"
@@ -114,7 +146,7 @@ zstd = "0.11.2"
 
 # Used exclusively as dev-dependencies
 assert_cmd = "2.0"
-insta = { version = "1.20", features = ["redactions", "json", "yaml"]}
+insta = { version = "1.20", features = ["redactions", "json", "yaml"] }
 criterion = "0.3"
 glob = "0.3"
 
@@ -128,7 +160,7 @@ warp = "0.3.3"
 
 [profile.release]
 incremental = true
-debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
+debug = 0          # Set this to 1 or 2 to get more useful backtraces in debugger.
 
 [patch.'crates-io']
 rocksdb = { git = "https://github.com/jgraettinger/rust-rocksdb" }

--- a/crates/agent-sql/Cargo.toml
+++ b/crates/agent-sql/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/agent-sql/src/id.rs
+++ b/crates/agent-sql/src/id.rs
@@ -1,3 +1,4 @@
+use hex::FromHexError;
 use sqlx::{postgres, Decode, Encode, Type, TypeInfo};
 
 /// Id is the Rust equivalent of the Postgres `flowid` type domain.
@@ -11,6 +12,15 @@ impl Id {
     }
     pub fn new(b: [u8; 8]) -> Self {
         Self(b)
+    }
+    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, FromHexError> {
+        let vec_bytes = hex::decode(hex)?;
+        let exact: [u8; 8] = vec_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| FromHexError::InvalidStringLength)?;
+
+        Ok(Id(exact))
     }
 }
 

--- a/crates/agent-sql/src/id.rs
+++ b/crates/agent-sql/src/id.rs
@@ -1,4 +1,3 @@
-use hex::FromHexError;
 use sqlx::{postgres, Decode, Encode, Type, TypeInfo};
 
 /// Id is the Rust equivalent of the Postgres `flowid` type domain.
@@ -13,12 +12,12 @@ impl Id {
     pub fn new(b: [u8; 8]) -> Self {
         Self(b)
     }
-    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, FromHexError> {
+    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, hex::FromHexError> {
         let vec_bytes = hex::decode(hex)?;
         let exact: [u8; 8] = vec_bytes
             .as_slice()
             .try_into()
-            .map_err(|_| FromHexError::InvalidStringLength)?;
+            .map_err(|_| hex::FromHexError::InvalidStringLength)?;
 
         Ok(Id(exact))
     }

--- a/crates/agent-sql/tests/publications.rs
+++ b/crates/agent-sql/tests/publications.rs
@@ -59,8 +59,8 @@ async fn test_publication_data_operations() {
     .await
     .unwrap();
 
-    let draft_id = Id::new([0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd]);
-    let pub_id = Id::new([0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee]);
+    let draft_id = Id::from_hex("dddddddddddddddd").unwrap();
+    let pub_id = Id::from_hex("eeeeeeeeeeeeeeee").unwrap();
     let alice = Uuid::from_bytes([
         0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
         0x11,
@@ -102,7 +102,7 @@ async fn test_publication_data_operations() {
 
     // Remove a stale flow of a now-deleted spec.
     agent_sql::publications::delete_stale_flow(
-        Id::new([0xbb, 0, 0, 0, 0, 0, 0, 0]),
+        Id::from_hex("bb00000000000000").unwrap(),
         CatalogType::Collection,
         &mut txn,
     )
@@ -112,7 +112,7 @@ async fn test_publication_data_operations() {
     // Insert a number of flows between `aliceCo/Test/Fixture` and other specs.
     // Expect all flows that can be resolved, are resolved. Others are ignored.
     agent_sql::publications::insert_live_spec_flows(
-        Id::new([0xcc, 0, 0, 0, 0, 0, 0, 0]),
+        Id::from_hex("cc00000000000000").unwrap(),
         &Some(agent_sql::CatalogType::Test),
         Some(vec!["aliceCo/First/Thing", "does/not/exist"]),
         Some(vec![

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -220,10 +220,6 @@ impl PublishHandler {
         }
 
         if test_run {
-            agent_sql::publications::rollback_noop(txn)
-                .await
-                .context("rolling back to savepoint")?;
-
             return Ok((row.pub_id, JobStatus::Success));
         }
 

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -17,7 +17,7 @@ pub struct Error {
 }
 
 /// JobStatus is the possible outcomes of a handled draft submission.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum JobStatus {
     Queued,
@@ -73,7 +73,7 @@ impl Handler for PublishHandler {
             None
         };
 
-        let (id, status) = self.process(row, &mut txn).await?;
+        let (id, status) = self.process(row, &mut txn, false).await?;
         info!(%id, ?status, "finished");
 
         agent_sql::publications::resolve(id, &status, &mut txn).await?;
@@ -95,6 +95,7 @@ impl PublishHandler {
         &mut self,
         row: Row,
         txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        test_run: bool,
     ) -> anyhow::Result<(Id, JobStatus)> {
         info!(
             %row.created_at,
@@ -216,6 +217,14 @@ impl PublishHandler {
         .await?;
         if !errors.is_empty() {
             return stop_with_errors(errors, JobStatus::BuildFailed, row, txn).await;
+        }
+
+        if test_run {
+            agent_sql::publications::rollback_noop(txn)
+                .await
+                .context("rolling back to savepoint")?;
+
+            return Ok((row.pub_id, JobStatus::Success));
         }
 
         let tmpdir = tempfile::TempDir::new().context("creating tempdir")?;

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -569,34 +569,6 @@ mod test {
 
     const FIXED_DATABASE_URL: &str = "postgresql://postgres:postgres@localhost:5432/postgres";
 
-    const CLEANUP: &str = r#"
-    with specs_delete as (
-        delete from live_specs
-    ),
-    drafts_delete as (
-        delete from drafts
-    ),
-    draft_specs_delete as (
-        delete from draft_specs
-    ),
-    publications_delete as (
-        delete from publications
-    ),
-    role_grants_delete as (
-        delete from role_grants
-    ),
-    user_grants_delete as (
-        delete from user_grants
-    ),
-    tags_delete as (
-        delete from connector_tags
-    ),
-    connectors_delete as (
-        delete from connectors
-    )
-    select 1;
-    "#;
-
     async fn execute_publications(txn: &mut Transaction<'_, Postgres>) -> Vec<ScenarioResult> {
         let bs_url: Url = "http://example.com".parse().unwrap();
 

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -282,8 +282,8 @@ pub fn validate_transition(
 
         // Verify that the live specification has not existed and then been deleted in the past.
         // TODO(johnny): remove once we introduce data plane pet-names.
-        if live_type.is_none() && draft_type.is_some() && *last_pub_id != pub_id   {
-                errors.push(Error {
+        if live_type.is_none() && draft_type.is_some() && *last_pub_id != pub_id {
+            errors.push(Error {
                     catalog_name: catalog_name.clone(),
                     detail: format!(
                         "A specification with this name previously existed and then was deleted. At present Flow does not allow for re-creation with this same name."
@@ -544,5 +544,176 @@ fn split_tag(image_full: &str) -> (String, String) {
         (image, tag)
     } else {
         (image, String::new())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::publications::JobStatus;
+
+    use super::super::PublishHandler;
+    use agent_sql::Id;
+    use reqwest::Url;
+    use sqlx::{Connection, Postgres, Transaction};
+
+    // Squelch warnings about struct fields never being read.
+    // They actually are read by insta when snapshotting.
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct ScenarioResult {
+        draft_id: Id,
+        status: JobStatus,
+        errors: Vec<String>,
+    }
+
+    const FIXED_DATABASE_URL: &str = "postgresql://postgres:postgres@localhost:5432/postgres";
+
+    const CLEANUP: &str = r#"
+    with specs_delete as (
+        delete from live_specs
+    ),
+    drafts_delete as (
+        delete from drafts
+    ),
+    draft_specs_delete as (
+        delete from draft_specs
+    ),
+    publications_delete as (
+        delete from publications
+    ),
+    role_grants_delete as (
+        delete from role_grants
+    ),
+    user_grants_delete as (
+        delete from user_grants
+    ),
+    tags_delete as (
+        delete from connector_tags
+    ),
+    connectors_delete as (
+        delete from connectors
+    )
+    select 1;
+    "#;
+
+    async fn scenario_snapshot<'c>(
+        scenario: &str,
+        mut txn: Transaction<'c, Postgres>,
+    ) -> Vec<ScenarioResult> {
+        sqlx::query(CLEANUP).execute(&mut txn).await.unwrap();
+        sqlx::query(scenario).execute(&mut txn).await.unwrap();
+
+        let bs_url: Url = "http://example.com".parse().unwrap();
+
+        let (logs_tx, mut logs_rx) = tokio::sync::mpsc::channel(8192);
+
+        // Just in case anything gets through
+        logs_rx.close();
+
+        let mut handler = PublishHandler::new("", &bs_url, &bs_url, "", &bs_url, &logs_tx);
+
+        let mut results: Vec<ScenarioResult> = vec![];
+
+        while let Some(row) = agent_sql::publications::dequeue(&mut txn).await.unwrap() {
+            let mut sub_tx = txn.begin().await.unwrap();
+            let row_draft_id = row.draft_id.clone();
+            let (id, status) = handler.process(row, &mut sub_tx, true).await.unwrap();
+
+            let errors = sqlx::query!(
+                r#"
+            select draft_id as "draft_id: Id", scope, detail
+            from draft_errors
+            where draft_errors.draft_id = $1::flowid;"#,
+                row_draft_id as Id
+            )
+            .fetch_all(&mut sub_tx)
+            .await
+            .unwrap();
+
+            let formatted_errors: Vec<String> = errors.into_iter().map(|e| e.detail).collect();
+
+            results.push(ScenarioResult {
+                draft_id: row_draft_id,
+                status: status.clone(),
+                errors: formatted_errors,
+            });
+
+            agent_sql::publications::resolve(id, &status, &mut sub_tx)
+                .await
+                .unwrap();
+            sub_tx.commit().await.unwrap();
+        }
+
+        results
+    }
+
+    #[tokio::test]
+    async fn test_happy_path() {
+        let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+            .await
+            .unwrap();
+        let txn = conn.begin().await.unwrap();
+
+        let results = scenario_snapshot(r#"
+            with p1 as (
+              insert into auth.users (id) values
+              ('43a18a3e-5a59-11ed-9b6a-0242ac120002')
+            ),
+            p2 as (
+              insert into drafts (id, user_id) values
+              ('1110000000000000', '43a18a3e-5a59-11ed-9b6a-0242ac120002')
+            ),
+            p3 as (
+                insert into live_specs (id, catalog_name, spec, spec_type, last_build_id, last_pub_id) values
+                ('1000000000000000', 'usageB/CollectionA', '{"schema": {},"key": ["foo"]}'::json, 'collection', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb')
+            ),
+            p4 as (
+              insert into draft_specs (id, draft_id, catalog_name, spec, spec_type) values
+              (
+                '1111000000000000',
+                '1110000000000000',
+                'usageB/DerivationA',
+                '{
+                    "schema": {},
+                    "key": ["foo"],
+                    "derivation": {
+                        "transform":{
+                            "key": {
+                                "source": {
+                                    "name": "usageB/CollectionA"
+                                }
+                            }
+                        }
+                    }
+                }'::json,
+                'collection'
+              )
+            ),
+            p5 as (
+              insert into publications (id, job_status, user_id, draft_id) values
+              ('1111100000000000', '{"type": "queued"}'::json, '43a18a3e-5a59-11ed-9b6a-0242ac120002', '1110000000000000')
+            ),
+            p6 as (
+              insert into role_grants (subject_role, object_role, capability) values
+              ('usageB/', 'usageB/', 'admin')
+            ),
+            p7 as (
+              insert into user_grants (user_id, object_role, capability) values
+              ('43a18a3e-5a59-11ed-9b6a-0242ac120002', 'usageB/', 'admin')
+            )
+            select 1;
+        "#,
+        txn).await;
+
+        insta::assert_debug_snapshot!(results, @r#"
+        [
+            ScenarioResult {
+                draft_id: 1110000000000000,
+                status: Success,
+                errors: [],
+            },
+        ]
+        "#);
     }
 }


### PR DESCRIPTION
I found myself having to make these changes multiple times in [my](https://github.com/estuary/flow/pull/739) [different](https://github.com/estuary/flow/pull/746) [prs](https://github.com/estuary/flow/pull/752), so I decided to make it its own branch and then base all of those PR branches ontop

* Introduce publication test infra, with example happy path
* Add `Id::from_hex` to make tests more legible

It also looks like my rustfmt automatically ran on `Cargo.toml` because I added the `hex` dependency... but looking at the diff, all of those changes appear to be legitimate formatting/consistency improvements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/765)
<!-- Reviewable:end -->
