### PR TITLE
Docs: schema updates

### DIFF
--- a/site/docs/concepts/derivations.md
+++ b/site/docs/concepts/derivations.md
@@ -96,10 +96,6 @@ collections:
             # Name of the collection to be read.
             # Required.
             name: acmeCo/my/source/collection
-            # JSON Schema to validate against the source collection.
-            # If not set, the schema of the source collection is used.
-            # Optional, type: string (relative URL form) or object (inline form)
-            schema: {}
             # Partition selector of the source collection.
             # Optional. Default is to read all partitions.
             partitions: {}

--- a/site/docs/concepts/schemas.md
+++ b/site/docs/concepts/schemas.md
@@ -6,6 +6,7 @@ sidebar_position: 7
 Flow documents and [collections](collections.md) always have an associated schema
 that defines the structure, representation, and constraints
 of your documents.
+Collections must have one schema, but [may have two](#write-and-read-schemas) for different types of Flow tasks.
 
 Schemas are a powerful tool for data quality.
 Flow verifies every document against its schema whenever it's read or written,
@@ -80,6 +81,8 @@ properties:
 
 Flow extends JSON Schema with additional annotation keywords,
 which provide Flow with further instruction for how documents should be processed.
+In particular, the [`reduce`](#reduce-annotations) and [`default`](#default-annotations) keywords
+help you define merge behaviors and avoid null values at your destination systems, respectively.
 
 What’s especially powerful about annotations is that they respond to
 **conditionals** within the schema.
@@ -211,6 +214,15 @@ but you can also use absolute URLs to a third-party schema like
 [schemastore.org](https://www.schemastore.org).
 :::
 
+## Write and read schemas
+
+In some cases, you may want to impose different constraints to data that is entering (_written to_) the collection
+and data that is exiting (_read from_) the collection.
+
+To achieve this, you can replace the collection's standard `schema` with a `writeSchema` and `readSchema`.
+
+MORE INFO AND EXAMPLE HERE
+
 ## Reductions
 
 Flow collections have keys, and multiple documents
@@ -315,3 +327,26 @@ oneOf:
 Combining schema conditionals with annotations can be used to build
 [rich behaviors](../reference/reduction-strategies/composing-with-conditionals.md).
 
+## `default` annotations
+
+You can use `default` annotations to prevent null values from being materialized to your endpoint system.
+
+When this annotation is absent for a non-required field, missing values in that field are materialized as `null`.
+When the annotation is present, missing values are materialized with the field's `default` value:
+
+```yaml
+collections:
+  acmeCo/coyotes:
+    schema:
+      type: object
+      required: [id]
+      properties:
+        id: {type: integer}
+        anvils_dropped: {type: integer}
+          reduce: {strategy: sum }
+          default: 0
+    key: [/id]
+```
+
+`default` annotations are only used for materializations; they're ignored by captures in derivations.
+If your collection has both a [write and read schema](#write-and-read-schemas), make sure you add this annotation to the read schema.

--- a/site/docs/concepts/schemas.md
+++ b/site/docs/concepts/schemas.md
@@ -219,9 +219,36 @@ but you can also use absolute URLs to a third-party schema like
 In some cases, you may want to impose different constraints to data that is entering (_written to_) the collection
 and data that is exiting (_read from_) the collection.
 
-To achieve this, you can replace the collection's standard `schema` with a `writeSchema` and `readSchema`.
+For example, you may need to start capturing data _now_ from a source system; say, a pub-sub system with short-lived
+historical data support or an HTTP endpoint, but don't have time to construct the ideal schema you'll need later.
+You can capture the data with a permissive write schema, and impose a stricter read schema on the data
+as you need to perform a derivation or materialization.
+You can safely experiment with the read schema at your convenience, knowing the data has already been captured.
 
-MORE INFO AND EXAMPLE HERE
+To achieve this, edit the collection, re-naming the standard `schema` to `writeSchema` and adding a `readSchema`.
+You can also supply a `writeSchema` in place of `schema` at capture time; it will be used for both writes and reads until a `readSchema` is added.
+
+Here's a simple example in which you don't know how purchase prices are formatted when capturing them,
+but find out later that `number` is the appropriate data type:
+
+```yaml
+collections:
+  purchases:
+    writeSchema:
+      type: object
+      title: Store price as strings
+      description: Not sure if prices contain characters such as $, so capturing them as strings.
+      properties:
+        id: { type: integer}
+        price: {type: string}
+    readSchema:
+      type: object
+      title: Prices as numbers
+      properties:
+        id: { type: integer}
+        price: {type: number}
+    key: [/id]
+```
 
 ## Reductions
 
@@ -324,7 +351,7 @@ oneOf:
 # [1, 2], [3, 4, 5], [] => []
 ```
 
-Combining schema conditionals with annotations can be used to build
+You can combine schema conditionals with annotations to build
 [rich behaviors](../reference/reduction-strategies/composing-with-conditionals.md).
 
 ## `default` annotations


### PR DESCRIPTION
**Description:**

Updates conceptual Schema docs for two recent PRs:

* https://github.com/estuary/flow/pull/826 
* https://github.com/estuary/flow/pull/825

**Notes for reviewers:**

* My schema-writing skills aren't the strongest - I created samples in both new sections but please let me know if they don't make sense / if you have a better, more robust example I can sub in. 
* Writing about `default` annotations caused me to pause on an older line in the docs: _"Flow extends JSON Schema with additional annotation keywords, which provide Flow with further instruction for how documents should be processed."_ This feels like it should be followed by a comprehensive list - I know about `reduce` and now `default` but are there other Flow-specific keywords we should call out? Wasn't able to find in the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/845)
<!-- Reviewable:end -->
