### PR TITLE
agent: add alternate documentation url column for connectors

### DIFF
--- a/crates/agent-sql/src/connector_tags.rs
+++ b/crates/agent-sql/src/connector_tags.rs
@@ -10,6 +10,7 @@ use sqlx::{types::Uuid, FromRow};
 pub struct Row {
     pub connector_id: Id,
     pub created_at: DateTime<Utc>,
+    pub documentation_url_override: Option<String>,
     pub external_url: String,
     pub image_name: String,
     pub image_tag: String,
@@ -26,6 +27,7 @@ pub async fn dequeue(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> sqlx::R
             c.external_url,
             c.image_name,
             t.created_at,
+            t.documentation_url_override,
             t.id as "tag_id: Id",
             t.image_tag,
             t.logs_token,

--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -128,12 +128,16 @@ impl TagHandler {
             oauth2_spec: Option<Box<RawValue>>,
         }
         let Spec {
-            documentation_url,
+            mut documentation_url,
             endpoint_spec_schema,
             protocol,
             resource_spec_schema,
             oauth2_spec,
         } = serde_json::from_slice(&spec.1).context("parsing connector spec output")?;
+
+        if let Some(doc_url_override) = row.documentation_url_override {
+            documentation_url = doc_url_override
+        }
 
         agent_sql::connector_tags::update_tag_fields(
             row.tag_id,

--- a/supabase/migrations/06_connectors.sql
+++ b/supabase/migrations/06_connectors.sql
@@ -57,12 +57,13 @@ grant select(id, detail, updated_at, created_at, image_name, external_url, title
 create table connector_tags (
   like internal._model_async including all,
 
-  connector_id          flowid not null references connectors(id),
-  documentation_url     text,     -- Job output.
-  endpoint_spec_schema  json_obj, -- Job output.
-  image_tag             text not null,
-  protocol              text,     -- Job output.
-  resource_spec_schema  json_obj, -- Job output.
+  connector_id                flowid not null references connectors(id),
+  documentation_url           text,     -- Job output.
+  endpoint_spec_schema        json_obj, -- Job output.
+  image_tag                   text not null,
+  protocol                    text,     -- Job output.
+  resource_spec_schema        json_obj, -- Job output.
+  documentation_url_override  text,
   unique(connector_id, image_tag),
   --
   constraint "image_tag must start with : (as in :latest) or @sha256:<hash>"
@@ -92,6 +93,8 @@ comment on column connector_tags.protocol is
   'Protocol of the connector';
 comment on column connector_tags.resource_spec_schema is
   'Resource specification JSON-Schema of the tagged connector';
+comment on column connector_tags.documentation_url_override is
+  'Alternative documentation URL to the one from the connector specification';
 
 -- authenticated may select all connector_tags without restrictions.
 grant select on table connector_tags to authenticated;

--- a/supabase/pending/alt_doc_url_column.sql
+++ b/supabase/pending/alt_doc_url_column.sql
@@ -1,0 +1,1 @@
+alter table connector_tags add column documentation_url_override text;

--- a/supabase/pending/remove_ops_grants.sql
+++ b/supabase/pending/remove_ops_grants.sql
@@ -1,1 +1,0 @@
-delete from role_grants where object_role like 'ops/%/';


### PR DESCRIPTION
**Description:**

Adds a new column `documentation_url_override` to the `connector_tags` table, and `agent` logic to process it.  This will allow us to set the correct documentation URL for connectors that are built as re-tags of other connectors, like `source-mariadb` vs . `source-mysql`. In these cases we would like the doc links to be for the variant rather than the connector it is re-tagged from.

Closes https://github.com/estuary/flow/issues/967

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/972)
<!-- Reviewable:end -->
