### PR TITLE
validation: better error message when names collide

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -14,10 +14,19 @@ pub enum Error {
         unmatched: String,
     },
     #[error(
-        "{lhs_entity} {lhs_name} {error_class} {rhs_entity} {rhs_name}, defined at {rhs_scope}"
+        "{lhs_entity} \"{lhs_name}\" collides with {rhs_entity} \"{rhs_name}\", defined at {rhs_scope}. Consider renaming your {lhs_entity} \"{lhs_name}\"."
     )]
     NameCollision {
-        error_class: &'static str,
+        lhs_entity: &'static str,
+        lhs_name: String,
+        rhs_entity: &'static str,
+        rhs_name: String,
+        rhs_scope: Url,
+    },
+    #[error(
+        "{lhs_entity} \"{lhs_name}\" is a prohibited prefix of {rhs_entity} \"{rhs_name}\", defined at {rhs_scope}. Consider renaming your {lhs_entity} \"{lhs_name}\" and adding a suffix to it."
+    )]
+    PrefixCollision {
         lhs_entity: &'static str,
         lhs_name: String,
         rhs_entity: &'static str,

--- a/crates/validation/src/indexed.rs
+++ b/crates/validation/src/indexed.rs
@@ -59,8 +59,7 @@ where
                 Some(EitherOrBoth::Right(r)) if r == '/' => {
                     // LHS finished *just* as we reached a '/',
                     // as in "foo/bar" vs "foo/bar/".
-                    Error::NameCollision {
-                        error_class: "is a prohibited prefix of",
+                    Error::PrefixCollision {
                         lhs_entity,
                         lhs_name: lhs.to_string(),
                         rhs_entity,
@@ -76,7 +75,6 @@ where
                 None => {
                     // Iterator finished with no different characters.
                     Error::NameCollision {
-                        error_class: "collides with",
                         lhs_entity,
                         lhs_name: lhs.to_string(),
                         rhs_entity,

--- a/crates/validation/tests/snapshots/scenario_tests__cross_entity_name_prefixes_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__cross_entity_name_prefixes_and_duplicates.snap
@@ -5,35 +5,35 @@ expression: errors
 [
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~11,
-        error: capture testing/b/1 collides with collection testing/b/1, defined at test://example/catalog.yaml#/collections/testing~1b~11,
+        error: capture "testing/b/1" collides with collection "testing/b/1", defined at test://example/catalog.yaml#/collections/testing~1b~11. Consider renaming your capture "testing/b/1".,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing~1b~11,
-        error: collection testing/b/1 is a prohibited prefix of materialization testing/b/1/suffix, defined at test://example/catalog.yaml#/materializations/testing~1b~11~1suffix,
+        error: collection "testing/b/1" is a prohibited prefix of materialization "testing/b/1/suffix", defined at test://example/catalog.yaml#/materializations/testing~1b~11~1suffix. Consider renaming your collection "testing/b/1" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing~1b~12,
-        error: collection testing/b/2 collides with materialization testing/b/2, defined at test://example/catalog.yaml#/materializations/testing~1b~12,
+        error: collection "testing/b/2" collides with materialization "testing/b/2", defined at test://example/catalog.yaml#/materializations/testing~1b~12. Consider renaming your collection "testing/b/2".,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~12,
-        error: materialization testing/b/2 is a prohibited prefix of capture testing/b/2/suffix, defined at test://example/catalog.yaml#/captures/testing~1b~12~1suffix,
+        error: materialization "testing/b/2" is a prohibited prefix of capture "testing/b/2/suffix", defined at test://example/catalog.yaml#/captures/testing~1b~12~1suffix. Consider renaming your materialization "testing/b/2" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~13,
-        error: capture testing/b/3 collides with materialization testing/b/3, defined at test://example/catalog.yaml#/materializations/testing~1b~13,
+        error: capture "testing/b/3" collides with materialization "testing/b/3", defined at test://example/catalog.yaml#/materializations/testing~1b~13. Consider renaming your capture "testing/b/3".,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~13,
-        error: materialization testing/b/3 is a prohibited prefix of collection testing/b/3/suffix, defined at test://example/catalog.yaml#/collections/testing~1b~13~1suffix,
+        error: materialization "testing/b/3" is a prohibited prefix of collection "testing/b/3/suffix", defined at test://example/catalog.yaml#/collections/testing~1b~13~1suffix. Consider renaming your materialization "testing/b/3" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~14,
-        error: materialization testing/b/4 is a prohibited prefix of test testing/b/4/suffix, defined at test://example/catalog.yaml#/tests/testing~1b~14~1suffix,
+        error: materialization "testing/b/4" is a prohibited prefix of test "testing/b/4/suffix", defined at test://example/catalog.yaml#/tests/testing~1b~14~1suffix. Consider renaming your materialization "testing/b/4" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/testing~1b~15,
-        error: test testing/b/5 is a prohibited prefix of capture testing/b/5/suffix, defined at test://example/catalog.yaml#/captures/testing~1b~15~1suffix,
+        error: test "testing/b/5" is a prohibited prefix of capture "testing/b/5/suffix", defined at test://example/catalog.yaml#/captures/testing~1b~15~1suffix. Consider renaming your test "testing/b/5" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~11,

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_and_duplicate_storage_mappings.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_and_duplicate_storage_mappings.snap
@@ -25,18 +25,18 @@ expression: errors
     },
     Error {
         scope: test://example/int-string#/storageMappings/,
-        error: storageMapping  is a prohibited prefix of storageMapping /leading/Slash, defined at test://example/int-string#/storageMappings/~1leading~1Slash~1,
+        error: storageMapping "" is a prohibited prefix of storageMapping "/leading/Slash", defined at test://example/int-string#/storageMappings/~1leading~1Slash~1. Consider renaming your storageMapping "" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/storageMappings/not-matched~1,
-        error: storageMapping not-matched is a prohibited prefix of storageMapping Not-Matched/foobar, defined at test://example/int-string#/storageMappings/Not-Matched~1foobar~1,
+        error: storageMapping "not-matched" is a prohibited prefix of storageMapping "Not-Matched/foobar", defined at test://example/int-string#/storageMappings/Not-Matched~1foobar~1. Consider renaming your storageMapping "not-matched" and adding a suffix to it.,
     },
     Error {
         scope: test://example/int-string#/storageMappings/recoverY~1,
-        error: storageMapping recoverY is a prohibited prefix of storageMapping recovery/testing, defined at test://example/catalog.yaml#/storageMappings/recovery~1testing~1,
+        error: storageMapping "recoverY" is a prohibited prefix of storageMapping "recovery/testing", defined at test://example/catalog.yaml#/storageMappings/recovery~1testing~1. Consider renaming your storageMapping "recoverY" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/storageMappings/testing~1,
-        error: storageMapping testing collides with storageMapping testing, defined at test://example/int-string#/storageMappings/testing~1,
+        error: storageMapping "testing" collides with storageMapping "testing", defined at test://example/int-string#/storageMappings/testing~1. Consider renaming your storageMapping "testing".,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_capture_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_capture_names_and_duplicates.snap
@@ -5,11 +5,11 @@ expression: errors
 [
     Error {
         scope: test://example/captures#/captures/testing,
-        error: capture testing is a prohibited prefix of capture testing/SoMe-source, defined at test://example/captures#/captures/testing~1SoMe-source,
+        error: capture "testing" is a prohibited prefix of capture "testing/SoMe-source", defined at test://example/captures#/captures/testing~1SoMe-source. Consider renaming your capture "testing" and adding a suffix to it.,
     },
     Error {
         scope: test://example/captures#/captures/testing~1SoMe-source,
-        error: capture testing/SoMe-source collides with capture testing/some-source, defined at test://example/captures#/captures/testing~1some-source,
+        error: capture "testing/SoMe-source" collides with capture "testing/some-source", defined at test://example/captures#/captures/testing~1some-source. Consider renaming your capture "testing/SoMe-source".,
     },
     Error {
         scope: test://example/captures#/captures/~1bad~1name,

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_collection_names_prefixes_and_duplicates.snap
@@ -41,18 +41,18 @@ expression: errors
     },
     Error {
         scope: test://example/catalog.yaml#/collections/,
-        error: collection  is a prohibited prefix of collection /testing/bad/name, defined at test://example/catalog.yaml#/collections/~1testing~1bad~1name,
+        error: collection "" is a prohibited prefix of collection "/testing/bad/name", defined at test://example/catalog.yaml#/collections/~1testing~1bad~1name. Consider renaming your collection "" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing,
-        error: collection testing is a prohibited prefix of collection testing/array-key, defined at test://example/array-key#/collections/testing~1array-key,
+        error: collection "testing" is a prohibited prefix of collection "testing/array-key", defined at test://example/array-key#/collections/testing~1array-key. Consider renaming your collection "testing" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing~1Int-Halve,
-        error: collection testing/Int-Halve collides with collection testing/int-halve, defined at test://example/int-halve#/collections/testing~1int-halve,
+        error: collection "testing/Int-Halve" collides with collection "testing/int-halve", defined at test://example/int-halve#/collections/testing~1int-halve. Consider renaming your collection "testing/Int-Halve".,
     },
     Error {
         scope: test://example/catalog.yaml#/collections/testing~1int-sTRinG,
-        error: collection testing/int-sTRinG collides with collection testing/int-string, defined at test://example/int-string#/collections/testing~1int-string,
+        error: collection "testing/int-sTRinG" collides with collection "testing/int-string", defined at test://example/int-string#/collections/testing~1int-string. Consider renaming your collection "testing/int-sTRinG".,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_materialization_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_materialization_names_and_duplicates.snap
@@ -5,11 +5,11 @@ expression: errors
 [
     Error {
         scope: test://example/materializations#/materializations/testing,
-        error: materialization testing is a prohibited prefix of materialization testing/SoMe-target, defined at test://example/materializations#/materializations/testing~1SoMe-target,
+        error: materialization "testing" is a prohibited prefix of materialization "testing/SoMe-target", defined at test://example/materializations#/materializations/testing~1SoMe-target. Consider renaming your materialization "testing" and adding a suffix to it.,
     },
     Error {
         scope: test://example/materializations#/materializations/testing~1SoMe-target,
-        error: materialization testing/SoMe-target collides with materialization testing/some-target, defined at test://example/materializations#/materializations/testing~1some-target,
+        error: materialization "testing/SoMe-target" collides with materialization "testing/some-target", defined at test://example/materializations#/materializations/testing~1some-target. Consider renaming your materialization "testing/SoMe-target".,
     },
     Error {
         scope: test://example/materializations#/materializations/~1bad~1name,

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_partition_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_partition_names_and_duplicates.snap
@@ -5,11 +5,11 @@ expression: errors
 [
     Error {
         scope: test://example/int-string#/collections/testing~1int-string/projections/bIt,
-        error: projection bIt collides with projection bit, defined at test://example/int-string#/collections/testing~1int-string/projections/bit,
+        error: projection "bIt" collides with projection "bit", defined at test://example/int-string#/collections/testing~1int-string/projections/bit. Consider renaming your projection "bIt".,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string/projections/INT,
-        error: projection INT collides with projection Int, defined at test://example/int-string#/collections/testing~1int-string/projections/Int,
+        error: projection "INT" collides with projection "Int", defined at test://example/int-string#/collections/testing~1int-string/projections/Int. Consider renaming your projection "INT".,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string/projections/,

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_test_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_test_names_and_duplicates.snap
@@ -29,26 +29,26 @@ expression: errors
     },
     Error {
         scope: test://example/catalog.yaml#/tests/,
-        error: test  is a prohibited prefix of test /testing/bad/name, defined at test://example/catalog.yaml#/tests/~1testing~1bad~1name,
+        error: test "" is a prohibited prefix of test "/testing/bad/name", defined at test://example/catalog.yaml#/tests/~1testing~1bad~1name. Consider renaming your test "" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/testing,
-        error: test testing is a prohibited prefix of test testing/bad name, defined at test://example/catalog.yaml#/tests/testing~1bad%20name,
+        error: test "testing" is a prohibited prefix of test "testing/bad name", defined at test://example/catalog.yaml#/tests/testing~1bad%20name. Consider renaming your test "testing" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/testing~1TeSt,
-        error: test testing/TeSt collides with test testing/test, defined at test://example/int-string-tests#/tests/testing~1test,
+        error: test "testing/TeSt" collides with test "testing/test", defined at test://example/int-string-tests#/tests/testing~1test. Consider renaming your test "testing/TeSt".,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/,
-        error: test  is a prohibited prefix of test /testing/bad/name, defined at test://example/catalog.yaml#/tests/~1testing~1bad~1name,
+        error: test "" is a prohibited prefix of test "/testing/bad/name", defined at test://example/catalog.yaml#/tests/~1testing~1bad~1name. Consider renaming your test "" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/testing,
-        error: test testing is a prohibited prefix of collection testing/array-key, defined at test://example/array-key#/collections/testing~1array-key,
+        error: test "testing" is a prohibited prefix of collection "testing/array-key", defined at test://example/array-key#/collections/testing~1array-key. Consider renaming your test "testing" and adding a suffix to it.,
     },
     Error {
         scope: test://example/catalog.yaml#/tests/testing~1TeSt,
-        error: test testing/TeSt collides with test testing/test, defined at test://example/int-string-tests#/tests/testing~1test,
+        error: test "testing/TeSt" collides with test "testing/test", defined at test://example/int-string-tests#/tests/testing~1test. Consider renaming your test "testing/TeSt".,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_transform_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_transform_names_and_duplicates.snap
@@ -21,6 +21,6 @@ expression: errors
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse/derive/transforms/0,
-        error: transform reverseIntString collides with transform reVeRsEIntString, defined at test://example/int-reverse#/collections/testing~1int-reverse/derive/transforms/5,
+        error: transform "reverseIntString" collides with transform "reVeRsEIntString", defined at test://example/int-reverse#/collections/testing~1int-reverse/derive/transforms/5. Consider renaming your transform "reverseIntString".,
     },
 ]


### PR DESCRIPTION
**Description:**

- Question: is it fair to suggest renaming `lhs_name` in the case of `NameCollision`? Is the left-hand side always the "new" thing? In case of prefixes it is, but I'm not sure if in caes of complete collision it also is?

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/990)
<!-- Reviewable:end -->
