### PR TITLE
agent: quiet logging for gsutil

### DIFF
--- a/crates/agent/src/publications/builds.rs
+++ b/crates/agent/src/publications/builds.rs
@@ -71,6 +71,7 @@ pub async fn build_catalog(
         &logs_tx,
         logs_token,
         tokio::process::Command::new("gsutil")
+            .arg("-q")
             .arg("cp")
             .arg(&db_path)
             .arg(dest_url.to_string()),


### PR DESCRIPTION
**Description:**

Runs `gsutil` with the -q option, which suppresses logs from normal operations completing successfully and instead only outputs errors if they occur.

Notably this will get rid of the `Copying file:///...` types of logs that are included at the end of the log stream when publishing tasks which should simplify interpretation of them, particularly in the case of errors with the publication.

**Workflow steps:**

Publish a task and observe the log output.

For example, prior to this change the expanded log output looks like this:

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/55118525/226968864-fe01c0eb-e49e-4ecf-9101-5f3b478d6a0b.png">

With this change in place the log output looks like this:

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/55118525/226969260-2c1887d1-3a55-4ebf-a032-2f41b40a75b3.png">


**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/982)
<!-- Reviewable:end -->
