### PR TITLE
derive-sqlite: require that URI is passed with DeriveRequestExt (fixes checkpoint bug)

### DIFF
--- a/crates/derive-typescript/src/lib.rs
+++ b/crates/derive-typescript/src/lib.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
+use locate_bin::locate;
 use proto_flow::{derive, flow};
 use serde_json::json;
 use std::io::{BufRead, Write};
 use std::{collections::BTreeMap, process::Stdio};
-use locate_bin::locate;
 
 mod codegen;
 
@@ -219,7 +219,7 @@ fn validate(validate: derive::request::Validate) -> anyhow::Result<derive::respo
         .current_dir(temp_dir)
         .args(["check", MAIN_NAME])
         .output()
-        .unwrap();
+        .expect("The Deno runtime is a prerequisite for TypeScript but could not be found. Please install Deno from https://deno.com");
 
     if !output.status.success() {
         anyhow::bail!(rewrite_deno_stderr(

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -142,12 +142,14 @@ func (d *Derive) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint, err 
 			// * The database was opened and a `gazette_checkpoints` table was created.
 			// * We closed the actual database from the Go side and we won't use it again,
 			//   but we WILL use the registered VFS from Rust.
-			requestExt.Open.SqliteVfsUri = d.sqlite.URIForDB("primary.db")
 		} else {
 			requestExt.Open.RocksdbDescriptor = bindings.NewRocksDBDescriptor(d.recorder)
 		}
 	}
 
+	if d.sqlite != nil {
+		requestExt.Open.SqliteVfsUri = d.sqlite.URIForDB("primary.db")
+	}
 	_ = doSend(d.client, &pd.Request{
 		Open: &pd.Request_Open{
 			Collection: d.collection,


### PR DESCRIPTION
**Description:**

Use a default of :memory: only if no DeriveRequestExt is sent (as is the
case with preview).

Then, update the Go runtime to always pass `SqliteVfsUri` with each Open
and re-Open. This resolves a bug where a derivation would re-Open with
a :memory: database, which was not intended.

Tested manually using a local stack. Confirmed that shard unassignment
continues to work correctly (it always had), and that updated
publications now work (where they had not previously).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1029)
<!-- Reviewable:end -->
