### PR TITLE
fix: Add schema inference to `start-flow.sh`

### DIFF
--- a/local/start-flow.sh
+++ b/local/start-flow.sh
@@ -84,8 +84,8 @@ log "Created new tmux session called '$SESSION'"
 # tmux seems to always create a window automatically
 tmux send-keys -t "=${SESSION}:=terminal" 'echo Use this terminal for whatever you want' Enter
 
-flow_components=("temp-data-plane" "control-plane" "ui" "control-plane-agent" "data-plane-gateway" "config-encryption" "oauth-edge")
-for component in ${flow_components[@]}; do
+flow_components=("temp-data-plane" "control-plane" "ui" "control-plane-agent" "data-plane-gateway" "config-encryption" "oauth-edge" "schema-inference")
+for component in "${flow_components[@]}"; do
     start_component "$component"
 done
 


### PR DESCRIPTION
@kiahna-tucker discovered that I had forgotten to add this when schema inference didn't work locally. This adds the schema inference server to `start-flow.sh` so it starts up with the rest of 'em!

I also made a few updates as recommended by shellcheck

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/851)
<!-- Reviewable:end -->
