### PR TITLE
fix: Adjacent log lines updates

### DIFF
--- a/ops-catalog/task-failures.flow.yaml
+++ b/ops-catalog/task-failures.flow.yaml
@@ -37,6 +37,18 @@ collections:
               INSERT INTO related_log_lines_2 SELECT * from related_log_lines;
               DROP TABLE related_log_lines;
               ALTER TABLE related_log_lines_2 RENAME TO related_log_lines;
+            - |
+              -- Remove unique constraint on shard+message
+              CREATE TABLE related_log_lines_2 (
+                shard TEXT,
+                ts TEXT,
+                level TEXT,
+                message TEXT,
+                PRIMARY KEY (shard,ts)
+              );
+              INSERT INTO related_log_lines_2 SELECT * from related_log_lines;
+              DROP TABLE related_log_lines;
+              ALTER TABLE related_log_lines_2 RENAME TO related_log_lines;
 
       transforms:
         - name: notifyAboutTaskFailures


### PR DESCRIPTION
* Remove unhelpful unique constraint on log line that was preventing faithful log reproduction
* Show all log lines, not just `error` or `warn`
* Sort adjacent log lines by timestamp so they're presented in order

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1088)
<!-- Reviewable:end -->
