### PR TITLE
agent: add built spec and validate response to control plane db

### DIFF
--- a/crates/agent-sql/tests/snapshots/publications__publication_data_operations-4.snap
+++ b/crates/agent-sql/tests/snapshots/publications__publication_data_operations-4.snap
@@ -4,6 +4,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
 ---
 [
   {
+    "built_spec": null,
     "catalog_name": "aliceCo/First/Thing",
     "connector_image_name": "an/image",
     "connector_image_tag": "a-tag",
@@ -24,6 +25,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
     ]
   },
   {
+    "built_spec": null,
     "catalog_name": "aliceCo/New/Thing",
     "connector_image_name": "an/image",
     "connector_image_tag": "a-tag",
@@ -44,6 +46,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
     ]
   },
   {
+    "built_spec": null,
     "catalog_name": "aliceCo/Second/Thing",
     "connector_image_name": "an/image",
     "connector_image_tag": "a-tag",
@@ -64,6 +67,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
     ]
   },
   {
+    "built_spec": null,
     "catalog_name": "aliceCo/Test/Fixture",
     "connector_image_name": "an/image",
     "connector_image_tag": "a-tag",
@@ -84,6 +88,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
     ]
   },
   {
+    "built_spec": null,
     "catalog_name": "aliceCo/Unrelated/Thing",
     "connector_image_name": null,
     "connector_image_tag": null,
@@ -100,6 +105,7 @@ expression: "flows.iter().map(|r| -> serde_json::Value { r.get(0) }).collect::<V
     "writes_to": null
   },
   {
+    "built_spec": null,
     "catalog_name": "otherCo/Not/AliceCo",
     "connector_image_name": "an/image",
     "connector_image_tag": "a-tag",

--- a/supabase/migrations/07_drafts.sql
+++ b/supabase/migrations/07_drafts.sql
@@ -60,6 +60,8 @@ create table draft_specs (
   expect_pub_id   flowid default null,
   spec            json,
   spec_type       catalog_spec_type,
+  built_spec      json,
+  validated       json,
 
   constraint "spec and spec_type must be consistent" check (
     json_typeof(spec) is distinct from 'null' and (spec is null) = (spec_type is null)
@@ -105,3 +107,7 @@ and the specification will be deleted when this draft is published.
 ';
 comment on column draft_specs.spec_type is
   'Type of this draft catalog specification';
+comment on column draft_specs.built_spec is
+  'Built specification for this catalog';
+comment on column draft_specs.validated is
+  'Serialized response from the connector Validate RPC as populated by a dry run of this draft specification';

--- a/supabase/migrations/09_publications.sql
+++ b/supabase/migrations/09_publications.sql
@@ -53,6 +53,7 @@ create table live_specs (
   spec                  json,
   spec_type             catalog_spec_type,
   writes_to             text[],
+  built_spec            json,
   -- JSON specs are encoded into the database with leading spaces which must be trimmed to compute
   -- an accurate md5.
   md5                   text generated always as (md5(trim(spec::text))) stored,
@@ -110,6 +111,8 @@ List of collections written by this catalog task specification,
 or NULL if not applicable to this specification type.
 These adjacencies are also indexed within `live_spec_flows`.
 ';
+comment on column live_specs.built_spec is
+  'Built specification for this catalog';
 
 
 -- Data-flows between live specifications.

--- a/supabase/pending/built_specs.sql
+++ b/supabase/pending/built_specs.sql
@@ -1,0 +1,79 @@
+begin;
+
+alter table live_specs add column built_spec json;
+comment on column live_specs.built_spec is
+  'Built specification for this catalog';
+
+alter table draft_specs add column built_spec json;
+alter table draft_specs add column validated json;
+comment on column draft_specs.built_spec is
+  'Built specification for this catalog';
+comment on column draft_specs.validated is
+  'Serialized response from the connector Validate RPC as populated by a dry run of this draft specification';
+
+-- The live_specs_ext and draft_specs_ext views must be dropped & re-created to include their new
+-- columns (built_spec for live_specs_ext; built_spec & validated for draft_specs_ext) since these
+-- columns are included in the views from their "base" table through the "*" part of select l.*/d.*
+
+drop view draft_specs_ext;
+drop view live_specs_ext;
+
+-- Below here (down to the "commit;") is copied verbatim from 10_spec_ext.sql for creating the
+-- live_specs_ext & draft_specs_ext view.
+
+-- Extended view of live catalog specifications.
+create view live_specs_ext as
+select
+  l.*,
+  c.external_url as connector_external_url,
+  c.id as connector_id,
+  c.title as connector_title,
+  c.short_description as connector_short_description,
+  c.logo_url as connector_logo_url,
+  c.recommended as connector_recommended,
+  t.id as connector_tag_id,
+  t.documentation_url as connector_tag_documentation_url,
+  p.detail as last_pub_detail,
+  p.user_id as last_pub_user_id,
+  u.avatar_url as last_pub_user_avatar_url,
+  u.email as last_pub_user_email,
+  u.full_name as last_pub_user_full_name
+from live_specs l
+left outer join publication_specs p on l.id = p.live_spec_id and l.last_pub_id = p.pub_id
+left outer join connectors c on c.image_name = l.connector_image_name
+left outer join connector_tags t on c.id = t.connector_id and l.connector_image_tag = t.image_tag
+left outer join internal.user_profiles u on u.user_id = p.user_id
+where l.id in (
+  -- User must admin catalog_name. Compare to select RLS policy.
+  select l.id from auth_roles('read') r, live_specs l
+    where l.catalog_name ^@ r.role_prefix
+)
+;
+-- live_specs_ext includes its own authorization checks.
+grant select on live_specs_ext to authenticated;
+
+comment on view live_specs_ext is
+  'View of `live_specs` extended with metadata of its last publication';
+
+-- Extended view of user draft specifications.
+create view draft_specs_ext as
+select
+  d.*,
+  l.last_pub_detail,
+  l.last_pub_id,
+  l.last_pub_user_id,
+  l.last_pub_user_avatar_url,
+  l.last_pub_user_email,
+  l.last_pub_user_full_name,
+  l.spec as live_spec,
+  l.spec_type as live_spec_type
+from draft_specs d
+left outer join live_specs_ext l
+  on d.catalog_name = l.catalog_name
+;
+alter view draft_specs_ext owner to authenticated;
+
+comment on view draft_specs_ext is
+  'View of `draft_specs` extended with metadata of its live specification';
+
+commit;

--- a/supabase/pending/remove_ops_grants.sql
+++ b/supabase/pending/remove_ops_grants.sql
@@ -1,1 +1,0 @@
-delete from role_grants where object_role like 'ops/%/';


### PR DESCRIPTION
**Description:**

As part of a publication the agent will add the built spec to the `live_specs` table.

If the publication is a dry run, the agent will add the built spec and the validated response to the `draft_specs` table for further use in the publication authoring process.

I tested this manually by:
- Start up a local stack on the current main branch (without this change)
- Create a few tasks - they don't have built spec/validated data saved
- Apply the pending migrations in this PR to the local stack supabase
- Re-build the agent from this PR and re-start it
- Create new tasks - now they have built spec & validated data saved to the local stack supabase for their drafts and live specs

**Workflow steps:**

Create publications and the additional columns are populated in the control plane database

**Documentation links affected:**

N/A

**Notes for reviewers:**

I experimented a little bit with automated tests for this. The `PublishHandler` currently has a `test_run` flag that is used for other automated tests, but that [ends the processing](https://github.com/estuary/flow/blob/6c131c6830d4a848cd67155ea8e187a6c6a2a51f/crates/agent/src/publications.rs#L269-L271) prior to actually running the build so we wouldn't be able to test anything happening in this PR with that. Maybe this could be re-worked to take some kind of mock build output instead but I did not pursue that very far since it seemed like it would add more complexity than it was worth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1085)
<!-- Reviewable:end -->
