### PR TITLE
implement formal JSON connector protocol and make it opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,10 +729,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
+ "connector-protocol",
  "futures",
  "insta",
  "ops",
  "prost",
+ "proto-convert",
  "proto-flow",
  "proto-grpc",
  "serde",
@@ -742,6 +744,16 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "connector-protocol"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2922,6 +2934,23 @@ dependencies = [
 [[package]]
 name = "proto-build"
 version = "0.0.0"
+
+[[package]]
+name = "proto-convert"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "connector-protocol",
+ "hex",
+ "insta",
+ "prost",
+ "proto-flow",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tuple",
+]
 
 [[package]]
 name = "proto-flow"

--- a/crates/connector-init/Cargo.toml
+++ b/crates/connector-init/Cargo.toml
@@ -13,7 +13,9 @@ name = "flow-connector-init"
 path = "src/main.rs"
 
 [dependencies]
+connector-protocol = { path = "../connector-protocol" }
 ops = { path = "../ops" }
+proto-convert = { path = "../proto-convert" }
 proto-flow = { path = "../proto-flow" }
 proto-grpc = { path = "../proto-grpc", features = ["capture_server", "materialize_server"] }
 

--- a/crates/connector-protocol/Cargo.toml
+++ b/crates/connector-protocol/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "connector-protocol"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/connector-protocol/src/capture.rs
+++ b/crates/connector-protocol/src/capture.rs
@@ -1,0 +1,202 @@
+use super::{CollectionSpec, OAuth2, RawValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Request is a message written into a capture connector by the Flow runtime.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Request {
+    /// Spec requests the specification definition of this connector.
+    /// Notably this includes its endpoint and resource configuration JSON schema.
+    #[serde(rename_all = "camelCase")]
+    Spec {},
+    /// Discover returns the set of resources available from this Driver.
+    #[serde(rename_all = "camelCase")]
+    Discover {
+        /// # Connector endpoint configuration.
+        config: RawValue,
+    },
+    /// Validate a connector configuration and proposed bindings.
+    #[serde(rename_all = "camelCase")]
+    Validate {
+        /// # Name of the capture being validated.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Proposed bindings of the validated capture.
+        bindings: Vec<ValidateBinding>,
+    },
+    /// Apply a connector configuration and binding specifications.
+    #[serde(rename_all = "camelCase")]
+    Apply {
+        /// # Name of the capture being applied.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Binding specifications of the applied capture.
+        bindings: Vec<ApplyBinding>,
+        /// # Opaque, unique version of this capture application.
+        version: String,
+        /// # Is this application a dry run?
+        /// Dry-run applications take no action.
+        dry_run: bool,
+    },
+    /// Open a capture connector for reading documents from the endpoint.
+    /// Unless the connector requests explicit acknowledgements, Open is the
+    /// last message which will be sent to the connector's stdin.
+    #[serde(rename_all = "camelCase")]
+    Open {
+        /// # Name of the capture being opened.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Binding specifications of the opened capture.
+        bindings: Vec<ApplyBinding>,
+        /// # Opaque, unique version of this capture.
+        version: String,
+        /// # Beginning key-range which this connector invocation must capture.
+        /// [keyBegin, keyEnd] are the inclusive range of keys processed by this
+        /// connector invocation. Ranges reflect the disjoint chunks of ownership
+        /// specific to each instance of a scale-out capture.
+        ///
+        /// The meaning of a "key" in this range is up to the connector.
+        /// For example, captures of a partitioned system (like Kafka or Kinesis)
+        /// might hash dynamically listed partitions into a 32-bit unsigned integer,
+        /// and then capture only those which fall within its opened key range.
+        key_begin: u32,
+        /// # Ending key-range which this connector invocation must capture.
+        key_end: u32,
+        /// # Last-persisted driver checkpoint from a previous capture invocation.
+        /// Or empty, if the driver has cleared or never set its checkpoint.
+        /// Each key-range of the capture has its own durable checkpoint,
+        /// which is managed by the Flow runtime.
+        driver_checkpoint: RawValue,
+        /// # Frequency of connector restarts.
+        /// Restart intervals are applicable only for captures which poll ready
+        /// documents from their endpoint and then exit. Unbounded, streaming
+        /// connectors are restarted only when necessary.
+        interval_seconds: u32,
+    },
+    /// Acknowledge to the connector that its checkpoint has committed to the Flow runtime recovery log.
+    /// Acknowledgments are sent only if requested by the connector in its Opened response,
+    /// and one Acknowledge is sent for each preceding Checkpoint response of the connector.
+    #[serde(rename_all = "camelCase")]
+    Acknowledge {},
+}
+
+/// A proposed binding of the capture to validate.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValidateBinding {
+    /// # Collection of the proposed binding.
+    pub collection: CollectionSpec,
+    /// # Resource configuration of the proposed binding.
+    pub resource_config: RawValue,
+}
+
+/// A binding specification of the capture.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ApplyBinding {
+    /// # Collection of this binding.
+    pub collection: CollectionSpec,
+    /// # Resource configuration of this binding.
+    pub resource_config: RawValue,
+    /// # Resource path which fully qualifies the endpoint resource identified by this binding.
+    /// For an RDBMS, this might be ["my-schema", "my-table"].
+    /// For Kafka, this might be ["my-topic-name"].
+    /// For Redis or DynamoDB, this might be ["/my/key/prefix"].
+    pub resource_path: Vec<String>,
+}
+
+/// Response is a message written by a capture connector to the Flow runtime.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Response {
+    /// Spec responds to a Request "spec" command.
+    #[serde(rename_all = "camelCase")]
+    Spec {
+        /// # URL for connector's documentation.
+        documentation_url: String,
+        /// # JSON schema of the connector's endpoint configuration.
+        config_schema: RawValue,
+        /// # JSON schema of a binding's resource specification.
+        resource_config_schema: RawValue,
+        /// # Optional OAuth2 configuration.
+        #[serde(default)]
+        oauth2: Option<OAuth2>,
+    },
+    /// Discovered responds to a Request "discover" command.
+    #[serde(rename_all = "camelCase")]
+    Discovered {
+        /// # Discovered bindings of the endpoint.
+        bindings: Vec<DiscoveredBinding>,
+    },
+    /// Validated responds to a Request "validate" command.
+    #[serde(rename_all = "camelCase")]
+    Validated {
+        /// # Validated bindings of the endpoint.
+        bindings: Vec<ValidatedBinding>,
+    },
+    /// Applied responds to a Request "apply" command.
+    #[serde(rename_all = "camelCase")]
+    Applied {
+        /// # User-facing description of the action taken by this application.
+        /// If the apply was a dry-run, then this is a description of actions
+        /// that would have been taken.
+        action_description: String,
+    },
+    /// Opened responds to a Request "open" command.
+    #[serde(rename_all = "camelCase")]
+    Opened {
+        /// # Should the runtime explicitly respond to the connector's Checkpoints?
+        explicit_acknowledgements: bool,
+    },
+    /// Document captured by this connector invocation.
+    /// Emitted documents are pending, and are not committed to their bound collection
+    /// until a following Checkpoint is emitted.
+    #[serde(rename_all = "camelCase")]
+    Document {
+        /// # Index of the Open binding for which this document is captured.
+        binding: u32,
+        /// # Document value.
+        doc: RawValue,
+    },
+    /// Checkpoint all preceding documents of this invocation since the last checkpoint.
+    /// The Flow runtime may begin to commit documents in a transaction.
+    /// Note that the runtime may include more than one checkpoint in a single transaction.
+    #[serde(rename_all = "camelCase")]
+    Checkpoint {
+        /// # Updated driver checkpoint to commit with this checkpoint.
+        driver_checkpoint: RawValue,
+        /// # Is this a partial update of the driver's checkpoint?
+        /// If true, then treat the driver checkpoint as a partial state update
+        /// which is incorporated into the full checkpoint as a RFC7396 Merge patch.
+        /// Otherwise the checkpoint is completely replaced.
+        merge_patch: bool,
+    },
+}
+
+/// A discovered endpoint resource which may be bound to a Flow Collection.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DiscoveredBinding {
+    /// # Recommended partial name for this binding's collection.
+    /// For example, a SQL database capture might use the table's name.
+    pub recommended_name: String,
+    /// # Resource configuration for this binding.
+    pub resource_config: RawValue,
+    /// # JSON Schema for documents captured via the binding.
+    pub document_schema: RawValue,
+    /// # Composite key of documents captured via the binding.
+    /// Keys are specified as an ordered sequence of JSON-Pointers.
+    pub key: Vec<String>,
+}
+
+/// A validated binding.
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValidatedBinding {
+    /// # Resource path which fully qualifies the endpoint resource identified by this binding.
+    pub resource_path: Vec<String>,
+}

