### PR TITLE
runtime: temporary code to drop ack intents for old ops journals

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/estuary/flow/go/bindings"
@@ -19,6 +20,7 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/estuary/flow/go/shuffle"
 	"go.gazette.dev/core/broker/client"
+	"go.gazette.dev/core/broker/protocol"
 	"go.gazette.dev/core/consumer"
 	"go.gazette.dev/core/consumer/recoverylog"
 	"go.gazette.dev/core/message"
@@ -117,7 +119,24 @@ func (c *Capture) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err
 		return pf.Checkpoint{}, err
 	}
 
+	removeOldOpsJournalAckIntents(cp.AckIntents)
+
 	return cp, nil
+}
+
+// TODO(whb): Remove this and associated code when the tasks writing to the "old" ops journals are
+// no longer blocked since these journals don't exist anymore. This is a temporary hack to remove
+// ack intents for journals like `ops/tenant/stats` and `ops/tenant/logs` since we have cleared
+// those journals out. Any tasks with ackIntents in their recovery log for these are currently stuck
+// forever retrying to write to the non-existant journal.
+var oldOpsJournalRe = regexp.MustCompile(`^ops\/.+?\/(stats|logs)`)
+
+func removeOldOpsJournalAckIntents(ackIntents map[protocol.Journal][]byte) {
+	for journal := range ackIntents {
+		if oldOpsJournalRe.MatchString(journal.String()) {
+			delete(ackIntents, journal)
+		}
+	}
 }
 
 // StartReadingMessages starts a concurrent read of the pull RPC,

--- a/go/runtime/capture_test.go
+++ b/go/runtime/capture_test.go
@@ -6,7 +6,36 @@ import (
 	"github.com/estuary/flow/go/ops"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
+	"go.gazette.dev/core/broker/protocol"
 )
+
+func TestRemoveOldOpsJournalAckIntents(t *testing.T) {
+	cp := pf.Checkpoint{
+		AckIntents: map[protocol.Journal][]byte{
+			protocol.Journal("a/good/journal"):                                                   []byte("keep1"),
+			protocol.Journal("ops/estuary/logs/kind=materialization/name=materialization"):       []byte("drop1"),
+			protocol.Journal("ops/estuary/stats/kind=capture/name=capture"):                      []byte("drop2"),
+			protocol.Journal("ops/some.tenant/logs/kind=derivation/name=something"):              []byte("drop3"),
+			protocol.Journal("ops/other-tenant/stats/kind=materialization/name=someting/else"):   []byte("drop4"),
+			protocol.Journal("ops.us-central1.v1/stats/kind=materialization/name=something"):     []byte("keep2"),
+			protocol.Journal("ops.us-central1.v1/logs/kind=capture/name=another"):                []byte("keep3"),
+			protocol.Journal("hello/ops/estuary/logs/kind=materialization/name=materialization"): []byte("keep4"),
+		},
+	}
+
+	removeOldOpsJournalAckIntents(cp.AckIntents)
+
+	want := pf.Checkpoint{
+		AckIntents: map[protocol.Journal][]byte{
+			protocol.Journal("a/good/journal"):                                                   []byte("keep1"),
+			protocol.Journal("ops.us-central1.v1/stats/kind=materialization/name=something"):     []byte("keep2"),
+			protocol.Journal("ops.us-central1.v1/logs/kind=capture/name=another"):                []byte("keep3"),
+			protocol.Journal("hello/ops/estuary/logs/kind=materialization/name=materialization"): []byte("keep4"),
+		},
+	}
+
+	require.Equal(t, want, cp)
+}
 
 func TestCaptureStats(t *testing.T) {
 	// Simulate a capture with two bindings, where only one of them participated in the transaction.

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -111,6 +111,9 @@ func (d *Derive) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err 
 	}
 
 	cp, err = d.binding.RestoreCheckpoint()
+
+	removeOldOpsJournalAckIntents(cp.AckIntents)
+
 	return cp, err
 }
 

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -186,6 +186,8 @@ func (m *Materialize) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint,
 		checkpointSource = "recoveryLog"
 	}
 
+	removeOldOpsJournalAckIntents(cp.AckIntents)
+
 	return cp, nil
 }
 


### PR DESCRIPTION
**Description:**

This is a temporary hack to remove ack intents for journals like `ops/tenant/stats` and `ops/tenant/logs` since we have cleared those journals out. Any tasks with ackIntents in their recovery log for these are currently stuck forever retrying to write to the non-existant journal.

It should be reverted once those tasks are unstuck.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/975)
<!-- Reviewable:end -->
