### PR TITLE
oauth: fix default content-type not being overriden sometimes

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -81,12 +81,14 @@ export async function accessToken(req: Record<string, any>) {
         );
     }
 
+    const defaultContentType = Object.keys(headers).some(h => h.toLowerCase() == 'content-type') ? {} : { 'content-type': 'application/json' };
+
     const response = await fetch(url, {
         method: 'POST',
         body: body,
         headers: {
             accept: 'application/json',
-            'content-type': 'application/json',
+            ...defaultContentType,
             ...corsHeaders,
             ...headers,
         },


### PR DESCRIPTION
**Description:**

- if a connector specified the content-type header using a different casing than `content-type`, the default content-type would not be overriden and cause issues.
- with this fix, we check for case-insensitive presence of that header and set the default only if the header is not present in the connector's oauth2 spec

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1016)
<!-- Reviewable:end -->
