### PR TITLE
gh-webhook: trigger a connector_tags re-sync on ghcr package webhook

### DIFF
--- a/supabase/functions/gh-webhook/index.ts
+++ b/supabase/functions/gh-webhook/index.ts
@@ -1,0 +1,50 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+import { serve } from "https://deno.land/std@0.131.0/http/server.ts"
+import { supabaseClient } from "../_shared/supabaseClient.ts";
+
+console.log("GitHub webhooks functions started.")
+
+serve(async (req) => {
+  const { action, ...body } = await req.json()
+
+  const package_url: string = body.package.package_version.package_url;
+  const [image_name, image_tag] = package_url.split(':');
+  const { data: connector, error }: { data: { id: string, image_name: string } | null, error: any } = await supabaseClient
+    .from("connectors")
+    .select("id,image_name")
+    .eq("image_name", image_name)
+    .single();
+
+  if (error != null) {
+    console.error("error finding connector", error);
+  }
+
+  const { data: connector_tag, error: err }: { data: object | null, error: any } = await supabaseClient
+    .from("connector_tags")
+    .update({ job_status: {"type":"queued"}})
+    .match({ "connector_id": connector?.id, "image_tag": `:${image_tag}` });
+
+  if (err != null) {
+    console.error("error updating connector_tags", err);
+  }
+
+  return new Response(
+    '{}',
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+// To invoke:
+// curl -i --location --request POST 'http://localhost:54321/functions/v1/' \
+//   --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs' \
+//   --header 'Content-Type: application/json' \
+//   --data '{
+//   "action":"published", "package": {
+//    "package_version": {
+//      "package_url": "ghcr.io/estuary/source-hello-world:v1"
+//      }
+//    }
+//  }'

--- a/supabase/functions/gh-webhook/index.ts
+++ b/supabase/functions/gh-webhook/index.ts
@@ -20,6 +20,10 @@ serve(async (req) => {
 
   if (error != null) {
     console.error("error finding connector", error);
+    return new Response(
+      '{"error": "could not find connector"}',
+      { headers: { "Content-Type": "application/json" } },
+    );
   }
 
   const { data: connector_tag, error: err }: { data: object | null, error: any } = await supabaseClient


### PR DESCRIPTION
**Description:**

- Introduce a new supabase function which can be called to trigger a connector_tags job for the agent for a given `package_url`
- The schema of the input is compatible with GitHub webhooks for the event `package`, _however_, GitHub does not allow custom headers to be set when creating a webhook, and Supabase makes `Authorization` header mandatory, so alternatively, I'm using a GitHub action to send a HTTP request, see https://github.com/estuary/airbyte/commit/033d6ce9583eae142f39701efd905451a17df37c
- Resolves #850 

**Workflow steps:**

- Send a HTTP request in the form of:
```
curl -i --location -XPOST 'http://localhost:5431/functions/v1/' --data @gh-webhook.json --header 'Authorization: Bearer TOKEN' --header 'Content-Type: application/json'
```
Where `gh-webhook.json` is:
```
{
  "action": "published",
  "package": {
    "package_version": {
       "package_url": "ghcr.io/estuary/source-hello-world:v1"
     }
  }
}
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/849)
<!-- Reviewable:end -->
