### PR TITLE
Phil/custom s3 endpoints

### DIFF
--- a/crates/assemble/src/lib.rs
+++ b/crates/assemble/src/lib.rs
@@ -141,7 +141,10 @@ pub fn partition_template(
             path_postfix_template,
             refresh_interval,
             retention,
-            stores: stores.iter().map(|s| s.to_url().into()).collect(),
+            stores: stores
+                .iter()
+                .map(|s| s.to_url(&collection).into())
+                .collect(),
         }),
         flags,
         labels: Some(broker::LabelSet { labels }),
@@ -225,7 +228,7 @@ pub fn recovery_log_template(
             path_postfix_template,
             refresh_interval,
             retention,
-            stores: stores.iter().map(|s| s.to_url().into()).collect(),
+            stores: stores.iter().map(|s| s.to_url(task_name).into()).collect(),
         }),
         flags,
         labels: Some(broker::LabelSet { labels }),

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -26,7 +26,8 @@ pub use derivations::{
     Derivation, Publish, Register, TransformDef, TransformSource, TypescriptModule, Update,
 };
 pub use journals::{
-    BucketType, CompressionCodec, FragmentTemplate, JournalTemplate, StorageDef, Store,
+    BucketAndPrefix, CompressionCodec, CustomStore, FragmentTemplate, JournalTemplate, StorageDef,
+    Store,
 };
 pub use materializations::{
     MaterializationBinding, MaterializationDef, MaterializationEndpoint, MaterializationFields,
@@ -34,7 +35,7 @@ pub use materializations::{
 };
 pub use references::{
     Capture, Collection, CompositeKey, Field, JsonPointer, Materialization, PartitionField, Prefix,
-    RelativeUrl, Test, Transform,
+    RelativeUrl, StorageEndpoint, Test, Transform,
 };
 pub use resources::{ContentType, Import, ResourceDef};
 pub use schemas::Schema;

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -178,18 +178,6 @@ expression: "&schema"
   },
   "additionalProperties": false,
   "definitions": {
-    "BucketType": {
-      "description": "BucketType is a provider of object storage buckets, which are used to durably storage journal fragments.",
-      "examples": [
-        "S3"
-      ],
-      "type": "string",
-      "enum": [
-        "GCS",
-        "S3",
-        "AZURE"
-      ]
-    },
     "Capture": {
       "description": "Capture names are paths of Unicode letters, numbers, '-', '_', or '.'. Each path component is separated by a slash '/', and a name may not begin or end in a '/'.",
       "examples": [
@@ -1176,6 +1164,14 @@ expression: "&schema"
         }
       }
     },
+    "StorageEndpoint": {
+      "description": "An address for a custom storage endpoint",
+      "examples": [
+        "storage.example.com"
+      ],
+      "type": "string",
+      "pattern": "^^(http://|https://)?[a-z0-9]+[a-z0-9\\.:-]*[a-z0-9]+$"
+    },
     "Store": {
       "description": "A Store into which Flow journal fragments may be written.\n\nThe persisted path of a journal fragment is determined by composing the Store's bucket and prefix with the journal name and a content-addressed fragment file name.\n\nEg, given a Store to S3 with bucket \"my-bucket\" and prefix \"a/prefix\", along with a collection \"example/events\" having a logical partition \"region\", then a complete persisted path might be:\n\ns3://my-bucket/a/prefix/example/events/region=EU/utc_date=2021-10-25/utc_hour=13/000123-000456-789abcdef.gzip",
       "examples": [
@@ -1185,34 +1181,169 @@ expression: "&schema"
           "provider": "S3"
         }
       ],
