### PR TITLE
oauth: allow using templates in OAuth response template

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -22,6 +22,15 @@ export const mustacheHelpers = {
         return btoa(render(s));
       }
     },
+    now_plus: function(s: any) {
+      return (s: string, render: any) => {
+        const now = new Date();
+        const inputSeconds = parseInt(render(s));
+        const newDate = new Date(now.getTime() + inputSeconds * 1000);
+
+        return newDate.toISOString()
+      }
+    }
 };
 
 export const compileTemplate = (template: string, data: any, connector_id: string) => {

--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -114,7 +114,11 @@ export async function accessToken(req: Record<string, any>) {
 
     let mappedData: Record<string, any> = {};
     for (const key in accessTokenResponseMap) {
-        mappedData[key] = jsonpointer.get(responseData, accessTokenResponseMap[key]);
+        if (accessTokenResponseMap[key].startsWith('/')) {
+          mappedData[key] = jsonpointer.get(responseData, accessTokenResponseMap[key]);
+        } else {
+          mappedData[key] = compileTemplate(accessTokenResponseMap[key], responseData);
+        }
     }
 
     return new Response(JSON.stringify(mappedData), {


### PR DESCRIPTION
**Description:**

airbyte has recently introduced new fields to their OAuth response mappings, which need processing. In this case, we have AirTable which requires the `expires_in` field of response to be added to `now()` and rendered as an RFC3339 date to work. [See here](https://github.com/estuary/airbyte/blob/master/airbyte-integrations/connectors/source-airtable/oauth2.patch.json#L13) So I'm adding a condition here which allows response map to be rendered using a template instead of just jsonpointer.

In hindsight, we can probably just get rid of jsonpointers here and use mustache templates for the responseMap since it can do the same job anyway. For now I'm keeping both.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1010)
<!-- Reviewable:end -->
