### PR TITLE
parser: improve parser schema for UI display

### DIFF
--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -45,6 +45,7 @@ expression: schema
       "default": {
         "type": "auto"
       },
+      "type": "object",
       "oneOf": [
         {
           "title": "Auto",
@@ -56,6 +57,7 @@ expression: schema
           "properties": {
             "type": {
               "default": "auto",
+              "type": "string",
               "const": "auto"
             }
           }
@@ -70,6 +72,7 @@ expression: schema
           "properties": {
             "type": {
               "default": "avro",
+              "type": "string",
               "const": "avro"
             }
           }
@@ -84,6 +87,7 @@ expression: schema
           "properties": {
             "type": {
               "default": "json",
+              "type": "string",
               "const": "json"
             }
           }
@@ -455,6 +459,7 @@ expression: schema
             },
             "type": {
               "default": "csv",
+              "type": "string",
               "const": "csv"
             }
           }
@@ -489,6 +494,7 @@ expression: schema
             },
             "type": {
               "default": "protobuf",
+              "type": "string",
               "const": "protobuf"
             }
           }
@@ -503,6 +509,7 @@ expression: schema
           "properties": {
             "type": {
               "default": "w3cExtendedLog",
+              "type": "string",
               "const": "w3cExtendedLog"
             }
           }


### PR DESCRIPTION
**Description:**

Adjusts the generated parser schema so that it renders correctly in the UI.

Recently the UI became more strict about showing errors for schema that it considers invalid. So we now have some connectors that are showing errors in the configuration pages, see https://github.com/estuary/connectors/issues/467. This updates the `parser` schema so that it can be shown correctly. It seems that the UI needs a `"type": "object"` for the `format` property, and also doesn't want the `type` to be removed from the `type` objects it contains.

**Workflow steps:**

Open the parser config in the UI and observe that there are no more error messages shown.

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/864)
<!-- Reviewable:end -->
