### PR TITLE
feature: Add CI for docs PRs

### DIFF
--- a/.github/workflows/docs-ci-previews.yaml
+++ b/.github/workflows/docs-ci-previews.yaml
@@ -1,0 +1,39 @@
+# .github/workflows/preview.yml
+name: "docs.estuary.dev: Deploy PR previews"
+
+on:
+  pull_request:
+    paths:
+      - site/**
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: ./site/package-lock.json
+      - name: Install dependencies
+        working-directory: ./site
+        run: npm ci
+      - name: Build `docs.estuary.dev`
+        working-directory: ./site
+        run: npm run build
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/build/

--- a/.github/workflows/docs-ci-prod.yaml
+++ b/.github/workflows/docs-ci-prod.yaml
@@ -1,0 +1,38 @@
+# .github/workflows/preview.yml
+name: "docs.estuary.dev: Deploy"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - site/**
+
+concurrency: docs-${{ github.ref }}
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: ./site/package-lock.json
+      - name: Install dependencies
+        working-directory: ./site
+        run: npm ci
+      - name: Build `docs.estuary.dev`
+        working-directory: ./site
+        run: npm run build
+      - name: Deploy preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          # Don't delete preview deploys
+          clean-exclude: pr-preview/
+          force: false
+          folder: ./site/build/


### PR DESCRIPTION
**Description:**

Add CI for https://docs.estuary.dev:
* PRs that update docs will get a link to a review deploy that gets torn down on merge
* Pushes to `master` that change the `site` folder will get automatically built and deployed to the main docs site


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1081)
<!-- Reviewable:end -->
