### PR TITLE
fix: Specify a 30s timeout for discover operations.

### DIFF
--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -67,7 +67,7 @@ func (cmd apiDiscover) execute(ctx context.Context) (*pc.DiscoverResponse, error
 func (cmd apiDiscover) Execute(_ []string) error {
 	defer mbp.InitDiagnosticsAndRecover(cmd.Diagnostics)()
 	mbp.InitLog(cmd.Log)
-	var ctx, cancelFn = context.WithTimeout(context.Background(), time.Hour)
+	var ctx, cancelFn = context.WithTimeout(context.Background(), time.Second*30)
 	defer cancelFn()
 
 	logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
**Description:**

There appeared to already be a timeout in place in `cmd-api-discover.go`, but the codepath that introduced the timeout was never reached, and was instead called from `cmd-discover.go`.

Fixes #911 

**Note:** This doesn't change any SSH timeouts, as I believe those are in the specific connectors, or possibly the SQL connector boilerplate or something like that. That can come next if the 30s timeout is still not enough, unless we think it's critical to do it now

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/956)
<!-- Reviewable:end -->
