### PR TITLE
fix: Tuple snapshot tests to work on go 1.20

### DIFF
--- a/go/protocols/fdb/tuple/tuple_test.go
+++ b/go/protocols/fdb/tuple/tuple_test.go
@@ -12,6 +12,8 @@ import (
 
 var update = flag.Bool("update", false, "update .golden files")
 
+var src = rand.New(rand.NewSource(1))
+
 func loadGolden(t *testing.T) (golden map[string][]byte) {
 	f, err := os.Open("testdata/tuples.golden")
 	if err != nil {
@@ -48,9 +50,9 @@ func genBytes() interface{}     { return []byte("namespace") }
 func genBytesNil() interface{}  { return []byte{0xFF, 0x00, 0xFF} }
 func genString() interface{}    { return "namespace" }
 func genStringNil() interface{} { return "nam\x00es\xFFpace" }
-func genInt() interface{}       { return rand.Int63() }
-func genFloat() interface{}     { return float32(rand.NormFloat64()) }
-func genDouble() interface{}    { return rand.NormFloat64() }
+func genInt() interface{}       { return src.Int63() }
+func genFloat() interface{}     { return float32(src.NormFloat64()) }
+func genDouble() interface{}    { return src.NormFloat64() }
 
 func mktuple(gen func() interface{}, count int) Tuple {
 	tt := make(Tuple, count)
@@ -99,7 +101,7 @@ func TestTuplePacking(t *testing.T) {
 			}
 
 			if !bytes.Equal(result, golden[tt.name]) {
-				t.Errorf("packing mismatch: expected %v, got %v", golden[tt.name], result)
+				t.Errorf("packing mismatch for %v: expected %v, got %v", tt.name, golden[tt.name], result)
 			}
 		})
 	}
@@ -121,7 +123,7 @@ func BenchmarkTuplePacking(b *testing.B) {
 }
 
 func TestTupleString(t *testing.T) {
-	testCases :=[ ]struct {
+	testCases := []struct {
 		input    Tuple
 		expected string
 	}{


### PR DESCRIPTION
**Description:**

Go 1.20's [changelog](https://tip.golang.org/doc/go1.20) says:

> The [math/rand](https://tip.golang.org/pkg/math/rand/) package now automatically seeds the global random number generator (used by top-level functions like Float64 and Int) with a random value, and the top-level [Seed](https://tip.golang.org/pkg/math/rand/#Seed) function has been deprecated. Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using rand.New(rand.NewSource(seed)).

These tuple packing tests originally came from the [FoundationDB](https://github.com/apple/foundationdb/blob/main/bindings/go/src/fdb/tuple/tuple_test.go) code, and relied on the behavior of `math/rand` initializing with the same seed every time. I ran into this test failure on my local machine as I had installed go 1.20, whereas we test with 1.19 in CI.

I could have opted to just set `GODEBUG=randautoseed=0`, which would have kept the previous fixed-seed behavior, but it felt more fragile to do that than just change the tests to use the original fixed seed value of `1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1074)
<!-- Reviewable:end -->
