### PR TITLE
Phil/wasm lib

### DIFF
--- a/.github/workflows/flow-web.yaml
+++ b/.github/workflows/flow-web.yaml
@@ -1,0 +1,50 @@
+name: Flow-web CI
+
+# Controls when the action will run. Triggers the workflow on push
+# or pull request events, but only for the primary branch.
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/flow-web/**"
+      - "Cargo.lock"
+  pull_request:
+    branches: [master]
+    paths:
+      - "crates/flow-web/**"
+      - "Cargo.lock"
+
+jobs:
+  buildAndPublish:
+    runs-on: ubuntu-20.04
+    permissions: 
+      contents: read
+      packages: write 
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen
+        run: |
+          curl -sSL https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.83/wasm-bindgen-0.2.83-x86_64-unknown-linux-musl.tar.gz | tar -zxv
+          mv wasm-bindgen-0.2.83-x86_64-unknown-linux-musl/wasm* ~/.cargo/bin/
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build flow-web
+        run: wasm-pack build --scope estuary crates/flow-web
+
+      - name: Publish flow-web
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          cd crates/flow-web/pkg
+          echo '@estuary:registry=https://npm.pkg.github.com' > .npmrc
+          wasm-pack publish --access=public --tag=dev
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
 dependencies = [
- "psl",
  "psl-types",
 ]
 
@@ -2960,15 +2959,6 @@ version = "0.0.0"
 dependencies = [
  "proto-flow",
  "proto-gazette",
-]
-
-[[package]]
-name = "psl"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07242622d9f4b9c1a6fe9c2691cf18ee7d34400a5eed2e1668c756bfaea93fb3"
-dependencies = [
- "psl-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -611,7 +617,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "encoding_rs",
  "memchr",
 ]
@@ -740,6 +746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +810,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -839,7 +855,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -849,7 +865,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -861,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -874,7 +890,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -884,7 +900,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -951,7 +967,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1118,7 +1134,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
 ]
 
@@ -1192,6 +1208,25 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flow-web"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "doc",
+ "getrandom 0.2.7",
+ "js-sys",
+ "json",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "thiserror",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -1426,7 +1461,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1437,9 +1472,11 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1773,7 +1810,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1984,7 +2021,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -2045,7 +2082,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2112,6 +2149,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "mime"
@@ -2343,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2440,7 +2483,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -2454,7 +2497,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3607,6 +3650,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,7 +3759,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -3716,7 +3770,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -3727,7 +3781,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -4100,7 +4154,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -4447,7 +4501,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4894,7 +4948,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -4919,7 +4973,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4955,6 +5009,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,6 +5059,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/estuary/flow"
 license = "BSL"
 
 [workspace.dependencies]
-addr = { version = "0.15.4", features = ["idna", "std", "psl"] }
+addr = { version = "0.15.4", default-features = false, features = ["std"] }
 anyhow = "1.0"
 async-compression = { version = "0.3", features = [
     "futures-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.2", features = ["derive", "env"] }
 comfy-table = "6.1"
+# The `console_error_panic_hook` crate causes panics in a Rust WASM module to be logged
+# with `console.error`.
+console_error_panic_hook = { version = "0.1.6" }
 crossterm = "0.25"
 csv = "1.1"
 dirs = "4.0"
@@ -60,6 +63,7 @@ iri-string = "0.6.0"
 jemallocator = "0.3"
 jemalloc-ctl = "0.3"
 json-patch = "0.2"
+js-sys = "0.3.60"
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "6.20", default-features = false, features = [
@@ -103,6 +107,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"] }
 serde_yaml = "0.8"
 serde-transcode = "1.1"
+serde-wasm-bindgen = "0.4"
 size = "0.4"
 strsim = "0.10"
 strum = { version = "0.24", features = ["derive"] }
@@ -147,6 +152,11 @@ validator = { version = "0.15", features = ["derive"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 walkdir = "2"
+wasm-bindgen = "0.2.62"
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however. It is an optional dependency for WASM modules.
+wee_alloc = { version = "0.4" }
 yaml-merge-keys = { version = "0.5", features = ["serde_yaml"] }
 zip = "0.5"
 zstd = "0.11.2"
@@ -160,6 +170,7 @@ insta = { version = "1.20", features = ["redactions", "json", "yaml"] }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = { version = "0.4" }
 serial_test = "0.9"
+wasm-bindgen-test = "0.3.13"
 
 # Used exclusively as build-dependencies
 cbindgen = "0.23"

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -18,7 +18,7 @@ fancy-regex = { workspace = true }
 futures = { workspace = true }
 fxhash = { workspace = true }
 itertools = { workspace = true }
-lz4 = { workspace = true }
+lz4 = { workspace = true, optional = true }
 rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -40,3 +40,8 @@ rand_distr = { workspace = true }
 serde-transcode = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+
+[features]
+default = ["combine"]
+
+combine = ["lz4"]

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -96,7 +96,9 @@ pub use validation::{
 pub mod reduce;
 
 // Documents may be combined.
+#[cfg(feature = "combine")]
 pub mod combine;
+#[cfg(feature = "combine")]
 pub use combine::Combiner;
 
 // Nodes may be packed as FoundationDB tuples.

--- a/crates/flow-web/.appveyor.yml
+++ b/crates/flow-web/.appveyor.yml
@@ -1,0 +1,11 @@
+install:
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - if not defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --locked

--- a/crates/flow-web/.gitignore
+++ b/crates/flow-web/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/crates/flow-web/.travis.yml
+++ b/crates/flow-web/.travis.yml
@@ -1,0 +1,69 @@
+language: rust
+sudo: false
+
+cache: cargo
+
+matrix:
+  include:
+
+  # Builds with wasm-pack.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    addons:
+      firefox: latest
+      chrome: stable
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+    script:
+      - cargo generate --git . --name testing
+      # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
+      # in any of our parent dirs is problematic.
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - wasm-pack build
+      - wasm-pack test --chrome --firefox --headless
+
+  # Builds on nightly.
+  - rust: nightly
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
+
+  # Builds on beta.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      # Note: no enabling the `wee_alloc` feature here because it requires
+      # nightly for now.

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "flow-web"
+
+# wasm-pack isn't yet fully compatible with workspace inheritance, so we can't use that for these fields
+version = "0.1.0"
+authors = ["Estuary developers  <engineering@estuary.dev>"]
+edition = "2021"
+license = "BSL"
+rust-version = "1.65"
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+
+# Also optimize for small code size when building dev/test code. This
+# regretably slows things down, but it works around some potential pitfalls
+# with the default `opt-level = 0`, which can produce WASM functions with more
+# than 50k local variables, which seems to be a common limit. We could probably
+# get away with using `opt-level = 1`, if this is too slow, but I kept it
+# consistent with the release profile for now.
+[profile.dev]
+opt-level = "s"
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+json = { path = "../json" }
+# Disable default-featrues of doc to exclude `combine`, which requires `lz4`, which doesn't currently compile to WASM.
+doc = { path = "../doc", default-features = false }
+
+url = { workspace = true }
+thiserror = { workspace = true }
+wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+
+
+# These are optional, since they both have significant impact on the size of the module.
+# `console_error_panic_hook` pulls in the Rust panic machinery to cause any panics to get
+# logged using `console.error`. It is enabled by default.
+console_error_panic_hook = { workspace = true, optional = true }
+# This is a smaller (in terms of compiled code size) allocator that we _might_
+# try to use to keep the WASM module small. It is disabled by default.
+wee_alloc = { workspace = true, optional = true }
+
+# this is not a workspace dependency because it's only a transitive dependency, and it's only included here
+# because we need to enable the "js" feature when building for wasm
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"]}
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+

--- a/crates/flow-web/README.md
+++ b/crates/flow-web/README.md
@@ -1,0 +1,31 @@
+# Flow all up in your browser
+
+This is the source for the `flow-web` NPM package, which exposes Javascript/Typescript bindings to Flow library functions in Web Assembly (WASM).
+The gist is that we compile this Rust crate to WASM and then generate the corresponding JS/TS files using `wasm-bindgen`. We use `wasm-pack` to put
+everything together into an NPM package that works with Webpack, and publish that to Github packages.
+
+### Prerequisites
+
+In order to build this crate, you need the following things installed:
+
+- [`wasm-pack` CLI](https://rustwasm.github.io/wasm-pack/installer/)
+- The `wasm32-unknown-unknown` compilation target (`rustup target add wasm32-unknown-unknown`)
+
+### 🛠️ Build with `wasm-pack build`
+
+```
+wasm-pack build crates/flow-web
+```
+
+### 🔬 Test in Headless Browsers with `wasm-pack test`
+
+```
+wasm-pack test --headless --firefox crates/flow-web
+```
+
+
+## Capabilities
+
+Currently, this only exposes a basic schema inference function, to prove out the functionality and give us a starting point.
+We'll very likely need to add functionality in order to make this truly useful by the UI.
+

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -1,0 +1,125 @@
+mod utils;
+
+use doc::inference::{Exists, Reduction, Shape};
+use doc::{Annotation, Schema, SchemaIndexBuilder};
+use json::schema;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen]
+extern "C" {
+    fn alert(s: &str);
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Property {
+    pub name: Option<String>,
+    pub is_pattern_property: bool,
+    pub exists: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub reduction: String,
+    pub pointer: String,
+    pub types: Vec<String>,
+    pub enum_vals: Vec<serde_json::Value>,
+    pub string_format: Option<String>,
+}
+fn reduce_description(reduce: doc::inference::Reduction) -> &'static str {
+    match reduce {
+        Reduction::Unset => "unset",
+        Reduction::Append => "append",
+        Reduction::FirstWriteWins => "first-write-wins",
+        Reduction::LastWriteWins => "last-write-wins",
+        Reduction::Maximize => "maximize",
+        Reduction::Merge => "merge",
+        Reduction::Minimize => "minimize",
+        Reduction::Set => "set",
+        Reduction::Sum => "sum",
+        Reduction::Multiple => "multiple strategies may apply",
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AnalyzedSchema {
+    pub properties: Vec<Property>,
+}
+
+#[wasm_bindgen]
+pub fn infer(schema: JsValue) -> Result<JsValue, JsValue> {
+    let schema_uri =
+        url::Url::parse("https://estuary.dev").expect("parse should not fail on hard-coded url");
+
+    let parsed_schema: serde_json::Value =
+        ::serde_wasm_bindgen::from_value(schema).map_err(|err| {
+            let err_string = format!("invalid JSON schema: {:?}", err);
+            JsValue::from_str(&err_string)
+        })?;
+    let schema =
+        schema::build::build_schema::<Annotation>(schema_uri, &parsed_schema).map_err(|err| {
+            let err_string = format!("invalid JSON schema: {}", err);
+            JsValue::from_str(&err_string)
+        })?;
+
+    let mut index = schema::index::IndexBuilder::new();
+    index.add(&schema).map_err(|err| {
+        let err_string = format!("invalid JSON schema reference: {}", err);
+        JsValue::from_str(&err_string)
+    })?;
+    index.verify_references().map_err(|err| {
+        let err_string = format!("invalid JSON schema reference: {}", err);
+        JsValue::from_str(&err_string)
+    })?;
+    let index = index.into_index();
+
+    let shape = Shape::infer(&schema, &index);
+
+    let properties: Vec<Property> = shape
+        .locations()
+        .into_iter()
+        .map(|(ptr, is_pattern, prop_shape, exists)| {
+            let name = if ptr.is_empty() || is_pattern {
+                None
+            } else {
+                Some((&ptr[1..]).to_string())
+            };
+            let types = prop_shape.type_.iter().map(|ty| ty.to_string()).collect();
+
+            let enum_vals = prop_shape
+                .enum_
+                .as_ref()
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(|val| val.clone())
+                .collect();
+            let string_format = prop_shape.string.format.as_ref().map(|f| f.to_string());
+            let ex = match exists {
+                Exists::May => "may",
+                Exists::Cannot => "cannot",
+                Exists::Implicit => "implicit",
+                Exists::Must => "must",
+            };
+            Property {
+                name,
+                exists: ex.to_string(),
+                is_pattern_property: is_pattern,
+                title: prop_shape.title.clone(),
+                description: prop_shape.description.clone(),
+                reduction: reduce_description(prop_shape.reduction.clone()).to_string(),
+                pointer: ptr,
+                types,
+                enum_vals,
+                string_format,
+            }
+        })
+        .collect();
+    serde_wasm_bindgen::to_value(&AnalyzedSchema { properties }).map_err(|err| {
+        let msg = format!("failed to serialize result: {}", err);
+        JsValue::from_str(&msg)
+    })
+}

--- a/crates/flow-web/src/utils.rs
+++ b/crates/flow-web/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/crates/flow-web/tests/web.rs
+++ b/crates/flow-web/tests/web.rs
@@ -1,0 +1,149 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use flow_web::{infer, AnalyzedSchema, Property};
+use serde_json::json;
+use serde_wasm_bindgen::{from_value as from_js_value, Serializer};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn test_end_to_end_schema_inferrence() {
+    let schema: JsValue = to_js_value(&json!({
+        "type": "object",
+        "reduce": { "strategy": "merge" },
+        "properties": {
+            "a": { "title": "A", "type": "integer", "reduce": { "strategy": "sum"} },
+            "b": { "description": "the b", "type": "string", "format": "date-time"},
+            "c": { "type": ["string", "integer"] },
+            "d": { "type": "boolean"},
+            "e": {
+                "type": "object",
+                "patternProperties": {
+                    "e.*": {"type": "number"}
+                }
+            },
+            "f": { "const": "F"}
+        },
+        "required": ["a", "e"]
+    }));
+    let result = infer(schema).expect("failed to infer");
+    let inferred: serde_json::Value =
+        from_js_value(result).expect("failed to deserialize analyzed schema");
+
+    let expected = json!({
+      "properties": [
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "must",
+          "is_pattern_property": false,
+          "name": null,
+          "pointer": "",
+          "reduction": "merge",
+          "string_format": null,
+          "title": null,
+          "types": [ "object" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "must",
+          "is_pattern_property": false,
+          "name": "a",
+          "pointer": "/a",
+          "reduction": "sum",
+          "string_format": null,
+          "title": "A",
+          "types": [ "integer" ]
+        },
+        {
+          "description": "the b",
+          "enum_vals": [],
+          "exists": "may",
+          "is_pattern_property": false,
+          "name": "b",
+          "pointer": "/b",
+          "reduction": "unset",
+          "string_format": "date-time",
+          "title": null,
+          "types": [ "string" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "may",
+          "is_pattern_property": false,
+          "name": "c",
+          "pointer": "/c",
+          "reduction": "unset",
+          "string_format": null,
+          "title": null,
+          "types": [ "integer", "string" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "may",
+          "is_pattern_property": false,
+          "name": "d",
+          "pointer": "/d",
+          "reduction": "unset",
+          "string_format": null,
+          "title": null,
+          "types": [ "boolean" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "must",
+          "is_pattern_property": false,
+          "name": "e",
+          "pointer": "/e",
+          "reduction": "unset",
+          "string_format": null,
+          "title": null,
+          "types": [ "object" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [],
+          "exists": "may",
+          "is_pattern_property": true,
+          "name": null,
+          "pointer": "/e/e.*",
+          "reduction": "unset",
+          "string_format": null,
+          "title": null,
+          "types": [ "number" ]
+        },
+        {
+          "description": null,
+          "enum_vals": [ "F" ],
+          "exists": "may",
+          "is_pattern_property": false,
+          "name": "f",
+          "pointer": "/f",
+          "reduction": "unset",
+          "string_format": null,
+          "title": null,
+          "types": [ "string" ]
+        }
+      ]
+    });
+    assert_eq!(expected, inferred);
+}
+
+fn to_js_value(val: &serde_json::Value) -> JsValue {
+    use serde::Serialize;
+    // We need to use the json compatible serializer because the default
+    // serializer will use a `Map` instead of an `Object`, which doesn't
+    // directly work with JSON. Note that we may just want to deal with that
+    // in our deserialization code, somehow, if library callers want to use
+    // `Map`s for some reason. But it didn't seem worth the effort for now.
+    val.serialize(&Serializer::json_compatible()).unwrap()
+}


### PR DESCRIPTION
**Description:**

Introduces the `flow-web` crate, which produces a NPM package that can be used by our UI to call Rust code directly in the browser. This is currently an extremely minimal proof of concept, which only exposes a schema inference function. The idea is to land this minimal WASM library so that we can start publishing an NPM package, which we can then iterate on as needed.

The NPM package will theoretically be published to github packages on each successful build from the `master` branch. That actions workflow only runs when files under `crates/flow-web/` are changed, or if the top-level `Cargo.lock` changes.

**Notes for reviewers:**

This includes a few other changes that were required in order to get things compiling to WASM. See those individual commit messages for details.

Some notable things that are missing from this PR:

- There's no meaninful Typescript classes that are generated at this time. The function accepts and returns `any`. This is because the code generation doesn't really work well with structs having embedded arbitrary JSON values. We can probably improve on this in the future if desired.
- We'll likely need to include some more flow crates in the future in order to make this really useful. `validation` is probably a good next goal for WASM.
- The error handling approach here hasn't been especially well thought out, and may need revision once we start integrating this into the UI. I think it makes sense to defer until then, though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/866)
<!-- Reviewable:end -->
