### PR TITLE
Phil/data plane auth

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -83,6 +83,14 @@ The Flow UI should open in your browser automatically.
 
 To login locally, you need to use the "magic link" method. Oauth does not work locally. You can enter any email address you like, and all emails will be sent to [http://localhost:5434/monitor]. After it says "email sent", go to that address and click the link in the email to complete the login process.
 
+### Data-plane-gateway TLS certificates
+
+Data-plane-gateway requires TLS, even locally. `start-component.sh` will generate a self-signed certificate automatically and store it in the root of the data-plane-gateway local repository.
+In order for the UI to work correctly, you'll need to tell your browser to trust that certificate. To do that, navigate to (https://localhost:28318/) and click through the warnings to trust the certificate.
+As long as you don't delete and regenerate the certificates, you should only need to do this once per year (the certificate is valid for a year).
+
+Once you trust the certificate, you should start seeing shard statuses in the UI.
+
 ### Stopping Flow
 
 - Kill the tmux session (`crtl+b` `:` then type `kill-session` and hit enter)

--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -105,7 +105,7 @@ function start_data_plane_gateway() {
     wait_until_listening $BROKER_PORT 'Gazette broker'
     wait_until_listening $CONSUMER_PORT 'Flow reactor'
     wait_until_listening $INFERENCE_PORT 'Schema inference'
-    must_run go run . --tls-certificate "${cert_path}" --tls-private-key "${key_path}" --log.level debug --inference-address "${INFERENCE_ADDRESS}"
+    must_run go run . --tls-certificate "${cert_path}" --tls-private-key "${key_path}" --log.level debug --inference-address "${INFERENCE_ADDRESS}" --control-plane-auth-url "http://localhost:3000"
 }
 
 function start_control_plane() {

--- a/supabase/migrations/14_gateway_auth.sql
+++ b/supabase/migrations/14_gateway_auth.sql
@@ -48,29 +48,40 @@ returns text as $$
 
 $$ language sql stable security definer;
 
-
-
 create function gateway_auth_token(variadic prefixes text[])
 returns table (token text, gateway_url text) as $$
+declare
+  -- The number of distinct prefixes (i.e. scopes) that were requested.
+  requested_prefixes int := (select count(distinct p) from unnest(prefixes) p);
+  -- The distinct prefixes, filtered by whether or not they are authorized.
+  authorized_prefixes text[];
+begin
+  
+  select array_agg(distinct p) into authorized_prefixes
+    from 
+      unnest(prefixes) as p
+      join auth_roles() as r on starts_with(p, r.role_prefix);
 
-  with authorized_prefixes as (
-    select p as prefix
-    from auth_roles() as r, unnest(prefixes) as p
-    where starts_with(p, r.role_prefix)
-  )
+  -- authorized_prefixes will be null when _none_ of the requested prefixes are authorized.
+  -- In that case the array_length comparison won't work, so we need an explicit null check.
+  if authorized_prefixes is null or array_length(authorized_prefixes, 1) != requested_prefixes then
+    -- errcode 28000 causes potgrest to return an HTTP 403
+    -- see: https://www.postgresql.org/docs/current/errcodes-appendix.html
+    -- and: https://postgrest.org/en/stable/errors.html#status-codes
+    raise 'you are not authorized for all of the requested scopes' using errcode = 28000;
+  end if;
 
-  select internal.sign_jwt(
+  return query select internal.sign_jwt(
     json_build_object(
       'exp', trunc(extract(epoch from (now() + interval '1 hour'))),
       'iat', trunc(extract(epoch from (now()))),
       'operation', 'read',
-      'prefixes', array_agg(distinct ap.prefix),
+      'prefixes', authorized_prefixes,
       'sub', auth_uid()
     )
-  ) as token, internal.gateway_endpoint_url() as gateway_url
-  from authorized_prefixes as ap
-
-$$ language sql stable security definer;
+  ) as token, internal.gateway_endpoint_url() as gateway_url;
+end;
+$$ language plpgsql stable security definer;
 
 comment on function gateway_auth_token is
   'gateway_auth_token returns a jwt that can be used with the Data Plane Gateway to interact directly with Gazette RPCs.';

--- a/supabase/migrations/14_gateway_auth.sql
+++ b/supabase/migrations/14_gateway_auth.sql
@@ -21,7 +21,7 @@ create table internal.gateway_endpoints (
 );
 
 insert into internal.gateway_endpoints (name, url, detail) values (
-  'local', 'http://localhost:28317/', 'Used for development only. This value will be changed manually when deployed to production.'
+  'local', 'https://localhost:28318/', 'Used for development only. This value will be changed manually when deployed to production.'
 );
 
 


### PR DESCRIPTION
**Description:**

This PR rolls up a few minor fixes related to estuary/data-plane-gateway#30. 

The main change introduced here is to use the https endpoint of data-plane-gateway when running flow locally. **This introduces a breaking change to start-flow.sh** (see below).

In addition, I'd noticed that our `gateway_auth_token` function had some weird behavior when you request scopes that you're not authorized to, so the second commit addresses that. There's still a number of other issues with how we generate these auth tokens, and I think it's best to leave those aspects unaddressed until #688 is addressed.

**Workflow steps:**

In order to get local flow installations working properly after this commit:

- Pull the latest changes from the flow, ui, and data-plane-gateway repos.
- Update the gateway URL to the HTTPS version, using one of two options:
    - Run `supabase db reset` or `supabase stop && supabase start`, and the new URL will be setup by the database seed.
    - Run the sql statement `update internal.gateway_endpoints set url = 'https://localhost:28318/';`
- Start flow using `./local/start-flow.sh` and wait for the data-plane-gateway to be up and running.
- Open your browser and navigate to (https://localhost:28318/healthz) and click through all the warnings and trust the self-signed certificate for data-plane-gateway, and you should be all good.

Trusting the TLS certificate will be a requirement from now on. Assuming you don't delete the certificates, though, you should only need to do that once per year, since that's how long the cert is valid for.

**Documentation links affected:**

no user-facing changes here

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/980)
<!-- Reviewable:end -->
