### PR TITLE
connector-init: various tweaks to improve ops logs and errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,6 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "schemars",
- "scopeguard",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ rkyv = { version = "0.7", features = ["archive_le"] }
 rpassword = "7.2"
 rusqlite = { version = "0.27", features = ["bundled-full"] }
 schemars = "0.8"
-scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"] }
 serde_yaml = "0.8"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -26,7 +26,6 @@ itertools = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
 schemars = { workspace = true }
-scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/connector-init/src/lib.rs
+++ b/crates/connector-init/src/lib.rs
@@ -49,6 +49,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
             _ = sigint.recv() => (),
             _ = sigterm.recv() => (),
         }
+        tracing::info!("caught signal to exit");
     };
 
     let () = tonic::transport::Server::builder()

--- a/crates/connector-init/src/main.rs
+++ b/crates/connector-init/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
     let log_level =
         std::env::var("LOG_LEVEL").context("missing expected environment variable LOG_LEVEL")?;
     let env_filter = tracing_subscriber::EnvFilter::try_from(format!(
-        "flow_connector_init,connector_init={log_level}"
+        "flow_connector_init={log_level},connector_init={log_level}"
     ))
     .context("parsing LOG_LEVEL environment filter failed")?;
 
@@ -31,6 +31,7 @@ fn main() -> anyhow::Result<()> {
         .context("building tokio runtime")?;
 
     // Run until signaled, then gracefully stop.
+    tracing::info!(%log_level, port=args.port, message = "connector-init started");
     let result = runtime.block_on(connector_init::run(args));
 
     // Explicitly call Runtime::shutdown_background as an alternative to calling Runtime::Drop.
@@ -41,6 +42,6 @@ fn main() -> anyhow::Result<()> {
     runtime.shutdown_background();
 
     let () = result?;
-    tracing::debug!(message = "connector-init exiting");
+    tracing::info!(message = "connector-init exiting");
     Ok(())
 }

--- a/crates/ops/src/decode.rs
+++ b/crates/ops/src/decode.rs
@@ -52,9 +52,15 @@ enum FlexLevel {
     Debug,
     #[serde(alias = "INFO")]
     Info,
-    #[serde(alias = "WARN")]
+    #[serde(alias = "WARN", alias = "warning", alias = "WARNING")]
     Warn,
-    #[serde(alias = "ERROR")]
+    #[serde(
+        alias = "ERROR",
+        alias = "fatal",
+        alias = "FATAL",
+        alias = "panic",
+        alias = "PANIC"
+    )]
     Error,
 }
 
