### PR TITLE
go/protocols: adapter streamServer Send() must account for context cancellation

### DIFF
--- a/go/protocols/capture/adapter.go
+++ b/go/protocols/capture/adapter.go
@@ -201,8 +201,16 @@ func (a *adapterStreamServer) Send(m *PullResponse) error {
 	// Under the gRPC model, the server controls RPC termination. The client cannot
 	// revoke the server's ability to send (in the absence of a broken transport,
 	// which we don't model here).
-	a.tx <- PullResponseError{PullResponse: m}
-	return nil
+	//
+	// However here in the real we must ensure that Send doesn't block indefinitely
+	// if the context is cancelled, because the connector's stdout may be stuffed
+	// and prevent docker's internal communication over its unix domain socket.
+	select {
+	case <-a.ctx.Done():
+		return a.ctx.Err()
+	case a.tx <- PullResponseError{PullResponse: m}:
+		return nil
+	}
 }
 
 func (a *adapterStreamServer) SendMsg(m interface{}) error { return a.Send(m.(*PullResponse)) }


### PR DESCRIPTION
**Description:**

Fix an observed production behavior of connectors often not exiting after the runtime shard fails with (for example and most commonly) a schema violation.

While it's technically true that the server controls context cancellation, in practice this causes deadlocks with docker. I suspect this is because it's muxing process stdout and process control over a single unix domain socket without proper per-stream flow control, but not 100% confirmed :shrug: Instead, drop a current Send on the floor and propagate an error.

Testing:

I reproduced the essential behaviors we're seeing in production, including a schema violation, a connector that is stuffing its stdout, and the continued running of a connector and hangs of `docker inspect`/ `docker stop` after a shard is unassigned.

After implementing this change and trying again, connectors exit promptly after being unassigned.

**Workflow steps:**

No changes.

**Documentation links affected:**

No changes.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/781)
<!-- Reviewable:end -->
