### PR TITLE
crates/json: add integer and number string formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +1956,7 @@ name = "json"
 version = "0.0.0"
 dependencies = [
  "addr",
+ "bigdecimal",
  "bitvec",
  "criterion",
  "fancy-regex",
@@ -1953,6 +1965,7 @@ dependencies = [
  "iri-string",
  "itertools 0.10.5",
  "lazy_static",
+ "num-bigint 0.4.3",
  "percent-encoding",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ atty = "0.2"
 avro-rs = { version = "0.13", features = ["snappy"] }
 
 base64 = "0.13"
+bigdecimal = "0.3.0"
 # TODO(johnny): bitvec had a breaking 1.0 release we've not upgraded to yet.
 bitvec = "0.19"
 bytecount = { version = "0.6.3", features = ["runtime-dispatch-simd"] }

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -10,12 +10,14 @@ license.workspace = true
 
 [dependencies]
 addr = { workspace = true }
+bigdecimal = { workspace = true }
 bitvec = { workspace = true }
 fancy-regex = { workspace = true }
 fxhash = { workspace = true }
 iri-string = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
+num-bigint = { workspace = true }
 percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -43,6 +43,8 @@ pub enum Format {
     Regex,
     #[serde(rename = "relative-json-pointer")]
     RelativeJsonPointer,
+    Integer,
+    Number,
 }
 
 // Some are from https://github.com/JamesNK/Newtonsoft.Json.Schema/blob/master/Src/Newtonsoft.Json.Schema/Infrastructure/FormatHelpers.cs
@@ -155,6 +157,8 @@ impl Format {
             Self::RelativeJsonPointer => {
                 ValidationResult::from(RELATIVE_JSON_POINTER_RE.is_match(val).unwrap_or(false))
             }
+            Self::Integer => ValidationResult::from(true),
+            Self::Number => ValidationResult::from(true),
         }
     }
 }


### PR DESCRIPTION
**Description:**

Part of https://github.com/estuary/connectors/issues/505

Adds support for string formats of "integer" and "number". These will allow connectors to handle integers and numbers encoded as strings.

See related PR for the SQL materialization connectors that require this change: https://github.com/estuary/connectors/pull/507

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/883)
<!-- Reviewable:end -->
