### PR TITLE
oauth/helpers: support mustache and handlebars block helpers

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -13,11 +13,33 @@ export const returnPostgresError = (error: any) => {
 };
 
 export const handlebarsHelpers = {
-    urlencode: function (s: string) {
-        return encodeURIComponent(s);
+    urlencode: function (s: any) {
+        // Handlebars block helpers work this way
+        if (s) {
+          if (s.fn) {
+            return encodeURIComponent(s.fn(this));
+          } else {
+            return encodeURIComponent(s);
+          }
+        }
+
+        // Mustache works this way
+        return (s: string, render: any) => {
+          return encodeURIComponent(render(s));
+        }
     },
-    basicauth: function (user: string, password: string) {
-        return btoa(`${user}:${password}`);
+    basicauth: function (s: any, b: any) {
+      if (s) {
+        if (s.fn) {
+          return btoa(s.fn(this));
+        } else if (b) {
+          return btoa(`${s}:${b}`);
+        }
+      }
+
+      return (s: string, render: any) => {
+        return btoa(render(s));
+      }
     },
 };
 


### PR DESCRIPTION
**Description:**

- Mustache does not support inline helpers like Handlebars, that is: `{{ urlencode x }}` is not supported by Mustache.
- All helpers are block helpers in Mustache, so we need to support `{{#urlencode}}{{{x}}}{{/urlencode}}`. This is also supported by Handlebars.
- This pull-request updates our helpers so that they support inline helpers (current templates), block helpers in Handlebars, and block helpers in Mustache, so we can start switching all helper usages to block helpers as we go while not breaking things.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/833)
<!-- Reviewable:end -->
