### PR TITLE
Introduce the `jsonSchemaMerge` reduction strategy

### DIFF
--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -98,6 +98,7 @@ pub enum Reduction {
 
     Append,
     FirstWriteWins,
+    JsonSchemaMerge,
     LastWriteWins,
     Maximize,
     Merge,
@@ -107,8 +108,6 @@ pub enum Reduction {
 
     // Multiple concrete strategies may apply at the location.
     Multiple,
-
-    JsonSchemaMerge,
 }
 
 impl Reduction {

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -107,6 +107,8 @@ pub enum Reduction {
 
     // Multiple concrete strategies may apply at the location.
     Multiple,
+
+    JsonSchemaMerge,
 }
 
 impl Reduction {
@@ -177,6 +179,7 @@ impl From<&reduce::Strategy> for Reduction {
             Strategy::Set(_) => Reduction::Set,
             Strategy::Sum => Reduction::Sum,
             Strategy::Merge(_) => Reduction::Merge,
+            Strategy::JsonSchemaMerge => Reduction::JsonSchemaMerge,
         }
     }
 }

--- a/crates/doc/src/reduce/mod.rs
+++ b/crates/doc/src/reduce/mod.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 pub mod strategy;
 pub use strategy::Strategy;
 
+mod schema;
 mod set;
 
 pub static DEFAULT_STRATEGY: &Strategy = &Strategy::LastWriteWins;

--- a/crates/doc/src/reduce/mod.rs
+++ b/crates/doc/src/reduce/mod.rs
@@ -20,6 +20,8 @@ pub enum Error {
     SumNumericOverflow,
     #[error("'sum' strategy expects numbers")]
     SumWrongType,
+    #[error("'json-schema-merge' strategy expects objects containing valid JSON schemas. {}", .detail.as_deref().unwrap_or_default())]
+    JsonSchemaMergeWrongType { detail: Option<String> },
     #[error("'merge' strategy expects objects or arrays")]
     MergeWrongType,
     #[error(

--- a/crates/doc/src/reduce/schema.rs
+++ b/crates/doc/src/reduce/schema.rs
@@ -1,0 +1,133 @@
+use super::{count_nodes_heap, Cursor, Error, Result};
+use crate::{inference::Shape, schema::SchemaBuilder, AsNode, HeapNode};
+use json::schema::index::IndexBuilder;
+
+pub fn json_schema_merge<'alloc, L: AsNode, R: AsNode>(
+    cur: Cursor<'alloc, '_, '_, '_, '_, L, R>,
+) -> Result<HeapNode<'alloc>> {
+    let Cursor {
+        tape,
+        loc,
+        full: _,
+        lhs,
+        rhs,
+        alloc,
+    } = cur;
+
+    let (lhs, rhs) = (lhs.into_heap_node(alloc), rhs.into_heap_node(alloc));
+
+    *tape = &tape[count_nodes_heap(&rhs)..];
+
+    // Ensure that we're working with objects on both sides
+    // Question: Should we actually relax this to support
+    // reducing valid schemas like "true" and "false"?
+    let (
+        lhs @ HeapNode::Object(_),
+        rhs @ HeapNode::Object(_)
+    ) = (lhs, rhs) else {
+        return Err(Error::with_location(Error::JsonSchemaMergeWrongType { detail: None }, loc) )
+    };
+
+    let left = shape_from_node(lhs).map_err(|e| Error::with_location(e, loc))?;
+    let right = shape_from_node(rhs).map_err(|e| Error::with_location(e, loc))?;
+
+    let mut merged_shape = Shape::union(left, right);
+    merged_shape.enforce_field_count_limits(json::Location::Root);
+
+    // Union together the LHS and RHS, and convert back from `Shape` into `HeapNode`.
+    let merged_doc = serde_json::to_value(&SchemaBuilder::new(merged_shape).root_schema())
+        .and_then(|value| HeapNode::from_serde(value, alloc))
+        .map_err(|e| {
+            Error::with_location(
+                Error::JsonSchemaMergeWrongType {
+                    detail: Some(e.to_string()),
+                },
+                loc,
+            )
+        })?;
+
+    Ok(merged_doc)
+}
+
+fn shape_from_node<'a, N: AsNode>(node: N) -> Result<Shape> {
+    // Should this be something more specific/useful?
+    let url = url::Url::parse("json-schema-reduction:///").unwrap();
+
+    let serialized =
+        serde_json::to_value(node.as_node()).map_err(|e| Error::JsonSchemaMergeWrongType {
+            detail: Some(e.to_string()),
+        })?;
+
+    let schema = json::schema::build::build_schema::<crate::Annotation>(url.clone(), &serialized)
+        .map_err(|e| Error::JsonSchemaMergeWrongType {
+        detail: Some(e.to_string()),
+    })?;
+
+    let mut index = IndexBuilder::new();
+    index.add(&schema).unwrap();
+    index.verify_references().unwrap();
+    let index = index.into_index();
+
+    Ok(Shape::infer(
+        index
+            .must_fetch(&url)
+            .map_err(|e| Error::JsonSchemaMergeWrongType {
+                detail: Some(e.to_string()),
+            })?,
+        &index,
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::test::*;
+    use super::*;
+
+    #[test]
+    fn test_merge_json_schemas() {
+        run_reduce_cases(
+            json!({ "reduce": { "strategy": "jsonSchemaMerge" } }),
+            vec![
+                Partial {
+                    rhs: json!({
+                        "type": "string",
+                        "maxLength": 5,
+                        "minLength": 5
+                    }),
+                    expect: Ok(json!({
+                        "type": "string",
+                        "maxLength": 5,
+                        "minLength": 5
+                    })),
+                },
+                Partial {
+                    rhs: json!("oops!"),
+                    expect: Err(Error::JsonSchemaMergeWrongType { detail: None }),
+                },
+                Partial {
+                    rhs: json!({
+                        "type": "foo"
+                    }),
+                    expect: Err(Error::JsonSchemaMergeWrongType {
+                        detail: Some(
+                            r#"at keyword 'type' of schema 'json-schema-reduction:///': expected a type or array of types: invalid type name: 'foo'"#.to_owned(),
+                        ),
+                    }),
+                },
+                Partial {
+                    rhs: json!({
+                        "type": "string",
+                        "minLength": 8,
+                        "maxLength": 10
+                    }),
+                    expect: Ok(json!({
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "string",
+                        "minLength": 5,
+                        "maxLength": 10,
+                    })),
+                },
+            ],
+        )
+    }
+}

--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -1,13 +1,9 @@
-use json::schema::index::IndexBuilder;
-
 use super::{
     compare_key_lazy, count_nodes, count_nodes_generic, count_nodes_heap, reduce_item, reduce_prop,
-    Cursor, Error, Result,
+    schema::json_schema_merge, Cursor, Error, Result,
 };
 use crate::{
-    inference::Shape,
     lazy::{LazyArray, LazyDestructured, LazyObject},
-    schema::SchemaBuilder,
     AsNode, BumpVec, HeapNode, Node, Pointer,
 };
 
@@ -127,7 +123,7 @@ impl Strategy {
             Strategy::Minimize(min) => Self::minimize(cur, min),
             Strategy::Set(set) => set.apply(cur),
             Strategy::Sum => Self::sum(cur),
-            Strategy::JsonSchemaMerge => Self::json_schema_merge(cur),
+            Strategy::JsonSchemaMerge => json_schema_merge(cur),
         }
     }
 
