### PR TITLE
protocols/airbyte: Support `log.level` anywhere in command line

### DIFF
--- a/go/protocols/airbyte/args.go
+++ b/go/protocols/airbyte/args.go
@@ -39,19 +39,35 @@ func (c ConfigFile) Parse(target interface{ Validate() error }) error {
 	return c.ConfigFile.Parse(target)
 }
 
-// LogConfig configures handling of application log events.
-type LogConfig struct {
-	Level  string `long:"level" env:"LEVEL" default:"info" choice:"info" choice:"debug" choice:"warn" description:"Logging level"`
-	Format string `long:"format" env:"FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+// logConfig configures handling of application log events.
+type logConfig struct {
+	Level  string `long:"log.level" env:"LOG_LEVEL" default:"info" choice:"info" choice:"debug" choice:"warn" description:"Logging level"`
+	Format string `long:"log.format" env:"LOG_FORMAT" default:"text" choice:"json" choice:"text" choice:"color" description:"Logging output format"`
+}
+
+func (cfg *logConfig) setup() {
+	if cfg.Format == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if cfg.Format == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	} else if cfg.Format == "color" {
+		log.SetFormatter(&log.TextFormatter{ForceColors: true})
+	}
+
+	if lvl, err := log.ParseLevel(cfg.Level); err != nil {
+		log.WithField("err", err).Fatal("unrecognized log level")
+	} else {
+		log.SetLevel(lvl)
+	}
 }
 
 type SpecCmd struct {
-	LogConfig  `group:"Logging" namespace:"log" env-namespace:"LOG"`
+	logging    *logConfig
 	actualSpec Spec `no-flag:"y"`
 }
 
 func (c *SpecCmd) Execute(_ []string) error {
-	initLog(c.LogConfig)
+	c.logging.setup()
 	return NewStdoutEncoder().Encode(
 		&Message{
 			Type: MessageTypeSpec,
@@ -61,60 +77,65 @@ func (c *SpecCmd) Execute(_ []string) error {
 
 type CheckCmd struct {
 	ConfigFile
-	LogConfig `group:"Logging" namespace:"log" env-namespace:"LOG"`
-	doCheck   func(CheckCmd) error `no-flag:"y"`
+	logging *logConfig
+	doCheck func(CheckCmd) error `no-flag:"y"`
 }
 
 func (c *CheckCmd) Execute(_ []string) error {
-	initLog(c.LogConfig)
+	c.logging.setup()
 	return c.doCheck(*c)
 }
 
 type DiscoverCmd struct {
 	ConfigFile
-	LogConfig  `group:"Logging" namespace:"log" env-namespace:"LOG"`
+	logging    *logConfig
 	doDiscover func(DiscoverCmd) error `no-flag:"y"`
 }
 
 func (c *DiscoverCmd) Execute(_ []string) error {
-	initLog(c.LogConfig)
+	c.logging.setup()
 	return c.doDiscover(*c)
 }
 
 type ReadCmd struct {
 	ConfigFile
-	LogConfig   `group:"Logging" namespace:"log" env-namespace:"LOG"`
-	StateFile   JSONFile            `long:"state"`
-	CatalogFile JSONFile            `long:"catalog"`
+	StateFile   JSONFile `long:"state"`
+	CatalogFile JSONFile `long:"catalog"`
+	logging     *logConfig
 	doRead      func(ReadCmd) error `no-flag:"y"`
 }
 
 func (c *ReadCmd) Execute(_ []string) error {
-	initLog(c.LogConfig)
+	c.logging.setup()
 	return c.doRead(*c)
 }
 
 // RunMain does argument parsing and executes the given subcommand. This function will not return.
 // It will call `os.Exit` with an appropriate exit code.
 func RunMain(spec Spec, doCheck func(CheckCmd) error, doDiscover func(DiscoverCmd) error, doRead func(ReadCmd) error) {
-	var parser = flags.NewParser(nil, flags.Default)
+	var logConfig = &logConfig{}
+	var parser = flags.NewParser(logConfig, flags.Default)
 	var specCmd = SpecCmd{
+		logging:    logConfig,
 		actualSpec: spec,
 	}
 	parser.AddCommand("spec", "prints the spec", "prints the ConnectorDefinition to stdout and exits", &specCmd)
 
 	var checkCmd = CheckCmd{
+		logging: logConfig,
 		doCheck: doCheck,
 	}
 	parser.AddCommand("check", "Checks the connection", "Tries to connect to the external system to validate the connection information", &checkCmd)
 
 	var discoverCmd = DiscoverCmd{
+		logging:    logConfig,
 		doDiscover: doDiscover,
 	}
 	parser.AddCommand("discover", "List Streams that can be captured", "Prints a Catalog enumerating all of the Streams that may be read", &discoverCmd)
 
 	var readCmd = ReadCmd{
-		doRead: doRead,
+		logging: logConfig,
+		doRead:  doRead,
 	}
 	parser.AddCommand("read", "Read records from the remote system", "Reads records and prints them to stdout", &readCmd)
 
@@ -130,20 +151,4 @@ func RunMain(spec Spec, doCheck func(CheckCmd) error, doDiscover func(DiscoverCm
 
 func NewStdoutEncoder() *json.Encoder {
 	return json.NewEncoder(os.Stdout)
-}
-
-func initLog(cfg LogConfig) {
-	if cfg.Format == "json" {
-		log.SetFormatter(&log.JSONFormatter{})
-	} else if cfg.Format == "text" {
-		log.SetFormatter(&log.TextFormatter{})
-	} else if cfg.Format == "color" {
-		log.SetFormatter(&log.TextFormatter{ForceColors: true})
-	}
-
-	if lvl, err := log.ParseLevel(cfg.Level); err != nil {
-		log.WithField("err", err).Fatal("unrecognized log level")
-	} else {
-		log.SetLevel(lvl)
-	}
 }


### PR DESCRIPTION
**Description:**

Previously the `log.level` flag was implemented as a property of each subcommand, but that meant that it had to come after the subcommand: `./connector --log.level=debug spec` would fail, for instance.

This commit moves the logging config into the global 'Application Options' option group so that it can be parsed at any position in the command line, and then changes the plumbing for how that gets applied during command execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/780)
<!-- Reviewable:end -->
