### PR TITLE
Fix flowctl catalog pull-specs with merge-spec

### DIFF
--- a/crates/models/src/catalogs.rs
+++ b/crates/models/src/catalogs.rs
@@ -61,6 +61,17 @@ impl Catalog {
         let generator = schemars::gen::SchemaGenerator::new(settings);
         generator.into_root_schema_for::<Self>()
     }
+
+    /// Returns the names of all specs that are directly included within this catalog.
+    /// This does _not_ include specs from imported catalogs.
+    pub fn all_spec_names(&self) -> impl Iterator<Item = &str> {
+        self.collections
+            .keys()
+            .map(AsRef::<str>::as_ref)
+            .chain(self.captures.keys().map(AsRef::<str>::as_ref))
+            .chain(self.materializations.keys().map(AsRef::<str>::as_ref))
+            .chain(self.tests.keys().map(AsRef::<str>::as_ref))
+    }
 }
 
 fn collections_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {


### PR DESCRIPTION
**Description:**

Fixes #924

When running `flowctl catalog pull-specs --existing merge-spec`, it was possible to mangle the content of indirected resources such as typescript modules, connector configs, schemas, etc. This would happen if you had an existing directory with the spec for `acmeCo/specA` and then ran:
`flowctl catalog pull-specs --existing merge-spec --name acmeCo/specB` In that case, an existing indirected typescript module (or schema or whatever) from `specA` would end up having its first line of content overwritten by the relative path to that content.

The fix here is to just skip re-writing indirected content for specs that are already in the current directory, but not included in the set of specs being pulled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/927)
<!-- Reviewable:end -->
