### PR TITLE
Add Tilt for running Flow locally

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,112 @@
+# This file is interpreted by `tilt`, and describes how to get a local flow environment running.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+os.putenv("DATABASE_URL", DATABASE_URL)
+os.putenv ("RUST_LOG", "info")
+
+
+REPO_BASE= '%s/..' % os.getcwd()
+TEST_KMS_KEY="projects/helpful-kingdom-273219/locations/us-central1/keyRings/dev/cryptoKeys/testing"
+
+HOME_DIR=os.getenv("HOME")
+FLOW_DIR=os.getenv("FLOW_DIR", os.path.join(HOME_DIR, "flow-local"))
+ETCD_DATA_DIR=os.path.join(FLOW_DIR, "etcd")
+FLOW_BUILDS_DIR=os.path.join(FLOW_DIR, "builds")
+
+# Start supabase, which is needed in order to compile the agent
+local_resource('supabase', cmd='supabase start', links='http://localhost:5433')
+
+# Builds many of the binaries that we'll need
+local_resource('make', cmd='make', resource_deps=['supabase'])
+
+
+local_resource('ops-catalog',
+    cmd='./local/ops-publication.sh | psql "%s"' % DATABASE_URL,
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    resource_deps=['supabase'])
+
+local_resource('etcd', serve_cmd='%s/flow/.build/package/bin/etcd \
+    --data-dir %s \
+    --log-level info \
+    --logger zap' % (REPO_BASE, ETCD_DATA_DIR),
+    resource_deps=['make'],
+    readiness_probe=probe(
+        initial_delay_secs=5,
+        http_get=http_get_action(port=2379, path='/health')
+    ))
+
+local_resource('gazette', serve_cmd='%s/flow/.build/package/bin/gazette serve \
+    --broker.port=8080 \
+    --broker.host=localhost \
+    --broker.disable-stores \
+    --broker.max-replication=1 \
+    --log.level=info' % REPO_BASE,
+    links='http://localhost:8080/debug/pprof',
+    resource_deps=['etcd'],
+    readiness_probe=probe(
+        initial_delay_secs=5,
+        http_get=http_get_action(port=8080, path='/debug/ready')
+    ))
+
+local_resource('reactor', serve_cmd='%s/flow/.build/package/bin/flowctl-go serve consumer \
+    --broker.address http://localhost:8080 \
+    --broker.cache.size 128 \
+    --consumer.limit 1024 \
+    --consumer.max-hot-standbys 0 \
+    --consumer.port 9000 \
+    --consumer.host localhost \
+    --etcd.address http://localhost:2379 \
+    --flow.builds-root file://%s/ \
+    --log.format text \
+    --log.level info \
+    --flow.network supabase_network_flow' % (REPO_BASE, FLOW_BUILDS_DIR),
+    links='http://localhost:9000/debug/pprof',
+    resource_deps=['etcd'],
+    readiness_probe=probe(
+        initial_delay_secs=5,
+        http_get=http_get_action(port=9000, path='/debug/ready')
+    ))
+
+local_resource('agent', serve_cmd='%s/flow/.build/package/bin/agent \
+    --connector-network supabase_network_flow \
+    --bin-dir %s/flow/.build/package/bin' % (REPO_BASE, REPO_BASE),
+    deps=[],
+    resource_deps=['reactor', 'gazette'])
+
+local_resource('config-encryption', serve_cmd='%s/config-encryption/target/debug/flow-config-encryption \
+    --gcp-kms %s' % (REPO_BASE, TEST_KMS_KEY),
+    deps=[])
+
+local_resource('oauth', serve_cmd='cd %s/flow && supabase functions serve oauth' % REPO_BASE, deps=['config-encryption'])
+
+local_resource('ui', serve_dir='%s/ui' % REPO_BASE, serve_cmd='BROWSER=none npm start', deps=[], links='http://localhost:3000')
+
+DPG_REPO='%s/data-plane-gateway' % REPO_BASE
+DPG_TLS_CERT_PATH='%s/local-tls-cert.pem' % DPG_REPO
+DPG_TLS_KEY_PATH='%s/local-tls-private-key.pem' % DPG_REPO
+
+local_resource('dpg-tls-cert',
+    dir='%s/data-plane-gateway' % REPO_BASE,
+    cmd='[ -f %s ] || openssl req -x509 -nodes -days 365 \
+        -subj  "/C=CA/ST=QC/O=Estuary/CN=localhost:28318" \
+        -newkey rsa:2048 -keyout "%s" \
+        -out "%s"' % (DPG_TLS_KEY_PATH, DPG_TLS_KEY_PATH, DPG_TLS_CERT_PATH))
+
+local_resource('data-plane-gateway',
+    dir=DPG_REPO,
+    serve_dir=DPG_REPO,
+    cmd='go build .',
+    serve_cmd='./data-plane-gateway \
+        --tls-private-key=%s \
+        --tls-certificate=%s \
+        --broker-address=localhost:8080 \
+        --consumer-address=localhost:9000 \
+        --log.level=debug \
+        --inference-address=localhost:9090 \
+        --control-plane-auth-url=http://localhost:3000' % (
+            DPG_TLS_KEY_PATH,
+            DPG_TLS_CERT_PATH
+        ),
+    links='https://localhost:28318/',
+    resource_deps=['gazette', 'reactor', 'dpg-tls-cert'])
+

--- a/local/README.md
+++ b/local/README.md
@@ -5,6 +5,8 @@
 
 ### Clone these repositories locally:
 
