### PR TITLE
parser: include file name in error message when failing to infer format

### DIFF
--- a/crates/parser/src/format/mod.rs
+++ b/crates/parser/src/format/mod.rs
@@ -22,9 +22,9 @@ pub enum ParseError {
     MissingFormat,
 
     #[error(
-        "unable to automatically determine the format. explicit format configuration required"
+        "unable to automatically determine the format for file '{0}'. explicit format configuration required"
     )]
-    CannotInferFormat,
+    CannotInferFormat(String),
 
     #[error("unsupported format: '{0}'")]
     UnsupportedFormat(String),
@@ -63,7 +63,11 @@ pub fn resolve_config(
         tracing::debug!("using user-provided format: {:?}", f);
         f.clone()
     } else {
-        let inferred = determine_format(&config).ok_or_else(|| ParseError::CannotInferFormat)?;
+        let inferred = determine_format(&config).ok_or_else(|| {
+            ParseError::CannotInferFormat(
+                config.filename.as_deref().unwrap_or("<stdin>").to_string(),
+            )
+        })?;
         tracing::info!(format = %inferred, "inferred format");
         inferred
     };


### PR DESCRIPTION
**Description:**

Includes the file name in the error message when failing to infer a format.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

N/A

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1095)
<!-- Reviewable:end -->
