### PR TITLE
ops-catalog: stats derivation does not output explicit zero values

### DIFF
--- a/ops-catalog/ops-catalog-stats-schema.json
+++ b/ops-catalog/ops-catalog-stats-schema.json
@@ -30,7 +30,6 @@
                 "writtenToMe": { "$ref": "ops-stats-schema.json#/$defs/docsAndBytes" }
             },
             "reduce": {"strategy": "merge"},
-            "required": ["readByMe", "readFromMe", "writtenByMe", "writtenToMe"]
         },
         "taskStats": {
             "type": "object",

--- a/ops-catalog/ops-stats-schema.json
+++ b/ops-catalog/ops-stats-schema.json
@@ -84,11 +84,13 @@
                 "docsTotal": {
                     "description": "Total number of documents",
                     "type": "integer",
+                    "default": 0,
                     "reduce": {"strategy": "sum"}
                 },
                 "bytesTotal": {
                     "description": "Total number of bytes representing the JSON encoded documents",
                     "type": "integer",
+                    "default": 0,
                     "reduce": {"strategy": "sum"}
                 }
             },

--- a/ops-catalog/stats-local-endpoint.sops.yaml
+++ b/ops-catalog/stats-local-endpoint.sops.yaml
@@ -1,4 +1,4 @@
-address: localhost:5432
+address: supabase_db_flow.supabase_network_flow:5432
 database: postgres
 password: stats_loader_password
 user: stats_loader

--- a/ops-catalog/template-common.flow.yaml
+++ b/ops-catalog/template-common.flow.yaml
@@ -61,6 +61,10 @@ tests:
               tenant/test/collection:
                 right: { docsTotal: 1, bytesTotal: 15 }
                 out: { docsTotal: 2, bytesTotal: 20 }
+              # Capture task with multiple bound collections.
+              tenant/test/otherCaptureCollection:
+                right: { docsTotal: 5, bytesTotal: 55 }
+                out: { docsTotal: 6, bytesTotal: 65 }
             txnCount: 2
             openSecondsTotal: 0.012
           # Same capture at a different hour, but the same day & month.
@@ -89,6 +93,9 @@ tests:
             materialize:
               tenant/test/collection:
                 right: { docsTotal: 10, bytesTotal: 150 }
+              # Materialization task with multiple bound collections.
+              tenant/test/otherMaterializationCollection:
+                right: { docsTotal: 5, bytesTotal: 75 }
             txnCount: 2
             openSecondsTotal: 0.012
 
@@ -123,184 +130,161 @@ tests:
             txnCount: 2
             openSecondsTotal: 0.012
     - verify:
-        # Note: Spot checking docs counts in the monthly entry for tenant/test/collection.
         collection: ops/TENANT/catalog-stats
         documents:
-            # Capture task
+          # Capture task
           - catalogName: "tenant/test/cap"
             grain: "daily"
             ts: "2022-04-03T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 65 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              writtenByMe: { bytesTotal: 130, docsTotal: 12 }
           - catalogName: "tenant/test/cap"
             grain: "hourly"
             ts: "2022-04-03T02:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 20 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              writtenByMe: { bytesTotal: 85, docsTotal: 8 }
           - catalogName: "tenant/test/cap"
             grain: "hourly"
             ts: "2022-04-03T03:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 45 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              writtenByMe: { bytesTotal: 45, docsTotal: 4 }
           - catalogName: "tenant/test/cap"
             grain: "monthly"
             ts: "2022-04-01T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 65 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              writtenByMe: { bytesTotal: 130, docsTotal: 12 }
 
             # Collection & derivation combo entity
           - catalogName: "tenant/test/collection"
             grain: "daily"
             ts: "2022-04-03T00:00:00.000Z" # Capture day
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 65 }
+              writtenToMe: { bytesTotal: 65, docsTotal: 6 }
           - catalogName: "tenant/test/collection"
             grain: "daily"
             ts: "2022-04-04T00:00:00.000Z" # Materialization day
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 150 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 150, docsTotal: 10 }
           - catalogName: "tenant/test/collection"
             grain: "daily"
             ts: "2022-04-05T00:00:00.000Z" # Derivation day
             statsSummary:
