### PR TITLE
docs: salesforce-next

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -47,6 +47,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 * PostgreSQL
   * [Configuration](./PostgreSQL.md)
   * Package — ghcr.io/estuary/source-postgres:dev
+* Salesforce (for real-time data)
+  * [Configuration](./salesforce-real-time.md)
+  * Package - ghcr.io/estuary/source-salesforce-next:dev
 
 
 ### Third party connectors
@@ -108,7 +111,7 @@ The versions made available in Flow have been adapted for compatibility.
 * Mailchimp
   * [Configuration](./mailchimp.md)
   * Package - ghcr.io/estuary/source-mailchimp:dev
-* Salesforce
+* Salesforce (For historical data)
   * [Configuration](./salesforce.md)
   * Package - ghcr.io/estuary/source-salesforce:dev
 * Notion


### PR DESCRIPTION
**Description:**

Adds simple reference docs for real-time salesforce connector -- in-depth guide on using the two salesforce connectors in parallel will come later.

**Notes for reviewers:**

A lot of this is copied/slightly modified from the other connector docs. The one thing I really wasn't sure about was the supported salesforce objects.... I couldn't figure out in the code if there was a specific list for this connector, so I used the list from the other one for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/922)
<!-- Reviewable:end -->
