### PR TITLE
Add prefix to new tenant storage mappings

### DIFF
--- a/crates/agent-sql/src/directives/beta_onboard.rs
+++ b/crates/agent-sql/src/directives/beta_onboard.rs
@@ -93,7 +93,7 @@ pub async fn provision_tenant(
         ),
         create_storage_mappings as (
             insert into storage_mappings (catalog_prefix, spec, detail) values
-                ($2, '{"stores": [{"provider": "GCS", "bucket": "estuary-trial"}]}', $3),
+                ($2, '{"stores": [{"provider": "GCS", "bucket": "estuary-trial", "prefix": "collection-data/"}]}', $3),
                 ('recovery/' || $2, '{"stores": [{"provider": "GCS", "bucket": "estuary-trial"}]}', $3)
             on conflict do nothing
         ),

--- a/crates/agent/src/directives/beta_onboard.rs
+++ b/crates/agent/src/directives/beta_onboard.rs
@@ -315,6 +315,7 @@ mod test {
               "stores": [
                 {
                   "bucket": "estuary-trial",
+                  "prefix": "collection-data/",
                   "provider": "GCS"
                 }
               ]


### PR DESCRIPTION
**Description:**

When creating a new tenant, setup their default storage mapping such that collection data (but not recovery log data) gets written under the `collection-data/` prefix. This allows us to put an object lifecycle policy on that prefix to automatically delete old data.

New tenants that are created via the betaOnboarding directive will now store collection data under the `collection-data/` prefix. Existing storage mappings are unaffected by _this_ change, but will be updated via a separate migration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/847)
<!-- Reviewable:end -->
