### PR TITLE
flowctl: fix logs and stats subcommands, sort of

### DIFF
--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -7,6 +7,7 @@ mod auth;
 mod catalog;
 mod collection;
 mod config;
+mod connector;
 mod controlplane;
 mod dataplane;
 mod draft;
@@ -17,7 +18,6 @@ mod output;
 mod poll;
 mod preview;
 mod raw;
-mod connector;
 
 use output::{Output, OutputType};
 use poll::poll_while_queued;
@@ -82,17 +82,21 @@ pub enum Command {
     /// They can be edited, developed, and tested while still a draft.
     /// Then when you're ready, publish your draft to make your changes live.
     Draft(draft::Draft),
+    /// This command does not (yet) work for end users
+    ///
+    /// Note: We're still working on allowing users access to task logs, and this command will not work until we do.
     /// Prints the runtime logs of a task (capture, derivation, or materialization).
-    ///
-    /// Reads contents from the `ops/<tenant>/logs` collection, selecting the partition
+    /// Reads contents from the `ops.<data-plane>/logs` collection, selecting the partition
     /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
-    /// `flowctl collections read --collection ops/<tenant>/logs --include-partition estuary.dev/field/name=<task> --uncommitted`
+    /// `flowctl collections read --collection ops.<data-plane>/logs --include-partition estuary.dev/field/name=<task> --uncommitted`
     Logs(ops::Logs),
-    /// Prints the runtime stats of a task (capture, derivation, or materialization).
+    /// This command does not (yet) work for end users
     ///
-    /// Reads contents from the `ops/<tenant>/stats` collection, selecting the partition
+    /// Note: We're still working on allowing users access to task stats, and this command will not work until we do.
+    /// Prints the runtime stats of a task (capture, derivation, or materialization).
+    /// Reads contents from the `ops.<data-plane>/stats` collection, selecting the partition
     /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
-    /// `flowctl collections read --collection ops/<tenant>/stats --include-partition estuary.dev/field/name=<task>`
+    /// `flowctl collections read --collection ops.<data-plane>/stats --include-partition estuary.dev/field/name=<task>`
     Stats(ops::Stats),
     /// Advanced, low-level, and experimental commands which are less common.
     Raw(raw::Advanced),

--- a/crates/flowctl/src/ops.rs
+++ b/crates/flowctl/src/ops.rs
@@ -50,8 +50,9 @@ fn read_args(
     bounds: &ReadBounds,
     uncommitted: bool,
 ) -> ReadArgs {
-    let tenant = tenant(task_name);
-    let collection = format!("ops/{tenant}/{logs_or_stats}");
+    // Once we implement federated data planes, we'll need to update this to
+    // fetch the name of the data plane based on the tenant.
+    let collection = format!("ops.us-central1.v1/{logs_or_stats}");
     let selector = CollectionJournalSelector {
         collection,
         include_partitions: vec![Partition {

--- a/site/docs/guides/flowctl/troubleshoot-task.md
+++ b/site/docs/guides/flowctl/troubleshoot-task.md
@@ -3,6 +3,10 @@ sidebar_position: 3
 ---
 # Troubleshoot a task with flowctl
 
+:::caution
+The flowctl logs and stats subcommands have been temporarily disabled while we work on some important changes to our authorization system. We expect to have these working again soon. In the meantime, please reach out to us via Slack or email (support@estuary.dev) if you want any help.
+:::
+
 flowctl offers the most advanced views of [task logs](../../concepts/advanced/logs-stats.md).
 If a task has errors or is failing in the web app, you'll be able to troubleshoot more effectively with flowctl.
 


### PR DESCRIPTION
**Description:**

This commit updates the flowctl logs and stats subcommands to be compatible with the new collection names. It allows anyone with a grant to `ops.us-central1.v1/logs|stats` to once again use flowctl to view logs and stats.

This does not yet allow end-users to view their logs or stats. That won't be possible until partition-level authorization gets implemented. So, I've also updated the help messages of the logs and stats subcommands to reflect that and hopefully make things slightly less confusing for users. I also updated the docs page with a similar message.

**Documentation links affected:**

https://docs.estuary.dev/guides/flowctl/troubleshoot-task/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1044)
<!-- Reviewable:end -->
