### PR TITLE
flowctl: automatically login if FLOW_AUTH_TOKEN is available

### DIFF
--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -126,11 +126,15 @@ pub struct API {
     pub user_id: Option<String>,
 }
 
+pub const PUBLIC_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco";
+
+pub const ENDPOINT: &str = "https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1";
+
 impl API {
     fn managed(access_token: String, user_id: String) -> Self {
         Self {
-            endpoint: url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap(),
-            public_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco".to_string(),
+            endpoint: url::Url::parse(ENDPOINT).unwrap(),
+            public_token: PUBLIC_TOKEN.to_string(),
             access_token,
             user_id: Some(user_id),
         }

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -91,16 +91,11 @@ impl CliContext {
     /// This function will return an error if the authentication credentials
     /// are missing, invalid, or expired.
     pub async fn controlplane_client(&mut self) -> anyhow::Result<controlplane::Client> {
-        let CliContext {
-            ref mut config,
-            ref mut controlplane_client,
-            ..
-        } = self;
-        if controlplane_client.is_none() {
-            let client = controlplane::new_client(config).await?;
-            *controlplane_client = Some(client.clone())
+        if self.controlplane_client.is_none() {
+            let client = controlplane::new_client(self).await?;
+            self.controlplane_client = Some(client.clone())
         }
-        Ok(controlplane_client.clone().unwrap())
+        Ok(self.controlplane_client.clone().unwrap())
     }
 
     pub fn config_mut(&mut self) -> &mut config::Config {


### PR DESCRIPTION
**Description:**

- In the case where the user has not done an initial login (mostly in non-interactive environments), we want to be able to just provide a refresh token through `FLOW_AUTH_TOKEN` and have `flowctl` use that to generate an `access_token`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/959)
<!-- Reviewable:end -->