+When running flow locally, we require and assume that these repos are all cloned under the same parent directory, and have names consistent with the repo names in github (the last part of the URL).
+
 - [github.com/estuary/flow](https://github.com/estuary/flow).
 - [github.com/estuary/data-plane-gateway](https://github.com/estuary/data-plane-gateway).
 - [github.com/estuary/ui](https://github.com/estuary/ui).
@@ -14,6 +16,7 @@
 
 Where links are provided, just follow the linked instructions to install the latest version. If there's no link, then use whatever is provided by your package manager of choice and it'll probably be fine.
 
+- [Tilt](https://tilt.dev/) (see below)
 - [Supabase CLI](https://github.com/supabase/cli)
 - [SOPS CLI](https://github.com/mozilla/sops)
 - [Deno](https://deno.land/manual/getting_started/installation)
@@ -46,9 +49,25 @@ rustup target add x86_64-unknown-linux-musl
 rustup target add wasm32-unknown-unknown
 ```
 
-## Build and preparation
+## Using Tilt
 
-### Start Supabase:
+The fancy new way to start flow locally is to run `tilt up` from the root of the Flow repo. You just need to have all of the dependencies described above, and `tilt up` should take care of the rest.
+
+**Installing Tilt** can be done by just running the `curl ... | bash` instructions [on their website](https://docs.tilt.dev/install.html). Note that you shouldn't need to follow any of the Kubernetes-related instructions, since we're not using k8s with Tilt. Just installing the `tilt` binary ought to be enough.
+
+This is still pretty new, so the old `start-flow.sh` is still in place for the time being.
+
+To stop Flow, just CTRL+c the terminal where you started it.
+
+### State
+
+When using Tilt, data is persisted across restarts. Control-plane data is still just stored in the containers that are started by `supabase start`.
+By default, the data-plane data is stored in `~/flow-local/`. You can change the directory that's used for data-plane data by setting the `FLOW_DIR` env var.
+It's on you to ensure that the control-plane and data-plane states are consistent. If you stop supabase, then you'll probably want to also run `rm -rf ~/flow-local`, and vice versa.
+
+## Using `start-flow.sh`
+
+**1: Start Supabase**
 
 From the root of the `flow` repo, run:
 
@@ -65,13 +84,13 @@ supabase db reset
 - You can access the Supabase UI at (http://localhost:5433)
 - Access the email testing server at (http://localhost:5434/monitor), which is used for local logins using "magic links"
 
-### Build Flow binaries
+**2: Build Flow binaries**
 
 From the root of the `flow` repository, run `make` and ensure that it completes successfully. If there's a problem here, feel free to ask for help, as it's possible these instructions have become out of date. This will take a while the very first time you run it, but should be a bit faster on subsequent runs.
 
 This creates a directory of binaries `${your_checkout}/.build/package/bin/` which the control-plane agent refers to as `--bin-dir` or `$BIN_DIR`.
 
-## Start Flow
+**3: Start Flow**
 
 From the root of the `flow` repository, run `./local/start-flow.sh`. This will open a tmux session where each component is running in its own window (tab). Here's a [tmux quick reference](https://quickref.me/tmux#tmux-shortcuts). If you're unfamiliar with tmux key combinations, most of them involve hitting `ctrl+b` and then (after releasing those) hitting another key, like `n` to move to the next window.
 
@@ -79,21 +98,23 @@ You can use `ctrl+b` `n` to cycle between windows and ensure that all the compon
 
 The Flow UI should open in your browser automatically.
 
+**Stopping Flow**
+
+- Kill the tmux session (`crtl+b` `:` then type `kill-session` and hit enter)
+- run `supabase stop` from the root of the `flow` repo
+- Local Flow instances sometimes leave dangling docker containers, which you can cleanup using `docker ps` and `docker stop`.
+
+## Notes on 
 ### Logging in locally
 
 To login locally, you need to use the "magic link" method. Oauth does not work locally. You can enter any email address you like, and all emails will be sent to [http://localhost:5434/monitor]. After it says "email sent", go to that address and click the link in the email to complete the login process.
 
 ### Data-plane-gateway TLS certificates
 
-Data-plane-gateway requires TLS, even locally. `start-component.sh` will generate a self-signed certificate automatically and store it in the root of the data-plane-gateway local repository.
+Data-plane-gateway requires TLS, even locally. Starting Flow with either method will generate a self-signed certificate automatically and store it in the root of the data-plane-gateway local repository.
 In order for the UI to work correctly, you'll need to tell your browser to trust that certificate. To do that, navigate to (https://localhost:28318/) and click through the warnings to trust the certificate.
 As long as you don't delete and regenerate the certificates, you should only need to do this once per year (the certificate is valid for a year).
 
 Once you trust the certificate, you should start seeing shard statuses in the UI.
 
-### Stopping Flow
-
-- Kill the tmux session (`crtl+b` `:` then type `kill-session` and hit enter)
-- run `supabase stop` from the root of the `flow` repo
-- Local Flow instances sometimes leave dangling docker containers, which you can cleanup using `docker ps` and `docker stop`.
 


### PR DESCRIPTION
**Description:**

This adds a new way of running flow locally, as an alternative to `start-flow.sh`. This new method uses [Tilt](https://docs.tilt.dev/), which provides a way to orchestrate the startup of the various components. With the exception of supabase, the components are all run as direct binary invocations, not as docker images.

The motivation for this was to provide a way to have data-plane state persist across restarts when runnign locally. Unlike `start-flow.sh`, the Tiltfile does not use `temp-data-plane`, and instead runs etcd, gazette, and reactor as separate components.

This initial implementation probably still has some issues, especially for mac users. I left `start-flow.sh` in place for the time being, to ensure we can get the bugs worked out and give people time to transition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/989)
<!-- Reviewable:end -->
