### PR TITLE
oauth: add seed for local oauth2 connectors

### DIFF
--- a/control_plane_readme.md
+++ b/control_plane_readme.md
@@ -151,6 +151,16 @@ cd [flow dir]/supabase
 psql -U postgres -w -d postgres -f seed.sql
 ```
 
+### Seed oauth2 connectors
+
+We have connectors with their dev-specific oauth2 configuration available in an
+encrypted file in `supabase/oauth_seed.sql`. You can use this seed by
+unencrypting the file and feeding it to your postgres instance:
+
+```console
+sops --decrypt supabase/oauth_seed.sql | psql -U postgres -h localhost -d postgres
+```
+
 ### Start `temp-data-plane`:
 
 Suppose that `${BIN_DIR}` is the `make package` binaries under `.build/package/bin` of your Flow checkout.

--- a/supabase/oauth_seed.sql
+++ b/supabase/oauth_seed.sql
@@ -1,0 +1,21 @@
+{
+	"data": "ENC[AES256_GCM,data:FgjPZNv/jBLc48jEHY6bQIinEmZe+tIMgV9lgg79qFinram+gJa0rvAxVmwMxKG3+LF9Fr3vtfR/dAl41/Ifz5e/Ni4t1ws/YqjVq9ytmbZxj9o+r7SJFdN3+QSrtpI4DAe8/s30SHui4zIop+2cfNz3+6iKdsng1TcUFZprRBDbcJ8uPISYsmn9cWorRH2+v1BqYkmu0TJbKxpdBbwfH6r9M/KmraQSlXUdP1PDm/Sa4Lh+YjOlYoBdgcY6eVYzu7Pqe30vTtjEbnNUQRNTajobik33wfrTIVd85Kvy961LhaiQbcHlNbI+ZAAKcrFdn86BSADRza0mGG3xFUgXvCp5KQjxU3inN8gLAnCEM/FBoi+qm9hEEJBbaOfEYf7bv+1IKNeDwz5Lj15kQaHC+RAznB21Zl1zPlaNM6qc4vLFbW+KaywYJpO7myO8mLPKGXAz5sevJBveuIQW951HPFrdKrLifGL/tcHmbBH2ap4xg6Ybjktk+FCYM+Mlhb9KK3qw8BFq5p8PMaZJCQ+k33+15xnz36jehCYtM7J7gBi3dhW9AP04duuzWJZ0hLHQnerBCwO9LnMAKsz/NihSSzXIHXkks46Y0x2G/vRQD21FjkGyeer5HtMYBAx6AxIuba23TnBOWAU2Yyio3jCzuRV7CICgs2wrzQNMxm9Bx4p7Jq82g+fcNA01v7FDwVeu6MuzjyuzjTc/1rfvrzH2gC/QiVU4HJSGZU3D2hzXTNFP4CIPQIjizsp2mp/phrKTE2NC/0NfewvFKqeEIXHDoqHnn5zO8LeIfCW0VV3AInE2kiujgTBg9EQqAbThVwUa7bA5HApyMVTBUYawGzL8MS3Jow0BYl7xPBMfKy4iQ854cn36C/ZcVpNFrfKBWE7mGQbj,iv:29awtQF3yebFOksk6AwuVSh9yWfQPFzpWhU6qxZSq3c=,tag:jf1MfU3lBUxKCoK5qxiTsw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/estuary-sandbox/locations/global/keyRings/sops/cryptoKeys/sops-key",
+				"created_at": "2022-12-16T14:43:24Z",
+				"enc": "CiQAUgSTnm0aAbrPE1JqtkeKr1IKnPM6qqOTNeIxMg2CYZPSZT4SSQArfuq0V0hxcFjP9jk6buSjYJSlWWiaQczJ51BkoxB5RIR9xtKrbhkkI5KYf8GzdF2OKfHnDa/lhWo/f++2eQGmB+plZLRaEuI="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-12-16T14:52:36Z",
+		"mac": "ENC[AES256_GCM,data:ZktxUJLBKJPW9ohHcAAMPs9VPOxUCqoT87tfhVDKUUB4SG49BDmm/SxB1ye4SazKV7JWD+YZIW2KcPAUcVHkw/SYFk9qqGMXEpFmuKqYEPn/7JNO30Tc66s4DZs8R36LZuK7+U/axLC1mYE8TWS5l0GzPZtpeUceohzSa+W8zXI=,iv:YDk6MBaAgXhi1BtUHCBaDlQ39KNew7d64D3gDpyV1II=,tag:GGlCchFy2RVyVL3p9IXDWQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}


### PR DESCRIPTION
**Description:**

- Add a new encrypted seed file that contains dev-specific oauth2 configurations for our connectors. These OAuth2 apps are separate and independent of our production OAuth2 app, and they are not going to be used for production use.
- So far I've only added github, but I'm setting the stone with this PR and want to make sure we like the method I'm using here, if not we can change how we do this, and then I'm adding all the other connectors.

**Workflow steps:**

- `control_plane_readme.md` describes how to get this seed into the database

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/852)
<!-- Reviewable:end -->
