### PR TITLE
flowctl: catalog delete must require either `name` or `prefix`

### DIFF
--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -80,7 +80,7 @@ pub enum Command {
 #[derive(Default, Debug, Clone, clap::Args)]
 pub struct NameSelector {
     /// Select a spec by name. May be provided multiple times.
-    #[clap(long)]
+    #[clap(long, required = true)]
     pub name: Vec<String>,
     /// Select catalog items under the given prefix
     ///


### PR DESCRIPTION
**Description:**

- clap is smart enough to understand that because `name` and `prefix` conflict with each other, one being marked as `required` is sufficient. 

**Workflow steps:**

- Try `flowctl catalog delete` with no `--name` or `--prefix` arguments

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/910)
<!-- Reviewable:end -->
