### PR TITLE
bindings: ignore context cancellation when sending trampoline results

### DIFF
--- a/go/bindings/trampoline.go
+++ b/go/bindings/trampoline.go
@@ -106,10 +106,10 @@ func (s *trampolineServer) startTask(request []byte) {
 			"err":     err,
 		}).Trace("resolving trampoline task")
 
-		select {
-		case s.resolvedCh <- response:
-		case <-s.ctx.Done():
-		}
+		// We _must_ send the response, even if the context has been cancelled.
+		// This is because the BuildCatalog function will wait indefinitely on
+		// trampoline tasks to complete.
+		s.resolvedCh <- response
 	}()
 }
 


### PR DESCRIPTION
**Description:**

This fixes a deadlock in `flowctl-go api build` that was observed in prod.  The proximal cause of the deadlock is the line in `trampoline.go` that is removed in this PR.  The context was cancelled, and so it never sent the result through the `resolvedCh`. Meanwhile, on [this line](https://github.com/estuary/flow/blob/33844329ca876352c9b0583112c886e17a091de5/go/bindings/build.go#L221) in `build.go`, it's waiting indefinitely on all the results of all trampoline tasks.

In case you're wondering how the context got cancelled, it happened due to our [overall build timeout](https://github.com/estuary/flow/blob/33844329ca876352c9b0583112c886e17a091de5/go/flowctl-go/cmd-api-build.go#L84), which cancelled the parent context.

So the fix is to just get rid of the line that skips resolving the task when there's a context cancellation.  This works because `build.go` always awaits the completion of _all_ trampoline tasks before it returns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1111)
<!-- Reviewable:end -->
