### PR TITLE
fix: Handle the end of a fragment properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "bzip2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3435,7 @@ dependencies = [
  "anyhow",
  "assemble",
  "bytes",
+ "bytesize",
  "clap 3.2.22",
  "doc",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.13"
 bitvec = "0.19"
 bytecount = { version = "0.6.3", features = ["runtime-dispatch-simd"] }
 bytes = "1.2"
+bytesize = "1.1.0"
 bumpalo = { version = "3.11", features = ["collections"] }
 bytelines = "2.4"
 byteorder = "1.4"

--- a/crates/schema-inference/Cargo.toml
+++ b/crates/schema-inference/Cargo.toml
@@ -21,23 +21,24 @@ assemble = { path = "../assemble" }
 models = { path = "../models" }
 proto-gazette = { path = "../proto-gazette" }
 
-humantime = {workspace=true}
-anyhow = {workspace=true}
-clap = {workspace=true}
-itertools = {workspace=true}
-schemars ={workspace=true}
-serde = {workspace=true}
-serde_json = {workspace=true}
-tonic = {workspace=true}
-tokio = {workspace=true}
-tracing = {workspace=true}
-tracing-subscriber ={workspace=true}
-thiserror = {workspace=true}
-tokio-util ={workspace=true}
-futures-util ={workspace=true}
-futures = {workspace=true}
-bytes ={workspace=true}
-warp = {workspace=true}
+humantime = { workspace = true }
+bytesize = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+itertools = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tonic = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+tokio-util = { workspace = true }
+futures-util = { workspace = true }
+futures = { workspace = true }
+bytes = { workspace = true }
+warp = { workspace = true }
 
 [dev-dependencies]
-insta = {workspace=true}
+insta = { workspace = true }

--- a/crates/schema-inference/src/json_decoder.rs
+++ b/crates/schema-inference/src/json_decoder.rs
@@ -88,7 +88,6 @@ where
                 let offset = iter.byte_offset();
                 self.bytes += offset;
                 buf.advance(offset);
-                // tracing::trace!(bytes_advance = offset, "Successfully read document");
 
                 Ok(Some(v))
             }

--- a/crates/schema-inference/src/server.rs
+++ b/crates/schema-inference/src/server.rs
@@ -156,7 +156,7 @@ async fn infer_schema(
             tracing::info!(
                 collection=collection_name,
                 documents_read=docs,
-                bytes_read=bytes,
+                bytes_read=format!("{:.1} MB", bytes as f32/1_000_000f32),
                 fully_read_collection=!*abort_rx.borrow(),
                 duration=?end_time,
                 "Finished schema inference"
@@ -271,7 +271,11 @@ async fn fragment_to_shape(
     }
 
     let bytes_read = doc_bytes_stream.decoder().bytes_read().try_into().unwrap();
-    tracing::debug!(bytes_read, docs_read = docs, "Done reading fragment");
+    tracing::debug!(
+        bytes_read = format!("{:.1} MB", bytes_read as f32 / 1_000_000f32),
+        docs_read = docs,
+        "Done reading fragment"
+    );
 
     match accumulator {
         Some(accum) => Ok(Some(ShapeAndMeta {


### PR DESCRIPTION
Previously we'd just sit in an infinite loop :facepalm:

The actual fix is here: https://github.com/estuary/flow/compare/bugfix/schema_inference_fragment_end?expand=1#diff-8a4f203851e6710c1af18f044b54a78c49ddb6eedaecf6aa5d4804fdf2c58187R261

This PR also introduces a bit of plumbing to allow for logging the total number of bytes read when inferring a schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/822)
<!-- Reviewable:end -->
