### PR TITLE
flowctl: generate, persist and use refresh_token for continuous access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "agent"
 version = "0.0.0"
 dependencies = [
@@ -188,6 +200,36 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "async-io"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -409,12 +451,37 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -651,6 +718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +797,15 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -964,6 +1049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,7 +1158,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -1161,6 +1256,27 @@ checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1283,6 +1399,7 @@ dependencies = [
  "humantime",
  "itertools 0.10.5",
  "journal-client",
+ "keyring",
  "labels",
  "lazy_static",
  "md5",
@@ -1420,6 +1537,21 @@ name = "futures-io"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1624,11 +1756,31 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1984,6 +2136,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba264b266563c1363dcce004776cbf198d7422a4262f77f4ca285bf26ae30955"
+dependencies = [
+ "byteorder",
+ "secret-service",
+ "security-framework",
+ "winapi",
+]
+
+[[package]]
 name = "labels"
 version = "0.0.0"
 
@@ -2282,6 +2446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bb540dc6ef51cfe1916ec038ce7a620daf3a111e2502d745197cd53d6bca15"
+dependencies = [
+ "libc",
+ "socket2",
+]
+
+[[package]]
 name = "network-tunnel"
 version = "0.0.0"
 dependencies = [
@@ -2303,6 +2477,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2497,20 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2335,12 +2536,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.4.3",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2384,6 +2617,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
@@ -2471,6 +2710,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -2779,6 +3024,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "postgrest"
 version = "1.3.0"
 source = "git+https://github.com/estuary/postgrest-rs?branch=johnny/patches#382f37ab8fec3b413be08c15790a69f88dcc0dec"
@@ -2827,6 +3086,25 @@ checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3641,6 +3919,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secret-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1da5c423b8783185fd3fecd1c8796c267d2c089d894ce5a93c280a5d3f780a2"
+dependencies = [
+ "aes",
+ "block-modes",
+ "hkdf 0.11.0",
+ "lazy_static",
+ "num",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "zbus",
+ "zbus_macros",
+ "zvariant",
+ "zvariant_derive",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +4034,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +4114,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4001,8 +4323,8 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.3",
+ "hmac 0.12.1",
  "indexmap",
  "itoa 1.0.3",
  "libc",
@@ -4016,7 +4338,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
@@ -4041,7 +4363,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "sqlx-core",
  "sqlx-rt",
  "syn",
@@ -4059,6 +4381,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -4440,6 +4768,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4920,6 +5265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5121,6 +5472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "which"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5274,6 +5634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "winnow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,6 +5676,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zbus"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbeb2291cd7267a94489b71376eda33496c1b9881adf6b36f26cc2779f3fc49"
+dependencies = [
+ "async-io",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "fastrand",
+ "futures",
+ "nb-connect",
+ "nix",
+ "once_cell",
+ "polling",
+ "scoped-tls",
+ "serde",
+ "serde_repr",
+ "zbus_macros",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3959a7847cf95e3d51e312856617c5b1b77191176c65a79a5f14d778bbe0a6"
+dependencies = [
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5371,4 +5775,30 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "zvariant"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c7b55f2074489b7e8e07d2d0a6ee6b4f233867a653c664d8020ba53692525"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca5e22593eb4212382d60d26350065bf2a02c34b85bc850474a74b589a3de9"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ jemallocator = "0.3"
 jemalloc-ctl = "0.3"
 json-patch = "0.2"
 js-sys = "0.3.60"
+keyring = "1.2"
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "6.20", default-features = false, features = [

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -38,6 +38,7 @@ md5 = { workspace = true }
 
 # open is used for opening URLs in the user's browser
 open = { workspace = true }
+keyring = { workspace = true }
 postgrest = { workspace = true }
 reqwest = { workspace = true }
 # rpassword is used for reading credentials from stdin

--- a/crates/flowctl/src/auth/mod.rs
+++ b/crates/flowctl/src/auth/mod.rs
@@ -61,7 +61,7 @@ impl Auth {
         match &self.cmd {
             Command::Login => do_login(ctx).await,
             Command::Token(Token { token }) => {
-                controlplane::configure_new_access_token(ctx, token.clone())?;
+                controlplane::configure_new_access_token(ctx, token.clone()).await?;
                 println!("Configured access token.");
                 Ok(())
             }
@@ -85,7 +85,7 @@ async fn do_login(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
             .context("failed to read auth token")?;
         // copied credentials will often accidentally contain extra whitespace characters
         let token = token.trim().to_string();
-        ctx.config_mut().set_access_token(token);
+        controlplane::configure_new_access_token(ctx, token).await?;
         println!("\nConfigured access token.");
         Ok(())
     } else {

--- a/crates/flowctl/src/auth/roles.rs
+++ b/crates/flowctl/src/auth/roles.rs
@@ -138,7 +138,7 @@ pub async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("combined_grants_ext")
             .select(
                 vec![
@@ -176,7 +176,7 @@ pub async fn do_grant(
     // Upsert user grants to `user_grants` and role grants to `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -193,7 +193,7 @@ pub async fn do_grant(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -228,7 +228,7 @@ pub async fn do_revoke(
     // Revoke user grants from `user_grants` and role grants from `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .eq("user_id", subject_user_id.to_string())
@@ -238,7 +238,7 @@ pub async fn do_revoke(
         .await?
     } else if let Some(subject_role) = subject_role {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .eq("subject_role", subject_role)

--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -70,7 +70,7 @@ pub async fn do_delete(
         deleted: false,
     };
 
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     let specs = catalog::fetch_live_specs(
         client.clone(),
         &list_args,
@@ -125,7 +125,7 @@ pub async fn do_delete(
         .collect::<Vec<DraftSpec>>();
 
     api_exec::<Vec<serde_json::Value>>(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("draft_specs")
             //.select("catalog_name,spec_type")
             .upsert(serde_json::to_string(&draft_specs).unwrap())

--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -471,7 +471,7 @@ async fn do_list(ctx: &mut crate::CliContext, list_args: &List) -> anyhow::Resul
         columns.push("reads_from");
         columns.push("writes_to");
     }
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     let rows = fetch_live_specs(client, list_args, columns).await?;
 
     ctx.write_all(rows, list_args.flows)
@@ -522,7 +522,7 @@ async fn do_history(ctx: &mut crate::CliContext, History { name }: &History) -> 
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("publication_specs_ext")
             .like("catalog_name", format!("{name}%"))
             .select(
@@ -572,7 +572,7 @@ async fn do_draft(
         mut spec_type,
     } = if let Some(publication_id) = publication_id {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("publication_specs_ext")
                 .eq("catalog_name", name)
                 .eq("pub_id", publication_id)
@@ -582,7 +582,7 @@ async fn do_draft(
         .await?
     } else {
         api_exec(
-            ctx.controlplane_client()?
+            ctx.controlplane_client().await?
                 .from("live_specs")
                 .eq("catalog_name", name)
                 .select("catalog_name,last_pub_id,pub_id:last_pub_id,spec,spec_type")
@@ -616,7 +616,7 @@ async fn do_draft(
     tracing::debug!(?draft_spec, "inserting draft");
 
     let rows: Vec<SpecSummaryItem> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("draft_specs")
             .select("catalog_name,spec_type")
             .upsert(serde_json::to_string(&draft_spec).unwrap())

--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -97,7 +97,7 @@ pub async fn do_publish(ctx: &mut CliContext, args: &Publish) -> anyhow::Result<
     // in common error scenarios. For example, we don't create the draft until after bundling, because
     // then we'd have to clean up the empty draft if the bundling fails. The very first thing is to create the client,
     // since that can fail due to missing/expired credentials.
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
 
     anyhow::ensure!(args.auto_approve || std::io::stdin().is_tty(), "The publish command must be run interactively unless the `--auto-approve` flag is provided");
 

--- a/crates/flowctl/src/catalog/pull_specs.rs
+++ b/crates/flowctl/src/catalog/pull_specs.rs
@@ -25,7 +25,7 @@ pub struct PullSpecs {
 }
 
 pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Result<()> {
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     let columns = vec![
         "catalog_name",
         "id",

--- a/crates/flowctl/src/catalog/test.rs
+++ b/crates/flowctl/src/catalog/test.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 /// and discoverable to users. There's also no need for any confirmation steps, since we're not
 /// actually modifying the published specs.
 pub async fn do_test(ctx: &mut CliContext, args: &source::SourceArgs) -> anyhow::Result<()> {
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
 
     let catalog = crate::source::bundle(args).await?;
 

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -226,7 +226,7 @@ async fn do_list_fragments(
     args: &ListFragmentsArgs,
 ) -> Result<(), anyhow::Error> {
     let mut client = journal_client_for(
-        ctx.controlplane_client()?,
+        ctx.controlplane_client().await?,
         vec![args.selector.collection.clone()],
     )
     .await?;
@@ -269,7 +269,7 @@ async fn do_list_journals(
     args: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
     let mut client =
-        journal_client_for(ctx.controlplane_client()?, vec![args.collection.clone()]).await?;
+        journal_client_for(ctx.controlplane_client().await?, vec![args.collection.clone()]).await?;
 
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -26,7 +26,7 @@ pub async fn get_collection_inferred_schema(
         anyhow::bail!("flowctl is not yet able to read from partitioned collections (coming soon)");
     }
 
-    let cp_client = ctx.controlplane_client()?;
+    let cp_client = ctx.controlplane_client().await?;
     let token = fetch_data_plane_access_token(cp_client, vec![args.selector.collection.clone()])
         .await
         .context("fetching data plane access token")?;
@@ -111,7 +111,7 @@ pub async fn read_collection(ctx: &mut crate::CliContext, args: &ReadArgs) -> an
         );
     }
 
-    let cp_client = ctx.controlplane_client()?;
+    let cp_client = ctx.controlplane_client().await?;
     let mut data_plane_client =
         dataplane::journal_client_for(cp_client, vec![args.selector.collection.clone()]).await?;
 

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -82,6 +82,13 @@ impl Config {
         }
     }
 
+    pub fn set_refresh_token(&mut self, refresh_token: RefreshToken) {
+        // Don't overwrite the other fields of api if they are already present.
+        if let Some(api) = self.api.as_mut() {
+            api.refresh_token = Some(refresh_token);
+        }
+    }
+
     pub fn get_dashboard_url(&self, path: &str) -> anyhow::Result<url::Url> {
         let base = self
             .dashboard_url
@@ -94,6 +101,12 @@ impl Config {
     }
 }
 
+#[derive(Deserialize, Serialize, Debug)]
+pub struct RefreshToken {
+    pub id: String,
+    pub secret: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct API {
     // URL endpoint of the Flow control-plane Rest API.
@@ -102,6 +115,8 @@ pub struct API {
     pub public_token: String,
     // Secret access token of the control-plane API.
     pub access_token: String,
+    // Secret refresh token of the control-plane API, used to generate access_token when it expires
+    pub refresh_token: Option<RefreshToken>,
 }
 
 impl API {
@@ -110,6 +125,7 @@ impl API {
             endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
             public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
             access_token,
+            refresh_token: None,
         }
     }
 }

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -77,7 +77,7 @@ impl Config {
         // Don't overwrite the other fields of api if they are already present.
         if let Some(api) = self.api.as_mut() {
             api.access_token = access_token;
-            api.user_id = user_id;
+            api.user_id = Some(user_id);
         } else {
             self.api = Some(API::managed(access_token, user_id));
         }
@@ -123,7 +123,7 @@ pub struct API {
     // Secret access token of the control-plane API.
     pub access_token: String,
     // User identifier
-    pub user_id: String,
+    pub user_id: Option<String>,
 }
 
 impl API {
@@ -132,7 +132,7 @@ impl API {
             endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
             public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
             access_token,
-            user_id,
+            user_id: Some(user_id),
         }
     }
 }

--- a/crates/flowctl/src/controlplane.rs
+++ b/crates/flowctl/src/controlplane.rs
@@ -97,10 +97,16 @@ fn check_access_token(access_token: &str) -> anyhow::Result<JWT> {
     Ok(jwt)
 }
 
+const FLOW_AUTH_TOKEN: &str = "FLOW_AUTH_TOKEN";
+
 async fn retrieve_credentials(
     endpoint: &url::Url,
     user_id: &str,
 ) -> anyhow::Result<RefreshToken> {
+    if let Ok(env_token) = std::env::var(FLOW_AUTH_TOKEN) {
+        return RefreshToken::from_base64(&env_token);
+    }
+
     let keychain_entry = keychain_auth_entry(endpoint, user_id)?;
     let user_id = user_id.to_string(); // clone so we can use it in the closure
                                              // We use spawn_blocking because accessing the keychain is a blocking call, which may prompt the user

--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -122,9 +122,9 @@ pub async fn do_author(
 ) -> anyhow::Result<()> {
     let cur_draft = ctx.config().cur_draft()?;
     let catalog = crate::source::bundle(source_args).await?;
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     clear_draft(client.clone(), &cur_draft).await?;
-    let rows = upsert_draft_specs(ctx.controlplane_client()?, &cur_draft, &catalog).await?;
+    let rows = upsert_draft_specs(ctx.controlplane_client().await?, &cur_draft, &catalog).await?;
 
     ctx.write_all(rows, ())
 }

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -16,7 +16,7 @@ pub async fn do_develop(
 ) -> anyhow::Result<()> {
     let draft_id = ctx.config().cur_draft()?;
     let rows: Vec<DraftSpecRow> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("draft_specs")
             .select("catalog_name,spec,spec_type")
             .not("is", "spec_type", "null")

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -145,7 +145,7 @@ pub async fn delete_draft(client: Client, draft_id: &str) -> Result<DraftRow, an
 }
 
 async fn do_create(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     let row = create_draft(client).await?;
 
     ctx.config_mut().draft = Some(row.id.clone());
@@ -170,7 +170,7 @@ async fn do_delete(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
             to_table_row(self, &["/id", "/updated_at"])
         }
     }
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
     let draft_id = ctx.config().cur_draft()?;
     let row = delete_draft(client, &draft_id).await?;
 
@@ -212,7 +212,7 @@ async fn do_describe(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("draft_specs_ext")
             .select(
                 vec![
@@ -257,7 +257,7 @@ async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         }
     }
     let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("drafts_ext")
             .select("created_at,detail,id,num_specs,updated_at"),
     )
@@ -281,7 +281,7 @@ async fn do_select(
     Select { id: select_id }: &Select,
 ) -> anyhow::Result<()> {
     let matched: Vec<serde_json::Value> = api_exec(
-        ctx.controlplane_client()?
+        ctx.controlplane_client().await?
             .from("drafts")
             .eq("id", select_id)
             .select("id"),
@@ -298,7 +298,7 @@ async fn do_select(
 
 async fn do_publish(ctx: &mut crate::CliContext, dry_run: bool) -> anyhow::Result<()> {
     let draft_id = ctx.config().cur_draft()?;
-    let client = ctx.controlplane_client()?;
+    let client = ctx.controlplane_client().await?;
 
     publish(client, dry_run, &draft_id).await?;
 

--- a/crates/flowctl/src/raw.rs
+++ b/crates/flowctl/src/raw.rs
@@ -117,7 +117,7 @@ impl Advanced {
 }
 
 async fn do_get(ctx: &mut crate::CliContext, Get { table, query }: &Get) -> anyhow::Result<()> {
-    let req = ctx.controlplane_client()?.from(table).build().query(query);
+    let req = ctx.controlplane_client().await?.from(table).build().query(query);
     tracing::debug!(?req, "built request to execute");
 
     println!("{}", req.send().await?.text().await?);
@@ -129,7 +129,7 @@ async fn do_update(
     Update { table, query, body }: &Update,
 ) -> anyhow::Result<()> {
     let req = ctx
-        .controlplane_client()?
+        .controlplane_client().await?
         .from(table)
         .update(body)
         .build()
@@ -149,7 +149,7 @@ async fn do_rpc(
     }: &Rpc,
 ) -> anyhow::Result<()> {
     let req = ctx
-        .controlplane_client()?
+        .controlplane_client().await?
         .rpc(function, body)
         .build()
         .query(query);

--- a/crates/flowctl/src/typescript/mod.rs
+++ b/crates/flowctl/src/typescript/mod.rs
@@ -114,7 +114,7 @@ pub async fn do_generate(
             .is_some();
         let is_fetched = live_specs_catalog.collections.contains_key(source_name);
         if !is_included_in_sources && !is_fetched {
-            let resolved = try_resolve_collection(ctx.controlplane_client()?, source_name).await.with_context(|| {
+            let resolved = try_resolve_collection(ctx.controlplane_client().await?, source_name).await.with_context(|| {
                 anyhow::anyhow!("resolving the collection '{source_name}', referenced from the transform '{}' in derivation '{}'", transform_row.transform, transform_row.derivation)
             })?;
             live_specs_catalog


### PR DESCRIPTION
**Description:**

- Use the given `access_token` on at login time to generate a `refresh_token` and use that `refresh_token` to generate new `access_tokens` if they are expired.

**Workflow steps:**

```
flowctl auth token --token='YOUR TOKEN'
# wait for expiry (one day) then the command below should still work
# you can check whether the access_token has been updated by checking the
# config directory
# $HOME/.config/flowctl/${profile}.json on linux
# $HOME/Library/Application Support/flowctl/${profile}.json on macos

flowctl draft list
```

- You can also manually edit the JWT token using https://jwt.io/ debugger and set the expiry date to a time in the past to see the refresh logic in action

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/953)
<!-- Reviewable:end -->