@@ -309,54 +305,6 @@ impl Strategy {
         }
     }
 
-    fn json_schema_merge<'alloc, L: AsNode, R: AsNode>(
-        cur: Cursor<'alloc, '_, '_, '_, '_, L, R>,
-    ) -> Result<HeapNode<'alloc>> {
-        let Cursor {
-            tape,
-            loc,
-            full: _,
-            lhs,
-            rhs,
-            alloc,
-        } = cur;
-
-        let (lhs, rhs) = (lhs.into_heap_node(alloc), rhs.into_heap_node(alloc));
-
-        // Precompute this up here because we're going to consume `rhs` later on
-        let rhs_tape_len = count_nodes_heap(&rhs);
-
-        // Ensure that we're working with objects on both sides
-        // Question: Should we actually relax this to support
-        // reducing valid schemas like "true" and "false"?
-        let (
-            lhs @ HeapNode::Object(_),
-            rhs @ HeapNode::Object(_)
-        ) = (lhs, rhs) else {
-            return Err(Error::with_location(Error::JsonSchemaMergeWrongType { detail: None }, loc) )
-        };
-
-        let left = shape_from_node(lhs).map_err(|e| Error::with_location(e, loc))?;
-        let right = shape_from_node(rhs).map_err(|e| Error::with_location(e, loc))?;
-
-        // Union together the LHS and RHS, and convert back from `Shape` into `HeapNode`.
-        let merged_doc =
-            serde_json::to_value(&SchemaBuilder::new(Shape::union(left, right)).root_schema())
-                .and_then(|value| HeapNode::from_serde(value, alloc))
-                .map_err(|e| {
-                    Error::with_location(
-                        Error::JsonSchemaMergeWrongType {
-                            detail: Some(e.to_string()),
-                        },
-                        loc,
-                    )
-                })?;
-
-        *tape = &tape[rhs_tape_len..];
-
-        Ok(merged_doc)
-    }
-
     fn merge<'alloc, L: AsNode, R: AsNode>(
         cur: Cursor<'alloc, '_, '_, '_, '_, L, R>,
         merge: &Merge,