-      "type": "object",
-      "required": [
-        "bucket",
-        "provider"
-      ],
-      "properties": {
-        "bucket": {
-          "description": "Bucket into which Flow will store data.",
-          "type": "string",
-          "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
-        },
-        "prefix": {
-          "description": "Optional prefix of keys written to the bucket.",
-          "default": null,
-          "anyOf": [
+      "oneOf": [
+        {
+          "title": "Amazon Simple Storage Service.",
+          "examples": [
             {
-              "$ref": "#/definitions/Prefix"
-            },
-            {
-              "type": "null"
+              "bucket": "my-bucket",
+              "prefix": null
             }
-          ]
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "S3"
+              ]
+            }
+          }
         },
-        "provider": {
-          "description": "Cloud storage provider.",
-          "$ref": "#/definitions/BucketType"
+        {
+          "title": "Google Cloud Storage.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "prefix": null
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "GCS"
+              ]
+            }
+          }
+        },
+        {
+          "title": "Azure object storage service.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "prefix": null
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "AZURE"
+              ]
+            }
+          }
+        },
+        {
+          "title": "An S3-compatible endpoint",
+          "description": "Details of an s3-compatible storage endpoint, such as Minio or R2.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "endpoint": "storage.example.com"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "endpoint",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+            },
+            "endpoint": {
+              "description": "endpoint is required when provider is \"custom\", and specifies the address of an s3-compatible storage provider.",
+              "$ref": "#/definitions/StorageEndpoint"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "CUSTOM"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "Test": {
       "description": "Test names are paths of Unicode letters, numbers, '-', '_', or '.'. Each path component is separated by a slash '/', and a name may not begin or end in a '/'.",

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -39,6 +39,16 @@ pub enum Error {
     },
     #[error("at least one storage mapping must be defined")]
     NoStorageMappings {},
+    /// This comes from a validation that ensures users cannot specify the `endpoint` property of a Store that pertains
+    /// to the 'default/' prefix. This is because the prefix is used to look up the AWS credentials for each store that
+    /// uses a custom endpoint, but the 'default' profile is always used for Flow's own credentials. Therefore, allowing
+    /// a user to specify a custom endpoint for that profile could result in Flow's own credentials being sent to a
+    /// malicious endpoint. This also pertains to the empty storage prefix, which is also disallowed for custom storage endpoints.
+    #[error("'custom' storage mapping '{prefix}' is not allowed under the {disallowed} prefix")]
+    InvalidCustomStoragePrefix {
+        prefix: String,
+        disallowed: &'static str, // will either be "empty" or "'default/'"
+    },
     #[error("could not map {this_entity} {this_thing} into a storage mapping; did you mean {suggest_name} defined at {suggest_scope}?")]
     NoStorageMappingSuggest {
         this_thing: String,

--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -65,6 +65,14 @@ function project_dir() {
 
 function start_config_encryption() {
     cd "$(project_dir 'config-encryption')"
+
+    # This is part of a hack to allow the oauth edge function to call the config-encryption service locally.
+    # The _other_ part of the hack is down in `start_oauth_edge`.
+    # This container exists to do nothing other than to attach to the supabase docker network and expose port 8765, which
+    # is what config-encryption listens on. The pause container exists for just these kinds of shennanigans.
+    # Per: https://stackoverflow.com/a/44739847 the `docker start` will return 0 if the container is already running
+    docker start config_encryption_hack_proxy || \
+         must_run docker run --rm --name config_encryption_hack_proxy -p 8765 --network supabase_network_flow --detach google/pause:latest
     must_run cargo run -- --gcp-kms "$TEST_KMS_KEY"
 }
 
@@ -132,7 +140,22 @@ function start_control_plane_agent() {
 
 function start_oauth_edge() {
     cd "$(project_dir 'flow')"
-    must_run supabase functions serve oauth
+    # We need to do some weird crap to allow the oauth edge function to connect to the config-encryption
+    # service running on localhost (outside of docker). The hostname that's used for config-encyrption
+    # will be set to the gateway IP of the docker network. A dummy container, which is attached to that network
+    # and listening on port 8765, ensures that port 8765 will be exposed on the host at that address.
+    # Determine the gateway IP of the supabase docker network:
+    local gateway_ip="$(docker network inspect supabase_network_flow -f '{{ (index .IPAM.Config 0).Gateway }}' )"
+    # lol I guess this is a way to trim whitespace from a bash variable: https://stackoverflow.com/a/12973694
+    gateway_ip="$(echo "$gateway_ip" | xargs echo )"
+    if [[ -z "$gateway_ip" ]]; then
+        bail "unable to determine docker network gateway ip"
+    fi
+    # put this file in /var/tmp/ because macs have issues mounting other files into a docker container, which is
+    # what I _think_ supabase functions serve is doing?
+    echo "CONFIG_ENCRYPTION_URL=http://${gateway_ip}:8765/v1/encrypt-config" > /var/tmp/config-encryption-hack-proxy-addr
+    must_run supabase functions serve oauth --env-file /var/tmp/config-encryption-hack-proxy-addr
+
 }
 
 function start_schema_inference() {

--- a/supabase/functions/oauth/encrypt-config.ts
+++ b/supabase/functions/oauth/encrypt-config.ts
@@ -3,8 +3,17 @@ import { corsHeaders } from "../_shared/cors.ts";
 import { returnPostgresError } from "../_shared/helpers.ts";
 import { supabaseClient } from "../_shared/supabaseClient.ts";
 
-const ENCRYPTION_SERVICE =
-  "https://config-encryption.estuary.dev/v1/encrypt-config";
+const config_encryption_url = () => {
+  const env = Deno.env.get('CONFIG_ENCRYPTION_URL');
+  // A more principled approach would be to require that this url is always provided by the
+  // env var. But that would require using a supabase secret to set the value in prod,
+  // and _that_ seemed like a whole ordeal that I don't have time for right now.
+  if (env) {
+    return env
+  } else {
+    return "https://config-encryption.estuary.dev/v1/encrypt-config"
+  }
+}
 
 const CREDENTIALS_KEY = "credentials";
 
@@ -58,7 +67,7 @@ export async function encryptConfig(req: Record<string, any>) {
 
   const { endpoint_spec_schema } = connectorTagData as ConnectorTagsResponse;
 
-  const response = await fetch(ENCRYPTION_SERVICE, {
+  const response = await fetch(config_encryption_url(), {
     method: "POST",
     body: JSON.stringify({
       config,

--- a/supabase/pending/custom_storage_endpoints.sql
+++ b/supabase/pending/custom_storage_endpoints.sql
@@ -1,0 +1,8 @@
+-- migration to setup custom endpoints for storage mappings
+
+-- If a user supplies a custom storage endpoint, then we'll always use their tenant name as the AWS profile, which is used for looking up
+-- the credentials. But the `default` AWS profile is special, and is configured with Flow's own credentials, so if a malicious
+-- user created a `default` tenant with a custom storage endpoint, then we could end up sending our credentials to that endpoint.
+-- This prevents a user from being able to create such a tenant.
+insert into internal.illegal_tenant_names (name) values ('default') on conflict do nothing;
+


### PR DESCRIPTION
**Description:**

Resolves #892 

Adds support for custom storage endpoints in catalog specs. This is not yet a user-facing change, since there isn't yet a user-facing edit capability for storage mappings. But I've tested and verified that custom storage endpoints can be use in `storage_mappings`.

**Workflow steps:**

Note that these steps apply to a control plane operator, _not_ an end user.

1. Ensure that the gazette brokers have an appropriate AWS `profile` that specifies _both_ the credentials _and_ a `region`. The `profile` must be named exactly the same as the tenant name portion of the storage mapping prefix.
    - It's important that the `region` configuration is present _before_ any journals try to use the profile, though there is a pending fix for this in gazette/core#330
2. In the `storage_mappings` table, you may now add a custom store to the spec. For example `{"provider":"CUSTOM","bucket":"the-bucket","endpoint":"some.storage.endpoint.com"}`
3. Create a publication that includes any affected tasks and collections. The easiest way to do this is to use `flowctl catalog pull-specs --prefix <storage-mapping-prefix>` in an empty directory, and then run `flowctl catalog publish --source flow.yaml`.

**Documentation links affected:**

We don't yet have this documented, and I'm thinking it's best to hold off on that until we figure out how we want to handle end-user edits to storage mappings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/901)
<!-- Reviewable:end -->
