### PR TITLE
json/schema: consider format: date-time as ISO8601

### DIFF
--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -91,7 +91,7 @@ impl Format {
             }
             Self::DateTime => ValidationResult::from(time::OffsetDateTime::parse(
                 val,
-                &time::format_description::well_known::Rfc3339,
+                &time::format_description::well_known::Iso8601::DEFAULT,
             )),
             Self::Time => ValidationResult::from(time::Time::parse(
                 val,
@@ -174,8 +174,10 @@ mod test {
         for (format, value, expect) in [
             ("date", "2022-09-11", true),
             ("date", "2022-09-11T10:31:25.123Z", false),
-            ("date-time", "2022-09-11T10:31:25.123Z", true),
+            ("date-time", "2022-09-11T10:31:25.123Z", true), // RFC3339
             ("datetime", "2022-09-11T10:31:25.123Z", true), // Accepted alias.
+            ("date-time", "2019-09-07T15:50+00Z ", true), // ISO8601, but not RFC3339
+            ("date-time", "2019-09-07T15:50-04:00", true), // ISO8601, but not RFC3339
             ("date-time", "10:31:25.123Z", false),
             ("time", "10:31:25.123Z", true),
             ("email", "john@doe.com", true),


### PR DESCRIPTION
**Description:**

- Consider `format: date-time` to be ISO8601 instead of RFC3339
- This is because `format: date-time` is sometimes used by connectors where the underlying value is not actually RFC3339, but rather ISO8601. The other option of removing `format: date-time` from such connectors reduces Flow's knowledge about the value, making it a string, whereas in cases such as materializing to postgres, ISO8601 is a valid date time value.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/766)
<!-- Reviewable:end -->
