### PR TITLE
refactor: skip running expensive tasks (npm, tests) if they're not neccesary

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -57,11 +57,6 @@ where
         load_and_validate(root_url.clone(), root_spec, fetcher, drivers, &config).await;
     all_tables.meta.insert_row(config.clone());
 
-    // all_tables will tell us if we have any derivations/NPM modules
-    // places to look:
-    // Resources table: of type npm_module or npm_package for each build
-    // derivations that define a typescript module
-
     let has_typescript_derivations = all_tables
         .derivations
         .iter()

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use models::ContentType;
 use protocol::flow;
 use serde_json::value::RawValue;
 use std::{
@@ -56,6 +57,23 @@ where
         load_and_validate(root_url.clone(), root_spec, fetcher, drivers, &config).await;
     all_tables.meta.insert_row(config.clone());
 
+    // all_tables will tell us if we have any derivations/NPM modules
+    // places to look:
+    // Resources table: of type npm_module or npm_package for each build
+    // derivations that define a typescript module
+
+    let has_typescript_derivations = all_tables
+        .derivations
+        .iter()
+        .any(|derivation| derivation.typescript_module.is_some());
+
+    let has_npm_resources = all_tables
+        .resources
+        .iter()
+        .any(|resource| resource.content_type == protocol::flow::ContentType::TypescriptModule);
+
+    let typescript_enabled = has_typescript_derivations || has_npm_resources;
+
     // Output database path is implied from the configured directory and ID.
     let output_path = directory.join(&config.build_id);
     let db = rusqlite::Connection::open(&output_path).context("failed to open catalog database")?;
@@ -63,6 +81,7 @@ where
     // Generate TypeScript package? Generation should always succeed if the input catalog is valid.
     if all_tables.errors.is_empty()
         && (config.typescript_generate || config.typescript_compile || config.typescript_package)
+        && typescript_enabled
     {
         if let Err(err) = generate_npm_package(&all_tables, &directory)
             .context("failed to generate TypeScript package")
@@ -71,13 +90,16 @@ where
         }
     }
     // Compile TypeScript? This may fail due to a user-caused error.
-    if all_tables.errors.is_empty() && (config.typescript_compile || config.typescript_package) {
+    if all_tables.errors.is_empty()
+        && (config.typescript_compile || config.typescript_package)
+        && typescript_enabled
+    {
         if let Err(err) = compile_npm(&directory) {
             all_tables.errors.insert_row(&root_url, err);
         }
     }
     // Package TypeScript?
-    if all_tables.errors.is_empty() && config.typescript_package {
+    if all_tables.errors.is_empty() && config.typescript_package && typescript_enabled {
         let npm_resources = pack_npm(&directory).context("failed to pack TypeScript package")?;
         tables::persist_tables(&db, &[&npm_resources]).context("failed to persist NPM package")?;
     }
@@ -243,8 +265,12 @@ fn npm_cmd(package_dir: &std::path::Path, args: &[&str]) -> Result<(), anyhow::E
     let output = cmd.output().context("failed to spawn `npm` command")?;
 
     if !output.status.success() {
-        stdout().write(output.stdout.as_slice()).context("failed to write `npm` output to stdout")?;
-        stderr().write(output.stderr.as_slice()).context("failed to write `npm` output to stderr")?;
+        stdout()
+            .write(output.stdout.as_slice())
+            .context("failed to write `npm` output to stdout")?;
+        stderr()
+            .write(output.stderr.as_slice())
+            .context("failed to write `npm` output to stderr")?;
         anyhow::bail!("npm command {:?} failed, output logged", args.join(" "))
     }
     Ok(())


### PR DESCRIPTION
In addition to being smart about detecting when to run NPM, I also realized that we were naively always running tests, even if there weren't any tests to run. Skipping this early shaved off ~50% from my build time locally

Fixes #761

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/789)
<!-- Reviewable:end -->
