### PR TITLE
parser: log error details in the message when exiting with an error

### DIFF
--- a/crates/parser/src/main.rs
+++ b/crates/parser/src/main.rs
@@ -1,10 +1,10 @@
+use clap::Parser;
 use parser::{parse, Input, ParseConfig};
 use std::fs::File;
 use std::io;
 use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 use std::os::unix::io::FromRawFd;
-use clap::Parser;
 
 /// parser is a program that parses a variety of formats and emits records in jsonl format.
 /// Data can be passed either as a
@@ -142,7 +142,9 @@ where
             Ok(t) => t,
             Err(e) => {
                 tracing::debug!(error_details = ?e, message);
-                tracing::error!(error = %e, message);
+                // These logs are user-facing error messages, so the message should include details
+                // about the error.
+                tracing::error!("{}: {}", message, e);
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
**Description:**

The actual `message` is what gets picked up as the shard failure reason when a connector fails, and with https://github.com/estuary/connectors/pull/762 this will be logged from the parser when a connector fails due to a parsing error. This changes the logged `message` to include the error details.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1084)
<!-- Reviewable:end -->
