### PR TITLE
Phil/flowctl suggest schema fix

### DIFF
--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -268,8 +268,11 @@ async fn do_list_journals(
     ctx: &mut crate::CliContext,
     args: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
-    let mut client =
-        journal_client_for(ctx.controlplane_client().await?, vec![args.collection.clone()]).await?;
+    let mut client = journal_client_for(
+        ctx.controlplane_client().await?,
+        vec![args.collection.clone()],
+    )
+    .await?;
 
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -88,7 +88,7 @@ pub struct ReadBounds {
 
 pub async fn journal_reader(
     ctx: &mut crate::CliContext,
-    args: &ReadArgs
+    args: &ReadArgs,
 ) -> anyhow::Result<Reader<ExponentialBackoff>> {
     let cp_client = ctx.controlplane_client().await?;
     let mut data_plane_client =

--- a/crates/flowctl/src/connector.rs
+++ b/crates/flowctl/src/connector.rs
@@ -1,21 +1,27 @@
 use anyhow::anyhow;
-use std::{fs, process::{Command, Stdio, Output, Child}, pin::Pin};
 use anyhow::Context;
-use futures::{stream, TryStream, Stream};
+use futures::{stream, Stream, TryStream};
 use proto_flow::capture::{Request, Response};
-use tempfile::{tempdir, TempDir};
 use proto_grpc::capture::connector_client::ConnectorClient;
+use std::{
+    fs,
+    pin::Pin,
+    process::{Child, Command, Output, Stdio},
+};
+use tempfile::{tempdir, TempDir};
 
 fn pull(image: &str) -> anyhow::Result<Output> {
     Command::new("docker")
         .args(["pull", image])
-        .output().map_err(|e| e.into())
+        .output()
+        .map_err(|e| e.into())
 }
 
 fn inspect(image: &str) -> anyhow::Result<Output> {
     Command::new("docker")
         .args(["inspect", image])
-        .output().map_err(|e| e.into())
+        .output()
+        .map_err(|e| e.into())
 }
 
 const CONNECTOR_INIT_PORT: u16 = 49092;
@@ -31,30 +37,40 @@ pub fn docker_spawn(image: &str, args: &[&str]) -> anyhow::Result<(Child, TempDi
     let host_inspect_str = host_inspect.clone().into_os_string().into_string().unwrap();
 
     fs::write(&host_inspect, inspect_output.stdout)?;
-    let host_connector_init = locate_bin::locate("flow-connector-init").context("locating flow-connector-init")?;
+    let host_connector_init =
+        locate_bin::locate("flow-connector-init").context("locating flow-connector-init")?;
     let host_connector_init_str = host_connector_init.into_os_string().into_string().unwrap();
     let target_connector_init = "/tmp/connector_init";
 
     let port = portpicker::pick_unused_port().expect("No ports free");
 
     let child = Command::new("docker")
-        .args([&[
-              "run",
-              "--interactive",
-              "--init",
-              "--rm",
-              "--log-driver=none",
-              "--mount",
-              &format!("type=bind,source={host_inspect_str},target={target_inspect}"),
-              "--mount",
-              &format!("type=bind,source={host_connector_init_str},target={target_connector_init}"),
-		      "--publish", &format!("0.0.0.0:{}:{}/tcp", port, CONNECTOR_INIT_PORT),
-              "--entrypoint",
-              target_connector_init,
-              image,
-              &format!("--image-inspect-json-path={target_inspect}"),
-              &format!("--port={CONNECTOR_INIT_PORT}"),
-        ], args].concat())
+        .args(
+            [
+                &[
+                    "run",
+                    "--interactive",
+                    "--init",
+                    "--rm",
+                    "--log-driver=none",
+                    "--mount",
+                    &format!("type=bind,source={host_inspect_str},target={target_inspect}"),
+                    "--mount",
+                    &format!(
+                        "type=bind,source={host_connector_init_str},target={target_connector_init}"
+                    ),
+                    "--publish",
+                    &format!("0.0.0.0:{}:{}/tcp", port, CONNECTOR_INIT_PORT),
+                    "--entrypoint",
+                    target_connector_init,
+                    image,
+                    &format!("--image-inspect-json-path={target_inspect}"),
+                    &format!("--port={CONNECTOR_INIT_PORT}"),
+                ],
+                args,
+            ]
+            .concat(),
+        )
         .stderr(Stdio::inherit())
         .spawn()
         .context("spawning docker run child")?;
@@ -83,19 +99,27 @@ pub async fn docker_run(image: &str, req: Request) -> anyhow::Result<Response> {
 
     let response = response_stream.get_mut().message().await?;
 
-    return response.ok_or(anyhow!("no response message"))
+    return response.ok_or(anyhow!("no response message"));
 }
 
-pub async fn docker_run_stream(image: &str, stream: Pin<Box<dyn Stream<Item = Request> + Send + Sync>>) -> anyhow::Result<Pin<Box<dyn TryStream<Item = anyhow::Result<Response>, Ok = Response, Error = anyhow::Error>>>> {
+pub async fn docker_run_stream(
+    image: &str,
+    stream: Pin<Box<dyn Stream<Item = Request> + Send + Sync>>,
+) -> anyhow::Result<
+    Pin<Box<dyn TryStream<Item = anyhow::Result<Response>, Ok = Response, Error = anyhow::Error>>>,
+> {
     let (_child, _dir, port) = docker_spawn(image, &[])?;
     let mut client = connector_client(port).await?;
     let response_stream = client.capture(stream).await?;
 
-    Ok(Box::pin(stream::try_unfold(response_stream, |mut rs| async move {
-        if let Some(msg) = rs.get_mut().message().await? {
-            Ok(Some((msg, rs)))
-        } else {
-            Ok(None)
-        }
-    })))
+    Ok(Box::pin(stream::try_unfold(
+        response_stream,
+        |mut rs| async move {
+            if let Some(msg) = rs.get_mut().message().await? {
+                Ok(Some((msg, rs)))
+            } else {
+                Ok(None)
+            }
+        },
+    )))
 }

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -149,7 +149,11 @@ pub async fn do_suggest_schema(
         };
 
     // The original collection schema to be used as the starting point of schema-inference
-    let schema_model = collection_def.schema.unwrap();
+    let schema_model = collection_def
+        .schema
+        .as_ref()
+        .or(collection_def.read_schema.as_ref())
+        .expect("collection must define either schema or readSchema");
     // The inferred shape, we start by using the existing schema of the collection
     let mut inferred_shape = raw_schema_to_shape(&schema_model)?;
 


### PR DESCRIPTION
**Description:**

This rolls up a couple of bug fixes for the `flowctl raw suggest-schema` subcommand.
Additionally, the second commit just runs rustfmt on the `flowctl` crate, since my editor runs it automatically and otherwise it was annoying to ignore those change.

I've tested the specific case that was failing, and it's now working with these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1125)
<!-- Reviewable:end -->
