### PR TITLE
flowctl: handle possibility for deleted specs during catalog publish

### DIFF
--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -31,7 +31,7 @@ pub async fn remove_unchanged(
     #[derive(Deserialize, Debug)]
     struct SpecChecksumRow {
         catalog_name: String,
-        md5: String,
+        md5: Option<String>,
     }
 
     let spec_names = input_catalog.all_spec_names();
@@ -44,7 +44,13 @@ pub async fn remove_unchanged(
         let rows: Vec<SpecChecksumRow> = api_exec(builder).await?;
         let chunk_checksums = rows
             .iter()
-            .map(|row| (row.catalog_name.clone(), row.md5.clone()))
+            .filter_map(|row| {
+                if let Some(md5) = row.md5.as_ref() {
+                    Some((row.catalog_name.clone(), md5.clone()))
+                } else {
+                    None
+                }
+            })
             .collect::<HashMap<String, String>>();
 
         spec_checksums.extend(chunk_checksums);


### PR DESCRIPTION
**Description:**

The spec md5 checking previously assumed that all specs would have an md5 value. This isn't the case if a local set of specs includes a spec that has been deleted from the remote control plane. In this case the md5 column is `null`.

This is probably not typical, but previous behavior would result in a pretty incomprehensible error message when it happens. This fix allows for the md5 value to be null and handles it appropriately.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/977)
<!-- Reviewable:end -->