--- a/crates/connector-protocol/src/lib.rs
+++ b/crates/connector-protocol/src/lib.rs
@@ -1,0 +1,217 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub mod capture;
+pub mod materialize;
+
+/// Specification of a Flow collection.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CollectionSpec {
+    /// # Name of this collection.
+    pub name: String,
+    /// # Composite key of the collection.
+    /// Keys are specified as an ordered sequence of JSON-Pointers.
+    pub key: Vec<String>,
+    /// # Logically-partitioned fields of this collection.
+    pub partition_fields: Vec<String>,
+    /// # Projections of this collection.
+    pub projections: Vec<Projection>,
+    /// # JSON Schema against which collection documents are validated.
+    /// If set, then writeSchema and readSchema are not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<Box<RawValue>>,
+    /// # JSON Schema against which written collection documents are validated.
+    /// If set, then readSchema is also and schema is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_schema: Option<Box<RawValue>>,
+    /// # JSON Schema against which read collection documents are validated.
+    /// If set, then writeSchema is also and schema is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_schema: Option<Box<RawValue>>,
+}
+
+/// Projections are named locations within a collection document which
+/// may be used for logical partitioning, or may be mapped into a tabular
+/// representation such as a SQL database table.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Projection {
+    /// # Document location of this projection, as a JSON-Pointer.
+    pub ptr: String,
+    /// # Flattened, tabular alias of this projection.
+    /// A field may correspond to a SQL table column, for example.
+    pub field: String,
+    /// # Was this projection explicitly provided ?
+    /// (As opposed to implicitly created through static analysis of the schema).
+    pub explicit: bool,
+    /// # Does this projection constitute a logical partitioning of the collection?
+    pub is_partition_key: bool,
+    /// # Does this location form (part of) the collection key?
+    pub is_primary_key: bool,
+    /// # Inference of this projection.
+    pub inference: Inference,
+}
+
+/// Static inference over this document location, extracted from a JSON Schema.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Inference {
+    /// The possible types for this location. Subset of:
+    /// ["null", "boolean", "object", "array", "integer", "numeric", "string"].
+    pub types: Vec<String>,
+    /// String type-specific inferences, or null iff types
+    /// doesn't include "string".
+    pub string: Option<StringInference>,
+    /// The title from the schema, if provided.
+    pub title: String,
+    /// The description from the schema, if provided.
+    pub description: String,
+    /// The default value from the schema, or "null" if there is no default.
+    pub default: Box<RawValue>,
+    /// Whether this location is marked as a secret, like a credential or password.
+    pub secret: bool,
+    /// Existence of this document location.
+    pub exists: Exists,
+}
+
+/// Static inference over a document location of type "string", extracted from a JSON schema.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StringInference {
+    /// # Annotated Content-Type when the projection is of "string" type.
+    pub content_type: String,
+    // # Annotated format when the projection is of "string" type.
+    pub format: String,
+    /// # Annotated Content-Encoding when the projection is of "string" type.
+    pub content_encoding: String,
+    /// # Is the Content-Encoding "base64" (case-invariant)?
+    pub is_base64: bool,
+    /// # Maximum length when the projection is of "string" type.
+    /// Zero for no limit.
+    pub max_length: usize,
+}
+
+/// Enumeration which describes what's known about a location's existence
+/// documents of the schema.
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub enum Exists {
+    /// The location must exist.
+    Must = 1,
+    /// The location may exist or be undefined.
+    /// Its schema has explicit keywords which allow it to exist
+    /// and which may constrain its shape, such as additionalProperties,
+    /// items, unevaluatedProperties, or unevaluatedItems.
+    May = 2,
+    /// The location may exist or be undefined.
+    /// Its schema omits any associated keywords, but the specification's
+    /// default behavior allows the location to exist.
+    Implicit = 3,
+    /// The location cannot exist. For example, it's outside of permitted
+    /// array bounds, or is a disallowed property, or has an impossible type.
+    Cannot = 4,
+}
+
+/// OAuth2 describes an OAuth2 provider and templates how it should be used.
+///
+/// The templates are mustache templates and have a set of variables
+/// available to them, the variables available everywhere are:
+/// client_id: OAuth2 provider client id
+/// redirect_uri: OAuth2 provider client registered redirect URI
+///
+/// Variables available in Auth URL request:
+/// state: the state parameter, this parameter is used to prevent attacks
+/// against our users. the parameter must be generated randomly and not
+/// guessable. It must be associated with a user session, and we must check in
+/// our redirect URI that the state we receive from the OAuth provider is the
+/// same as the one we passed in. Scenario: user A can initiate an OAuth2 flow,
+/// and send the OAuth Provider's Login URL to another person, user B. Once
+/// this other person logs in through the OAuth2 Provider, they will be
+/// redirected, and if there is no state check, we will authorise user A
+/// to access user B's account. With the state check, the state will not be
+/// available in user B's session, and therefore the state check will fail,
+/// preventing the attack.
+///
+/// Variables available in Access Token request:
+/// code: the code resulting from the suthorization step used to fetch the
+/// token
+/// client_secret: OAuth2 provider client secret
+///
+/// Variables available on Refresh Token request:
+/// refresh_token: the refresh token
+/// client_secret: OAuth2 provider client secret
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OAuth2 {
+    /// # Name of the OAuth2 provider.
+    /// This is a machine-readable key and must stay consistent.
+    /// One example use case is to map providers to their respective style of buttons in the UI.
+    pub provider: String,
+    /// # Authorization URL template.
+    /// This is the first step of the OAuth2 flow where the user is redirected
+    /// to the OAuth2 provider to authorize access to their account.
+    pub auth_url_template: String,
+    /// # Template for access token URL.
+    /// This is the second step of the OAuth2 flow, where we request an access token from the provider.
+    pub access_token_url_template: String,
+    /// # The method used to send Access Token requests.
+    /// If not specified, POST is used by default.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub access_token_method: String,
+    /// # The request body of the Access Token request.
+    /// If not specified, the request body is empty.
+    #[serde(default)]
+    pub access_token_body: String,
+    /// # Headers for the Access Token request.
+    #[serde(default)]
+    pub access_token_headers: BTreeMap<String, String>,
+    /// # Mapping from OAuth provider response documents of an Access Token request.
+    /// Maps keys into correct locations of the connector endpoint configuration.
+    /// If the connector supports refresh tokens, must include `refresh_token` and
+    /// `expires_in`. If this mapping is not provided, the keys from the response
+    /// are passed as-is to the connector config.
+    #[serde(default)]
+    pub access_token_response_map: BTreeMap<String, String>,
+    /// # Template for refresh token URL
+    /// If not specified, refresh tokens are not requested.
+    #[serde(default)]
+    pub refresh_token_url_template: String,
+    /// # The method used to send Refresh Token requests.
+    /// If not specified, POST is used by default.
+    #[serde(default)]
+    pub refresh_token_method: String,
+    /// # The request body of Refresh Token requests.
+    /// If not specified, the request body is empty.
+    #[serde(default)]
+    pub refresh_token_body: String,
+    /// # Headers for the Refresh Token request.
+    #[serde(default)]
+    pub refresh_token_headers: BTreeMap<String, String>,
+    /// # Mapping from OAuth provider response documents of a Refresh Token request.
+    #[serde(default)]
+    pub refresh_token_response_map: BTreeMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RawValue(pub Box<serde_json::value::RawValue>);
+
+impl JsonSchema for RawValue {
+    fn schema_name() -> String {
+        "Value".to_string()
+    }
+    fn is_referenceable() -> bool {
+        false
+    }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        serde_json::Value::json_schema(gen)
+    }
+}
+
+impl std::ops::Deref for RawValue {
+    type Target = serde_json::value::RawValue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/connector-protocol/src/materialize.rs
+++ b/crates/connector-protocol/src/materialize.rs
@@ -1,0 +1,280 @@
+use super::{CollectionSpec, OAuth2, RawValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Request is a message written into a materialization connector by the Flow runtime.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Request {
+    /// Spec requests the specification definition of this connector.
+    /// Notably this includes its endpoint and resource configuration JSON schema.
+    #[serde(rename_all = "camelCase")]
+    Spec {},
+    /// Validate a connector configuration and proposed bindings.
+    #[serde(rename_all = "camelCase")]
+    Validate {
+        /// # Name of the materialization being validated.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Proposed bindings of the validated materialization.
+        bindings: Vec<ValidateBinding>,
+    },
+    /// Apply a connector configuration and binding specifications.
+    #[serde(rename_all = "camelCase")]
+    Apply {
+        /// # Name of the materialization being applied.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Binding specifications of the applied materialization.
+        bindings: Vec<ApplyBinding>,
+        /// # Opaque, unique version of this materialization application.
+        version: String,
+        /// # Is this application a dry run?
+        /// Dry-run applications take no action.
+        dry_run: bool,
+    },
+    /// Open a materialization connector for materialization of documents to the endpoint.
+    #[serde(rename_all = "camelCase")]
+    Open {
+        /// # Name of the materialization being opened.
+        name: String,
+        /// # Connector endpoint configuration.
+        config: RawValue,
+        /// # Binding specifications of the opened materialization.
+        bindings: Vec<ApplyBinding>,
+        /// # Opaque, unique version of this materialization.
+        version: String,
+        /// # Beginning key-range which this connector invocation will materialize.
+        /// [keyBegin, keyEnd] are the inclusive range of keys processed by this
+        /// connector invocation. Ranges reflect the disjoint chunks of ownership
+        /// specific to each instance of a scale-out materialization.
+        ///
+        /// The Flow runtime manages the routing of document keys to distinct
+        /// connector invocations, and each invocation will receive only disjoint
+        /// subsets of possible keys. Thus, this key range is merely advisory.
+        key_begin: u32,
+        /// # Ending key-range which this connector invocation will materialize.
+        key_end: u32,
+        /// # Last-persisted driver checkpoint from a previous materialization invocation.
+        /// Or empty, if the driver has cleared or never set its checkpoint.
+        driver_checkpoint: RawValue,
+    },
+    /// Acknowledge to the connector that the previous transaction has committed
+    /// to the Flow runtime's recovery log.
+    #[serde(rename_all = "camelCase")]
+    Acknowledge {},
+    /// Load a document identified by its key. The given key may have never before been stored,
+    /// but a given key will be sent in a transaction Load just one time.
+    #[serde(rename_all = "camelCase")]
+    Load {
+        /// # Index of the Open binding for which this document is loaded.
+        binding: u32,
+        /// # Packed hexadecimal encoding of the key to load.
+        /// The packed encoding is order-preserving: given two instances of a
+        /// composite key K1 and K2, if K2 > K1 then K2's packed key is lexicographically
+        /// greater than K1's packed key.
+        key_packed: String,
+        /// # Composite key to load.
+        key: Vec<Value>,
+    },
+    /// Flush loads. No further Loads will be sent in this transaction,
+    /// and the runtime will await the connector's remaining Loaded responses
+    /// followed by one Flushed response.
+    #[serde(rename_all = "camelCase")]
+    Flush {},
+    /// Store documents updated by the current transaction.
+    #[serde(rename_all = "camelCase")]
+    Store {
+        /// # Index of the Open binding for which this document is stored.
+        binding: u32,
+        /// # Packed hexadecimal encoding of the key to store.
+        key_packed: String,
+        /// # Composite key to store.
+        key: Vec<Value>,
+        /// # Array of selected, projected document values to store.
+        values: Vec<Value>,
+        /// # Complete JSON document to store.
+        doc: Box<RawValue>,
+        /// # Does this key exist in the endpoint?
+        /// True if this document was previously loaded or stored.
+        /// A SQL materialization might toggle between INSERT vs UPDATE behavior
+        /// depending on this value.
+        exists: bool,
+    },
+    /// Mark the end of the Store phase, and if the remote store is authoritative,
+    /// instruct it to start committing its transaction.
+    #[serde(rename_all = "camelCase")]
+    StartCommit {
+        /// # Opaque, base64-encoded Flow runtime checkpoint.
+        /// If the endpoint is authoritative, the connector must store this checkpoint
+        /// for a retrieval upon a future Open.
+        runtime_checkpoint: String,
+    },
+}
+
+/// A proposed binding of the materialization to validate.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValidateBinding {
+    /// # Collection of the proposed binding.
+    pub collection: CollectionSpec,
+    /// # Resource configuration of the proposed binding.
+    pub resource_config: Box<RawValue>,
+    /// # Field configuration of the proposed binding.
+    pub field_config: BTreeMap<String, Box<RawValue>>,
+}
+
+/// A binding specification of the materialization.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ApplyBinding {
+    /// # Collection of this binding.
+    pub collection: CollectionSpec,
+    /// # Resource configuration of this binding.
+    pub resource_config: Box<RawValue>,
+    /// # Resource path which fully qualifies the endpoint resource identified by this binding.
+    /// For an RDBMS, this might be ["my-schema", "my-table"].
+    /// For Kafka, this might be ["my-topic-name"].
+    /// For Redis or DynamoDB, this might be ["/my/key/prefix"].
+    pub resource_path: Vec<String>,
+    /// # Does this binding use delta-updates instead of standard materialization?
+    pub delta_updates: bool,
+    /// # Fields which have been selected for materialization.
+    pub field_selection: FieldSelection,
+}
+
+/// Field selection describes the projected keys, values, and (optionally)
+/// the document to materialize, as well as any custom field configuration.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FieldSelection {
+    /// # Selected fields which are collection key components.
+    pub keys: Vec<String>,
+    /// # Selected fields which are values.
+    pub values: Vec<String>,
+    /// # Field which represents the Flow document, or null if the document isn't materialized.
+    pub document: Option<String>,
+    /// # Custom field configuration of the binding, keyed by field.
+    pub field_config: BTreeMap<String, Box<RawValue>>,
+}
+
+/// Response is a message written by a materialization connector to the Flow runtime.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum Response {
+    /// Spec responds to a Request "spec" command.
+    #[serde(rename_all = "camelCase")]
+    Spec {
+        /// # URL for connector's documentation.
+        documentation_url: String,
+        /// # JSON schema of the connector's endpoint configuration.
+        config_schema: RawValue,
+        /// # JSON schema of a binding's resource specification.
+        resource_config_schema: RawValue,
+        /// # Optional OAuth2 configuration.
+        #[serde(default)]
+        oauth2: Option<OAuth2>,
+    },
+    /// Validated responds to a Request "validate" command.
+    #[serde(rename_all = "camelCase")]
+    Validated {
+        /// # Validated bindings of the endpoint.
+        bindings: Vec<ValidatedBinding>,
+    },
+    /// Applied responds to a Request "apply" command.
+    #[serde(rename_all = "camelCase")]
+    Applied {
+        /// # User-facing description of the action taken by this application.
+        /// If the apply was a dry-run, then this is a description of actions
+        /// that would have been taken.
+        action_description: String,
+    },
+    /// Opened responds to a Request "open" command.
+    #[serde(rename_all = "camelCase")]
+    Opened {
+        /// # Flow runtime checkpoint to begin processing from. Optional.
+        /// If empty, the most recent checkpoint of the Flow recovery log is used.
+        ///
+        /// Or, a driver may send the value []byte{0xf8, 0xff, 0xff, 0xff, 0xf, 0x1}
+        /// to explicitly begin processing from a zero-valued checkpoint, effectively
+        /// rebuilding the materialization from scratch.
+        #[serde(default)]
+        runtime_checkpoint: String,
+    },
+    /// Loaded responds to a Request "load" command.
+    #[serde(rename_all = "camelCase")]
+    Loaded {
+        /// # Index of the Open binding for which this document is loaded.
+        binding: u32,
+        /// # Loaded document.
+        doc: Box<RawValue>,
+    },
+    /// Loaded responds to a Request "flush" command.
+    #[serde(rename_all = "camelCase")]
+    Flushed {},
+    /// StartedCommit responds to a Request "startCommit" command.
+    #[serde(rename_all = "camelCase")]
+    StartedCommit {
+        /// # Updated driver checkpoint to commit with this checkpoint.
+        driver_checkpoint: Box<RawValue>,
+        /// # Is this a partial update of the driver's checkpoint?
+        /// If true, then treat the driver checkpoint as a partial state update
+        /// which is incorporated into the full checkpoint as a RFC7396 Merge patch.
+        /// Otherwise the checkpoint is completely replaced.
+        merge_patch: bool,
+    },
+    /// Acknowledged follows Open and also StartedCommit, and tells the Flow Runtime
+    /// that a previously started commit has completed.
+    ///
+    /// Acknowledged is _not_ a direct response to Request "acknowledge" command,
+    /// and Acknowledge vs Acknowledged may be written in either order.
+    #[serde(rename_all = "camelCase")]
+    Acknowledged {},
+}
+
+/// A validated binding.
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValidatedBinding {
+    /// # Resource path which fully qualifies the endpoint resource identified by this binding.
+    pub resource_path: Vec<String>,
+    /// # Mapping of fields to their connector-imposed constraints.
+    /// The Flow runtime resolves a final set of fields from the user's specification
+    /// and the set of constraints returned by the connector.
+    pub constraints: BTreeMap<String, Constraint>,
+    /// # Should delta-updates be used for this binding?
+    pub delta_updates: bool,
+}
+
+/// A Constraint constrains the use of a collection projection within a materialization binding.
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Constraint {
+    /// # The type of this constraint.
+    pub r#type: ConstraintType,
+    /// # A user-facing reason for the constraint on this field.
+    pub reason: String,
+}
+
+/// The type of a field constraint.
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub enum ConstraintType {
+    /// This specific projection must be present.
+    FieldRequired = 0,
+    /// At least one projection with this location pointer must be present.
+    LocationRequired = 1,
+    /// A projection with this location is recommended, and should be included by
+    /// default.
+    LocationRecommended = 2,
+    /// This projection may be included, but should be omitted by default.
+    FieldOptional = 3,
+    /// This projection must not be present in the materialization.
+    FieldForbidden = 4,
+    /// This specific projection is required but is also unacceptable (e.x.,
+    /// because it uses an incompatible type with a previous applied version).
+    Unsatisfiable = 5,
+}

--- a/crates/connector-protocol/tests/schema_generation.rs
+++ b/crates/connector-protocol/tests/schema_generation.rs
@@ -1,0 +1,13 @@
+use connector_protocol::{capture, materialize};
+
+#[test]
+fn test_catalog_schema_snapshot() {
+    let mut settings = schemars::gen::SchemaSettings::draft2019_09();
+    settings.option_add_null_type = false;
+    let mut generator = schemars::gen::SchemaGenerator::new(settings);
+
+    insta::assert_json_snapshot!(&generator.root_schema_for::<capture::Request>());
+    insta::assert_json_snapshot!(&generator.root_schema_for::<capture::Response>());
+    insta::assert_json_snapshot!(&generator.root_schema_for::<materialize::Request>());
+    insta::assert_json_snapshot!(&generator.root_schema_for::<materialize::Response>());
+}

