### PR TITLE
increase document limit from 16MB => 32MB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,9 +1945,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -3620,13 +3620,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
  "url",
@@ -3778,6 +3778,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +3808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4722,9 +4744,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -4776,14 +4808,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4795,25 +4827,22 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4885,16 +4914,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
-tonic = { version = "0.8", features = ["tls", "tls-roots"] }
+tonic = { version = "0.9", features = ["tls", "tls-roots"] }
 tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
@@ -191,7 +191,7 @@ wasm-bindgen-test = "0.3.13"
 cbindgen = "0.23"
 pbjson-build = "0.5"
 prost-build = "0.11"
-tonic-build = "0.8"
+tonic-build = "0.9"
 
 warp = "0.3.3"
 

--- a/crates/connector-init/src/lib.rs
+++ b/crates/connector-init/src/lib.rs
@@ -38,16 +38,24 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     let capture = proto_grpc::capture::connector_server::ConnectorServer::new(capture::Proxy {
         entrypoint: entrypoint.clone(),
         codec,
-    });
+    })
+    .max_decoding_message_size(usize::MAX) // Up from 4MB. Accept whatever the runtime sends.
+    .max_encoding_message_size(usize::MAX); // The default, made explicit.
+
     let derive = proto_grpc::derive::connector_server::ConnectorServer::new(derive::Proxy {
         entrypoint: entrypoint.clone(),
         codec,
-    });
+    })
+    .max_decoding_message_size(usize::MAX) // Up from 4MB. Accept whatever the runtime sends.
+    .max_encoding_message_size(usize::MAX); // The default, made explicit.
+
     let materialize =
         proto_grpc::materialize::connector_server::ConnectorServer::new(materialize::Proxy {
             entrypoint: entrypoint.clone(),
             codec,
-        });
+        })
+        .max_decoding_message_size(usize::MAX) // Up from 4MB. Accept whatever the runtime sends.
+        .max_encoding_message_size(usize::MAX); // The default, made explicit.
 
     let proxy_handler = proxy::ProxyHandler::new("localhost");
     let proxy = proto_grpc::flow::network_proxy_server::NetworkProxyServer::new(proxy_handler);

--- a/crates/proto-grpc/src/capture.rs
+++ b/crates/proto-grpc/src/capture.rs
@@ -57,7 +57,7 @@ pub mod connector_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -113,12 +113,28 @@ pub mod connector_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn capture(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
                 Message = ::proto_flow::capture::Request,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<::proto_flow::capture::Response>>,
             tonic::Status,
         > {
@@ -135,7 +151,9 @@ pub mod connector_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/capture.Connector/Capture",
             );
-            self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut().insert(GrpcMethod::new("capture.Connector", "Capture"));
+            self.inner.streaming(req, path, codec).await
         }
     }
 }
@@ -149,14 +167,17 @@ pub mod connector_server {
     pub trait Connector: Send + Sync + 'static {
         /// Server streaming response type for the Capture method.
         type CaptureStream: futures_core::Stream<
-                Item = Result<::proto_flow::capture::Response, tonic::Status>,
+                Item = std::result::Result<
+                    ::proto_flow::capture::Response,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
         async fn capture(
             &self,
             request: tonic::Request<tonic::Streaming<::proto_flow::capture::Request>>,
-        ) -> Result<tonic::Response<Self::CaptureStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::CaptureStream>, tonic::Status>;
     }
     /// Captures is a very long lived RPC through which the Flow runtime and a
     /// connector cooperatively execute an unbounded number of transactions.
