### PR TITLE
Phil/catalog delete whoops

### DIFF
--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -42,6 +42,7 @@ pub struct Delete {
     /// Normally, delete will stop and ask for confirmation before it proceeds. This flag disables
     /// that confirmation. This is sometimes required in order to run flowctl non-interactively,
     /// such as in a shell script.
+    #[clap(long)]
     pub dangerous_auto_approve: bool,
 }
 


### PR DESCRIPTION
**Description:**

Fixes #909 
Also includes a fix for the dangerous-auto-approve argument, which had been mistakenly configured as a positional argument instead of a flag. See individual commit messages for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/913)
<!-- Reviewable:end -->
