### PR TITLE
agent: bump up the discovery timeout limit

### DIFF
--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -73,7 +73,9 @@ func (cmd apiDiscover) execute(ctx context.Context) (*pc.Response_Discovered, er
 func (cmd apiDiscover) Execute(_ []string) error {
 	defer mbp.InitDiagnosticsAndRecover(cmd.Diagnostics)()
 	mbp.InitLog(cmd.Log)
-	var ctx, cancelFn = context.WithTimeout(context.Background(), time.Second*30)
+	// TODO(whb): Change this timeout back to 30 seconds. Temporarily bumping it up to allow
+	// longer-running discoveries to succeed.
+	var ctx, cancelFn = context.WithTimeout(context.Background(), time.Second*60)
 	defer cancelFn()
 
 	logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
**Description:**

This is intended to be temporary and will allow certain captures (salesforce) to succeed with discovery that are currently taking a little longer than 20 seconds to complete.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1038)
<!-- Reviewable:end -->
