### PR TITLE
Docs: Firestore backfill mode and data model

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/google-firestore.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-firestore.md
@@ -8,7 +8,36 @@ This connector captures data from your Google Firestore collections into Flow co
 
 [`ghcr.io/estuary/source-firestore:dev`](https://ghcr.io/estuary/source-firestore:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
 
+## Data model
+
+Firestore is a NoSQL database. Its [data model](https://firebase.google.com/docs/firestore/data-model) consists of **documents** (lightweight records that contain mappings of fields and values) organized in **collections**.
+
+Collections are organized hierarchically. A given document in a collection can, in turn, be associated with a **[subcollection](https://firebase.google.com/docs/firestore/data-model#subcollections)**.
+
+For example, you might have a collection called `users`, which contains two documents, `alice` and `bob`.
+Each document has a subcollection called `messages` (for example, `users/alice/messages`), which contain more documents (for example, `users/alice/messages/1`).
+
+```console
+users
+├── alice
+│   └── messages
+│       ├── 1
+│       └── 2
+└── bob
+    └── messages
+        └── 1
+```
+
+The connector works by identifying documents associated with a particular sequence of Firestore collection names,
+regardless of documents that split the hierarchy.
+These document groupings are mapped to Flow collections using a [path](#bindings) in the pattern `collection/*/subcollection`.
+
+In this example, we'd end up with `users` and `users/*/messages` Flow collections, with the latter contain messages from both users.
+The `/_meta/path` property for each document contains its full, original path, so we'd still know which messages were Alice's and which were Bob's.
+
 ## Prerequisites
+
+You'll need:
 
 * A Google service account with:
 
@@ -35,7 +64,8 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/path`** | Path to Collection | Firestore collection from which a Flow collection is captured. Supports parent&#x2F;&#x2A;&#x2F;nested to capture all nested collections of parent&#x27;s children | string | Required |
+| **`/backfillMode`** | Backfill Mode | Configures the handling of data already in the collection. See [below](#backfill-mode) for details or just stick with &#x27;async&#x27; | string | Required |
+| **`/path`** | Path to Collection | Supports parent&#x2F;&#x2A;&#x2F;nested to capture all nested collections of parent&#x27;s children | string | Required |
 
 ### Sample
 
@@ -59,15 +89,43 @@ captures:
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
     bindings:
       - resource:
+          #The below `path` will capture all Firestore documents that match the pattern
+          #`orgs/<orgID>/runs/<runID>/runResults/<runResultID>/queryResults`.
+          #See the Data Model section above for details.
           path: orgs/*/runs/*/runResults/*/queryResults
+          backfillMode: async
         target: ${PREFIX}/orgs_runs_runResults_queryResults
       - resource:
           path: orgs/*/runs/*/runResults
+          backfillMode: async
         target: ${PREFIX}/orgs_runs_runResults
       - resource:
           path: orgs/*/runs
+          backfillMode: async
         target: ${PREFIX}/orgs_runs
       - resource:
           path: orgs
+          backfillMode: async
         target: ${PREFIX}/orgs
 ```
+
+## Backfill mode
+
+In each captured collection's [binding configuration](#bindings), you can choose whether and how to backfill historical data.
+There are three options:
+
+* `none`: Skip preexisting data in the Firestore collection. Capture only new documents and changes to existing documents that occur after the capture is published.
+
+* `sync`: Request that Firestore stream all changes to the collection since its creation, in order.
+
+   This mode provides the strongest guarantee against duplicated data, but can cause errors for large datasets as Firestore may terminate the process after about ten minutes.
+
+* `async`: Use two threads to capture data. The first captures new documents, as with `none`.
+The second progressively ingests historical data in chunks.
+
+   This mode is most reliable for Firestore collections of all sizes but provides slightly weaker guarantees against data duplication.
+
+   The connector uses a [reduction](../../../concepts/schemas.md#reductions) to reconcile changes to the same document found on the parallel threads.
+   The version with the most recent timestamp the document metadata will be preserved (`{"strategy": "maximize", "key": "/_meta/mtime"}`). For most collections, this produces an accurate copy of your Firestore collections in Flow.
+
+If you're unsure which backfill mode to use, choose `async`.


### PR DESCRIPTION
**Description:**

Per https://github.com/estuary/connectors/pull/395 and https://github.com/estuary/connectors/pull/409, this updates and enhances the Firestore connector docs. 

* Document new backfill mode option in the binding config
* Add information section on FIrestore's data model and how we handle it (basically paraphrasing @willdonnelly's README).

**Documentation links affected:**

go.estuary.dev/source-firestore - doesn't need to be modified but it'll be more useful now that we have better info.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/775)
<!-- Reviewable:end -->
