### PR TITLE
Automatically fetch collections for TS generation

### DIFF
--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -24,8 +24,7 @@ pub async fn do_publish(ctx: &mut CliContext, args: &Publish) -> anyhow::Result<
 
     anyhow::ensure!(args.auto_approve || std::io::stdin().is_tty(), "The publish command must be run interactively unless the `--auto-approve` flag is provided");
 
-    let sources = args.source_args.resolve_sources().await?;
-    let catalog = crate::source::bundle(sources).await?;
+    let catalog = crate::source::bundle(&args.source_args).await?;
 
     let draft = draft::create_draft(client.clone()).await?;
     println!("Created draft: {}", &draft.id);

--- a/crates/flowctl/src/catalog/pull_specs.rs
+++ b/crates/flowctl/src/catalog/pull_specs.rs
@@ -29,7 +29,7 @@ pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Re
 
     let list_args = List {
         flows: true,
-        prefix_selector: args.prefix_selector.clone(),
+        name_selector: args.prefix_selector.clone(),
         type_selector: args.type_selector.clone(),
     };
 

--- a/crates/flowctl/src/catalog/pull_specs.rs
+++ b/crates/flowctl/src/catalog/pull_specs.rs
@@ -1,17 +1,27 @@
 use crate::catalog::{collect_specs, fetch_live_specs, List, NameSelector, SpecTypeSelector};
-use crate::source;
 use crate::CliContext;
+use crate::{source, typescript};
+use anyhow::Context;
 
 /// Arguments for the pull-specs subcommand
 #[derive(Debug, clap::Args)]
 pub struct PullSpecs {
     #[clap(flatten)]
-    pub prefix_selector: NameSelector,
+    pub name_selector: NameSelector,
     #[clap(flatten)]
     pub type_selector: SpecTypeSelector,
 
     #[clap(flatten)]
     pub output_args: source::LocalSpecsArgs,
+
+    /// Skip generating typescript classes for derivations.
+    ///
+    /// This is useful if you're authorized to access to a derivation, but
+    /// lack authorization for all of its source collections. In that case,
+    /// generating typescript would return an error due to being unable to
+    /// fetch the source collection specs.
+    #[clap(long)]
+    pub no_generate_typescript: bool,
 }
 
 pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Result<()> {
@@ -29,13 +39,32 @@ pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Re
 
     let list_args = List {
         flows: true,
-        name_selector: args.prefix_selector.clone(),
+        name_selector: args.name_selector.clone(),
         type_selector: args.type_selector.clone(),
     };
 
     let live_specs = fetch_live_specs(client, &list_args, columns).await?;
     tracing::debug!(count = live_specs.len(), "successfully fetched live specs");
     let catalog = collect_specs(live_specs)?;
+    let has_any_derivations = catalog.collections.values().any(|c| c.derivation.is_some());
 
-    source::write_local_specs(catalog, &args.output_args).await
+    source::write_local_specs(catalog, &args.output_args).await?;
+    tracing::info!(%has_any_derivations, "finished writing specs");
+
+    if has_any_derivations && !args.no_generate_typescript {
+        // We intentionally don't re-use the bundled catalog during typescript generation
+        // because there may be pre-existing specs in the directory, and we want typescript
+        // generation to account for all of them.
+        let generate = typescript::Generate {
+            root_dir: args.output_args.output_dir.clone(),
+            source: source::SourceArgs {
+                source_dir: vec![args.output_args.output_dir.display().to_string()],
+                ..Default::default()
+            },
+        };
+        typescript::do_generate(ctx, &generate)
+            .await
+            .context("generating typescript")?;
+    }
+    Ok(())
 }

