### PR TITLE
oauth: code_verifier must be between 43 and 128 characters long

### DIFF
--- a/supabase/functions/oauth/auth-url.ts
+++ b/supabase/functions/oauth/auth-url.ts
@@ -6,9 +6,9 @@ import { supabaseClient } from '../_shared/supabaseClient.ts';
 
 import { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v1.0.0/mod.ts";
 
-const generateUniqueRandomKey = () => {
+const generateUniqueRandomKey = (size: number = 40) => {
     const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    let array = new Uint8Array(40) as any;
+    let array = new Uint8Array(size) as any;
     window.crypto.getRandomValues(array);
     array = array.map((x: number) => validChars.codePointAt(x % validChars.length));
     return String.fromCharCode.apply(null, array);
@@ -51,7 +51,7 @@ export async function authURL(req: { connector_id: string; config: object; redir
     );
 
     // See https://www.oauth.com/oauth2-servers/pkce/authorization-request/
-    const codeVerifier = generateUniqueRandomKey();
+    const codeVerifier = generateUniqueRandomKey(50);
     const codeChallenge = base64URLSafe(sha256(codeVerifier, "utf8", "base64") as string);
     const codeChallengeMethod = 'S256';
 


### PR DESCRIPTION
**Description:**

- oauth: code_verifier must be between 43 and 128 characters long

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1009)
<!-- Reviewable:end -->
