### PR TITLE
make: build flowctl for host arch, not musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,9 @@ ${RUSTBIN}/librocks-exp/librocksdb.a:
 ${RUSTBIN}/agent:
 	cargo build --release --locked -p agent
 
+.PHONY: ${RUSTBIN}/flowctl
+${RUSTBIN}/flowctl:
+	cargo build --release --locked -p flowctl
 
 # Statically linked binaries using MUSL:
 
@@ -184,10 +187,6 @@ ${RUST_MUSL_BIN}/flow-schema-inference:
 ${RUST_MUSL_BIN}/flow-schemalate:
 	cargo build --target x86_64-unknown-linux-musl --release --locked -p schemalate
 
-.PHONY: ${RUST_MUSL_BIN}/flowctl
-${RUST_MUSL_BIN}/flowctl:
-	cargo build --target x86_64-unknown-linux-musl --release --locked -p flowctl
-
 ########################################################################
 # Final output packaging:
 
@@ -196,10 +195,10 @@ GNU_TARGETS = \
 	${PKGDIR}/bin/etcd \
 	${PKGDIR}/bin/flowctl-go \
 	${PKGDIR}/bin/gazette \
-	${PKGDIR}/bin/sops
+	${PKGDIR}/bin/sops \
+	${PKGDIR}/bin/flowctl \
 
 MUSL_TARGETS = \
-	${PKGDIR}/bin/flowctl \
 	${PKGDIR}/bin/flow-connector-init \
 	${PKGDIR}/bin/flow-network-tunnel \
 	${PKGDIR}/bin/flow-parser \
@@ -211,8 +210,7 @@ linux-gnu-binaries: $(GNU_TARGETS)
 
 .PHONY: linux-musl-binaries
 linux-musl-binaries: | ${PKGDIR}
-	cargo build --target x86_64-unknown-linux-musl --release --locked -p flowctl -p connector-init -p network-tunnel -p parser -p schema-inference -p schemalate
-	cp -f target/x86_64-unknown-linux-musl/release/flowctl .build/package/bin/
+	cargo build --target x86_64-unknown-linux-musl --release --locked -p connector-init -p network-tunnel -p parser -p schema-inference -p schemalate
 	cp -f target/x86_64-unknown-linux-musl/release/flow-connector-init .build/package/bin/
 	cp -f target/x86_64-unknown-linux-musl/release/flow-network-tunnel .build/package/bin/
 	cp -f target/x86_64-unknown-linux-musl/release/flow-parser .build/package/bin/
@@ -249,8 +247,8 @@ ${PKGDIR}/bin/flow-schema-inference: ${RUST_MUSL_BIN}/flow-schema-inference | ${
 ${PKGDIR}/bin/flow-schemalate: ${RUST_MUSL_BIN}/flow-schemalate | ${PKGDIR}
 	cp ${RUST_MUSL_BIN}/flow-schemalate $@
 
-${PKGDIR}/bin/flowctl: ${RUST_MUSL_BIN}/flowctl | ${PKGDIR}
-	cp ${RUST_MUSL_BIN}/flowctl $@
+${PKGDIR}/bin/flowctl: ${RUSTBIN}/flowctl | ${PKGDIR}
+	cp ${RUSTBIN}/flowctl $@
 
 # Control-plane binaries
 
@@ -288,11 +286,11 @@ install-tools: ${PKGDIR}/bin/etcd ${PKGDIR}/bin/sops
 
 .PHONY: rust-gnu-test
 rust-gnu-test:
-	cargo test --release --locked --workspace --exclude parser --exclude network-tunnel --exclude schemalate --exclude connector-init --exclude flowctl
+	cargo test --release --locked --workspace --exclude parser --exclude network-tunnel --exclude schemalate --exclude connector-init
 
 .PHONY: rust-musl-test
 rust-musl-test:
-	cargo test --release --locked --target x86_64-unknown-linux-musl --package parser --package network-tunnel --package schemalate --package connector-init --package flowctl
+	cargo test --release --locked --target x86_64-unknown-linux-musl --package parser --package network-tunnel --package schemalate --package connector-init
 
 # `go` test targets must have PATH-based access to tools (etcd & sops),
 # because the `go` tool compiles tests as binaries within a temp directory,


### PR DESCRIPTION
**Description:**

- I realised we are building `flowctl` as a musl target, but it's actually used on the host machine, so I changed our makefile to build `flowctl` for the host target.
- flowctl is released through a CI pipeline that does not depend on the Makefile, so it shouldn't affect our flowctl release process: https://github.com/estuary/flow/blob/master/.github/workflows/flowctl-release.yaml
- This will allow mac users to use locally-built `flowctl` after running `make`

**Workflow steps:**

- `make`
- `flowctl`

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/876)
<!-- Reviewable:end -->
