### PR TITLE
plumbing improvements for connector errors

### DIFF
--- a/crates/agent/src/publications/builds.rs
+++ b/crates/agent/src/publications/builds.rs
@@ -185,7 +185,8 @@ pub async fn test_catalog(
 
     if !job.success() {
         errors.push(Error {
-            detail: "test setup failed".to_string(),
+            detail: "Test setup failed. View logs for details and reach out to support@estuary.dev"
+                .to_string(),
             ..Default::default()
         });
         return Ok(errors);
@@ -213,7 +214,7 @@ pub async fn test_catalog(
 
     if !job.success() {
         errors.push(Error {
-            detail: "one or more test cases failed".to_string(),
+            detail: "One or more test cases failed. View logs for details.".to_string(),
             ..Default::default()
         });
     }
@@ -242,7 +243,9 @@ pub async fn test_catalog(
 
     if !job.success() {
         errors.push(Error {
-            detail: "test cleanup failed".to_string(),
+            detail:
+                "Test cleanup failed. View logs for details and reach out to support@estuary.dev"
+                    .to_string(),
             ..Default::default()
         });
     }
@@ -309,8 +312,8 @@ pub async fn deploy_build(
 
     if !job.success() {
         errors.push(Error {
-            detail: "one or more activations failed".to_string(),
-            ..Default::default()
+            detail: "One or more task activations failed. View logs for details and reach out to support@estuary.dev".to_string(),
+             ..Default::default()
         });
     }
 
@@ -359,8 +362,8 @@ pub async fn deploy_build(
 
         if !job.success() {
             errors.push(Error {
-                detail: "one or more deletions failed".to_string(),
-                ..Default::default()
+            detail: "One or more task deletions failed. View logs for details and reach out to support@estuary.dev".to_string(),
+            ..Default::default()
             });
         }
     }

--- a/crates/ops/src/tracing.rs
+++ b/crates/ops/src/tracing.rs
@@ -14,12 +14,12 @@ use serde_json::json;
 
 pub struct Layer<H, T>(H, T)
 where
-    H: Fn(Log),
+    H: Fn(&Log),
     T: Fn() -> std::time::SystemTime;
 
 impl<H, T> Layer<H, T>
 where
-    H: Fn(Log),
+    H: Fn(&Log),
     T: Fn() -> std::time::SystemTime,
 {
     pub fn new(handler: H, timesource: T) -> Self {
@@ -48,7 +48,7 @@ impl<S, H, T> tracing_subscriber::Layer<S> for Layer<H, T>
 where
     S: tracing::Subscriber,
     S: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
-    H: Fn(Log) + 'static,
+    H: Fn(&Log) + 'static,
     T: Fn() -> std::time::SystemTime + 'static,
 {
     fn on_new_span(
@@ -93,7 +93,7 @@ where
             }
         }
 
-        self.0(log)
+        self.0(&log)
     }
 }
 
@@ -228,7 +228,7 @@ mod test {
         let _guard = tracing_subscriber::registry()
             .with(
                 Layer::new(
-                    move |log| out_clone.lock().unwrap().push(log),
+                    move |log| out_clone.lock().unwrap().push(log.clone()),
                     move || {
                         let mut seq = seq.lock().unwrap();
                         *seq += 10;

--- a/crates/runtime/src/derive/connectors.rs
+++ b/crates/runtime/src/derive/connectors.rs
@@ -3,13 +3,13 @@ use proto_flow::derive::{Request, Response};
 use proto_flow::ops;
 use std::path::Path;
 
-pub fn typescript_connector<L, R>(
+pub fn typescript_connector<H, R>(
     _peek_request: &Request,
-    log_handler: L,
+    log_handler: H,
     request_rx: R,
 ) -> tonic::Result<impl Stream<Item = tonic::Result<Response>>>
 where
-    L: Fn(ops::Log) + Send + Sync + 'static,
+    H: Fn(&ops::Log) + Send + Sync + 'static,
     R: futures::stream::Stream<Item = tonic::Result<Request>> + Send + 'static,
 {
     // Look for `flowctl` alongside the current running program (or perhaps it *is* the

--- a/crates/runtime/src/derive/middleware.rs
+++ b/crates/runtime/src/derive/middleware.rs
@@ -8,20 +8,20 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct Middleware<L>
+pub struct Middleware<H>
 where
-    L: Fn(ops::Log) + Send + Sync + Clone + 'static,
+    H: Fn(&ops::Log) + Send + Sync + Clone + 'static,
 {
-    log_handler: L,
+    log_handler: H,
     set_log_level: Option<Arc<dyn Fn(ops::log::Level) + Send + Sync>>,
 }
 
 pub type BoxStream = std::pin::Pin<Box<dyn futures::Stream<Item = tonic::Result<Response>> + Send>>;
 
 #[tonic::async_trait]
-impl<L> proto_grpc::derive::connector_server::Connector for Middleware<L>
+impl<H> proto_grpc::derive::connector_server::Connector for Middleware<H>
 where
-    L: Fn(ops::Log) + Send + Sync + Clone + 'static,
+    H: Fn(&ops::Log) + Send + Sync + Clone + 'static,
 {
     type DeriveStream = BoxStream;
 
@@ -40,12 +40,12 @@ where
     }
 }
 
-impl<L> Middleware<L>
+impl<H> Middleware<H>
 where
-    L: Fn(ops::Log) + Send + Sync + Clone + 'static,
+    H: Fn(&ops::Log) + Send + Sync + Clone + 'static,
 {
     pub fn new(
-        log_handler: L,
+        log_handler: H,
         set_log_level: Option<Arc<dyn Fn(ops::log::Level) + Send + Sync>>,
     ) -> Self {
         Self {

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations.snap
@@ -85,31 +85,19 @@ Sources {
     errors: [
         Error {
             scope: test://example/catalog.yaml#/materializations/materialization~1with-config-fragment/endpoint/connector/config,
-            error: failed to fetch resource test://example/referenced/config.yaml#/bad/fragment
-            
-            Caused by:
-                resources cannot have fragments,
+            error: failed to fetch resource test://example/referenced/config.yaml#/bad/fragment: resources cannot have fragments,
         },
         Error {
             scope: test://example/catalog.yaml#/captures/capture~1config-missing/endpoint/connector/config,
-            error: failed to fetch resource test://example/config/not/found.yaml
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://example/config/not/found.yaml: fixture not found,
         },
         Error {
             scope: test://example/catalog.yaml#/captures/capture~1config-missing/bindings/0/resource,
-            error: failed to fetch resource test://example/resource/not/found.yaml
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://example/resource/not/found.yaml: fixture not found,
         },
         Error {
             scope: test://example/catalog.yaml#/materializations/materialization~1missing-config/bindings/0/resource,
-            error: failed to fetch resource test://example/referenced/not/found.yaml
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://example/referenced/not/found.yaml: fixture not found,
         },
     ],
     fetches: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__simple_catalog.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__simple_catalog.snap
@@ -26,17 +26,11 @@ Sources {
     errors: [
         Error {
             scope: test://example/catalog.yaml#/import/1,
-            error: failed to fetch resource test://example/sibling#/bad/fragment
-            
-            Caused by:
-                resources cannot have fragments,
+            error: failed to fetch resource test://example/sibling#/bad/fragment: resources cannot have fragments,
         },
         Error {
             scope: test://example/catalog.yaml#/import/2,
-            error: failed to fetch resource test://not/found
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://not/found: fixture not found,
         },
     ],
     fetches: [

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case.snap
@@ -8,31 +8,19 @@ Sources {
     errors: [
         Error {
             scope: test://example/catalog-err-not-an-array.yaml#/tests/acmeCo~1parse~1failure/0/documents,
-            error: failed to parse document fixtures as an array of objects
-            
-            Caused by:
-                invalid type: map, expected a sequence at line 1 column 0,
+            error: failed to parse document fixtures as an array of objects: invalid type: map, expected a sequence at line 1 column 0,
         },
         Error {
             scope: test://example/catalog-err-not-an-object.yaml#/tests/acmeCo~1parse~1failure/0/documents,
-            error: failed to parse document fixtures as an array of objects
-            
-            Caused by:
-                invalid type: string "not-an-object", expected a map at line 1 column 16,
+            error: failed to parse document fixtures as an array of objects: invalid type: string "not-an-object", expected a map at line 1 column 16,
         },
         Error {
             scope: test://example/not-an-array.json,
-            error: failed to parse document fixtures as an array of objects
-            
-            Caused by:
-                invalid type: map, expected a sequence at line 1 column 0,
+            error: failed to parse document fixtures as an array of objects: invalid type: map, expected a sequence at line 1 column 0,
         },
         Error {
             scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/1/documents,
-            error: failed to fetch resource test://example/not-found.json
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://example/not-found.json: fixture not found,
         },
     ],
     fetches: [

--- a/crates/tables/src/lib.rs
+++ b/crates/tables/src/lib.rs
@@ -313,7 +313,7 @@ mod behaviors;
 // Additional bespoke column implementations for types that require extra help.
 impl Column for anyhow::Error {
     fn column_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{:#}", self)
     }
 }
 
@@ -323,7 +323,7 @@ impl SqlColumn for anyhow::Error {
         "TEXT"
     }
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(format!("{:?}", self).into())
+        Ok(format!("{:#}", self).into())
     }
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         Ok(anyhow::anyhow!(String::column_result(value)?))

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -62,11 +62,7 @@ pub async fn walk_all_captures<C: Connectors>(
         // Unwrap `response` and bail out if it failed.
         let validated = match response {
             Err(err) => {
-                Error::CaptureConnector {
-                    name: request.name,
-                    detail: err,
-                }
-                .push(scope, errors);
+                Error::Connector { detail: err }.push(scope, errors);
                 continue;
             }
             Ok(response) => response,
@@ -85,13 +81,9 @@ pub async fn walk_all_captures<C: Connectors>(
         } = &validated;
 
         if binding_requests.len() != binding_responses.len() {
-            Error::CaptureConnector {
-                name: name.to_string(),
-                detail: anyhow::anyhow!(
-                    "connector returned wrong number of bindings (expected {}, got {})",
-                    binding_requests.len(),
-                    binding_responses.len()
-                ),
+            Error::WrongConnectorBindings {
+                expect: binding_requests.len(),
+                got: binding_responses.len(),
             }
             .push(scope, errors);
         }

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -94,11 +94,7 @@ pub async fn walk_all_derivations<C: Connectors>(
         // Unwrap `response` and bail out if it failed.
         let validated = match response {
             Err(err) => {
-                Error::DeriveConnector {
-                    name: name.clone(),
-                    detail: err,
-                }
-                .push(scope, errors);
+                Error::Connector { detail: err }.push(scope, errors);
                 continue;
             }
             Ok(response) => response,
@@ -121,13 +117,9 @@ pub async fn walk_all_derivations<C: Connectors>(
         } = &validated;
 
         if transform_requests.len() != transform_responses.len() {
-            Error::DeriveConnector {
-                name: name.clone(),
-                detail: anyhow::anyhow!(
-                    "connector returned wrong number of bindings (expected {}, got {})",
-                    transform_requests.len(),
-                    transform_responses.len()
-                ),
+            Error::WrongConnectorBindings {
+                expect: transform_requests.len(),
+                got: transform_responses.len(),
             }
             .push(scope, errors);
         }

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -151,24 +151,13 @@ pub enum Error {
         #[source]
         detail: anyhow::Error,
     },
-    #[error("connector error while validating capture {name}")]
-    CaptureConnector {
-        name: String,
-        #[source]
+    #[error(transparent)]
+    Connector {
+        #[from]
         detail: anyhow::Error,
     },
-    #[error("connector error while validating derivation {name}")]
-    DeriveConnector {
-        name: String,
-        #[source]
-        detail: anyhow::Error,
-    },
-    #[error("connector error while validating materialization {name}")]
-    MaterializationConnector {
-        name: String,
-        #[source]
-        detail: anyhow::Error,
-    },
+    #[error("connector returned wrong number of bindings (expected {expect}, got {got})")]
+    WrongConnectorBindings { expect: usize, got: usize },
     #[error("error while resolving referenced collections from the control plane")]
     ResolveCollections {
         #[source]

--- a/crates/validation/tests/snapshots/scenario_tests__capture_driver_returns_error.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__capture_driver_returns_error.snap
@@ -5,9 +5,6 @@ expression: errors
 [
     Error {
         scope: test://example/int-string-captures#/captures/testing~1s3-source,
-        error: connector error while validating capture testing/s3-source
-        
-        Caused by:
-            A driver error!,
+        error: A driver error!,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__collection_key_empty.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__collection_key_empty.snap
@@ -9,9 +9,6 @@ expression: errors
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse,
-        error: connector error while validating derivation testing/int-reverse
-        
-        Caused by:
-            shuffle types mismatch: [Integer] vs [],
+        error: shuffle types mismatch: [Integer] vs [],
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__cross_entity_name_prefixes_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__cross_entity_name_prefixes_and_duplicates.snap
@@ -37,58 +37,34 @@ expression: errors
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~11,
-        error: connector error while validating capture testing/b/1
-        
-        Caused by:
-            driver fixture not found: testing/b/1,
+        error: driver fixture not found: testing/b/1,
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~12~1suffix,
-        error: connector error while validating capture testing/b/2/suffix
-        
-        Caused by:
-            driver fixture not found: testing/b/2/suffix,
+        error: driver fixture not found: testing/b/2/suffix,
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~13,
-        error: connector error while validating capture testing/b/3
-        
-        Caused by:
-            driver fixture not found: testing/b/3,
+        error: driver fixture not found: testing/b/3,
     },
     Error {
         scope: test://example/catalog.yaml#/captures/testing~1b~15~1suffix,
-        error: connector error while validating capture testing/b/5/suffix
-        
-        Caused by:
-            driver fixture not found: testing/b/5/suffix,
+        error: driver fixture not found: testing/b/5/suffix,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~11~1suffix,
-        error: connector error while validating materialization testing/b/1/suffix
-        
-        Caused by:
-            driver fixture not found: testing/b/1/suffix,
+        error: driver fixture not found: testing/b/1/suffix,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~12,
-        error: connector error while validating materialization testing/b/2
-        
-        Caused by:
-            driver fixture not found: testing/b/2,
+        error: driver fixture not found: testing/b/2,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~13,
-        error: connector error while validating materialization testing/b/3
-        
-        Caused by:
-            driver fixture not found: testing/b/3,
+        error: driver fixture not found: testing/b/3,
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/testing~1b~14,
-        error: connector error while validating materialization testing/b/4
-        
-        Caused by:
-            driver fixture not found: testing/b/4,
+        error: driver fixture not found: testing/b/4,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__derive_driver_returns_error.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__derive_driver_returns_error.snap
@@ -5,9 +5,6 @@ expression: errors
 [
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve,
-        error: connector error while validating derivation testing/int-halve
-        
-        Caused by:
-            A driver error!,
+        error: A driver error!,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -5217,10 +5217,7 @@ All {
     errors: [
         Error {
             scope: test://example/from-array-key#/collections/testing~1from-array-key/derive/using/sqlite/migrations/1,
-            error: failed to fetch resource test://example/mi%C3%9F%C3%9Fing/migration.sql
-            
-            Caused by:
-                fixture not found,
+            error: failed to fetch resource test://example/mi%C3%9F%C3%9Fing/migration.sql: fixture not found,
         },
     ],
     fetches: [

--- a/crates/validation/tests/snapshots/scenario_tests__image_inspection_is_malformed.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__image_inspection_is_malformed.snap
@@ -5,30 +5,18 @@ expression: errors
 [
     Error {
         scope: test://example/int-string-captures#/captures/testing~1db-cdc/endpoint/connector/image,
-        error: error while extracting metadata from the connector image 'database'
-        
-        Caused by:
-            failed to parse `docker inspect` output: [{"whoops": "bad"}]: missing field `Config` at line 1 column 18,
+        error: error while extracting metadata from the connector image 'database': failed to parse `docker inspect` output: [{"whoops": "bad"}]: missing field `Config` at line 1 column 18,
     },
     Error {
         scope: test://example/int-string-captures#/captures/testing~1s3-source/endpoint/connector/image,
-        error: error while extracting metadata from the connector image 's3'
-        
-        Caused by:
-            failed to parse `docker inspect` output: [{"Invalid": "Inspection"}]: missing field `Config` at line 1 column 26,
+        error: error while extracting metadata from the connector image 's3': failed to parse `docker inspect` output: [{"Invalid": "Inspection"}]: missing field `Config` at line 1 column 26,
     },
     Error {
         scope: test://example/db-views#/materializations/testing~1db-views/endpoint/connector/image,
-        error: error while extracting metadata from the connector image 'database/image'
-        
-        Caused by:
-            failed to parse `docker inspect` output: {"also": "bad"}: invalid type: map, expected a sequence at line 1 column 0,
+        error: error while extracting metadata from the connector image 'database/image': failed to parse `docker inspect` output: {"also": "bad"}: invalid type: map, expected a sequence at line 1 column 0,
     },
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/endpoint/connector/image,
-        error: error while extracting metadata from the connector image 'webhook/connector'
-        
-        Caused by:
-            failed to parse `docker inspect` output: {"me": "too"}: invalid type: map, expected a sequence at line 1 column 0,
+        error: error while extracting metadata from the connector image 'webhook/connector': failed to parse `docker inspect` output: {"me": "too"}: invalid type: map, expected a sequence at line 1 column 0,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_capture_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_capture_names_and_duplicates.snap
@@ -33,30 +33,18 @@ expression: errors
     },
     Error {
         scope: test://example/captures#/captures/good,
-        error: connector error while validating capture good
-        
-        Caused by:
-            driver fixture not found: good,
+        error: driver fixture not found: good,
     },
     Error {
         scope: test://example/captures#/captures/testing,
-        error: connector error while validating capture testing
-        
-        Caused by:
-            driver fixture not found: testing,
+        error: driver fixture not found: testing,
     },
     Error {
         scope: test://example/captures#/captures/testing~1SoMe-source,
-        error: connector error while validating capture testing/SoMe-source
-        
-        Caused by:
-            driver fixture not found: testing/SoMe-source,
+        error: driver fixture not found: testing/SoMe-source,
     },
     Error {
         scope: test://example/captures#/captures/testing~1some-source,
-        error: connector error while validating capture testing/some-source
-        
-        Caused by:
-            driver fixture not found: testing/some-source,
+        error: driver fixture not found: testing/some-source,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__invalid_materialization_names_and_duplicates.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__invalid_materialization_names_and_duplicates.snap
@@ -33,30 +33,18 @@ expression: errors
     },
     Error {
         scope: test://example/materializations#/materializations/good,
-        error: connector error while validating materialization good
-        
-        Caused by:
-            driver fixture not found: good,
+        error: driver fixture not found: good,
     },
     Error {
         scope: test://example/materializations#/materializations/testing,
-        error: connector error while validating materialization testing
-        
-        Caused by:
-            driver fixture not found: testing,
+        error: driver fixture not found: testing,
     },
     Error {
         scope: test://example/materializations#/materializations/testing~1SoMe-target,
-        error: connector error while validating materialization testing/SoMe-target
-        
-        Caused by:
-            driver fixture not found: testing/SoMe-target,
+        error: driver fixture not found: testing/SoMe-target,
     },
     Error {
         scope: test://example/materializations#/materializations/testing~1some-target,
-        error: connector error while validating materialization testing/some-target
-        
-        Caused by:
-            driver fixture not found: testing/some-target,
+        error: driver fixture not found: testing/some-target,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
@@ -29,9 +29,6 @@ expression: errors
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse,
-        error: connector error while validating derivation testing/int-reverse
-        
-        Caused by:
-            shuffle types mismatch: [Integer] vs [0],
+        error: shuffle types mismatch: [Integer] vs [0],
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__materialization_driver_conflicts.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__materialization_driver_conflicts.snap
@@ -17,10 +17,7 @@ expression: errors
     },
     Error {
         scope: test://example/db-views#/materializations/testing~1db-views/bindings/0,
-        error: connector error while validating materialization testing/db-views
-        
-        Caused by:
-            connector sent constraint for unknown field Unknown,
+        error: connector sent constraint for unknown field Unknown,
     },
     Error {
         scope: test://example/db-views#/materializations/testing~1db-views/bindings/0,

--- a/crates/validation/tests/snapshots/scenario_tests__materialization_driver_returns_error.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__materialization_driver_returns_error.snap
@@ -5,9 +5,6 @@ expression: errors
 [
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries,
-        error: connector error while validating materialization testing/webhook/deliveries
-        
-        Caused by:
-            A driver error!,
+        error: A driver error!,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__materialization_driver_unknown_constraint.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__materialization_driver_unknown_constraint.snap
@@ -9,10 +9,7 @@ expression: errors
     },
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/bindings/0,
-        error: connector error while validating materialization testing/webhook/deliveries
-        
-        Caused by:
-            unknown constraint type 98,
+        error: unknown constraint type 98,
     },
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/bindings/1,
@@ -20,9 +17,6 @@ expression: errors
     },
     Error {
         scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/bindings/1,
-        error: connector error while validating materialization testing/webhook/deliveries
-        
-        Caused by:
-            unknown constraint type 99,
+        error: unknown constraint type 99,
     },
 ]

--- a/crates/validation/tests/snapshots/scenario_tests__unknown_locations.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__unknown_locations.snap
@@ -17,9 +17,6 @@ expression: errors
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse,
-        error: connector error while validating derivation testing/int-reverse
-        
-        Caused by:
-            shuffle types mismatch: [Integer] vs [2, 0],
+        error: shuffle types mismatch: [Integer] vs [2, 0],
     },
 ]

--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -83,7 +84,12 @@ func (cmd apiDiscover) Execute(_ []string) error {
 	pb.RegisterGRPCDispatcher("local")
 
 	var resp, err = cmd.execute(ctx)
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		err = fmt.Errorf("Timeout while communicating with the endpoint. Please verify any address or firewall settings.")
+	}
 	if err != nil {
+		fmt.Println(err.Error()) // Write to stdout so the agent can map into a draft error.
 		return err
 	}
 

--- a/tests/source-test-fail/data-plane.out.expect
+++ b/tests/source-test-fail/data-plane.out.expect
@@ -1,1 +1,1 @@
-level=error msg="servePrimary failed" err="runTransactions: readMessage: connector failed (exit status: 1) with stderr:\\na horrible, no good error!.*
+level=error msg="servePrimary failed" err="runTransactions: readMessage: a horrible, no good error!.*


### PR DESCRIPTION
**Description:**

 * Previously, `flow-connector-init` would collect a ring-buffer of recent stderr output and build a terminal error out of that unmodified buffer. This does pass through a comprehensive detailing of what went wrong, but it's hard to understand and it's also duplicative with ops logs and the control-plane `internal.log_lines` table. So, stop doing that and instead:
   * Build an error from the message of the very last ops::Log, and
   * Attach the entire final ops::Log to the gRPC error response. We plan to use this in the future but not yet.
 
 * Update discovery within the `agent` to properly populate the `draft_errors` table with a draft error for display when discovery fails.
 
 * Generally audit, tweak, and make errors more succinct for users.
 
 See screenshots posted in Slack for the end-to-end UX of errors in the UI.
 This depends on work within the UI as well, to better display errors.
 
**Workflow steps:**

No new steps. Just observe better structured draft errors in the UI.

**Documentation links affected:**

None I'm aware of.

**Notes for reviewers:**

Probably best to review commit by commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1028)
<!-- Reviewable:end -->