@@ -202,7 +208,7 @@ mod test {
     fn test_decode_log_fixtures() {
         let fixtures = [
             // Typical example produced by our Go connectors.
-            "{\"fence\":1,\"keyBegin\":0,\"keyEnd\":4294967295,\"level\":\"debug\",\"materialization\":\"examples/stats\",\"msg\":\"Acknowledge finished\",\"time\":\"2022-11-20T17:46:37Z\"}",
+            "{\"fence\":1,\"keyBegin\":0,\"keyEnd\":4294967295,\"level\":\"warning\",\"materialization\":\"examples/stats\",\"msg\":\"Acknowledge finished\",\"time\":\"2022-11-20T17:46:37Z\"}",
             // Structured log with extra gunk.
             r#"{"hello":"world"} !"#,
             // Example of a canonical ops Log that we expect to pass-through unmodified.
@@ -260,7 +266,7 @@ Final line without a newline, which is not grouped into previous lines"#,
         [
           {
             "ts": "2022-11-20T17:46:37Z",
-            "level": "debug",
+            "level": "warn",
             "message": "Acknowledge finished",
             "fields": {
               "fence": 1,

--- a/go/protocols/capture/coordinator.go
+++ b/go/protocols/capture/coordinator.go
@@ -1,15 +1,12 @@
 package capture
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"math"
 
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"go.gazette.dev/core/broker/client"
-	"google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 )
 
 // coordinator encapsulates common coordination of PushServer and PullClient.
@@ -227,9 +224,6 @@ func (c *coordinator) loop(
 
 		var err error
 		if drained, err = nextFn(c.next.full); err != nil {
-			if status, ok := status.FromError(err); ok && status.Code() == codes.Internal {
-				err = errors.New(status.Message())
-			}
 			return err
 		}
 	}

--- a/go/protocols/materialize/adapter.go
+++ b/go/protocols/materialize/adapter.go
@@ -54,6 +54,8 @@ func TransactionResponseChannel(stream Driver_TransactionsClient) <-chan Transac
 			if err != io.EOF {
 				if status, ok := status.FromError(err); ok && status.Code() == codes.Internal {
 					err = errors.New(status.Message())
+				} else if ok && status.Code() == codes.Canceled {
+					err = context.Canceled
 				}
 				ch <- TransactionResponseError{Error: err}
 			}

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -76,7 +76,7 @@ func (c *Capture) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err
 				"build", c.labels.Build,
 				"checkpoint", cp,
 			)
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			ops.PublishLog(c.opsPublisher, pf.LogLevel_error,
 				"failed to initialize processing term",
 				"error", err,

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/estuary/flow/go/bindings"
@@ -66,7 +68,7 @@ func (d *Derive) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err 
 				"build", d.labels.Build,
 				"checkpoint", cp,
 			)
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			ops.PublishLog(d.opsPublisher, pf.LogLevel_error,
 				"failed to initialize processing term",
 				"error", err,

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -84,7 +84,7 @@ func (m *Materialize) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint,
 				"checkpoint", cp,
 				"checkpointSource", checkpointSource,
 			)
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			ops.PublishLog(m.opsPublisher, pf.LogLevel_error,
 				"failed to initialize processing term",
 				"error", err,

--- a/ops-catalog/ops-log-schema.json
+++ b/ops-catalog/ops-log-schema.json
@@ -13,6 +13,7 @@
         },
         "level": {
             "enum": [
+                "trace",
                 "debug",
                 "info",
                 "warn",

--- a/tests/citi-bike-success/logs
+++ b/tests/citi-bike-success/logs
@@ -10,3 +10,4 @@ examples/citi-bike/views,materialization,info,.*opening database.*
 examples/citi-bike/rides-from-s3,capture,info,"sweeping tripdata\/JC-201703 starting at .*
 examples/citi-bike/rides-from-s3,capture,info,"processing file ""tripdata/JC-201703-citibike-tripdata.csv.zip"" modified at 2017-04-06 21:01:44 +0000 UTC"
 examples/citi-bike/rides-from-s3,capture,info,completed sweep of tripdata/JC-201703 from 0001-01-01 00:00:00 +0000 UTC through .*
+examples/citi-bike/rides-from-s3,capture,info,connector exited

--- a/tests/source-test-exit-status/data-plane.out.expect
+++ b/tests/source-test-exit-status/data-plane.out.expect
@@ -1,1 +1,1 @@
-level=error msg="servePrimary failed" err="runTransactions: readMessage: connector failed (exit status 1) with stderr:\\na horrible, no good error!.*
+level=error msg="servePrimary failed" err="runTransactions: readMessage: connector failed (exit status: 1) with stderr:\\na horrible, no good error!.*

--- a/tests/source-test-exit-status/logs
+++ b/tests/source-test-exit-status/logs
@@ -1,3 +1,3 @@
 name,kind,level,message
 examples/source-test-fail,capture,error,"a horrible, no good error!"
-examples/source-test-fail,capture,error,shard failed
+examples/source-test-fail,capture,error,connector failed

--- a/tests/source-test-no-state/logs
+++ b/tests/source-test-no-state/logs
@@ -1,2 +1,3 @@
 name,kind,level,message
 examples/source-test-no-state,capture,warn,"go.estuary.dev/W001: connector exited without writing a final state checkpoint, writing an empty object {} merge patch driver checkpoint."
+examples/source-test-no-state,capture,info,connector exited


### PR DESCRIPTION
**Description:**

* Log failed / success exit status for the connector, in addition to returning an error. Format the exit `status` directly as it has nice handling for distinguishing signals vs exit codes.

* Log stdout processing failure and (debug) success for the connector.

^ There's an unavoidable race between stdout processing and the connector's exit status. Tonic can only return the first error. By logging both, we ensure that the ops collection at least has the full story.

* Use `error` instead of `err` consistently.

* Add `trace` as a supported ops log level, and further add various aliases for other common error levels we should flexibly parse.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/843)
<!-- Reviewable:end -->
