### PR TITLE
docs: update materialization docs to use update delay instead of minTxnDuration

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -11,19 +11,6 @@ The tables in the bucket act as a temporary staging area for data storage and re
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/materialize-bigquery:dev`](https://github.com/estuary/connectors/pkgs/container/materialize-bigquery) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
-## Performance considerations
-
-Like other Estuary connectors, this is a real-time connector that materializes documents using continuous [transactions](../../../concepts/advanced/shards.md#transactions).
-However, in practice, there are speed limitations.
-Standard BigQuery tables are [limited to 1500 operations per day](https://cloud.google.com/bigquery/quotas#standard_tables).
-This means that the connector is limited 1500 transactions per day.
-
-To avoid running up against this limit, you should set the minimum transaction time to a recommended value of 2 minutes,
-or a minimum value of 1 minute. You do this by configuring the materialization's [task shard](../../Configuring-task-shards.md). This causes an apparent delay in the materialization, but is necessary to prevent error.
-This also makes transactions more efficient, which reduces costs in BigQuery, especially for large datasets.
-
-Instructions to set the minimum transaction time are detailed [below](#shard-configuration).
-
 ## Prerequisites
 
 To use this connector, you'll need:
@@ -99,34 +86,6 @@ To learn more about project billing, [see the BigQuery docs](https://cloud.googl
 | **`/table`** | Table | Table name. | string | Required |
 | `/delta_updates` | Delta updates. | Whether to use standard or [delta updates](#delta-updates) | boolean | false |
 
-### Shard configuration
-
-:::info Beta
-UI controls for this workflow will be added to the Flow web app soon.
-For now, you must edit the materialization specification manually, either in the web app or using the CLI.
-:::
-
-To avoid exceeding your BigQuery tables' daily operation limits as discussed in [Performance considerations](#performance-considerations),
-complete the following steps when configuring your materialization:
-
-1. Using the [Flow web application](../../../guides/create-dataflow.md#create-a-materialization) or the [flowctl CLI](../../../concepts/flowctl.md#working-with-drafts),
-create a draft materialization as you normally would.
-   1. If using the web app, input the required values and click **Discover Endpoint**.
-   2. If using the flowctl, create your materialization specification manually.
-
-2. Add the [`shards` configuration](../../Configuring-task-shards.md) to the materialization specification at the same indentation level as `endpoint` and `bindings`.
-Set the `minTxnDuration` property to at least `1m` (we recommend `2m`).
-In the web app, you do this in the Catalog Editor.
-
-   ```yaml
-   shards:
-     minTxnDuration: 2m
-   ```
-
-   A full sample is included [below](#sample).
-
-3. Continue to test, save, and publish the materialization as usual.
-
 ### Sample
 
 ```yaml
@@ -146,8 +105,6 @@ materializations:
   	- resource:
       	table: ${table_name}
       source: ${PREFIX}/${source_collection}
-    shards:
-      minTxnDuration: 2m
 ```
 
 ## Delta updates

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -95,6 +95,8 @@ Use the below properties to configure a Snowflake materialization, which will di
 | **`/schema`** | Schema | Snowflake schema within the database to which to materialize | string | Required |
 | **`/user`** | User | Snowflake username | string | Required |
 | `/warehouse` | Warehouse | Name of the data warehouse that contains the database | string |  |
+| `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
+| `/advanced/updateDelay`     | Update Delay    | Potentially reduce active warehouse time by increasing the delay between updates. | string  |  |
 
 #### Bindings
 
@@ -190,38 +192,10 @@ To mitigate this, we recommend a two-pronged approach:
    ALTER WAREHOUSE ESTUARY_WH SET auto_suspend = 60;
    ```
 
-* Configure the materialization's **minimum transaction duration** to as long as 30 minutes.
-
-   This ensures that Flow will wait at least 30 minutes between new data commits to Snowflake.
-   If no new data appears within the 30-minute window, the interval will be longer.
-   You can change this setting in the materialization's [shard configuration](../../Configuring-task-shards.md#properties)
-   as described [below](#adding-the-shard-configuration).
+* Configure the materialization's **update delay** by setting a value in the advanced configuration.
 
 For example, if you set the warehouse to auto-suspend after 60 seconds and set the materialization's
-minimum transaction duration to 30 minutes, you can incur as little as 48 minutes per day of active time in the warehouse.
-
-#### Adding the shard configuration
-
-:::info Beta
-UI controls for this workflow will be added to the Flow web app soon.
-For now, you must edit the materialization specification manually, either in the web app or using the CLI.
-:::
-
-1. Using the [Flow web application](../../../guides/create-dataflow.md#create-a-materialization) or the [flowctl CLI](../../../concepts/flowctl.md#working-with-drafts),
-create a draft materialization as you normally would.
-   1. If using the web app, input the required values and click **Discover Endpoint**.
-   2. If using the flowctl, create your materialization specification manually.
-
-2. Add the [`shards` configuration](../../Configuring-task-shards.md) to the materialization specification at the same indentation level as `endpoint` and `bindings`.
-Set the `minTxnDuration` property as high as `30m` (we recommend between `15m` and `30m` for significant cost savings).
-In the web app, you do this in the Catalog Editor.
-
-   ```yaml
-   shards:
-     minTxnDuration: 30m
-   ```
-
-3. Continue to test, save, and publish the materialization as usual.
+update delay to 30 minutes, you can incur as little as 48 minutes per day of active time in the warehouse.
 
 ## Reserved words
 


### PR DESCRIPTION
**Description:**

Removes the instructions to set the `minTxnDuration` for BigQuery and Snowflake.

BigQuery will have the 2 minute delay built-in, and Snowflake will have a configuration for setting a delay as part of the connector config. See connectors PR https://github.com/estuary/connectors/pull/774

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1094)
<!-- Reviewable:end -->
