### PR TITLE
specify npm credentials for flow-web publish

### DIFF
--- a/.github/workflows/flow-web.yaml
+++ b/.github/workflows/flow-web.yaml
@@ -44,7 +44,10 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           cd crates/flow-web/pkg
-          echo '@estuary:registry=https://npm.pkg.github.com' > .npmrc
+          echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' > .npmrc
+          echo '@estuary:registry=https://npm.pkg.github.com' >> .npmrc
           wasm-pack publish --access=public --tag=dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
**Description:**

This will hopefully fix the publication of the flow-web NPM module. :crossed_fingers: There's not really a great way to test this locally, so I'd like to just see how it goes after being merged to master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/885)
<!-- Reviewable:end -->
