### PR TITLE
agent: default accounts-email is support@estuary.dev

### DIFF
--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
     #[clap(long = "bin-dir", env = "BIN_DIR")]
     bindir: String,
     /// Email address of user which provisions and maintains tenant accounts.
-    #[clap(long = "accounts-email", default_value = "accounts@estuary.dev")]
+    #[clap(long = "accounts-email", default_value = "support@estuary.dev")]
     accounts_email: String,
     /// Path to the Flow specification template used to provision new tenant accounts.
     #[clap(long = "tenant-template")]

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -3,7 +3,7 @@ begin;
 insert into auth.users (id, email) values
   -- Root account which provisions other accounts.
   -- It must exist for the agent to function.
-  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'accounts@estuary.dev'),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'support@estuary.dev'),
   -- Accounts which are commonly used in tests.
   ('11111111-1111-1111-1111-111111111111', 'alice@example.com'),
   ('22222222-2222-2222-2222-222222222222', 'bob@example.com'),
@@ -40,9 +40,9 @@ insert into directives (catalog_prefix, spec, token) values
   ('ops/', '{"type":"clickToAccept"}', 'd4a37dd7-1bf5-40e3-b715-60c4edd0f6dc'),
   ('ops/', '{"type":"betaOnboard"}', '453e00cd-e12a-4ce5-b12d-3837aa385751');
 
--- Provision the ops/ tenant owned by the accounts@estuary.dev user.
+-- Provision the ops/ tenant owned by the support@estuary.dev user.
 with accounts_root_user as (
-  select (select id from auth.users where email = 'accounts@estuary.dev' limit 1) as accounts_id
+  select (select id from auth.users where email = 'support@estuary.dev' limit 1) as accounts_id
 )
 insert into applied_directives (directive_id, user_id, user_claims)
   select d.id, a.accounts_id, '{"requestedTenant":"ops"}'


### PR DESCRIPTION
**Description:**

Changes the default value for `accounts-email` used by the agent to be `support@estuary.dev`. This is consistent with the name of the account on prod. In practice this will only effect local development, making the two emails consistent.

**Workflow steps:**

Start a local flow development instance and observe the new value used for `accounts-email`. 

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/794)
<!-- Reviewable:end -->
