### PR TITLE
connector-init: start listening on tcp port before check_protocol

### DIFF
--- a/crates/flowctl/src/connector.rs
+++ b/crates/flowctl/src/connector.rs
@@ -50,18 +50,16 @@ pub fn docker_spawn(image: &str, args: &[&str]) -> anyhow::Result<(Child, TempDi
                 &[
                     "run",
                     "--rm",
+                    "--entrypoint",
+                    target_connector_init,
                     "--mount",
                     &format!(
                         "type=bind,source={host_connector_init_str},target={target_connector_init}"
                     ),
-                    "--entrypoint",
-                    target_connector_init,
-                    "--env",
-                    "LOG_LEVEL=trace",
-                    "--publish",
-                    &format!("0.0.0.0:{}:{}/tcp", port, CONNECTOR_INIT_PORT),
                     "--mount",
                     &format!("type=bind,source={host_inspect_str},target={target_inspect}"),
+                    "--publish",
+                    &format!("0.0.0.0:{}:{}/tcp", port, CONNECTOR_INIT_PORT),
                     image,
                     &format!("--image-inspect-json-path={target_inspect}"),
                     &format!("--port={CONNECTOR_INIT_PORT}"),


### PR DESCRIPTION
**Description:**

- With this change, we start listening on the tcp port in `connector-init` as soon as possible, but we don't process the requests while we check the protocol. After we have checked the protocol, we use the incoming stream to serve requests.
- This allows clients to connect to the server earlier and write to it, in a sense buffering some request(s)
- This is motivated by our code in `flowctl`'s `docker_run` not being able to clearly distinguish between a port that it can connect to, and a port that is ready for data to be written to it [here](https://github.com/estuary/flow/blob/master/crates/flowctl/src/connector.rs#L82). It's still a mystery to me how the go implementation of the same connection works fine and waits until the grpc server actually starts processing before it considers the connection as ready. The relevant go code is [here](https://github.com/grpc/grpc-go/blob/5ce5686d5e7111d8336f4a0d8b3036c1439e82b1/clientconn.go#L275-L300) and Tonic seems to conceptually check for readiness [here](https://github.com/estuary/flow/blob/master/crates/proto-grpc/src/capture.rs#L142), however it seems it has a different formulation of readiness.


I still don’t love this, because I would like to understand why the tonic client considers the connection ready and the go client doesn’t, and ideally we would have the tonic client behave similar to the go client…

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1127)
<!-- Reviewable:end -->
