### PR TITLE
agent: evolutions handling inferred schemas

### DIFF
--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
@@ -34,6 +34,36 @@ expression: new_draft
         ),
     },
     Record {
+        catalog_name: "evolution/CaptureB",
+        spec_type: Some(
+            Capture,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "resource": Object {
+                            "thingy": String("baz"),
+                        },
+                        "target": String("evolution/CollectionC"),
+                    },
+                    Object {
+                        "resource": Object {
+                            "thingy": String("qux"),
+                        },
+                        "target": String("evolution/NewCollectionD"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("captureImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+    Record {
         catalog_name: "evolution/CollectionA_v2",
         spec_type: Some(
             Collection,
@@ -58,6 +88,31 @@ expression: new_draft
         ),
     },
     Record {
+        catalog_name: "evolution/CollectionC",
+        spec_type: Some(
+            Collection,
+        ),
+        spec: Some(
+            Object {
+                "key": Array [
+                    String("id"),
+                ],
+                "schema": Object {
+                    "properties": Object {
+                        "id": Object {
+                            "type": String("integer"),
+                        },
+                    },
+                    "required": Array [
+                        String("id"),
+                    ],
+                    "type": String("object"),
+                    "x-infer-schema": Bool(true),
+                },
+            },
+        ),
+    },
+    Record {
         catalog_name: "evolution/MaterializationA",
         spec_type: Some(
             Materialization,
@@ -70,7 +125,7 @@ expression: new_draft
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("CollectionA_v2"),
+                            "targetThingy": String("aThing_v2"),
                         },
                         "source": String("evolution/CollectionA_v2"),
                     },
@@ -82,6 +137,42 @@ expression: new_draft
                             "targetThingy": String("NewCollectionB"),
                         },
                         "source": String("evolution/NewCollectionB"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("matImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+    Record {
+        catalog_name: "evolution/MaterializationB",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("cThing_v2"),
+                        },
+                        "source": String("evolution/CollectionC"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("NewCollectionD"),
+                        },
+                        "source": String("evolution/NewCollectionD"),
                     },
                 ],
                 "endpoint": Object {
@@ -140,6 +231,31 @@ expression: new_draft
                         String("id"),
                     ],
                     "type": String("object"),
+                },
+            },
+        ),
+    },
+    Record {
+        catalog_name: "evolution/NewCollectionD",
+        spec_type: Some(
+            Collection,
+        ),
+        spec: Some(
+            Object {
+                "key": Array [
+                    String("id"),
+                ],
+                "schema": Object {
+                    "properties": Object {
+                        "id": Object {
+                            "type": String("integer"),
+                        },
+                    },
+                    "required": Array [
+                        String("id"),
+                    ],
+                    "type": String("object"),
+                    "x-infer-schema": Bool(true),
                 },
             },
         ),

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution.snap
@@ -17,4 +17,15 @@ evolved_collections:
       - evolution/MaterializationC
     updated_captures:
       - evolution/CaptureA
+  - old_name: evolution/CollectionC
+    new_name: evolution/CollectionC
+    updated_materializations:
+      - evolution/MaterializationB
+    updated_captures: []
+  - old_name: evolution/CollectionD
+    new_name: evolution/NewCollectionD
+    updated_materializations:
+      - evolution/MaterializationB
+    updated_captures:
+      - evolution/CaptureB
 

--- a/crates/agent/src/evolution/test.rs
+++ b/crates/agent/src/evolution/test.rs
@@ -18,7 +18,9 @@ async fn test_collection_evolution() {
 
     let input = serde_json::value::to_raw_value(&serde_json::json!([
         {"old_name": "evolution/CollectionA"},
-        {"old_name": "evolution/CollectionB", "new_name": "evolution/NewCollectionB"}
+        {"old_name": "evolution/CollectionB", "new_name": "evolution/NewCollectionB"},
+        {"old_name": "evolution/CollectionC"},
+        {"old_name": "evolution/CollectionD", "new_name": "evolution/NewCollectionD"}
     ]))
     .unwrap();
     let evolution_row = Row {

--- a/crates/agent/src/evolution/test_setup.sql
+++ b/crates/agent/src/evolution/test_setup.sql
@@ -25,7 +25,27 @@ with s1 as (
       'bbbbbbbbbbbbbbbb'
     ), 
     (
-      'a300000000000000', 'evolution/CaptureA', 
+      'a300000000000000', 'evolution/CollectionC', 
+      '{"schema": {
+            "x-infer-schema": true,
+            "type": "object",
+            "properties": { "id": {"type": "string"}}, "required": ["id"]
+        }, "key": ["id"]}' :: json, 
+      'collection', 'bbbbbbbbbbbbbbbb', 
+      'bbbbbbbbbbbbbbbb'
+    ),
+    (
+      'a400000000000000', 'evolution/CollectionD', 
+      '{"schema": {
+            "x-infer-schema": true,
+            "type": "object",
+            "properties": { "id": {"type": "string"}}, "required": ["id"]
+        }, "key": ["id"]}' :: json, 
+      'collection', 'bbbbbbbbbbbbbbbb', 
+      'bbbbbbbbbbbbbbbb'
+    ), 
+    (
+      'a600000000000000', 'evolution/CaptureA', 
       '{
             "bindings": [
                 {"target": "evolution/CollectionA", "resource": {"thingy": "foo"}},
@@ -36,7 +56,18 @@ with s1 as (
       'capture', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
     ), 
     (
-      'a400000000000000', 'evolution/MaterializationA', 
+      'a700000000000000', 'evolution/CaptureB', 
+      '{
+            "bindings": [
+                {"target": "evolution/CollectionC", "resource": {"thingy": "baz"}},
+                {"target": "evolution/CollectionD", "resource": {"thingy": "qux"}}
+            ],
+            "endpoint": {"connector": {"image": "captureImage:v1", "config": {}}}
+        }' :: json, 
+      'capture', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
+    ), 
+    (
+      'a800000000000000', 'evolution/MaterializationA', 
       '{
             "bindings": [
                 {"source": "evolution/CollectionA", "resource": {"targetThingy": "aThing"}},
@@ -47,19 +78,37 @@ with s1 as (
       'materialization', 'bbbbbbbbbbbbbbbb', 
       'bbbbbbbbbbbbbbbb'
     ), 
+    (
+      'a900000000000000', 'evolution/MaterializationB', 
+      '{
+            "bindings": [
+                {"source": "evolution/CollectionC", "resource": {"targetThingy": "cThing"}},
+                {"source": "evolution/CollectionD", "resource": {"targetThingy": "dThing"}}
+            ],
+            "endpoint": {"connector": {"image": "matImage:v1", "config": {}}}
+        }' :: json, 
+      'materialization', 'bbbbbbbbbbbbbbbb', 
+      'bbbbbbbbbbbbbbbb'
+    ), 
 	-- These specs are here so that we can ensure we don't update tasks that the user isn't authorized to.
     (
       'b100000000000000', 'schmevolution/CaptureZ',
       '{
-            "bindings": [{"target": "evolution/CollectionB", "resource": {"thing": "testSourceThing"}}],
+            "bindings": [
+              {"target": "evolution/CollectionB", "resource": {"thing": "testSourceThingB"}},
+              {"target": "evolution/CollectionD", "resource": {"thing": "testSourceThingD"}}
+            ],
             "endpoint": {"connector": {"image": "captureImage:v1", "config": {}}}
         }' :: json, 
-      'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
+      'capture', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
     ),
     (
       'b200000000000000', 'schmevolution/MaterializationZ',
       '{
-            "bindings": [{"source": "evolution/CollectionA", "resource": {"targetThingy": "testTargetThing"}}],
+            "bindings": [
+              {"source": "evolution/CollectionA", "resource": {"targetThingy": "testTargetThingA"}},
+              {"source": "evolution/CollectionC", "resource": {"targetThingy": "testTargetThingC"}}
+            ],
             "endpoint": {"connector": {"image": "matImage:v1", "config": {}}}
         }' :: json, 
       'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
@@ -69,23 +118,52 @@ s2 as (
   insert into live_spec_flows (source_id, target_id, flow_type) 
   values 
     (
-      'a300000000000000', 'a100000000000000', 
+      'a600000000000000', 'a100000000000000',
       'capture'
     ), 
     (
-      'a300000000000000', 'a200000000000000', 
+      'a600000000000000', 'a200000000000000',
       'capture'
     ), 
     (
-      'a100000000000000', 'a400000000000000', 
+      'a700000000000000', 'a300000000000000',
+      'capture'
+    ), 
+    (
+      'a700000000000000', 'a400000000000000',
+      'capture'
+    ), 
+    (
+      'a100000000000000', 'a800000000000000',
       'materialization'
     ), 
     (
-      'a200000000000000', 'a400000000000000', 
+      'a200000000000000', 'a800000000000000',
       'materialization'
     ), 
     (
-      'a200000000000000', 'b100000000000000', 
+      'a300000000000000', 'a900000000000000',
+      'materialization'
+    ), 
+    (
+      'a400000000000000', 'a900000000000000',
+      'materialization'
+    ), 
+
+    (
+      'b100000000000000', 'a200000000000000',
+      'capture'
+    ),
+    (
+      'b100000000000000', 'a400000000000000',
+      'capture'
+    ),
+    (
+      'a100000000000000', 'b200000000000000',
+      'materialization'
+    ),
+    (
+      'a300000000000000', 'b200000000000000',
       'materialization'
     )
 ),
@@ -120,7 +198,7 @@ s6 as (
   ) 
   values 
     (
-      '1113000000000000', '2230000000000000', 
+      '1111000000000000', '2230000000000000',
       'evolution/CollectionA', '{"schema": {
             "type": "object",
             "properties": { "id": {"type": "integer"}}, "required": ["id"]
@@ -128,7 +206,7 @@ s6 as (
       'collection'
     ),
     (
-      '1114000000000000', '2230000000000000', 
+      '1112000000000000', '2230000000000000',
       'evolution/CollectionB', '{"schema": {
             "type": "object",
             "properties": { "id": {"type": "integer"}}, "required": ["id"]
@@ -136,7 +214,25 @@ s6 as (
       'collection'
     ),
     (
-      '1115000000000000', '2230000000000000', 
+      '1113000000000000', '2230000000000000',
+      'evolution/CollectionC', '{"schema": {
+            "x-infer-schema": true,
+            "type": "object",
+            "properties": { "id": {"type": "integer"}}, "required": ["id"]
+        }, "key": ["id"]}' :: json, 
+      'collection'
+    ),
+    (
+      '1114000000000000', '2230000000000000',
+      'evolution/CollectionD', '{"schema": {
+            "x-infer-schema": true,
+            "type": "object",
+            "properties": { "id": {"type": "integer"}}, "required": ["id"]
+        }, "key": ["id"]}' :: json, 
+      'collection'
+    ),
+    (
+      '1115000000000000', '2230000000000000',
       'evolution/MaterializationC', '{
         "endpoint": {"connector": {"image": "matImage:v1", "config": {}}},
         "bindings": [{


### PR DESCRIPTION
**Description:**

This addresses a portion of #1063, but it seemed useful on its own and separable from the rest of the work related to it.

There's a big difference between collections that use inferred schemas and those that don't, and the overall aim of this commit is to have the `evolutions` handler do the "right thing" in both cases. This means introducing some special behavior for collections that bear the `x-infer-schema` annotation in their schema.

If a collection is using an inferred schema, then re-creating it is unlikely to help, and can be quite costly and inefficient. So generally in that case we'd prefer to _only_ update the materialization bindings to materialize the existing collection to a new table. But there are still cases where re-creating the collection is necessary. For example, if the key is updated.

So the following updates to the evolutions behavior will only apply when the collection schema has `x-infer-schema` and the `collections` input does _not_ explicitly request re-creating the collection (by specifying a `new_name`).

In that case, evolution will _not_ re-create the collection, but will instead only set a new resource name in any affected materialization bindings. For example, if you'd materialized `acmeCo/foo` to table `my_table`, then it would be updated to materialize to `my_table_v2`. The `new_name` in the `job_status` will then be the same as the `old_name`.

**Workflow steps:**

When you try to publish a change to a collection that uses `x-infer-schema` and it gets rejected, you'll still see the same message that recommends re-creating the collections. Now, when you click that button it will no longer re-create the collection, but will instead only update the materialization binding to materialize the same collection to a new resource.

For collections that _don't_ use `x-infer-schema`, the behavior is unchanged.

**Documentation links affected:**

no docs on this _yet_, but I'm working on it.

**Notes for reviewers:**

- The `x-infer-schema` annotation isn't a _great_ way to identify these collections, especially now that the behavior is diverging based on the annotation. It seems desirable in the future to hoist `x-infer-schema` into a top-level property of a `models::CollectionDef`. But I left that out of this PR for the time being.
- @dyaffe @travjenkins @kiahna-tucker This changes the semantics of `evolutions` to no longer be synonymous with "re-creating" collections. So we should probably also coordinate a change to the wording in our UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1065)
<!-- Reviewable:end -->