-              readByMe:     { bytesTotal: 90 }
-              writtenByMe:  { bytesTotal: 75 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 75 }
+              readByMe: { bytesTotal: 90, docsTotal: 18 }
+              writtenByMe: { bytesTotal: 75, docsTotal: 7 }
+              writtenToMe: { bytesTotal: 75, docsTotal: 7 }
           - catalogName: "tenant/test/collection"
             grain: "hourly"
             ts: "2022-04-03T02:00:00.000Z" # Capture hour 1
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 20 }
+              writtenToMe: { bytesTotal: 20, docsTotal: 2 }
           - catalogName: "tenant/test/collection"
             grain: "hourly"
             ts: "2022-04-03T03:00:00.000Z" # Capture hour 2
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 45 }
+              writtenToMe: { bytesTotal: 45, docsTotal: 4 }
           - catalogName: "tenant/test/collection"
             grain: "hourly"
             ts: "2022-04-04T03:00:00.000Z" # Materialization hour
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 150 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 150, docsTotal: 10 }
           - catalogName: "tenant/test/collection"
             grain: "hourly"
             ts: "2022-04-05T05:00:00.000Z" # Derivation hour
             statsSummary:
-              readByMe:     { bytesTotal: 90 }
-              writtenByMe:  { bytesTotal: 75 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 75 }
+              readByMe: { bytesTotal: 90, docsTotal: 18 }
+              writtenByMe: { bytesTotal: 75, docsTotal: 7 }
+              writtenToMe: { bytesTotal: 75, docsTotal: 7 }
           - catalogName: "tenant/test/collection"
             grain: "monthly"
             ts: "2022-04-01T00:00:00.000Z" # Same month for capture, materialization, and derivation.
             statsSummary:
-              readByMe:     { bytesTotal: 90,  docsTotal: 18 }
-              writtenByMe:  { bytesTotal: 75,  docsTotal: 7 }
-              readFromMe:   { bytesTotal: 150, docsTotal: 10 }
-              writtenToMe:  { bytesTotal: 140, docsTotal: 13 }
+              readByMe: { bytesTotal: 90, docsTotal: 18 }
+              writtenByMe: { bytesTotal: 75, docsTotal: 7 }
+              readFromMe: { bytesTotal: 150, docsTotal: 10 }
+              writtenToMe: { bytesTotal: 140, docsTotal: 13 }
 
             # The materializaton task.
           - catalogName: "tenant/test/mat"
             grain: "daily"
             ts: "2022-04-04T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 150 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              readByMe: { bytesTotal: 225, docsTotal: 15 }
           - catalogName: "tenant/test/mat"
             grain: "hourly"
             ts: "2022-04-04T03:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 150 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              readByMe: { bytesTotal: 225, docsTotal: 15 }
           - catalogName: "tenant/test/mat"
             grain: "monthly"
             ts: "2022-04-01T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 150 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 0 }
-              writtenToMe:  { bytesTotal: 0 }
+              readByMe: { bytesTotal: 225, docsTotal: 15 }
+
+            # The "other" bound capture collection.
+          - catalogName: "tenant/test/otherCaptureCollection"
+            grain: "daily"
+            ts: "2022-04-03T00:00:00.000Z"
+            statsSummary:
+              writtenToMe: { bytesTotal: 65, docsTotal: 6 }
+          - catalogName: "tenant/test/otherCaptureCollection"
+            grain: "hourly"
+            ts: "2022-04-03T02:00:00.000Z"
+            statsSummary:
+              writtenToMe: { bytesTotal: 65, docsTotal: 6 }
+          - catalogName: "tenant/test/otherCaptureCollection"
+            grain: "monthly"
+            ts: "2022-04-01T00:00:00.000Z"
+            statsSummary:
+              writtenToMe: { bytesTotal: 65, docsTotal: 6 }
+
+            # The "other" bound materialization collection.
+          - catalogName: "tenant/test/otherMaterializationCollection"
+            grain: "daily"
+            ts: "2022-04-04T00:00:00.000Z"
+            statsSummary:
+              readFromMe: { bytesTotal: 75, docsTotal: 5 }
+          - catalogName: "tenant/test/otherMaterializationCollection"
+            grain: "hourly"
+            ts: "2022-04-04T03:00:00.000Z"
+            statsSummary:
+              readFromMe: { bytesTotal: 75, docsTotal: 5 }
+          - catalogName: "tenant/test/otherMaterializationCollection"
+            grain: "monthly"
+            ts: "2022-04-01T00:00:00.000Z"
+            statsSummary:
+              readFromMe: { bytesTotal: 75, docsTotal: 5 }
 
             # Source collections for the derivation.
           - catalogName: "tenant/test/source-collection1"
             grain: "daily"
             ts: "2022-04-05T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 60 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 60, docsTotal: 12 }
           - catalogName: "tenant/test/source-collection1"
             grain: "hourly"
             ts: "2022-04-05T05:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 60 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 60, docsTotal: 12 }
           - catalogName: "tenant/test/source-collection1"
             grain: "monthly"
             ts: "2022-04-01T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 60 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 60, docsTotal: 12 }
           - catalogName: "tenant/test/source-collection2"
             grain: "daily"
             ts: "2022-04-05T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 30 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 30, docsTotal: 6 }
           - catalogName: "tenant/test/source-collection2"
             grain: "hourly"
             ts: "2022-04-05T05:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 30 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 30, docsTotal: 6 }
           - catalogName: "tenant/test/source-collection2"
             grain: "monthly"
             ts: "2022-04-01T00:00:00.000Z"
             statsSummary:
