### PR TITLE
agent: better errors when key pointers change

### DIFF
--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -167,10 +167,16 @@ impl PublishHandler {
             return stop_with_errors(errors, JobStatus::build_failed(Vec::new()), row, txn).await;
         }
 
-        let errors =
-            specs::validate_transition(&draft_catalog, &live_catalog, row.pub_id, &spec_rows);
-        if !errors.is_empty() {
-            return stop_with_errors(errors, JobStatus::build_failed(Vec::new()), row, txn).await;
+        if let Err((errors, incompatible_collections)) =
+            specs::validate_transition(&draft_catalog, &live_catalog, row.pub_id, &spec_rows)
+        {
+            return stop_with_errors(
+                errors,
+                JobStatus::build_failed(incompatible_collections),
+                row,
+                txn,
+            )
+            .await;
         }
 
         let live_spec_ids: Vec<_> = spec_rows.iter().map(|row| row.live_spec_id).collect();

--- a/crates/agent/src/publications/builds.rs
+++ b/crates/agent/src/publications/builds.rs
@@ -21,6 +21,7 @@ pub struct BuildOutput {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct IncompatibleCollection {
     pub collection: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub affected_materializations: Vec<AffectedConsumer>,
 }
 

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -1,3 +1,4 @@
+use super::builds::IncompatibleCollection;
 use super::draft::Error;
 use agent_sql::publications::{ExpandedRow, SpecRow, Tenant};
 use agent_sql::{Capability, CatalogType, Id};
@@ -99,8 +100,9 @@ pub fn validate_transition(
     live: &models::Catalog,
     pub_id: Id,
     spec_rows: &[SpecRow],
-) -> Vec<Error> {
+) -> Result<(), (Vec<Error>, Vec<IncompatibleCollection>)> {
     let mut errors = Vec::new();
+    let mut incompatible_collections = Vec::new();
 
     for spec_row @ SpecRow {
         catalog_name,
@@ -241,6 +243,10 @@ pub fn validate_transition(
                 ),
                 ..Default::default()
             });
+            incompatible_collections.push(IncompatibleCollection {
+                collection: catalog_name.to_string(),
+                affected_materializations: Vec::new(),
+            });
         }
 
         let partitions = |projections: &BTreeMap<models::Field, models::Projection>| {
@@ -273,10 +279,18 @@ pub fn validate_transition(
                 ),
                 ..Default::default()
             });
+            incompatible_collections.push(IncompatibleCollection {
+                collection: catalog_name.to_string(),
+                affected_materializations: Vec::new(),
+            });
         }
     }
 
-    errors
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err((errors, incompatible_collections))
+    }
 }
 
 pub async fn enforce_resource_quotas(
@@ -706,6 +720,99 @@ mod test {
                         ),
                     },
                 ],
+            },
+        ]
+        "###);
+    }
+
+    #[tokio::test]
+    #[serial_test::parallel]
+    async fn test_incompatible_collections() {
+        let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+            .await
+            .unwrap();
+        let mut txn = conn.begin().await.unwrap();
+
+        sqlx::query(r#"
+            with p1 as (
+              insert into auth.users (id) values
+              ('43a18a3e-5a59-11ed-9b6a-0242ac120003')
+            ),
+            p2 as (
+              insert into drafts (id, user_id) values
+              ('2220000000000000', '43a18a3e-5a59-11ed-9b6a-0242ac120003')
+            ),
+            p3 as (
+                insert into live_specs (id, catalog_name, spec, spec_type, last_build_id, last_pub_id) values
+                ('6000000000000000', 'compat-test/CollectionA', '{"schema": {},"key": ["/foo"]}'::json, 'collection', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'),
+                ('7000000000000000', 'compat-test/CollectionB', '{
+                    "schema": {},
+                    "key": ["/foo"],
+                    "projections": {
+                        "foo": { "location": "/foo", "partition": true }
+                    }
+                }'::json, 'collection', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb')
+            ),
+            p4 as (
+              insert into draft_specs (id, draft_id, catalog_name, spec, spec_type) values
+              (
+                '2222000000000000',
+                '2220000000000000',
+                'compat-test/CollectionA',
+                '{ "schema": {}, "key": ["/new_key"] }'::json,
+                'collection'
+              ),
+              (
+                '3333000000000000',
+                '2220000000000000',
+                'compat-test/CollectionB',
+                -- missing partition definition, which should be an error
+                '{ "schema": {}, "key": ["/foo"] }'::json,
+                'collection'
+              )
+            
+            ),
+            p5 as (
+              insert into publications (id, job_status, user_id, draft_id) values
+              ('2222200000000000', '{"type": "queued"}'::json, '43a18a3e-5a59-11ed-9b6a-0242ac120003', '2220000000000000')
+            ),
+            p6 as (
+              insert into role_grants (subject_role, object_role, capability) values
+              ('compat-test/', 'compat-test/', 'admin')
+            ),
+            p7 as (
+              insert into user_grants (user_id, object_role, capability) values
+              ('43a18a3e-5a59-11ed-9b6a-0242ac120003', 'compat-test/', 'admin')
+            )
+            select 1;"#,
+        )
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+        let results = execute_publications(&mut txn).await;
+
+        insta::assert_debug_snapshot!(results, @r###"
+        [
+            ScenarioResult {
+                draft_id: 2220000000000000,
+                status: BuildFailed {
+                    incompatible_collections: [
+                        IncompatibleCollection {
+                            collection: "compat-test/CollectionA",
+                            affected_materializations: [],
+                        },
+                        IncompatibleCollection {
+                            collection: "compat-test/CollectionB",
+                            affected_materializations: [],
+                        },
+                    ],
+                },
+                errors: [
+                    "Cannot change key of an established collection from CompositeKey([JsonPointer(\"/foo\")]) to CompositeKey([JsonPointer(\"/new_key\")])",
+                    "Cannot change partitions of an established collection (from [\"foo\"] to [])",
+                ],
+                live_specs: [],
             },
         ]
         "###);


### PR DESCRIPTION
**Description:**

When publishing collection specs, the agent will now return `incompatible_collections` when either the `key` or partition fields of a collection have changed. This addresses the scenario where a user re-runs discovery on their endpoint and the connector outputs collections with new keys. In this case, the UI will now suggest re-creating the affected collections with new names.

**Workflow steps:**

- Create a SQL capture of table `foo`
- In the source database, change the primary key of `foo` to a different column
- edit a capture
- click "refresh" in the bindings component to discover the collection with a different key
- click save and publish
- With this PR, you'll now see an error like this one, with the suggestion to re-create the collections:

![Screenshot from 2023-05-19 15-33-02](https://github.com/estuary/flow/assets/4495829/028dc5c9-6a12-4028-907d-36ca5a3837b0)

**Documentation links affected:** I don't think we currently document this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1052)
<!-- Reviewable:end -->
