### PR TITLE
publication: fix error message, misplaced types

### DIFF
--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -170,7 +170,7 @@ pub fn validate_transition(
             errors.push(Error {
                 catalog_name: catalog_name.clone(),
                 detail: format!(
-                    "Draft has an incompatible type {draft_type:?} vs current type {live_type:?}. This may be caused by an attempt to create a {live_type:?} while an existing {draft_type:?} with this name exists.",
+                    "Draft has an incompatible type {draft_type:?} vs current type {live_type:?}. This may be caused by an attempt to create a {draft_type:?} while an existing {live_type:?} with this name exists.",
                     draft_type = draft_type.as_ref().unwrap(),
                     live_type = live_type.as_ref().unwrap(),
                 ),


### PR DESCRIPTION
**Description:**

- I got the ordering of the types wrong in the error message, see the error below when I tried to create a materialization when a capture with the same name exists:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/2807772/213001771-8bbea148-e269-4c38-9644-6ef5bbc1a46d.png">

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

