### PR TITLE
Phil/flowctl login ux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
  "anyhow",
  "assemble",
  "assert_cmd",
+ "base64",
  "bytes",
  "clap 3.2.22",
  "comfy-table",
@@ -1219,11 +1220,14 @@ dependencies = [
  "itertools 0.10.5",
  "journal-client",
  "labels",
+ "lazy_static",
  "models",
+ "open",
  "postgrest",
  "proto-flow",
  "proto-gazette",
  "reqwest",
+ "rpassword",
  "schema-inference",
  "serde",
  "serde-transcode",
@@ -2144,7 +2148,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2318,6 +2322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "open"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+dependencies = [
+ "pathdiff",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2453,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2509,6 +2523,12 @@ checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pathfinding"
@@ -3316,6 +3336,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,7 +3459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -5004,12 +5045,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5018,10 +5080,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5030,16 +5104,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ mime = "0.3"
 memchr = "2.5"
 num-bigint = "0.4"
 
+open = "3"
 openssl-sys = { version = "0.9", features = ['vendored'] }
 openssl = "0.10"
 
@@ -94,6 +95,7 @@ rocksdb = { version = "0.17", default-features = false, features = [
     "rtti",
 ] }
 rkyv = { version = "0.7", features = ["archive_le"] }
+rpassword = "7.2"
 rusqlite = { version = "0.27", features = ["bundled-full"] }
 schemars = "0.8"
 scopeguard = "1.1"

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -24,6 +24,7 @@ tables = { path = "../tables" }
 validation = { path = "../validation" }
 
 anyhow = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 comfy-table = { workspace = true }
@@ -32,14 +33,22 @@ dirs = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 itertools = { workspace = true }
+lazy_static = { workspace = true }
+
+# open is used for opening URLs in the user's browser
+open = { workspace = true }
 postgrest = { workspace = true }
 reqwest = { workspace = true }
+# rpassword is used for reading credentials from stdin
+rpassword = { workspace = true }
+
 serde = { workspace = true }
 serde-transcode = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 size = { workspace = true }
 superslice = { workspace = true }
+
 tempfile = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/crates/flowctl/src/auth/mod.rs
+++ b/crates/flowctl/src/auth/mod.rs
@@ -1,5 +1,3 @@
-use super::config;
-
 mod roles;
 
 #[derive(Debug, clap::Args)]
@@ -16,11 +14,6 @@ pub enum Command {
     ///
     /// You can find this token within Flow UI dashboard under "Admin".
     Token(Token),
-    /// Authenticate to a local development instance of the Flow control plane.
-    ///
-    /// This is intended for developers who are running local instances
-    /// of the Flow control and data-planes.
-    Develop(Develop),
     /// Work with authorization roles and grants.
     ///
     /// Roles are prefixes of the Flow catalog namespace.
@@ -47,24 +40,12 @@ pub struct Token {
     token: String,
 }
 
-#[derive(Debug, clap::Args)]
-#[clap(rename_all = "kebab-case")]
-pub struct Develop {
-    #[clap(long)]
-    token: Option<String>,
-}
-
 impl Auth {
     pub async fn run(&self, ctx: &mut crate::CliContext) -> Result<(), anyhow::Error> {
         match &self.cmd {
             Command::Token(Token { token }) => {
-                ctx.config_mut().api = Some(config::API::managed(token.clone()));
+                ctx.config_mut().set_access_token(token.clone());
                 println!("Configured access token.");
-                Ok(())
-            }
-            Command::Develop(Develop { token }) => {
-                ctx.config_mut().api = Some(config::API::development(token.clone()));
-                println!("Configured for local development.");
                 Ok(())
             }
             Command::Roles(roles) => roles.run(ctx).await,

--- a/crates/flowctl/src/auth/mod.rs
+++ b/crates/flowctl/src/auth/mod.rs
@@ -1,5 +1,9 @@
 mod roles;
 
+use anyhow::Context;
+
+use crate::controlplane;
+
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct Auth {
@@ -10,9 +14,21 @@ pub struct Auth {
 #[derive(Debug, clap::Subcommand)]
 #[clap(rename_all = "kebab-case")]
 pub enum Command {
+    /// Authenticate with Flow
+    ///
+    /// This is typically the first command you'll run with `flowctl`.
+    /// Opens your web browser to the /admin/api page and waits for you
+    /// to paste the authentication token you get from there.
+    /// If you're running in an environment that doesn't have a browser,
+    /// then you can alternatively navigate yourself to:
+    /// https://dashboard.estuary.dev/admin/api
+    /// and then run `flowctl auth token --token <paste-token-here>`
+    /// in order to authenticate.
+    Login,
     /// Authenticate to Flow using a secret access token.
     ///
-    /// You can find this token within Flow UI dashboard under "Admin".
+    /// You can find this token within Flow UI dashboard under "Admin"
+    /// (https://dashboard.estuary.dev/admin/api).
     Token(Token),
     /// Work with authorization roles and grants.
     ///
@@ -43,12 +59,42 @@ pub struct Token {
 impl Auth {
     pub async fn run(&self, ctx: &mut crate::CliContext) -> Result<(), anyhow::Error> {
         match &self.cmd {
+            Command::Login => do_login(ctx).await,
             Command::Token(Token { token }) => {
-                ctx.config_mut().set_access_token(token.clone());
+                controlplane::configure_new_access_token(ctx, token.clone())?;
                 println!("Configured access token.");
                 Ok(())
             }
             Command::Roles(roles) => roles.run(ctx).await,
         }
+    }
+}
+
+async fn do_login(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
+    use crossterm::tty::IsTty;
+
+    let url = ctx.config().get_dashboard_url("/admin/api")?.to_string();
+
+    println!("\nopening browser to: {url}");
+    open::that(&url).context("failed to open web browser")?;
+
+    if std::io::stdin().is_tty() {
+        println!("please paste the token from the CLI auth page and hit Enter");
+        let token = tokio::task::spawn_blocking(|| rpassword::prompt_password("Auth Token: "))
+            .await?
+            .context("failed to read auth token")?;
+        // copied credentials will often accidentally contain extra whitespace characters
+        let token = token.trim().to_string();
+        ctx.config_mut().set_access_token(token);
+        println!("\nConfigured access token.");
+        Ok(())
+    } else {
+        // This is not necessarily a problem for the user, because they can just run
+        // `auth token --token ...`, but we still need to exit non-zero
+        anyhow::bail!(
+            "unable to read auth token because flowctl \
+            is not running interactively. You can still login non-interactively \
+            by running `flowctl auth token --token <paste-token-here>`"
+        );
     }
 }

--- a/crates/flowctl/src/auth/roles.rs
+++ b/crates/flowctl/src/auth/roles.rs
@@ -138,7 +138,7 @@ pub async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("combined_grants_ext")
             .select(
                 vec![
@@ -176,7 +176,7 @@ pub async fn do_grant(
     // Upsert user grants to `user_grants` and role grants to `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -193,7 +193,7 @@ pub async fn do_grant(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -228,7 +228,7 @@ pub async fn do_revoke(
     // Revoke user grants from `user_grants` and role grants from `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .eq("user_id", subject_user_id.to_string())
@@ -238,7 +238,7 @@ pub async fn do_revoke(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .eq("subject_role", subject_role)

--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -147,7 +147,7 @@ async fn do_list(ctx: &mut crate::CliContext, List { flows }: &List) -> anyhow::
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("live_specs_ext")
             .select(columns.join(",")),
     )
@@ -201,7 +201,7 @@ async fn do_history(ctx: &mut crate::CliContext, History { name }: &History) -> 
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("publication_specs_ext")
             .like("catalog_name", format!("{name}%"))
             .select(
@@ -251,7 +251,7 @@ async fn do_draft(
         mut spec_type,
     } = if let Some(publication_id) = publication_id {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("publication_specs_ext")
                 .eq("catalog_name", name)
                 .eq("pub_id", publication_id)
@@ -261,7 +261,7 @@ async fn do_draft(
         .await?
     } else {
         api_exec(
-            ctx.client()?
+            ctx.controlplane_client()?
                 .from("live_specs")
                 .eq("catalog_name", name)
                 .select("catalog_name,last_pub_id,pub_id:last_pub_id,spec,spec_type")
@@ -295,7 +295,7 @@ async fn do_draft(
     tracing::debug!(?draft_spec, "inserting draft");
 
     let rows: Vec<SpecSummaryItem> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("draft_specs")
             .select("catalog_name,spec_type")
             .upsert(serde_json::to_string(&draft_spec).unwrap())

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -225,8 +225,11 @@ async fn do_list_fragments(
     ctx: &mut crate::CliContext,
     args: &ListFragmentsArgs,
 ) -> Result<(), anyhow::Error> {
-    let mut client =
-        journal_client_for(ctx.config(), vec![args.selector.collection.clone()]).await?;
+    let mut client = journal_client_for(
+        ctx.controlplane_client()?,
+        vec![args.selector.collection.clone()],
+    )
+    .await?;
 
     let journals = list::list_journals(&mut client, &args.selector.build_label_selector()).await?;
 
@@ -265,7 +268,8 @@ async fn do_list_journals(
     ctx: &mut crate::CliContext,
     args: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
-    let mut client = journal_client_for(ctx.config(), vec![args.collection.clone()]).await?;
+    let mut client =
+        journal_client_for(ctx.controlplane_client()?, vec![args.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -32,6 +32,15 @@ impl Config {
             }
         }
     }
+
+    pub fn set_access_token(&mut self, access_token: String) {
+        // Don't overwrite the other fields of api if they are already present.
+        if let Some(api) = self.api.as_mut() {
+            api.access_token = access_token;
+        } else {
+            self.api = Some(API::managed(access_token));
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -45,21 +54,11 @@ pub struct API {
 }
 
 impl API {
-    pub fn managed(access_token: String) -> Self {
+    fn managed(access_token: String) -> Self {
         Self {
             endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
             public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
             access_token,
-        }
-    }
-    pub fn development(access_token: Option<String>) -> Self {
-        Self {
-            endpoint: url::Url::parse("http://localhost:5431/rest/v1").unwrap(),
-            public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs".to_string(),
-            // Access token for user "bob" in the development database, good for ten years.
-            access_token: access_token.unwrap_or(
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoyMjgwMDY3NTAwLCJzdWIiOiIyMjIyMjIyMi0yMjIyLTIyMjItMjIyMi0yMjIyMjIyMjIyMjIiLCJlbWFpbCI6ImJvYkBleGFtcGxlLmNvbSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.7BJJJI17d24Hb7ZImlGYDRBCMDHkqU1ppVTTfqD5l8I".to_string(),
-            )
         }
     }
 }

--- a/crates/flowctl/src/controlplane.rs
+++ b/crates/flowctl/src/controlplane.rs
@@ -1,0 +1,95 @@
+use crate::config::Config;
+use crate::CliContext;
+
+use anyhow::Context;
+use serde::Deserialize;
+use std::fmt::{self, Debug};
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// A wafer-thin wrapper around a `Postgrest` client that makes it
+/// cheaply cloneable and implements `Debug`. This allows us to create
+/// a client once and then store it in the `CliContext` for future re-use.
+/// This client implements `Deref<Target=Postgrest>`, so you can use it
+/// just like you would the normal `Postgrest` client.
+#[derive(Clone)]
+pub struct Client(Arc<postgrest::Postgrest>);
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We can't really give a better debug impl since Postgrest
+        // keeps all of its members private.
+        f.write_str("controlplane::Client")
+    }
+}
+
+impl Deref for Client {
+    type Target = postgrest::Postgrest;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+/// Creates a new client. **you should instead call `CliContext::controlplane_client(&mut Self)`**, which
+/// will re-use the existing client if possible.
+pub(crate) fn new_client(config: &Config) -> anyhow::Result<Client> {
+    match &config.api {
+        Some(api) => {
+            // Try to give users a more friendly error message if we know their credentials are expired.
+            check_access_token(&api.access_token)?;
+            let client = postgrest::Postgrest::new(api.endpoint.as_str());
+            let client = client.insert_header("apikey", &api.public_token);
+            let client =
+                client.insert_header("Authorization", format!("Bearer {}", &api.access_token));
+            Ok(Client(Arc::new(client)))
+        }
+        None => {
+            anyhow::bail!("You must run `auth login` first")
+        }
+    }
+}
+
+pub fn configure_new_access_token(ctx: &mut CliContext, token: String) -> anyhow::Result<()> {
+    // try to catch issues caused by missing or extra data that may have been accidentally copied
+    let email = check_access_token(&token)?;
+    ctx.config_mut().set_access_token(token);
+    println!("Configured access token for user: '{email}'");
+    Ok(())
+}
+
+fn check_access_token(token: &str) -> anyhow::Result<String> {
+    let jwt = parse_jwt(token).context("invalid access_token")?;
+    // Try to give users a more friendly error message if we know their credentials are expired.
+    if jwt.is_expired() {
+        anyhow::bail!("access token is expired, please re-authenticate and then try again");
+    }
+    Ok(jwt.email)
+}
+
+#[derive(Deserialize)]
+struct JWT {
+    email: String,
+    exp: i64,
+}
+
+impl JWT {
+    fn is_expired(&self) -> bool {
+        let exp = time::OffsetDateTime::from_unix_timestamp(self.exp).unwrap_or_else(|err| {
+            tracing::error!(exp = self.exp, error = %err, "invalid exp in JWT");
+            time::OffsetDateTime::UNIX_EPOCH
+        });
+        time::OffsetDateTime::now_utc() >= exp
+    }
+}
+
+fn parse_jwt(jwt: &str) -> anyhow::Result<JWT> {
+    let payload = jwt
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("invalid JWT"))?;
+    let json_data =
+        base64::decode_config(payload, base64::URL_SAFE_NO_PAD).context("invalid JWT")?;
+    let data: JWT = serde_json::from_slice(&json_data).context("parsing JWT data")?;
+    Ok(data)
+}

--- a/crates/flowctl/src/dataplane.rs
+++ b/crates/flowctl/src/dataplane.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::controlplane;
 use anyhow::Context;
 use serde::Deserialize;
 
@@ -11,10 +11,9 @@ pub struct DataPlaneAccess {
 
 /// Fetches connection info for accessing a data plane for the given catalog namespace prefixes.
 pub async fn fetch_data_plane_access_token(
-    cfg: &Config,
+    client: controlplane::Client,
     prefixes: Vec<String>,
 ) -> anyhow::Result<DataPlaneAccess> {
-    let client = cfg.client()?;
     tracing::debug!(?prefixes, "requesting data-plane access token for prefixes");
 
     let body = serde_json::to_string(&serde_json::json!({
@@ -47,13 +46,13 @@ pub async fn fetch_data_plane_access_token(
 
 /// Returns an authenticated journal client that's authorized to the given prefixes.
 pub async fn journal_client_for(
-    cfg: &Config,
+    cp_client: controlplane::Client,
     prefixes: Vec<String>,
 ) -> anyhow::Result<journal_client::Client> {
     let DataPlaneAccess {
         auth_token,
         gateway_url,
-    } = fetch_data_plane_access_token(cfg, prefixes).await?;
+    } = fetch_data_plane_access_token(cp_client, prefixes).await?;
     tracing::debug!(%gateway_url, "acquired data-plane-gateway access token");
 
     let client =

--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -99,7 +99,7 @@ pub async fn do_author(
     body.push(']' as u8);
 
     let rows: Vec<SpecSummaryItem> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("draft_specs")
             .select("catalog_name,spec_type")
             .upsert(String::from_utf8(body).expect("serialized JSON is always UTF-8"))

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -31,7 +31,7 @@ pub async fn do_develop(
         spec_type: String,
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("draft_specs")
             .select("catalog_name,spec,spec_type")
             .not("is", "spec_type", "null")

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -110,7 +110,7 @@ async fn do_create(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let row: Row = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("drafts")
             .select("id, created_at")
             .insert(serde_json::json!({"detail": "Created by flowctl"}).to_string())
@@ -141,7 +141,7 @@ async fn do_delete(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let row: Row = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("drafts")
             .select("id,updated_at")
             .delete()
@@ -188,7 +188,7 @@ async fn do_describe(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("draft_specs_ext")
             .select(
                 vec![
@@ -233,7 +233,7 @@ async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("drafts_ext")
             .select("created_at,detail,id,num_specs,updated_at"),
     )
@@ -257,7 +257,7 @@ async fn do_select(
     Select { id: select_id }: &Select,
 ) -> anyhow::Result<()> {
     let matched: Vec<serde_json::Value> = api_exec(
-        ctx.client()?
+        ctx.controlplane_client()?
             .from("drafts")
             .eq("id", select_id)
             .select("id"),
@@ -274,7 +274,7 @@ async fn do_select(
 
 async fn do_publish(ctx: &mut crate::CliContext, dry_run: bool) -> anyhow::Result<()> {
     let cur_draft = ctx.config().cur_draft()?;
-    let client = ctx.client()?;
+    let client = ctx.controlplane_client()?;
 
     #[derive(Deserialize)]
     struct Row {

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -35,7 +35,7 @@ pub struct Cli {
     /// Profile are distinct configurations of the `flowctl` tool, and are
     /// completely optional. Use multiple profiles to track multiple accounts
     /// or development endpoints.
-    #[clap(long, default_value = "default")]
+    #[clap(long, default_value = "default", env = "FLOWCTL_PROFILE")]
     profile: String,
 
     #[clap(subcommand)]

--- a/crates/flowctl/src/raw.rs
+++ b/crates/flowctl/src/raw.rs
@@ -108,7 +108,7 @@ impl Advanced {
 }
 
 async fn do_get(ctx: &mut crate::CliContext, Get { table, query }: &Get) -> anyhow::Result<()> {
-    let req = ctx.client()?.from(table).build().query(query);
+    let req = ctx.controlplane_client()?.from(table).build().query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);
@@ -119,7 +119,12 @@ async fn do_update(
     ctx: &mut crate::CliContext,
     Update { table, query, body }: &Update,
 ) -> anyhow::Result<()> {
-    let req = ctx.client()?.from(table).update(body).build().query(query);
+    let req = ctx
+        .controlplane_client()?
+        .from(table)
+        .update(body)
+        .build()
+        .query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);
@@ -134,7 +139,11 @@ async fn do_rpc(
         body,
     }: &Rpc,
 ) -> anyhow::Result<()> {
-    let req = ctx.client()?.rpc(function, body).build().query(query);
+    let req = ctx
+        .controlplane_client()?
+        .rpc(function, body)
+        .build()
+        .query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);

--- a/local/local-flowctl-config.json
+++ b/local/local-flowctl-config.json
@@ -1,4 +1,5 @@
 {
+	"dashboard_url": "http://localhost:3000",
 	"api": {
 		"endpoint": "http://localhost:5431/rest/v1",
 		"public_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs",

--- a/local/local-flowctl-config.json
+++ b/local/local-flowctl-config.json
@@ -1,0 +1,7 @@
+{
+	"api": {
+		"endpoint": "http://localhost:5431/rest/v1",
+		"public_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs",
+		"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoyMjgwMDY3NTAwLCJzdWIiOiIyMjIyMjIyMi0yMjIyLTIyMjItMjIyMi0yMjIyMjIyMjIyMjIiLCJlbWFpbCI6ImJvYkBleGFtcGxlLmNvbSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.7BJJJI17d24Hb7ZImlGYDRBCMDHkqU1ppVTTfqD5l8I"
+	}
+}

--- a/local/start-flow.sh
+++ b/local/start-flow.sh
@@ -39,6 +39,19 @@ function bail() {
 # verify requirements here, before we get into the tmux session.
 command -v nc || bail "netcat must be installed (nc command was not found)"
 
+function copy_local_flowctl_config() {
+    local src="${SCRIPT_DIR}/local-flowctl-config.json"
+    local target="${HOME}/.config/flowctl/local.json"
+    if [[ "$(uname)" == 'Darwin' ]]; then
+        target="${HOME}/Library/Application Support/flowctl/local.json"
+    fi
+
+    if [[ ! -f "$target" ]]; then
+        log "copying local flowctl config from '${src}' to '${target}'"
+        cp "$src" "$target"
+    fi
+}
+
 function start_component() {
     local component="$1"
     tmux new-window -d -t "$SESSION" -n "$component"
@@ -60,6 +73,11 @@ if tmux has -t "$SESSION"; then
     exit 0
 fi
 
+copy_local_flowctl_config
+# Exporting this variable means that all `flowctl` invocations from inside the tmux
+# session will use the local config by default, so you don't need to pass `--profile local`
+# every time.
+export FLOWCTL_PROFILE=local
 tmux new-session -d -s "$SESSION" -n 'terminal'
 log "Created new tmux session called '$SESSION'"
 


### PR DESCRIPTION
**Description:**

This rolls up a few improvements to the user experience of `flowctl auth` subcommands:

- Removes `flowctl auth develop`
- Adds a default local configuration for use with `start-flow.sh`
- Adds the `flowctl auth login` subcommand

**Workflow steps:**

`flowctl auth login`:

The current authentication workflow will continue to work and there's no reason to discourage it's use. `flowctl auth login` provides an easier entrypoint to that process, which may be easier for CLI users to discover (`flowctl auth --help`) and use. To use this, just run `flowctl auth login`, and it will open the browser to the `/admin/api` page. You copy your token and then paste it into the terminal where `flowctl` is waiting.

`start-flow.sh`:

- `start-flow.sh` will now provide a default config file for the `local`
  profile. You can run `flowctl --profile local` in order to use that
  config file.
- The `--profile` argument may also be provided by the `FLOWCTL_PROFILE`
  environment variable. This allows you to `export FLOWCTL_PROFILE=local`
  to avoid the need to pass `--profile` every time.
- `start-flow.sh` was updated to automatically export `FLOWCTL_PROFILE=local`
  in the tmux windows it opens, so any `flowctl` commands you run
  in those panes will automatically work against the local instance.

**Documentation links affected:**

We could update the [getting started docs](https://docs.estuary.dev/getting-started/installation/#get-started-with-the-flow-cli), but I think we should wait until estuary/ui#399 is addressed before we make this workflow too public.

**Notes for reviewers:**

Commit by commit will definitely be easiest here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/828)
<!-- Reviewable:end -->
