### PR TITLE
oauth2: implement PKCE extension's code_verifier and code_challenge

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -13,7 +13,7 @@ interface OauthSettings {
 }
 
 export async function accessToken(req: Record<string, any>) {
-    const { state, config, redirect_uri, ...params } = req;
+    const { state, code_verifier, config, redirect_uri, ...params } = req;
 
     const decodedState = JSON.parse(atob(state));
     const { connector_id } = decodedState;
@@ -38,6 +38,7 @@ export async function accessToken(req: Record<string, any>) {
             client_id: oauth2_client_id,
             client_secret: oauth2_client_secret,
             config,
+            code_verifier,
             ...oauth2_injected_values,
             ...params,
         },
@@ -53,6 +54,7 @@ export async function accessToken(req: Record<string, any>) {
                 client_id: oauth2_client_id,
                 client_secret: oauth2_client_secret,
                 config,
+                code_verifier,
                 ...oauth2_injected_values,
                 ...params,
             },
@@ -70,6 +72,7 @@ export async function accessToken(req: Record<string, any>) {
                     client_id: oauth2_client_id,
                     client_secret: oauth2_client_secret,
                     config,
+                    code_verifier,
                     ...oauth2_injected_values,
                     ...params,
                 },

--- a/supabase/functions/oauth/auth-url.ts
+++ b/supabase/functions/oauth/auth-url.ts
@@ -4,6 +4,8 @@ import { corsHeaders } from '../_shared/cors.ts';
 import { returnPostgresError, compileTemplate } from '../_shared/helpers.ts';
 import { supabaseClient } from '../_shared/supabaseClient.ts';
 
+import { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v1.0.0/mod.ts";
+
 const generateUniqueRandomKey = () => {
     const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     let array = new Uint8Array(40) as any;
@@ -11,6 +13,13 @@ const generateUniqueRandomKey = () => {
     array = array.map((x: number) => validChars.codePointAt(x % validChars.length));
     return String.fromCharCode.apply(null, array);
 };
+
+// map a standard base64 encoding to a url-safe encoding
+// see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+const base64URLSafe = (str: string) =>
+  str.replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/\=+/, '')
 
 interface OauthSettings {
     oauth2_client_id: string;
@@ -41,6 +50,11 @@ export async function authURL(req: { connector_id: string; config: object; redir
         }),
     );
 
+    // See https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+    const codeVerifier = generateUniqueRandomKey();
+    const codeChallenge = base64URLSafe(sha256(codeVerifier, "utf8", "base64") as string);
+    const codeChallengeMethod = 'S256';
+
     const url = compileTemplate(
         oauth2_spec.authUrlTemplate,
         {
@@ -48,11 +62,13 @@ export async function authURL(req: { connector_id: string; config: object; redir
             redirect_uri: redirect_uri ?? 'https://dashboard.estuary.dev/oauth',
             client_id: oauth2_client_id,
             config,
+            code_challenge: codeChallenge,
+            code_challenge_method: codeChallengeMethod,
         },
         connector_id,
     );
 
-    return new Response(JSON.stringify({ url: url, state: finalState }), {
+    return new Response(JSON.stringify({ url: url, state: finalState, code_verifier: codeVerifier }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
 }


### PR DESCRIPTION
**Description:**

- Implement `code_verifier` generation and `code_challenge` encoding as part of PKCE extension to OAuth2
- We will need the front-end to send back the `code_verifier` when it is sending request to get access token.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1004)
<!-- Reviewable:end -->
