### PR TITLE
add flow.UnwrapGRPCError and use it consistently

### DIFF
--- a/go/protocols/capture/pull_client_test.go
+++ b/go/protocols/capture/pull_client_test.go
@@ -161,7 +161,7 @@ func TestPullClientLifecycle(t *testing.T) {
 	commitOp.Resolve(nil)
 
 	// We're notified of the server failure.
-	require.EqualError(t, <-startCommitCh, "rpc error: code = Unknown desc = crash!")
+	require.EqualError(t, <-startCommitCh, "crash!")
 	// The client closes gracefully.
 	rpc.Close()
 	// A further attempt to set a LogCommitOp errors, since serve() is no longer running.

--- a/go/protocols/materialize/client.go
+++ b/go/protocols/materialize/client.go
@@ -305,7 +305,7 @@ func (c *TxnClient) writeErr(err error) error {
 	// Otherwise we must synchronously read the error.
 	for {
 		if _, err = c.client.Recv(); err != nil {
-			return err
+			return pf.UnwrapGRPCError(err)
 		}
 	}
 }

--- a/go/protocols/materialize/client_transactor_test.go
+++ b/go/protocols/materialize/client_transactor_test.go
@@ -16,8 +16,6 @@ import (
 	pc "go.gazette.dev/core/consumer/protocol"
 	"go.gazette.dev/core/server"
 	"go.gazette.dev/core/task"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 //go:generate flowctl-go api build --build-id test-build --build-id testdata/temp.db --source testdata/flow.yaml
@@ -304,12 +302,7 @@ func (t *testServer) Materialize(stream Connector_MaterializeServer) error {
 		panic("not an open")
 	}
 
-	if err = RunTransactions(stream, *request.Open, t.OpenedTx, t.Transactor); err != nil {
-		// Send Internal code, as flow-connector-init does.
-		// This is unwrapped by the TxnClient.
-		return status.Error(codes.Internal, err.Error())
-	}
-	return nil
+	return RunTransactions(stream, *request.Open, t.OpenedTx, t.Transactor)
 }
 
 // testTransactor implements Transactor.

--- a/go/protocols/materialize/sql/driver.go
+++ b/go/protocols/materialize/sql/driver.go
@@ -262,7 +262,7 @@ func (d *Driver) Materialize(stream pm.Connector_MaterializeServer) error {
 		if err == io.EOF {
 			return nil
 		} else if err != nil {
-			return err
+			return pf.UnwrapGRPCError(err)
 		} else if err := request.Validate_(); err != nil {
 			return err
 		}

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -21,8 +21,6 @@ import (
 	"go.gazette.dev/core/consumer/recoverylog"
 	store_sqlite "go.gazette.dev/core/consumer/store-sqlite"
 	"go.gazette.dev/core/message"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Derive is a top-level Application which implements the derivation workflow.
@@ -302,12 +300,9 @@ func doSend(client pd.Connector_DeriveClient, request *pd.Request) error {
 }
 
 func doRecv(client pd.Connector_DeriveClient) (*pd.Response, error) {
-	var response, err = client.Recv()
-	if err != nil {
-		if status, ok := status.FromError(err); ok && status.Code() == codes.Internal {
-			err = errors.New(status.Message())
-		}
-		return nil, err
+	if r, err := client.Recv(); err != nil {
+		return nil, pf.UnwrapGRPCError(err)
+	} else {
+		return r, nil
 	}
-	return response, nil
 }


### PR DESCRIPTION
Centralize the means by which we unwrap gRPC status codes and map them into canonical Go errors into a single function.

Update to use this function consistently throughout Flow, including coverage of additional places that formerly had not been unwrapped:
 - `materialize.TxnClient.writeErr`
 - `capture.Open` when reading `Opened`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1071)
<!-- Reviewable:end -->
