### PR TITLE
functions: compileTemplate doesn't need connector_id

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -33,7 +33,7 @@ export const mustacheHelpers = {
     }
 };
 
-export const compileTemplate = (template: string, data: any, connector_id: string) => {
+export const compileTemplate = (template: string, data: any) => {
     const mustacheOutput = Mustache.render(template, {
         ...data,
         ...mustacheHelpers,

--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -39,8 +39,7 @@ export async function accessToken(req: Record<string, any>) {
             code_verifier,
             ...oauth2_injected_values,
             ...params,
-        },
-        connector_id,
+        }
     );
 
     let body = null;
@@ -55,8 +54,7 @@ export async function accessToken(req: Record<string, any>) {
                 code_verifier,
                 ...oauth2_injected_values,
                 ...params,
-            },
-            connector_id,
+            }
         );
     }
 
@@ -73,8 +71,7 @@ export async function accessToken(req: Record<string, any>) {
                     code_verifier,
                     ...oauth2_injected_values,
                     ...params,
-                },
-                connector_id,
+                }
             ),
         );
     }

--- a/supabase/functions/oauth/auth-url.ts
+++ b/supabase/functions/oauth/auth-url.ts
@@ -64,8 +64,7 @@ export async function authURL(req: { connector_id: string; config: object; redir
             config,
             code_challenge: codeChallenge,
             code_challenge_method: codeChallengeMethod,
-        },
-        connector_id,
+        }
     );
 
     return new Response(JSON.stringify({ url: url, state: finalState, code_verifier: codeVerifier }), {


### PR DESCRIPTION
**Description:**

- this is a leftover parameter, we don't need it

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1051)
<!-- Reviewable:end -->
