### PR TITLE
Introduce task failures derivation to the ops log

### DIFF
--- a/ops-catalog/notify-failure-logs.sql
+++ b/ops-catalog/notify-failure-logs.sql
@@ -1,0 +1,223 @@
+INSERT INTO failures (shard, ts)
+    SELECT
+        $name,
+        $ts
+    WHERE $message = 'shard failed';
+
+INSERT INTO related_log_lines (shard, ts, level, message)
+    SELECT
+        $name,
+        $ts,
+        $level,
+        $message
+    WHERE $level in ('error', 'warn') AND $message != 'shard failed'
+    ON CONFLICT DO NOTHING;
+
+-- Only keep around the last 10 log lines
+DELETE FROM related_log_lines
+WHERE (shard, ts) IN
+    (
+        SELECT shard, ts from related_log_lines
+        WHERE shard = $name
+        ORDER BY ts DESC
+        LIMIT -1 OFFSET 10
+    );
+
+WITH events_since_previous_notification as (
+    select
+        count(*) as event_count
+    from
+        failures
+    where
+        failures.shard = $name
+        and julianday(failures.ts) > COALESCE(
+            (
+                SELECT
+                    ts
+                from
+                    failure_notifications
+                where
+                    failure_notifications.shard = $name
+                    AND julianday(failure_notifications.ts) < julianday($ts)
+                order by
+                    julianday(failure_notifications.ts) desc
+            ), 0
+        )
+),
+return_values as (
+    select
+    $message,
+    substr(COALESCE($fields->>'error','Missing `error` field, failure reason unknown.'),0,2500) as reason,
+    $ts,
+    $name as task_name,
+    $shard$name as sub_name,
+    $shard$kind as task_kind,
+    substr($name,0,length($name)-length($shard$name)) as tenant_name,
+    (SELECT json_group_array(json_object(
+        'shard',shard,
+        'ts',ts,
+        'level',level,
+        'message',message,
+        'formatted_message',SUBSTR('[ts='||ts||' level='||level||']: '||message,0,2500)
+    )) from related_log_lines WHERE shard=$name) as log_lines,
+    (SELECT event_count from events_since_previous_notification) AS events_since_last_notification,
+    (SELECT json_group_object(key, value) from json_each($fields) where key != 'error') as filtered_metadata
+)
+INSERT INTO
+    failure_notifications (shard, ts)
+SELECT
+    $name,
+    $ts
+WHERE
+    $ts IS NOT NULL AND
+    (
+        $message = 'shard failed'
+        -- We actually _do_ want these because they represent useful failure signals
+        -- But we don't intelligently track errors, so it's a bit spammy atm
+        -- OR $message = 'connector failed'
+    )
+    -- No more than 1 notification messages every hour
+    AND (
+        select
+            count(*)
+        from
+            failure_notifications
+        where
+            failure_notifications.shard = $name
+            AND cast(julianday(failure_notifications.ts)*24 as int) = cast(julianday($ts)*24 as int)
+    ) = 0
+    -- No more than 3 notifications per day
+    AND (
+        select
+            count(*)
+        from
+            failure_notifications
+        where
+            failure_notifications.shard = $name
+            AND cast(julianday(failure_notifications.ts) as int) = cast(julianday($ts) as int)
+    ) < 3
+RETURNING
+    $message,
+    (select reason from return_values) as reason,
+    $ts,
+    (select task_name from return_values) as task_name,
+    (select sub_name from return_values) as sub_name,
+    (select task_kind from return_values) as task_kind,
+    (select tenant_name from return_values) as tenant_name,
+    (select log_lines from return_values) as log_lines,
+    (select events_since_last_notification from return_values) as events_since_last_notification,
+    (
+        select
+            $message|| ': ' || return_values.task_kind || ' `' || $name || '`' || char(10) || 'Date: _' || Datetime($ts) || '_' || char(10) || '```' || char(10) || return_values.reason || '```' as slack_text
+        from return_values
+    ) as slack_text,
+    (
+        select JSON_GROUP_ARRAY(value)
+        from JSON_EACH(
+            JSON_ARRAY(
+                JSON_OBJECT(
+                    'type','header',
+                    'text',JSON_OBJECT(
+                        'type', 'plain_text',
+                        'text', ':rotating_light: ' || $message
+                    )
+                ),
+                JSON_OBJECT(
+                    'type','section',
+                    'text',JSON_OBJECT(
+                        'type', 'mrkdwn',
+                        'text', '*Task Name:* `' || $name || '`'
+                    )
+                ),
+                JSON_OBJECT(
+                    'type', 'context',
+                    'elements', JSON_ARRAY(
+                        JSON_OBJECT(
+                            'text', '*'||datetime($ts)||'* | Kind: *'||return_values.task_kind||'*',
+                            'type', 'mrkdwn'
+                        )
+                    )
+                ),
+                JSON_OBJECT('type', 'divider'),
+                JSON_OBJECT(
+                    'type','section',
+                    'text',JSON_OBJECT(
+                        'type', 'mrkdwn',
+                        'text', '*Failure Reason:*'
+                    )
+                ),
+                JSON_OBJECT(
+                    'type','section',
+                    'text',JSON_OBJECT(
+                        'type', 'mrkdwn',
+                        'text', '```'||return_values.reason||'```'
+                    )
+                ),
+                CASE (select count(*) from json_each(return_values.log_lines))
+                    WHEN 0 THEN NULL
+                    ELSE JSON_OBJECT('type', 'divider')
+                END,
+                CASE (select count(*) from json_each(return_values.log_lines))
+                    WHEN 0 THEN NULL
+                    ELSE JSON_OBJECT(
+                        'type','section',
+                        'text',JSON_OBJECT(
+                            'type', 'mrkdwn',
+                            'text', '*Adjacent Log Messages:*'
+                        )
+                    )
+                END,
+                CASE (select count(*) from json_each(return_values.log_lines))
+                    WHEN 0 THEN NULL
+                    ELSE JSON_OBJECT(
+                        'type','section',
+                        'text',JSON_OBJECT(
+                            'type', 'mrkdwn',
+                            'text', '```'||(SELECT group_concat(value->>'formatted_message', CHAR(10)) from json_each(return_values.log_lines))||'```'
+                            -- 'text', '```'||(SELECT group_concat(value->'message', CHAR(10)) from json_each(return_values.log_lines))||'```'
+                        )
+                    )
+                END,
+                CASE (select count(*) from json_each(return_values.filtered_metadata))
+                    WHEN 0 THEN NULL
+                    ELSE JSON_OBJECT('type', 'divider')
+                END,
+                CASE (select count(*) from json_each(return_values.filtered_metadata))
+                    WHEN 0 THEN NULL
+                    ELSE JSON_OBJECT(
+                        'type','section',
+                        'text',JSON_OBJECT(
+                            'type', 'mrkdwn',
+                            'text', '*Metadata:*'
+                        )
+                    )
+                END,
+                CASE (select count(*) from json_each(return_values.filtered_metadata))
+                    WHEN 0 THEN NULL
+                    ELSE
+                        JSON_OBJECT(
+                            'type',
+                            'section',
+                            'fields',
+                            (
+                                select
+                                    JSON_GROUP_ARRAY(
+                                        JSON_OBJECT(
+                                            'type',
+                                            'mrkdwn',
+                                            'text',
+                                            CASE
+                                                WHEN length(value) < 10 THEN ('*' || key || '*: `' || value || '`')
+                                                ELSE ('*' || key || '*: ```' || value || '```')
+                                            END
+                                        )
+                                    )
+                                from
+                                    json_each(return_values.filtered_metadata)
+                            )
+                        )
+                END
+            )
+        ), return_values
+        WHERE type != 'null'
+    ) as slack_blocks;

