### PR TITLE
schema-inference: infer format: integer/number for string values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,6 +3539,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assemble",
+ "bigdecimal",
  "bytes",
  "bytesize",
  "clap 3.2.22",
@@ -3551,6 +3552,7 @@ dependencies = [
  "journal-client",
  "json",
  "models",
+ "num-bigint 0.4.3",
  "proto-gazette",
  "schemars",
  "serde",

--- a/crates/schema-inference/Cargo.toml
+++ b/crates/schema-inference/Cargo.toml
@@ -22,10 +22,12 @@ models = { path = "../models" }
 proto-gazette = { path = "../proto-gazette" }
 
 humantime = { workspace = true }
+bigdecimal = { workspace = true }
 bytesize = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
+num-bigint = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/schema-inference/src/analyze.rs
+++ b/crates/schema-inference/src/analyze.rs
@@ -157,4 +157,126 @@ mod test {
         let schema = analyze(to_stream(vec![data_one, data_two, data_three])).unwrap();
         insta::assert_json_snapshot!(schema);
     }
+
+    #[test]
+    fn string_format_integer_merging() {
+        let data_one = json!({
+            "a": 1,
+        });
+        let data_two = json!({
+            "a": "2",
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "1",
+        });
+        let data_two = json!({
+            "a": 2,
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+    }
+
+    #[test]
+    fn string_format_number_merging() {
+        let data_one = json!({
+            "a": 1,
+        });
+        let data_two = json!({
+            "a": "2.1",
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": 1.1,
+        });
+        let data_two = json!({
+            "a": "2",
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "1",
+        });
+        let data_two = json!({
+            "a": 2.1,
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "1.1",
+        });
+        let data_two = json!({
+            "a": 2,
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+    }
+
+    #[test]
+    fn string_format_number_back_to_string() {
+        let data_one = json!({
+            "a": 1,
+        });
+        let data_two = json!({
+            "a": "test"
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "a",
+        });
+        let data_two = json!({
+            "a": "1"
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+    }
+
+    #[test]
+    fn string_format_number_special_strings() {
+        let data_one = json!({
+            "a": 1,
+        });
+        let data_two = json!({
+            "a": "NaN"
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "Infinity",
+        });
+        let data_two = json!({
+            "a": "1"
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+
+        let data_one = json!({
+            "a": "-Infinity",
+        });
+        let data_two = json!({
+            "a": "1"
+        });
+
+        let schema = analyze(to_stream(vec![data_one, data_two])).unwrap();
+        insta::assert_json_snapshot!(schema);
+    }
 }

--- a/crates/schema-inference/src/schema.rs
+++ b/crates/schema-inference/src/schema.rs
@@ -35,6 +35,7 @@ impl SchemaBuilder {
 pub fn to_schema(shape: &Shape) -> Schema {
     let mut schema_object = SchemaObject {
         instance_type: Some(shape_type_to_schema_type(shape.type_)),
+        format: shape.string.format.map(|f| f.to_string()),
         ..Default::default()
     };
 

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_integer_merging-2.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_integer_merging-2.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "format": "integer"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_integer_merging.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_integer_merging.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "format": "integer"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_back_to_string-2.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_back_to_string-2.snap
@@ -1,0 +1,19 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "integer",
+        "string"
+      ]
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_back_to_string.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_back_to_string.snap
@@ -1,0 +1,19 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "integer",
+        "string"
+      ]
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-2.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-2.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-3.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-3.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-4.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging-4.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_merging.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings-2.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings-2.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings-3.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings-3.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__string_format_number_special_strings.snap
@@ -1,0 +1,20 @@
+---
+source: crates/schema-inference/src/analyze.rs
+expression: schema
+---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": [
+        "number",
+        "string"
+      ],
+      "format": "number"
+    }
+  }
+}


### PR DESCRIPTION
**Description:**

- Try to parse strings as integer or fractional, and based on that suggest `format: integer` or `format: number`.
- Take `NaN`, `Infinity` and `-Infinity` into consideration when doing this

**Workflow steps:**

- Feed in documents with string fields containing numerical values

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/949)
<!-- Reviewable:end -->
