### PR TITLE
tests: run e2e tests without `--poll` (tail)

### DIFF
--- a/tests/run-end-to-end.sh
+++ b/tests/run-end-to-end.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script runs the examples catalog to completion using a temp-data-plane in --poll mode,
+# This script runs the examples catalog to completion using a temp-data-plane,
 # and outputs selected materializations.
 
 # -m turns on job management, required for our use of `fg` below.
@@ -78,14 +78,12 @@ export BROKER_ADDRESS=unix://localhost${TESTDIR}/gazette.sock
 export CONSUMER_ADDRESS=unix://localhost${TESTDIR}/consumer.sock
 
 # Start an empty local data plane within our TESTDIR as a background job.
-# --poll so that connectors are polled rather than continuously tailed.
 # --sigterm to verify we cleanly tear down the test catalog (otherwise it hangs).
 # --tempdir to use our known TESTDIR rather than creating a new temporary directory.
 # --unix-sockets to create UDS socket files in TESTDIR in well-known locations.
 ${FLOWCTL} temp-data-plane \
     --log.level info \
     --network flow-test-network \
-    --poll \
     --sigterm \
     --tempdir ${TESTDIR} \
     --unix-sockets \

--- a/tests/source-test-no-state/flow.yaml
+++ b/tests/source-test-no-state/flow.yaml
@@ -19,13 +19,12 @@ captures:
   examples/source-test-no-state:
     endpoint:
       connector:
-        image: ghcr.io/estuary/source-test:dev
+        image: ghcr.io/estuary/source-test:3e06f40
         config:
           # Number of greeting documents to produce
           # [integer] (required)
           exit_after: 100
           skip_state: true
-          # TODO(johnny): no longer used but still required by the source-test connector.
           greetings: 1
     bindings:
       - resource:

--- a/tests/source-test-no-state/flow.yaml
+++ b/tests/source-test-no-state/flow.yaml
@@ -19,7 +19,7 @@ captures:
   examples/source-test-no-state:
     endpoint:
       connector:
-        image: ghcr.io/estuary/source-test:3e06f40
+        image: ghcr.io/estuary/source-test:dev
         config:
           # Number of greeting documents to produce
           # [integer] (required)


### PR DESCRIPTION
**Description:**

- Don't use `--poll`, instead use a modified version of `source-test` that can be told to exit: https://github.com/estuary/connectors/pull/429

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/817)
<!-- Reviewable:end -->
