### PR TITLE
combine: drainer considers default values during field extraction

### DIFF
--- a/crates/assemble/src/lib.rs
+++ b/crates/assemble/src/lib.rs
@@ -19,7 +19,7 @@ pub fn inference(shape: &Shape, exists: Exists) -> flow::Inference {
     let default_json = shape
         .default
         .as_ref()
-        .map(|v| v.to_string())
+        .map(|(v, _)| v.to_string())
         .unwrap_or_default();
 
     let is_base64 = shape
@@ -798,7 +798,7 @@ mod test {
     fn test_inference() {
         let mut shape = Shape {
             type_: types::STRING | types::BOOLEAN,
-            default: Some(json!({"hello": "world"})),
+            default: Some((json!({"hello": "world"}), None)),
             description: Some("the description".to_string()),
             title: Some("the title".to_owned()),
             secret: Some(true),

--- a/crates/derive/src/combine_api.rs
+++ b/crates/derive/src/combine_api.rs
@@ -118,9 +118,6 @@ impl cgo::Service for API {
                 };
 
                 let validator = new_validator(&schema_json)?;
-                if validator.schemas().len() != 1 as usize {
-                    panic!("Validator built from bundled JSON schema must have a single schema")
-                };
                 let shape =
                     doc::inference::Shape::infer(&validator.schemas()[0], validator.schema_index());
 
@@ -295,7 +292,7 @@ fn exists_or_default<T>(
             let (inner, _) = shape.locate(p);
 
             match &inner.default {
-                Some(val) => val.pack(arena, TupleDepth::new().increment()),
+                Some((val, _)) => val.pack(arena, TupleDepth::new().increment()),
                 None => {
                     doc::Node::Null::<serde_json::Value>.pack(arena, TupleDepth::new().increment())
                 }
@@ -520,7 +517,7 @@ pub mod test {
 
         let field_ptrs = vec![
             "/intProp".to_owned(),
-            "/numProp".to_owned(), // TODO: Snapshot for this doesn't work very well.
+            "/numProp".to_owned(),
             "/strProp".to_owned(),
             "/boolProp".to_owned(),
             "/objProp".to_owned(),

--- a/crates/derive/src/combine_api.rs
+++ b/crates/derive/src/combine_api.rs
@@ -64,6 +64,8 @@ struct State {
     // JSON-Pointer into which a UUID placeholder should be set,
     // or None if a placeholder shouldn't be set.
     uuid_placeholder_ptr: Option<doc::Pointer>,
+    // Shape of the schema used by the this combiner.
+    shape: doc::inference::Shape,
 }
 
 impl cgo::Service for API {
@@ -115,11 +117,18 @@ impl cgo::Service for API {
                     s => Some(doc::Pointer::from(s)),
                 };
 
+                let validator = new_validator(&schema_json)?;
+                if validator.schemas().len() != 1 as usize {
+                    panic!("Validator built from bundled JSON schema must have a single schema")
+                };
+                let shape =
+                    doc::inference::Shape::infer(&validator.schemas()[0], validator.schema_index());
+
                 let combiner = doc::Combiner::new(
                     key_ptrs.clone(),
                     None,
                     tempfile::tempfile().context("opening temporary spill file")?,
-                    new_validator(&schema_json)?,
+                    validator,
                 )?;
 
                 self.state = Some(State {
@@ -128,6 +137,7 @@ impl cgo::Service for API {
                     key_ptrs,
                     uuid_placeholder_ptr,
                     stats: CombineStats::default(),
+                    shape,
                 });
                 Ok(())
             }
@@ -177,6 +187,7 @@ impl cgo::Service for API {
                     arena,
                     out,
                     &mut state.stats.out,
+                    Some(&state.shape),
                 )?;
 
                 if !more {
@@ -225,6 +236,7 @@ pub fn drain_chunk(
     arena: &mut Vec<u8>,
     out: &mut Vec<cgo::Out>,
     stats: &mut DocCounter,
+    shape: Option<&doc::inference::Shape>,
 ) -> Result<bool, doc::combine::Error> {
     // Convert target from a delta to an absolute target length of the arena.
     let target_length = target_length + arena.len();
@@ -250,18 +262,13 @@ pub fn drain_chunk(
             let begin = arena.len();
             for p in ptrs.iter() {
                 match &doc {
-                    doc::LazyNode::Heap(n) => p
-                        .query(n)
-                        .map(AsNode::as_node)
-                        .unwrap_or(doc::Node::Null)
-                        .pack(arena, TupleDepth::new().increment()),
-                    doc::LazyNode::Node(n) => p
-                        .query(*n)
-                        .map(AsNode::as_node)
-                        .unwrap_or(doc::Node::Null)
-                        .pack(arena, TupleDepth::new().increment()),
+                    doc::LazyNode::Heap(n) => {
+                        exists_or_default(p.query(n).map(AsNode::as_node), p, shape, arena)
+                    }
+                    doc::LazyNode::Node(n) => {
+                        exists_or_default(p.query(*n).map(AsNode::as_node), p, shape, arena)
+                    }
                 }
-                .expect("vec<u8> never fails to write");
             }
             cgo::send_bytes(code as u32, begin, arena, out);
         }
@@ -271,11 +278,39 @@ pub fn drain_chunk(
     })
 }
 
+fn exists_or_default<T>(
+    n: Option<doc::Node<T>>,
+    p: &doc::Pointer,
+    shape: Option<&doc::inference::Shape>,
+    arena: &mut Vec<u8>,
+) where
+    T: doc::AsNode,
+{
+    match (n, shape) {
+        (Some(val), _) => val.pack(arena, TupleDepth::new().increment()),
+        (None, None) => {
+            doc::Node::Null::<serde_json::Value>.pack(arena, TupleDepth::new().increment())
+        }
+        (None, Some(shape)) => {
+            let (inner, _) = shape.locate(p);
+
+            match &inner.default {
+                Some(val) => val.pack(arena, TupleDepth::new().increment()),
+                None => {
+                    doc::Node::Null::<serde_json::Value>.pack(arena, TupleDepth::new().increment())
+                }
+            }
+        }
+    }
+    .expect("vec<u8> never fails to write");
+}
+
 #[cfg(test)]
 pub mod test {
     use super::super::test::build_min_max_sum_schema;
     use super::{Code, Error, API};
     use cgo::Service;
+    use itertools::Itertools;
     use prost::Message;
     use proto_flow::flow::{
         combine_api::{self, Stats},
@@ -394,6 +429,286 @@ pub mod test {
             ),
             Err(Error::EmptyKey)
         ));
+    }
+
+    #[test]
+    fn test_combine_with_defaults_simple() {
+        let schema_json = serde_json::json!({
+            "properties": {
+                "intProp": {
+                    "type": "integer",
+                    "default": 7,
+                    "reduce": {"strategy": "sum"}
+                },
+                "strProp": {
+                    "default": "defaultStringExtracted",
+                    "type": "string",
+                },
+                "strPropNotExtracted": {
+                    "default": "defaultStringNotExtracted",
+                    "type": "string",
+                },
+            },
+            "reduce": {"strategy": "merge"},
+        })
+        .to_string();
+
+        let key_ptrs = vec!["/aKey".to_owned()];
+
+        let field_ptrs = vec!["/intProp".to_owned(), "/strProp".to_owned()];
+
+        let docs = vec![
+            // If any of the combined documents have an actual value for a field, no default values
+            // apply. Default values are not reduced into other documents. In this case, intProp for
+            // the reduced document is 4 and the extracted field is also 4 due to the sum reduction
+            // of the two actually present values, and the default for intProp has no effect.
+            (true, json!({"aKey": "a", "intProp": 3})),
+            (false, json!({"aKey": "a", "intProp": 1})),
+            (false, json!({"aKey": "a", "strProp": "something"})),
+            // The default value applies exclusively to extracted fields when none of the combined
+            // documents have a value present for the field. Here the value for the extracted field
+            // intProp is equal to the default value, but not summed from each document with the
+            // value absent. The default value is not present in the reduced document.
+            (true, json!({"aKey": "b"})),
+            (false, json!({"aKey": "b"})),
+            (false, json!({"aKey": "b", "strProp": "something"})),
+            // A field with a default value that is not included in extracted fields will never be
+            // present in the extracted fields, and as before never be included in document
+            // reduction.
+            (true, json!({"aKey": "c", "strPropNotExtracted": "first"})),
+            (false, json!({"aKey": "c", "strPropNotExtracted": "second"})),
+            (false, json!({"aKey": "c"})),
+        ];
+
+        insta::assert_debug_snapshot!(run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs));
+    }
+
+    #[test]
+    fn test_combine_with_defaults_different_types() {
+        let schema_json = serde_json::json!({
+            "properties": {
+                "intProp": {
+                    "type": "integer",
+                    "default": 7,
+                },
+                "numProp": {
+                    "default": 12.4,
+                    "type": "number",
+                },
+                "strProp": {
+                    "default": "defaultString",
+                    "type": "string",
+                },
+                "boolProp": {
+                    "default": true,
+                    "type": "boolean",
+                },
+                "objProp": {
+                    "default": { "prop": "val" },
+                    "type": "object",
+                },
+                "arrayProp": {
+                    "default": [1, "hello", null],
+                    "type": "array",
+                },
+            },
+            "reduce": {"strategy": "merge"},
+        })
+        .to_string();
+
+        let key_ptrs = vec!["/aKey".to_owned()];
+
+        let field_ptrs = vec![
+            "/intProp".to_owned(),
+            "/numProp".to_owned(), // TODO: Snapshot for this doesn't work very well.
+            "/strProp".to_owned(),
+            "/boolProp".to_owned(),
+            "/objProp".to_owned(),
+            "/arrayProp".to_owned(),
+        ];
+
+        let docs = vec![(true, json!({"aKey": "a"}))];
+
+        insta::assert_debug_snapshot!(run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs));
+    }
+
+    #[test]
+    fn test_combine_with_defaults_nested() {
+        let schema_json = serde_json::json!({
+            "properties": {
+                "objPropNoDefaultParent": {
+                    "type": "object",
+                    "properties": {
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "val": {
+                                    "type": "string",
+                                    "default": "nestedValNoDefaultParent",
+                                },
+                            },
+                        },
+                    },
+                },
+                "objPropWithDefaultParent": {
+                    "type": "object",
+                    "default": { "other": "thing" },
+                    "properties": {
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "val": {
+                                    "type": "string",
+                                    "default": "nestedValWithDefaultParent",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        })
+        .to_string();
+
+        let key_ptrs = vec!["/aKey".to_owned()];
+
+        let field_ptrs = vec![
+            // Uses the default value of a located nested property, even though the parent object
+            // doesn't have a default value.
+            "/objPropNoDefaultParent/nested/val".to_owned(),
+            // But the default value of nested properties is not used if the parent property
+            // is omitted & does not have a default value.
+            "/objPropNoDefaultParent".to_owned(),
+            // A nested value can be extracted from a parent object even if the parent
+            // object is not present and has a default value that does not include the
+            // extracted field.
+            "/objPropWithDefaultParent/nested/val".to_owned(),
+            // The default value for an object that is not present overrides any default
+            // values from the object's properties.
+            "/objPropWithDefaultParent".to_owned(),
+        ];
+
+        let docs = vec![(true, json!({"aKey": "a", "intProp": 3}))];
+
+        insta::assert_debug_snapshot!(run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs));
+    }
+
+    #[test]
+    fn test_combine_with_defaults_array() {
+        let schema_json = serde_json::json!({
+            "properties": {
+                "arrayItems": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "default": "firstDefault",
+                        },
+                        {
+                            "type": "string",
+                            "default": "secondDefault",
+                        },
+                    ],
+                    "minItems": 1,
+                    "maxItems": 3,
+                },
+                "arrayContains": {
+                    "type": "array",
+                    "contains": {
+                        "type": "string",
+                        "default": "containsDefault",
+                    },
+                    "minContains": 1,
+                    "maxContains": 3,
+                },
+            },
+        })
+        .to_string();
+
+        let key_ptrs = vec!["/aKey".to_owned()];
+
+        let field_ptrs = vec![
+            // Defaults work positionally with items.
+            "/arrayItems/0".to_owned(), // Matches default at idx 0
+            "/arrayItems/1".to_owned(), // Matches default at idx 1
+            "/arrayItems/2".to_owned(), // Cannot be located -> null
+            // Defaults are not applied for contains.
+            "/arrayContains/0".to_owned(),
+        ];
+
+        let docs = vec![(true, json!({"aKey": "a"}))];
+
+        insta::assert_debug_snapshot!(run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs));
+    }
+
+    // Runs a combine svc to completion for a set of inputs and return the results sans stats with
+    // some simple formatting applied.
+    fn run_simple_svc(
+        schema_json: String,
+        key_ptrs: Vec<String>,
+        field_ptrs: Vec<String>,
+        docs: &[(bool, serde_json::Value)],
+    ) -> Vec<Vec<String>> {
+        let mut svc = API::create();
+        let mut arena = Vec::new();
+        let mut out = Vec::new();
+
+        svc.invoke_message(
+            Code::Configure as u32,
+            combine_api::Config {
+                schema_json,
+                key_ptrs,
+                field_ptrs,
+                uuid_placeholder_ptr: String::new(),
+            },
+            &mut arena,
+            &mut out,
+        )
+        .unwrap();
+
+        for (left, doc) in docs {
+            svc.invoke(
+                if *left {
+                    Code::ReduceLeft
+                } else {
+                    Code::CombineRight
+                } as u32,
+                serde_json::to_vec(doc).unwrap().as_ref(),
+                &mut arena,
+                &mut out,
+            )
+            .unwrap();
+        }
+
+        svc.invoke(
+            Code::DrainChunk as u32,
+            &(1024 as u32).to_be_bytes(),
+            &mut arena,
+            &mut out,
+        )
+        .unwrap();
+
+        let stats_out = out.pop().expect("missing stats");
+        assert_eq!(Code::DrainedStats as u32, stats_out.code);
+
+        let code_seq = vec![
+            Code::DrainedReducedDocument,
+            Code::DrainedKey,
+            Code::DrainedFields,
+        ];
+
+        out.iter()
+            .chunks(3)
+            .into_iter()
+            .map(|i| {
+                i.enumerate()
+                    .map(|(idx, pos)| {
+                        assert_eq!(code_seq[idx] as u32, pos.code);
+                        String::from_utf8_lossy(&arena[pos.begin as usize..pos.end as usize])
+                            .to_string()
+                    })
+                    .collect()
+            })
+            .collect()
     }
 }
 

--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -402,6 +402,7 @@ impl Pipeline {
             arena,
             out,
             &mut self.combiner_stats,
+            None,
         )?;
 
         if more {

--- a/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_array.snap
+++ b/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_array.snap
@@ -1,0 +1,11 @@
+---
+source: crates/derive/src/combine_api.rs
+expression: "run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs)"
+---
+[
+    [
+        "{\"aKey\":\"a\"}",
+        "\u{2}a\0",
+        "\u{2}firstDefault\0\u{2}secondDefault\0\0\0",
+    ],
+]

--- a/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_different_types.snap
+++ b/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_different_types.snap
@@ -1,0 +1,11 @@
+---
+source: crates/derive/src/combine_api.rs
+expression: "run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs)"
+---
+[
+    [
+        "{\"aKey\":\"a\"}",
+        "\u{2}a\0",
+        "\u{15}\u{7}!�(������\u{2}defaultString\0'\u{1}{\"prop\":\"val\"}\0\u{1}[1,\"hello\",null]\0",
+    ],
+]

--- a/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_nested.snap
+++ b/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_nested.snap
@@ -1,0 +1,11 @@
+---
+source: crates/derive/src/combine_api.rs
+expression: "run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs)"
+---
+[
+    [
+        "{\"aKey\":\"a\",\"intProp\":3}",
+        "\u{2}a\0",
+        "\u{2}nestedValNoDefaultParent\0\0\u{2}nestedValWithDefaultParent\0\u{1}{\"other\":\"thing\"}\0",
+    ],
+]

--- a/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_simple.snap
+++ b/crates/derive/src/snapshots/derive__combine_api__test__combine_with_defaults_simple.snap
@@ -1,0 +1,21 @@
+---
+source: crates/derive/src/combine_api.rs
+expression: "run_simple_svc(schema_json, key_ptrs, field_ptrs, &docs)"
+---
+[
+    [
+        "{\"aKey\":\"a\",\"intProp\":4,\"strProp\":\"something\"}",
+        "\u{2}a\0",
+        "\u{15}\u{4}\u{2}something\0",
+    ],
+    [
+        "{\"aKey\":\"b\",\"strProp\":\"something\"}",
+        "\u{2}b\0",
+        "\u{15}\u{7}\u{2}something\0",
+    ],
+    [
+        "{\"aKey\":\"c\",\"strPropNotExtracted\":\"second\"}",
+        "\u{2}c\0",
+        "\u{15}\u{7}\u{2}defaultStringExtracted\0",
+    ],
+]

--- a/crates/doc/src/snapshots/doc__inference__test__default_value_validation.snap
+++ b/crates/doc/src/snapshots/doc__inference__test__default_value_validation.snap
@@ -1,0 +1,97 @@
+---
+source: crates/doc/src/inference.rs
+expression: obj.inspect()
+---
+[
+    InvalidDefaultValue(
+        "/array-wrong-items",
+        FailedValidation {
+            basic_output: Object {
+                "errors": Array [
+                    Object {
+                        "absoluteKeywordLocation": String("http://example/schema#/properties/array-wrong-items/items"),
+                        "error": String("Invalid: Must be of type \"integer\"."),
+                        "instanceLocation": String("/0"),
+                        "keywordLocation": String("#/items"),
+                    },
+                ],
+                "valid": Bool(false),
+            },
+            document: Array [
+                String("aString"),
+            ],
+        },
+    ),
+    InvalidDefaultValue(
+        "/multi-type",
+        FailedValidation {
+            basic_output: Object {
+                "errors": Array [
+                    Object {
+                        "absoluteKeywordLocation": String("http://example/schema#/properties/multi-type"),
+                        "error": String("Invalid: Must be of type \"array\", \"string\"."),
+                        "instanceLocation": String(""),
+                        "keywordLocation": String("#"),
+                    },
+                ],
+                "valid": Bool(false),
+            },
+            document: Number(1234),
+        },
+    ),
+    InvalidDefaultValue(
+        "/object-type-missing-prop",
+        FailedValidation {
+            basic_output: Object {
+                "errors": Array [
+                    Object {
+                        "absoluteKeywordLocation": String("http://example/schema#/properties/object-type-missing-prop"),
+                        "error": String("Invalid: Properties \"requiredProp\" are required."),
+                        "instanceLocation": String(""),
+                        "keywordLocation": String("#"),
+                    },
+                ],
+                "valid": Bool(false),
+            },
+            document: Object {
+                "otherProp": String("stringValue"),
+            },
+        },
+    ),
+    InvalidDefaultValue(
+        "/object-type-prop-wrong-type",
+        FailedValidation {
+            basic_output: Object {
+                "errors": Array [
+                    Object {
+                        "absoluteKeywordLocation": String("http://example/schema#/properties/object-type-prop-wrong-type/properties/requiredProp"),
+                        "error": String("Invalid: Must be of type \"string\"."),
+                        "instanceLocation": String("/requiredProp"),
+                        "keywordLocation": String("#/properties/requiredProp"),
+                    },
+                ],
+                "valid": Bool(false),
+            },
+            document: Object {
+                "requiredProp": Number(1234),
+            },
+        },
+    ),
+    InvalidDefaultValue(
+        "/scalar-type",
+        FailedValidation {
+            basic_output: Object {
+                "errors": Array [
+                    Object {
+                        "absoluteKeywordLocation": String("http://example/schema#/properties/scalar-type"),
+                        "error": String("Invalid: Must be of type \"string\"."),
+                        "instanceLocation": String(""),
+                        "keywordLocation": String("#"),
+                    },
+                ],
+                "valid": Bool(false),
+            },
+            document: Number(1234),
+        },
+    ),
+]

--- a/crates/doc/src/validation.rs
+++ b/crates/doc/src/validation.rs
@@ -171,7 +171,7 @@ impl<'schema, 'doc, 'tmp, N: AsNode> Validation<'schema, 'doc, 'tmp, N> {
     }
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct FailedValidation {
     pub basic_output: serde_json::Value,
     pub document: serde_json::Value,

--- a/crates/schemalate/src/markdown.rs
+++ b/crates/schemalate/src/markdown.rs
@@ -47,6 +47,7 @@ pub fn run(args: Args) -> anyhow::Result<()> {
         let title = shape.title.as_deref().unwrap_or("");
         let desc = shape.description.as_deref().unwrap_or("");
         let type_ = shape.type_.to_vec().join(", ");
+        let def = shape.default.as_ref().map(|(def, _)| def);
 
         println!(
             "| {} | {} | {} | {} | {} |",
@@ -54,7 +55,7 @@ pub fn run(args: Args) -> anyhow::Result<()> {
             md_escape(title),
             md_escape(desc),
             type_,
-            RequiredAndDefault(exists, shape.default.as_ref()),
+            RequiredAndDefault(exists, def),
         );
     }
 


### PR DESCRIPTION
**Description:**

Teaches the drainer to look for default values from `default` annotations in the schema of draining documents if an actual value is not present when extracting fields. This only takes place for a materialization, and is a means to provide an alternative to materializing `null` values.

Closes https://github.com/estuary/flow/issues/764

**Workflow steps:**

Schemas can be annotated with default values, and materializations will use those default values instead of `null`. The values provided in the schema will be validated during builds to ensure they are compatible with the fields they are specified for.

**Documentation links affected:**

It would be good to update our schema annotations docs with this: https://docs.estuary.dev/concepts/schemas/#annotations

We should say that `default` annotations are used by materializations in place of a `null` value, and are not used for captures or derivations. They are only used for materializing into the endpoint.

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/825)
<!-- Reviewable:end -->
