### PR TITLE
Update gazette dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20230420142205-546dc8d7d508
+	go.gazette.dev/core v0.89.1-0.20230508195708-e25e7996a8af
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/api v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,8 @@ go.gazette.dev/core v0.89.1-0.20230106205712-a2d374cdd6be h1:U1VCL/6BkY8nfPOZCxI
 go.gazette.dev/core v0.89.1-0.20230106205712-a2d374cdd6be/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.gazette.dev/core v0.89.1-0.20230420142205-546dc8d7d508 h1:FHd55Jkm69K3ln0ZjKsQGKxQHRQyKVgsWAuZRiNYDm4=
 go.gazette.dev/core v0.89.1-0.20230420142205-546dc8d7d508/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
+go.gazette.dev/core v0.89.1-0.20230508195708-e25e7996a8af h1:+f1PwX2A7Q7ysRL6Zizc6Q9rOoe7QG9FRQSdmUYEP+k=
+go.gazette.dev/core v0.89.1-0.20230508195708-e25e7996a8af/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
**Description:**

Updates the gazette dependency to the latest tip of master (e25e799). This pulls in a fix for an issue with `key_space.go` that causes a ton of noisy log output. The bug itself was otherwise innocuous.

**Notes for reviewers:**

The gazette PR is gazette/core#338

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1045)
<!-- Reviewable:end -->