--- a/ops-catalog/task-failures.flow.yaml
+++ b/ops-catalog/task-failures.flow.yaml
@@ -1,0 +1,103 @@
+collections:
+  ops.us-central1.v1/failure-notifications/v1:
+    derive:
+      using:
+        sqlite:
+          migrations:
+            - |
+              CREATE TABLE failures (
+                shard TEXT,
+                ts TEXT,
+                PRIMARY KEY (shard, ts)
+              );
+              CREATE TABLE failure_notifications (
+                shard TEXT,
+                ts TEXT,
+                PRIMARY KEY (shard,ts)
+              );
+            - |
+              CREATE TABLE related_log_lines (
+                shard TEXT,
+                ts TEXT,
+                level TEXT,
+                message TEXT,
+                PRIMARY KEY (shard,ts)
+                UNIQUE(message)
+              );
+            - |
+              -- SQLite doesn't support dropping constraints lol
+              CREATE TABLE related_log_lines_2 (
+                shard TEXT,
+                ts TEXT,
+                level TEXT,
+                message TEXT,
+                PRIMARY KEY (shard,ts)
+                UNIQUE (shard,message)
+              );
+              INSERT INTO related_log_lines_2 SELECT * from related_log_lines;
+              DROP TABLE related_log_lines;
+              ALTER TABLE related_log_lines_2 RENAME TO related_log_lines;
+
+      transforms:
+        - name: notifyAboutTaskFailures
+          shuffle:
+            key: [/shard/name]
+          source: ops.us-central1.v1/logs
+          lambda: notify-failure-logs.sql
+        - name: cleanUp
+          shuffle:
+            key: [/shard/name]
+          source: ops.us-central1.v1/logs
+          readDelay: 48h
+          lambda: DELETE FROM failures WHERE shard = $name AND ts=$ts; DELETE FROM failure_notifications WHERE shard = $name AND ts=$ts;
+    projections:
+      ts: /ts
+      task_name: /task_name
+      text: /slack_text
+      blocks: /slack_blocks
+    key: [/ts, /task_name]
+    schema:
+      type: object
+      required:
+        - task_name
+        - ts
+      properties:
+        message:
+          type: string
+          description: The message indicating failure.
+        reason:
+          type: string
+          description: The reason for the task failure
+        ts:
+          description: The timestamp at which the task failure was reported
+          format: date-time
+          type: string
+        task_name:
+          type: string
+          description: The full name of the task
+        sub_name:
+          type: string
+          description: The name of the task without tenant
+        task_kind:
+          description: The kind of the task
+          enum:
+            - capture
+            - derivation
+            - materialization
+        tenant_name:
+          type: string
+          description: The name of the tenant that owns the task
+        events_since_last_notification:
+          type: number
+        log_lines:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        slack_text:
+          type: string
+        slack_blocks:
+          type: array
+          items:
+            type: object
+            additionalProperties: true

