### PR TITLE
supabase/live_specs_ext: avoid duplicate specs due to multiple roles

### DIFF
--- a/supabase/tests/live_specs_ext.test.sql
+++ b/supabase/tests/live_specs_ext.test.sql
@@ -1,0 +1,85 @@
+-- We can resolve all roles granted with a minimum capability.
+-- This is commonly used for row-level security checks.
+create function tests.test_live_specs_ext()
+returns setof text as $$
+
+  -- Replace seed grants with fixtures for this test.
+  delete from user_grants;
+  insert into user_grants (user_id, object_role, capability) values
+    ('11111111-1111-1111-1111-111111111111', 'aliceCo/', 'admin'),
+    ('22222222-2222-2222-2222-222222222222', 'bobCo/', 'admin'),
+    ('33333333-3333-3333-3333-333333333333', 'carolCo/', 'read')
+  ;
+
+  delete from role_grants;
+  insert into role_grants (subject_role, object_role, capability) values
+    ('aliceCo/widgets/', 'bobCo/burgers/', 'admin'),
+    ('aliceCo/anvils/', 'carolCo/paper/', 'write'),
+    ('aliceCo/duplicate/', 'carolCo/paper/', 'read'),
+    ('aliceCo/stuff/', 'carolCo/shared/', 'read'),
+    ('carolCo/shared/', 'carolCo/hidden/', 'read')
+  ;
+
+  select results_eq(
+    $i$ select role_prefix::text, capability::text
+        from auth_roles()
+        order by role_prefix, capability
+    $i$,
+    $i$ VALUES  ('aliceCo/','admin'),
+                ('bobCo/burgers/','admin'),
+                ('carolCo/paper/','read'),
+                ('carolCo/paper/','write'),
+                ('carolCo/shared/', 'read')
+    $i$,
+    'alice roles'
+  );
+
+  select results_eq(
+    $i$ select role_prefix::text, capability::text from
+        internal.user_roles('22222222-2222-2222-2222-222222222222')
+        order by role_prefix, capability
+    $i$,
+    $i$ VALUES  ('bobCo/','admin')
+    $i$,
+    'bob roles'
+  );
+
+  select results_eq(
+    $i$ select role_prefix::text, capability::text from
+        internal.user_roles('33333333-3333-3333-3333-333333333333')
+        order by role_prefix, capability
+    $i$,
+    $i$ VALUES  ('carolCo/','read') $i$,
+    'carol roles'
+  );
+
+  -- seed live_specs, publication_specs, connectors and connector_tags 
+  delete from publications;
+  insert into publications (id, user_id) values
+    ('0101010101010101', '11111111-1111-1111-1111-111111111111');
+
+  delete from live_specs;
+  insert into live_specs (id, catalog_name, last_build_id, last_pub_id) values
+    ('0202020202020202', 'aliceCo/widgets/test1', '0101010101010101', '0101010101010101'),
+    -- alice is authorised to access carolCo through two different roles_grants, but
+    -- must only be returned once in live_specs_ext
+    ('0303030303030303', 'carolCo/paper/test1', '0101010101010101', '0101010101010101'),
+    -- alice is not authorised to access unknownCo
+    ('0404040404040404', 'unknownCo/foo/bar', '0101010101010101', '0101010101010101')
+  ;
+
+  delete from publication_specs;
+  insert into publication_specs (live_spec_id, pub_id, user_id) values
+    ('0202020202020202', '0101010101010101', '11111111-1111-1111-1111-111111111111')
+  ;
+
+  select results_eq(
+    $i$ select catalog_name from
+        live_specs_ext
+    $i$,
+    $i$ VALUES  ('aliceCo/widgets/test1'::catalog_name), ('carolCo/paper/test1'::catalog_name)
+    $i$,
+    'alice live specs'
+  );
+
+$$ language sql;


### PR DESCRIPTION
**Description:**

- if a user has multiple rows giving them access to the same resource, we would show duplicate rows in `live_specs_ext`, with this PR, we avoid that by filtering with a common table expression that uses `distinct role_prefix`.
- I checked the performance of this query, and it seems to be as good as the previous one

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/777)
<!-- Reviewable:end -->
