### PR TITLE
Increase maxMessageSize to 16MB

### DIFF
--- a/go/connector/run.go
+++ b/go/connector/run.go
@@ -458,5 +458,5 @@ func copyToTempFile(r io.Reader, mode os.FileMode) (*os.File, error) {
 }
 
 const maxStderrBytes = 4096
-const maxMessageSize = 1 << 23 // 8 MB.
+const maxMessageSize = 1 << 24 // 16 MB.
 const flowConnectorProxy = "flow-connector-proxy"


### PR DESCRIPTION
**Description:**

Increases the maximum size of a message in the capture and materialization protocols, to allow Flow to process individual documents that are up to approximately 16MB. This seems like a reasonable maximum document size, and allows Flow to be useful for processing blockchain data, which tends to occasionally have documents in the 8-12MB range.

**Workflow steps:**

No change to the workflow, but things will now work properly if a user captures documents up to about 16MB.

**Documentation links affected:**

We don't currently document our maximumm document size, but I think we should.

**Notes for reviewers:**

I tested this locally by capturing a ~9MB JSON document from GCS, and also running it through a derivation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/779)
<!-- Reviewable:end -->
