### PR TITLE
docs: documents and size

### DIFF
--- a/site/docs/concepts/captures.md
+++ b/site/docs/concepts/captures.md
@@ -14,6 +14,7 @@ Each binding adds documents to a corresponding Flow **collection**.
 Captures run continuously:
 as soon as new documents are made available at the endpoint resources,
 Flow validates their schema and adds them to the appropriate collection.
+Captures can process [documents](./collections.md#documents) up to 16 MB in size.
 
 ![](<captures-new.svg>)
 

--- a/site/docs/concepts/collections.md
+++ b/site/docs/concepts/collections.md
@@ -29,15 +29,16 @@ Flow allows documents up to 16 MB in size, but it's rare for documents to approa
 An example document for a collection with two fields, `name` and `count` is shown below.
 
 ```json
-root:{
-  _meta:{
-    uuid:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  }
-  count:5954
-  message:"Hello #5954"
+{
+  "_meta": {
+    "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  },
+  "count": 5954,
+  "message": "Hello #5954"
+}
 ```
 
-The `_meta` object is present in all Flow documents and is used for internal processing only.
+The `_meta` object is present in all Flow documents, and contains metadata added by Flow. Minimally, every document `_meta` always has a `uuid`, which is a globally unique id for each document. Some capture connectors may add additional `_meta` properties to tie each document to a specific record within the source system. Documents that were captured from cloud storage connectors, for example, will contain `/_meta/file` and `/_meta/offset` properties that tell you where the document came from within your cloud storage bucket.
 
 ## Viewing collection documents
 

--- a/site/docs/concepts/collections.md
+++ b/site/docs/concepts/collections.md
@@ -15,16 +15,40 @@ you define one or more new collections as part of that process.
 Every collection has a key and an associated [schema](#schemas)
 that its documents must validate against.
 
-## Viewing collection data
+## Documents
+
+Flow processes and stores data in terms of documents: JSON files that consist of multiple key-value pair objects. Collections are comprised of documents; Flow tasks (captures, materializations, and derivations) process data in terms of documents.
+
+A Flow document corresponds to different units of data in different types of endpoint systems.
+For example, it might map to a table row, a pub/sub message, or an API response.
+The structure of a given collection’s documents is determined by that collection’s [schema](#schemas) and the way in which tasks handle documents is determined by the collection [key](#keys).
+
+The size of a document depends on the complexity of the source data.
+Flow allows documents up to 16 MB in size, but it's rare for documents to approach this limit.
+
+An example document for a collection with two fields, `name` and `count` is shown below.
+
+```json
+root:{
+  _meta:{
+    uuid:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+  count:5954
+  message:"Hello #5954"
+```
+
+The `_meta` object is present in all Flow documents and is used for internal processing only.
+
+## Viewing collection documents
 
 In many cases, it's not necessary to view your collection data — you're able to materialize it directly to a destination in the correct shape using a [connector](../concepts/README.md#connectors).
 
-However, it can be helpful to view collection data to confirm the source data was captured as expected, or verify a schema change.
+However, it can be helpful to view collection documents to confirm the source data was captured as expected, or verify a schema change.
 
 #### In the web application
 
 Sign into the Flow web application and click the **Collections** tab. The collections to which you have access are listed.
-Click the **Details** drop down to show a sample of collection data as well as the collection [specification](#specification).
+Click the **Details** drop down to show a sample of collection documents as well as the collection [specification](#specification).
 
 The collection documents are displayed by key. Click the desired key to preview it in its native JSON format.
 

--- a/site/docs/concepts/materialization.md
+++ b/site/docs/concepts/materialization.md
@@ -9,8 +9,9 @@ Materializations are a type of Flow **task**.
 They connect to an external destination system,
 or **endpoint**, and bind one or more Flow collections to resources at the endpoint, such as database tables.
 
-As data is added to the bound collections,
+As documents added to the bound collections,
 the materialization continuously pushes it to the destination resources, where it is reflected with very low latency.
+Materializations can process [documents](./collections.md#documents) up to 16 MB in size.
 
 Materializations are the conceptual inverse of [captures](captures.md).
 


### PR DESCRIPTION
**Description:**

Documentation about documents :) 

Per https://github.com/estuary/flow/pull/779, notes maximum size of documents in collections, captures, and materializations concept docs. 

I realized that previously, we never explicitly stated plainly for our less-technical users that "collections are made up of documents and documents are..." I amended this by adding a small section to the top of the Collections page. 

**Notes for reviewers:**

If there's any other pertinent information we should add about this topic please let me know!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/797)
<!-- Reviewable:end -->
