### PR TITLE
refactor: Update the Push capture logic

### DIFF
--- a/go/protocols/capture/coordinator.go
+++ b/go/protocols/capture/coordinator.go
@@ -243,3 +243,11 @@ func (c *coordinator) loop(
 // further documents and checkpoints will not be folded into the
 // transaction.
 var combinerByteThreshold = (1 << 27) // 128MB.
+
+func GetCombinerByteThreshold() int {
+	return combinerByteThreshold
+}
+
+func SetCombinerByteThreshold(newThreshold int) {
+	combinerByteThreshold = newThreshold
+}

--- a/go/protocols/capture/lifecycle_test.go
+++ b/go/protocols/capture/lifecycle_test.go
@@ -1,9 +1,10 @@
-package capture
+package capture_test
 
 import (
 	"io"
 	"testing"
 
+	"github.com/estuary/flow/go/protocols/capture"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
@@ -12,15 +13,15 @@ func TestPullWrites(t *testing.T) {
 	var stream = new(pullStream)
 	var srv = &pullSrvStream{pullStream: stream}
 
-	var staged *PullResponse
-	require.NoError(t, StagePullDocuments(srv, &staged, 0, []byte(`"doc-1"`)))
-	require.NoError(t, StagePullDocuments(srv, &staged, 1, []byte(`"doc-2"`)))
-	require.NoError(t, StagePullDocuments(srv, &staged, 1, []byte(`"doc-3"`)))
-	require.NoError(t, StagePullDocuments(srv, &staged, 2, []byte(`"doc-4"`)))
-	require.NoError(t, WritePullCheckpoint(srv, &staged, makeCheckpoint(map[string]int{"a": 1})))
-	require.NoError(t, WritePullCheckpoint(srv, &staged, makeCheckpoint(map[string]int{"b": 2})))
+	var staged *capture.PullResponse
+	require.NoError(t, capture.StagePullDocuments(srv, &staged, 0, []byte(`"doc-1"`)))
+	require.NoError(t, capture.StagePullDocuments(srv, &staged, 1, []byte(`"doc-2"`)))
+	require.NoError(t, capture.StagePullDocuments(srv, &staged, 1, []byte(`"doc-3"`)))
+	require.NoError(t, capture.StagePullDocuments(srv, &staged, 2, []byte(`"doc-4"`)))
+	require.NoError(t, capture.WritePullCheckpoint(srv, &staged, makeCheckpoint(map[string]int{"a": 1})))
+	require.NoError(t, capture.WritePullCheckpoint(srv, &staged, makeCheckpoint(map[string]int{"b": 2})))
 
-	require.Equal(t, []*PullResponse{
+	require.Equal(t, []*capture.PullResponse{
 		{Documents: makeDocs(0, "doc-1")},
 		{Documents: makeDocs(1, "doc-2", "doc-3")},
 		{Documents: makeDocs(2, "doc-4")},
@@ -36,19 +37,19 @@ func TestPushRoundTrip(t *testing.T) {
 	var srv = &pushSrvStream{pushStream: stream}
 
 	// Write a sequence of documents with varying bindings, and checkpoints.
-	var staged *PushRequest
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-1"`)))
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-2"`)))
-	require.NoError(t, StagePushDocuments(cli, &staged, 1, []byte(`"doc-3"`)))
-	require.NoError(t, WritePushCheckpoint(cli, &staged, makeCheckpoint(map[string]int{"a": 1})))
-	require.NoError(t, StagePushDocuments(cli, &staged, 1, []byte(`"doc-4"`)))
-	require.NoError(t, WritePushCheckpoint(cli, &staged, makeCheckpoint(map[string]int{"b": 2})))
+	var staged *capture.PushRequest
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-1"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-2"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 1, []byte(`"doc-3"`)))
+	require.NoError(t, capture.WritePushCheckpoint(cli, &staged, makeCheckpoint(map[string]int{"a": 1})))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 1, []byte(`"doc-4"`)))
+	require.NoError(t, capture.WritePushCheckpoint(cli, &staged, makeCheckpoint(map[string]int{"b": 2})))
 
 	// Expect to read two separate checkpointed chunks.
-	var docs, checkpoint, err = ReadPushCheckpoint(srv, 1024)
+	var docs, checkpoint, err = capture.ReadPushCheckpoint(srv, 1024)
 	require.NoError(t, err)
 
-	require.Equal(t, []Documents{
+	require.Equal(t, []capture.Documents{
 		*makeDocs(0, "doc-1", "doc-2"), // Merged.
 		*makeDocs(1, "doc-3"),
 	}, docs)
@@ -57,10 +58,10 @@ func TestPushRoundTrip(t *testing.T) {
 		Rfc7396MergePatch:    true,
 	}, checkpoint)
 
-	docs, checkpoint, err = ReadPushCheckpoint(srv, 1024)
+	docs, checkpoint, err = capture.ReadPushCheckpoint(srv, 1024)
 	require.NoError(t, err)
 
-	require.Equal(t, []Documents{
+	require.Equal(t, []capture.Documents{
 		*makeDocs(1, "doc-4"),
 	}, docs)
 	require.Equal(t, pf.DriverCheckpoint{
@@ -69,34 +70,34 @@ func TestPushRoundTrip(t *testing.T) {
 	}, checkpoint)
 
 	// Followed by EOF.
-	_, _, err = ReadPushCheckpoint(srv, 1024)
+	_, _, err = capture.ReadPushCheckpoint(srv, 1024)
 	require.Equal(t, io.EOF, err)
 
 	// Case: checkpoint is too large.
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-5"`)))
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-6"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-5"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-6"`)))
 	cli.Send(staged)
 
-	_, _, err = ReadPushCheckpoint(srv, 8)
+	_, _, err = capture.ReadPushCheckpoint(srv, 8)
 	require.EqualError(t, err, "too many documents without a checkpoint (14 bytes vs max of 8)")
 
 	// Case: Documents, then without a checkpoint.
 	*stream, staged = pushStream{}, nil // Reset.
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-7"`)))
-	require.NoError(t, StagePushDocuments(cli, &staged, 0, []byte(`"doc-8"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-7"`)))
+	require.NoError(t, capture.StagePushDocuments(cli, &staged, 0, []byte(`"doc-8"`)))
 	cli.Send(staged)
 
-	_, _, err = ReadPushCheckpoint(srv, 1024)
+	_, _, err = capture.ReadPushCheckpoint(srv, 1024)
 	require.Equal(t, io.ErrUnexpectedEOF, err)
 }
 
 type pullStream struct {
-	req  []*PullRequest
-	resp []*PullResponse
+	req  []*capture.PullRequest
+	resp []*capture.PullResponse
 }
 type pushStream struct {
-	req  []*PushRequest
-	resp []*PushResponse
+	req  []*capture.PushRequest
+	resp []*capture.PushResponse
 }
 
 type pullClientStream struct{ *pullStream }
@@ -105,24 +106,24 @@ type pullSrvStream struct{ *pullStream }
 type pushClientStream struct{ *pushStream }
 type pushSrvStream struct{ *pushStream }
 
-func (s *pullClientStream) Send(r *PullRequest) error {
+func (s *pullClientStream) Send(r *capture.PullRequest) error {
 	s.req = append(s.req, r)
 	return nil
 }
-func (s *pushClientStream) Send(r *PushRequest) error {
+func (s *pushClientStream) Send(r *capture.PushRequest) error {
 	s.req = append(s.req, r)
 	return nil
 }
-func (s *pullSrvStream) Send(r *PullResponse) error {
+func (s *pullSrvStream) Send(r *capture.PullResponse) error {
 	s.resp = append(s.resp, r)
 	return nil
 }
-func (s *pushSrvStream) Send(r *PushResponse) error {
+func (s *pushSrvStream) Send(r *capture.PushResponse) error {
 	s.resp = append(s.resp, r)
 	return nil
 }
 
-func (s *pushSrvStream) Recv() (*PushRequest, error) {
+func (s *pushSrvStream) Recv() (*capture.PushRequest, error) {
 	if len(s.req) == 0 {
 		return nil, io.EOF
 	}

--- a/go/protocols/capture/push_server_test.go
+++ b/go/protocols/capture/push_server_test.go
@@ -3,19 +3,16 @@ package capture_test
 import (
 	"context"
 	"encoding/json"
-	fmt "fmt"
 	"io"
 	"io/ioutil"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
-	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/ops"
 	"github.com/estuary/flow/go/protocols/capture"
 	"github.com/estuary/flow/go/protocols/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.gazette.dev/core/broker/client"
 )
@@ -50,15 +47,7 @@ func TestPushServerLifecycle(t *testing.T) {
 			return new(pf.MockCombiner), nil
 		},
 		func(binding *flow.CaptureSpec_Binding) (pf.Extractor, error) {
-			var extractor, err = bindings.NewExtractor(localPublisher)
-			if err != nil {
-				return nil, err
-			}
-			logrus.Info(fmt.Sprintf("Configuring extractor with this schema: %s", string(binding.Collection.WriteSchemaJson)))
-
-			extractor.Configure("", []string{}, binding.Collection.WriteSchemaJson)
-
-			return extractor, nil
+			return new(pf.MockExtractor), nil
 		},
 		pf.NewFullRange(),
 		&spec,

--- a/go/protocols/flow/combiner.go
+++ b/go/protocols/flow/combiner.go
@@ -6,6 +6,26 @@ import (
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 
+// Extractor validates and extracts keys from documents
+type Extractor interface {
+	// Configure or re-configure the Extractor. If schemaURI is non-empty, it's
+	// validated during extraction and the SchemaIndex must be non-nil.
+	// Otherwise, both may be zero-valued.
+	Configure(
+		uuidPtr string,
+		fieldPtrs []string,
+		schemaJSON json.RawMessage,
+	) error
+
+	// Document queues a document for extraction.
+	Document(doc []byte)
+
+	// Extract UUIDs and field tuples from all documents queued since the last Extract.
+	// The returned UUIDParts and tuples are valid *only* until the next
+	// call to Extract -- you *must* copy out before calling Extract again.
+	Extract() ([]UUIDParts, [][]byte, error)
+}
+
 // Combiner combines and reduces keyed documents.
 type Combiner interface {
 	// ReduceLeft reduces the document on its key with a current right-hand side combined state.

--- a/go/protocols/flow/combiner.go
+++ b/go/protocols/flow/combiner.go
@@ -26,6 +26,24 @@ type Extractor interface {
 	Extract() ([]UUIDParts, [][]byte, error)
 }
 
+// MockCombiner implements Extractor by doing nothing useful, always validating
+type MockExtractor struct {
+}
+
+func (c *MockExtractor) Configure(
+	uuidPtr string,
+	fieldPtrs []string,
+	schemaJSON json.RawMessage,
+) error {
+	return nil
+}
+
+func (c *MockExtractor) Document(doc []byte) {}
+
+func (c *MockExtractor) Extract() ([]UUIDParts, [][]byte, error) {
+	return nil, nil, nil
+}
+
 // Combiner combines and reduces keyed documents.
 type Combiner interface {
 	// ReduceLeft reduces the document on its key with a current right-hand side combined state.


### PR DESCRIPTION
**Description:**

* Answer `Open` messages with `Opened` messages, allowing clients to get the capture spec. This is important because the client needs to provide the binding _index_ as part of its Push request, which can only be determined given the correct spec
* Pre-validate documents in order to respond with prompt, clear validation errors rather than failing the shard and timing out the request. This has a few yak-shaves, including:
  * Update the extraction API to handle empty UUIDs as an intent to skip UUID extraction, allowing it to be used for purely validation if desired
  * Move the push/pull tests into a separate package in order to fix a circular dependency issue
  * In order to access the extraction service, we have to do some indirection magic with interfaces and factory functions, which is the justification for the new `pf.Extractor` interface, and the whole `newExtractorFn` stuff

Part of #814

Note: I'm going to go through this in a bit and remove some extra-verbose debug logging

**TODO**: figure out how to authorize requests here

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/836)
<!-- Reviewable:end -->
