### PR TITLE
models: disable bindings using a boolean

### DIFF
--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -251,17 +251,14 @@ impl DiscoverHandler {
         let targets = capture
             .bindings
             .iter()
-            .map(|models::CaptureBinding { target, .. }| target.as_ref().cloned())
+            .map(|models::CaptureBinding { target, .. }| target.clone())
             .collect::<Vec<_>>();
 
         catalog.captures.insert(capture_name, capture); // Replace merged capture.
 
         // Now resolve all targeted collections, if they exist.
         let resolved = agent_sql::discovers::resolve_merge_target_specs(
-            &targets
-                .iter()
-                .flat_map(|t| t.iter().map(models::Collection::as_str))
-                .collect::<Vec<_>>(),
+            &targets.iter().map(|t| t.as_str()).collect::<Vec<_>>(),
             CatalogType::Collection,
             draft_id,
             user_id,

--- a/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_update.snap
+++ b/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_update.snap
@@ -13,11 +13,12 @@ expression: json!(out)
         "target": "acmeCo/renamed"
       },
       {
+        "disable": true,
         "resource": {
           "modified": "yup",
           "stream": "disabled"
         },
-        "target": null
+        "target": "test/collection/disabled"
       }
     ],
     "endpoint": {

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -417,8 +417,8 @@ fn evolve_collection(
                 .or_insert_with(|| cap_spec.clone());
 
             for binding in new_spec.bindings.iter_mut() {
-                if binding.target.as_ref() == Some(&old_collection) {
-                    binding.target = Some(new_name.clone()).into();
+                if &binding.target == &old_collection {
+                    binding.target = new_name.clone();
                 }
             }
         }
@@ -435,9 +435,7 @@ fn evolve_collection(
 }
 
 fn has_cap_binding(spec: &models::CaptureDef, collection: &models::Collection) -> bool {
-    spec.bindings
-        .iter()
-        .any(|b| b.target.as_ref() == Some(collection))
+    spec.bindings.iter().any(|b| &b.target == collection)
 }
 
 fn has_mat_binding(spec: &models::MaterializationDef, collection: &models::Collection) -> bool {

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -628,7 +628,9 @@ fn extract_spec_metadata<'a>(
 
             if let Some(derivation) = &collection.derive {
                 for tdef in &derivation.transforms {
-                    reads_from.push(tdef.source.collection().as_ref());
+                    if !tdef.disable {
+                        reads_from.push(tdef.source.collection().as_ref());
+                    }
                 }
                 reads_from.reserve(1);
             }
@@ -642,7 +644,9 @@ fn extract_spec_metadata<'a>(
                 image_parts = Some(split_tag(&config.image));
             }
             for binding in &materialization.bindings {
-                reads_from.push(binding.source.collection().as_ref());
+                if !binding.disable {
+                    reads_from.push(binding.source.collection().as_ref());
+                }
             }
             reads_from.reserve(1);
         }

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -616,8 +616,8 @@ fn extract_spec_metadata<'a>(
             image_parts = Some(split_tag(&config.image));
 
             for binding in &capture.bindings {
-                if let Some(target) = binding.target.as_ref() {
-                    writes_to.push(target.as_ref());
+                if !binding.disable {
+                    writes_to.push(binding.target.as_ref());
                 }
             }
             writes_to.reserve(1);

--- a/crates/flowctl/src/raw/discover.rs
+++ b/crates/flowctl/src/raw/discover.rs
@@ -92,7 +92,8 @@ pub async fn do_discover(
             let collection = Collection::new(collection_name);
 
             capture_bindings.push(CaptureBinding {
-                target: Some(collection.clone()).into(),
+                target: collection.clone(),
+                disable: false,
                 resource: RawValue::from_string(binding.resource_config_json.clone())?.into(),
             });
 

--- a/crates/models/src/derivation.rs
+++ b/crates/models/src/derivation.rs
@@ -1,5 +1,5 @@
 use super::{
-    CompositeKey, ConnectorConfig, DeriveUsingSqlite, DeriveUsingTypescript, RawValue,
+    is_false, CompositeKey, ConnectorConfig, DeriveUsingSqlite, DeriveUsingTypescript, RawValue,
     ShardTemplate, Source, Transform,
 };
 use schemars::{schema::Schema, JsonSchema};
@@ -82,6 +82,11 @@ pub struct TransformDef {
     /// or as a relative URL to a file containing the lambda.
     #[serde(default, skip_serializing_if = "RawValue::is_null")]
     pub lambda: RawValue,
+
+    /// # Whether to disable this transform.
+    /// Disabled transforms are completely ignored at runtime and are not validated.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub disable: bool,
 }
 
 /// A Shuffle specifies how a shuffling key is to be extracted from

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -1,4 +1,4 @@
-use super::{ConnectorConfig, Field, RawValue, RelativeUrl, ShardTemplate, Source};
+use super::{is_false, ConnectorConfig, Field, RawValue, RelativeUrl, ShardTemplate, Source};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -39,6 +39,10 @@ pub struct MaterializationBinding {
     pub resource: RawValue,
     /// # The collection to be materialized.
     pub source: Source,
+    /// # Whether to disable the binding
+    /// Disabled bindings are inactive, and not validated.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub disable: bool,
     /// # Selected projections for this materialization.
     #[serde(default)]
     pub fields: MaterializationFields,
@@ -46,7 +50,7 @@ pub struct MaterializationBinding {
 
 impl MaterializationBinding {
     pub fn non_null_resource(&self) -> Option<&RawValue> {
-        if self.resource.is_null() {
+        if self.disable {
             None
         } else {
             Some(&self.resource)
@@ -90,6 +94,7 @@ impl MaterializationBinding {
         Self {
             resource: serde_json::from_value(json!({"table": "a_table"})).unwrap(),
             source: Source::example(),
+            disable: false,
             fields: MaterializationFields::default(),
         }
     }

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -48,16 +48,6 @@ pub struct MaterializationBinding {
     pub fields: MaterializationFields,
 }
 
-impl MaterializationBinding {
-    pub fn non_null_resource(&self) -> Option<&RawValue> {
-        if self.disable {
-            None
-        } else {
-            Some(&self.resource)
-        }
-    }
-}
-
 /// MaterializationFields defines a selection of projections to materialize,
 /// as well as optional per-projection, driver-specific configuration.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/crates/sources/src/indirect.rs
+++ b/crates/sources/src/indirect.rs
@@ -331,15 +331,13 @@ fn indirect_materialization(
 
     for (index, models::MaterializationBinding { resource, .. }) in bindings.iter_mut().enumerate()
     {
-        if !resource.is_null() {
-            indirect_dom(
-                scope,
-                resource,
-                format!("{base}.resource.{index}.config"),
-                resources,
-                threshold,
-            )
-        }
+        indirect_dom(
+            scope,
+            resource,
+            format!("{base}.resource.{index}.config"),
+            resources,
+            threshold,
+        )
     }
 }
 

--- a/crates/sources/src/inline.rs
+++ b/crates/sources/src/inline.rs
@@ -163,10 +163,7 @@ fn inline_materialization(
     }
 
     for models::MaterializationBinding { resource, .. } in bindings {
-        if !resource.is_null() {
-            // a null resource would be ignored by inline config
-            inline_config(resource, scope, resources)
-        }
+        inline_config(resource, scope, resources)
     }
 }
 

--- a/crates/sources/src/loader.rs
+++ b/crates/sources/src/loader.rs
@@ -658,7 +658,7 @@ impl<F: Fetcher> Loader<F> {
         };
 
         for (index, binding) in spec.bindings.iter().enumerate() {
-            if let Some(resource) = binding.non_null_resource() {
+            if !binding.disable {
                 tasks.push(
                     async move {
                         self.load_config(
@@ -666,7 +666,7 @@ impl<F: Fetcher> Loader<F> {
                                 .push_prop("bindings")
                                 .push_item(index)
                                 .push_prop("resource"),
-                            resource,
+                            &binding.resource,
                         )
                         .await
                     }

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -207,21 +207,17 @@ expression: "&schema"
         "target"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable the binding",
+          "description": "Disabled bindings are inactive, and not validated. They can be used to represent discovered resources that are intentionally not being captured.",
+          "type": "boolean"
+        },
         "resource": {
           "title": "Endpoint resource to capture from."
         },
         "target": {
           "title": "Name of the collection to capture into.",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Collection"
-            },
-            {
-              "title": "Disabled binding",
-              "description": "a null target indicates that the binding is disabled and will be ignored at runtime",
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/Collection"
         }
       },
       "additionalProperties": false
@@ -705,6 +701,11 @@ expression: "&schema"
         "source"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable the binding",
+          "description": "Disabled bindings are inactive, and not validated.",
+          "type": "boolean"
+        },
         "fields": {
           "title": "Selected projections for this materialization.",
           "default": {

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -1211,6 +1211,11 @@ expression: "&schema"
         "source"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable this transform.",
+          "description": "Disabled transforms are completely ignored at runtime and are not validated.",
+          "type": "boolean"
+        },
         "lambda": {
           "title": "Lambda applied to the sourced documents of this transform.",
           "description": "Lambdas may be provided inline, or as a relative URL to a file containing the lambda."

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -256,7 +256,9 @@ fn walk_capture_binding<'a>(
     errors: &mut tables::Errors,
 ) -> Option<capture::request::validate::Binding> {
     let models::CaptureBinding {
-        resource, target, ..
+        resource,
+        target,
+        disable: _,
     } = binding;
 
     // We must resolve the target collection to continue.

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -322,6 +322,7 @@ fn walk_derive_request<'a>(
         Vec<Vec<ShuffleType>>,
     ) = transforms
         .iter()
+        .filter(|t| !t.disable)
         .enumerate()
         .map(|(transform_index, transform)| {
             walk_derive_transform(
@@ -432,6 +433,7 @@ fn walk_derive_transform(
         priority: _,
         read_delay: _,
         lambda,
+        disable: _,
     } = transform;
 
     indexed::walk_name(

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -124,10 +124,11 @@ pub async fn walk_all_materializations<C: Connectors>(
                 let models::MaterializationBinding {
                     ref source,
                     ref fields,
-                    ..
+                    disable: _,
+                    resource: _,
                 } = binding_models
                     .iter()
-                    .filter(|b| b.non_null_resource().is_some())
+                    .filter(|b| !b.disable)
                     .nth(binding_index)
                     .expect("models bindings are consistent with validation requests bindings");
 
@@ -327,7 +328,7 @@ fn walk_materialization_binding<'a>(
                 exclude: fields_exclude,
                 recommended: _,
             },
-        ..
+        disable: _,
     } = binding;
 
     let (collection, source_partitions) = match source {

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -283,7 +283,7 @@ fn walk_materialization_request<'a>(
         .iter()
         .enumerate()
         // Filter the bindings that we send to the connector to only those that are enabled.
-        .filter(|(_, b)| b.non_null_resource().is_some())
+        .filter(|(_, b)| !b.disable)
         .map(|(binding_index, binding)| {
             walk_materialization_binding(
                 scope.push_prop("bindings").push_item(binding_index),
@@ -327,6 +327,7 @@ fn walk_materialization_binding<'a>(
                 exclude: fields_exclude,
                 recommended: _,
             },
+        ..
     } = binding;
 
     let (collection, source_partitions) = match source {

--- a/crates/validation/src/reference.rs
+++ b/crates/validation/src/reference.rs
@@ -11,9 +11,7 @@ pub fn gather_referenced_collections<'a>(
 
     for capture in captures {
         for binding in &capture.spec.bindings {
-            if let Some(collection) = binding.target.as_ref() {
-                out.insert(collection);
-            }
+            out.insert(&binding.target);
         }
     }
     for collection in collections {

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -74,23 +74,27 @@ test://example/catalog.yaml:
     testing/partially-disabled-capture:
       endpoint: { connector: { image: s3, config: {} }}
       bindings:
-        - target: ~
+        - target: disabled/test/one
+          disable: true
           resource: { stream: disabled-stream }
         - target: testing/collection
           resource: { stream: enabled-stream }
     testing/fully-disabled-capture:
       endpoint: { connector: { image: s3, config: {} }}
       bindings:
-        - target: ~
+        - target: disabled/test/two
+          disable: true
           resource: { stream: disabled-stream }
-        - target: ~
+        - target: disabled/test/three
+          disable: true
           resource: { stream: another-disabled-stream }
   materializations:
     testing/partially-disabled-materialization:
       endpoint: { connector: { image: s3, config: {} }}
       bindings:
         - source: testing/collection
-          resource: null
+          disable: true
+          resource: { stream: disabled-stream }
         - source: testing/collection
           resource: { stream: enabled-stream }
 
@@ -98,7 +102,8 @@ test://example/catalog.yaml:
       endpoint: { connector: { image: s3, config: {} }}
       bindings:
         - source: testing/collection
-          resource: null
+          disable: true
+          resource: { stream: disabled-stream }
       
   storageMappings:
     testing/:

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -69,6 +69,46 @@ test://example/catalog.yaml:
         properties:
           id: {type: string}
         required: [id]
+    testing/partly-disabled-derivation:
+      key: [/id]
+      schema:
+        type: object
+        properties:
+          id: {type: string}
+        required: [id]
+      derive:
+        using:
+          sqlite: {}
+        transforms:
+          - name: enabledTransform
+            shuffle: any
+            source: { name: testing/collection }
+            lambda: 'select $id, 1 as count;'
+          - name: disabledTransform
+            shuffle: any
+            source: { name: testing/collection }
+            lambda: 'select $id, 2 as count;'
+            disable: true
+    testing/fully-disabled-derivation:
+      key: [/id]
+      schema:
+        type: object
+        properties:
+          id: {type: string}
+        required: [id]
+      derive:
+        using:
+          sqlite: {}
+        transforms:
+          - name: disabledTransformA
+            source: { name: testing/collection }
+            lambda: select $id, 1 as count;
+            disable: true
+          - name: disabledTransformB
+            source: { name: testing/collection }
+            lambda: select $id, 2 as count;
+            disable: true
+  
 
   captures:
     testing/partially-disabled-capture:
@@ -116,7 +156,22 @@ driver:
     s3:
       output: '[{"Config": {}}]'
 
-  derivations: {}
+  derivations:
+    testing/partly-disabled-derivation:
+      connectorType: SQLITE
+      config: {}
+      transforms:
+        - readOnly: true
+      shuffleKeyTypes: []
+      generatedFiles: {}
+
+    testing/fully-disabled-derivation:
+      connectorType: SQLITE
+      config: {}
+      transforms: []
+      shuffleKeyTypes: []
+      generatedFiles: {}
+
   captures:
     testing/partially-disabled-capture:
       connectorType: IMAGE

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -203,21 +203,17 @@
         "target"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable the binding",
+          "description": "Disabled bindings are inactive, and not validated. They can be used to represent discovered resources that are intentionally not being captured.",
+          "type": "boolean"
+        },
         "resource": {
           "title": "Endpoint resource to capture from."
         },
         "target": {
           "title": "Name of the collection to capture into.",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Collection"
-            },
-            {
-              "title": "Disabled binding",
-              "description": "a null target indicates that the binding is disabled and will be ignored at runtime",
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/Collection"
         }
       },
       "additionalProperties": false
@@ -701,6 +697,11 @@
         "source"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable the binding",
+          "description": "Disabled bindings are inactive, and not validated.",
+          "type": "boolean"
+        },
         "fields": {
           "title": "Selected projections for this materialization.",
           "default": {

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -1207,6 +1207,11 @@
         "source"
       ],
       "properties": {
+        "disable": {
+          "title": "Whether to disable this transform.",
+          "description": "Disabled transforms are completely ignored at runtime and are not validated.",
+          "type": "boolean"
+        },
         "lambda": {
           "title": "Lambda applied to the sourced documents of this transform.",
           "description": "Lambdas may be provided inline, or as a relative URL to a file containing the lambda."


### PR DESCRIPTION
**Description:**

This changes the representation of disabled capture and materialization bindings in Flow specs.  We previously used `target: null` and `resource: null` to represent disabled capture and materialization bindings respctively.  That change was introduced quite recently and has not seen any use yet.  This commit changes both capture and materialization bindings to use `disabled: true`.

Ultimately, the reason for this is to make it easier to programatically manipulate Flow specs.  Say a user runs a discover of an existing capture via the UI. Afterward, the draft could contain a bunch of disabled bindings with `target: null` along with a corresponding collection for each disabled binding. The UI needs those collections so that it can make sure they're included in the draft if the user re-enables any of the disabled bindings. But the UI would have no idea how to match a disabled binding with its corresponding collection spec because the `target` is null. We'd have a similar problem in Flowctl. The output of a discover needs to somehow communicate the relationship between each binding and the collection that goes along with it. Rather than introduce a separate data structure containing these relationships, it seems preferable to just keep them within the specs themselves.

This ends up being a simpler, it works the same for both captures and materializations, and seems a bit more obvious and clear. It also means that disabled capture bindings would be required to have a non-null `target`.  The validation logic is skipped for bindings that are disabled, so disabled bindings can have _any_ collection name. It's a little awkward, but it seems preferable to the alternative of having a separate data structure containing the mappings from resources to collections.

**Workflow steps:**

To disable a capture binding, use:

```yaml
captures:
  acmeCo/foo:
    bindings:
    - resource: { stream: foo }
      target: acmeCo/some/collection
      disable: true
```

and for materializations:

```yaml
materializations:
  acmeCo/foo:
    bindings:
    - resource: { table: foo }
      source: acmeCo/some/collection
      disable: true
```

**Documentation links affected:**

None yet.

**Notes for reviewers:**

I want to explicitly call out that the premise of this PR is open for debate. There's tradeoffs here, where we're using a somewhat less elegant representation (due to having a required `target` for disabled bindings), in order to make it easier to programmatically manipulate the specs. We don't _have_ to do this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1100)
<!-- Reviewable:end -->
