### PR TITLE
trigger flow-web CI when workflow file changes

### DIFF
--- a/.github/workflows/flow-web.yaml
+++ b/.github/workflows/flow-web.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches: [master]
     paths:
+      - ".github/workflows/flow-web.yaml"
       - "crates/flow-web/**"
       - "Cargo.lock"
 


### PR DESCRIPTION
I'd pushed #885 to specify the credentials for publishing, but the publish workflow only triggers if one of the files in `crates/flow-web/` is modified. This broadens that check so that the workflow will also run if the workflow yaml itself is modified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/886)
<!-- Reviewable:end -->