--- a/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-2.snap
+++ b/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-2.snap
@@ -1,0 +1,571 @@
+---
+source: crates/connector-protocol/tests/schema_generation.rs
+expression: "&generator.root_schema_for::<capture::Response>()"
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Response",
+  "description": "Response is a message written by a capture connector to the Flow runtime.",
+  "oneOf": [
+    {
+      "description": "Spec responds to a Request \"spec\" command.",
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "configSchema",
+            "documentationUrl",
+            "resourceConfigSchema"
+          ],
+          "properties": {
+            "configSchema": {
+              "title": "JSON schema of the connector's endpoint configuration."
+            },
+            "documentationUrl": {
+              "title": "URL for connector's documentation.",
+              "type": "string"
+            },
+            "oauth2": {
+              "title": "Optional OAuth2 configuration.",
+              "default": null,
+              "$ref": "#/definitions/OAuth2"
+            },
+            "resourceConfigSchema": {
+              "title": "JSON schema of a binding's resource specification."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Discovered responds to a Request \"discover\" command.",
+      "type": "object",
+      "required": [
+        "discovered"
+      ],
+      "properties": {
+        "discovered": {
+          "type": "object",
+          "required": [
+            "bindings"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Discovered bindings of the endpoint.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DiscoveredBinding"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Validated responds to a Request \"validate\" command.",
+      "type": "object",
+      "required": [
+        "validated"
+      ],
+      "properties": {
+        "validated": {
+          "type": "object",
+          "required": [
+            "bindings"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Validated bindings of the endpoint.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ValidatedBinding"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Applied responds to a Request \"apply\" command.",
+      "type": "object",
+      "required": [
+        "applied"
+      ],
+      "properties": {
+        "applied": {
+          "type": "object",
+          "required": [
+            "actionDescription"
+          ],
+          "properties": {
+            "actionDescription": {
+              "title": "User-facing description of the action taken by this application.",
+              "description": "If the apply was a dry-run, then this is a description of actions that would have been taken.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Opened responds to a Request \"open\" command.",
+      "type": "object",
+      "required": [
+        "opened"
+      ],
+      "properties": {
+        "opened": {
+          "type": "object",
+          "required": [
+            "explicitAcknowledgements"
+          ],
+          "properties": {
+            "explicitAcknowledgements": {
+              "title": "Should the runtime explicitly respond to the connector's Checkpoints?",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Document captured by this connector invocation. Emitted documents are pending, and are not committed to their bound collection until a following Checkpoint is emitted.",
+      "type": "object",
+      "required": [
+        "document"
+      ],
+      "properties": {
+        "document": {
+          "type": "object",
+          "required": [
+            "binding",
+            "doc"
+          ],
+          "properties": {
+            "binding": {
+              "title": "Index of the Open binding for which this document is captured.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "doc": {
+              "title": "Document value."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Checkpoint all preceding documents of this invocation since the last checkpoint. The Flow runtime may begin to commit documents in a transaction. Note that the runtime may include more than one checkpoint in a single transaction.",
+      "type": "object",
+      "required": [
+        "checkpoint"
+      ],
+      "properties": {
+        "checkpoint": {
+          "type": "object",
+          "required": [
+            "driverCheckpoint",
+            "mergePatch"
+          ],
+          "properties": {
+            "driverCheckpoint": {
+              "title": "Updated driver checkpoint to commit with this checkpoint."
+            },
+            "mergePatch": {
+              "title": "Is this a partial update of the driver's checkpoint?",
+              "description": "If true, then treat the driver checkpoint as a partial state update which is incorporated into the full checkpoint as a RFC7396 Merge patch. Otherwise the checkpoint is completely replaced.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ApplyBinding": {
+      "description": "A binding specification of the capture.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig",
+        "resourcePath"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of this binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of this binding."
+        },
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "description": "For an RDBMS, this might be [\"my-schema\", \"my-table\"]. For Kafka, this might be [\"my-topic-name\"]. For Redis or DynamoDB, this might be [\"/my/key/prefix\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CollectionSpec": {
+      "description": "Specification of a Flow collection.",
+      "type": "object",
+      "required": [
+        "key",
+        "name",
+        "partitionFields",
+        "projections"
+      ],
+      "properties": {
+        "key": {
+          "title": "Composite key of the collection.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "title": "Name of this collection.",
+          "type": "string"
+        },
+        "partitionFields": {
+          "title": "Logically-partitioned fields of this collection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "projections": {
+          "title": "Projections of this collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Projection"
+          }
+        },
+        "readSchema": {
+          "title": "JSON Schema against which read collection documents are validated.",
+          "description": "If set, then writeSchema is also and schema is not."
+        },
+        "schema": {
+          "title": "JSON Schema against which collection documents are validated.",
+          "description": "If set, then writeSchema and readSchema are not."
+        },
+        "writeSchema": {
+          "title": "JSON Schema against which written collection documents are validated.",
+          "description": "If set, then readSchema is also and schema is not."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DiscoveredBinding": {
+      "description": "A discovered endpoint resource which may be bound to a Flow Collection.",
+      "type": "object",
+      "required": [
+        "documentSchema",
+        "key",
+        "recommendedName",
+        "resourceConfig"
+      ],
+      "properties": {
+        "documentSchema": {
+          "title": "JSON Schema for documents captured via the binding."
+        },
+        "key": {
+          "title": "Composite key of documents captured via the binding.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendedName": {
+          "title": "Recommended partial name for this binding's collection.",
+          "description": "For example, a SQL database capture might use the table's name.",
+          "type": "string"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration for this binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Exists": {
+      "description": "Enumeration which describes what's known about a location's existence documents of the schema.",
+      "type": "string",
+      "enum": [
+        "Must",
+        "May",
+        "Implicit",
+        "Cannot"
+      ]
+    },
+    "Inference": {
+      "description": "Static inference over this document location, extracted from a JSON Schema.",
+      "type": "object",
+      "required": [
+        "default",
+        "description",
+        "exists",
+        "secret",
+        "title",
+        "types"
+      ],
+      "properties": {
+        "default": {
+          "description": "The default value from the schema, or \"null\" if there is no default."
+        },
+        "description": {
+          "description": "The description from the schema, if provided.",
+          "type": "string"
+        },
+        "exists": {
+          "description": "Existence of this document location.",
+          "$ref": "#/definitions/Exists"
+        },
+        "secret": {
+          "description": "Whether this location is marked as a secret, like a credential or password.",
+          "type": "boolean"
+        },
+        "string": {
+          "description": "String type-specific inferences, or null iff types doesn't include \"string\".",
+          "$ref": "#/definitions/StringInference"
+        },
+        "title": {
+          "description": "The title from the schema, if provided.",
+          "type": "string"
+        },
+        "types": {
+          "description": "The possible types for this location. Subset of: [\"null\", \"boolean\", \"object\", \"array\", \"integer\", \"numeric\", \"string\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuth2": {
+      "description": "OAuth2 describes an OAuth2 provider and templates how it should be used.\n\nThe templates are mustache templates and have a set of variables available to them, the variables available everywhere are: client_id: OAuth2 provider client id redirect_uri: OAuth2 provider client registered redirect URI\n\nVariables available in Auth URL request: state: the state parameter, this parameter is used to prevent attacks against our users. the parameter must be generated randomly and not guessable. It must be associated with a user session, and we must check in our redirect URI that the state we receive from the OAuth provider is the same as the one we passed in. Scenario: user A can initiate an OAuth2 flow, and send the OAuth Provider's Login URL to another person, user B. Once this other person logs in through the OAuth2 Provider, they will be redirected, and if there is no state check, we will authorise user A to access user B's account. With the state check, the state will not be available in user B's session, and therefore the state check will fail, preventing the attack.\n\nVariables available in Access Token request: code: the code resulting from the suthorization step used to fetch the token client_secret: OAuth2 provider client secret\n\nVariables available on Refresh Token request: refresh_token: the refresh token client_secret: OAuth2 provider client secret",
+      "type": "object",
+      "required": [
+        "accessTokenUrlTemplate",
+        "authUrlTemplate",
+        "provider"
+      ],
+      "properties": {
+        "accessTokenBody": {
+          "title": "The request body of the Access Token request.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "accessTokenHeaders": {
+          "title": "Headers for the Access Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenMethod": {
+          "title": "The method used to send Access Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "type": "string"
+        },
+        "accessTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of an Access Token request.",
+          "description": "Maps keys into correct locations of the connector endpoint configuration. If the connector supports refresh tokens, must include `refresh_token` and `expires_in`. If this mapping is not provided, the keys from the response are passed as-is to the connector config.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenUrlTemplate": {
+          "title": "Template for access token URL.",
+          "description": "This is the second step of the OAuth2 flow, where we request an access token from the provider.",
+          "type": "string"
+        },
+        "authUrlTemplate": {
+          "title": "Authorization URL template.",
+          "description": "This is the first step of the OAuth2 flow where the user is redirected to the OAuth2 provider to authorize access to their account.",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Name of the OAuth2 provider.",
+          "description": "This is a machine-readable key and must stay consistent. One example use case is to map providers to their respective style of buttons in the UI.",
+          "type": "string"
+        },
+        "refreshTokenBody": {
+          "title": "The request body of Refresh Token requests.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenHeaders": {
+          "title": "Headers for the Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenMethod": {
+          "title": "The method used to send Refresh Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of a Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenUrlTemplate": {
+          "title": "Template for refresh token URL",
+          "description": "If not specified, refresh tokens are not requested.",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Projection": {
+      "description": "Projections are named locations within a collection document which may be used for logical partitioning, or may be mapped into a tabular representation such as a SQL database table.",
+      "type": "object",
+      "required": [
+        "explicit",
+        "field",
+        "inference",
+        "isPartitionKey",
+        "isPrimaryKey",
+        "ptr"
+      ],
+      "properties": {
+        "explicit": {
+          "title": "Was this projection explicitly provided ?",
+          "description": "(As opposed to implicitly created through static analysis of the schema).",
+          "type": "boolean"
+        },
+        "field": {
+          "title": "Flattened, tabular alias of this projection.",
+          "description": "A field may correspond to a SQL table column, for example.",
+          "type": "string"
+        },
+        "inference": {
+          "title": "Inference of this projection.",
+          "$ref": "#/definitions/Inference"
+        },
+        "isPartitionKey": {
+          "title": "Does this projection constitute a logical partitioning of the collection?",
+          "type": "boolean"
+        },
+        "isPrimaryKey": {
+          "title": "Does this location form (part of) the collection key?",
+          "type": "boolean"
+        },
+        "ptr": {
+          "title": "Document location of this projection, as a JSON-Pointer.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringInference": {
+      "description": "Static inference over a document location of type \"string\", extracted from a JSON schema.",
+      "type": "object",
+      "required": [
+        "contentEncoding",
+        "contentType",
+        "format",
+        "isBase64",
+        "maxLength"
+      ],
+      "properties": {
+        "contentEncoding": {
+          "title": "Annotated Content-Encoding when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "contentType": {
+          "title": "Annotated Content-Type when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "isBase64": {
+          "title": "Is the Content-Encoding \"base64\" (case-invariant)?",
+          "type": "boolean"
+        },
+        "maxLength": {
+          "title": "Maximum length when the projection is of \"string\" type.",
+          "description": "Zero for no limit.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidateBinding": {
+      "description": "A proposed binding of the capture to validate.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of the proposed binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of the proposed binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidatedBinding": {
+      "description": "A validated binding.",
+      "type": "object",
+      "required": [
+        "resourcePath"
+      ],
+      "properties": {
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-3.snap
+++ b/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-3.snap
@@ -1,0 +1,675 @@
+---
+source: crates/connector-protocol/tests/schema_generation.rs
+expression: "&generator.root_schema_for::<materialize::Request>()"
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Request",
+  "description": "Request is a message written into a materialization connector by the Flow runtime.",
+  "oneOf": [
+    {
+      "description": "Spec requests the specification definition of this connector. Notably this includes its endpoint and resource configuration JSON schema.",
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Validate a connector configuration and proposed bindings.",
+      "type": "object",
+      "required": [
+        "validate"
+      ],
+      "properties": {
+        "validate": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "name"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Proposed bindings of the validated materialization.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ValidateBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "name": {
+              "title": "Name of the materialization being validated.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Apply a connector configuration and binding specifications.",
+      "type": "object",
+      "required": [
+        "apply"
+      ],
+      "properties": {
+        "apply": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "dryRun",
+            "name",
+            "version"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Binding specifications of the applied materialization.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ApplyBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "dryRun": {
+              "title": "Is this application a dry run?",
+              "description": "Dry-run applications take no action.",
+              "type": "boolean"
+            },
+            "name": {
+              "title": "Name of the materialization being applied.",
+              "type": "string"
+            },
+            "version": {
+              "title": "Opaque, unique version of this materialization application.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Open a materialization connector for materialization of documents to the endpoint.",
+      "type": "object",
+      "required": [
+        "open"
+      ],
+      "properties": {
+        "open": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "driverCheckpoint",
+            "keyBegin",
+            "keyEnd",
+            "name",
+            "version"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Binding specifications of the opened materialization.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ApplyBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "driverCheckpoint": {
+              "title": "Last-persisted driver checkpoint from a previous materialization invocation.",
+              "description": "Or empty, if the driver has cleared or never set its checkpoint."
+            },
+            "keyBegin": {
+              "title": "Beginning key-range which this connector invocation will materialize.",
+              "description": "[keyBegin, keyEnd] are the inclusive range of keys processed by this connector invocation. Ranges reflect the disjoint chunks of ownership specific to each instance of a scale-out materialization.\n\nThe Flow runtime manages the routing of document keys to distinct connector invocations, and each invocation will receive only disjoint subsets of possible keys. Thus, this key range is merely advisory.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "keyEnd": {
+              "title": "Ending key-range which this connector invocation will materialize.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "name": {
+              "title": "Name of the materialization being opened.",
+              "type": "string"
+            },
+            "version": {
+              "title": "Opaque, unique version of this materialization.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Acknowledge to the connector that the previous transaction has committed to the Flow runtime's recovery log.",
+      "type": "object",
+      "required": [
+        "acknowledge"
+      ],
+      "properties": {
+        "acknowledge": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Load a document identified by its key. The given key may have never before been stored, but a given key will be sent in a transaction Load just one time.",
+      "type": "object",
+      "required": [
+        "load"
+      ],
+      "properties": {
+        "load": {
+          "type": "object",
+          "required": [
+            "binding",
+            "key",
+            "keyPacked"
+          ],
+          "properties": {
+            "binding": {
+              "title": "Index of the Open binding for which this document is loaded.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "key": {
+              "title": "Composite key to load.",
+              "type": "array",
+              "items": true
+            },
+            "keyPacked": {
+              "title": "Packed hexadecimal encoding of the key to load.",
+              "description": "The packed encoding is order-preserving: given two instances of a composite key K1 and K2, if K2 > K1 then K2's packed key is lexicographically greater than K1's packed key.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Flush loads. No further Loads will be sent in this transaction, and the runtime will await the connector's remaining Loaded responses followed by one Flushed response.",
+      "type": "object",
+      "required": [
+        "flush"
+      ],
+      "properties": {
+        "flush": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Store documents updated by the current transaction.",
+      "type": "object",
+      "required": [
+        "store"
+      ],
+      "properties": {
+        "store": {
+          "type": "object",
+          "required": [
+            "binding",
+            "doc",
+            "exists",
+            "key",
+            "keyPacked",
+            "values"
+          ],
+          "properties": {
+            "binding": {
+              "title": "Index of the Open binding for which this document is stored.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "doc": {
+              "title": "Complete JSON document to store."
+            },
+            "exists": {
+              "title": "Does this key exist in the endpoint?",
+              "description": "True if this document was previously loaded or stored. A SQL materialization might toggle between INSERT vs UPDATE behavior depending on this value.",
+              "type": "boolean"
+            },
+            "key": {
+              "title": "Composite key to store.",
+              "type": "array",
+              "items": true
+            },
+            "keyPacked": {
+              "title": "Packed hexadecimal encoding of the key to store.",
+              "type": "string"
+            },
+            "values": {
+              "title": "Array of selected, projected document values to store.",
+              "type": "array",
+              "items": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Mark the end of the Store phase, and if the remote store is authoritative, instruct it to start committing its transaction.",
+      "type": "object",
+      "required": [
+        "startCommit"
+      ],
+      "properties": {
+        "startCommit": {
+          "type": "object",
+          "required": [
+            "runtimeCheckpoint"
+          ],
+          "properties": {
+            "runtimeCheckpoint": {
+              "title": "Opaque, base64-encoded Flow runtime checkpoint.",
+              "description": "If the endpoint is authoritative, the connector must store this checkpoint for a retrieval upon a future Open.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ApplyBinding": {
+      "description": "A binding specification of the capture.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig",
+        "resourcePath"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of this binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of this binding."
+        },
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "description": "For an RDBMS, this might be [\"my-schema\", \"my-table\"]. For Kafka, this might be [\"my-topic-name\"]. For Redis or DynamoDB, this might be [\"/my/key/prefix\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CollectionSpec": {
+      "description": "Specification of a Flow collection.",
+      "type": "object",
+      "required": [
+        "key",
+        "name",
+        "partitionFields",
+        "projections"
+      ],
+      "properties": {
+        "key": {
+          "title": "Composite key of the collection.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "title": "Name of this collection.",
+          "type": "string"
+        },
+        "partitionFields": {
+          "title": "Logically-partitioned fields of this collection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "projections": {
+          "title": "Projections of this collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Projection"
+          }
+        },
+        "readSchema": {
+          "title": "JSON Schema against which read collection documents are validated.",
+          "description": "If set, then writeSchema is also and schema is not."
+        },
+        "schema": {
+          "title": "JSON Schema against which collection documents are validated.",
+          "description": "If set, then writeSchema and readSchema are not."
+        },
+        "writeSchema": {
+          "title": "JSON Schema against which written collection documents are validated.",
+          "description": "If set, then readSchema is also and schema is not."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DiscoveredBinding": {
+      "description": "A discovered endpoint resource which may be bound to a Flow Collection.",
+      "type": "object",
+      "required": [
+        "documentSchema",
+        "key",
+        "recommendedName",
+        "resourceConfig"
+      ],
+      "properties": {
+        "documentSchema": {
+          "title": "JSON Schema for documents captured via the binding."
+        },
+        "key": {
+          "title": "Composite key of documents captured via the binding.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendedName": {
+          "title": "Recommended partial name for this binding's collection.",
+          "description": "For example, a SQL database capture might use the table's name.",
+          "type": "string"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration for this binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Exists": {
+      "description": "Enumeration which describes what's known about a location's existence documents of the schema.",
+      "type": "string",
+      "enum": [
+        "Must",
+        "May",
+        "Implicit",
+        "Cannot"
+      ]
+    },
+    "Inference": {
+      "description": "Static inference over this document location, extracted from a JSON Schema.",
+      "type": "object",
+      "required": [
+        "default",
+        "description",
+        "exists",
+        "secret",
+        "title",
+        "types"
+      ],
+      "properties": {
+        "default": {
+          "description": "The default value from the schema, or \"null\" if there is no default."
+        },
+        "description": {
+          "description": "The description from the schema, if provided.",
+          "type": "string"
+        },
+        "exists": {
+          "description": "Existence of this document location.",
+          "$ref": "#/definitions/Exists"
+        },
+        "secret": {
+          "description": "Whether this location is marked as a secret, like a credential or password.",
+          "type": "boolean"
+        },
+        "string": {
+          "description": "String type-specific inferences, or null iff types doesn't include \"string\".",
+          "$ref": "#/definitions/StringInference"
+        },
+        "title": {
+          "description": "The title from the schema, if provided.",
+          "type": "string"
+        },
+        "types": {
+          "description": "The possible types for this location. Subset of: [\"null\", \"boolean\", \"object\", \"array\", \"integer\", \"numeric\", \"string\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuth2": {
+      "description": "OAuth2 describes an OAuth2 provider and templates how it should be used.\n\nThe templates are mustache templates and have a set of variables available to them, the variables available everywhere are: client_id: OAuth2 provider client id redirect_uri: OAuth2 provider client registered redirect URI\n\nVariables available in Auth URL request: state: the state parameter, this parameter is used to prevent attacks against our users. the parameter must be generated randomly and not guessable. It must be associated with a user session, and we must check in our redirect URI that the state we receive from the OAuth provider is the same as the one we passed in. Scenario: user A can initiate an OAuth2 flow, and send the OAuth Provider's Login URL to another person, user B. Once this other person logs in through the OAuth2 Provider, they will be redirected, and if there is no state check, we will authorise user A to access user B's account. With the state check, the state will not be available in user B's session, and therefore the state check will fail, preventing the attack.\n\nVariables available in Access Token request: code: the code resulting from the suthorization step used to fetch the token client_secret: OAuth2 provider client secret\n\nVariables available on Refresh Token request: refresh_token: the refresh token client_secret: OAuth2 provider client secret",
+      "type": "object",
+      "required": [
+        "accessTokenUrlTemplate",
+        "authUrlTemplate",
+        "provider"
+      ],
+      "properties": {
+        "accessTokenBody": {
+          "title": "The request body of the Access Token request.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "accessTokenHeaders": {
+          "title": "Headers for the Access Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenMethod": {
+          "title": "The method used to send Access Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "type": "string"
+        },
+        "accessTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of an Access Token request.",
+          "description": "Maps keys into correct locations of the connector endpoint configuration. If the connector supports refresh tokens, must include `refresh_token` and `expires_in`. If this mapping is not provided, the keys from the response are passed as-is to the connector config.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenUrlTemplate": {
+          "title": "Template for access token URL.",
+          "description": "This is the second step of the OAuth2 flow, where we request an access token from the provider.",
+          "type": "string"
+        },
+        "authUrlTemplate": {
+          "title": "Authorization URL template.",
+          "description": "This is the first step of the OAuth2 flow where the user is redirected to the OAuth2 provider to authorize access to their account.",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Name of the OAuth2 provider.",
+          "description": "This is a machine-readable key and must stay consistent. One example use case is to map providers to their respective style of buttons in the UI.",
+          "type": "string"
+        },
+        "refreshTokenBody": {
+          "title": "The request body of Refresh Token requests.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenHeaders": {
+          "title": "Headers for the Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenMethod": {
+          "title": "The method used to send Refresh Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of a Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenUrlTemplate": {
+          "title": "Template for refresh token URL",
+          "description": "If not specified, refresh tokens are not requested.",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Projection": {
+      "description": "Projections are named locations within a collection document which may be used for logical partitioning, or may be mapped into a tabular representation such as a SQL database table.",
+      "type": "object",
+      "required": [
+        "explicit",
+        "field",
+        "inference",
+        "isPartitionKey",
+        "isPrimaryKey",
+        "ptr"
+      ],
+      "properties": {
+        "explicit": {
+          "title": "Was this projection explicitly provided ?",
+          "description": "(As opposed to implicitly created through static analysis of the schema).",
+          "type": "boolean"
+        },
+        "field": {
+          "title": "Flattened, tabular alias of this projection.",
+          "description": "A field may correspond to a SQL table column, for example.",
+          "type": "string"
+        },
+        "inference": {
+          "title": "Inference of this projection.",
+          "$ref": "#/definitions/Inference"
+        },
+        "isPartitionKey": {
+          "title": "Does this projection constitute a logical partitioning of the collection?",
+          "type": "boolean"
+        },
+        "isPrimaryKey": {
+          "title": "Does this location form (part of) the collection key?",
+          "type": "boolean"
+        },
+        "ptr": {
+          "title": "Document location of this projection, as a JSON-Pointer.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringInference": {
+      "description": "Static inference over a document location of type \"string\", extracted from a JSON schema.",
+      "type": "object",
+      "required": [
+        "contentEncoding",
+        "contentType",
+        "format",
+        "isBase64",
+        "maxLength"
+      ],
+      "properties": {
+        "contentEncoding": {
+          "title": "Annotated Content-Encoding when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "contentType": {
+          "title": "Annotated Content-Type when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "isBase64": {
+          "title": "Is the Content-Encoding \"base64\" (case-invariant)?",
+          "type": "boolean"
+        },
+        "maxLength": {
+          "title": "Maximum length when the projection is of \"string\" type.",
+          "description": "Zero for no limit.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidateBinding": {
+      "description": "A proposed binding of the capture to validate.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of the proposed binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of the proposed binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidatedBinding": {
+      "description": "A validated binding.",
+      "type": "object",
+      "required": [
+        "resourcePath"
+      ],
+      "properties": {
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-4.snap
+++ b/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot-4.snap
@@ -1,0 +1,572 @@
+---
+source: crates/connector-protocol/tests/schema_generation.rs
+expression: "&generator.root_schema_for::<materialize::Response>()"
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Response",
+  "description": "Response is a message written by a materialization connector to the Flow runtime.",
+  "oneOf": [
+    {
+      "description": "Spec responds to a Request \"spec\" command.",
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "configSchema",
+            "documentationUrl",
+            "resourceConfigSchema"
+          ],
+          "properties": {
+            "configSchema": {
+              "title": "JSON schema of the connector's endpoint configuration."
+            },
+            "documentationUrl": {
+              "title": "URL for connector's documentation.",
+              "type": "string"
+            },
+            "oauth2": {
+              "title": "Optional OAuth2 configuration.",
+              "default": null,
+              "$ref": "#/definitions/OAuth2"
+            },
+            "resourceConfigSchema": {
+              "title": "JSON schema of a binding's resource specification."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Validated responds to a Request \"validate\" command.",
+      "type": "object",
+      "required": [
+        "validated"
+      ],
+      "properties": {
+        "validated": {
+          "type": "object",
+          "required": [
+            "bindings"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Validated bindings of the endpoint.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ValidatedBinding"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Applied responds to a Request \"apply\" command.",
+      "type": "object",
+      "required": [
+        "applied"
+      ],
+      "properties": {
+        "applied": {
+          "type": "object",
+          "required": [
+            "actionDescription"
+          ],
+          "properties": {
+            "actionDescription": {
+              "title": "User-facing description of the action taken by this application.",
+              "description": "If the apply was a dry-run, then this is a description of actions that would have been taken.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Opened responds to a Request \"open\" command.",
+      "type": "object",
+      "required": [
+        "opened"
+      ],
+      "properties": {
+        "opened": {
+          "type": "object",
+          "properties": {
+            "runtimeCheckpoint": {
+              "title": "Flow runtime checkpoint to begin processing from. Optional.",
+              "description": "If empty, the most recent checkpoint of the Flow recovery log is used.\n\nOr, a driver may send the value []byte{0xf8, 0xff, 0xff, 0xff, 0xf, 0x1} to explicitly begin processing from a zero-valued checkpoint, effectively rebuilding the materialization from scratch.",
+              "default": "",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Loaded responds to a Request \"load\" command.",
+      "type": "object",
+      "required": [
+        "loaded"
+      ],
+      "properties": {
+        "loaded": {
+          "type": "object",
+          "required": [
+            "binding",
+            "doc"
+          ],
+          "properties": {
+            "binding": {
+              "title": "Index of the Open binding for which this document is loaded.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "doc": {
+              "title": "Loaded document."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Loaded responds to a Request \"flush\" command.",
+      "type": "object",
+      "required": [
+        "flushed"
+      ],
+      "properties": {
+        "flushed": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "StartedCommit responds to a Request \"startCommit\" command.",
+      "type": "object",
+      "required": [
+        "startedCommit"
+      ],
+      "properties": {
+        "startedCommit": {
+          "type": "object",
+          "required": [
+            "driverCheckpoint",
+            "mergePatch"
+          ],
+          "properties": {
+            "driverCheckpoint": {
+              "title": "Updated driver checkpoint to commit with this checkpoint."
+            },
+            "mergePatch": {
+              "title": "Is this a partial update of the driver's checkpoint?",
+              "description": "If true, then treat the driver checkpoint as a partial state update which is incorporated into the full checkpoint as a RFC7396 Merge patch. Otherwise the checkpoint is completely replaced.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Acknowledged follows Open and also StartedCommit, and tells the Flow Runtime that a previously started commit has completed.\n\nAcknowledged is _not_ a direct response to Request \"acknowledge\" command, and Acknowledge vs Acknowledged may be written in either order.",
+      "type": "object",
+      "required": [
+        "acknowledged"
+      ],
+      "properties": {
+        "acknowledged": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ApplyBinding": {
+      "description": "A binding specification of the capture.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig",
+        "resourcePath"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of this binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of this binding."
+        },
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "description": "For an RDBMS, this might be [\"my-schema\", \"my-table\"]. For Kafka, this might be [\"my-topic-name\"]. For Redis or DynamoDB, this might be [\"/my/key/prefix\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CollectionSpec": {
+      "description": "Specification of a Flow collection.",
+      "type": "object",
+      "required": [
+        "key",
+        "name",
+        "partitionFields",
+        "projections"
+      ],
+      "properties": {
+        "key": {
+          "title": "Composite key of the collection.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "title": "Name of this collection.",
+          "type": "string"
+        },
+        "partitionFields": {
+          "title": "Logically-partitioned fields of this collection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "projections": {
+          "title": "Projections of this collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Projection"
+          }
+        },
+        "readSchema": {
+          "title": "JSON Schema against which read collection documents are validated.",
+          "description": "If set, then writeSchema is also and schema is not."
+        },
+        "schema": {
+          "title": "JSON Schema against which collection documents are validated.",
+          "description": "If set, then writeSchema and readSchema are not."
+        },
+        "writeSchema": {
+          "title": "JSON Schema against which written collection documents are validated.",
+          "description": "If set, then readSchema is also and schema is not."
+        }
+      },
+      "additionalProperties": false
+    },
+    "DiscoveredBinding": {
+      "description": "A discovered endpoint resource which may be bound to a Flow Collection.",
+      "type": "object",
+      "required": [
+        "documentSchema",
+        "key",
+        "recommendedName",
+        "resourceConfig"
+      ],
+      "properties": {
+        "documentSchema": {
+          "title": "JSON Schema for documents captured via the binding."
+        },
+        "key": {
+          "title": "Composite key of documents captured via the binding.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendedName": {
+          "title": "Recommended partial name for this binding's collection.",
+          "description": "For example, a SQL database capture might use the table's name.",
+          "type": "string"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration for this binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Exists": {
+      "description": "Enumeration which describes what's known about a location's existence documents of the schema.",
+      "type": "string",
+      "enum": [
+        "Must",
+        "May",
+        "Implicit",
+        "Cannot"
+      ]
+    },
+    "Inference": {
+      "description": "Static inference over this document location, extracted from a JSON Schema.",
+      "type": "object",
+      "required": [
+        "default",
+        "description",
+        "exists",
+        "secret",
+        "title",
+        "types"
+      ],
+      "properties": {
+        "default": {
+          "description": "The default value from the schema, or \"null\" if there is no default."
+        },
+        "description": {
+          "description": "The description from the schema, if provided.",
+          "type": "string"
+        },
+        "exists": {
+          "description": "Existence of this document location.",
+          "$ref": "#/definitions/Exists"
+        },
+        "secret": {
+          "description": "Whether this location is marked as a secret, like a credential or password.",
+          "type": "boolean"
+        },
+        "string": {
+          "description": "String type-specific inferences, or null iff types doesn't include \"string\".",
+          "$ref": "#/definitions/StringInference"
+        },
+        "title": {
+          "description": "The title from the schema, if provided.",
+          "type": "string"
+        },
+        "types": {
+          "description": "The possible types for this location. Subset of: [\"null\", \"boolean\", \"object\", \"array\", \"integer\", \"numeric\", \"string\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuth2": {
+      "description": "OAuth2 describes an OAuth2 provider and templates how it should be used.\n\nThe templates are mustache templates and have a set of variables available to them, the variables available everywhere are: client_id: OAuth2 provider client id redirect_uri: OAuth2 provider client registered redirect URI\n\nVariables available in Auth URL request: state: the state parameter, this parameter is used to prevent attacks against our users. the parameter must be generated randomly and not guessable. It must be associated with a user session, and we must check in our redirect URI that the state we receive from the OAuth provider is the same as the one we passed in. Scenario: user A can initiate an OAuth2 flow, and send the OAuth Provider's Login URL to another person, user B. Once this other person logs in through the OAuth2 Provider, they will be redirected, and if there is no state check, we will authorise user A to access user B's account. With the state check, the state will not be available in user B's session, and therefore the state check will fail, preventing the attack.\n\nVariables available in Access Token request: code: the code resulting from the suthorization step used to fetch the token client_secret: OAuth2 provider client secret\n\nVariables available on Refresh Token request: refresh_token: the refresh token client_secret: OAuth2 provider client secret",
+      "type": "object",
+      "required": [
+        "accessTokenUrlTemplate",
+        "authUrlTemplate",
+        "provider"
+      ],
+      "properties": {
+        "accessTokenBody": {
+          "title": "The request body of the Access Token request.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "accessTokenHeaders": {
+          "title": "Headers for the Access Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenMethod": {
+          "title": "The method used to send Access Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "type": "string"
+        },
+        "accessTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of an Access Token request.",
+          "description": "Maps keys into correct locations of the connector endpoint configuration. If the connector supports refresh tokens, must include `refresh_token` and `expires_in`. If this mapping is not provided, the keys from the response are passed as-is to the connector config.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "accessTokenUrlTemplate": {
+          "title": "Template for access token URL.",
+          "description": "This is the second step of the OAuth2 flow, where we request an access token from the provider.",
+          "type": "string"
+        },
+        "authUrlTemplate": {
+          "title": "Authorization URL template.",
+          "description": "This is the first step of the OAuth2 flow where the user is redirected to the OAuth2 provider to authorize access to their account.",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Name of the OAuth2 provider.",
+          "description": "This is a machine-readable key and must stay consistent. One example use case is to map providers to their respective style of buttons in the UI.",
+          "type": "string"
+        },
+        "refreshTokenBody": {
+          "title": "The request body of Refresh Token requests.",
+          "description": "If not specified, the request body is empty.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenHeaders": {
+          "title": "Headers for the Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenMethod": {
+          "title": "The method used to send Refresh Token requests.",
+          "description": "If not specified, POST is used by default.",
+          "default": "",
+          "type": "string"
+        },
+        "refreshTokenResponseMap": {
+          "title": "Mapping from OAuth provider response documents of a Refresh Token request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "refreshTokenUrlTemplate": {
+          "title": "Template for refresh token URL",
+          "description": "If not specified, refresh tokens are not requested.",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Projection": {
+      "description": "Projections are named locations within a collection document which may be used for logical partitioning, or may be mapped into a tabular representation such as a SQL database table.",
+      "type": "object",
+      "required": [
+        "explicit",
+        "field",
+        "inference",
+        "isPartitionKey",
+        "isPrimaryKey",
+        "ptr"
+      ],
+      "properties": {
+        "explicit": {
+          "title": "Was this projection explicitly provided ?",
+          "description": "(As opposed to implicitly created through static analysis of the schema).",
+          "type": "boolean"
+        },
+        "field": {
+          "title": "Flattened, tabular alias of this projection.",
+          "description": "A field may correspond to a SQL table column, for example.",
+          "type": "string"
+        },
+        "inference": {
+          "title": "Inference of this projection.",
+          "$ref": "#/definitions/Inference"
+        },
+        "isPartitionKey": {
+          "title": "Does this projection constitute a logical partitioning of the collection?",
+          "type": "boolean"
+        },
+        "isPrimaryKey": {
+          "title": "Does this location form (part of) the collection key?",
+          "type": "boolean"
+        },
+        "ptr": {
+          "title": "Document location of this projection, as a JSON-Pointer.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringInference": {
+      "description": "Static inference over a document location of type \"string\", extracted from a JSON schema.",
+      "type": "object",
+      "required": [
+        "contentEncoding",
+        "contentType",
+        "format",
+        "isBase64",
+        "maxLength"
+      ],
+      "properties": {
+        "contentEncoding": {
+          "title": "Annotated Content-Encoding when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "contentType": {
+          "title": "Annotated Content-Type when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "isBase64": {
+          "title": "Is the Content-Encoding \"base64\" (case-invariant)?",
+          "type": "boolean"
+        },
+        "maxLength": {
+          "title": "Maximum length when the projection is of \"string\" type.",
+          "description": "Zero for no limit.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidateBinding": {
+      "description": "A proposed binding of the capture to validate.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of the proposed binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of the proposed binding."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidatedBinding": {
+      "description": "A validated binding.",
+      "type": "object",
+      "required": [
+        "resourcePath"
+      ],
+      "properties": {
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/connector-protocol/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -1,0 +1,440 @@
+---
+source: crates/connector-protocol/tests/schema_generation.rs
+expression: "&generator.root_schema_for::<capture::Request>()"
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Request",
+  "description": "Request is a message written into a capture connector by the Flow runtime.",
+  "oneOf": [
+    {
+      "description": "Spec requests the specification definition of this connector. Notably this includes its endpoint and resource configuration JSON schema.",
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Discover returns the set of resources available from this Driver.",
+      "type": "object",
+      "required": [
+        "discover"
+      ],
+      "properties": {
+        "discover": {
+          "type": "object",
+          "required": [
+            "config"
+          ],
+          "properties": {
+            "config": {
+              "title": "Connector endpoint configuration."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Validate a connector configuration and proposed bindings.",
+      "type": "object",
+      "required": [
+        "validate"
+      ],
+      "properties": {
+        "validate": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "name"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Proposed bindings of the validated capture.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ValidateBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "name": {
+              "title": "Name of the capture being validated.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Apply a connector configuration and binding specifications.",
+      "type": "object",
+      "required": [
+        "apply"
+      ],
+      "properties": {
+        "apply": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "dryRun",
+            "name",
+            "version"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Binding specifications of the applied capture.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ApplyBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "dryRun": {
+              "title": "Is this application a dry run?",
+              "description": "Dry-run applications take no action.",
+              "type": "boolean"
+            },
+            "name": {
+              "title": "Name of the capture being applied.",
+              "type": "string"
+            },
+            "version": {
+              "title": "Opaque, unique version of this capture application.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Open a capture connector for reading documents from the endpoint. Unless the connector requests explicit acknowledgements, Open is the last message which will be sent to the connector's stdin.",
+      "type": "object",
+      "required": [
+        "open"
+      ],
+      "properties": {
+        "open": {
+          "type": "object",
+          "required": [
+            "bindings",
+            "config",
+            "driverCheckpoint",
+            "intervalSeconds",
+            "keyBegin",
+            "keyEnd",
+            "name",
+            "version"
+          ],
+          "properties": {
+            "bindings": {
+              "title": "Binding specifications of the opened capture.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ApplyBinding"
+              }
+            },
+            "config": {
+              "title": "Connector endpoint configuration."
+            },
+            "driverCheckpoint": {
+              "title": "Last-persisted driver checkpoint from a previous capture invocation.",
+              "description": "Or empty, if the driver has cleared or never set its checkpoint. Each key-range of the capture has its own durable checkpoint, which is managed by the Flow runtime."
+            },
+            "intervalSeconds": {
+              "title": "Frequency of connector restarts.",
+              "description": "Restart intervals are applicable only for captures which poll ready documents from their endpoint and then exit. Unbounded, streaming connectors are restarted only when necessary.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "keyBegin": {
+              "title": "Beginning key-range which this connector invocation must capture.",
+              "description": "[keyBegin, keyEnd] are the inclusive range of keys processed by this connector invocation. Ranges reflect the disjoint chunks of ownership specific to each instance of a scale-out capture.\n\nThe meaning of a \"key\" in this range is up to the connector. For example, captures of a partitioned system (like Kafka or Kinesis) might hash dynamically listed partitions into a 32-bit unsigned integer, and then capture only those which fall within its opened key range.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "keyEnd": {
+              "title": "Ending key-range which this connector invocation must capture.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "name": {
+              "title": "Name of the capture being opened.",
+              "type": "string"
+            },
+            "version": {
+              "title": "Opaque, unique version of this capture.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Acknowledge to the connector that its checkpoint has committed to the Flow runtime recovery log. Acknowledgments are sent only if requested by the connector in its Opened response, and one Acknowledge is sent for each preceding Checkpoint response of the connector.",
+      "type": "object",
+      "required": [
+        "acknowledge"
+      ],
+      "properties": {
+        "acknowledge": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ApplyBinding": {
+      "description": "A binding specification of the capture.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig",
+        "resourcePath"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of this binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of this binding."
+        },
+        "resourcePath": {
+          "title": "Resource path which fully qualifies the endpoint resource identified by this binding.",
+          "description": "For an RDBMS, this might be [\"my-schema\", \"my-table\"]. For Kafka, this might be [\"my-topic-name\"]. For Redis or DynamoDB, this might be [\"/my/key/prefix\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CollectionSpec": {
+      "description": "Specification of a Flow collection.",
+      "type": "object",
+      "required": [
+        "key",
+        "name",
+        "partitionFields",
+        "projections"
+      ],
+      "properties": {
+        "key": {
+          "title": "Composite key of the collection.",
+          "description": "Keys are specified as an ordered sequence of JSON-Pointers.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "title": "Name of this collection.",
+          "type": "string"
+        },
+        "partitionFields": {
+          "title": "Logically-partitioned fields of this collection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "projections": {
+          "title": "Projections of this collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Projection"
+          }
+        },
+        "readSchema": {
+          "title": "JSON Schema against which read collection documents are validated.",
+          "description": "If set, then writeSchema is also and schema is not."
+        },
+        "schema": {
+          "title": "JSON Schema against which collection documents are validated.",
+          "description": "If set, then writeSchema and readSchema are not."
+        },
+        "writeSchema": {
+          "title": "JSON Schema against which written collection documents are validated.",
+          "description": "If set, then readSchema is also and schema is not."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Exists": {
+      "description": "Enumeration which describes what's known about a location's existence documents of the schema.",
+      "type": "string",
+      "enum": [
+        "Must",
+        "May",
+        "Implicit",
+        "Cannot"
+      ]
+    },
+    "Inference": {
+      "description": "Static inference over this document location, extracted from a JSON Schema.",
+      "type": "object",
+      "required": [
+        "default",
+        "description",
+        "exists",
+        "secret",
+        "title",
+        "types"
+      ],
+      "properties": {
+        "default": {
+          "description": "The default value from the schema, or \"null\" if there is no default."
+        },
+        "description": {
+          "description": "The description from the schema, if provided.",
+          "type": "string"
+        },
+        "exists": {
+          "description": "Existence of this document location.",
+          "$ref": "#/definitions/Exists"
+        },
+        "secret": {
+          "description": "Whether this location is marked as a secret, like a credential or password.",
+          "type": "boolean"
+        },
+        "string": {
+          "description": "String type-specific inferences, or null iff types doesn't include \"string\".",
+          "$ref": "#/definitions/StringInference"
+        },
+        "title": {
+          "description": "The title from the schema, if provided.",
+          "type": "string"
+        },
+        "types": {
+          "description": "The possible types for this location. Subset of: [\"null\", \"boolean\", \"object\", \"array\", \"integer\", \"numeric\", \"string\"].",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Projection": {
+      "description": "Projections are named locations within a collection document which may be used for logical partitioning, or may be mapped into a tabular representation such as a SQL database table.",
+      "type": "object",
+      "required": [
+        "explicit",
+        "field",
+        "inference",
+        "isPartitionKey",
+        "isPrimaryKey",
+        "ptr"
+      ],
+      "properties": {
+        "explicit": {
+          "title": "Was this projection explicitly provided ?",
+          "description": "(As opposed to implicitly created through static analysis of the schema).",
+          "type": "boolean"
+        },
+        "field": {
+          "title": "Flattened, tabular alias of this projection.",
+          "description": "A field may correspond to a SQL table column, for example.",
+          "type": "string"
+        },
+        "inference": {
+          "title": "Inference of this projection.",
+          "$ref": "#/definitions/Inference"
+        },
+        "isPartitionKey": {
+          "title": "Does this projection constitute a logical partitioning of the collection?",
+          "type": "boolean"
+        },
+        "isPrimaryKey": {
+          "title": "Does this location form (part of) the collection key?",
+          "type": "boolean"
+        },
+        "ptr": {
+          "title": "Document location of this projection, as a JSON-Pointer.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringInference": {
+      "description": "Static inference over a document location of type \"string\", extracted from a JSON schema.",
+      "type": "object",
+      "required": [
+        "contentEncoding",
+        "contentType",
+        "format",
+        "isBase64",
+        "maxLength"
+      ],
+      "properties": {
+        "contentEncoding": {
+          "title": "Annotated Content-Encoding when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "contentType": {
+          "title": "Annotated Content-Type when the projection is of \"string\" type.",
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "isBase64": {
+          "title": "Is the Content-Encoding \"base64\" (case-invariant)?",
+          "type": "boolean"
+        },
+        "maxLength": {
+          "title": "Maximum length when the projection is of \"string\" type.",
+          "description": "Zero for no limit.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidateBinding": {
+      "description": "A proposed binding of the capture to validate.",
+      "type": "object",
+      "required": [
+        "collection",
+        "resourceConfig"
+      ],
+      "properties": {
+        "collection": {
+          "title": "Collection of the proposed binding.",
+          "$ref": "#/definitions/CollectionSpec"
+        },
+        "resourceConfig": {
+          "title": "Resource configuration of the proposed binding."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/proto-convert/Cargo.toml
+++ b/crates/proto-convert/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "proto-convert"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+proto-flow = { path = "../proto-flow" }
+connector-protocol = { path = "../connector-protocol" }
+tuple = { path = "../tuple" }
+
+anyhow = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+prost = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/proto-convert/src/capture/mod.rs
+++ b/crates/proto-convert/src/capture/mod.rs
@@ -1,0 +1,2 @@
+mod proto_from;
+mod proto_into;

--- a/crates/proto-convert/src/capture/proto_from.rs
+++ b/crates/proto-convert/src/capture/proto_from.rs
@@ -1,0 +1,198 @@
+use crate::{Convert, FromMessage};
+use connector_protocol::{
+    capture::{DiscoveredBinding, Response, ValidatedBinding},
+    OAuth2,
+};
+use proto_flow::{
+    capture::{self, discover_response, pull_response, validate_response},
+    flow,
+};
+
+impl FromMessage for capture::SpecResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Spec{
+            documentation_url,
+            config_schema,
+            resource_config_schema,
+            oauth2,
+        } = msg else {
+            anyhow::bail!("expected spec, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self {
+            documentation_url,
+            endpoint_spec_schema_json: config_schema.to_string(),
+            resource_spec_schema_json: resource_config_schema.to_string(),
+            oauth2_spec: oauth2.map(Convert::convert),
+        }))
+    }
+}
+
+impl FromMessage for capture::DiscoverResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Discovered {
+            bindings,
+        } = msg else {
+            anyhow::bail!("expected discovered, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self {
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+        }))
+    }
+}
+
+impl FromMessage for capture::ValidateResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Validated { bindings } = msg else {
+            anyhow::bail!("expected validated, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self {
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+        }))
+    }
+}
+
+impl FromMessage for capture::ApplyResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Applied { action_description } = msg else {
+            anyhow::bail!("expected applied, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self { action_description }))
+    }
+}
+
+impl FromMessage for capture::PullResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        match msg {
+            Response::Opened {
+                explicit_acknowledgements,
+            } => out.push(capture::PullResponse {
+                opened: Some(pull_response::Opened {
+                    explicit_acknowledgements,
+                }),
+                ..Default::default()
+            }),
+            Response::Document { binding, doc } => {
+                let documents = match out.last_mut() {
+                    Some(capture::PullResponse {
+                        documents: Some(documents),
+                        ..
+                    }) if binding == documents.binding
+                        && documents.arena.capacity()
+                            >= documents.arena.len() + doc.get().len() =>
+                    {
+                        documents
+                    }
+                    _ => {
+                        out.push(capture::PullResponse {
+                            documents: Some(capture::Documents {
+                                binding,
+                                arena: Vec::with_capacity(1 << 16), // 64K
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        });
+                        out.last_mut().unwrap().documents.as_mut().unwrap()
+                    }
+                };
+                let begin = documents.arena.len() as u32;
+                documents.arena.extend_from_slice(doc.get().as_bytes());
+                let end = documents.arena.len() as u32;
+                documents.docs_json.push(flow::Slice { begin, end });
+            }
+            Response::Checkpoint {
+                driver_checkpoint,
+                merge_patch,
+            } => {
+                let driver_checkpoint: Box<str> = driver_checkpoint.0.into();
+
+                out.push(capture::PullResponse {
+                    checkpoint: Some(flow::DriverCheckpoint {
+                        driver_checkpoint_json: driver_checkpoint.into_boxed_bytes().into_vec(),
+                        rfc7396_merge_patch: merge_patch,
+                    }),
+                    ..Default::default()
+                });
+            }
+            msg => {
+                anyhow::bail!(
+                    "expected opened, document, or checkpoint, not: {}",
+                    serde_json::to_string_pretty(&msg).unwrap()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Convert for DiscoveredBinding {
+    type Target = discover_response::Binding;
+    fn convert(self: Self) -> Self::Target {
+        let DiscoveredBinding {
+            recommended_name,
+            resource_config,
+            document_schema,
+            key: key_ptrs,
+        } = self;
+        Self::Target {
+            recommended_name,
+            resource_spec_json: resource_config.to_string(),
+            document_schema_json: document_schema.to_string(),
+            key_ptrs,
+        }
+    }
+}
+
+impl Convert for ValidatedBinding {
+    type Target = validate_response::Binding;
+    fn convert(self: Self) -> Self::Target {
+        let Self { resource_path } = self;
+        Self::Target { resource_path }
+    }
+}
+
+impl Convert for OAuth2 {
+    type Target = flow::OAuth2Spec;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            provider,
+            auth_url_template,
+            access_token_url_template,
+            access_token_method,
+            access_token_body,
+            access_token_headers,
+            access_token_response_map,
+            refresh_token_url_template,
+            refresh_token_method,
+            refresh_token_body,
+            refresh_token_headers,
+            refresh_token_response_map,
+        } = self;
+
+        Self::Target {
+            provider,
+            auth_url_template,
+            access_token_url_template,
+            access_token_method,
+            access_token_body,
+            access_token_headers_json: serde_json::to_string(&access_token_headers).unwrap(),
+            access_token_response_map_json: serde_json::to_string(&access_token_response_map)
+                .unwrap(),
+            refresh_token_url_template,
+            refresh_token_method,
+            refresh_token_body,
+            refresh_token_headers_json: serde_json::to_string(&refresh_token_headers).unwrap(),
+            refresh_token_response_map_json: serde_json::to_string(&refresh_token_response_map)
+                .unwrap(),
+        }
+    }
+}

--- a/crates/proto-convert/src/capture/proto_into.rs
+++ b/crates/proto-convert/src/capture/proto_into.rs
@@ -1,0 +1,291 @@
+use crate::{Convert, IntoMessages};
+use connector_protocol::{
+    capture::{ApplyBinding, Request, ValidateBinding},
+    RawValue,
+};
+use proto_flow::{
+    capture::{self, pull_request, validate_request},
+    flow::{self, capture_spec, inference},
+};
+
+impl IntoMessages for capture::SpecRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            endpoint_type: _,
+            endpoint_spec_json: _,
+        } = self;
+        vec![Request::Spec {}]
+    }
+}
+
+impl IntoMessages for capture::DiscoverRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            endpoint_type: _,
+            endpoint_spec_json,
+        } = self;
+        vec![Request::Discover {
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+        }]
+    }
+}
+
+impl IntoMessages for capture::ValidateRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            capture,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+        } = self;
+
+        vec![Request::Validate {
+            name: capture,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+        }]
+    }
+}
+
+impl IntoMessages for capture::ApplyRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            capture,
+            dry_run,
+            version,
+        } = self;
+
+        let flow::CaptureSpec {
+            capture,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+            interval_seconds: _,
+            shard_template: _,
+            recovery_log_template: _,
+        } = capture.unwrap();
+
+        vec![Request::Apply {
+            name: capture,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+            version,
+            dry_run,
+        }]
+    }
+}
+
+impl IntoMessages for capture::PullRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self { open, acknowledge } = self;
+        let mut out = Vec::with_capacity(1);
+
+        if let Some(open) = open {
+            out.push(open.convert());
+        }
+        if let Some(capture::Acknowledge {}) = acknowledge {
+            out.push(Request::Acknowledge {})
+        }
+        out
+    }
+}
+
+impl Convert for pull_request::Open {
+    type Target = Request;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            capture,
+            driver_checkpoint_json,
+            key_begin,
+            key_end,
+            version,
+        } = self;
+
+        let flow::CaptureSpec {
+            capture,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+            interval_seconds,
+            shard_template: _,
+            recovery_log_template: _,
+        } = capture.unwrap();
+
+        Request::Open {
+            name: capture,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+            version,
+            key_begin,
+            key_end,
+            driver_checkpoint: serde_json::from_slice::<RawValue>(&driver_checkpoint_json).unwrap(),
+            interval_seconds,
+        }
+    }
+}
+
+impl Convert for validate_request::Binding {
+    type Target = ValidateBinding;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            collection,
+            resource_spec_json,
+        } = self;
+
+        Self::Target {
+            collection: collection.unwrap().convert(),
+            resource_config: serde_json::from_str(&resource_spec_json).unwrap(),
+        }
+    }
+}
+
+impl Convert for capture_spec::Binding {
+    type Target = ApplyBinding;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            collection,
+            resource_spec_json,
+            resource_path,
+        } = self;
+
+        Self::Target {
+            collection: collection.unwrap().convert(),
+            resource_config: serde_json::from_str(&resource_spec_json).unwrap(),
+            resource_path,
+        }
+    }
+}
+
+impl Convert for flow::CollectionSpec {
+    type Target = connector_protocol::CollectionSpec;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            ack_json_template: _,
+            collection,
+            key_ptrs,
+            partition_fields,
+            partition_template: _,
+            projections,
+            read_schema_json,
+            read_schema_uri: _,
+            uuid_ptr: _,
+            write_schema_json,
+            write_schema_uri: _,
+        } = self;
+
+        let (schema, read_schema, write_schema) = if read_schema_json.is_empty() {
+            (
+                Some(serde_json::from_str(&write_schema_json).unwrap()),
+                None,
+                None,
+            )
+        } else {
+            (
+                None,
+                Some(serde_json::from_str(&read_schema_json).unwrap()),
+                Some(serde_json::from_str(&write_schema_json).unwrap()),
+            )
+        };
+
+        Self::Target {
+            name: collection,
+            key: key_ptrs,
+            partition_fields,
+            projections: projections.into_iter().map(Convert::convert).collect(),
+            schema,
+            write_schema,
+            read_schema,
+        }
+    }
+}
+
+impl Convert for flow::Projection {
+    type Target = connector_protocol::Projection;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            ptr,
+            field,
+            explicit,
+            is_partition_key,
+            is_primary_key,
+            inference,
+        } = self;
+
+        Self::Target {
+            ptr,
+            field,
+            explicit,
+            is_partition_key,
+            is_primary_key,
+            inference: inference.unwrap().convert(),
+        }
+    }
+}
+
+impl Convert for flow::Inference {
+    type Target = connector_protocol::Inference;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            types,
+            string,
+            title,
+            description,
+            default_json,
+            secret,
+            exists,
+        } = self;
+
+        Self::Target {
+            types,
+            string: string.map(Convert::convert),
+            title,
+            description,
+            default: if default_json.is_empty() {
+                serde_json::from_str("null").unwrap()
+            } else {
+                serde_json::from_str(&default_json).unwrap()
+            },
+            secret,
+            exists: inference::Exists::from_i32(exists).unwrap().convert(),
+        }
+    }
+}
+
+impl Convert for inference::String {
+    type Target = connector_protocol::StringInference;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            content_encoding,
+            content_type,
+            format,
+            is_base64,
+            max_length,
+        } = self;
+
+        Self::Target {
+            content_encoding,
+            content_type,
+            format,
+            is_base64,
+            max_length: max_length as usize,
+        }
+    }
+}
+
+impl Convert for inference::Exists {
+    type Target = connector_protocol::Exists;
+    fn convert(self: Self) -> Self::Target {
+        match self {
+            inference::Exists::Must => Self::Target::Must,
+            inference::Exists::May => Self::Target::May,
+            inference::Exists::Implicit => Self::Target::Implicit,
+            inference::Exists::Cannot => Self::Target::Cannot,
+            inference::Exists::Invalid => unreachable!("invalid exists variant"),
+        }
+    }
+}

--- a/crates/proto-convert/src/lib.rs
+++ b/crates/proto-convert/src/lib.rs
@@ -1,0 +1,23 @@
+pub trait IntoMessages {
+    type Message: serde::Serialize + Sized;
+
+    fn into_messages(self) -> Vec<Self::Message>;
+}
+
+pub trait FromMessage: Sized {
+    type Message: for<'de> serde::Deserialize<'de> + Sized;
+
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()>;
+}
+
+// Convert is an internal trait similar to Into, which plays a role similar to From,
+// but is defined over types of external crates.
+trait Convert {
+    type Target;
+    #[must_use]
+    fn convert(self: Self) -> Self::Target;
+}
+
+pub mod capture;
+pub mod materialize;
+pub mod test;

--- a/crates/proto-convert/src/materialize/mod.rs
+++ b/crates/proto-convert/src/materialize/mod.rs
@@ -1,0 +1,2 @@
+mod proto_from;
+mod proto_into;

--- a/crates/proto-convert/src/materialize/proto_from.rs
+++ b/crates/proto-convert/src/materialize/proto_from.rs
@@ -1,0 +1,159 @@
+use crate::{Convert, FromMessage};
+use anyhow::Context;
+use connector_protocol::materialize::{Constraint, Response, ValidatedBinding};
+use proto_flow::{
+    flow,
+    materialize::{self, transaction_response, validate_response},
+};
+
+impl FromMessage for materialize::SpecResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Spec {
+            documentation_url,
+            config_schema,
+            resource_config_schema,
+            oauth2,
+        } = msg else {
+            anyhow::bail!("expected spec, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self {
+            documentation_url,
+            endpoint_spec_schema_json: config_schema.to_string(),
+            resource_spec_schema_json: resource_config_schema.to_string(),
+            oauth2_spec: oauth2.map(Convert::convert),
+        }))
+    }
+}
+
+impl FromMessage for materialize::ValidateResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Validated { bindings } = msg else {
+            anyhow::bail!("expected validated, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self {
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+        }))
+    }
+}
+
+impl FromMessage for materialize::ApplyResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        let Response::Applied { action_description } = msg else {
+            anyhow::bail!("expected applied, not: {}", serde_json::to_string_pretty(&msg).unwrap());
+        };
+
+        Ok(out.push(Self { action_description }))
+    }
+}
+
+impl FromMessage for materialize::TransactionResponse {
+    type Message = Response;
+    fn from_message(msg: Self::Message, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        match msg {
+            Response::Opened { runtime_checkpoint } => {
+                let runtime_checkpoint = base64::decode(runtime_checkpoint)
+                    .context("decoding runtime checkpoint base64")?;
+                out.push(materialize::TransactionResponse {
+                    opened: Some(transaction_response::Opened { runtime_checkpoint }),
+                    ..Default::default()
+                });
+            }
+            Response::Acknowledged {} => {
+                out.push(materialize::TransactionResponse {
+                    acknowledged: Some(transaction_response::Acknowledged {}),
+                    ..Default::default()
+                });
+            }
+            Response::Loaded { binding, doc } => {
+                let loaded = match out.last_mut() {
+                    Some(materialize::TransactionResponse {
+                        loaded: Some(loaded),
+                        ..
+                    }) if binding == loaded.binding
+                        && loaded.arena.capacity() >= loaded.arena.len() + doc.get().len() =>
+                    {
+                        loaded
+                    }
+                    _ => {
+                        out.push(materialize::TransactionResponse {
+                            loaded: Some(transaction_response::Loaded {
+                                binding,
+                                arena: Vec::with_capacity(1 << 16), // 64K
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        });
+                        out.last_mut().unwrap().loaded.as_mut().unwrap()
+                    }
+                };
+                let begin = loaded.arena.len() as u32;
+                loaded.arena.extend_from_slice(doc.get().as_bytes());
+                let end = loaded.arena.len() as u32;
+                loaded.docs_json.push(flow::Slice { begin, end });
+            }
+            Response::Flushed {} => {
+                out.push(materialize::TransactionResponse {
+                    flushed: Some(transaction_response::Flushed {}),
+                    ..Default::default()
+                });
+            }
+            Response::StartedCommit {
+                driver_checkpoint,
+                merge_patch,
+            } => {
+                let driver_checkpoint: Box<str> = driver_checkpoint.0.into();
+
+                out.push(materialize::TransactionResponse {
+                    started_commit: Some(transaction_response::StartedCommit {
+                        driver_checkpoint: Some(flow::DriverCheckpoint {
+                            driver_checkpoint_json: driver_checkpoint.into_boxed_bytes().into_vec(),
+                            rfc7396_merge_patch: merge_patch,
+                        }),
+                    }),
+                    ..Default::default()
+                });
+            }
+            msg => {
+                anyhow::bail!(
+                    "expected opened, acknowledged, loaded, flushed, or startedCommit, not: {}",
+                    serde_json::to_string_pretty(&msg).unwrap()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Convert for ValidatedBinding {
+    type Target = validate_response::Binding;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            resource_path,
+            constraints,
+            delta_updates,
+        } = self;
+
+        Self::Target {
+            resource_path,
+            constraints: constraints
+                .into_iter()
+                .map(|(field, Constraint { r#type, reason })| {
+                    (
+                        field,
+                        materialize::Constraint {
+                            r#type: r#type as i32,
+                            reason,
+                        },
+                    )
+                })
+                .collect(),
+            delta_updates,
+        }
+    }
+}

--- a/crates/proto-convert/src/materialize/proto_into.rs
+++ b/crates/proto-convert/src/materialize/proto_into.rs
@@ -1,0 +1,269 @@
+use crate::{Convert, IntoMessages};
+use connector_protocol::{
+    materialize::{ApplyBinding, FieldSelection, Request, ValidateBinding},
+    RawValue,
+};
+use proto_flow::{
+    flow::{self, materialization_spec},
+    materialize::{self, transaction_request, validate_request},
+};
+use serde_json::Value;
+use tuple::{Element, TupleUnpack};
+
+impl IntoMessages for materialize::SpecRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            endpoint_type: _,
+            endpoint_spec_json: _,
+        } = self;
+        vec![Request::Spec {}]
+    }
+}
+
+impl IntoMessages for materialize::ValidateRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            materialization,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+        } = self;
+
+        vec![Request::Validate {
+            name: materialization,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+        }]
+    }
+}
+
+impl IntoMessages for materialize::ApplyRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self {
+            materialization,
+            dry_run,
+            version,
+        } = self;
+
+        let flow::MaterializationSpec {
+            materialization,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+            shard_template: _,
+            recovery_log_template: _,
+        } = materialization.unwrap();
+
+        vec![Request::Apply {
+            name: materialization,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+            version,
+            dry_run,
+        }]
+    }
+}
+
+impl IntoMessages for materialize::TransactionRequest {
+    type Message = Request;
+    fn into_messages(self) -> Vec<Self::Message> {
+        let mut out = Vec::with_capacity(1);
+
+        let Self {
+            open,
+            acknowledge,
+            load,
+            flush,
+            store,
+            start_commit,
+        } = self;
+
+        if let Some(open) = open {
+            out.push(open.convert());
+        }
+        if let Some(transaction_request::Acknowledge {}) = acknowledge {
+            out.push(Request::Acknowledge {});
+        }
+        if let Some(transaction_request::Load {
+            binding,
+            arena,
+            packed_keys,
+        }) = load
+        {
+            for flow::Slice { begin, end } in packed_keys {
+                let key_packed = &arena[begin as usize..end as usize];
+                let key: Vec<Element> = Vec::unpack_root(key_packed).unwrap();
+                let key: Vec<Value> = key.into_iter().map(element_to_value).collect();
+
+                out.push(Request::Load {
+                    binding,
+                    key_packed: hex::encode(key_packed),
+                    key,
+                });
+            }
+        }
+        if let Some(transaction_request::Flush {}) = flush {
+            out.push(Request::Flush {});
+        }
+        if let Some(transaction_request::Store {
+            binding,
+            arena,
+            packed_keys,
+            packed_values,
+            docs_json,
+            exists,
+        }) = store
+        {
+            for i in 0..packed_keys.len() {
+                let flow::Slice { begin, end } = packed_keys[i];
+                let key_packed = &arena[begin as usize..end as usize];
+                let key: Vec<Element> = Vec::unpack_root(key_packed).unwrap();
+                let key: Vec<Value> = key.into_iter().map(element_to_value).collect();
+
+                let flow::Slice { begin, end } = packed_values[i];
+                let values_packed = &arena[begin as usize..end as usize];
+                let values: Vec<Element> = Vec::unpack_root(values_packed).unwrap();
+                let values: Vec<Value> = values.into_iter().map(element_to_value).collect();
+
+                let flow::Slice { begin, end } = docs_json[i];
+                let doc_json = &arena[begin as usize..end as usize];
+                let doc = serde_json::from_slice(doc_json).unwrap();
+
+                out.push(Request::Store {
+                    binding,
+                    key_packed: hex::encode(key_packed),
+                    key,
+                    values,
+                    doc,
+                    exists: exists[i],
+                });
+            }
+        }
+        if let Some(transaction_request::StartCommit { runtime_checkpoint }) = start_commit {
+            out.push(Request::StartCommit {
+                runtime_checkpoint: base64::encode(runtime_checkpoint),
+            });
+        }
+
+        out
+    }
+}
+
+impl Convert for transaction_request::Open {
+    type Target = Request;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            materialization,
+            driver_checkpoint_json,
+            key_begin,
+            key_end,
+            version,
+        } = self;
+
+        let flow::MaterializationSpec {
+            materialization,
+            endpoint_type: _,
+            endpoint_spec_json,
+            bindings,
+            shard_template: _,
+            recovery_log_template: _,
+        } = materialization.unwrap();
+
+        Request::Open {
+            name: materialization,
+            config: serde_json::from_str(&endpoint_spec_json).unwrap(),
+            bindings: bindings.into_iter().map(Convert::convert).collect(),
+            version,
+            key_begin,
+            key_end,
+            driver_checkpoint: serde_json::from_slice::<RawValue>(&driver_checkpoint_json).unwrap(),
+        }
+    }
+}
+
+impl Convert for validate_request::Binding {
+    type Target = ValidateBinding;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            collection,
+            resource_spec_json,
+            field_config_json,
+        } = self;
+
+        ValidateBinding {
+            collection: collection.unwrap().convert(),
+            resource_config: serde_json::from_str(&resource_spec_json).unwrap(),
+            field_config: field_config_json
+                .into_iter()
+                .map(|(k, v)| (k, serde_json::from_str(&v).unwrap()))
+                .collect(),
+        }
+    }
+}
+
+impl Convert for materialization_spec::Binding {
+    type Target = ApplyBinding;
+
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            collection,
+            resource_spec_json,
+            resource_path,
+            delta_updates,
+            field_selection,
+            shuffle: _,
+        } = self;
+
+        ApplyBinding {
+            collection: collection.unwrap().convert(),
+            resource_config: serde_json::from_str(&resource_spec_json).unwrap(),
+            resource_path,
+            delta_updates,
+            field_selection: field_selection.unwrap().convert(),
+        }
+    }
+}
+
+impl Convert for flow::FieldSelection {
+    type Target = FieldSelection;
+    fn convert(self: Self) -> Self::Target {
+        let Self {
+            keys,
+            document,
+            field_config_json,
+            values,
+        } = self;
+
+        let field_config = field_config_json
+            .into_iter()
+            .map(|(field, config)| (field, serde_json::from_str(&config).unwrap()))
+            .collect();
+
+        FieldSelection {
+            keys,
+            values,
+            document: if document.is_empty() {
+                None
+            } else {
+                Some(document)
+            },
+            field_config,
+        }
+    }
+}
+
+fn element_to_value(element: tuple::Element) -> Value {
+    match element {
+        Element::Bool(b) => Value::Bool(b),
+        Element::Bytes(buf) => serde_json::from_slice::<Value>(&buf).unwrap(),
+        Element::Double(d) => Value::Number(serde_json::Number::from_f64(d).unwrap()),
+        Element::Float(f) => Value::Number(serde_json::Number::from_f64(f as f64).unwrap()),
+        Element::Int(i) => Value::Number(i.into()),
+        Element::Nil => Value::Null,
+        Element::String(s) => Value::String(s.to_string()),
+        elem => panic!("tuple element {:?} not supported", elem),
+    }
+}

--- a/crates/proto-convert/src/test.rs
+++ b/crates/proto-convert/src/test.rs
@@ -1,0 +1,31 @@
+use super::{FromMessage, IntoMessages};
+use proto_flow::flow;
+
+/// TestSpec is a stub of the flow TestSpec protobuf type,
+/// which implements IntoMessages and FromMessage.
+/// It's exposed only to facilitate higher-level testing of protocol conversions.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct TestSpec {
+    pub test: String,
+}
+
+impl IntoMessages for flow::TestSpec {
+    type Message = TestSpec;
+
+    fn into_messages(self) -> Vec<Self::Message> {
+        let Self { test, steps: _ } = self;
+
+        vec![TestSpec { test }]
+    }
+}
+
+impl FromMessage for flow::TestSpec {
+    type Message = TestSpec;
+
+    fn from_message(TestSpec { test }: TestSpec, out: &mut Vec<Self>) -> anyhow::Result<()> {
+        Ok(out.push(Self {
+            test,
+            steps: Vec::new(),
+        }))
+    }
+}

--- a/crates/proto-convert/tests/proto_conversion.rs
+++ b/crates/proto-convert/tests/proto_conversion.rs
@@ -1,0 +1,538 @@
+use proto_convert::{FromMessage, IntoMessages};
+use proto_flow::{
+    capture::{self, pull_request},
+    flow::{self, inference},
+    materialize::{self, transaction_request},
+};
+use serde_json::{json, Value};
+use std::io::Write;
+use tuple::TuplePack;
+
+#[test]
+fn test_proto_request_to_json() {
+    let collection_one = flow::CollectionSpec {
+        collection: "collection/one".to_string(),
+        key_ptrs: vec!["/key/one".to_string(), "/two/3".to_string()],
+        partition_fields: vec!["part-field".to_string()],
+        projections: vec![flow::Projection {
+            explicit: false,
+            is_partition_key: true,
+            is_primary_key: false,
+            field: "a-field".to_string(),
+            ptr: "/json/ptr".to_string(),
+            inference: Some(flow::Inference {
+                default_json: json!({"def": "ault"}).to_string(),
+                description: "desc".to_string(),
+                title: "title".to_string(),
+                exists: inference::Exists::Must as i32,
+                secret: false,
+                string: Some(inference::String {
+                    content_encoding: "enc".to_string(),
+                    content_type: "typ".to_string(),
+                    format: "date".to_string(),
+                    is_base64: false,
+                    max_length: 12345,
+                }),
+                types: vec!["integer".to_string(), "string".to_string()],
+            }),
+        }],
+        write_schema_json: json!({"common": "schema"}).to_string(),
+        ..Default::default()
+    };
+    let collection_two = flow::CollectionSpec {
+        collection: "collection/two".to_string(),
+        key_ptrs: vec!["/a/key".to_string()],
+        write_schema_json: json!({"write": "schema"}).to_string(),
+        read_schema_json: json!({"read": "schema"}).to_string(),
+        ..Default::default()
+    };
+
+    let capture = flow::CaptureSpec {
+        capture: "some/capture".to_string(),
+        endpoint_spec_json: json!({"endpoint": "config"}).to_string(),
+        interval_seconds: 300,
+        bindings: vec![
+            flow::capture_spec::Binding {
+                collection: Some(collection_one.clone()),
+                resource_spec_json: json!({"first": "resource"}).to_string(),
+                resource_path: vec!["table_one".to_string()],
+            },
+            flow::capture_spec::Binding {
+                collection: Some(collection_two.clone()),
+                resource_spec_json: json!({"resource": 2}).to_string(),
+                resource_path: vec!["other_schema".to_string(), "table_two".to_string()],
+            },
+        ],
+        ..Default::default()
+    };
+
+    let materialization = flow::MaterializationSpec {
+        materialization: "some/materialization".to_string(),
+        endpoint_spec_json: json!({"endpoint": "config"}).to_string(),
+        bindings: vec![
+            flow::materialization_spec::Binding {
+                collection: Some(collection_one.clone()),
+                resource_spec_json: json!({"first": "resource"}).to_string(),
+                resource_path: vec!["table_one".to_string()],
+                field_selection: Some(flow::FieldSelection {
+                    keys: vec!["key/one".to_string()],
+                    values: vec!["val1".to_string(), "val2".to_string()],
+                    document: "flow_document".to_string(),
+                    field_config_json: [
+                        ("val1".to_string(), json!({"a": "setting"}).to_string()),
+                        ("val2".to_string(), json!({}).to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+                delta_updates: false,
+                shuffle: None,
+            },
+            flow::materialization_spec::Binding {
+                collection: Some(collection_two.clone()),
+                resource_spec_json: json!({"resource": 2}).to_string(),
+                resource_path: vec!["other_schema".to_string(), "table_two".to_string()],
+                field_selection: Some(flow::FieldSelection {
+                    keys: vec!["k1".to_string(), "k2".to_string()],
+                    values: vec!["value_field".to_string()],
+                    document: String::new(),
+                    field_config_json: [].into_iter().collect(),
+                }),
+                delta_updates: true,
+                shuffle: None,
+            },
+        ],
+        ..Default::default()
+    };
+
+    let mut output = Vec::new();
+
+    test_case(
+        "Capture Spec",
+        capture::SpecRequest {
+            endpoint_type: flow::EndpointType::FlowSink as i32,
+            endpoint_spec_json: json!({
+                "foo": "capture",
+                "forty": 2,
+            })
+            .to_string(),
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Spec",
+        materialize::SpecRequest {
+            endpoint_type: flow::EndpointType::FlowSink as i32,
+            endpoint_spec_json: json!({
+                "foo": "materialize",
+                "forty": 2,
+            })
+            .to_string(),
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Capture Discover",
+        capture::DiscoverRequest {
+            endpoint_type: flow::EndpointType::FlowSink as i32,
+            endpoint_spec_json: json!({
+                "foo": "bar",
+                "forty": 2,
+            })
+            .to_string(),
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Capture Validate",
+        capture::ValidateRequest {
+            endpoint_type: flow::EndpointType::FlowSink as i32,
+            endpoint_spec_json: json!({
+                "foo": "capture",
+                "forty": 2,
+            })
+            .to_string(),
+            capture: "name/of/capture".to_string(),
+            bindings: vec![
+                capture::validate_request::Binding {
+                    collection: Some(collection_one.clone()),
+                    resource_spec_json: json!({"first": "resource"}).to_string(),
+                },
+                capture::validate_request::Binding {
+                    collection: Some(collection_two.clone()),
+                    resource_spec_json: json!({"resource": 2}).to_string(),
+                },
+            ],
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Validate",
+        materialize::ValidateRequest {
+            endpoint_type: flow::EndpointType::FlowSink as i32,
+            endpoint_spec_json: json!({
+                "foo": "materialize",
+                "forty": 2,
+            })
+            .to_string(),
+            materialization: "name/of/materialization".to_string(),
+            bindings: vec![
+                materialize::validate_request::Binding {
+                    collection: Some(collection_one.clone()),
+                    resource_spec_json: json!({"first": "resource"}).to_string(),
+                    field_config_json: [
+                        ("field-one".to_string(), json!({"one": 1}).to_string()),
+                        ("two".to_string(), json!({"two": 2}).to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                },
+                materialize::validate_request::Binding {
+                    collection: Some(collection_two.clone()),
+                    resource_spec_json: json!({"resource": 2}).to_string(),
+                    field_config_json: [].into_iter().collect(),
+                },
+            ],
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Capture Apply",
+        capture::ApplyRequest {
+            capture: Some(capture.clone()),
+            dry_run: true,
+            version: "aabbccddee".to_string(),
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Apply",
+        materialize::ApplyRequest {
+            materialization: Some(materialization.clone()),
+            dry_run: true,
+            version: "aabbccddee".to_string(),
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Capture Open",
+        capture::PullRequest {
+            open: Some(pull_request::Open {
+                capture: Some(capture.clone()),
+                key_begin: 12345,
+                key_end: 678910,
+                version: "aabbccddee".to_string(),
+                driver_checkpoint_json: serde_json::to_vec(&json!({"driver": "checkpoint"}))
+                    .unwrap(),
+            }),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Capture Acknowledge",
+        capture::PullRequest {
+            acknowledge: Some(capture::Acknowledge {}),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Open",
+        materialize::TransactionRequest {
+            open: Some(transaction_request::Open {
+                materialization: Some(materialization.clone()),
+                key_begin: 12345,
+                key_end: 678910,
+                version: "aabbccddee".to_string(),
+                driver_checkpoint_json: serde_json::to_vec(&json!({"driver": "checkpoint"}))
+                    .unwrap(),
+            }),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    // Build an arena fixture with keys, values, and documents.
+    // We'll use portions of this arena in multiple request fixtures.
+    let mut arena = vec![0x0, 0x1, 0x2, 0x3]; // Extra unused bytes.
+    let pivot = arena.len();
+
+    vec![json!("key"), json!("one")]
+        .pack_root(&mut arena)
+        .unwrap();
+    let (key1, pivot) = (pivot..arena.len(), arena.len());
+
+    vec![json!(1), json!({"two": "three"}), json!("four")]
+        .pack_root(&mut arena)
+        .unwrap();
+    let (values1, pivot) = (pivot..arena.len(), arena.len());
+
+    serde_json::to_writer(&mut arena, &json!({"doc": "one"})).unwrap();
+    let (doc1, pivot) = (pivot..arena.len(), arena.len());
+
+    vec![json!("key"), json!(2)].pack_root(&mut arena).unwrap();
+    let (key2, pivot) = (pivot..arena.len(), arena.len());
+
+    vec![json!(1), json!({"two": "three"}), json!("four")]
+        .pack_root(&mut arena)
+        .unwrap();
+    let (values2, pivot) = (pivot..arena.len(), arena.len());
+
+    serde_json::to_writer(&mut arena, &json!({"doc": 2})).unwrap();
+    let (doc2, _pivot) = (pivot..arena.len(), arena.len());
+
+    test_case(
+        "Materialize Load",
+        materialize::TransactionRequest {
+            load: Some(transaction_request::Load {
+                arena: arena.clone(),
+                binding: 2,
+                packed_keys: vec![
+                    flow::Slice {
+                        begin: key1.start as u32,
+                        end: key1.end as u32,
+                    },
+                    flow::Slice {
+                        begin: key2.start as u32,
+                        end: key2.end as u32,
+                    },
+                ],
+            }),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Flush",
+        materialize::TransactionRequest {
+            flush: Some(transaction_request::Flush {}),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Store",
+        materialize::TransactionRequest {
+            store: Some(transaction_request::Store {
+                arena: arena.clone(),
+                binding: 2,
+                packed_keys: vec![
+                    flow::Slice {
+                        begin: key1.start as u32,
+                        end: key1.end as u32,
+                    },
+                    flow::Slice {
+                        begin: key2.start as u32,
+                        end: key2.end as u32,
+                    },
+                ],
+                packed_values: vec![
+                    flow::Slice {
+                        begin: values1.start as u32,
+                        end: values1.end as u32,
+                    },
+                    flow::Slice {
+                        begin: values2.start as u32,
+                        end: values2.end as u32,
+                    },
+                ],
+                docs_json: vec![
+                    flow::Slice {
+                        begin: doc1.start as u32,
+                        end: doc1.end as u32,
+                    },
+                    flow::Slice {
+                        begin: doc2.start as u32,
+                        end: doc2.end as u32,
+                    },
+                ],
+                exists: vec![true, false],
+            }),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Start Commit",
+        materialize::TransactionRequest {
+            start_commit: Some(transaction_request::StartCommit {
+                runtime_checkpoint: vec![0x1, 0x2, 0x32, 0x1, 0x2, 0x32, 0x1, 0x2, 0x32, 0x99],
+            }),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    test_case(
+        "Materialize Acknowledge",
+        materialize::TransactionRequest {
+            acknowledge: Some(transaction_request::Acknowledge {}),
+            ..Default::default()
+        },
+        &mut output,
+    );
+
+    insta::assert_display_snapshot!(String::from_utf8_lossy(&output));
+}
+
+#[test]
+fn test_json_responses_to_proto() {
+    let spec = json!({
+        "spec": {
+            "documentationUrl": "https://docs.example.com",
+            "configSchema": {
+                "$schema": "https://config-schema.example.com",
+                "type": "object",
+            },
+            "resourceConfigSchema": {
+                "$schema": "https://resource-schema.example.com",
+                "type": "object",
+            },
+            "oauth2": {
+                "provider": "facebook",
+                "authUrlTemplate": "https://www.facebook.com/v15.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
+                "accessTokenResponseMap": {
+                    "access_token": "/access_token"
+                },
+                "accessTokenUrlTemplate": "https://graph.facebook.com/v15.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
+            }
+        }
+    });
+
+    insta::assert_debug_snapshot!(parse_responses::<capture::SpecResponse>(vec![spec.clone()]));
+    insta::assert_debug_snapshot!(parse_responses::<materialize::SpecResponse>(vec![
+        spec.clone()
+    ]));
+
+    insta::assert_debug_snapshot!(parse_responses::<capture::DiscoverResponse>(vec![json!({
+        "discovered": {
+            "bindings": [
+                {
+                    "recommendedName": "thing_one",
+                    "resourceConfig": {
+                        "table": "one",
+                        "foo": "bar"
+                    },
+                    "documentSchema": {
+                        "type": "object",
+                        "const": "document"
+                    },
+                    "key": ["/key/one", "/two"],
+                },
+                {
+                    "recommendedName": "thing_2",
+                    "resourceConfig": {
+                        "table": 2,
+                    },
+                    "documentSchema": {
+                        "type": "object",
+                        "const": "document-two"
+                    },
+                    "key": ["/key/key"],
+                },
+            ]
+        }
+    })]));
+
+    insta::assert_debug_snapshot!(parse_responses::<capture::ValidateResponse>(vec![json!({
+        "validated": {
+            "bindings": [
+                { "resourcePath": ["thing_one"] },
+                { "resourcePath": ["schema", "thing_2"] },
+            ]
+        }
+    })]));
+    insta::assert_debug_snapshot!(parse_responses::<materialize::ValidateResponse>(vec![
+        json!({
+            "validated": {
+                // Use many bindings, because the protobuf type uses a hash map
+                // and iterates in random order which breaks the debug fixtures.
+                "bindings": [
+                    { "resourcePath": ["one"], "constraints": { "field_required": {"type": "FieldRequired", "reason": "doesn't fit"} }, "deltaUpdates": true},
+                    { "resourcePath": ["two"], "constraints": { "loc_required": {"type": "LocationRequired", "reason": "gaak" } }, "deltaUpdates": false},
+                    { "resourcePath": ["three"], "constraints": { "loc_recommended": {"type": "LocationRecommended", "reason": "cool"} }, "deltaUpdates": true},
+                    { "resourcePath": ["four"], "constraints": { "field_optional": {"type": "FieldOptional", "reason": "don't like the cut of it's jib"} }, "deltaUpdates": false},
+                    { "resourcePath": ["five"], "constraints": { "field_forbidden": {"type": "FieldForbidden", "reason": "bad bad"} }, "deltaUpdates": true},
+                    { "resourcePath": ["six"], "constraints": { "super-bad": {"type": "Unsatisfiable", "reason": "whoops"} }, "deltaUpdates": false},
+                ]
+            }
+        })
+    ]));
+
+    let applied = json!({
+        "applied": {
+            "actionDescription": "something something"
+        }
+    });
+
+    insta::assert_debug_snapshot!(parse_responses::<capture::ApplyResponse>(vec![
+        applied.clone()
+    ]));
+    insta::assert_debug_snapshot!(parse_responses::<materialize::ApplyResponse>(vec![
+        applied.clone()
+    ]));
+
+    insta::assert_debug_snapshot!(parse_responses::<capture::PullResponse>(vec![
+        json!({"opened": { "explicitAcknowledgements": true } }),
+        json!({ "document": {"binding": 1, "doc": {"p": 1}} }),
+        json!({ "document": {"binding": 1, "doc": {"p": 2}} }),
+        json!({ "document": {"binding": 1, "doc": {"p": 3}} }),
+        json!({ "document": {"binding": 2, "doc": {"p": 4}} }),
+        json!({ "checkpoint": {"driverCheckpoint": {"check": "point"}, "mergePatch": true} }),
+    ]));
+
+    insta::assert_debug_snapshot!(parse_responses::<materialize::TransactionResponse>(vec![
+        json!({ "opened": { "runtimeCheckpoint": "aGVsbG8=" } }),
+        json!({ "loaded": {"binding": 1, "doc": {"p": 1}} }),
+        json!({ "loaded": {"binding": 1, "doc": {"p": 2}} }),
+        json!({ "loaded": {"binding": 1, "doc": {"p": 3}} }),
+        json!({ "loaded": {"binding": 2, "doc": {"p": 4}} }),
+        json!({ "flushed": {} }),
+        json!({ "startedCommit": {"driverCheckpoint": {"check": "point"}, "mergePatch": true} }),
+        json!({ "acknowledged": {} }),
+    ]));
+}
+
+fn test_case<M>(name: &str, m: M, w: &mut Vec<u8>)
+where
+    M: IntoMessages,
+    M::Message: for<'de> serde::Deserialize<'de>,
+{
+    write!(w, "\n// {name}:\n").unwrap();
+    for m in m.into_messages() {
+        let v = serde_json::to_vec_pretty(&m).unwrap();
+
+        let _: M::Message =
+            serde_json::from_slice(&v).expect("we can round-trip to parse message encodings");
+
+        w.write(&v).unwrap();
+        write!(w, "\n").unwrap();
+    }
+}
+
+fn parse_responses<M>(input: Vec<Value>) -> Vec<M>
+where
+    M: FromMessage,
+    M::Message: serde::Serialize,
+{
+    let mut out = Vec::new();
+    for value in input {
+        let msg = serde_json::from_value(value).unwrap();
+        let _ = serde_json::to_vec(&msg).unwrap(); // Ensure we can serialize without error.
+        M::from_message(msg, &mut out).unwrap();
+    }
+    out
+}

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-2.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-2.snap
@@ -1,0 +1,27 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<materialize::SpecResponse>(vec![spec.clone()])"
+---
+[
+    SpecResponse {
+        endpoint_spec_schema_json: "{\"$schema\":\"https://config-schema.example.com\",\"type\":\"object\"}",
+        resource_spec_schema_json: "{\"$schema\":\"https://resource-schema.example.com\",\"type\":\"object\"}",
+        documentation_url: "https://docs.example.com",
+        oauth2_spec: Some(
+            OAuth2Spec {
+                provider: "facebook",
+                auth_url_template: "https://www.facebook.com/v15.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
+                access_token_url_template: "https://graph.facebook.com/v15.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
+                access_token_method: "",
+                access_token_body: "",
+                access_token_headers_json: "{}",
+                access_token_response_map_json: "{\"access_token\":\"/access_token\"}",
+                refresh_token_url_template: "",
+                refresh_token_method: "",
+                refresh_token_body: "",
+                refresh_token_headers_json: "{}",
+                refresh_token_response_map_json: "{}",
+            },
+        ),
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-3.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-3.snap
@@ -1,0 +1,27 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<capture::DiscoverResponse>(vec![json!\n        ({\n            \"discovered\" :\n            {\n                \"bindings\" :\n                [{\n                    \"recommendedName\" : \"thing_one\", \"resourceConfig\" :\n                    { \"table\" : \"one\", \"foo\" : \"bar\" }, \"documentSchema\" :\n                    { \"type\" : \"object\", \"const\" : \"document\" }, \"keyPtrs\" :\n                    [\"/key/one\", \"/two\"],\n                },\n                {\n                    \"recommendedName\" : \"thing_2\", \"resourceConfig\" :\n                    { \"table\" : 2, }, \"documentSchema\" :\n                    { \"type\" : \"object\", \"const\" : \"document-two\" }, \"keyPtrs\" :\n                    [\"/key/key\"],\n                },]\n            }\n        })])"
+---
+[
+    DiscoverResponse {
+        bindings: [
+            Binding {
+                recommended_name: "thing_one",
+                resource_spec_json: "{\"foo\":\"bar\",\"table\":\"one\"}",
+                document_schema_json: "{\"const\":\"document\",\"type\":\"object\"}",
+                key_ptrs: [
+                    "/key/one",
+                    "/two",
+                ],
+            },
+            Binding {
+                recommended_name: "thing_2",
+                resource_spec_json: "{\"table\":2}",
+                document_schema_json: "{\"const\":\"document-two\",\"type\":\"object\"}",
+                key_ptrs: [
+                    "/key/key",
+                ],
+            },
+        ],
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-4.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-4.snap
@@ -1,0 +1,21 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<capture::ValidateResponse>(vec![json!\n        ({\n            \"validated\" :\n            {\n                \"bindings\" :\n                [{ \"resourcePath\" : [\"thing_one\"] },\n                { \"resourcePath\" : [\"schema\", \"thing_2\"] },]\n            }\n        })])"
+---
+[
+    ValidateResponse {
+        bindings: [
+            Binding {
+                resource_path: [
+                    "thing_one",
+                ],
+            },
+            Binding {
+                resource_path: [
+                    "schema",
+                    "thing_2",
+                ],
+            },
+        ],
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-5.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-5.snap
@@ -1,0 +1,82 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<materialize::ValidateResponse>(vec![json!\n        ({\n            \"validated\" :\n            {\n                \"bindings\" :\n                [{\n                    \"resourcePath\" : [\"one\"], \"constraints\" :\n                    {\n                        \"field_required\" :\n                        { \"type\" : \"FieldRequired\", \"reason\" : \"doesn't fit\" }\n                    }, \"deltaUpdates\" : true\n                },\n                {\n                    \"resourcePath\" : [\"two\"], \"constraints\" :\n                    {\n                        \"loc_required\" :\n                        { \"type\" : \"LocationRequired\", \"reason\" : \"gaak\" }\n                    }, \"deltaUpdates\" : false\n                },\n                {\n                    \"resourcePath\" : [\"three\"], \"constraints\" :\n                    {\n                        \"loc_recommended\" :\n                        { \"type\" : \"LocationRecommended\", \"reason\" : \"cool\" }\n                    }, \"deltaUpdates\" : true\n                },\n                {\n                    \"resourcePath\" : [\"four\"], \"constraints\" :\n                    {\n                        \"field_optional\" :\n                        {\n                            \"type\" : \"FieldOptional\", \"reason\" :\n                            \"don't like the cut of it's jib\"\n                        }\n                    }, \"deltaUpdates\" : false\n                },\n                {\n                    \"resourcePath\" : [\"five\"], \"constraints\" :\n                    {\n                        \"field_forbidden\" :\n                        { \"type\" : \"FieldForbidden\", \"reason\" : \"bad bad\" }\n                    }, \"deltaUpdates\" : true\n                },\n                {\n                    \"resourcePath\" : [\"six\"], \"constraints\" :\n                    {\n                        \"super-bad\" :\n                        { \"type\" : \"Unsatisfiable\", \"reason\" : \"whoops\" }\n                    }, \"deltaUpdates\" : false\n                },]\n            }\n        })])"
+---
+[
+    ValidateResponse {
+        bindings: [
+            Binding {
+                constraints: {
+                    "field_required": Constraint {
+                        r#type: FieldRequired,
+                        reason: "doesn't fit",
+                    },
+                },
+                resource_path: [
+                    "one",
+                ],
+                delta_updates: true,
+            },
+            Binding {
+                constraints: {
+                    "loc_required": Constraint {
+                        r#type: LocationRequired,
+                        reason: "gaak",
+                    },
+                },
+                resource_path: [
+                    "two",
+                ],
+                delta_updates: false,
+            },
+            Binding {
+                constraints: {
+                    "loc_recommended": Constraint {
+                        r#type: LocationRecommended,
+                        reason: "cool",
+                    },
+                },
+                resource_path: [
+                    "three",
+                ],
+                delta_updates: true,
+            },
+            Binding {
+                constraints: {
+                    "field_optional": Constraint {
+                        r#type: FieldOptional,
+                        reason: "don't like the cut of it's jib",
+                    },
+                },
+                resource_path: [
+                    "four",
+                ],
+                delta_updates: false,
+            },
+            Binding {
+                constraints: {
+                    "field_forbidden": Constraint {
+                        r#type: FieldForbidden,
+                        reason: "bad bad",
+                    },
+                },
+                resource_path: [
+                    "five",
+                ],
+                delta_updates: true,
+            },
+            Binding {
+                constraints: {
+                    "super-bad": Constraint {
+                        r#type: Unsatisfiable,
+                        reason: "whoops",
+                    },
+                },
+                resource_path: [
+                    "six",
+                ],
+                delta_updates: false,
+            },
+        ],
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-6.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-6.snap
@@ -1,0 +1,9 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<capture::ApplyResponse>(vec![applied.clone()])"
+---
+[
+    ApplyResponse {
+        action_description: "something something",
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-7.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-7.snap
@@ -1,0 +1,9 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<materialize::ApplyResponse>(vec![applied.clone()])"
+---
+[
+    ApplyResponse {
+        action_description: "something something",
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-8.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-8.snap
@@ -1,0 +1,113 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<capture::PullResponse>(vec![json!\n        ({ \"opened\" : { \"explicitAcknowledgements\" : true } }), json!\n        ({ \"document\" : { \"binding\" : 1, \"doc\" : { \"p\" : 1 } } }), json!\n        ({ \"document\" : { \"binding\" : 1, \"doc\" : { \"p\" : 2 } } }), json!\n        ({ \"document\" : { \"binding\" : 1, \"doc\" : { \"p\" : 3 } } }), json!\n        ({ \"document\" : { \"binding\" : 2, \"doc\" : { \"p\" : 4 } } }), json!\n        ({\n            \"checkpoint\" :\n            {\n                \"driverCheckpoint\" : { \"check\" : \"point\" },\n                \"rfc7396MergePatch\" : true\n            }\n        }),])"
+---
+[
+    PullResponse {
+        opened: Some(
+            Opened {
+                explicit_acknowledgements: true,
+            },
+        ),
+        documents: None,
+        checkpoint: None,
+    },
+    PullResponse {
+        opened: None,
+        documents: Some(
+            Documents {
+                binding: 1,
+                arena: [
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    49,
+                    125,
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    50,
+                    125,
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    51,
+                    125,
+                ],
+                docs_json: [
+                    Slice {
+                        begin: 0,
+                        end: 7,
+                    },
+                    Slice {
+                        begin: 7,
+                        end: 14,
+                    },
+                    Slice {
+                        begin: 14,
+                        end: 21,
+                    },
+                ],
+            },
+        ),
+        checkpoint: None,
+    },
+    PullResponse {
+        opened: None,
+        documents: Some(
+            Documents {
+                binding: 2,
+                arena: [
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    52,
+                    125,
+                ],
+                docs_json: [
+                    Slice {
+                        begin: 0,
+                        end: 7,
+                    },
+                ],
+            },
+        ),
+        checkpoint: None,
+    },
+    PullResponse {
+        opened: None,
+        documents: None,
+        checkpoint: Some(
+            DriverCheckpoint {
+                driver_checkpoint_json: [
+                    123,
+                    34,
+                    99,
+                    104,
+                    101,
+                    99,
+                    107,
+                    34,
+                    58,
+                    34,
+                    112,
+                    111,
+                    105,
+                    110,
+                    116,
+                    34,
+                    125,
+                ],
+                rfc7396_merge_patch: true,
+            },
+        ),
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-9.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto-9.snap
@@ -1,0 +1,149 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<materialize::TransactionResponse>(vec![json!\n        ({ \"opened\" : { \"runtimeCheckpoint\" : \"aGVsbG8=\" } }), json!\n        ({ \"loaded\" : { \"binding\" : 1, \"doc\" : { \"p\" : 1 } } }), json!\n        ({ \"loaded\" : { \"binding\" : 1, \"doc\" : { \"p\" : 2 } } }), json!\n        ({ \"loaded\" : { \"binding\" : 1, \"doc\" : { \"p\" : 3 } } }), json!\n        ({ \"loaded\" : { \"binding\" : 2, \"doc\" : { \"p\" : 4 } } }), json!\n        ({ \"flushed\" : {} }), json!\n        ({\n            \"startedCommit\" :\n            {\n                \"driverCheckpoint\" : { \"check\" : \"point\" },\n                \"rfc7396MergePatch\" : true\n            }\n        }), json! ({ \"acknowledged\" : {} }),])"
+---
+[
+    TransactionResponse {
+        opened: Some(
+            Opened {
+                runtime_checkpoint: [
+                    104,
+                    101,
+                    108,
+                    108,
+                    111,
+                ],
+            },
+        ),
+        loaded: None,
+        flushed: None,
+        started_commit: None,
+        acknowledged: None,
+    },
+    TransactionResponse {
+        opened: None,
+        loaded: Some(
+            Loaded {
+                binding: 1,
+                arena: [
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    49,
+                    125,
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    50,
+                    125,
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    51,
+                    125,
+                ],
+                docs_json: [
+                    Slice {
+                        begin: 0,
+                        end: 7,
+                    },
+                    Slice {
+                        begin: 7,
+                        end: 14,
+                    },
+                    Slice {
+                        begin: 14,
+                        end: 21,
+                    },
+                ],
+            },
+        ),
+        flushed: None,
+        started_commit: None,
+        acknowledged: None,
+    },
+    TransactionResponse {
+        opened: None,
+        loaded: Some(
+            Loaded {
+                binding: 2,
+                arena: [
+                    123,
+                    34,
+                    112,
+                    34,
+                    58,
+                    52,
+                    125,
+                ],
+                docs_json: [
+                    Slice {
+                        begin: 0,
+                        end: 7,
+                    },
+                ],
+            },
+        ),
+        flushed: None,
+        started_commit: None,
+        acknowledged: None,
+    },
+    TransactionResponse {
+        opened: None,
+        loaded: None,
+        flushed: Some(
+            Flushed,
+        ),
+        started_commit: None,
+        acknowledged: None,
+    },
+    TransactionResponse {
+        opened: None,
+        loaded: None,
+        flushed: None,
+        started_commit: Some(
+            StartedCommit {
+                driver_checkpoint: Some(
+                    DriverCheckpoint {
+                        driver_checkpoint_json: [
+                            123,
+                            34,
+                            99,
+                            104,
+                            101,
+                            99,
+                            107,
+                            34,
+                            58,
+                            34,
+                            112,
+                            111,
+                            105,
+                            110,
+                            116,
+                            34,
+                            125,
+                        ],
+                        rfc7396_merge_patch: true,
+                    },
+                ),
+            },
+        ),
+        acknowledged: None,
+    },
+    TransactionResponse {
+        opened: None,
+        loaded: None,
+        flushed: None,
+        started_commit: None,
+        acknowledged: Some(
+            Acknowledged,
+        ),
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__json_responses_to_proto.snap
@@ -1,0 +1,27 @@
+---
+source: crates/connector-protocol/tests/proto_conversion.rs
+expression: "parse_responses::<capture::SpecResponse>(vec![spec.clone()])"
+---
+[
+    SpecResponse {
+        endpoint_spec_schema_json: "{\"$schema\":\"https://config-schema.example.com\",\"type\":\"object\"}",
+        resource_spec_schema_json: "{\"$schema\":\"https://resource-schema.example.com\",\"type\":\"object\"}",
+        documentation_url: "https://docs.example.com",
+        oauth2_spec: Some(
+            OAuth2Spec {
+                provider: "facebook",
+                auth_url_template: "https://www.facebook.com/v15.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&state={{#urlencode}}{{{  state }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management",
+                access_token_url_template: "https://graph.facebook.com/v15.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
+                access_token_method: "",
+                access_token_body: "",
+                access_token_headers_json: "{}",
+                access_token_response_map_json: "{\"access_token\":\"/access_token\"}",
+                refresh_token_url_template: "",
+                refresh_token_method: "",
+                refresh_token_body: "",
+                refresh_token_headers_json: "{}",
+                refresh_token_response_map_json: "{}",
+            },
+        ),
+    },
+]

--- a/crates/proto-convert/tests/snapshots/proto_conversion__proto_request_to_json.snap
+++ b/crates/proto-convert/tests/snapshots/proto_conversion__proto_request_to_json.snap
@@ -1,0 +1,590 @@
+---
+source: crates/proto-convert/tests/proto_conversion.rs
+expression: "String::from_utf8_lossy(&output)"
+---
+
+// Capture Spec:
+{
+  "spec": {}
+}
+
+// Materialize Spec:
+{
+  "spec": {}
+}
+
+// Capture Discover:
+{
+  "discover": {
+    "config": {"foo":"bar","forty":2}
+  }
+}
+
+// Capture Validate:
+{
+  "validate": {
+    "name": "name/of/capture",
+    "config": {"foo":"capture","forty":2},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"}
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2}
+      }
+    ]
+  }
+}
+
+// Materialize Validate:
+{
+  "validate": {
+    "name": "name/of/materialization",
+    "config": {"foo":"materialize","forty":2},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"},
+        "fieldConfig": {
+          "field-one": {"one":1},
+          "two": {"two":2}
+        }
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2},
+        "fieldConfig": {}
+      }
+    ]
+  }
+}
+
+// Capture Apply:
+{
+  "apply": {
+    "name": "some/capture",
+    "config": {"endpoint":"config"},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"},
+        "resourcePath": [
+          "table_one"
+        ]
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2},
+        "resourcePath": [
+          "other_schema",
+          "table_two"
+        ]
+      }
+    ],
+    "version": "aabbccddee",
+    "dryRun": true
+  }
+}
+
+// Materialize Apply:
+{
+  "apply": {
+    "name": "some/materialization",
+    "config": {"endpoint":"config"},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"},
+        "resourcePath": [
+          "table_one"
+        ],
+        "deltaUpdates": false,
+        "fieldSelection": {
+          "keys": [
+            "key/one"
+          ],
+          "values": [
+            "val1",
+            "val2"
+          ],
+          "document": "flow_document",
+          "fieldConfig": {
+            "val1": {"a":"setting"},
+            "val2": {}
+          }
+        }
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2},
+        "resourcePath": [
+          "other_schema",
+          "table_two"
+        ],
+        "deltaUpdates": true,
+        "fieldSelection": {
+          "keys": [
+            "k1",
+            "k2"
+          ],
+          "values": [
+            "value_field"
+          ],
+          "document": null,
+          "fieldConfig": {}
+        }
+      }
+    ],
+    "version": "aabbccddee",
+    "dryRun": true
+  }
+}
+
+// Capture Open:
+{
+  "open": {
+    "name": "some/capture",
+    "config": {"endpoint":"config"},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"},
+        "resourcePath": [
+          "table_one"
+        ]
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2},
+        "resourcePath": [
+          "other_schema",
+          "table_two"
+        ]
+      }
+    ],
+    "version": "aabbccddee",
+    "keyBegin": 12345,
+    "keyEnd": 678910,
+    "driverCheckpoint": {"driver":"checkpoint"},
+    "intervalSeconds": 300
+  }
+}
+
+// Capture Acknowledge:
+{
+  "acknowledge": {}
+}
+
+// Materialize Open:
+{
+  "open": {
+    "name": "some/materialization",
+    "config": {"endpoint":"config"},
+    "bindings": [
+      {
+        "collection": {
+          "name": "collection/one",
+          "key": [
+            "/key/one",
+            "/two/3"
+          ],
+          "partitionFields": [
+            "part-field"
+          ],
+          "projections": [
+            {
+              "ptr": "/json/ptr",
+              "field": "a-field",
+              "explicit": false,
+              "isPartitionKey": true,
+              "isPrimaryKey": false,
+              "inference": {
+                "types": [
+                  "integer",
+                  "string"
+                ],
+                "string": {
+                  "contentType": "typ",
+                  "format": "date",
+                  "contentEncoding": "enc",
+                  "isBase64": false,
+                  "maxLength": 12345
+                },
+                "title": "title",
+                "description": "desc",
+                "default": {"def":"ault"},
+                "secret": false,
+                "exists": "Must"
+              }
+            }
+          ],
+          "schema": {"common":"schema"}
+        },
+        "resourceConfig": {"first":"resource"},
+        "resourcePath": [
+          "table_one"
+        ],
+        "deltaUpdates": false,
+        "fieldSelection": {
+          "keys": [
+            "key/one"
+          ],
+          "values": [
+            "val1",
+            "val2"
+          ],
+          "document": "flow_document",
+          "fieldConfig": {
+            "val1": {"a":"setting"},
+            "val2": {}
+          }
+        }
+      },
+      {
+        "collection": {
+          "name": "collection/two",
+          "key": [
+            "/a/key"
+          ],
+          "partitionFields": [],
+          "projections": [],
+          "writeSchema": {"write":"schema"},
+          "readSchema": {"read":"schema"}
+        },
+        "resourceConfig": {"resource":2},
+        "resourcePath": [
+          "other_schema",
+          "table_two"
+        ],
+        "deltaUpdates": true,
+        "fieldSelection": {
+          "keys": [
+            "k1",
+            "k2"
+          ],
+          "values": [
+            "value_field"
+          ],
+          "document": null,
+          "fieldConfig": {}
+        }
+      }
+    ],
+    "version": "aabbccddee",
+    "keyBegin": 12345,
+    "keyEnd": 678910,
+    "driverCheckpoint": {"driver":"checkpoint"}
+  }
+}
+
+// Materialize Load:
+{
+  "load": {
+    "binding": 2,
+    "keyPacked": "026b657900026f6e6500",
+    "key": [
+      "key",
+      "one"
+    ]
+  }
+}
+{
+  "load": {
+    "binding": 2,
+    "keyPacked": "026b6579001502",
+    "key": [
+      "key",
+      2
+    ]
+  }
+}
+
+// Materialize Flush:
+{
+  "flush": {}
+}
+
+// Materialize Store:
+{
+  "store": {
+    "binding": 2,
+    "keyPacked": "026b657900026f6e6500",
+    "key": [
+      "key",
+      "one"
+    ],
+    "values": [
+      1,
+      {
+        "two": "three"
+      },
+      "four"
+    ],
+    "doc": {"doc":"one"},
+    "exists": true
+  }
+}
+{
+  "store": {
+    "binding": 2,
+    "keyPacked": "026b6579001502",
+    "key": [
+      "key",
+      2
+    ],
+    "values": [
+      1,
+      {
+        "two": "three"
+      },
+      "four"
+    ],
+    "doc": {"doc":2},
+    "exists": false
+  }
+}
+
+// Materialize Start Commit:
+{
+  "startCommit": {
+    "runtimeCheckpoint": "AQIyAQIyAQIymQ=="
+  }
+}
+
+// Materialize Acknowledge:
+{
+  "acknowledge": {}
+}
+


### PR DESCRIPTION
**Description:**

* Create a formal JSON protocol for captures and materializations, under the new `connector-protocol` crate, with support for JSON schema generation.

* Implement conversions between our existing protobuf protocol and this JSON protocol through a new `proto-convert` crate.

* Implement opt-in support for connectors to use the JSON protocol within `flow-connector-init`, toggled via image `LABEL FLOW_RUNTIME_CODEC=json`.

No changes for connectors that don't elect to use JSON.

I'll post gists shortly, with a "hello world" capture and materialization for demonstration purposes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/895)
<!-- Reviewable:end -->
