### PR TITLE
publications: better error message when creating duplicate named publication

### DIFF
--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -170,7 +170,7 @@ pub fn validate_transition(
             errors.push(Error {
                 catalog_name: catalog_name.clone(),
                 detail: format!(
-                    "Draft has an incompatible {draft_type:?} vs current {live_type:?}",
+                    "Draft has an incompatible type {draft_type:?} vs current type {live_type:?}. This may be caused by an attempt to create a {live_type:?} while an existing {draft_type:?} with this name exists.",
                     draft_type = draft_type.as_ref().unwrap(),
                     live_type = live_type.as_ref().unwrap(),
                 ),


### PR DESCRIPTION
**Description:**

solves #878: if a capture exists with name X, and a user attempts to create a materialization (or another non-capture entity), the error would be ambiguous and confusing. This commit tries to clarify the message.

**Workflow steps:**

- Try to create a capture with a name that conflicts with an existing materialization (or vice versa)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/880)
<!-- Reviewable:end -->