@@ -453,35 +401,6 @@ impl Strategy {
             (lhs, rhs) => Err(Error::with_details(Error::MergeWrongType, loc, lhs, rhs)),
         }
     }
-}
-
-fn shape_from_node<'a, N: AsNode>(node: N) -> Result<Shape> {
-    // Should this be something more specific/useful?
-    let url = url::Url::parse("json-schema-reduction:///").unwrap();
-
-    let serialized =
-        serde_json::to_value(node.as_node()).map_err(|e| Error::JsonSchemaMergeWrongType {
-            detail: Some(e.to_string()),
-        })?;
-
-    let schema = json::schema::build::build_schema::<crate::Annotation>(url.clone(), &serialized)
-        .map_err(|e| Error::JsonSchemaMergeWrongType {
-        detail: Some(e.to_string()),
-    })?;
-
-    let mut index = IndexBuilder::new();
-    index.add(&schema).unwrap();
-    index.verify_references().unwrap();
-    let index = index.into_index();
-
-    Ok(Shape::infer(
-        index
-            .must_fetch(&url)
-            .map_err(|e| Error::JsonSchemaMergeWrongType {
-                detail: Some(e.to_string()),
-            })?,
-        &index,
-    ))
 }
 
 #[cfg(test)]
@@ -1025,54 +944,6 @@ mod test {
                         {"k": "b", "v": [{"k": 1}, {"k": 3}, {"k": 5, "d": true}]},
                         {"k": "c", "v": [{"k": 9}]},
                     ])),
-                },
-            ],
-        )
-    }
-
-    #[test]
-    fn test_merge_json_schemas() {
-        run_reduce_cases(
-            json!({ "reduce": { "strategy": "jsonSchemaMerge" } }),
-            vec![
-                Partial {
-                    rhs: json!({
-                        "type": "string",
-                        "maxLength": 5,
-                        "minLength": 5
-                    }),
-                    expect: Ok(json!({
-                        "type": "string",
-                        "maxLength": 5,
-                        "minLength": 5
-                    })),
-                },
-                Partial {
-                    rhs: json!("oops!"),
-                    expect: Err(Error::JsonSchemaMergeWrongType { detail: None }),
-                },
-                Partial {
-                    rhs: json!({
-                        "type": "foo"
-                    }),
-                    expect: Err(Error::JsonSchemaMergeWrongType {
-                        detail: Some(
-                            r#"at keyword 'type' of schema 'json-schema-reduction:///': expected a type or array of types: invalid type name: 'foo'"#.to_owned(),
-                        ),
-                    }),
-                },
-                Partial {
-                    rhs: json!({
-                        "type": "string",
-                        "minLength": 8,
-                        "maxLength": 10
-                    }),
-                    expect: Ok(json!({
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "type": "string",
-                        "minLength": 5,
-                        "maxLength": 10,
-                    })),
                 },
             ],
         )

--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -340,17 +340,17 @@ impl Strategy {
         let right = shape_from_node(rhs).map_err(|e| Error::with_location(e, loc))?;
 
         // Union together the LHS and RHS, and convert back from `Shape` into `HeapNode`.
-        let merged_doc = Shape::union(left, right)
-            .to_serde()
-            .and_then(|value| HeapNode::from_serde(value, alloc))
-            .map_err(|e| {
-                Error::with_location(
-                    Error::JsonSchemaMergeWrongType {
-                        detail: Some(e.to_string()),
-                    },
-                    loc,
-                )
-            })?;
+        let merged_doc =
+            serde_json::to_value(&SchemaBuilder::new(Shape::union(left, right)).root_schema())
+                .and_then(|value| HeapNode::from_serde(value, alloc))
+                .map_err(|e| {
+                    Error::with_location(
+                        Error::JsonSchemaMergeWrongType {
+                            detail: Some(e.to_string()),
+                        },
+                        loc,
+                    )
+                })?;
 
         *tape = &tape[rhs_tape_len..];
 

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -42,6 +42,7 @@ fn reduce_description(reduce: doc::inference::Reduction) -> &'static str {
         Reduction::Set => "set",
         Reduction::Sum => "sum",
         Reduction::Multiple => "multiple strategies may apply",
+        Reduction::JsonSchemaMerge => "merge json schemas",
     }
 }
 


### PR DESCRIPTION
**Description:**

Introduces the `jsonSchemaMerge` reduction strategy. I still need to add some more tests, but we should really be relying on the tests for `Shape::union()` (which are extensive) and `doc::schema::to_schema()` (which very much are not) to ensure correctness in all cases here.

This closes https://github.com/estuary/flow/issues/1131, and is part of the work laid out in https://github.com/estuary/flow/issues/1103.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1132)
<!-- Reviewable:end -->
