### PR TITLE
fix: Typo in DPG's `--inference-address`

### DIFF
--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -13,7 +13,7 @@ CONSUMER_PORT=9000
 INFERENCE_PORT=9090
 export BROKER_ADDRESS=http://localhost:$BROKER_PORT
 export CONSUMER_ADDRESS=http://localhost:$CONSUMER_PORT
-export INFERENCE_ADDRESS=http://localhost:$INFERENCE_PORT
+export INFERENCE_ADDRESS=localhost:$INFERENCE_PORT
 
 # The kms key used by the local config-encryption. All of estuary engineering should have access to this key.
 TEST_KMS_KEY=projects/helpful-kingdom-273219/locations/us-central1/keyRings/dev/cryptoKeys/testing


### PR DESCRIPTION
We already append `http://` in DPG, so adding it here too broke things

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/853)
<!-- Reviewable:end -->
