### PR TITLE
materialize: export load and store iterator total field

### DIFF
--- a/go/protocols/materialize/lifecycle.go
+++ b/go/protocols/materialize/lifecycle.go
@@ -152,11 +152,11 @@ type LoadIterator struct {
 	Binding   int         // Binding index of this document to load.
 	Key       tuple.Tuple // Key of the document to load.
 	PackedKey []byte      // PackedKey of the document to load.
+	Total     int         // Total number of iterated keys.
 
 	stream      RequestRx
 	request     *Request        // Request read into.
 	awaitDoneCh <-chan struct{} // Signaled when last commit acknowledgment has completed.
-	total       int             // Total number of iterated keys.
 	err         error           // Terminal error.
 }
 
@@ -187,7 +187,7 @@ func (it *LoadIterator) Next() bool {
 
 	// Read next `Load` request from `stream`.
 	if err := recv(it.stream, it.request); err == io.EOF {
-		if it.total != 0 {
+		if it.Total != 0 {
 			it.err = fmt.Errorf("unexpected EOF when there are loaded keys")
 		} else {
 			it.err = io.EOF // Clean shutdown.
@@ -221,7 +221,7 @@ func (it *LoadIterator) Next() bool {
 		return false
 	}
 
-	it.total++
+	it.Total++
 	return true
 }
 
@@ -247,10 +247,10 @@ type StoreIterator struct {
 	PackedKey []byte          // PackedKey of the document to store.
 	RawJSON   json.RawMessage // Document to store.
 	Values    tuple.Tuple     // Values of the document to store.
+	Total     int             // Total number of iterated stores.
 
 	stream  RequestRx
 	request *Request // Request read into.
-	total   int      // Total number of iterated stores.
 	err     error    // Terminal error.
 }
 
@@ -295,7 +295,7 @@ func (it *StoreIterator) Next() bool {
 	it.RawJSON = s.DocJson
 	it.Exists = s.Exists
 
-	it.total++
+	it.Total++
 	return true
 }
 

--- a/go/protocols/materialize/transactor.go
+++ b/go/protocols/materialize/transactor.go
@@ -166,7 +166,7 @@ func RunTransactions(
 		defer func() {
 			logrus.WithFields(logrus.Fields{
 				"round":  round,
-				"total":  it.total,
+				"total":  it.Total,
 				"loaded": loaded,
 				"error":  __out,
 			}).Debug("load finished")
@@ -264,7 +264,7 @@ func RunTransactions(
 		if err != nil {
 			return fmt.Errorf("transactor.Store: %w", err)
 		}
-		logrus.WithFields(logrus.Fields{"round": round, "stored": storeIt.total}).Debug("Store finished")
+		logrus.WithFields(logrus.Fields{"round": round, "stored": storeIt.Total}).Debug("Store finished")
 
 		var runtimeCheckpoint *pc.Checkpoint
 		if runtimeCheckpoint, err = ReadStartCommit(&rxRequest); err != nil {


### PR DESCRIPTION
**Description:**

Export the `Total` field on `StoreIterator` and `LoadIterator`.  From `StoreIterator` this is useful for materializations implementing a transaction delay where the delay may not be applied if a large number of documents were stored in this transaction, which would be indicative of an on-going backfill (see https://github.com/estuary/connectors/pull/774). `LoadIterator` doesn't have an immediate use but it seems like it might be handy to have exported too.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1091)
<!-- Reviewable:end -->
