### PR TITLE
use local flowctl profile with ops-publication.sh

### DIFF
--- a/local/ops-publication.sh
+++ b/local/ops-publication.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-bundled_ops_catalog="$(.build/package/bin/flowctl raw bundle --source ops-catalog/template-local.flow.yaml | sed "s/'/''/g")"
+bundled_ops_catalog="$(.build/package/bin/flowctl --profile local raw bundle --source ops-catalog/template-local.flow.yaml | sed "s/'/''/g")"
 
 cat << EOF
 begin;


### PR DESCRIPTION
**Description:**

Explicitly uses the local profile in `ops-publication.sh`, since the `FLOWCTL_PROFILE` variable is not set when running with `tilt`. The is important because flowctl requires a valid login in order to run `raw bundle`, and it's super confusing to have it try to login to production in order to bundle specs for a local instance.

**Workflow steps:**

This is for devs, not end users. Start flow locally using `tilt up`, then run the `ops-publication.sh` script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/997)
<!-- Reviewable:end -->
