### PR TITLE
Phil/flowctl moar ux

### DIFF
--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -1,0 +1,132 @@
+use crate::{api_exec, catalog, draft, CliContext};
+use anyhow::Context;
+use serde::Serialize;
+
+#[derive(Debug, clap::Args)]
+pub struct Delete {
+    #[clap(flatten)]
+    pub name_selector: catalog::NameSelector,
+    #[clap(flatten)]
+    pub type_selector: catalog::SpecTypeSelector,
+    /// Proceed with deletion without prompting for confirmation.
+    ///
+    /// Normally, delete will stop and ask for confirmation before it proceeds. This flag disables
+    /// that confirmation. This is sometimes required in order to run flowctl non-interactively,
+    /// such as in a shell script.
+    pub dangerous_auto_approve: bool,
+}
+
+#[derive(Serialize, Debug)]
+struct DraftSpec {
+    draft_id: String,
+    catalog_name: String,
+    expect_pub_id: String,
+    spec_type: serde_json::Value, // always null, since we're deleting
+    spec: serde_json::Value,      // always null, since we're deleting
+}
+
+pub async fn do_delete(
+    ctx: &mut CliContext,
+    Delete {
+        name_selector,
+        type_selector,
+        dangerous_auto_approve,
+    }: &Delete,
+) -> anyhow::Result<()> {
+    let list_args = catalog::List {
+        flows: false,
+        name_selector: name_selector.clone(),
+        type_selector: type_selector.clone(),
+        deleted: false,
+    };
+
+    let client = ctx.controlplane_client()?;
+    let specs = catalog::fetch_live_specs(
+        client.clone(),
+        &list_args,
+        vec![
+            "id",
+            "catalog_name",
+            "spec_type",
+            "updated_at",
+            "last_pub_id",
+            "last_pub_user_email",
+            "last_pub_user_id",
+            "last_pub_user_full_name",
+        ],
+    )
+    .await
+    .context("fetching live specs")?;
+
+    if specs.is_empty() {
+        anyhow::bail!("no specs found matching given selector");
+    }
+
+    // show the user the specs before we ask for confirmation
+    ctx.write_all(specs.clone(), false)?;
+
+    if !(*dangerous_auto_approve || prompt_to_continue().await) {
+        anyhow::bail!("delete operation cancelled");
+    }
+
+    let draft = draft::create_draft(client.clone())
+        .await
+        .context("failed to create draft")?;
+    println!(
+        "Deleting {} item(s) using draft: {}",
+        specs.len(),
+        &draft.id
+    );
+    tracing::info!(draft_id = %draft.id, "created draft");
+
+    // create the draft specs now, so we can pass owned `specs` to `write_all`
+    let draft_specs = specs
+        .into_iter()
+        .map(|spec| DraftSpec {
+            draft_id: draft.id.clone(),
+            catalog_name: spec.catalog_name.clone(),
+            spec_type: serde_json::Value::Null,
+            spec: serde_json::Value::Null,
+            expect_pub_id: spec
+                .last_pub_id
+                .clone()
+                .expect("spec is missing last_pub_id"),
+        })
+        .collect::<Vec<DraftSpec>>();
+
+    api_exec::<Vec<serde_json::Value>>(
+        ctx.controlplane_client()?
+            .from("draft_specs")
+            //.select("catalog_name,spec_type")
+            .upsert(serde_json::to_string(&draft_specs).unwrap())
+            .on_conflict("draft_id,catalog_name"),
+    )
+    .await?;
+    tracing::debug!("added deletions to draft");
+
+    draft::publish(client.clone(), false, &draft.id).await?;
+
+    // extra newline before, since `publish` will output a bunch of logs
+    println!("\nsuccessfully deleted {} spec(s)", draft_specs.len());
+    Ok(())
+}
+
+async fn prompt_to_continue() -> bool {
+    tokio::task::spawn_blocking(|| {
+        println!(
+            "\nIf you continue, the listed specs will all be deleted. This cannot be undone.\n\
+            Enter the word 'delete' to continue, or anything else to abort:\n"
+        );
+        let mut buf = String::with_capacity(8);
+
+        match std::io::stdin().read_line(&mut buf) {
+            Ok(_) => buf.trim() == "delete",
+            Err(err) => {
+                tracing::error!(error = %err, "failed to read from stdin");
+                false
+            }
+        }
+    })
+    .await
+    .expect("failed to join spawned task")
+}

