### PR TITLE
Phil/flowctl creds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "agent"
 version = "0.0.0"
 dependencies = [
@@ -189,6 +201,36 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "async-io"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -399,12 +441,37 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -629,6 +696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +775,15 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -920,6 +1005,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,7 +1113,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -1119,6 +1214,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,7 +1326,6 @@ dependencies = [
  "assert_cmd",
  "base64",
  "bytes",
- "chrono",
  "clap 3.2.22",
  "comfy-table",
  "crossterm",
@@ -1220,8 +1335,10 @@ dependencies = [
  "humantime",
  "itertools 0.10.5",
  "journal-client",
+ "keyring",
  "labels",
  "models",
+ "open",
  "postgrest",
  "proto-flow",
  "proto-gazette",
@@ -1351,6 +1468,21 @@ name = "futures-io"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1571,11 +1703,31 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1929,6 +2081,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fb8399ddcabfccb274577a8d90f0653e0b5b5977797c1c8834ad09839a10e5"
+dependencies = [
+ "byteorder",
+ "secret-service",
+ "security-framework",
+ "winapi",
+]
+
+[[package]]
 name = "labels"
 version = "0.0.0"
 
@@ -2145,7 +2309,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2215,6 +2379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bb540dc6ef51cfe1916ec038ce7a620daf3a111e2502d745197cd53d6bca15"
+dependencies = [
+ "libc",
+ "socket2",
+]
+
+[[package]]
 name = "network-tunnel"
 version = "0.0.0"
 dependencies = [
@@ -2236,6 +2410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2430,20 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2268,12 +2469,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.4.3",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2317,6 +2550,22 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "open"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+dependencies = [
+ "pathdiff",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "openssl"
@@ -2396,6 +2645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,7 +2695,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2510,6 +2765,12 @@ checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pathfinding"
@@ -2696,6 +2957,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "postgrest"
 version = "1.3.0"
 source = "git+https://github.com/estuary/postgrest-rs?branch=johnny/patches#382f37ab8fec3b413be08c15790a69f88dcc0dec"
@@ -2744,6 +3019,26 @@ checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -3419,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3529,6 +3824,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secret-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1da5c423b8783185fd3fecd1c8796c267d2c089d894ce5a93c280a5d3f780a2"
+dependencies = [
+ "aes",
+ "block-modes",
+ "hkdf 0.11.0",
+ "lazy_static",
+ "num",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "zbus",
+ "zbus_macros",
+ "zvariant",
+ "zvariant_derive",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,6 +3928,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +4008,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3864,8 +4203,8 @@ dependencies = [
  "futures-util",
  "hashlink 0.8.1",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.3",
+ "hmac 0.12.1",
  "indexmap",
  "itoa 1.0.3",
  "libc",
@@ -3879,7 +4218,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
@@ -3904,7 +4243,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "sqlx-core",
  "sqlx-rt",
  "syn",
@@ -3922,6 +4261,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -4782,6 +5127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,6 +5298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "which"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,12 +5365,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5019,10 +5400,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5031,16 +5424,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -5076,6 +5493,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zbus"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbeb2291cd7267a94489b71376eda33496c1b9881adf6b36f26cc2779f3fc49"
+dependencies = [
+ "async-io",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "fastrand",
+ "futures",
+ "nb-connect",
+ "nix",
+ "once_cell",
+ "polling",
+ "scoped-tls",
+ "serde",
+ "serde_repr",
+ "zbus_macros",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3959a7847cf95e3d51e312856617c5b1b77191176c65a79a5f14d778bbe0a6"
+dependencies = [
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5140,4 +5592,30 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "zvariant"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c7b55f2074489b7e8e07d2d0a6ee6b4f233867a653c664d8020ba53692525"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca5e22593eb4212382d60d26350065bf2a02c34b85bc850474a74b589a3de9"
+dependencies = [
+ "proc-macro-crate 1.2.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ iri-string = "0.6.0"
 jemallocator = "0.3"
 jemalloc-ctl = "0.3"
 json-patch = "0.2"
+keyring = "1.2"
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "6.20", default-features = false, features = [
@@ -70,6 +71,7 @@ mime = "0.3"
 memchr = "2.5"
 num-bigint = "0.4"
 
+open = "3.2"
 openssl-sys = { version = "0.9", features = ['vendored'] }
 openssl = "0.10"
 

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -23,7 +23,6 @@ tables = { path = "../tables" }
 validation = { path = "../validation" }
 
 base64 = { workspace = true }
-chrono = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
@@ -33,6 +32,8 @@ dirs = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 itertools = { workspace = true }
+keyring = { workspace = true }
+open = { workspace = true }
 postgrest = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -222,8 +222,7 @@ async fn do_list_fragments(
     ctx: &mut crate::CliContext,
     args: &ListFragmentsArgs,
 ) -> Result<(), anyhow::Error> {
-    let mut client =
-        journal_client_for(ctx.config_mut(), vec![args.selector.collection.clone()]).await?;
+    let mut client = journal_client_for(ctx, vec![args.selector.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.selector.build_label_selector()).await?;
 
@@ -262,7 +261,7 @@ async fn do_list_journals(
     ctx: &mut crate::CliContext,
     args: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
-    let mut client = journal_client_for(ctx.config_mut(), vec![args.collection.clone()]).await?;
+    let mut client = journal_client_for(ctx, vec![args.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -65,7 +65,7 @@ pub async fn read_collection(ctx: &mut crate::CliContext, args: &ReadArgs) -> an
     }
 
     let mut data_plane_client =
-        dataplane::journal_client_for(ctx.config_mut(), vec![args.selector.collection.clone()]).await?;
+        dataplane::journal_client_for(ctx, vec![args.selector.collection.clone()]).await?;
 
     let selector = args.selector.build_label_selector();
     tracing::debug!(?selector, "build label selector");

--- a/crates/flowctl/src/controlplane.rs
+++ b/crates/flowctl/src/controlplane.rs
@@ -1,0 +1,286 @@
+use crate::{config, CliContext};
+use anyhow::Context;
+use keyring::Entry;
+use serde::{Deserialize, Serialize};
+
+/// A structure containing credentials that can be refreshed. This is represented
+/// in serialized form as a base64 encoded JSON object, which is provided by the UI.
+#[derive(Deserialize, Serialize)]
+struct RefreshableToken {
+    /// JWT that is used in the Authorization header for requests to the control plane.
+    pub access_token: String,
+    /// Can be exchanged for a brand new `RefreshableToken`
+    pub refresh_token: String,
+    /// The expiration time of the token, unix timestamp in UTC with second precision.
+    pub expires_at: i64,
+}
+
+impl RefreshableToken {
+    /// Returns true if the token expires within `renew_before` of the current time.
+    pub fn expires_within(&self, renew_before: time::Duration) -> bool {
+        let expiry =
+            time::OffsetDateTime::from_unix_timestamp(self.expires_at).unwrap_or_else(|err| {
+                tracing::error!(
+                    error = %err,
+                    expires_at = self.expires_at,
+                    "invalid expires_at on auth token"
+                );
+                time::OffsetDateTime::UNIX_EPOCH // we'll consider this to be expired
+            });
+
+        expiry.saturating_sub(renew_before) < time::OffsetDateTime::now_utc()
+    }
+
+    pub fn from_base64(encoded_token: &str) -> anyhow::Result<RefreshableToken> {
+        let decoded = base64::decode(encoded_token).context("invalid base64")?;
+        let tk: RefreshableToken = serde_json::from_slice(&decoded)?;
+        Ok(tk)
+    }
+
+    pub fn to_base64(&self) -> anyhow::Result<String> {
+        let ser = serde_json::to_vec(self)?;
+        Ok(base64::encode(&ser))
+    }
+}
+
+impl From<RefreshResponse> for RefreshableToken {
+    fn from(response: RefreshResponse) -> RefreshableToken {
+        let expires_at = time::OffsetDateTime::now_utc()
+            .saturating_add(time::Duration::seconds(response.expires_in))
+            .unix_timestamp();
+        RefreshableToken {
+            access_token: response.access_token,
+            refresh_token: response.refresh_token,
+            expires_at,
+        }
+    }
+}
+
+/// private type that matches the response body from the /auth/v1/token endpoint
+#[derive(Deserialize)]
+struct RefreshResponse {
+    // Secret access token of the control-plane API.
+    pub access_token: String,
+    // Secret refresh token of the control-plane API.
+    pub refresh_token: String,
+    // Seconds to expiry of access_token
+    pub expires_in: i64,
+}
+
+fn should_refresh_credentials(credential: &RefreshableToken) -> bool {
+    // Add some padding to the expiration in order to deal with potentially
+    // long-running operations or imprecision in the expiration time.
+    // The environment variable is here to allow for testing the refresh.
+    credential.expires_within(time::Duration::minutes(10))
+        || std::env::var("FLOWCTL_FORCE_TOKEN_REFRESH").is_ok()
+}
+
+/// Create and configure a new client with authentication headers setup for the current user.
+/// The current user is identified by the presence of the `user_email` in the config.
+/// This requires that the user has previously authenticated `flowctl`.
+/// The credentials will be refreshed automatically if required.
+/// Credentials are stored in the system keychain. This means that the user may be prompted
+/// by the OS when this function is called.
+pub async fn new_authenticated_client(
+    ctx: &mut CliContext,
+) -> anyhow::Result<postgrest::Postgrest> {
+    // if the access token is provided by the env variable, then don't try to
+    // look up credentials from the system keychain. This allows using flowctl
+    // in environments that don't have a keychain, but it's not really intended
+    // to support service accounts, since we don't yet know what those will look like.
+    if let Ok(access_token) = std::env::var("FLOWCTL_ACCESS_TOKEN") {
+        return Ok(client_from_env_credential(ctx.config(), access_token));
+    }
+
+    // At this point, we're expecting that credentials must be present in the keychain.
+    // They may be expired, though, in which case we'll attempt to refresh them.
+    let api_config = ctx.config().api.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("missing api configuration, did you forget to run `flowctl auth login`?")
+    })?;
+
+    let user_email = api_config.user_email.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("config is missing user_email, did you forget to run `flowctl auth login`?")
+    })?;
+
+    let mut credentials = retrieve_credentials(&api_config.endpoint, &user_email).await?;
+    if should_refresh_credentials(&credentials) {
+        tracing::debug!(
+            expires_at = credentials.expires_at,
+            "current credentials need to be refreshed"
+        );
+        credentials = fetch_new_credential(&api_config, &credentials.refresh_token)
+            .await
+            .context("failed to refresh user credentials")?;
+
+        persist_credentials(&api_config.endpoint, &user_email, &credentials).await?;
+        tracing::debug!(
+            expires_at = credentials.expires_at,
+            "successfully refreshed credential"
+        );
+    }
+
+    Ok(new_client_with_credentials(
+        &api_config.endpoint,
+        &api_config.public_token,
+        &credentials.access_token,
+    ))
+}
+
+fn client_from_env_credential(
+    config: &config::Config,
+    access_token: String,
+) -> postgrest::Postgrest {
+    let api_config = config
+        .api
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(config::API::production);
+    new_client_with_credentials(
+        &api_config.endpoint,
+        &api_config.public_token,
+        &access_token,
+    )
+}
+
+fn new_client_with_credentials(
+    url: &url::Url,
+    public_token: &str,
+    access_token: &str,
+) -> postgrest::Postgrest {
+    postgrest::Postgrest::new(url.to_string())
+        .insert_header("apikey", public_token)
+        .insert_header("Authorization", format!("Bearer {}", access_token))
+}
+
+async fn fetch_new_credential(
+    api_config: &config::API,
+    refresh_token: &str,
+) -> anyhow::Result<RefreshableToken> {
+    let mut refresh_url = api_config.endpoint.clone();
+    refresh_url.set_path("/auth/v1/token");
+    refresh_url.set_query(Some("grant_type=refresh_token"));
+
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(refresh_url)
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .header("apikey", &api_config.public_token)
+        .send()
+        .await?;
+
+    tracing::debug!(headers = ?response.headers(), "got resp headers");
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!(
+            "Failed to refresh credentials, status: {:?}, response:\n{}",
+            status,
+            body
+        );
+    }
+
+    let resp: RefreshResponse =
+        serde_json::from_str(&body).context("failed to deserialize token refresh response")?;
+    Ok(RefreshableToken::from(resp))
+}
+
+pub async fn configure_new_credential(
+    ctx: &mut crate::CliContext,
+    token: &str,
+) -> anyhow::Result<()> {
+    // verify that the provided token is valid by decoding it and attempting to make a call
+    let api_config = ctx
+        .config()
+        .api
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(config::API::production);
+
+    let auth = RefreshableToken::from_base64(token).context("unable to parse credential")?;
+    let user_email = parse_jwt(&auth.access_token)
+        .context("failed to parse jwt")?
+        .email;
+
+    persist_credentials(&api_config.endpoint, &user_email, &auth).await?;
+
+    // Only update the config if the email is actually different than what's there.
+    if Some(&user_email) != api_config.user_email.as_ref() {
+        let mut new_cfg = api_config;
+        new_cfg.user_email = Some(user_email);
+        ctx.config_mut().api = Some(new_cfg);
+    }
+    Ok(())
+}
+
+async fn retrieve_credentials(
+    endpoint: &url::Url,
+    user_email: &str,
+) -> anyhow::Result<RefreshableToken> {
+    let keychain_entry = keychain_auth_entry(endpoint, user_email)?;
+    let user_email = user_email.to_string(); // clone so we can use it in the closure
+                                             // We use spawn_blocking because accessing the keychain is a blocking call, which may prompt the user
+                                             // to allow the access. This could take quite some time, and we don't want to block the executor
+                                             // during that period. Note that creating the Entry explicitly does not try to access the keychain.
+    let handle = tokio::task::spawn_blocking::<_, anyhow::Result<RefreshableToken>>(move || {
+        match keychain_entry.get_password() {
+            Err(keyring::Error::NoEntry) => {
+                // This is expected to be a common error case, so provide a helpful message.
+                anyhow::bail!("no credentials found for user '{user_email}', did you forget to run `flowctl auth login`?");
+            }
+            Ok(auth) => {
+                tracing::debug!("retrieved credentials from keychain");
+                let token = RefreshableToken::from_base64(&auth)?;
+                Ok(token)
+            }
+            Err(err) => {
+                Err(anyhow::Error::new(err).context("retrieving user credentials from keychain"))
+            }
+        }
+    });
+    let cred = handle.await??;
+    Ok(cred)
+}
+
+async fn persist_credentials(
+    endpoint: &url::Url,
+    user_email: &str,
+    credential: &RefreshableToken,
+) -> anyhow::Result<()> {
+    let entry = keychain_auth_entry(endpoint, user_email)?;
+    let token = credential.to_base64()?;
+    // See comment in `retrieve_credentials` for why we need to use `spawn_blocking`
+    let handle = tokio::task::spawn_blocking::<_, anyhow::Result<()>>(move || {
+        entry
+            .set_password(&token)
+            .context("persisting user credential to keychain")?;
+        tracing::info!("successfully persisted credential in keychain");
+        Ok(())
+    });
+    handle.await??;
+    Ok(())
+}
+
+fn keychain_auth_entry(endpoint: &url::Url, user_email: &str) -> anyhow::Result<Entry> {
+    let hostname = endpoint.domain().ok_or_else(|| {
+        anyhow::anyhow!("configured endpoint url '{}' is missing a domain", endpoint)
+    })?;
+    let entry_name = format!("estuary.dev-flowctl-{hostname}");
+    Ok(Entry::new(&entry_name, user_email))
+}
+
+#[derive(Deserialize)]
+struct JWT {
+    email: String,
+}
+
+fn parse_jwt(jwt: &str) -> anyhow::Result<JWT> {
+    let payload = jwt
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("invalid JWT"))?;
+    let json_data =
+        base64::decode_config(payload, base64::STANDARD_NO_PAD).context("invalid JWT")?;
+    let data: JWT = serde_json::from_slice(&json_data).context("parsing JWT data")?;
+    Ok(data)
+}

--- a/crates/flowctl/src/dataplane.rs
+++ b/crates/flowctl/src/dataplane.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::CliContext;
 use anyhow::Context;
 use serde::Deserialize;
 
@@ -11,10 +11,10 @@ pub struct DataPlaneAccess {
 
 /// Fetches connection info for accessing a data plane for the given catalog namespace prefixes.
 pub async fn fetch_data_plane_access_token(
-    cfg: &mut Config,
+    ctx: &mut CliContext,
     prefixes: Vec<String>,
 ) -> anyhow::Result<DataPlaneAccess> {
-    let client = cfg.client().await?;
+    let client = ctx.client().await?;
     tracing::debug!(?prefixes, "requesting data-plane access token for prefixes");
 
     let body = serde_json::to_string(&serde_json::json!({
@@ -47,13 +47,13 @@ pub async fn fetch_data_plane_access_token(
 
 /// Returns an authenticated journal client that's authorized to the given prefixes.
 pub async fn journal_client_for(
-    cfg: &mut Config,
+    ctx: &mut CliContext,
     prefixes: Vec<String>,
 ) -> anyhow::Result<journal_client::Client> {
     let DataPlaneAccess {
         auth_token,
         gateway_url,
-    } = fetch_data_plane_access_token(cfg, prefixes).await?;
+    } = fetch_data_plane_access_token(ctx, prefixes).await?;
     tracing::debug!(%gateway_url, "acquired data-plane-gateway access token");
 
     let client =

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -36,7 +36,7 @@ pub struct Cli {
     /// Profile are distinct configurations of the `flowctl` tool, and are
     /// completely optional. Use multiple profiles to track multiple accounts
     /// or development endpoints.
-    #[clap(long, default_value = "default")]
+    #[clap(long, default_value = "default", env = "FLOWCTL_PROFILE")]
     profile: String,
 
     #[clap(subcommand)]

--- a/local/start-flow.sh
+++ b/local/start-flow.sh
@@ -39,6 +39,19 @@ function bail() {
 # verify requirements here, before we get into the tmux session.
 command -v nc || bail "netcat must be installed (nc command was not found)"
 
+function copy_local_flowctl_config() {
+    local src="${SCRIPT_DIR}/local-flowctl-config.json"
+    local target="${HOME}/.config/flowctl/local.json"
+    if [[ "$(uname)" == 'Darwin' ]]; then
+        target="${HOME}/Library/Application Support/flowctl/local.json"
+    fi
+
+    if [[ ! -f "$target" ]]; then
+        log "copying local flowctl config from '${src}' to '${target}'"
+        cp "$src" "$target"
+    fi
+}
+
 function start_component() {
     local component="$1"
     tmux new-window -d -t "$SESSION" -n "$component"
@@ -60,6 +73,11 @@ if tmux has -t "$SESSION"; then
     exit 0
 fi
 
+copy_local_flowctl_config
+# Exporting this variable means that all `flowctl` invocations from inside the tmux
+# session will use the local config by default, so you don't need to pass `--profile local`
+# every time.
+export FLOWCTL_PROFILE=local
 tmux new-session -d -s "$SESSION" -n 'terminal'
 log "Created new tmux session called '$SESSION'"
 


### PR DESCRIPTION
**Description:**

This does some significant refactoring around how `flowctl` handles credentials. The main goals of this are to store user credentials more securely using the keychain service provided by the OS, and reduce some friction in the end-to-end process of authenticating the CLI.

This compliments https://github.com/estuary/ui/pull/391 and uses the new `/cli-auth/login` endpoint that was introduced there. The `flowctl auth login` command was added in order to make setting up `flowctl` authentication both obvious and discoverable from the CLI.

The credentials themselves are moved out of the config file, and into the users' keyring. While it's rare for an operating system to not have one, there are of course cases where that will be the case. As a "catch all" to support systems without the ability to use the keyring, the `FLOWCTL_ACCESS_TOKEN` environment variable was added. If set, then the value is used directly, and flowctl will skip any access of the keychain.

The `auth develop` subcommand was also removed. The intended replacement is to use `flowctl auth login` with local installations. The second commit tries to alleviate some of the pain that might cause for developers running `flowctl` against local instances.

**Workflow steps:**

The recommended login steps for `flowctl` will change to:

- Run `flowctl auth login`, which will open your browser to the login page (this respects the `--profile`)
- Login in the browser
- Copy the auth token you're presented with once done
- Paste that token into the terminal where `flowctl` is waiting.
- Profit

Note that `flowctl auth token --token` has not, and will not be changed. An alternative workflow, which will continue to be supported is for the user to navigate to `/cli-auth/login` on their own, and paste the resulting token into `flowctl auth token --token ...`. The `flowctl auth login` approach is functionally no different, and exists primarily to be discoverable in the CLI.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

- That first commit has kind of a lot going on, so just LMK if you want a tour.
- There's a complimentary UI PR at estuary/ui#391
- I've done a fair bit of testing locally, but I won't be very confident until the UI PR is merged so that I can test this with oauth logins.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/821)
<!-- Reviewable:end -->
