### PR TITLE
ops-catalog: make message optional in the logs schema

### DIFF
--- a/ops-catalog/ops-log-schema.json
+++ b/ops-catalog/ops-log-schema.json
@@ -30,7 +30,6 @@
   "required": [
     "shard",
     "ts",
-    "level",
-    "message"
+    "level"
   ]
 }

--- a/ops-catalog/tests.flow.yaml
+++ b/ops-catalog/tests.flow.yaml
@@ -116,8 +116,8 @@ tests:
           - {
               shard: *shard,
               ts: "2022-04-03T02:02:06Z",
-              level: warn,
-              message: darn,
+              level: warn
+              # Message is deliberately omitted.
             }
 
     - verify:


### PR DESCRIPTION
We're now using canonical protobuf encoding, and that encoding will omit fields entirely rather then emit them with an empty literal.

Tested locally by updating & running catalog tests.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/995)
<!-- Reviewable:end -->
