### PR TITLE
refactor: support pagination in flowctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "models",
  "open",
  "ops",
+ "page-turner",
  "pbjson-types",
  "portpicker",
  "postgrest",
@@ -2762,6 +2763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "page-turner"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e2600fd97e550faf2acfccde5342f3f0261c3566bb84698b3d7b3280230d07"
+dependencies = [
+ "async-trait",
+ "futures",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,8 +3089,8 @@ dependencies = [
 
 [[package]]
 name = "postgrest"
-version = "1.3.0"
-source = "git+https://github.com/estuary/postgrest-rs?branch=johnny/patches#382f37ab8fec3b413be08c15790a69f88dcc0dec"
+version = "1.5.0"
+source = "git+https://github.com/jshearer/postgrest-rs?branch=joseph/combined_changes_rebased#71285a6fa09f267b30bf0b44f65a0797b4a9eb81"
 dependencies = [
  "reqwest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,8 @@ pbjson = "0.5.1"
 pbjson-types = "0.5.1"
 percent-encoding = "2.1"
 pin-project = "1.0.12"
-postgrest = { git = "https://github.com/estuary/postgrest-rs", branch = "johnny/patches" }
+postgrest = { git = "https://github.com/jshearer/postgrest-rs", branch = "joseph/combined_changes_rebased" }
+page-turner = "0.8.2"
 prost = "0.11"
 protobuf = "3.1"
 protobuf-json-mapping = "3.1"

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -50,6 +50,7 @@ tonic = { workspace = true }
 rusqlite = { workspace = true }
 json-patch = { workspace = true }
 rustyline = { workspace = true }
+page-turner = { workspace = true }
 
 # open is used for opening URLs in the user's browser
 open = { workspace = true }

--- a/crates/flowctl/src/auth/roles.rs
+++ b/crates/flowctl/src/auth/roles.rs
@@ -1,4 +1,4 @@
-use crate::api_exec;
+use crate::api_exec_paginated;
 use crate::output::CliOutput;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -137,8 +137,9 @@ pub async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
             ]
         }
     }
