### PR TITLE
flowctl: catalog publish should not need newline before it shows prompt

### DIFF
--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -32,6 +32,7 @@ pub async fn do_publish(ctx: &mut CliContext, args: &Publish) -> anyhow::Result<
     let spec_rows = draft::upsert_draft_specs(client.clone(), &draft.id, &catalog).await?;
     println!("Will publish the following {} specs", spec_rows.len());
     ctx.write_all(spec_rows, ())?;
+    println!("");
 
     if !(args.auto_approve || prompt_to_continue().await) {
         println!("\nCancelling");


### PR DESCRIPTION
**Description:**

- `catalog publish` should not need a newline before it shows prompt. resolves #912 

**Workflow steps:**

- `flowctl catalog publish`

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/914)
<!-- Reviewable:end -->
