### PR TITLE
docs: fix materialization partitions example

### DIFF
--- a/site/docs/concepts/materialization.md
+++ b/site/docs/concepts/materialization.md
@@ -223,13 +223,14 @@ materializations:
   acmeCo/example/database-views:
     endpoint: ...
     bindings:
-      - source: acmeCo/anvil/orders
+      # The source can be specified as an object, which allows setting a partition selector.
+      - source:
+          name: acmeCo/anvil/orders
+          # Process partitions where "Coyote" is the customer.
+          partitions:
+            include:
+              customer: [Coyote]
         resource: { table: coyote_orders }
-
-        # Process partitions where "Coyote" is the customer.
-        partitions:
-          include:
-            customer: [Coyote]
 ```
 
 [Learn more about partition selectors](./advanced/projections.md#partition-selectors).


### PR DESCRIPTION
We recently discovered an incorrect example in the materialization docs, and this just fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1097)
<!-- Reviewable:end -->
