### PR TITLE
flowctl: use basic stdin readline for auth tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,6 @@ dependencies = [
  "proto-flow",
  "proto-gazette",
  "reqwest",
- "rpassword",
  "runtime",
  "schema-inference",
  "serde",
@@ -3583,27 +3582,6 @@ source = "git+https://github.com/jgraettinger/rust-rocksdb#e9f28e778b94914da7b7c
 dependencies = [
  "libc",
  "librocksdb-sys",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
-dependencies = [
- "libc",
- "rtoolbox",
- "winapi",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ rocksdb = { version = "0.17", default-features = false, features = [
     "rtti",
 ] }
 rkyv = { version = "0.7", features = ["archive_le"] }
-rpassword = "7.2"
 rusqlite = { version = "0.29", features = ["bundled-full"] }
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -47,8 +47,6 @@ tonic = { workspace = true }
 open = { workspace = true }
 postgrest = { workspace = true }
 reqwest = { workspace = true }
-# rpassword is used for reading credentials from stdin
-rpassword = { workspace = true }
 
 serde = { workspace = true }
 serde-transcode = { workspace = true }


### PR DESCRIPTION
**Description:**

Removes the use of `rpassword` crate for reading auth tokens from stdin. Turns out that OSX has a feature called "secure input", which can prevent users from pasting into terminals. This post seems to describe more or less what's going on:
https://fig.io/docs/support/secure-keyboard-input#conflicts-with-password-managers-1password-bitwarden It's of course still possible that users may still have trouble pasting into iterm in some scenarios due to secure input. But removing `rpassword` seems likely to help in most cases.

**Workflow steps:**

run `flowctl auth login`. Previously, a secure input was used for the token, so it didn't show up in plain text. Now, it just shows up in plain text.

**Documentation links affected:** n/a

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1014)
<!-- Reviewable:end -->