--- a/ops-catalog/task-failures.flow.yaml
+++ b/ops-catalog/task-failures.flow.yaml
@@ -87,17 +87,13 @@ collections:
         tenant_name:
           type: string
           description: The name of the tenant that owns the task
-        events_since_last_notification:
-          type: number
         log_lines:
           type: array
           items:
             type: object
-            additionalProperties: true
         slack_text:
           type: string
         slack_blocks:
           type: array
           items:
             type: object
-            additionalProperties: true

--- a/ops-catalog/template-common.flow.yaml
+++ b/ops-catalog/template-common.flow.yaml
@@ -1,3 +1,6 @@
+import:
+  - task-failures.flow.yaml
+
 collections:
   ops.us-central1.v1/logs:
     schema: ops-log-schema.json


### PR DESCRIPTION
**Note:** this already applied and running as `ops.us-central1.v1/failure-notifications/v1`

The goal is to create a collection of task failures by scanning through the ops logs for messages that we know indicate a failure. Specifically, the string `shard failed` [should always be logged](https://github.com/estuary/flow/blob/d4cd662499c53d62d7f425dd043bd885e830b970/go/runtime/flow_consumer.go#L115-L125) when a shard fails.

In addition to logging `shard failed`, the log message also contains an estimated "cause" for the error under the `/fields/error` key, as well as any other associated metadata fields.

Since we're already processing log messages, it was easy to enhance each failure notification event with data about the most recent `warning` and `error` level log messages.

The derivation outputs both "raw" data in the form of a JSON document describing the failure, as well as data specifically formatted for the Slack API. The final notifications in slack look like this:
![Screen Shot 2023-05-26 at 17 20 17](https://github.com/estuary/flow/assets/4368270/cf934cae-d87e-4aaa-9416-7905622a20c0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1062)
<!-- Reviewable:end -->
