### PR TITLE
fix: Update agent startup logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap 3.2.22",
+ "derivative",
  "futures",
  "insta",
  "itertools",
@@ -986,6 +987,17 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ quickcheck_macros = "1.0"
 yaml-merge-keys = { version = "0.5", features = ["serde_yaml"] }
 zip = "0.5"
 zstd = "0.11.2"
+derivative = "2.2.0"
 
 # Used exclusively as dev-dependencies
 assert_cmd = "2.0"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 validator = { workspace = true }
+derivative = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -1,13 +1,16 @@
 use anyhow::Context;
 use clap::Parser;
+use derivative::Derivative;
 use futures::{FutureExt, TryFutureExt};
 use serde::Deserialize;
 
 /// Agent is a daemon which runs server-side tasks of the Flow control-plane.
-#[derive(Parser, Debug)]
+#[derive(Derivative, Parser)]
+#[derivative(Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// URL of the postgres database.
+    #[derivative(Debug = "ignore")]
     #[clap(
         long = "database",
         env = "DATABASE_URL",


### PR DESCRIPTION
This change completely omits logging _certain_ fields. We could use a custom `Debug` impl instead, but that would mean that we could get out of sync when adding or removing fields from the `Args` struct, which felt smelly.

Alternatively, we could just not log the args at all... I don't really have an opinion on whether it's useful here or not.

Fixes #790

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/791)
<!-- Reviewable:end -->