--- a/crates/flowctl/src/catalog/test.rs
+++ b/crates/flowctl/src/catalog/test.rs
@@ -8,8 +8,7 @@ use anyhow::Context;
 pub async fn do_test(ctx: &mut CliContext, args: &source::SourceArgs) -> anyhow::Result<()> {
     let client = ctx.controlplane_client()?;
 
-    let sources = args.resolve_sources().await?;
-    let catalog = crate::source::bundle(sources).await?;
+    let catalog = crate::source::bundle(args).await?;
 
     let draft = draft::create_draft(client.clone()).await?;
     println!("Created draft: {}", &draft.id);

--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -110,8 +110,7 @@ pub async fn do_author(
     Author { source_args }: &Author,
 ) -> anyhow::Result<()> {
     let cur_draft = ctx.config().cur_draft()?;
-    let specs = source_args.resolve_sources().await?;
-    let catalog = crate::source::bundle(specs).await?;
+    let catalog = crate::source::bundle(source_args).await?;
     let rows = upsert_draft_specs(ctx.controlplane_client()?, &cur_draft, &catalog).await?;
 
     ctx.write_all(rows, ())

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -1,4 +1,4 @@
-use crate::api_exec;
+use crate::{api_exec, typescript};
 use anyhow::Context;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -279,12 +279,18 @@ pub async fn do_develop(
     tracing::info!(%root_catalog_url, "wrote root catalog");
 
     let source_args = crate::source::SourceArgs {
-        source: vec![root_catalog_path.display().to_string()],
+        source_dir: vec![root_dir.display().to_string()],
         ..Default::default()
     };
-    crate::typescript::do_generate(ctx, &source_args)
-        .await
-        .context("generating TypeScript project")?;
+    typescript::do_generate(
+        ctx,
+        &typescript::Generate {
+            root_dir: root_dir.clone(),
+            source: source_args,
+        },
+    )
+    .await
+    .context("generating TypeScript project")?;
 
     println!("Wrote {rows_len} specifications under {root_catalog_url}.");
     Ok(())

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -278,7 +278,11 @@ pub async fn do_develop(
     )?;
     tracing::info!(%root_catalog_url, "wrote root catalog");
 
-    crate::typescript::do_generate(ctx, &root_catalog_path)
+    let source_args = crate::source::SourceArgs {
+        source: vec![root_catalog_path.display().to_string()],
+        ..Default::default()
+    };
+    crate::typescript::do_generate(ctx, &source_args)
         .await
         .context("generating TypeScript project")?;
 

--- a/crates/flowctl/src/raw.rs
+++ b/crates/flowctl/src/raw.rs
@@ -163,8 +163,7 @@ async fn do_bundle(
     _ctx: &mut crate::CliContext,
     sources: &source::SourceArgs,
 ) -> anyhow::Result<()> {
-    let source_files = sources.resolve_sources().await?;
-    let catalog = crate::source::bundle(source_files.iter().map(String::as_str)).await?;
+    let catalog = crate::source::bundle(sources).await?;
     serde_json::to_writer_pretty(io::stdout(), &catalog)?;
     Ok(())
 }
@@ -203,8 +202,7 @@ async fn do_combine(
 ) -> anyhow::Result<()> {
     let collection = models::Collection::new(collection);
 
-    let sources = source_args.resolve_sources().await?;
-    let catalog = crate::source::bundle(sources).await?;
+    let catalog = crate::source::bundle(source_args).await?;
 
     let Some(models::CollectionDef{schema, read_schema, key, .. }) = catalog.collections.get(&collection) else {
         anyhow::bail!("did not find collection {collection:?} in the source specification");

--- a/crates/flowctl/src/source.rs
+++ b/crates/flowctl/src/source.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_SPEC_FILENAME: &str = "flow.yaml";
 
 /// Common arguments for naming a set of sources to be included in an operation such as
 /// `bundle` or `publish`.
-#[derive(Debug, Default, clap::Args)]
+#[derive(Debug, clap::Args)]
 pub struct SourceArgs {
     /// Path or URL to a Flow specificiation file, commonly 'flow.yaml'
     #[clap(long, required_unless_present = "source-dir")]
@@ -31,6 +31,17 @@ pub struct SourceArgs {
     /// Follow symlinks when searching for Flow specs with `--source-dir`.
     #[clap(long, requires = "source-dir")]
     pub follow_symlinks: bool,
+}
+
+impl Default for SourceArgs {
+    fn default() -> Self {
+        SourceArgs {
+            source: Vec::new(),
+            source_dir: Vec::new(),
+            max_depth: 20,
+            follow_symlinks: false,
+        }
+    }
 }
 
 impl SourceArgs {

--- a/crates/flowctl/src/typescript/mod.rs
+++ b/crates/flowctl/src/typescript/mod.rs
@@ -1,5 +1,7 @@
+use crate::{catalog::CatalogSpecType, source::SourceArgs};
 use anyhow::Context;
 use proto_flow::flow;
+use std::path::Path;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
@@ -27,11 +29,8 @@ pub enum Command {
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct Generate {
-    /// Path to a local Flow catalog source file.
-    ///
-    /// TypeScript project files will be generated within its parent directory.
-    #[clap(long)]
-    source: std::path::PathBuf,
+    #[clap(flatten)]
+    source: SourceArgs,
 }
 
 impl TypeScript {
@@ -42,55 +41,49 @@ impl TypeScript {
     }
 }
 
+fn is_within_current_dir(cwd: &Path, resource_uri: &url::Url) -> bool {
+    if resource_uri.scheme() != "file" {
+        return false;
+    }
+    match resource_uri.to_file_path() {
+        Ok(resource_path) => resource_path.starts_with(cwd),
+        Err(_) => {
+            tracing::error!(%resource_uri, "failed to convert file URI into a local path");
+            false
+        }
+    }
+}
+
 pub async fn do_generate(
-    _ctx: &mut crate::CliContext,
-    source_path: &std::path::Path,
+    ctx: &mut crate::CliContext,
+    source_args: &SourceArgs,
 ) -> anyhow::Result<()> {
-    let source_path = std::fs::canonicalize(source_path)
-        .context(format!("finding {source_path:?} in the local filesystem"))?;
-    let source_url = url::Url::from_file_path(&source_path).unwrap();
+    let source_tables = source_args.load().await?;
 
-    let package_dir = source_path.parent().unwrap().to_owned();
-    let package_url = url::Url::from_file_path(&package_dir).unwrap();
-
-    // Load all catalog sources.
-    let loader = sources::Loader::new(tables::Sources::default(), crate::Fetcher {});
-    loader
-        .load_resource(
-            sources::Scope::new(&source_url),
-            &source_url,
-            flow::ContentType::Catalog,
-        )
-        .await;
-
-    let tables::Sources {
-        collections,
-        derivations,
-        errors,
-        imports,
-        npm_dependencies,
-        resources,
-        transforms,
-        ..
-    } = loader.into_tables();
-
+    let cwd = std::env::current_dir().context("cannot determine current working directory")?;
     // When generating TypeScript, users may reference TypeScript modules under
-    // their Flow catalog root file that don't (yet) exist. Squelch these errors.
+    // their current directory that don't (yet) exist. Squelch these errors.
     // generate_npm_package() will produce a stub implementation that we'll write out.
-    let errors = errors
-        .into_iter()
-        .filter(
-            |err| match (err.scope.fragment(), err.error.downcast_ref()) {
-                (Some(frag), Some(sources::LoadError::Fetch { uri, .. }))
-                    if frag.ends_with("typescript/module")
-                        && uri.starts_with(package_url.as_str()) =>
-                {
+    // The idea is to disallow generating Typescript stubs at remote URLs or
+    // files outside of the current directory, which might come up if a source
+    // file has an `import`.
+    let errors = source_tables.errors
+        .iter()
+        .filter( |err| {
+            if let Some(sources::LoadError::Fetch { uri, content_type, .. }) = err.error.downcast_ref() {
+                if *content_type == flow::ContentType::TypescriptModule && is_within_current_dir(&cwd, uri) {
                     println!("Generating implementation stub for {uri}");
                     false
+                } else if *content_type == flow::ContentType::TypescriptModule {
+                    tracing::error!(%uri, current_dir = %cwd.display(), "refusing to generate typescript module for URI because it is not within the current working directory");
+                    true
+                } else {
+                    true
                 }
-                _ => true,
-            },
-        )
+            } else {
+                true
+            }
+        })
         .collect::<Vec<_>>();
 
     // Bail if errors occurred while resolving sources.
@@ -101,8 +94,77 @@ pub async fn do_generate(
         anyhow::bail!("errors while loading catalog sources");
     }
 
+    // It's possible that the sources may reference a collection that's meant to be resolved against live_specs.
+    // We'll collect a set of unresolved collection references, and then attempt to resolve them by fetching their
+    // specs from `live_specs`, and including them in the build.
+    let mut live_specs_catalog = models::Catalog::default();
+
+    for transform_row in source_tables.transforms.iter() {
+        let source_name = &transform_row.spec.source.name;
+        let is_included_in_sources = source_tables
+            .collections
+            .iter()
+            .find(|c| &c.collection == source_name)
+            .is_some();
+        let is_fetched = live_specs_catalog.collections.contains_key(source_name);
+        if !is_included_in_sources && !is_fetched {
+            let resolved = try_resolve_collection(ctx.controlplane_client()?, source_name).await.with_context(|| {
+                anyhow::anyhow!("resolving the collection '{source_name}', referenced from the transform '{}' in derivation '{}'", transform_row.transform, transform_row.derivation)
+            })?;
+            live_specs_catalog
+                .collections
+                .insert(source_name.clone(), resolved);
+        }
+    }
+
+    // If we've fetched any collection specs, then we'll need to load them now.
+    let resolved_tables = if !live_specs_catalog.collections.is_empty() {
+        // Add the new specs to the existing ones using a new `Loader` with
+        // the existing `source_tables`. This requires serializing the bundled
+        // catalog because the loader doesn't expose a function to side-load
+        // resources from a parsed DOM.
+        let loader = sources::Loader::new(source_tables, crate::Fetcher);
+        let catalog = serde_json::to_vec(&live_specs_catalog)
+            .context("failed to serialize fetched collection specs")?;
+        let resource_url = url::Url::parse("flowctl://resolved-catalog-sources").unwrap();
+        let scope = sources::Scope::new(&resource_url);
+        loader
+            .load_resource_from_bytes(
+                scope,
+                &resource_url,
+                catalog.into(),
+                flow::ContentType::Catalog,
+            )
+            .await;
+        let tables = loader.into_tables();
+        // check the errors table one more time to make sure there wasn't an issue loading the fetched resources
+        let has_any_err = tables.errors.iter().filter(|err| {
+            err.scope.host_str() == Some("resolved-catalog-sources")
+        }).fold(false, |_, err| {
+            tracing::error!(error = ?err, "failed to load automatically resolved catalog sources");
+            true
+        });
+        anyhow::ensure!(
+            !has_any_err,
+            "failed to load one or more fetched collection specs"
+        );
+        tables
+    } else {
+        source_tables
+    };
+
+    let tables::Sources {
+        collections,
+        derivations,
+        imports,
+        npm_dependencies,
+        resources,
+        transforms,
+        ..
+    } = resolved_tables;
+
     let files = assemble::generate_npm_package(
-        &package_dir,
+        &cwd,
         &collections,
         &derivations,
         &imports,
@@ -113,8 +175,49 @@ pub async fn do_generate(
     .context("generating TypeScript package")?;
 
     let files_len = files.len();
-    assemble::write_npm_package(&package_dir, files)?;
+    assemble::write_npm_package(&cwd, files)?;
 
-    println!("Wrote {files_len} TypeScript project files under {package_url}.");
+    println!(
+        "Wrote {files_len} TypeScript project files under {}.",
+        cwd.display()
+    );
     Ok(())
+}
+
+async fn try_resolve_collection(
+    client: crate::controlplane::Client,
+    name: &str,
+) -> anyhow::Result<models::CollectionDef> {
+    tracing::info!(collection_name = %name, "attempting resolve collection from live_specs");
+    let list = crate::catalog::List::single(name);
+
+    let columns = vec![
+        "catalog_name",
+        "id",
+        "spec",
+        "spec_type",
+        "updated_at",
+        "last_pub_user_email",
+    ];
+    let mut rows = crate::catalog::fetch_live_specs(client, &list, columns)
+        .await
+        .context("fetching live spec")?;
+
+    let Some(row) = rows.pop() else {
+        anyhow::bail!("the collection does not exist or you do not have access to it");
+    };
+    tracing::debug!(catalog_name = %row.catalog_name, id = %row.id, last_pub_user_email = ?row.last_pub_user_email, updated_at = ?row.updated_at, spec_type = ?row.spec_type, "fetched live_spec");
+
+    let Some(ty) = row.spec_type else {
+        anyhow::bail!("the collection has been deleted");
+    };
+    if ty != CatalogSpecType::Collection {
+        anyhow::bail!(
+            "catalog spec must be a collection (you cannot use a '{ty}' as a transform source)"
+        );
+    }
+    let parsed_spec = row
+        .parse_spec::<models::CollectionDef>()
+        .context("deserializing spec")?;
+    Ok(parsed_spec)
 }


### PR DESCRIPTION
**Description:**


Fixes #862

Teaches the `typescript generate` subcommand to automatically fetch collections that are used as transform sources. This allows users to create derivations of source collections without needing to first pull their specs. Specs will be resolved by making a separate request for collection that's named as the `source` of a transform but not already included in the sources. I used a separate request per collection because it simplifies the process of generating good error messages, and because the number of collections to be fetched is expected to be relatively small. An example error message is:

```
Error: resolving the collection 'estuary/public/wikipedia/recentchangess', referenced from the transform 'fromWiki' in derivation 'phil/test/wikipedia/test-derivation'

Caused by:
    the collection does not exist or you do not have access to it
```

I also updated `typescript generate` to use the same `SourceArgs` as other commands. A minor related change is that the `flow_generated` directory is now always placed relative to the current working directory instead of within the direct parent of the `--source` argument. This plays nicer with the common `SourceArgs` wich allow passing multiple `--source` arguments.

**Workflow steps:**

- Create a derivation spec locally that uses a `source` that _isn't_ defined locally.
- Run `flowctl typescript generate --source-dir .`
- You now have typescript generated for the non-local collection, in addition to the local one.

**Documentation links affected:** n/a

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/863)
<!-- Reviewable:end -->
