### PR TITLE
Fix agent mising some tasks

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -186,9 +186,9 @@ async fn handle_task(
             }
         }
         Err(err) => {
-            // Do we actually just want to crash here?
             tracing::error!(handler = %handler.name(), table = %handler.table_name(), "Error invoking handler: {err}");
             active.store(false, Ordering::SeqCst);
+            return Err(err);
         }
     };
     Ok(())


### PR DESCRIPTION
**Description:**
This adds three things to the agent, both of which should fix the issue with the agent missing some tasks:
* Polling every 30s, and loudly complaining if actual work was found. There is a wrinkle where we don't want to poll currently active tasks, so I had to add a bit of complexity to handle that. This can be removed once we're confident in `LISTEN`/`NOTIFY`
* Explicitly handling message channel disconnects and explicitly waking up every handler. This way if/when messages are dropped on disconnect, we'll still find them.
* Add a glorious hack to emulate TCP keepalive on the `PgListener` connection, so we can guarantee we know when the connection actually disconnects

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/784)
<!-- Reviewable:end -->
