### PR TITLE
schemalate/firebolt: add action to get drop query

### DIFF
--- a/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
+++ b/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
@@ -163,6 +163,14 @@ pub fn build_firebolt_queries_bundle(
     })
 }
 
+pub fn build_drop_query(
+    table: &Table,
+) -> Result<String, Error> {
+    Ok(DropTable {
+        table,
+    }.to_string())
+}
+
 fn projection_type_to_firebolt_type(shape: &Shape) -> Option<FireboltType> {
     if shape.type_.overlaps(types::STRING) {
         Some(FireboltType::Text)


### PR DESCRIPTION
**Description:**

- Add a new action to schemalate/firebolt to build a drop table query, used by firebolt materialization to drop deleted bindings
- Used in https://github.com/estuary/connectors/pull/623

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/979)
<!-- Reviewable:end -->
