### PR TITLE
reactor: add reactor instance details to ops logs

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -414,8 +414,8 @@ func (c *Capture) FinalizeTxn(_ consumer.Shard, pub *message.Publisher) error {
 }
 
 // FinishedTxn logs if an error occurred.
-func (c *Capture) FinishedTxn(_ consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(c.opsPublisher, op)
+func (c *Capture) FinishedTxn(shard consumer.Shard, op consumer.OpFuture) {
+	logTxnFinished(c.opsPublisher, op, shard)
 }
 
 // Coordinator panics if called.

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -281,8 +281,8 @@ func (d *Derive) StartCommit(_ consumer.Shard, cp pf.Checkpoint, waitFor client.
 }
 
 // FinishedTxn logs if an error occurred.
-func (d *Derive) FinishedTxn(_ consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(d.opsPublisher, op)
+func (d *Derive) FinishedTxn(shard consumer.Shard, op consumer.OpFuture) {
+	logTxnFinished(d.opsPublisher, op, shard)
 }
 
 // ClearRegistersForTest delegates the request to its worker.

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -115,10 +115,10 @@ func (f *FlowConsumer) FinishedTxn(shard consumer.Shard, store consumer.Store, f
 // logTxnFinished spawns a goroutine that waits for the given op to complete and logs the error if
 // it fails. All task types should delegate to this function so that the error logging is
 // consistent.
-func logTxnFinished(publisher ops.Publisher, op consumer.OpFuture) {
+func logTxnFinished(publisher ops.Publisher, op consumer.OpFuture, shard consumer.Shard) {
 	go func() {
 		if err := op.Err(); err != nil && errors.Cause(err) != context.Canceled {
-			ops.PublishLog(publisher, ops.Log_error, "shard failed", "error", err)
+			ops.PublishLog(publisher, ops.Log_error, "shard failed", "error", err, "assignment", shard.Assignment().Decoded)
 		}
 	}()
 }

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -285,5 +285,5 @@ func (m *Materialize) FinalizeTxn(shard consumer.Shard, pub *message.Publisher) 
 
 // FinishedTxn implements Application.FinishedTxn.
 func (m *Materialize) FinishedTxn(shard consumer.Shard, op consumer.OpFuture) {
-	logTxnFinished(m.opsPublisher, op)
+	logTxnFinished(m.opsPublisher, op, shard)
 }

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -93,6 +93,7 @@ func (t *taskTerm) initTerm(shard consumer.Shard, host *FlowConsumer) error {
 		"initialized catalog task term",
 		"labels", t.labels,
 		"lastLabels", lastLabels,
+		"assignment", shard.Assignment().Decoded,
 	)
 	return nil
 }


### PR DESCRIPTION
**Description:**

Adds information about the reactor instance to the ops logs. We had an incident recently where a single reactor instance was faulting due to a problem with the k8s node. While it was easy to see which tasks were assigned to that instance at the time, it was quite difficult to determine that after the fact. So the goal of this commit is to make it easier to troubleshoot this type of thing in the future.

The details of the reactor instance are not added to _all_ logs in order to prevent unnecessary bloat. Instead they are only logged on term initialization and shard failure.

This is a new iteration on #1033, which will be closed.

Example of a logged field from a local instance:

```
{
  "ItemID": "materialize/aliceCo/mat1/00000000-00000000",
  "MemberZone": "local",
  "MemberSuffix": "notable-eft",
  "Slot": 0,
  "AssignmentValue": {}
}
```

In production, the `MemberSuffix` will be the k8s pod name, IIUC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1039)
<!-- Reviewable:end -->