-              readByMe:     { bytesTotal: 0 }
-              writtenByMe:  { bytesTotal: 0 }
-              readFromMe:   { bytesTotal: 30 }
-              writtenToMe:  { bytesTotal: 0 }
+              readFromMe: { bytesTotal: 30, docsTotal: 6 }
 
 # TODO(johnny): this is used only for local testing with `flowctl-go` and can go away soon.
 storageMappings:

--- a/ops-catalog/template-local.flow.yaml
+++ b/ops-catalog/template-local.flow.yaml
@@ -5,7 +5,7 @@ materializations:
   ops/TENANT/catalog-stats-view:
     endpoint:
       connector:
-        image: ghcr.io/estuary/materialize-postgres-rc:v1
+        image: ghcr.io/estuary/materialize-postgres:v4
         config: stats-local-endpoint.sops.yaml
 
     bindings:

--- a/ops-catalog/template-prod.flow.yaml
+++ b/ops-catalog/template-prod.flow.yaml
@@ -5,7 +5,7 @@ materializations:
   ops/TENANT/catalog-stats-view:
     endpoint:
       connector:
-        image: ghcr.io/estuary/materialize-postgres-rc:v1
+        image: ghcr.io/estuary/materialize-postgres:v4
         config: stats-production-endpoint.sops.yaml
 
     bindings:

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -86,16 +86,6 @@ begin
   returning id strict into connector_id;
   insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
 
-  insert into connectors (image_name, title, short_description, logo_url, external_url) values (
-    'ghcr.io/estuary/materialize-postgres-rc',
-    json_build_object('en-US','PostgreSQL'),
-    json_build_object('en-US','Materialize collections into PostgreSQL'),
-    json_build_object('en-US','https://www.postgresql.org/media/img/about/press/elephant.png'),
-    'https://postgresql.org'
-  )
-  returning id strict into connector_id;
-  insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
-
 end;
 $$ language plpgsql;
 


### PR DESCRIPTION
**Description:**

Following up on https://github.com/estuary/flow/issues/764, this updates the catalog stats derivation to not output explicit zeros. This will save space, since many of these fields are 0 most of the time. Using default values of `0` on `docsAndBytes` we can now materialize into the stats table without having `null` values.

Also in this PR I am updating the stats materialization to use the "normal" postgres connector, since it is now compatible with pgBouncer, see https://github.com/estuary/connectors/pull/439.

Some notes on how this can be rolled out:
- It needs https://github.com/estuary/flow/issues/764 to actually be deployed and running live, otherwise materializations from this pipeline will fail on attempting to insert `null` values into the stats table.
- Existing tenants will need their specs updated _somehow_. We've got it on the list to develop a process for doing this. Since there's currently only two tenants with stats materializations manual updating might be practical as well.
- I believe we will need to finangle the spec that is currently stored in the stats materialization table, as the new projections of the columns will be nullable whereas the current ones are not.

Closes https://github.com/estuary/flow/issues/831

**Workflow steps:**

Running a local stack as a test, the stats materialization will now happily populate the stats table with `0`'s, while the derived collection omits fields with only `0`'s.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/838)
<!-- Reviewable:end -->
