### PR TITLE
doc/ptr: pop method

### DIFF
--- a/crates/doc/src/ptr.rs
+++ b/crates/doc/src/ptr.rs
@@ -123,7 +123,7 @@ impl Pointer {
         })
     }
 
-    // Push a new Token onto the Pointer.
+    /// Push a new Token onto the Pointer.
     pub fn push<'t>(&mut self, token: Token<'t>) -> &mut Pointer {
         match token {
             Token::Index(ind) => {
@@ -144,6 +144,11 @@ impl Pointer {
             }
         }
         self
+    }
+
+    /// Pop last token from the pointer
+    pub fn pop(&mut self) {
+        self.0.pop();
     }
 
     /// Iterate over pointer tokens.


### PR DESCRIPTION
**Description:**

- This is useful when wanting to get pointer to parent of an existing pointer

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/768)
<!-- Reviewable:end -->
