### PR TITLE
flowctl: service-account instead of token and auto-refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "anyhow",
  "assemble",
  "assert_cmd",
+ "base64",
  "bytes",
  "chrono",
  "clap 3.2.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "assemble",
  "assert_cmd",
  "bytes",
+ "chrono",
  "clap 3.2.22",
  "comfy-table",
  "crossterm",

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -22,6 +22,7 @@ sources = { path = "../sources" }
 tables = { path = "../tables" }
 validation = { path = "../validation" }
 
+chrono = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -22,6 +22,7 @@ sources = { path = "../sources" }
 tables = { path = "../tables" }
 validation = { path = "../validation" }
 
+base64 = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/crates/flowctl/src/auth/mod.rs
+++ b/crates/flowctl/src/auth/mod.rs
@@ -47,7 +47,7 @@ pub enum Command {
 pub struct ServiceAccountArgs {
     /// Path to service account JSON file. Use `-` to read from stdin.
     #[clap(value_parser)]
-    file: String,
+    file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,14 +68,18 @@ impl Auth {
     pub async fn run(&self, ctx: &mut crate::CliContext) -> Result<(), anyhow::Error> {
         match &self.cmd {
             Command::ServiceAccount(ServiceAccountArgs { file }) => {
-                let (sa, msg): (ServiceAccount, &str) = if file == "-" {
-                    (serde_json::from_reader(std::io::stdin())?, "Configured service account.")
+                if let Some(file) = file {
+                    let (sa, msg): (ServiceAccount, &str) = if file == "-" {
+                        (serde_json::from_reader(std::io::stdin())?, "Configured service account.")
+                    } else {
+                        let sa_file = std::fs::File::open(file)?;
+                        (serde_json::from_reader(sa_file)?, "Configured service account. You may now delete the file.")
+                    };
+                    ctx.config_mut().api = Some(config::API::managed(sa));
+                    println!("{}", msg);
                 } else {
-                    let sa_file = std::fs::File::open(file)?;
-                    (serde_json::from_reader(sa_file)?, "Configured service account. You may now delete the file.")
-                };
-                ctx.config_mut().api = Some(config::API::managed(sa));
-                println!("{}", msg);
+                    println!("You can get your service-account from https://dashboard.estuary.dev/admin/api")
+                }
                 Ok(())
             }
             Command::Develop(Develop { token }) => {

--- a/crates/flowctl/src/auth/mod.rs
+++ b/crates/flowctl/src/auth/mod.rs
@@ -40,16 +40,14 @@ pub enum Command {
     /// Unlike 'read' or 'write', the subject of an 'admin' grant also inherits
     /// capabilities granted to the object role from still-other roles.
     Roles(roles::Roles),
-    /// Manually refresh tokens of service account
-    Refresh
 }
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct ServiceAccountArgs {
-    /// Path to service account JSON file
-    #[clap(long)]
-    path: String,
+    /// Path to service account JSON file. Use `-` to read from stdin.
+    #[clap(value_parser)]
+    file: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,11 +67,15 @@ pub struct Develop {
 impl Auth {
     pub async fn run(&self, ctx: &mut crate::CliContext) -> Result<(), anyhow::Error> {
         match &self.cmd {
-            Command::ServiceAccount(ServiceAccountArgs { path }) => {
-                let sa_file = std::fs::File::open(path)?;
-                let sa: ServiceAccount = serde_json::from_reader(sa_file)?;
+            Command::ServiceAccount(ServiceAccountArgs { file }) => {
+                let (sa, msg): (ServiceAccount, &str) = if file == "-" {
+                    (serde_json::from_reader(std::io::stdin())?, "Configured service account.")
+                } else {
+                    let sa_file = std::fs::File::open(file)?;
+                    (serde_json::from_reader(sa_file)?, "Configured service account. You may now delete the file.")
+                };
                 ctx.config_mut().api = Some(config::API::managed(sa));
-                println!("Configured service account.");
+                println!("{}", msg);
                 Ok(())
             }
             Command::Develop(Develop { token }) => {
@@ -81,14 +83,7 @@ impl Auth {
                 println!("Configured for local development.");
                 Ok(())
             }
-            Command::Roles(roles) => roles.run(ctx).await,
-            Command::Refresh => {
-                if let Some(api) = ctx.config_mut().api.as_mut() {
-                    api.refresh().await?;
-                }
-                println!("Configured service account.");
-                Ok(())
-            }
+            Command::Roles(roles) => roles.run(ctx).await
         }
     }
 }

--- a/crates/flowctl/src/auth/roles.rs
+++ b/crates/flowctl/src/auth/roles.rs
@@ -138,7 +138,7 @@ pub async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("combined_grants_ext")
             .select(
                 vec![
@@ -176,7 +176,7 @@ pub async fn do_grant(
     // Upsert user grants to `user_grants` and role grants to `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -193,7 +193,7 @@ pub async fn do_grant(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -228,7 +228,7 @@ pub async fn do_revoke(
     // Revoke user grants from `user_grants` and role grants from `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .eq("user_id", subject_user_id.to_string())
@@ -238,7 +238,7 @@ pub async fn do_revoke(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .eq("subject_role", subject_role)

--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -147,7 +147,7 @@ async fn do_list(ctx: &mut crate::CliContext, List { flows }: &List) -> anyhow::
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("live_specs_ext")
             .select(columns.join(",")),
     )
@@ -201,7 +201,7 @@ async fn do_history(ctx: &mut crate::CliContext, History { name }: &History) -> 
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("publication_specs_ext")
             .like("catalog_name", format!("{name}%"))
             .select(
@@ -251,7 +251,7 @@ async fn do_draft(
         mut spec_type,
     } = if let Some(publication_id) = publication_id {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("publication_specs_ext")
                 .eq("catalog_name", name)
                 .eq("pub_id", publication_id)
@@ -261,7 +261,7 @@ async fn do_draft(
         .await?
     } else {
         api_exec(
-            ctx.client()?
+            ctx.client().await?
                 .from("live_specs")
                 .eq("catalog_name", name)
                 .select("catalog_name,last_pub_id,pub_id:last_pub_id,spec,spec_type")
@@ -295,7 +295,7 @@ async fn do_draft(
     tracing::debug!(?draft_spec, "inserting draft");
 
     let rows: Vec<SpecSummaryItem> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("draft_specs")
             .select("catalog_name,spec_type")
             .upsert(serde_json::to_string(&draft_spec).unwrap())

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -223,7 +223,7 @@ async fn do_list_fragments(
     args: &ListFragmentsArgs,
 ) -> Result<(), anyhow::Error> {
     let mut client =
-        journal_client_for(ctx.config(), vec![args.selector.collection.clone()]).await?;
+        journal_client_for(ctx.config_mut(), vec![args.selector.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.selector.build_label_selector()).await?;
 
@@ -262,7 +262,7 @@ async fn do_list_journals(
     ctx: &mut crate::CliContext,
     args: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
-    let mut client = journal_client_for(ctx.config(), vec![args.collection.clone()]).await?;
+    let mut client = journal_client_for(ctx.config_mut(), vec![args.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -65,7 +65,7 @@ pub async fn read_collection(ctx: &mut crate::CliContext, args: &ReadArgs) -> an
     }
 
     let mut data_plane_client =
-        dataplane::journal_client_for(ctx.config(), vec![args.selector.collection.clone()]).await?;
+        dataplane::journal_client_for(ctx.config_mut(), vec![args.selector.collection.clone()]).await?;
 
     let selector = args.selector.build_label_selector();
     tracing::debug!(?selector, "build label selector");

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -42,14 +44,30 @@ pub struct API {
     pub public_token: String,
     // Secret access token of the control-plane API.
     pub access_token: String,
+    // Secret refresh token of the control-plane API.
+    pub refresh_token: Option<String>,
+    // Expiry of access_token
+    pub expires_at: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct APISessionResponse {
+    // Secret access token of the control-plane API.
+    pub access_token: String,
+    // Secret refresh token of the control-plane API.
+    pub refresh_token: String,
+    // Seconds to expiry of access_token
+    pub expires_in: i64,
 }
 
 impl API {
-    pub fn managed(access_token: String) -> Self {
+    pub fn managed(service_account: crate::auth::ServiceAccount) -> Self {
         Self {
             endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
             public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
-            access_token,
+            access_token: service_account.access_token,
+            refresh_token: Some(service_account.refresh_token),
+            expires_at: Some(service_account.expires_at),
         }
     }
     pub fn development(access_token: Option<String>) -> Self {
@@ -59,7 +77,45 @@ impl API {
             // Access token for user "bob" in the development database, good for ten years.
             access_token: access_token.unwrap_or(
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoyMjgwMDY3NTAwLCJzdWIiOiIyMjIyMjIyMi0yMjIyLTIyMjItMjIyMi0yMjIyMjIyMjIyMjIiLCJlbWFpbCI6ImJvYkBleGFtcGxlLmNvbSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.7BJJJI17d24Hb7ZImlGYDRBCMDHkqU1ppVTTfqD5l8I".to_string(),
-            )
+            ),
+            refresh_token: None,
+            expires_at: None,
         }
+    }
+
+    // Attempt to refresh the token. This function is no-op if there is no refresh_token
+    pub async fn refresh(&mut self) -> anyhow::Result<()> {
+        let mut refresh_url = self.endpoint.clone();
+        refresh_url.set_path("/auth/v1/token");
+        refresh_url.set_query(Some("grant_type=refresh_token"));
+
+        if let Some(refresh_token) = &self.refresh_token {
+            let client = reqwest::Client::new();
+
+            let body = client.post(refresh_url)
+                .json(&HashMap::from([
+                    ("refresh_token", refresh_token)
+                ]))
+                .header("apikey", &self.public_token)
+                .send()
+                .await?
+                .text()
+                .await?;
+
+             match serde_json::from_str::<APISessionResponse>(&body) {
+                Ok(sess) => {
+                    self.access_token = sess.access_token;
+                    self.refresh_token = Some(sess.refresh_token);
+                    self.expires_at = Some(chrono::Utc::now().timestamp() + sess.expires_in);
+                }
+                Err(e) => {
+                    tracing::error!("could not refresh token: {}, response {}", e, body);
+                    Err(e)?
+                }
+             }
+
+        }
+
+        Ok(())
     }
 }

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -117,7 +117,8 @@ impl API {
                     Ok(())
                 }
                 Err(e) => {
-                    tracing::error!("could not refresh token: {}, response {}", e, body);
+                    tracing::error!("Could not refresh token: {}, response {}", e, body);
+                    tracing::error!("Try re-authenticating: https://go.estuary.dev/2DgrAp");
                     Err(e)?
                 }
              }

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -68,13 +68,13 @@ struct APISessionResponse {
 }
 
 impl API {
-    pub fn managed(service_account: crate::auth::ServiceAccount) -> Self {
+    pub fn managed(token: crate::auth::RefreshableToken) -> Self {
         Self {
             endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
             public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
-            access_token: service_account.access_token,
-            refresh_token: Some(service_account.refresh_token),
-            expires_at: Some(service_account.expires_at),
+            access_token: token.access_token,
+            refresh_token: Some(token.refresh_token),
+            expires_at: Some(token.expires_at),
         }
     }
     pub fn development(access_token: Option<String>) -> Self {

--- a/crates/flowctl/src/dataplane.rs
+++ b/crates/flowctl/src/dataplane.rs
@@ -11,10 +11,10 @@ pub struct DataPlaneAccess {
 
 /// Fetches connection info for accessing a data plane for the given catalog namespace prefixes.
 pub async fn fetch_data_plane_access_token(
-    cfg: &Config,
+    cfg: &mut Config,
     prefixes: Vec<String>,
 ) -> anyhow::Result<DataPlaneAccess> {
-    let client = cfg.client()?;
+    let client = cfg.client().await?;
     tracing::debug!(?prefixes, "requesting data-plane access token for prefixes");
 
     let body = serde_json::to_string(&serde_json::json!({
@@ -47,7 +47,7 @@ pub async fn fetch_data_plane_access_token(
 
 /// Returns an authenticated journal client that's authorized to the given prefixes.
 pub async fn journal_client_for(
-    cfg: &Config,
+    cfg: &mut Config,
     prefixes: Vec<String>,
 ) -> anyhow::Result<journal_client::Client> {
     let DataPlaneAccess {

--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -99,7 +99,7 @@ pub async fn do_author(
     body.push(']' as u8);
 
     let rows: Vec<SpecSummaryItem> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("draft_specs")
             .select("catalog_name,spec_type")
             .upsert(String::from_utf8(body).expect("serialized JSON is always UTF-8"))

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -31,7 +31,7 @@ pub async fn do_develop(
         spec_type: String,
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("draft_specs")
             .select("catalog_name,spec,spec_type")
             .not("is", "spec_type", "null")

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -110,7 +110,7 @@ async fn do_create(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let row: Row = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("drafts")
             .select("id, created_at")
             .insert(serde_json::json!({"detail": "Created by flowctl"}).to_string())
@@ -141,7 +141,7 @@ async fn do_delete(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let row: Row = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("drafts")
             .select("id,updated_at")
             .delete()
@@ -188,7 +188,7 @@ async fn do_describe(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("draft_specs_ext")
             .select(
                 vec![
@@ -233,7 +233,7 @@ async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("drafts_ext")
             .select("created_at,detail,id,num_specs,updated_at"),
     )
@@ -257,7 +257,7 @@ async fn do_select(
     Select { id: select_id }: &Select,
 ) -> anyhow::Result<()> {
     let matched: Vec<serde_json::Value> = api_exec(
-        ctx.client()?
+        ctx.client().await?
             .from("drafts")
             .eq("id", select_id)
             .select("id"),
@@ -274,7 +274,7 @@ async fn do_select(
 
 async fn do_publish(ctx: &mut crate::CliContext, dry_run: bool) -> anyhow::Result<()> {
     let cur_draft = ctx.config().cur_draft()?;
-    let client = ctx.client()?;
+    let client = ctx.client().await?;
 
     #[derive(Deserialize)]
     struct Row {

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -73,8 +73,8 @@ pub struct CliContext {
 }
 
 impl CliContext {
-    pub fn client(&self) -> anyhow::Result<postgrest::Postgrest> {
-        self.config.client()
+    pub async fn client(&mut self) -> anyhow::Result<postgrest::Postgrest> {
+        self.config.client().await
     }
 
     pub fn config_mut(&mut self) -> &mut config::Config {
@@ -139,20 +139,6 @@ impl Cli {
             output,
             config_dirty: false,
         };
-
-        // Auth commands are exempt from refreshing auth token, this is to avoid a situation where
-        // an expired refresh_token prevents the user from setting a new service account
-        if !matches!(self.cmd, Command::Auth(_)) {
-            if let Some(api) = context.config.api.as_mut() {
-                if let Some(expires_at) = api.expires_at {
-                    // 10 minutes before expiry attempt a refresh
-                    if expires_at < (chrono::Utc::now() - chrono::Duration::minutes(10)).timestamp() {
-                        tracing::debug!("refreshing token");
-                        api.refresh().await?;
-                    }
-                }
-            }
-        }
 
         match &self.cmd {
             Command::Auth(auth) => auth.run(&mut context).await,

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -19,6 +19,7 @@ mod typescript;
 
 use output::{Output, OutputType};
 use poll::poll_while_queued;
+use reqwest::StatusCode;
 
 /// A command-line tool for working with Estuary Flow.
 #[derive(Debug, Parser)]
@@ -138,6 +139,20 @@ impl Cli {
             output,
             config_dirty: false,
         };
+
+        // Auth commands are exempt from refreshing auth token, this is to avoid a situation where
+        // an expired refresh_token prevents the user from setting a new service account
+        if !matches!(self.cmd, Command::Auth(_)) {
+            if let Some(api) = context.config.api.as_mut() {
+                if let Some(expires_at) = api.expires_at {
+                    // 10 minutes before expiry attempt a refresh
+                    if expires_at < (chrono::Utc::now() - chrono::Duration::minutes(10)).timestamp() {
+                        tracing::debug!("refreshing token");
+                        api.refresh().await?;
+                    }
+                }
+            }
+        }
 
         match &self.cmd {
             Command::Auth(auth) => auth.run(&mut context).await,

--- a/crates/flowctl/src/raw.rs
+++ b/crates/flowctl/src/raw.rs
@@ -108,7 +108,7 @@ impl Advanced {
 }
 
 async fn do_get(ctx: &mut crate::CliContext, Get { table, query }: &Get) -> anyhow::Result<()> {
-    let req = ctx.client()?.from(table).build().query(query);
+    let req = ctx.client().await?.from(table).build().query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);
@@ -119,7 +119,7 @@ async fn do_update(
     ctx: &mut crate::CliContext,
     Update { table, query, body }: &Update,
 ) -> anyhow::Result<()> {
-    let req = ctx.client()?.from(table).update(body).build().query(query);
+    let req = ctx.client().await?.from(table).update(body).build().query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);
@@ -134,7 +134,7 @@ async fn do_rpc(
         body,
     }: &Rpc,
 ) -> anyhow::Result<()> {
-    let req = ctx.client()?.rpc(function, body).build().query(query);
+    let req = ctx.client().await?.rpc(function, body).build().query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);


### PR DESCRIPTION
**Description:**

- Replace `Token` authentication with `ServiceAccount` which accepts a JSON file with three fields `access_token`, `refresh_token` and `expires_at` where `expires_at` is calculated [similar to how GoTrue does it](https://github.com/supabase/gotrue-js/blob/a441eef4d7291ec20b756cde99ccee87329594d0/src/lib/helpers.ts#L3-L6).
- Automatically refresh the `access_token` before running commands if expiry is close (in 10 minutes) or has already expired
- Solves the first item of https://github.com/estuary/animated-carnival/issues/43
- This requires a subsequent UI pull-request which changes the token presented to user to be a JSON object with the fields described. All these fields should already be available to the UI as part of `session` -- I made this [ui pull-request](https://github.com/estuary/ui/pull/377) which I think will cover this.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/792)
<!-- Reviewable:end -->
