### PR TITLE
ops-catalog: use flag for prod instead of local

### DIFF
--- a/crates/ops-catalog/assets/flow.yaml.hbs
+++ b/crates/ops-catalog/assets/flow.yaml.hbs
@@ -79,10 +79,10 @@ materializations:
     endpoint:
       connector:
         image: ghcr.io/estuary/materialize-postgres:v4
-        {{#if local}}
-        config: stats-local-endpoint.sops.yaml
-        {{else}}
+        {{#if prod}}
         config: stats-production-endpoint.sops.yaml
+        {{else}}
+        config: stats-local-endpoint.sops.yaml
         {{/if}}
 
 

--- a/crates/ops-catalog/src/generate.rs
+++ b/crates/ops-catalog/src/generate.rs
@@ -18,7 +18,7 @@ impl GenerateArgs {
             tenants.push(serde_json::from_str(&line?)?);
         }
 
-        let r = Renderer::new(true, true)?;
+        let r = Renderer::new(false, true)?;
         r.render(tenants, output_dir)?;
 
         Ok(())

--- a/crates/ops-catalog/src/monitor.rs
+++ b/crates/ops-catalog/src/monitor.rs
@@ -41,9 +41,9 @@ pub struct MonitorArgs {
     /// Profile used by flowctl.
     #[clap(long = "flowctl-profile", env = "FLOWCTL_PROFILE")]
     flowctl_profile: String,
-    /// Use the local materialization credentials. Used when running a local development stack.
-    #[clap(long = "local", env = "LOCAL", default_value = "true")]
-    local: bool,
+    /// Use the production materialization credentials. Applicable only when not running a local stack.
+    #[clap(long = "prod", env = "PROD")]
+    prod: bool,
 }
 
 impl MonitorArgs {
@@ -77,7 +77,7 @@ impl MonitorArgs {
             bin_dir = &self.bin_dir,
             working_dir = &self.working_dir,
             flowctl_profile = &self.flowctl_profile,
-            local = &self.local,
+            prod = &self.prod,
             "starting ops-catalog"
         );
 
@@ -85,7 +85,7 @@ impl MonitorArgs {
             pg_pool,
             bin_dir,
             working_dir,
-            self.local,
+            self.prod,
             &self.flowctl_profile,
             &self.flowctl_access_token,
         )
@@ -101,11 +101,11 @@ async fn monitor(
     pg_pool: sqlx::PgPool,
     bin_dir: &path::Path,
     working_dir: &path::Path,
-    local: bool,
+    prod: bool,
     profile: &str,
     access_token: &str,
 ) -> anyhow::Result<()> {
-    let renderer = Renderer::new(local, false)?;
+    let renderer = Renderer::new(prod, false)?;
     flowctl_auth(bin_dir, profile, access_token)?;
 
     loop {


### PR DESCRIPTION
**Description:**

Using the boolean flag `local` with a default of `true` made it effectively impossible to ever have local _not_ be true. This changes that around: Providing a flag of `--prod` will cause the templates to be rendered with the (encrypted) prod credentials, while not passing any flag will continue to render the template with the default local credentials. This way we can actually run with the production credentials in production, instead of being forever doomed to used local credentials.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/932)
<!-- Reviewable:end -->
