### PR TITLE
json: add "NaN", "Infinity" and "-Infinity" cases for number

### DIFF
--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -162,7 +162,9 @@ impl Format {
             Self::Integer => {
                 ValidationResult::from(BigInt::parse_bytes(val.as_bytes(), 10).is_some())
             }
-            Self::Number => ValidationResult::from(BigDecimal::from_str(val).is_ok()),
+            Self::Number => {
+                ValidationResult::from(BigDecimal::from_str(val).is_ok() || ["NaN", "Infinity", "-Infinity"].contains(&val))
+            }
         }
     }
 }
@@ -232,6 +234,12 @@ mod test {
             ("number", "-1.234", true),
             ("number", " 1234", false),
             ("number", " 1.234", false),
+            ("number", "NaN", true),
+            ("number", "xNaN", false),
+            ("number", "nan", false),
+            ("number", "Infinity", true),
+            ("number", "-Infinity", true),
+            ("number", "infinity", false),
         ] {
             let format: Format =
                 serde_json::from_value(serde_json::Value::String(format.to_string())).unwrap();


### PR DESCRIPTION
**Description:**

- Add special case of `NaN`, `Infinity` and `-Infinity` to jsonschema validation for `format: number`
- See https://github.com/estuary/connectors/issues/543

**Workflow steps:**

- Pass `"NaN"` to a field with `type: string, format: number`

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/945)
<!-- Reviewable:end -->
