### PR TITLE
Phil/auto publish discovers

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,6 +2,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
 os.putenv("DATABASE_URL", DATABASE_URL)
 os.putenv("RUST_LOG", "info")
+os.putenv("DOCKER_DEFAULT_PLATFORM", "linux/amd64")
 
 
 REPO_BASE= '%s/..' % os.getcwd()

--- a/crates/agent-sql/src/discovers.rs
+++ b/crates/agent-sql/src/discovers.rs
@@ -21,6 +21,8 @@ pub struct Row {
     pub update_only: bool,
     pub updated_at: DateTime<Utc>,
     pub user_id: Uuid,
+    pub auto_publish: bool,
+    pub auto_evolve: bool,
 }
 
 pub async fn dequeue(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> sqlx::Result<Option<Row>> {
@@ -40,6 +42,8 @@ pub async fn dequeue(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> sqlx::R
           connector_tags.protocol as "protocol!",
           discovers.update_only,
           discovers.updated_at,
+          discovers.auto_publish,
+          discovers.auto_evolve,
           drafts.user_id
       from discovers
       join drafts on discovers.draft_id = drafts.id

--- a/crates/agent-sql/src/id.rs
+++ b/crates/agent-sql/src/id.rs
@@ -42,6 +42,17 @@ impl serde::Serialize for Id {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let str_val = std::borrow::Cow::<'de, str>::deserialize(deserializer)?;
+        Id::from_hex(str_val.as_ref()).map_err(|err| D::Error::custom(format!("invalid id: {err}")))
+    }
+}
+
 impl Type<postgres::Postgres> for Id {
     fn type_info() -> postgres::PgTypeInfo {
         postgres::PgTypeInfo::with_name("flowid")

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -230,7 +230,7 @@ impl DiscoverHandler {
         let targets = capture
             .bindings
             .iter()
-            .map(|models::CaptureBinding { target, .. }| target.clone())
+            .map(|models::CaptureBinding { target, .. }| target.as_ref().cloned())
             .collect::<Vec<_>>();
 
         catalog.captures.insert(capture_name, capture); // Replace merged capture.
@@ -239,7 +239,7 @@ impl DiscoverHandler {
         let resolved = agent_sql::discovers::resolve_merge_target_specs(
             &targets
                 .iter()
-                .map(models::Collection::as_str)
+                .flat_map(|t| t.iter().map(models::Collection::as_str))
                 .collect::<Vec<_>>(),
             CatalogType::Collection,
             draft_id,

--- a/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_update.snap
+++ b/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_update.snap
@@ -11,6 +11,13 @@ expression: json!(out)
           "stream": "foo"
         },
         "target": "acmeCo/renamed"
+      },
+      {
+        "resource": {
+          "modified": "yup",
+          "stream": "disabled"
+        },
+        "target": null
       }
     ],
     "endpoint": {
@@ -34,6 +41,13 @@ expression: json!(out)
       "recommendedName": "suggested",
       "resourceConfig": {
         "stream": "foo"
+      }
+    },
+    {
+      "documentSchema": false,
+      "recommendedName": "other",
+      "resourceConfig": {
+        "stream": "disabled"
       }
     }
   ]

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -83,7 +83,10 @@ pub fn merge_capture(
         } else if !update_only {
             // Create a new CaptureBinding.
             capture_bindings.push(models::CaptureBinding {
-                target: models::Collection::new(format!("{capture_prefix}/{recommended_name}")),
+                target: Some(models::Collection::new(format!(
+                    "{capture_prefix}/{recommended_name}"
+                )))
+                .into(),
                 resource: models::RawValue::from_value(&resource),
             });
             filtered_bindings.push(discovered_binding);
@@ -104,7 +107,7 @@ pub fn merge_capture(
 pub fn merge_collections(
     discovered_bindings: Vec<Binding>,
     mut fetched_collections: BTreeMap<models::Collection, models::CollectionDef>,
-    targets: Vec<models::Collection>,
+    targets: Vec<Option<models::Collection>>,
 ) -> BTreeMap<models::Collection, models::CollectionDef> {
     assert_eq!(targets.len(), discovered_bindings.len());
 
@@ -119,6 +122,10 @@ pub fn merge_collections(
         },
     ) in targets.into_iter().zip(discovered_bindings.into_iter())
     {
+        // Skip over any disabled bindings, as indicated by them having no target.
+        let Some(target) = target else {
+            continue;
+        };
         let document_schema: models::Schema = serde_json::from_str(&document_schema_json).unwrap();
         // Unwrap a fetched collection, or initialize a blank one.
         let mut collection =
@@ -225,7 +232,7 @@ mod tests {
         let (discovered_bindings, fetched_collections, targets): (
             Vec<Binding>,
             BTreeMap<models::Collection, models::CollectionDef>,
-            Vec<models::Collection>,
+            Vec<Option<models::Collection>>,
         ) = serde_json::from_value(json!([
             [
                 // case/1: if there is no fetched collection, one is assembled.
@@ -297,6 +304,7 @@ mod tests {
     #[test]
     fn test_capture_merge_update() {
         // Fixture is an update of an existing capture, which uses a non-suggested collection name.
+        // There is also a disabled binding, which is expected to remain disabled after the merge.
         // Additional discovered bindings are filtered.
         let (discovered_endpoint, discovered_bindings, fetched_capture) =
             serde_json::from_value(json!([
@@ -304,11 +312,13 @@ mod tests {
                 [
                     { "recommendedName": "suggested", "resourceConfig": { "stream": "foo" }, "documentSchema": { "const": "discovered" } },
                     { "recommendedName": "other", "resourceConfig": { "stream": "bar" }, "documentSchema": false },
+                    { "recommendedName": "other", "resourceConfig": { "stream": "disabled" }, "documentSchema": false },
                 ],
                 {
                   "bindings": [
                     { "resource": { "stream": "foo", "modified": 1 }, "target": "acmeCo/renamed" },
                     { "resource": { "stream": "removed" }, "target": "acmeCo/discarded" },
+                    { "resource": { "stream": "disabled", "modified": "yup" }, "target": null },
                   ],
                   "endpoint": { "connector": { "config": { "fetched": 1 }, "image": "old/image" } },
                   // Extra fields which are passed-through.
@@ -378,7 +388,7 @@ mod tests {
             ("Foo", "Foo"),
             ("foo/bar", "foo/bar"),
             ("/foo/bar//baz/", "foo/bar_baz"), // Invalid leading, middle, & trailing slash.
-            ("#੫൬    , bar-_!", "੫൬_bar-_"), // Invalid leading, middle, & trailing chars.
+            ("#੫൬    , bar-_!", "੫൬_bar-_"),   // Invalid leading, middle, & trailing chars.
             ("One! two/_three", "One_two/_three"),
         ] {
             assert_eq!(

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -412,8 +412,8 @@ fn evolve_collection(
                 .or_insert_with(|| cap_spec.clone());
 
             for binding in new_spec.bindings.iter_mut() {
-                if &binding.target == &old_collection {
-                    binding.target = new_name.clone();
+                if binding.target.as_ref() == Some(&old_collection) {
+                    binding.target = Some(new_name.clone()).into();
                 }
             }
         }
@@ -430,7 +430,9 @@ fn evolve_collection(
 }
 
 fn has_cap_binding(spec: &models::CaptureDef, collection: &models::Collection) -> bool {
-    spec.bindings.iter().any(|b| &b.target == collection)
+    spec.bindings
+        .iter()
+        .any(|b| b.target.as_ref() == Some(collection))
 }
 
 fn has_mat_binding(spec: &models::MaterializationDef, collection: &models::Collection) -> bool {

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -21,7 +21,9 @@ pub struct EvolutionHandler;
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct EvolveRequest {
     /// The current name of the collection.
-    pub old_name: String,
+    #[serde(alias = "old_name")]
+    // alias can be removed after UI code is updated to use current_name
+    pub current_name: String,
     /// Optional new name for the collection. If provided, the collection will always
     /// be re-created, even if it uses an inferred schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,7 +104,12 @@ async fn process_row(
     // collect the requests into a map of old_name to new_name
     let collections: BTreeMap<String, Option<String>> = collections_requests
         .into_iter()
-        .map(|EvolveRequest { old_name, new_name }| (old_name, new_name))
+        .map(
+            |EvolveRequest {
+                 current_name,
+                 new_name,
+             }| (current_name, new_name),
+        )
         .collect();
 
     // Fetch all the specs from the draft that we're operating on

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution.snap
@@ -1,31 +1,29 @@
 ---
 source: crates/agent/src/evolution/test.rs
-expression: result
+expression: evolved_collections
 ---
-type: success
-evolved_collections:
-  - old_name: evolution/CollectionA
-    new_name: evolution/CollectionA_v2
-    updated_materializations:
-      - evolution/MaterializationA
-    updated_captures:
-      - evolution/CaptureA
-  - old_name: evolution/CollectionB
-    new_name: evolution/NewCollectionB
-    updated_materializations:
-      - evolution/MaterializationA
-      - evolution/MaterializationC
-    updated_captures:
-      - evolution/CaptureA
-  - old_name: evolution/CollectionC
-    new_name: evolution/CollectionC
-    updated_materializations:
-      - evolution/MaterializationB
-    updated_captures: []
-  - old_name: evolution/CollectionD
-    new_name: evolution/NewCollectionD
-    updated_materializations:
-      - evolution/MaterializationB
-    updated_captures:
-      - evolution/CaptureB
+- old_name: evolution/CollectionA
+  new_name: evolution/CollectionA_v2
+  updated_materializations:
+    - evolution/MaterializationA
+  updated_captures:
+    - evolution/CaptureA
+- old_name: evolution/CollectionB
+  new_name: evolution/NewCollectionB
+  updated_materializations:
+    - evolution/MaterializationA
+    - evolution/MaterializationC
+  updated_captures:
+    - evolution/CaptureA
+- old_name: evolution/CollectionC
+  new_name: evolution/CollectionC
+  updated_materializations:
+    - evolution/MaterializationB
+  updated_captures: []
+- old_name: evolution/CollectionD
+  new_name: evolution/NewCollectionD
+  updated_materializations:
+    - evolution/MaterializationB
+  updated_captures:
+    - evolution/CaptureB
 

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -432,7 +432,7 @@ fn to_evolutions_collections(
                 Some(crate::evolution::next_name(&ic.collection))
             };
             serde_json::to_value(crate::evolution::EvolveRequest {
-                old_name: ic.collection.clone(),
+                current_name: ic.collection.clone(),
                 new_name,
             })
             .unwrap()

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -20,6 +20,8 @@ pub enum JobStatus {
     BuildFailed {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         incompatible_collections: Vec<IncompatibleCollection>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        evolution_id: Option<Id>,
     },
     TestFailed,
     PublishFailed,
@@ -30,6 +32,7 @@ impl JobStatus {
     fn build_failed(incompatible_collections: Vec<IncompatibleCollection>) -> JobStatus {
         JobStatus::BuildFailed {
             incompatible_collections,
+            evolution_id: None,
         }
     }
 }
@@ -292,9 +295,7 @@ impl PublishHandler {
             let incompatible_collections = build_output.get_incompatible_collections();
             return stop_with_errors(
                 errors,
-                JobStatus::BuildFailed {
-                    incompatible_collections,
-                },
+                JobStatus::build_failed(incompatible_collections),
                 row,
                 txn,
             )
@@ -378,7 +379,7 @@ impl PublishHandler {
 
 async fn stop_with_errors(
     errors: Vec<Error>,
-    job_status: JobStatus,
+    mut job_status: JobStatus,
     row: Row,
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> anyhow::Result<(Id, JobStatus)> {
@@ -388,5 +389,53 @@ async fn stop_with_errors(
 
     draft::insert_errors(row.draft_id, errors, txn).await?;
 
-    Ok((row.pub_id, job_status.into()))
+    // If this is a result of a build failure, then we may need to create an evolutions job in response.
+    if let JobStatus::BuildFailed {
+        incompatible_collections,
+        evolution_id,
+    } = &mut job_status
+    {
+        if !incompatible_collections.is_empty() && row.auto_evolve {
+            let collections = to_evolutions_collections(&incompatible_collections);
+            let detail = format!(
+                "system created in response to failed publication: {}",
+                row.pub_id
+            );
+            let next_job = agent_sql::evolutions::create(
+                txn,
+                row.user_id,
+                row.draft_id,
+                collections,
+                true, // auto_publish
+                detail,
+            )
+            .await
+            .context("creating evolutions job")?;
+            *evolution_id = Some(next_job);
+        }
+    }
+
+    Ok((row.pub_id, job_status))
+}
+
+fn to_evolutions_collections(
+    incompatible_collections: &[IncompatibleCollection],
+) -> Vec<serde_json::Value> {
+    incompatible_collections
+        .iter()
+        .map(|ic| {
+            // Do we need to re-create the whole collection, or can we just re-create materialization bindings?
+            let new_name = if ic.requires_recreation.is_empty() {
+                None
+            } else {
+                tracing::debug!(reasons = ?ic.requires_recreation, collection = %ic.collection, "will attempt to re-create collection");
+                Some(crate::evolution::next_name(&ic.collection))
+            };
+            serde_json::to_value(crate::evolution::EvolveRequest {
+                old_name: ic.collection.clone(),
+                new_name,
+            })
+            .unwrap()
+        })
+        .collect()
 }

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -1,4 +1,4 @@
-use super::builds::{self, IncompatibleCollection};
+use super::builds::{self, IncompatibleCollection, ReCreateReason};
 use super::draft::Error;
 use agent_sql::publications::{ExpandedRow, SpecRow, Tenant};
 use agent_sql::{Capability, CatalogType, Id};
@@ -102,7 +102,13 @@ pub fn validate_transition(
     spec_rows: &[SpecRow],
 ) -> Result<(), (Vec<Error>, Vec<IncompatibleCollection>)> {
     let mut errors = Vec::new();
-    let mut incompatible_collections = Vec::new();
+
+    // If collection changes are deemed to be incompatible here, then it
+    // could potentially be for several reasons. Accumulate those reasons per
+    // collection, so we don't duplicate IncompatibleCollections. Note that any
+    // incompatibilities detected within this function will be issues that would
+    // require re-creating the collection.
+    let mut incompatible_collections: BTreeMap<String, Vec<ReCreateReason>> = BTreeMap::new();
 
     for spec_row @ SpecRow {
         catalog_name,
@@ -221,6 +227,13 @@ pub fn validate_transition(
                     ),
                     ..Default::default()
                 });
+            // If this is a collection spec, then we can suggest re-creating the spec with a _v2 suffix, so why not be helpful
+            if draft_type == &Some(CatalogType::Collection) {
+                let reasons = incompatible_collections
+                    .entry(catalog_name.to_string())
+                    .or_insert(Vec::new());
+                reasons.push(ReCreateReason::PrevDeletedSpec);
+            }
         }
     }
 
@@ -243,10 +256,10 @@ pub fn validate_transition(
                 ),
                 ..Default::default()
             });
-            incompatible_collections.push(IncompatibleCollection {
-                collection: catalog_name.to_string(),
-                affected_materializations: Vec::new(),
-            });
+            let reasons = incompatible_collections
+                .entry(catalog_name.to_string())
+                .or_insert(Vec::new());
+            reasons.push(ReCreateReason::KeyChange);
         }
 
         let partitions = |projections: &BTreeMap<models::Field, models::Projection>| {
@@ -279,17 +292,26 @@ pub fn validate_transition(
                 ),
                 ..Default::default()
             });
-            incompatible_collections.push(IncompatibleCollection {
-                collection: catalog_name.to_string(),
-                affected_materializations: Vec::new(),
-            });
+            let reasons = incompatible_collections
+                .entry(catalog_name.to_string())
+                .or_insert(Vec::new());
+            reasons.push(ReCreateReason::PartitionChange);
         }
     }
 
     if errors.is_empty() {
         Ok(())
     } else {
-        Err((errors, incompatible_collections))
+        let ics = incompatible_collections
+            .into_iter()
+            .map(|(collection, requires_recreation)| IncompatibleCollection {
+                collection,
+                requires_recreation,
+                affected_materializations: Vec::new(),
+            })
+            .collect();
+
+        Err((errors, ics))
     }
 }
 
@@ -918,13 +940,20 @@ mod test {
                     incompatible_collections: [
                         IncompatibleCollection {
                             collection: "compat-test/CollectionA",
+                            requires_recreation: [
+                                KeyChange,
+                            ],
                             affected_materializations: [],
                         },
                         IncompatibleCollection {
                             collection: "compat-test/CollectionB",
+                            requires_recreation: [
+                                PartitionChange,
+                            ],
                             affected_materializations: [],
                         },
                     ],
+                    evolution_id: None,
                 },
                 errors: [
                     "Cannot change key of an established collection from CompositeKey([JsonPointer(\"/foo\")]) to CompositeKey([JsonPointer(\"/new_key\")])",
@@ -983,6 +1012,7 @@ mod test {
                 draft_id: 1110000000000000,
                 status: BuildFailed {
                     incompatible_collections: [],
+                    evolution_id: None,
                 },
                 errors: [
                     "Forbidden connector image 'forbidden_connector'",
@@ -1147,6 +1177,7 @@ mod test {
                 draft_id: 1110000000000000,
                 status: BuildFailed {
                     incompatible_collections: [],
+                    evolution_id: None,
                 },
                 errors: [
                     "Request to add 1 task(s) would exceed tenant 'usageB/' quota of 2. 2 are currently in use.",
@@ -1213,6 +1244,7 @@ mod test {
                 draft_id: 1120000000000000,
                 status: BuildFailed {
                     incompatible_collections: [],
+                    evolution_id: None,
                 },
                 errors: [
                     "Request to add 1 task(s) would exceed tenant 'usageB/' quota of 2. 2 are currently in use.",

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -594,7 +594,9 @@ fn extract_spec_metadata<'a>(
             image_parts = Some(split_tag(&config.image));
 
             for binding in &capture.bindings {
-                writes_to.push(binding.target.as_ref());
+                if let Some(target) = binding.target.as_ref() {
+                    writes_to.push(target.as_ref());
+                }
             }
             writes_to.reserve(1);
         }

--- a/crates/flowctl/src/raw/discover.rs
+++ b/crates/flowctl/src/raw/discover.rs
@@ -1,14 +1,20 @@
 use anyhow::Context;
-use json::schema::{types, build::build_schema};
-use url::Url;
 use doc::{inference::Shape, SchemaIndexBuilder};
-use models::{ Catalog, CaptureDef, CaptureEndpoint, ConnectorConfig, Capture, ShardTemplate, CaptureBinding, Collection, CollectionDef, CompositeKey, JsonPointer, Schema };
-use proto_flow::{capture::{request, Request}, flow::capture_spec::ConnectorType};
+use json::schema::{build::build_schema, types};
+use models::{
+    Capture, CaptureBinding, CaptureDef, CaptureEndpoint, Catalog, Collection, CollectionDef,
+    CompositeKey, ConnectorConfig, JsonPointer, Schema, ShardTemplate,
+};
+use proto_flow::{
+    capture::{request, Request},
+    flow::capture_spec::ConnectorType,
+};
 use serde_json::{json, value::RawValue};
 use std::collections::BTreeMap;
+use url::Url;
 
-use crate::local_specs;
 use crate::connector::docker_run;
+use crate::local_specs;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
@@ -29,8 +35,22 @@ pub struct Discover {
     flat: bool,
 }
 
-pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix, overwrite, flat }: &Discover) -> anyhow::Result<()> {
-    let connector_name = image.rsplit_once('/').expect("image must include slashes").1.split_once(':').expect("image must include tag").0;
+pub async fn do_discover(
+    _ctx: &mut crate::CliContext,
+    Discover {
+        image,
+        prefix,
+        overwrite,
+        flat,
+    }: &Discover,
+) -> anyhow::Result<()> {
+    let connector_name = image
+        .rsplit_once('/')
+        .expect("image must include slashes")
+        .1
+        .split_once(':')
+        .expect("image must include tag")
+        .0;
 
     let catalog_file = format!("{connector_name}.flow.yaml");
 
@@ -39,20 +59,27 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
 
     let capture_name = format!("{prefix}/{connector_name}");
 
-    let cfg = sources.captures.first()
+    let cfg = sources
+        .captures
+        .first()
         .and_then(|c| match &c.spec.endpoint {
-            CaptureEndpoint::Connector(conn) => Some(conn.config.clone())
+            CaptureEndpoint::Connector(conn) => Some(conn.config.clone()),
         });
 
     // If config file exists, try a Discover RPC with the config file
     if let Some(config) = cfg {
-        let discover_output = docker_run(image, Request {
-            discover: Some(request::Discover {
-                connector_type: ConnectorType::Image.into(),
-                config_json: config.to_string(),
-            }),
-            ..Default::default()
-        }).await.context("connector discover")?;
+        let discover_output = docker_run(
+            image,
+            Request {
+                discover: Some(request::Discover {
+                    connector_type: ConnectorType::Image.into(),
+                    config_json: config.to_string(),
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .context("connector discover")?;
 
         let bindings = discover_output.discovered.unwrap().bindings;
 
@@ -64,30 +91,37 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
             let collection_name = format!("{prefix}/{}", binding.recommended_name);
             let collection = Collection::new(collection_name);
 
-            capture_bindings.push(
-                CaptureBinding {
-                    target: collection.clone(),
-                    resource: RawValue::from_string(binding.resource_config_json.clone())?.into(),
-                }
-            );
+            capture_bindings.push(CaptureBinding {
+                target: Some(collection.clone()).into(),
+                resource: RawValue::from_string(binding.resource_config_json.clone())?.into(),
+            });
 
-            collections.insert(collection,
+            collections.insert(
+                collection,
                 CollectionDef {
-                    schema: Some(Schema::new(RawValue::from_string(binding.document_schema_json.clone())?.into())),
+                    schema: Some(Schema::new(
+                        RawValue::from_string(binding.document_schema_json.clone())?.into(),
+                    )),
                     write_schema: None,
                     read_schema: None,
-                    key: CompositeKey::new(binding.key.iter().map(JsonPointer::new).collect::<Vec<JsonPointer>>()),
+                    key: CompositeKey::new(
+                        binding
+                            .key
+                            .iter()
+                            .map(JsonPointer::new)
+                            .collect::<Vec<JsonPointer>>(),
+                    ),
                     derive: None,
                     derivation: None,
                     projections: Default::default(),
                     journals: Default::default(),
-                }
+                },
             );
-        };
+        }
 
         let catalog = Catalog {
-            captures: BTreeMap::from([
-                (Capture::new(capture_name),
+            captures: BTreeMap::from([(
+                Capture::new(capture_name),
                 CaptureDef {
                     endpoint: CaptureEndpoint::Connector(ConnectorConfig {
                         image: image.to_string(),
@@ -96,8 +130,8 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
                     bindings: capture_bindings,
                     interval: CaptureDef::default_interval(),
                     shards: ShardTemplate::default(),
-                })
-            ]),
+                },
+            )]),
             collections,
             ..Default::default()
         };
@@ -113,19 +147,26 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
         println!("Wrote {count} specifications under {target}.");
     } else {
         // Otherwise send a Spec RPC and use that to write a sample config file
-        let spec_output = docker_run(image, Request {
-            spec: Some(request::Spec {
-                connector_type: ConnectorType::Image.into(),
-                config_json: "{}".to_string(),
-            }),
-            ..Default::default()
-        }).await?;
+        let spec_output = docker_run(
+            image,
+            Request {
+                spec: Some(request::Spec {
+                    connector_type: ConnectorType::Image.into(),
+                    config_json: "{}".to_string(),
+                }),
+                ..Default::default()
+            },
+        )
+        .await?;
 
-        let config_schema_json = serde_json::from_str::<serde_json::Value>(&spec_output.spec.unwrap().config_schema_json)?;
+        let config_schema_json = serde_json::from_str::<serde_json::Value>(
+            &spec_output.spec.unwrap().config_schema_json,
+        )?;
 
         // Run inference on the schema
         let curi = Url::parse("https://example/schema").unwrap();
-        let schema_root = build_schema(curi, &config_schema_json).context("failed to build JSON schema")?;
+        let schema_root =
+            build_schema(curi, &config_schema_json).context("failed to build JSON schema")?;
 
         let mut index = SchemaIndexBuilder::new();
         index.add(&schema_root).unwrap();
@@ -137,8 +178,8 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
         let config = schema_to_sample_json(&shape)?;
 
         let catalog = Catalog {
-            captures: BTreeMap::from([
-                (Capture::new(capture_name),
+            captures: BTreeMap::from([(
+                Capture::new(capture_name),
                 CaptureDef {
                     endpoint: CaptureEndpoint::Connector(ConnectorConfig {
                         image: image.to_string(),
@@ -147,8 +188,8 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
                     bindings: Vec::new(),
                     interval: CaptureDef::default_interval(),
                     shards: ShardTemplate::default(),
-                })
-            ]),
+                },
+            )]),
             ..Default::default()
         };
 
@@ -162,7 +203,6 @@ pub async fn do_discover(_ctx: &mut crate::CliContext, Discover { image, prefix,
         println!("Wrote {count} specifications under {target}.");
     }
 
-
     Ok(())
 }
 
@@ -172,7 +212,9 @@ fn schema_to_sample_json(schema_shape: &Shape) -> Result<serde_json::Value, anyh
 
     for (ptr, _is_pattern, shape, _exists) in locs.iter() {
         let p = doc::Pointer::from_str(ptr);
-        let v = p.create_value(&mut config).expect("structure must be valid");
+        let v = p
+            .create_value(&mut config)
+            .expect("structure must be valid");
 
         // If there is a default value for this location, use that
         if let Some((default_value, _)) = &shape.default {

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -191,7 +191,16 @@ expression: "&schema"
         },
         "target": {
           "title": "Name of the collection to capture into.",
-          "$ref": "#/definitions/Collection"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Collection"
+            },
+            {
+              "title": "Disabled binding",
+              "description": "a null target indicates that the binding is disabled and will be ignored at runtime",
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -219,6 +219,7 @@ fn walk_capture_request<'a>(
     let bindings = bindings
         .iter()
         .enumerate()
+        .filter(|(_, b)| b.target.is_some())
         .map(|(binding_index, binding)| {
             walk_capture_binding(
                 scope.push_prop("bindings").push_item(binding_index),
@@ -258,7 +259,9 @@ fn walk_capture_binding<'a>(
         scope,
         "this capture binding",
         "collection",
-        target,
+        target
+            .as_ref()
+            .expect("only enabled bindings are validated"),
         built_collections,
         |c| (&c.collection, Scope::new(&c.scope)),
         errors,

--- a/crates/validation/src/reference.rs
+++ b/crates/validation/src/reference.rs
@@ -11,7 +11,9 @@ pub fn gather_referenced_collections<'a>(
 
     for capture in captures {
         for binding in &capture.spec.bindings {
-            out.insert(&binding.target);
+            if let Some(collection) = binding.target.as_ref() {
+                out.insert(collection);
+            }
         }
     }
     for collection in collections {

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -187,7 +187,16 @@
         },
         "target": {
           "title": "Name of the collection to capture into.",
-          "$ref": "#/definitions/Collection"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Collection"
+            },
+            {
+              "title": "Disabled binding",
+              "description": "a null target indicates that the binding is disabled and will be ignored at runtime",
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/supabase/migrations/08_discovers.sql
+++ b/supabase/migrations/08_discovers.sql
@@ -7,7 +7,9 @@ create table discovers (
   connector_tag_id  flowid   not null references connector_tags(id),
   draft_id          flowid   not null references drafts(id) on delete cascade,
   endpoint_config   json_obj not null,
-  update_only       boolean  not null default false
+  update_only       boolean  not null default false,
+  auto_publish      boolean  not null default false,
+  auto_evolve       boolean  not null default false
 );
 alter table discovers enable row level security;
 alter publication supabase_realtime add table discovers;
@@ -36,3 +38,9 @@ comment on column discovers.endpoint_config is
 comment on column discovers.update_only is '
 If true, this operation will draft updates to existing bindings and their
 target collections but will not add new bindings or collections.';
+comment on column discovers.auto_publish is
+'whether to automatically publish the results of the discover, if successful';
+comment on column discovers.auto_evolve is
+'whether to automatically create an evolutions job if the automatic publication
+fails due to incompatible collection schemas. This determines the value of `auto_evolve`
+in the publications table when inserting a new row as a result of this discover.';

--- a/supabase/migrations/09_publications.sql
+++ b/supabase/migrations/09_publications.sql
@@ -8,7 +8,8 @@ create table publications (
 
   user_id   uuid references auth.users(id) not null default auth.uid(),
   draft_id  flowid not null,
-  dry_run   bool   not null default false
+  dry_run   bool   not null default false,
+  auto_evolve boolean not null default false
 );
 alter table publications enable row level security;
 alter publication supabase_realtime add table publications;
@@ -36,6 +37,9 @@ comment on column publications.draft_id is
   'Draft which is published';
 comment on column publications.dry_run is
   'A dry-run publication will test and verify a draft, but doesn''t publish into live specifications';
+comment on column publications.auto_evolve is
+  'Whether to automatically handle schema evolution if the publication fails due to incompatible collections.
+  If true, then an evolutions job will be created automatically if needed, and the results will be published again.';
 
 
 -- Live (current) specifications of the catalog.

--- a/supabase/migrations/19_evolutions.sql
+++ b/supabase/migrations/19_evolutions.sql
@@ -7,7 +7,8 @@ create table evolutions (
 
   user_id   uuid references auth.users(id) not null default auth.uid(),
   draft_id  flowid not null,
-  collections json not null  check (json_typeof(collections) = 'array')
+  collections json not null  check (json_typeof(collections) = 'array'),
+  auto_publish boolean not null default false
 );
 
 comment on table evolutions is
@@ -22,6 +23,8 @@ comment on column evolutions.collections is
   '{"old_name": "acmeCo/foo", "new_name": "acmeCo/foo_v2"}.'
   'Note that the old_name of each collection must identify a draft_spec of the '
   'given draft_id';
+comment on column evolutions.auto_publish is
+  'whether to automatically publish the results of the evolution, if successful';
 
 alter table evolutions enable row level security;
 alter publication supabase_realtime add table evolutions;


### PR DESCRIPTION
**Description:**

This rolls up a significant, but incomplete subset of the implementation for automatic propagation of schema changes (#1063). As of this PR, there are no user-visible changes.
The catalog models updates are being deferred until a subsequent PR, since those are only necessary for the automation of periodic re-discovers.

This implements everything that's needed in order to automatically publish the results of (re-)discovery, including automatically evolving drafts in response to incompatible collection changes. Individual commit messages have more details.

@travjenkins @kiahna-tucker there's a few different bits of UI work that get unblocked once this is merged. First is changing the captures editor to disable capture bindings instead of removing them when a user deselects the binding in the UI.

The other UI impact here is introduced in https://github.com/estuary/flow/commit/788ac651bd8f749800b2901b217b871f4decd788 and it explained in that commit message.

**Workflow steps:**

- start with a catalog having at least one capture and materialization
- make a change to the source system such that a re-discovered captured collection will differ from the live collection
- create a `discovers` row with `auto_publish` (and optionally `auto_evolve`) set to `true`

The expected behavior would be for the new discover output to be automatically published. And if the publication fails due to incompatible collections, then the draft should automatically be evolved and re-published.

**Documentation links affected:**

Still working on docs for this.

**Notes for reviewers:**

There's still more work that's pending for this, which wasn't quite ready to get across the finish line. A subsequent PR will introduce:

- `models::Catalog` changes to add `autoDiscover` and `sourceCapture` to captures and materializations respectively
- a `pg_cron` job for creating discovers jobs periodically
- continuous schema inference, and the ability to trigger `discovers` in response to validation errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1077)
<!-- Reviewable:end -->
