### PR TITLE
runtime: switch to single coordinator having shard context lifetime

### DIFF
--- a/go/shuffle/ring.go
+++ b/go/shuffle/ring.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/estuary/flow/go/bindings"
-	"github.com/estuary/flow/go/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/estuary/flow/go/protocols/ops"
 	"github.com/pkg/errors"
@@ -22,7 +21,6 @@ import (
 // Coordinator collects a set of rings servicing ongoing shuffle reads,
 // and matches new ShuffleConfigs to a new or existing ring.
 type Coordinator struct {
-	builds    *flow.BuildService
 	ctx       context.Context
 	publisher ops.Publisher
 	mu        sync.Mutex
@@ -33,12 +31,10 @@ type Coordinator struct {
 // NewCoordinator returns a new *Coordinator using the given clients.
 func NewCoordinator(
 	ctx context.Context,
-	builds *flow.BuildService,
 	publisher ops.Publisher,
 	rjc pb.RoutedJournalClient,
 ) *Coordinator {
 	return &Coordinator{
-		builds:    builds,
 		ctx:       ctx,
 		publisher: publisher,
 		rings:     make(map[*ring]struct{}),
@@ -216,11 +212,9 @@ func (r *ring) serve() {
 	r.log(ops.Log_debug, "started shuffle ring")
 
 	var (
-		build     = r.coordinator.builds.Open(r.shuffle.BuildId)
 		extractor *bindings.Extractor
 		initErr   error
 	)
-	defer build.Close()
 	// TODO(johnny): defer |extractor| cleanup (not yet implemented).
 
 	if extractor, initErr = bindings.NewExtractor(r.coordinator.publisher); initErr != nil {

--- a/go/shuffle/ring_test.go
+++ b/go/shuffle/ring_test.go
@@ -49,7 +49,7 @@ func TestReadingDocuments(t *testing.T) {
 		Arena:     make(pf.Arena, 1),
 	}
 
-	var coordinator = NewCoordinator(ctx, nil, localPublisher, bk.Client())
+	var coordinator = NewCoordinator(ctx, localPublisher, bk.Client())
 	var ring = newRing(coordinator, pf.JournalShuffle{
 		Journal:     "a/journal",
 		BuildId:     "a-build",
@@ -133,7 +133,7 @@ func TestReadingDocuments(t *testing.T) {
 }
 
 func TestDocumentExtraction(t *testing.T) {
-	var coordinator = NewCoordinator(context.Background(), nil, localPublisher, nil)
+	var coordinator = NewCoordinator(context.Background(), localPublisher, nil)
 	var r = newRing(coordinator, pf.JournalShuffle{
 		Journal:     "a/journal",
 		BuildId:     "a-build",


### PR DESCRIPTION
**Description:**

Swith to a single OpsPublisher having the shard lifetime, that updates with the labels of each task term. Use a Mutex to guard access.

Have a single shuffle.Coordinator that has the Shard's lifetime. This fixes the current cancellation race between the Coordinator (term context) and a replay read (shard context).

Tested on a local stack, where I published a materialization multiple times and confirmed it processed as expected.

Fixes #998

**Workflow steps:**

No changes.

**Documentation links affected:**

None.

**Notes for reviewers:**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/999)
<!-- Reviewable:end -->
