### PR TITLE
flowctl: raw suggest-schema command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "bytelines"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784face321c535fcd9a1456632fa720aa53ea0640b57341d961c8c09de2da59f"
+dependencies = [
+ "futures",
+ "tokio",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1478,7 @@ dependencies = [
  "assert_cmd",
  "async-process",
  "base64 0.13.1",
+ "bytelines",
  "bytes",
  "clap 3.2.24",
  "comfy-table",
@@ -1517,6 +1528,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid 1.3.1",
  "validation",
  "walkdir",
@@ -5098,6 +5110,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ shared_child = "1.0.0"
 unicode-bom = "1.1"
 unicode-normalization = "0.1"
 url = { version = "2.2", features = ["serde"] }
+urlencoding = { version = "2.1.2" }
 uuid = { version = "1.1", features = ["serde", "v4"] }
 validator = { version = "0.15", features = ["derive"] }
 quickcheck = "1.0"

--- a/crates/doc/src/validation.rs
+++ b/crates/doc/src/validation.rs
@@ -194,7 +194,7 @@ impl<'schema, 'doc, 'tmp, N: AsNode> Validation<'schema, 'doc, 'tmp, N> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FailedValidation {
     pub basic_output: serde_json::Value,
     pub document: serde_json::Value,

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -30,6 +30,7 @@ tables = { path = "../tables", features = ["persist"] }
 validation = { path = "../validation" }
 async-process = { path = "../async-process" }
 locate-bin = { path = "../locate-bin" }
+bytelines = { workspace = true }
 
 anyhow = { workspace = true }
 base64 = { workspace = true }
@@ -70,6 +71,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }
 uuid = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -12,7 +12,7 @@ use crate::output::{to_table_row, CliOutput, JsonCell};
 use self::read::{get_collection_inferred_schema, ReadArgs, SchemaInferenceArgs};
 
 /// Selector of collection journals, which is used for reads, journal and fragment listings, etc.
-#[derive(clap::Args, Debug, Clone)]
+#[derive(clap::Args, Default, Debug, Clone)]
 pub struct CollectionJournalSelector {
     /// The full name of the Flow collection
     #[clap(long)]

--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -6,6 +6,7 @@ use std::io::{self, Write};
 mod capture;
 mod discover;
 mod materialize_fixture;
+mod suggest_schema;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
@@ -48,6 +49,8 @@ pub enum Command {
     Discover(discover::Discover),
     /// Run a capture connector and combine its documents
     Capture(capture::Capture),
+    /// Suggest a schema that would alleviate document schema violations of a specific collection
+    SuggestSchema(suggest_schema::SuggestSchema),
 }
 
 #[derive(Debug, clap::Args)]
@@ -126,6 +129,7 @@ impl Advanced {
             }
             Command::Discover(args) => discover::do_discover(ctx, args).await,
             Command::Capture(args) => capture::do_capture(ctx, args).await,
+            Command::SuggestSchema(args) => suggest_schema::do_suggest_schema(ctx, args).await,
         }
     }
 }

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -27,8 +27,15 @@ use crate::{connector::docker_run, catalog::{fetch_live_specs, List, SpecTypeSel
 use crate::local_specs;
 use anyhow::anyhow;
 
-/// Read data from a collection, and the corresponding task ops logs (specifically document schema
-/// violation logs), and run schema inference on all documents of the collection as well as the
+/// With some of our captures, we have an existing document schema for their collections, but we
+/// frequently run into issues with these document schemas: they are sometimes completely wrong
+/// about type of a field, or sometimes they are too narrow about the type (e.g. a value is marked
+/// as "integer", but it is actually "number"), other times they are missing some fields that are
+/// being captured into the collection.
+///
+/// This tool is built for the purpose of helping with updating the schema of these collections, by
+/// reading data from a collection, and the corresponding task ops logs (specifically document schema
+/// violation logs), and running schema inference on all documents of the collection as well as the
 /// documents that violated the existing schema, to come up with a new schema that will allow those
 /// documents to pass validation. The schema inference run starts with the existing task schema as
 /// its starting point, and widens that schema to allow the invalid documents to pass validation.

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -74,9 +74,7 @@ pub async fn do_suggest_schema(
             },
             type_selector: SpecTypeSelector {
                 collections: Some(true),
-                captures: Some(false),
-                materializations: Some(false),
-                tests: Some(false),
+                ..Default::default()
             },
             deleted: false, // deleted specs have nothing to pull
         },

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -36,6 +36,11 @@ use anyhow::anyhow;
 /// The reason for including all documents from the collection is that the task's existing schema
 /// may be missing some fields, and we want to also be able to extend the existing schema with
 /// these missing fields.
+///
+/// The outputs of this command are two files: the original schema of the collection, and the new,
+/// suggested schema of the collection. There is also a diff run on the two files automatically by
+/// the command to help recognise the differences between them. This command is meant to be used by
+/// a user to come up with a good JSON Merge Patch for the collection.
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct SuggestSchema {
@@ -138,6 +143,8 @@ pub async fn do_suggest_schema(
     let mut inferred_shape = raw_schema_to_shape(&schema_model)?;
 
     // Create a JSONSchema object from the original schema so we can use it to run a diff later
+    // The reason for this is that this allows us to have JSONSchema outputs that have a similar
+    // structure, allowing us to do a more intuitive diff
     let original_jsonschema = SchemaBuilder::new(inferred_shape.clone()).root_schema();
 
     loop {

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -1,0 +1,222 @@
+use anyhow::Context;
+use bytes::Bytes;
+use doc::{inference::Shape, SchemaIndexBuilder, FailedValidation};
+use futures::{TryStreamExt, StreamExt};
+use journal_client::{broker, read::uncommitted::{ReadUntil, ReadStart, JournalRead, ExponentialBackoff, Reader}, list::list_journals, AuthHeader};
+use json::schema::{build::build_schema, types};
+use models::{
+    Capture, CaptureBinding, CaptureDef, CaptureEndpoint, Catalog, Collection, CollectionDef,
+    CompositeKey, ConnectorConfig, JsonPointer, Schema, ShardTemplate,
+};
+use proto_flow::{
+    capture::{request, Request},
+    flow::capture_spec::ConnectorType,
+    ops::Log
+};
+use bytelines::AsyncByteLines;
+use proto_grpc::broker::journal_client::JournalClient;
+use schema_inference::{json_decoder::JsonCodec, inference::infer_shape, shape, server::InferenceError, schema::SchemaBuilder};
+use serde_json::{json, value::RawValue, Value};
+use tokio::io::{BufReader, AsyncReadExt};
+use tokio_util::{compat::FuturesAsyncReadCompatExt, io::{ReaderStream, StreamReader}, codec::FramedRead};
+use tonic::{codegen::InterceptedService, transport::Channel};
+use std::{collections::BTreeMap, io::ErrorKind, time::{Duration, Instant}};
+use url::Url;
+
+use crate::{connector::docker_run, catalog::{fetch_live_specs, List, SpecTypeSelector, NameSelector, collect_specs}, dataplane::{self, fetch_data_plane_access_token}};
+use crate::local_specs;
+use anyhow::anyhow;
+
+#[derive(Debug, clap::Args)]
+#[clap(rename_all = "kebab-case")]
+pub struct SuggestSchema {
+    /// Collection name
+    #[clap(long)]
+    collection: String,
+
+    /// Task name
+    #[clap(long)]
+    task: String,
+}
+
+pub async fn do_suggest_schema(
+    ctx: &mut crate::CliContext,
+    SuggestSchema {
+        collection,
+        task,
+    }: &SuggestSchema,
+) -> anyhow::Result<()> {
+    let client = ctx.controlplane_client().await?;
+    // Retrieve identified live specifications.
+    let live_specs = fetch_live_specs(
+        client.clone(),
+        &List {
+            flows: true,
+            name_selector: NameSelector {
+                name: vec![collection.clone()],
+                prefix: Vec::new()
+            },
+            type_selector: SpecTypeSelector {
+                collections: Some(true),
+                captures: Some(false),
+                materializations: Some(false),
+                tests: Some(false),
+            },
+            deleted: false, // deleted specs have nothing to pull
+        },
+        vec![
+            "catalog_name",
+            "id",
+            "updated_at",
+            "last_pub_user_email",
+            "last_pub_user_full_name",
+            "last_pub_user_id",
+            "spec_type",
+            "spec",
+        ],
+    )
+    .await?;
+
+    let (key, collection_def) = collect_specs(live_specs)?.collections.pop_first().ok_or(anyhow!("could not find collection"))?;
+
+    let mut data_plane_client =
+        dataplane::journal_client_for(client, vec![collection.clone()]).await?;
+
+    // Reader for the collection itself
+    let selector = broker::LabelSelector {
+        include: Some(broker::LabelSet { labels: vec![broker::Label{
+            name: labels::COLLECTION.to_string(),
+            value: collection.clone(),
+        }]}),
+        exclude: None,
+    };
+    let reader = journal_reader(&mut data_plane_client, &selector).await?;
+
+    // Reader for the ops log of the task
+    let ops_collection = "ops.us-central1.v1/logs".to_string();
+    let selector = broker::LabelSelector {
+        include: Some(broker::LabelSet {
+            labels: vec![
+                broker::Label {
+                    name: labels::COLLECTION.to_string(),
+                    value: ops_collection.clone(),
+                }, broker::Label {
+                    name: format!("{}kind", labels::FIELD_PREFIX),
+                    value: "capture".to_string(),
+                }, broker::Label {
+                    name: format!("{}name", labels::FIELD_PREFIX),
+                    value: urlencoding::encode(task).into_owned(),
+                }]
+        }),
+        exclude: None,
+    };
+
+    let client = ctx.controlplane_client().await?;
+    let mut data_plane_client =
+        dataplane::journal_client_for(client, vec![ops_collection]).await?;
+    let log_reader = journal_reader(&mut data_plane_client, &selector).await?;
+    let mut log_stream = AsyncByteLines::new(BufReader::new(log_reader.compat())).into_stream();
+    let mut log_invalid_documents = log_stream.try_filter_map(|log| async move {
+        let parsed: Log = serde_json::from_slice(&log)?;
+        if parsed.message != "document failed validation against its collection JSON Schema" {
+            return Ok(None);
+        }
+
+        let error_string = &parsed.fields_json_map.get("error").ok_or(std::io::Error::new(ErrorKind::Other, "could not get 'error' field of ops log"))?;
+        let mut err: Vec<serde_json::Value> = serde_json::from_str(error_string)?;
+        let err_object = err.pop().ok_or(std::io::Error::new(ErrorKind::Other, "could not get second element of 'error' field in ops log"))?;
+        let failed_validation: FailedValidation = serde_json::from_value(err_object)?;
+
+        let buf: Bytes = serde_json::to_vec(&failed_validation.document)?.into();
+        return Ok(Some(buf));
+    });
+
+    let mut log_invalid_documents_reader = StreamReader::new(Box::pin(log_invalid_documents));
+
+    let codec = JsonCodec::new(); // do we want to limit length here? LinesCodec::new_with_max_length(...) does this
+    let mut doc_bytes_stream = FramedRead::new(FuturesAsyncReadCompatExt::compat(reader).chain(log_invalid_documents_reader), codec);
+
+    let schema_model = collection_def.schema.unwrap();
+
+    let mut accumulator = raw_schema_to_shape(&schema_model)?;
+    let original_schema_final = SchemaBuilder::new(accumulator.clone()).root_schema();
+
+    loop {
+        match doc_bytes_stream.next().await {
+            Some(Ok(doc_val)) => {
+                let parsed: Value = doc_val;
+                // There should probably be a higher-level API for this in `journal-client`
+
+                if parsed.pointer("/_meta/ack").is_none() {
+                    let inferred_shape = infer_shape(&parsed);
+
+                    accumulator = shape::merge(accumulator, inferred_shape)
+                }
+            }
+            Some(Err(e)) => return Err(InferenceError::from(e).into()),
+            None => break
+        }
+    }
+
+    let new_schema = serde_json::to_value(&SchemaBuilder::new(accumulator).root_schema())?;
+
+    std::fs::write("original.schema.json", serde_json::to_string_pretty(&original_schema_final)?)?;
+    std::fs::write("new.schema.json", serde_json::to_string_pretty(&new_schema)?)?;
+
+    eprintln!("Wrote original.schema.json and new.schema.json.");
+
+    std::process::Command::new("git")
+        .args(["diff", "--no-index", "original.schema.json", "new.schema.json"])
+        .status()
+        .expect("git diff failed");
+
+    Ok(())
+}
+
+fn raw_schema_to_shape(schema: &Schema) -> anyhow::Result<Shape> {
+    let value = serde_json::to_value(&schema)?;
+    let mut index = SchemaIndexBuilder::new();
+    let curi = Url::parse("https://example/schema").unwrap();
+    let root = build_schema(curi, &value)?;
+    index.add(&root).unwrap();
+    index.verify_references().unwrap();
+    let index = index.into_index();
+
+    return Ok(Shape::infer(&root, &index))
+}
+
+async fn journal_reader(
+    mut data_plane_client: &mut JournalClient<InterceptedService<Channel, AuthHeader>>,
+    selector: &broker::LabelSelector
+) -> anyhow::Result<Reader<ExponentialBackoff>> {
+    tracing::debug!(?selector, "journal label selector");
+
+    let mut journals = list_journals(&mut data_plane_client, &selector)
+        .await
+        .context("listing journals for collection read")?;
+    tracing::debug!(journal_count = journals.len(), selector = ?selector, "listed journals");
+    let maybe_journal = journals.pop();
+    if !journals.is_empty() {
+        // TODO: implement a sequencer and allow reading from multiple journals
+        anyhow::bail!("flowctl is not yet able to read from partitioned collections (coming soon)");
+    }
+
+    let journal = maybe_journal.ok_or_else(|| {
+        anyhow::anyhow!(
+            "collection '{:#?}' does not exist or has never been written to (it has no journals)",
+            selector
+        )
+    })?;
+
+    let read = JournalRead::new(journal.name.clone())
+        .starting_at(ReadStart::Offset(0))
+        .read_until(ReadUntil::WriteHead);
+
+    tracing::debug!(journal = %journal.name, "starting read of journal");
+
+    // It would seem unusual for a CLI to retry indefinitely, so limit the number of retries.
+    let backoff = ExponentialBackoff::new(5);
+    let reader = Reader::start_read(data_plane_client.clone(), read, backoff);
+
+    return Ok(reader);
+}

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -23,7 +23,7 @@ use tonic::{codegen::InterceptedService, transport::Channel};
 use std::{collections::BTreeMap, io::ErrorKind, time::{Duration, Instant}};
 use url::Url;
 
-use crate::{connector::docker_run, catalog::{fetch_live_specs, List, SpecTypeSelector, NameSelector, collect_specs}, dataplane::{self, fetch_data_plane_access_token}, collection::{CollectionJournalSelector, Partition}};
+use crate::{connector::docker_run, catalog::{fetch_live_specs, List, SpecTypeSelector, NameSelector, collect_specs}, dataplane::{self, fetch_data_plane_access_token}, collection::{CollectionJournalSelector, Partition, read::{journal_reader, ReadArgs}}};
 use crate::local_specs;
 use anyhow::anyhow;
 
@@ -102,8 +102,11 @@ pub async fn do_suggest_schema(
     let selector = CollectionJournalSelector {
         collection: collection.clone(),
         ..Default::default()
-    }.build_label_selector();
-    let reader = journal_reader(&mut data_plane_client, &selector).await?;
+    };
+    let reader = journal_reader(ctx, &ReadArgs {
+        selector,
+        ..Default::default()
+    }).await?;
 
     // Reader for the ops log of the task
     let ops_collection = "ops.us-central1.v1/logs".to_string();
@@ -117,14 +120,13 @@ pub async fn do_suggest_schema(
             value: "capture".to_string(),
         }],
         ..Default::default()
-    }.build_label_selector();
-
-    let client = ctx.controlplane_client().await?;
-    let mut data_plane_client =
-        dataplane::journal_client_for(client, vec![ops_collection]).await?;
+    };
 
     // Read log lines from the logs collection and filter "failed validation" documents
-    let log_reader = journal_reader(&mut data_plane_client, &selector).await?;
+    let log_reader = journal_reader(ctx, &ReadArgs {
+        selector,
+        ..Default::default()
+    }).await?;
     let mut log_stream = AsyncByteLines::new(BufReader::new(log_reader.compat())).into_stream();
     let mut log_invalid_documents = log_stream.try_filter_map(|log| async move {
         let parsed: Log = serde_json::from_slice(&log)?;
@@ -202,40 +204,4 @@ fn raw_schema_to_shape(schema: &Schema) -> anyhow::Result<Shape> {
 
 fn to_io_error<T: ToString>(message: T) -> std::io::Error {
     std::io::Error::new(ErrorKind::Other, message.to_string())
-}
-
-async fn journal_reader(
-    mut data_plane_client: &mut JournalClient<InterceptedService<Channel, AuthHeader>>,
-    selector: &broker::LabelSelector
-) -> anyhow::Result<Reader<ExponentialBackoff>> {
-    tracing::debug!(?selector, "journal label selector");
-
-    let mut journals = list_journals(&mut data_plane_client, &selector)
-        .await
-        .context("listing journals for collection read")?;
-    tracing::debug!(journal_count = journals.len(), selector = ?selector, "listed journals");
-    let maybe_journal = journals.pop();
-    if !journals.is_empty() {
-        // TODO: implement a sequencer and allow reading from multiple journals
-        anyhow::bail!("flowctl is not yet able to read from partitioned collections (coming soon)");
-    }
-
-    let journal = maybe_journal.ok_or_else(|| {
-        anyhow::anyhow!(
-            "collection '{:#?}' does not exist or has never been written to (it has no journals)",
-            selector
-        )
-    })?;
-
-    let read = JournalRead::new(journal.name.clone())
-        .starting_at(ReadStart::Offset(0))
-        .read_until(ReadUntil::WriteHead);
-
-    tracing::debug!(journal = %journal.name, "starting read of journal");
-
-    // It would seem unusual for a CLI to retry indefinitely, so limit the number of retries.
-    let backoff = ExponentialBackoff::new(5);
-    let reader = Reader::start_read(data_plane_client.clone(), read, backoff);
-
-    return Ok(reader);
 }

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -164,8 +164,9 @@ pub async fn do_suggest_schema(
     // Build a new JSONSchema from the updated inferred shape
     let new_jsonschema = SchemaBuilder::new(inferred_shape).root_schema();
 
-    std::fs::write("original.schema.json", serde_json::to_string_pretty(&original_jsonschema)?)?;
-    std::fs::write("new.schema.json", serde_json::to_string_pretty(&new_jsonschema)?)?;
+    let collection_name = collection.split("/").last().unwrap();
+    std::fs::write(format!("{collection_name}.original.schema.json"), serde_json::to_string_pretty(&original_jsonschema)?)?;
+    std::fs::write(format!("{collection_name}.new.schema.json"), serde_json::to_string_pretty(&new_jsonschema)?)?;
 
     eprintln!("Wrote original.schema.json and new.schema.json.");
 

--- a/crates/schema-inference/src/server.rs
+++ b/crates/schema-inference/src/server.rs
@@ -35,7 +35,7 @@ use warp::reply::Response;
 use warp::{Filter, Reply};
 
 #[derive(Error, Debug)]
-enum InferenceError {
+pub enum InferenceError {
     #[error(transparent)]
     ConnectionError(#[from] ConnectError),
     #[error("No documents found, cannot infer shape")]


### PR DESCRIPTION

**Description:**

reads a collection and ops logs of the relevant task, and runs schema inference on documents of the collection and documents that have violated schema validation to come up with a schema that will allow those documents to pass through the task. runs `git diff` on the resulting schema and the original schema to give an idea of how a patch may be constructed.

**Workflow steps:**

```
flowctl raw suggest-schema
  --collection estuary/marketing/google-ads/campaigns
  --task estuary/marketing/google-ads/source-google-ads
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1093)
<!-- Reviewable:end -->