@@ -208,6 +229,8 @@ pub mod connector_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Connector> ConnectorServer<T> {
@@ -220,6 +243,8 @@ pub mod connector_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -243,6 +268,22 @@ pub mod connector_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ConnectorServer<T>
     where
@@ -256,7 +297,7 @@ pub mod connector_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -281,13 +322,15 @@ pub mod connector_server {
                                 tonic::Streaming<::proto_flow::capture::Request>,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).capture(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -297,6 +340,10 @@ pub mod connector_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
                         Ok(res)
@@ -325,12 +372,14 @@ pub mod connector_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Connector> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto-grpc/src/consumer.rs
+++ b/crates/proto-grpc/src/consumer.rs
@@ -16,7 +16,7 @@ pub mod shard_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -72,11 +72,27 @@ pub mod shard_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Stat returns detailed status of a given Shard.
         pub async fn stat(
             &mut self,
             request: impl tonic::IntoRequest<::proto_gazette::consumer::StatRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::StatResponse>,
             tonic::Status,
         > {
@@ -91,13 +107,15 @@ pub mod shard_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/consumer.Shard/Stat");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("consumer.Shard", "Stat"));
+            self.inner.unary(req, path, codec).await
         }
         /// List Shards, their ShardSpecs and their processing status.
         pub async fn list(
             &mut self,
             request: impl tonic::IntoRequest<::proto_gazette::consumer::ListRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::ListResponse>,
             tonic::Status,
         > {
@@ -112,13 +130,15 @@ pub mod shard_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/consumer.Shard/List");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("consumer.Shard", "List"));
+            self.inner.unary(req, path, codec).await
         }
         /// Apply changes to the collection of Shards managed by the consumer.
         pub async fn apply(
             &mut self,
             request: impl tonic::IntoRequest<::proto_gazette::consumer::ApplyRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::ApplyResponse>,
             tonic::Status,
         > {
@@ -133,13 +153,15 @@ pub mod shard_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/consumer.Shard/Apply");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("consumer.Shard", "Apply"));
+            self.inner.unary(req, path, codec).await
         }
         /// GetHints fetches hints for a shard.
         pub async fn get_hints(
             &mut self,
             request: impl tonic::IntoRequest<::proto_gazette::consumer::GetHintsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::GetHintsResponse>,
             tonic::Status,
         > {
@@ -154,13 +176,15 @@ pub mod shard_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/consumer.Shard/GetHints");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("consumer.Shard", "GetHints"));
+            self.inner.unary(req, path, codec).await
         }
         /// Unassign a Shard.
         pub async fn unassign(
             &mut self,
             request: impl tonic::IntoRequest<::proto_gazette::consumer::UnassignRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::UnassignResponse>,
             tonic::Status,
         > {
@@ -175,7 +199,9 @@ pub mod shard_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/consumer.Shard/Unassign");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("consumer.Shard", "Unassign"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -191,7 +217,7 @@ pub mod shard_server {
         async fn stat(
             &self,
             request: tonic::Request<::proto_gazette::consumer::StatRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::StatResponse>,
             tonic::Status,
         >;
@@ -199,7 +225,7 @@ pub mod shard_server {
         async fn list(
             &self,
             request: tonic::Request<::proto_gazette::consumer::ListRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::ListResponse>,
             tonic::Status,
         >;
@@ -207,7 +233,7 @@ pub mod shard_server {
         async fn apply(
             &self,
             request: tonic::Request<::proto_gazette::consumer::ApplyRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::ApplyResponse>,
             tonic::Status,
         >;
@@ -215,7 +241,7 @@ pub mod shard_server {
         async fn get_hints(
             &self,
             request: tonic::Request<::proto_gazette::consumer::GetHintsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::GetHintsResponse>,
             tonic::Status,
         >;
@@ -223,7 +249,7 @@ pub mod shard_server {
         async fn unassign(
             &self,
             request: tonic::Request<::proto_gazette::consumer::UnassignRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_gazette::consumer::UnassignResponse>,
             tonic::Status,
         >;
@@ -237,6 +263,8 @@ pub mod shard_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Shard> ShardServer<T> {
@@ -249,6 +277,8 @@ pub mod shard_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -272,6 +302,22 @@ pub mod shard_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ShardServer<T>
     where
@@ -285,7 +331,7 @@ pub mod shard_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -309,13 +355,15 @@ pub mod shard_server {
                                 ::proto_gazette::consumer::StatRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).stat(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -325,6 +373,10 @@ pub mod shard_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -349,13 +401,15 @@ pub mod shard_server {
                                 ::proto_gazette::consumer::ListRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).list(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -365,6 +419,10 @@ pub mod shard_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -390,13 +448,15 @@ pub mod shard_server {
                                 ::proto_gazette::consumer::ApplyRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).apply(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -406,6 +466,10 @@ pub mod shard_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -431,13 +495,15 @@ pub mod shard_server {
                                 ::proto_gazette::consumer::GetHintsRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).get_hints(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -447,6 +513,10 @@ pub mod shard_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -472,13 +542,15 @@ pub mod shard_server {
                                 ::proto_gazette::consumer::UnassignRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).unassign(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -488,6 +560,10 @@ pub mod shard_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -516,12 +592,14 @@ pub mod shard_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Shard> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto-grpc/src/flow.rs
+++ b/crates/proto-grpc/src/flow.rs
@@ -12,7 +12,7 @@ pub mod shuffler_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -68,10 +68,26 @@ pub mod shuffler_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn shuffle(
             &mut self,
             request: impl tonic::IntoRequest<::proto_flow::flow::ShuffleRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<::proto_flow::flow::ShuffleResponse>,
             >,
@@ -88,7 +104,9 @@ pub mod shuffler_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/flow.Shuffler/Shuffle");
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("flow.Shuffler", "Shuffle"));
+            self.inner.server_streaming(req, path, codec).await
         }
     }
 }
@@ -106,7 +124,7 @@ pub mod testing_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -162,10 +180,26 @@ pub mod testing_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn reset_state(
             &mut self,
             request: impl tonic::IntoRequest<::proto_flow::flow::ResetStateRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_flow::flow::ResetStateResponse>,
             tonic::Status,
         > {
@@ -180,12 +214,14 @@ pub mod testing_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/flow.Testing/ResetState");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("flow.Testing", "ResetState"));
+            self.inner.unary(req, path, codec).await
         }
         pub async fn advance_time(
             &mut self,
             request: impl tonic::IntoRequest<::proto_flow::flow::AdvanceTimeRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_flow::flow::AdvanceTimeResponse>,
             tonic::Status,
         > {
@@ -200,12 +236,17 @@ pub mod testing_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/flow.Testing/AdvanceTime");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("flow.Testing", "AdvanceTime"));
+            self.inner.unary(req, path, codec).await
         }
         pub async fn ingest(
             &mut self,
             request: impl tonic::IntoRequest<::proto_flow::flow::IngestRequest>,
-        ) -> Result<tonic::Response<::proto_flow::flow::IngestResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<::proto_flow::flow::IngestResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -217,7 +258,9 @@ pub mod testing_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/flow.Testing/Ingest");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("flow.Testing", "Ingest"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -235,7 +278,7 @@ pub mod network_proxy_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -291,12 +334,28 @@ pub mod network_proxy_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn proxy(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
                 Message = ::proto_flow::flow::TaskNetworkProxyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<::proto_flow::flow::TaskNetworkProxyResponse>,
             >,
@@ -313,7 +372,9 @@ pub mod network_proxy_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/flow.NetworkProxy/Proxy");
-            self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut().insert(GrpcMethod::new("flow.NetworkProxy", "Proxy"));
+            self.inner.streaming(req, path, codec).await
         }
     }
 }
@@ -327,20 +388,25 @@ pub mod shuffler_server {
     pub trait Shuffler: Send + Sync + 'static {
         /// Server streaming response type for the Shuffle method.
         type ShuffleStream: futures_core::Stream<
-                Item = Result<::proto_flow::flow::ShuffleResponse, tonic::Status>,
+                Item = std::result::Result<
+                    ::proto_flow::flow::ShuffleResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
         async fn shuffle(
             &self,
             request: tonic::Request<::proto_flow::flow::ShuffleRequest>,
-        ) -> Result<tonic::Response<Self::ShuffleStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::ShuffleStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ShufflerServer<T: Shuffler> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Shuffler> ShufflerServer<T> {
@@ -353,6 +419,8 @@ pub mod shuffler_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -376,6 +444,22 @@ pub mod shuffler_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ShufflerServer<T>
     where
@@ -389,7 +473,7 @@ pub mod shuffler_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -413,13 +497,15 @@ pub mod shuffler_server {
                             &mut self,
                             request: tonic::Request<::proto_flow::flow::ShuffleRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).shuffle(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -429,6 +515,10 @@ pub mod shuffler_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -457,12 +547,14 @@ pub mod shuffler_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Shuffler> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -485,27 +577,32 @@ pub mod testing_server {
         async fn reset_state(
             &self,
             request: tonic::Request<::proto_flow::flow::ResetStateRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_flow::flow::ResetStateResponse>,
             tonic::Status,
         >;
         async fn advance_time(
             &self,
             request: tonic::Request<::proto_flow::flow::AdvanceTimeRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<::proto_flow::flow::AdvanceTimeResponse>,
             tonic::Status,
         >;
         async fn ingest(
             &self,
             request: tonic::Request<::proto_flow::flow::IngestRequest>,
-        ) -> Result<tonic::Response<::proto_flow::flow::IngestResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<::proto_flow::flow::IngestResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct TestingServer<T: Testing> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Testing> TestingServer<T> {
@@ -518,6 +615,8 @@ pub mod testing_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -541,6 +640,22 @@ pub mod testing_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for TestingServer<T>
     where
@@ -554,7 +669,7 @@ pub mod testing_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -578,13 +693,15 @@ pub mod testing_server {
                                 ::proto_flow::flow::ResetStateRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).reset_state(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -594,6 +711,10 @@ pub mod testing_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -618,7 +739,7 @@ pub mod testing_server {
                                 ::proto_flow::flow::AdvanceTimeRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).advance_time(request).await
                             };
@@ -627,6 +748,8 @@ pub mod testing_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -636,6 +759,10 @@ pub mod testing_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -658,13 +785,15 @@ pub mod testing_server {
                             &mut self,
                             request: tonic::Request<::proto_flow::flow::IngestRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).ingest(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -674,6 +803,10 @@ pub mod testing_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -702,12 +835,14 @@ pub mod testing_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Testing> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -729,7 +864,7 @@ pub mod network_proxy_server {
     pub trait NetworkProxy: Send + Sync + 'static {
         /// Server streaming response type for the Proxy method.
         type ProxyStream: futures_core::Stream<
-                Item = Result<
+                Item = std::result::Result<
                     ::proto_flow::flow::TaskNetworkProxyResponse,
                     tonic::Status,
                 >,
@@ -741,13 +876,15 @@ pub mod network_proxy_server {
             request: tonic::Request<
                 tonic::Streaming<::proto_flow::flow::TaskNetworkProxyRequest>,
             >,
-        ) -> Result<tonic::Response<Self::ProxyStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::ProxyStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct NetworkProxyServer<T: NetworkProxy> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: NetworkProxy> NetworkProxyServer<T> {
@@ -760,6 +897,8 @@ pub mod network_proxy_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -783,6 +922,22 @@ pub mod network_proxy_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for NetworkProxyServer<T>
     where
@@ -796,7 +951,7 @@ pub mod network_proxy_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -824,13 +979,15 @@ pub mod network_proxy_server {
                                 >,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).proxy(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -840,6 +997,10 @@ pub mod network_proxy_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
                         Ok(res)
@@ -868,12 +1029,14 @@ pub mod network_proxy_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: NetworkProxy> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto-grpc/src/materialize.rs
+++ b/crates/proto-grpc/src/materialize.rs
@@ -12,7 +12,7 @@ pub mod connector_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -68,12 +68,28 @@ pub mod connector_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn materialize(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
                 Message = ::proto_flow::materialize::Request,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<::proto_flow::materialize::Response>,
             >,
@@ -92,7 +108,10 @@ pub mod connector_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/materialize.Connector/Materialize",
             );
-            self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("materialize.Connector", "Materialize"));
+            self.inner.streaming(req, path, codec).await
         }
     }
 }
@@ -106,20 +125,28 @@ pub mod connector_server {
     pub trait Connector: Send + Sync + 'static {
         /// Server streaming response type for the Materialize method.
         type MaterializeStream: futures_core::Stream<
-                Item = Result<::proto_flow::materialize::Response, tonic::Status>,
+                Item = std::result::Result<
+                    ::proto_flow::materialize::Response,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
         async fn materialize(
             &self,
             request: tonic::Request<tonic::Streaming<::proto_flow::materialize::Request>>,
-        ) -> Result<tonic::Response<Self::MaterializeStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::MaterializeStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ConnectorServer<T: Connector> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Connector> ConnectorServer<T> {
@@ -132,6 +159,8 @@ pub mod connector_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -155,6 +184,22 @@ pub mod connector_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ConnectorServer<T>
     where
@@ -168,7 +213,7 @@ pub mod connector_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -193,13 +238,15 @@ pub mod connector_server {
                                 tonic::Streaming<::proto_flow::materialize::Request>,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).materialize(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -209,6 +256,10 @@ pub mod connector_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
                         Ok(res)
@@ -237,12 +288,14 @@ pub mod connector_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Connector> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/go/connector/container.go
+++ b/go/connector/container.go
@@ -320,5 +320,5 @@ func copyToTempFile(r io.Reader, mode os.FileMode) (*os.File, error) {
 	return tmp, nil
 }
 
-const maxMessageSize = 1 << 24 // 16 MB.
+const maxMessageSize = 1 << 25 // 32 MB.
 const flowConnectorInit = "flow-connector-init"


### PR DESCRIPTION
Update `tonic` to bring in new message bound behavior added in v0.9 Update capture/derive/materialize services to accept messages of unbounded size from the runtime, as the runtime will ultimiately enforce document size limitations.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1066)
<!-- Reviewable:end -->
