### PR TITLE
reactor: add reactor instance details to ops logs

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -62,7 +62,7 @@ func NewCaptureApp(host *FlowConsumer, shard consumer.Shard, recorder *recoveryl
 		host:        host,
 		spec:        pf.CaptureSpec{}, // Initialized in RestoreCheckpoint.
 		store:       store,
-		taskTerm:    taskTerm{}, // Initialized in RestoreCheckpoint.
+		taskTerm:    newUninitializedTerm(&host.Config.Consumer.ServiceConfig),
 	}, nil
 }
 
@@ -415,7 +415,7 @@ func (c *Capture) FinalizeTxn(_ consumer.Shard, pub *message.Publisher) error {
 
 // FinishedTxn logs if an error occurred.
 func (c *Capture) FinishedTxn(_ consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(c.opsPublisher, op)
+	logTxnFinished(c.opsPublisher, op, c.consumerConfig)
 }
 
 // Coordinator panics if called.

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -54,7 +54,7 @@ func NewDeriveApp(host *FlowConsumer, shard consumer.Shard, recorder *recoverylo
 		client:     nil, // Lazily initialized.
 		host:       host,
 		recorder:   recorder,
-		taskTerm:   taskTerm{},
+		taskTerm:   newUninitializedTerm(&host.Config.Consumer.ServiceConfig),
 		taskReader: taskReader{},
 	}
 	return derive, nil
@@ -282,7 +282,7 @@ func (d *Derive) StartCommit(_ consumer.Shard, cp pf.Checkpoint, waitFor client.
 
 // FinishedTxn logs if an error occurred.
 func (d *Derive) FinishedTxn(_ consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(d.opsPublisher, op)
+	logTxnFinished(d.opsPublisher, op, d.consumerConfig)
 }
 
 // ClearRegistersForTest delegates the request to its worker.

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -19,6 +19,7 @@ import (
 	"go.gazette.dev/core/consumer"
 	pc "go.gazette.dev/core/consumer/protocol"
 	"go.gazette.dev/core/consumer/recoverylog"
+	"go.gazette.dev/core/mainboilerplate"
 	"go.gazette.dev/core/mainboilerplate/runconsumer"
 	"go.gazette.dev/core/message"
 )
@@ -115,10 +116,10 @@ func (f *FlowConsumer) FinishedTxn(shard consumer.Shard, store consumer.Store, f
 // logTxnFinished spawns a goroutine that waits for the given op to complete and logs the error if
 // it fails. All task types should delegate to this function so that the error logging is
 // consistent.
-func logTxnFinished(publisher ops.Publisher, op consumer.OpFuture) {
+func logTxnFinished(publisher ops.Publisher, op consumer.OpFuture, consumerConfig *mainboilerplate.ServiceConfig) {
 	go func() {
 		if err := op.Err(); err != nil && errors.Cause(err) != context.Canceled {
-			ops.PublishLog(publisher, ops.Log_error, "shard failed", "error", err)
+			ops.PublishLog(publisher, ops.Log_error, "shard failed", "error", err, "reactorInstance", consumerConfig)
 		}
 	}()
 }

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -59,7 +59,7 @@ func NewMaterializeApp(host *FlowConsumer, shard consumer.Shard, recorder *recov
 		client:     nil,                      // Initialized in RestoreCheckpoint.
 		spec:       pf.MaterializationSpec{}, // Initialized in RestoreCheckpoint.
 		taskReader: taskReader{},             // Initialized in RestoreCheckpoint.
-		taskTerm:   taskTerm{},               // Initialized in RestoreCheckpoint.
+		taskTerm:   newUninitializedTerm(&host.Config.Consumer.ServiceConfig),
 	}
 
 	return out, nil
@@ -285,5 +285,5 @@ func (m *Materialize) FinalizeTxn(shard consumer.Shard, pub *message.Publisher) 
 
 // FinishedTxn implements Application.FinishedTxn.
 func (m *Materialize) FinishedTxn(shard consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(m.opsPublisher, op)
+	logTxnFinished(m.opsPublisher, op, m.consumerConfig)
 }

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -18,12 +18,14 @@ import (
 	"go.gazette.dev/core/consumer"
 	pc "go.gazette.dev/core/consumer/protocol"
 	"go.gazette.dev/core/keyspace"
+	"go.gazette.dev/core/mainboilerplate"
 	"go.gazette.dev/core/message"
 )
 
 // taskTerm holds task state used by Capture, Derive and Materialize runtimes,
 // which is re-initialized with each revision of the associated catalog task.
 type taskTerm struct {
+	consumerConfig *mainboilerplate.ServiceConfig
 	// Current ShardSpec under which the task term is running.
 	shardSpec *pf.ShardSpec
 	// The taskTerm Context wraps the Shard Context, and is further cancelled
@@ -35,6 +37,12 @@ type taskTerm struct {
 	build *flow.Build
 	// ops.Publisher of ops.Logs and ops.Stats.
 	opsPublisher *OpsPublisher
+}
+
+func newUninitializedTerm(consumerConfig *mainboilerplate.ServiceConfig) taskTerm {
+	return taskTerm{
+		consumerConfig: consumerConfig,
+	}
 }
 
 func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
@@ -93,6 +101,7 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 		"initialized catalog task term",
 		"labels", t.labels,
 		"lastLabels", lastLabels,
+		"reactorInstance", t.consumerConfig,
 	)
 	return nil
 }


### PR DESCRIPTION
**Description:**

Adds information about the reactor instance to the ops logs. We had an incident recently where a single reactor instance was faulting due to a problem with the k8s node. While it was easy to see which tasks were assigned to that instance at the time, it was quite difficult to determine that after the fact. So the goal of this commit is to make it easier to troubleshoot this type of thing in the future.

The details of the reactor instance are not added to _all_ logs in order to prevent unnecessary bloat. Instead they are only logged on term initialization and shard failure.

Example log messages:

```
{
  "_meta": {
    "uuid": "90f10600-ef51-11ed-8400-5382b2069d86"
  },
  "shard": {
    "kind": "materialization",
    "name": "aliceCo/matfail",
    "keyBegin": "00000000",
    "rClockBegin": "00000000"
  },
  "ts": "2023-05-10T16:41:52.145687112Z",
  "level": "info",
  "message": "initialized catalog task term",
  "fields": {
    "labels": {
      "build": "09bf8de556810000",
      "log_level": 3,
      "ports": null,
      "range": {
        "key_end": 4294967295,
        "r_clock_end": 4294967295
      },
      "task_name": "aliceCo/matfail",
      "task_type": 3
    },
    "lastLabels": {
      "ports": null,
      "range": {}
    },
    "reactorInstance": {
      "Zone": "local",
      "ID": "",
      "Host": "localhost",
      "Port": "9000"
    }
  }
}
```

```
{
  "_meta": {
    "uuid": "923430f3-ef51-11ed-8400-5382b2069d86"
  },
  "shard": {
    "kind": "materialization",
    "name": "aliceCo/matfail",
    "keyBegin": "00000000",
    "rClockBegin": "00000000"
  },
  "ts": "2023-05-10T16:41:54.263609149Z",
  "level": "error",
  "message": "shard failed",
  "fields": {
    "error": "txnStartCommit: app.FinalizeTxn: combine.Finish: document failed validation...",
    "reactorInstance": {
      "Zone": "local",
      "ID": "",
      "Host": "localhost",
      "Port": "9000"
    }
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1033)
<!-- Reviewable:end -->
