### PR TITLE
flowctl: fix draft author regression

### DIFF
--- a/crates/flowctl/src/draft/author.rs
+++ b/crates/flowctl/src/draft/author.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec_paginated, catalog::SpecSummaryItem, controlplane, local_specs};
+use crate::{api_exec, api_exec_paginated, catalog::SpecSummaryItem, controlplane, local_specs};
 use anyhow::Context;
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct Author {
 
 pub async fn clear_draft(client: controlplane::Client, draft_id: &str) -> anyhow::Result<()> {
     tracing::info!(%draft_id, "clearing existing specs from draft");
-    api_exec_paginated::<Vec<serde_json::Value>>(
+    api_exec::<Vec<serde_json::Value>>(
         client.from("draft_specs").eq("draft_id", draft_id).delete(),
     )
     .await


### PR DESCRIPTION
**Description:**

There was a bug in the `clear_draft` function that caused the function to fail if the draft was not already empty.  This was caused by an incorrect type parameter in the `api_exec_paginated` callsite. The prior type parameter `Vec<Value>` was incorrect because the return type of `api_exec_paginated` is `Vec<T>`, thus the actual type that was expected by the response deserialization logic ended up being `Vec<Vec<Value>>`.  So the fix was to simply change the type parameter to just plain `Value`.

While tracking that down, I added some additional logging to `api_exec`, which seemed useful enough to keep around.

Also included here is a fix for another tiny bug I noticed, where we would panic immediately upon a deserialization error instead of returning the error and letting `main` handle it.

**Notes for reviewers:**

I checked all the other callsites of `api_exec_paginated` that were introduced in #1101 and I didn't notice any others that would be affected by the same issue. So I'm pretty sure this was the only one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1107)
<!-- Reviewable:end -->