-    let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client().await?
+    let rows: Vec<Row> = api_exec_paginated(
+        ctx.controlplane_client()
+            .await?
             .from("combined_grants_ext")
             .select(
                 vec![
@@ -175,8 +176,9 @@ pub async fn do_grant(
 
     // Upsert user grants to `user_grants` and role grants to `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
-        api_exec(
-            ctx.controlplane_client().await?
+        api_exec_paginated(
+            ctx.controlplane_client()
+                .await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -192,8 +194,9 @@ pub async fn do_grant(
         )
         .await?
     } else if let Some(subject_role) = subject_role {
-        api_exec(
-            ctx.controlplane_client().await?
+        api_exec_paginated(
+            ctx.controlplane_client()
+                .await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .upsert(
@@ -227,8 +230,9 @@ pub async fn do_revoke(
 
     // Revoke user grants from `user_grants` and role grants from `role_grants`.
     let rows: Vec<GrantRevokeRow> = if let Some(subject_user_id) = subject_user_id {
-        api_exec(
-            ctx.controlplane_client().await?
+        api_exec_paginated(
+            ctx.controlplane_client()
+                .await?
                 .from("user_grants")
                 .select(grant_revoke_columns())
                 .eq("user_id", subject_user_id.to_string())
@@ -237,8 +241,9 @@ pub async fn do_revoke(
         )
         .await?
     } else if let Some(subject_role) = subject_role {
-        api_exec(
-            ctx.controlplane_client().await?
+        api_exec_paginated(
+            ctx.controlplane_client()
+                .await?
                 .from("role_grants")
                 .select(grant_revoke_columns())
                 .eq("subject_role", subject_role)

--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec, catalog, draft, CliContext};
+use crate::{api_exec_paginated, catalog, draft, CliContext};
 use anyhow::Context;
 use serde::Serialize;
 
@@ -124,8 +124,9 @@ pub async fn do_delete(
         })
         .collect::<Vec<DraftSpec>>();
 
-    api_exec::<Vec<serde_json::Value>>(
-        ctx.controlplane_client().await?
+    api_exec_paginated::<Vec<serde_json::Value>>(
+        ctx.controlplane_client()
+            .await?
             .from("draft_specs")
             //.select("catalog_name,spec_type")
             .upsert(serde_json::to_string(&draft_specs).unwrap())

--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec, controlplane, draft, local_specs, CliContext};
+use crate::{api_exec_paginated, controlplane, draft, local_specs, CliContext};
 use anyhow::Context;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -41,7 +41,7 @@ pub async fn remove_unchanged(
             .select("catalog_name,md5")
             .in_("catalog_name", names);
 
-        let rows: Vec<SpecChecksumRow> = api_exec(builder).await?;
+        let rows: Vec<SpecChecksumRow> = api_exec_paginated(builder).await?;
         let chunk_checksums = rows
             .iter()
             .filter_map(|row| {

--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec, catalog::SpecSummaryItem, controlplane, local_specs};
+use crate::{api_exec_paginated, catalog::SpecSummaryItem, controlplane, local_specs};
 use anyhow::Context;
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct Author {
 
 pub async fn clear_draft(client: controlplane::Client, draft_id: &str) -> anyhow::Result<()> {
     tracing::info!(%draft_id, "clearing existing specs from draft");
-    api_exec::<Vec<serde_json::Value>>(
+    api_exec_paginated::<Vec<serde_json::Value>>(
         client.from("draft_specs").eq("draft_id", draft_id).delete(),
     )
     .await
@@ -106,7 +106,7 @@ pub async fn upsert_draft_specs(
     }
     body.push(']' as u8);
 
-    let rows: Vec<SpecSummaryItem> = api_exec(
+    let rows: Vec<SpecSummaryItem> = api_exec_paginated(
         client
             .from("draft_specs")
             .select("catalog_name,spec_type")

--- a/crates/flowctl/src/draft/develop.rs
+++ b/crates/flowctl/src/draft/develop.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec, catalog, local_specs};
+use crate::{api_exec_paginated, catalog, local_specs};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
@@ -26,7 +26,7 @@ pub async fn do_develop(
 ) -> anyhow::Result<()> {
     let draft_id = ctx.config().cur_draft()?;
     let client = ctx.controlplane_client().await?;
-    let rows: Vec<DraftSpecRow> = api_exec(
+    let rows: Vec<DraftSpecRow> = api_exec_paginated(
         client
             .from("draft_specs")
             .select("catalog_name,spec,spec_type")

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api_exec,
+    api_exec, api_exec_paginated,
     controlplane::Client,
     output::{to_table_row, CliOutput, JsonCell},
 };
@@ -211,8 +211,9 @@ async fn do_describe(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
             ]
         }
     }
-    let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client().await?
+    let rows: Vec<Row> = api_exec_paginated(
+        ctx.controlplane_client()
+            .await?
             .from("draft_specs_ext")
             .select(
                 vec![
@@ -256,8 +257,9 @@ async fn do_list(ctx: &mut crate::CliContext) -> anyhow::Result<()> {
             )
         }
     }
-    let rows: Vec<Row> = api_exec(
-        ctx.controlplane_client().await?
+    let rows: Vec<Row> = api_exec_paginated(
+        ctx.controlplane_client()
+            .await?
             .from("drafts_ext")
             .select("created_at,detail,id,num_specs,updated_at"),
     )
@@ -280,8 +282,9 @@ async fn do_select(
     ctx: &mut crate::CliContext,
     Select { id: select_id }: &Select,
 ) -> anyhow::Result<()> {
-    let matched: Vec<serde_json::Value> = api_exec(
-        ctx.controlplane_client().await?
+    let matched: Vec<serde_json::Value> = api_exec_paginated(
+        ctx.controlplane_client()
+            .await?
             .from("drafts")
             .eq("id", select_id)
             .select("id"),
@@ -337,7 +340,7 @@ pub async fn publish(client: Client, dry_run: bool, draft_id: &str) -> Result<()
         scope: String,
         detail: String,
     }
-    let errors: Vec<DraftError> = api_exec(
+    let errors: Vec<DraftError> = api_exec_paginated(
         client
             .from("draft_errors")
             .select("scope,detail")

--- a/crates/flowctl/src/pagination.rs
+++ b/crates/flowctl/src/pagination.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use futures::Stream;
 use page_turner::PageTurner;
 use page_turner::PageTurnerOutput;
 use page_turner::TurnedPage;
@@ -95,6 +96,15 @@ where
             phantom: PhantomData,
         }
     }
+}
+
+pub fn into_items<T>(builder: postgrest::Builder) -> impl Stream<Item = Result<T, anyhow::Error>>
+where
+    T: serde::de::DeserializeOwned + Send + Sync + 'static,
+{
+    PaginationClient::<T>::new()
+        .into_pages(PaginationRequest::new(builder))
+        .items()
 }
 
 #[async_trait]

--- a/crates/flowctl/src/pagination.rs
+++ b/crates/flowctl/src/pagination.rs
@@ -13,23 +13,64 @@ pub struct PaginationRequest {
     builder: postgrest::Builder,
     page: usize,
     page_size: usize,
+    /// The original Builder's range value, if set. This is used to make sure we
+    /// don't paginate beyond the requested range
+    range: Option<(usize, usize)>,
 }
 
 impl PaginationRequest {
     pub fn new(builder: postgrest::Builder) -> Self {
+        // Extract the limit and offset values out of the builder, if they are defined.
+        // We have to do this before calling [`set_page()`] since that will override the range header.
+        // Limit and offset live in the Range header, which looks like this:
+        // > Range: 4-12
+        // Where 4 is the offset, and 12 is the limit.
+        let range = match builder
+            .clone()
+            .build()
+            .build()
+            .unwrap()
+            .headers()
+            .get("Range")
+        {
+            Some(range) => range
+                .to_str()
+                .ok()
+                .and_then(|str| {
+                    str.split("-")
+                        .map(|num| num.parse::<usize>().ok())
+                        .collect::<Option<Vec<usize>>>()
+                })
+                .and_then(|range| match &range[..] {
+                    &[lower, upper] => Some((lower, upper)),
+                    _ => None,
+                }),
+            None => None,
+        };
+
         Self {
             builder,
             page: 0,
             page_size: 1000,
+            range,
         }
+        .set_page(0)
     }
 
     fn set_page(mut self, page: usize) -> Self {
         self.page = page;
-        self.builder = self
-            .builder
-            .range(page * self.page_size, (page + 1) * self.page_size);
 
+        let (lower_page, upper_page) = ((page * self.page_size), ((page + 1) * self.page_size));
+
+        match self.range {
+            Some((offset, limit)) => {
+                self.builder = self.builder.range(
+                    (lower_page + offset).min(limit),
+                    (upper_page + offset).min(limit),
+                )
+            }
+            None => self.builder = self.builder.range(lower_page, upper_page),
+        }
         self
     }
 }
@@ -40,14 +81,14 @@ impl PaginationRequest {
 /// its own client and is responsible for making its own requests, this is empty.
 pub struct PaginationClient<Item>
 where
-    for<'de> Item: serde::Deserialize<'de> + Send + Sync,
+    Item: serde::de::DeserializeOwned + Send + Sync,
 {
     phantom: PhantomData<fn() -> Item>,
 }
 
 impl<T> PaginationClient<T>
 where
-    for<'de> T: serde::Deserialize<'de> + Send + Sync,
+    T: serde::de::DeserializeOwned + Send + Sync,
 {
     pub fn new() -> Self {
         Self {
@@ -59,7 +100,7 @@ where
 #[async_trait]
 impl<Item> PageTurner<PaginationRequest> for PaginationClient<Item>
 where
-    for<'de> Item: serde::Deserialize<'de> + Send + Sync,
+    Item: serde::de::DeserializeOwned + Send + Sync,
 {
     type PageItem = Item;
     type PageError = anyhow::Error;
@@ -70,10 +111,27 @@ where
     ) -> PageTurnerOutput<Self, PaginationRequest> {
         let resp: Vec<Item> = api_exec::<Vec<Item>>(request.builder.clone()).await?;
 
-        if resp.len() == request.page_size {
+        if resp.len() == request.page_size
+            // If the original builder had a limit set to the same value as page_size
+            // this ensures that we stop right at the limit, instead of issuing an extra
+            // request for 0 rows.
+            && request.range.map_or(true, |(_, limit)| {
+                ((request.page + 1) * request.page_size) < limit
+            })
+        {
             let current_page = request.page;
+            tracing::debug!(
+                ?current_page,
+                row_count = resp.len(),
+                "Got back a full response, progressing to the next page"
+            );
             Ok(TurnedPage::next(resp, request.set_page(current_page + 1)))
         } else {
+            tracing::debug!(
+                current_page = request.page,
+                row_count = resp.len(),
+                "Got back a non-full response or we reached the builder's original limit so we're done"
+            );
             Ok(TurnedPage::last(resp))
         }
     }

--- a/crates/flowctl/src/pagination.rs
+++ b/crates/flowctl/src/pagination.rs
@@ -1,0 +1,80 @@
+use std::marker::PhantomData;
+
+use page_turner::PageTurner;
+use page_turner::PageTurnerOutput;
+use page_turner::TurnedPage;
+use tonic::async_trait;
+
+use crate::api_exec;
+
+/// A simple wrapper around [`postgrest::Builder`] that lets us keep track of which page
+/// it's currently on. Used in [`page_turner::PageTurner`] to implement pagination.
+pub struct PaginationRequest {
+    builder: postgrest::Builder,
+    page: usize,
+    page_size: usize,
+}
+
+impl PaginationRequest {
+    pub fn new(builder: postgrest::Builder) -> Self {
+        Self {
+            builder,
+            page: 0,
+            page_size: 1000,
+        }
+    }
+
+    fn set_page(mut self, page: usize) -> Self {
+        self.page = page;
+        self.builder = self
+            .builder
+            .range(page * self.page_size, (page + 1) * self.page_size);
+
+        self
+    }
+}
+
+/// A placeholder struct onto which we can implement [`page_turner::PageTurner`].
+/// Normally this would be the API client responsible for actually executing the requests
+/// defined in [`PaginationRequest`], but since a [`postgrest::Builder`] already has
+/// its own client and is responsible for making its own requests, this is empty.
+pub struct PaginationClient<Item>
+where
+    for<'de> Item: serde::Deserialize<'de> + Send + Sync,
+{
+    phantom: PhantomData<fn() -> Item>,
+}
+
+impl<T> PaginationClient<T>
+where
+    for<'de> T: serde::Deserialize<'de> + Send + Sync,
+{
+    pub fn new() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<Item> PageTurner<PaginationRequest> for PaginationClient<Item>
+where
+    for<'de> Item: serde::Deserialize<'de> + Send + Sync,
+{
+    type PageItem = Item;
+    type PageError = anyhow::Error;
+
+    async fn turn_page(
+        &self,
+        request: PaginationRequest,
+    ) -> PageTurnerOutput<Self, PaginationRequest> {
+        let resp: Vec<Item> = api_exec::<Vec<Item>>(request.builder.clone()).await?;
+
+        if resp.len() == request.page_size {
+            let current_page = request.page;
+            Ok(TurnedPage::next(resp, request.set_page(current_page + 1)))
+        } else {
+            Ok(TurnedPage::last(resp))
+        }
+    }
+}


### PR DESCRIPTION
**Description:**

Introduce a new `api_exec_paginated()` method that automatically reads all possible rows from a `postgrest::Builder` by using Postgrest's built-in pagination support. Previously requests that returned multiple rows would potentially get cut off if the total row count exceeded the per-request limit set in Supabase of 1000.

In order to support pagination I had to make a change to [`postgrest-rs`](https://github.com/supabase-community/postgrest-rs) to allow cloning `Builder`s. I realized we already have a [fork](https://github.com/estuary/postgrest-rs), but I didn't have permission to write to it so I just made my own. I rebased my change plus our fork ontop of upstream, and made two PRs: 
* https://github.com/supabase-community/postgrest-rs/pull/52 for a change from a while ago to add support for building but not sending a request
* https://github.com/supabase-community/postgrest-rs/pull/51 which is my change to support cloning `Builder`s.

Until those are merged, this PR changes the target repo/branch of `postgrest-rs` in `Cargo.toml` to my fork. It could just as easily be our existing fork, I just don't have permission to push to that repo and wanted to get this PR up ASAP to support a customer who needs flowctl to support >1000 row requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1101)
<!-- Reviewable:end -->
