### PR TITLE
Phil/new tenant limits

### DIFF
--- a/supabase/pending/directive_limits.sql
+++ b/supabase/pending/directive_limits.sql
@@ -1,0 +1,52 @@
+-- Updates the directives table to have an optional limit on the number of times
+-- that it can be applied.
+
+alter table directives add column uses_remaining bigint;
+
+comment on column directives.uses_remaining is '
+The maximum number of times that this directive may be applied.
+This value gets decremented each time the directive is applied.
+Once it reaches 0, future attempts to apply the directive will fail.
+A null here means that there is no limit.
+';
+
+update directives set uses_remaining = 1 where single_use = true;
+
+alter table directives drop column single_use;
+
+create or replace function exchange_directive_token(bearer_token uuid)
+returns exchanged_directive as $$
+declare
+  directive_row directives;
+  applied_row applied_directives;
+begin
+
+  -- Note that uses_remaining could be null, and in that case `uses_remaining - 1`
+  -- would also evaluate to null. This means that we don't actually update
+  -- uses_remaining here if the current value is null.
+  -- We also intentionally leave the bearer_token in place when uses_remaining
+  -- drops to 0, because it's possible that something may come along and
+  -- increase uses_remaining again.
+  update directives
+    set uses_remaining = uses_remaining - 1
+    where directives.token = bearer_token
+    returning * into directive_row;
+
+  if not found then
+    raise 'Bearer token % is not valid', bearer_token
+      using errcode = 'check_violation';
+  end if;
+
+  if directive_row.uses_remaining is not null and directive_row.uses_remaining < 0 then
+    raise 'System quota has been reached, please contact support@estuary.dev in order to proceed.'
+      using errcode = 'check_violation';
+  end if;
+
+  insert into applied_directives (directive_id, user_id)
+  values (directive_row.id, auth.uid())
+  returning * into applied_row;
+
+  return (directive_row, applied_row);
+end;
+$$ language plpgsql security definer;
+


### PR DESCRIPTION
**Description:**

This adds the ability to limit the number of new tenants that can be created through the betaOnboarding directive. It does this by enforcing optional limits on the number of times that each directive may be applied. The default is to allow unlimited applications of each directive. If the `uses_remaining` column is non-null, then it is decremented each time the directive is applied, and returns an error if it is negative.

**Workflow steps:**

Not really a user-facing workflow, but here's the steps for a dev:

- To setup a limit of `n` new tenants, first find the `id` of the beta onboarding directive.
- In the DB: `update directives set uses_remaining = <n> where id = <directive-id>;`
- Login with a new account, and navigate to: `/auth?betaOnboarding=please_show`.
- Enter a prefix and hit the CTA.
- If `n` is greater than 0, then the tenant will be created. Otherwise, you will see this error:
- `n` will be decremented on every attempt to apply the directive, so a negative number immediately tells you the number of times an attempt was denied.

![image](https://user-images.githubusercontent.com/4495829/202828197-9c03ec72-5146-4638-87b3-c3c7d31f3b18.png)


**Documentation links affected:** n/a

**Notes for reviewers:**

I went back and forth on the approach for this. The first commit totally works, but requires an index and an additional query. The counter-based approach also seems like it'll be easier for us to manage as a rate-limiter. The idea being to have a cron job that executes roughly the following SQL every hour, for example, if we wanted a rate-limit of 100 new tenants per hour.

```sql
update directives set uses_remaining = 100 where directive_id = '<betaOnboardDirective>';
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/811)
<!-- Reviewable:end -->