--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -54,7 +54,7 @@ pub async fn do_publish(ctx: &mut CliContext, args: &Publish) -> anyhow::Result<
 async fn prompt_to_continue() -> bool {
     use tokio::io::AsyncReadExt;
 
-    print!("\nEnter Y to publish these specs, or anything else to abort: ");
+    println!("\nEnter Y to publish these specs, or anything else to abort: ");
     let mut buf = [0u8];
     match tokio::io::stdin().read_exact(&mut buf[..]).await {
         Ok(_) => &buf == b"y" || &buf == b"Y",

--- a/crates/flowctl/src/catalog/pull_specs.rs
+++ b/crates/flowctl/src/catalog/pull_specs.rs
@@ -41,6 +41,7 @@ pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Re
         flows: true,
         name_selector: args.name_selector.clone(),
         type_selector: args.type_selector.clone(),
+        deleted: false, // deleted specs have nothing to pull
     };
 
     let live_specs = fetch_live_specs(client, &list_args, columns).await?;

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -1,452 +1,73 @@
-use crate::{api_exec, typescript};
+use crate::{api_exec, catalog, source, typescript};
 use anyhow::Context;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use serde_json::{value::RawValue, Value};
-use std::collections::BTreeMap;
+use serde_json::value::RawValue;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct Develop {
-    /// Directory into which Flow catalog sources will be created.
-    ///
-    /// Flow catalog files are written into a directory hierarchy
-    /// corresponding to their catalog name.
-    /// The directory will be created if it doesn't exist.
-    #[clap(long, default_value = ".")]
-    root_dir: std::path::PathBuf,
-    /// If enabled, generated JSON files instead of YAML.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    local_specs: source::LocalSpecsArgs,
 }
 
 pub async fn do_develop(
     ctx: &mut crate::CliContext,
-    Develop { root_dir, json }: &Develop,
+    Develop { local_specs }: &Develop,
 ) -> anyhow::Result<()> {
-    #[derive(Deserialize)]
-    struct Row {
-        catalog_name: String,
-        spec: Box<RawValue>,
-        spec_type: String,
-    }
-    let rows: Vec<Row> = api_exec(
+    let draft_id = ctx.config().cur_draft()?;
+    let rows: Vec<DraftSpecRow> = api_exec(
         ctx.controlplane_client()?
             .from("draft_specs")
             .select("catalog_name,spec,spec_type")
             .not("is", "spec_type", "null")
-            .eq("draft_id", ctx.config().cur_draft()?),
+            .eq("draft_id", draft_id),
     )
     .await?;
-
-    let ext = if *json { "json" } else { "yaml" };
-    let catalog_base = format!("flow.{ext}");
-
-    std::fs::create_dir_all(&root_dir).context("couldn't create directory for draft")?;
-    let root_dir =
-        std::fs::canonicalize(root_dir).context("failed to canonicalize root directory")?;
-    let root_catalog_path = root_dir.join(&catalog_base);
-    let root_catalog_url = url::Url::from_file_path(&root_catalog_path).unwrap();
-
-    // Index all catalog names to the catalog URL which will define them.
-    // This is used to resolve imports which are necessary between catalog files.
-    let name_to_catalog_url: BTreeMap<_, _> = rows
-        .iter()
-        .map(|r| {
-            let m = root_catalog_url.join(&r.catalog_name).unwrap();
-            (r.catalog_name.clone(), m.join(&catalog_base).unwrap())
-        })
-        .collect();
-
     let rows_len = rows.len();
 
-    // This is a hairball, but is resistent to refactoring and I'm uncertain
-    // that more indirection will really help with clarity.
-    for (catalog_url, group) in rows
-        .into_iter()
-        .map(|r| (&name_to_catalog_url[&r.catalog_name], r))
-        .sorted_by(|(l_url, _), (r_url, _)| l_url.cmp(r_url))
-        .group_by(|(url, _row)| url.clone())
-        .into_iter()
-    {
-        tracing::info!(%catalog_url, "processing catalog file");
+    let bundled_catalog = catalog::collect_specs(rows)?;
+    source::write_local_specs(bundled_catalog, local_specs).await?;
 
-        let catalog_path = catalog_url.to_file_path().unwrap();
-        std::fs::create_dir_all(catalog_path.parent().unwrap())
-            .context("couldn't create parent directory for catalog file")?;
-
-        let mut catalog = models::Catalog::default();
-        let mut seen_names = Vec::<models::Collection>::new();
-
-        for (
-            _module,
-            Row {
-                catalog_name,
-                spec,
-                spec_type,
-            },
-        ) in group
-        {
-            let base = catalog_name
-                .rsplit_once("/")
-                .expect("catalog names have at least one '/'")
-                .1;
-
-            tracing::info!(%catalog_name, %base, %spec_type, "processing specification");
-
-            match spec_type.as_str() {
-                "collection" => {
-                    let mut spec: models::CollectionDef =
-                        serde_json::from_str(spec.get()).context("parsing collection")?;
-
-                    // Potentially write out separate schema files for the collection
-                    // schema / write_schema / read_schema.
-                    for (schema, filename) in [
-                        (spec.schema.as_mut(), format!("{base}.schema.{ext}")),
-                        (
-                            spec.write_schema.as_mut(),
-                            format!("{base}.write.schema.{ext}"),
-                        ),
-                        (
-                            spec.read_schema.as_mut(),
-                            format!("{base}.read.schema.{ext}"),
-                        ),
-                    ] {
-                        let Some(schema) = schema else { continue };
-
-                        maybe_indirect_schema(
-                            &catalog_url,
-                            &catalog_url.join(&filename).unwrap(),
-                            schema,
-                        )?;
-                    }
-
-                    if let Some(derivation) = &mut spec.derivation {
-                        maybe_indirect_schema(
-                            &catalog_url,
-                            &catalog_url
-                                .join(&format!("{base}.register.schema.{ext}"))
-                                .unwrap(),
-                            &mut derivation.register.schema,
-                        )?;
-
-                        for (_transform, transform_def) in derivation.transform.iter_mut() {
-                            seen_names.push(transform_def.source.name.clone());
-                        }
-
-                        if let Some(typescript) = &mut derivation.typescript {
-                            // Indirect the TypeScript module to a file, and track its reference.
-                            let base = format!("{base}.ts");
-                            let file_url = catalog_url.join(&base).unwrap();
-
-                            std::fs::write(
-                                file_url.to_file_path().unwrap(),
-                                typescript.module.as_bytes(),
-                            )?;
-                            typescript.module = base;
-                        }
-                    }
-
-                    catalog
-                        .collections
-                        .insert(models::Collection::new(catalog_name), spec);
-                }
-                "capture" => {
-                    let mut spec: models::CaptureDef =
-                        serde_json::from_str(spec.get()).context("parsing collection")?;
-
-                    if let models::CaptureEndpoint::Connector(connector) = &mut spec.endpoint {
-                        // Indirect the connector config to a file, and track its reference.
-                        let base = format!("{base}.config.{ext}");
-                        let file_url = catalog_url.join(&base).unwrap();
-
-                        std::fs::write(
-                            file_url.to_file_path().unwrap(),
-                            &to_contents(&file_url, &connector.config)?,
-                        )?;
-                        connector.config =
-                            RawValue::from_string(Value::String(base).to_string()).unwrap();
-                    }
-
-                    for binding in &spec.bindings {
-                        seen_names.push(binding.target.clone());
-                    }
-
-                    catalog
-                        .captures
-                        .insert(models::Capture::new(catalog_name), spec);
-                }
-                "materialization" => {
-                    let mut spec: models::MaterializationDef =
-                        serde_json::from_str(spec.get()).context("parsing materialization")?;
-
-                    if let models::MaterializationEndpoint::Connector(connector) =
-                        &mut spec.endpoint
-                    {
-                        // Indirect the connector config to a file, and track its reference.
-                        let base = format!("{base}.config.{ext}");
-                        let file_url = catalog_url.join(&base).unwrap();
-
-                        std::fs::write(
-                            file_url.to_file_path().unwrap(),
-                            &to_contents(&file_url, &connector.config)?,
-                        )?;
-                        connector.config =
-                            RawValue::from_string(Value::String(base).to_string()).unwrap();
-                    }
-
-                    for binding in &spec.bindings {
-                        seen_names.push(binding.source.clone());
-                    }
-
-                    catalog
-                        .materializations
-                        .insert(models::Materialization::new(catalog_name), spec);
-                }
-                "test" => {
-                    let mut steps = serde_json::from_str::<Vec<models::TestStep>>(spec.get())
-                        .context("parsing test steps")?;
-
-                    for (ind, step) in steps.iter_mut().enumerate() {
-                        let (collection, documents) = match step {
-                            models::TestStep::Ingest(ingest) => {
-                                (&ingest.collection, &mut ingest.documents)
-                            }
-                            models::TestStep::Verify(verify) => {
-                                (&verify.collection, &mut verify.documents)
-                            }
-                        };
-
-                        seen_names.push(collection.clone());
-
-                        // Indirect documents above a threshold size into a referenced file.
-                        let base = format!("{base}.{ind}.documents.json");
-                        let file_url = catalog_url.join(&base).unwrap();
-                        let contents = to_contents(&file_url, &documents)?;
-
-                        if contents.len() > MAX_INLINE_SIZE {
-                            std::fs::write(file_url.to_file_path().unwrap(), &contents)?;
-                            *documents = models::TestDocuments::Url(models::RelativeUrl::new(base));
-                        }
-                    }
-
-                    catalog.tests.insert(models::Test::new(catalog_name), steps);
-                }
-                _ => anyhow::bail!("invalid spec_type {spec_type}"),
-            }
-        }
-
-        catalog.import = seen_names
-            .into_iter()
-            .filter_map(|n| name_to_catalog_url.get(n.as_str()).cloned())
-            .sorted()
-            .dedup()
-            .filter_map(|target_url| {
-                if target_url != *catalog_url {
-                    Some(models::Import::Url(models::RelativeUrl::new(
-                        make_relative(catalog_url, &target_url).unwrap(),
-                    )))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        std::fs::write(
-            catalog_url.to_file_path().unwrap(),
-            &to_contents(&catalog_url, &catalog)?,
-        )?;
-        tracing::info!(%catalog_url, "wrote catalog");
-    }
-
-    let root_catalog = models::Catalog {
-        // Import all subordinate catalog file URLs through a relative path.
-        import: name_to_catalog_url
-            .into_values()
-            .sorted()
-            .dedup()
-            .map(|catalog_url| {
-                models::Import::Url(models::RelativeUrl::new(
-                    make_relative(&root_catalog_url, &catalog_url).unwrap(),
-                ))
-            })
-            .collect(),
-        ..Default::default()
-    };
-    std::fs::write(
-        &root_catalog_path,
-        &to_contents(&root_catalog_url, &root_catalog)?,
-    )?;
-    tracing::info!(%root_catalog_url, "wrote root catalog");
+    tracing::info!(dir = %local_specs.output_dir.display(), "wrote root catalog");
 
     let source_args = crate::source::SourceArgs {
-        source_dir: vec![root_dir.display().to_string()],
+        source_dir: vec![local_specs.output_dir.display().to_string()],
         ..Default::default()
     };
     typescript::do_generate(
         ctx,
         &typescript::Generate {
-            root_dir: root_dir.clone(),
+            root_dir: local_specs.output_dir.clone(),
             source: source_args,
         },
     )
     .await
     .context("generating TypeScript project")?;
 
-    println!("Wrote {rows_len} specifications under {root_catalog_url}.");
+    println!(
+        "Wrote {rows_len} specifications under {}.",
+        local_specs.output_dir.display()
+    );
     Ok(())
 }
 
-fn maybe_indirect_schema(
-    catalog_url: &url::Url,
-    schema_url: &url::Url,
-    schema: &mut models::Schema,
-) -> anyhow::Result<()> {
-    // Attempt to clean up the schema by removing a superfluous $id.
-    match schema {
-        models::Schema::Object(m) => {
-            if m.contains_key("definitions") || m.contains_key("$defs") {
-                // We can't touch $id, as it provides the canonical base against which
-                // $ref is resolved to definitions.
-            } else if let Some(true) = m
-                .get("$id")
-                .and_then(Value::as_str)
-                .map(|s| s.starts_with("file://"))
-            {
-                m.remove("$id");
-            }
-        }
-        _ => anyhow::bail!("expected object schema but got {schema:?}"),
-    };
-
-    let contents = to_contents(schema_url, &schema)?;
-
-    if contents.len() <= MAX_INLINE_SIZE {
-        // Leave small schema in-place.
-        return Ok(());
-    }
-
-    std::fs::write(schema_url.to_file_path().unwrap(), &contents)?;
-    *schema = models::Schema::Url(models::RelativeUrl::new(
-        make_relative(catalog_url, schema_url).unwrap(),
-    ));
-
-    Ok(())
+#[derive(Deserialize, Serialize)]
+pub struct DraftSpecRow {
+    pub catalog_name: String,
+    pub spec: Box<RawValue>,
+    pub spec_type: Option<catalog::CatalogSpecType>,
 }
 
-fn to_contents<S>(file_url: &url::Url, value: &S) -> anyhow::Result<Vec<u8>>
-where
-    S: Serialize,
-{
-    // Our models embed serde_json's RawValue, which can only be serialized by serde_json.
-    // Do that first.
-    let v = serde_json::to_vec_pretty(value).context("serializing JSON")?;
-
-    if file_url.as_str().ends_with(".json") {
-        Ok(v)
-    } else if file_url.as_str().ends_with(".yaml") {
-        // We want YAML, so transcode directly from serialized JSON to YAML.
-        let mut v2 = Vec::new();
-        let mut deser = serde_json::Deserializer::from_slice(&v);
-        serde_transcode::transcode(&mut deser, &mut serde_yaml::Serializer::new(&mut v2))
-            .context("serializing YAML")?;
-
-        Ok(v2)
-    } else {
-        anyhow::bail!("unrecognized file extension in {file_url}")
-    }
-}
-
-const MAX_INLINE_SIZE: usize = 512;
-
-// This is a verbatim copy of Url::make_relative, with one fix added from this still-open PR:
-// https://github.com/servo/rust-url/pull/754
-pub fn make_relative(self_: &url::Url, url: &url::Url) -> Option<String> {
-    if self_.cannot_be_a_base() {
-        return None;
+impl catalog::SpecRow for DraftSpecRow {
+    fn catalog_name(&self) -> &str {
+        &self.catalog_name
     }
 
-    // Scheme, host and port need to be the same
-    if self_.scheme() != url.scheme() || self_.host() != url.host() || self_.port() != url.port() {
-        return None;
+    fn spec_type(&self) -> Option<catalog::CatalogSpecType> {
+        self.spec_type
     }
 
-    // We ignore username/password at this point
-
-    // The path has to be transformed
-    let mut relative = String::new();
-
-    // Extract the filename of both URIs, these need to be handled separately
-    fn extract_path_filename(s: &str) -> (&str, &str) {
-        let last_slash_idx = s.rfind('/').unwrap_or(0);
-        let (path, filename) = s.split_at(last_slash_idx);
-        if filename.is_empty() {
-            (path, "")
-        } else {
-            (path, &filename[1..])
-        }
+    fn spec(&self) -> Option<&RawValue> {
+        Some(self.spec.as_ref())
     }
-
-    let (base_path, base_filename) = extract_path_filename(self_.path());
-    let (url_path, url_filename) = extract_path_filename(url.path());
-
-    let mut base_path = base_path.split('/').peekable();
-    let mut url_path = url_path.split('/').peekable();
-
-    // Skip over the common prefix
-    while base_path.peek().is_some() && base_path.peek() == url_path.peek() {
-        base_path.next();
-        url_path.next();
-    }
-
-    // Add `..` segments for the remainder of the base path
-    for base_path_segment in base_path {
-        // Skip empty last segments
-        if base_path_segment.is_empty() {
-            break;
-        }
-
-        if !relative.is_empty() {
-            relative.push('/');
-        }
-
-        relative.push_str("..");
-    }
-
-    // Append the remainder of the other URI
-    for url_path_segment in url_path {
-        if !relative.is_empty() {
-            relative.push('/');
-        }
-
-        relative.push_str(url_path_segment);
-    }
-
-    // Add the filename if they are not the same
-    if !relative.is_empty() || base_filename != url_filename {
-        // If the URIs filename is empty this means that it was a directory
-        // so we'll have to append a '/'.
-        //
-        // Otherwise append it directly as the new filename.
-        if url_filename.is_empty() {
-            relative.push('/');
-        } else {
-            if !relative.is_empty() {
-                relative.push('/');
-            }
-            relative.push_str(url_filename);
-        }
-    }
-
-    // Query and fragment are only taken from the other URI
-    if let Some(query) = url.query() {
-        relative.push('?');
-        relative.push_str(query);
-    }
-
-    if let Some(fragment) = url.fragment() {
-        relative.push('#');
-        relative.push_str(fragment);
-    }
-
-    Some(relative)
 }

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -251,7 +251,7 @@ async fn fetch_async(resource: url::Url) -> Result<bytes::Bytes, anyhow::Error> 
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] time::OffsetDateTime);
 
 impl std::fmt::Display for Timestamp {


### PR DESCRIPTION
**Description:**

Resolves #865 and #904

This rolls up a few different minor fixes and improvements to `flowctl`.
- Fixed a bug in confirmation in `catalog publish` that caused confirmation message to sometimes not appear.
- `draft author` now prunes any extra specs automatically (#865)
- `draft develop` no longer adds a bunch of extra imports. It now lays everything out in the same way as `catalog pull-specs`
- Introduced `flowctl catalog delete`, which works in a single-step (with confirmation), so you no longer need to manually deal with drafts during deletion (#904).
- `flowctl catalog list` was including deleted specs by default. This was updated so that deleted specs are never included unless you explicitly ask for them by providing the new `--deleted` flag.

**Workflow steps:**

Deleting specs:
Before:

- `flowctl draft crate`
- `flowctl catalog draft --name acmeCo/foo --delete`
- `flowctl catalog draft --name acmeCo/bar --delete`
- `flowctl draft publish`

After: `flowctl catalog delete --prefix acmeCo/`

**Documentation links affected:**

These changes seem to mostly avoid impacting existing docs. Delete could maybe use a docs page at some point, but mostly just to help set expectations around materialized tables being deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/906)
<!-- Reviewable:end -->
