### PR TITLE
fix flowctl logs|stats help messages

### DIFF
--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -29,7 +29,7 @@ pub struct ReadArgs {
 /// Common definition for arguments specifying the begin and and bounds of a read command.
 #[derive(clap::Args, Debug, Default, Clone)]
 pub struct ReadBounds {
-    /// Whether to block waiting for new data. If provided, the read will continue indefinitely until interrupted or ending due to an error.
+    /// Continue reading indefinitely until interrupted or ending due to an error.
     #[clap(long)]
     pub follow: bool,
 

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use anyhow::Context as _;
+use clap::AppSettings;
 use clap::Parser;
 use proto_flow::flow;
 
@@ -22,7 +23,12 @@ use poll::poll_while_queued;
 
 /// A command-line tool for working with Estuary Flow.
 #[derive(Debug, Parser)]
-#[clap(author, about, version)]
+#[clap(
+    author,
+    about,
+    version,
+    global_setting = AppSettings::DeriveDisplayOrder
+)]
 pub struct Cli {
     /// Configuration profile to use.
     ///
@@ -32,11 +38,11 @@ pub struct Cli {
     #[clap(long, default_value = "default")]
     profile: String,
 
-    #[clap(flatten)]
-    output: Output,
-
     #[clap(subcommand)]
     cmd: Command,
+
+    #[clap(flatten)]
+    output: Output,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -55,8 +61,16 @@ pub enum Command {
     /// Then when you're ready, publish your draft to make your changes live.
     Draft(draft::Draft),
     /// Prints the runtime logs of a task (capture, derivation, or materialization).
+    ///
+    /// Reads contents from the `ops/<tenant>/logs` collection, selecting the partition
+    /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
+    /// `flowctl collections read --collection ops/<tenant>/logs --include-partition estuary.dev/field/name=<task> --uncommitted`
     Logs(ops::Logs),
     /// Prints the runtime stats of a task (capture, derivation, or materialization).
+    ///
+    /// Reads contents from the `ops/<tenant>/stats` collection, selecting the partition
+    /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
+    /// `flowctl collections read --collection ops/<tenant>/stats --include-partition estuary.dev/field/name=<task>`
     Stats(ops::Stats),
     /// Develop TypeScript modules of your local Flow catalog source files.
     Typescript(typescript::TypeScript),

--- a/crates/flowctl/src/ops.rs
+++ b/crates/flowctl/src/ops.rs
@@ -70,19 +70,19 @@ fn read_args(
 /// Selects one or more Flow tasks within a single tenant.
 #[derive(clap::Args, Debug, Default, Clone)]
 pub struct TaskSelector {
-    /// Read the logs of the task with the given name
+    /// The name of the task
     #[clap(long)]
     pub task: String,
-    // Read the logs of all tasks with the given type
+    // Selects all tasks with the given type
     //
     // Requires the `--tenant <tenant>` argument
     //#[clap(long, arg_enum, requires("tenant"))]
     //pub task_type: Option<TaskType>,
 
-    // Read the logs of tasks within the given tenant
+    // Selects all tasks within the given tenant
     //
-    // The `--task-type` may also be specified to limit the selection to only tasks of the given
-    // type. Without a `--task-type`, it will return all logs from all tasks in the tenant.
+    // The `--task-type` may also be specified to further limit the selection to only tasks of the given
+    // type.
     //#[clap(long)]
     //pub tenant: Option<String>,
 }


### PR DESCRIPTION
**Description:**

fixes #726 

The new ouput of `flowctl logs --help`:

```
flowctl-logs
Prints the runtime logs of a task (capture, derivation, or materialization).

Reads contents from the `ops/<tenant>/logs` collection, selecting the partition that corresponds to
the selected task. This command is essentially equivalent to the much longer: `flowctl collections
read --collection ops/<tenant>/logs --include-partition estuary.dev/field/name=<task> --uncommitted`

USAGE:
    flowctl logs [OPTIONS] --task <TASK>

OPTIONS:
        --task <TASK>
            The name of the task

        --follow
            Whether to block waiting for new data. If provided, the read will continue indefinitely
            until interrupted or ending due to an error

    -o, --output <OUTPUT>
            How to format CLI output

            [possible values: json, yaml, table]

        --since <SINCE>
            Start reading from approximately this far in the past. For example `--since 10m` will
            output all data that was added within the last 10 minutes. The actual start of the read
            will always be at a fragment boundary, and thus may include data from significantly
            before the requested time period

    -h, --help
            Print help information
```

And the new output from `flowctl stats --help`:

```
flowctl-stats
Prints the runtime stats of a task (capture, derivation, or materialization).

Reads contents from the `ops/<tenant>/stats` collection, selecting the partition that corresponds to
the selected task. This command is essentially equivalent to the much longer: `flowctl collections
read --collection ops/<tenant>/stats --include-partition estuary.dev/field/name=<task>`

USAGE:
    flowctl stats [OPTIONS] --task <TASK>

OPTIONS:
        --task <TASK>
            The name of the task

        --follow
            Whether to block waiting for new data. If provided, the read will continue indefinitely
            until interrupted or ending due to an error

    -o, --output <OUTPUT>
            How to format CLI output

            [possible values: json, yaml, table]

        --since <SINCE>
            Start reading from approximately this far in the past. For example `--since 10m` will
            output all data that was added within the last 10 minutes. The actual start of the read
            will always be at a fragment boundary, and thus may include data from significantly
            before the requested time period

        --uncommitted
            Read raw data from stats journals, including possibly uncommitted or rolled back
            transactions. This flag is currently required, but will be made optional in the future
            as we add support for committed reads, which will become the default

    -h, --help
            Print help information
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/805)
<!-- Reviewable:end -->
