### PR TITLE
Use self-signed TLS cert for DPG in start-flow.sh

### DIFF
--- a/supabase/migrations/14_gateway_auth.sql
+++ b/supabase/migrations/14_gateway_auth.sql
@@ -21,7 +21,7 @@ create table internal.gateway_endpoints (
 );
 
 insert into internal.gateway_endpoints (name, url, detail) values (
-  'local', 'http://localhost:28318/', 'Used for development only. This value will be changed manually when deployed to production.'
+  'local', 'http://localhost:28317/', 'Used for development only. This value will be changed manually when deployed to production.'
 );
 
 


### PR DESCRIPTION
**Description:**

Generates a self-signed TLS certificate when starting a local Flow instance using `start-flow.sh`. The DPG requires TLS, even when the browser is only connecting to the plain HTTP port, because of the janky way that DPG proxies REST requests to its own gRPC service over the loopback interface.

**Workflow steps:**

For devs only:

- You need to have the `openssl` binary on your PATH.
- when you run `start-flow.sh`, it will now generate the self-signed certificate automatically.
- If you re-run the supabase migrations, then the correct gateway address will be populated in the database.
- If you _don't_ re-run the migrations, then you can just update the gateway address to `http://localhost:28317`

**Documentation links affected:** n/a

**Notes for reviewers:**

This goes along with estuary/data-plane-gateway#21

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/800)
<!-- Reviewable:end -->
