### PR TITLE
Fix `kill_on_drop`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,9 @@ dependencies = [
 name = "async-process"
 version = "0.0.0"
 dependencies = [
+ "shared_child",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4017,6 +4019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,13 @@ tokio-util = { version = "0.7", features = ["io", "compat"] }
 tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 tower = "0.4"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["time", "json", "env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = [
+    "time",
+    "json",
+    "env-filter",
+    "fmt",
+] }
+shared_child = "1.0.0"
 
 unicode-bom = "1.1"
 unicode-normalization = "0.1"

--- a/crates/async-process/Cargo.toml
+++ b/crates/async-process/Cargo.toml
@@ -9,5 +9,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-
 tokio = { workspace = true }
+tracing = { workspace = true }
+shared_child = { workspace = true }

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -25,7 +25,12 @@ impl Config {
         let config_file = Config::file_path(profile)?;
         let config = match std::fs::read(&config_file) {
             Ok(v) => {
-                let cfg = serde_json::from_slice(&v).context("parsing config")?;
+                let cfg = serde_json::from_slice(&v).with_context(|| {
+                    format!(
+                        "failed to parse flowctl config at {}",
+                        config_file.to_string_lossy(),
+                    )
+                })?;
                 tracing::debug!(path = %config_file.display(), "loaded and used config");
                 cfg
             }

--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use futures::{FutureExt, StreamExt, TryStreamExt};
+use futures::FutureExt;
 use proto_flow::{derive, flow};
 use std::collections::BTreeMap;
 
@@ -317,12 +317,12 @@ impl validation::Connectors for LocalConnectors {
                 validate: Some(request.clone()),
                 ..Default::default()
             };
-            let request_rx = futures::stream::once(async move { Ok(request) }).boxed();
-            let response = middleware.serve(request_rx).await?.try_next().await;
+            let response = middleware
+                .serve_unary(request)
+                .await
+                .map_err(|status| anyhow::Error::msg(status.message().to_string()))?;
 
             let validated = response
-                .map_err(|status| anyhow::Error::msg(status.message().to_string()))?
-                .context("derive connector did not return a response")?
                 .validated
                 .context("derive Response is not Validated")?;
 

--- a/crates/runtime/src/derive/middleware.rs
+++ b/crates/runtime/src/derive/middleware.rs
@@ -131,6 +131,18 @@ where
 
         Ok(response_rx)
     }
+
+    pub async fn serve_unary(self, request: Request) -> tonic::Result<Response> {
+        let request_rx = futures::stream::once(async move { Ok(request) }).boxed();
+        let mut responses: Vec<Response> = self.serve(request_rx).await?.try_collect().await?;
+
+        if responses.len() != 1 {
+            return Err(tonic::Status::unknown(
+                "unary request didn't return a response",
+            ));
+        }
+        Ok(responses.pop().unwrap())
+    }
 }
 
 // NOTE(johnny): This is a temporary joint to extract the ConnectorType for

--- a/go/bindings/task_service_test.go
+++ b/go/bindings/task_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"math"
 	"path"
 	"testing"
@@ -123,7 +124,11 @@ func TestSimpleDerive(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, startedCommit.StartedCommit)
 
+	// Send Close, and expect to read EOF.
 	stream.CloseSend()
+	_, err = stream.Recv()
+	require.Equal(t, io.EOF, err)
+
 	svc.Drop()
 
 	cupaloy.SnapshotT(t, published)


### PR DESCRIPTION
**Description:**

Ultimately, the problem was that `Child::wait()` had to take ownership of `Child::inner`, because [both `wait()` and `kill()` take `&mut self`](https://stackoverflow.com/q/35093869), meaning that if you've called `wait()`, you can't also call `kill()`. 

The solution here was to introduce [`shared_child`](https://docs.rs/shared_child/latest/shared_child/), which lifts that limitation, allowing the `impl Drop` handler to successfully `SIGKILL` the running process, and clean up properly.

**Note:** Because this is in a drop handler, we're `SIGKILL`ing the `temp-data-plane` instead of `SIGTERM`ing it. On linux, we set a flag to instruct the kernel to kill all of `temp-data-plane`'s child processes when it is killed, but we either can't or don't set that flag on MacOS. As a result we appear to still leak a bunch of `flowctl-go serve consumer` processes on Mac. This isn't a problem on Linux, so we decided to leave it be for the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1023)
<!-- Reviewable:end -->
