### PR TITLE
Refactor/schema builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "rkyv",
+ "schemars",
  "serde",
  "serde-transcode",
  "serde_json",

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -21,6 +21,7 @@ fxhash = { workspace = true }
 itertools = { workspace = true }
 lz4 = { workspace = true, optional = true }
 rkyv = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -1,5 +1,5 @@
 use super::{compare, ptr::Token, reduce, Annotation, Pointer, Schema, SchemaIndex};
-use crate::{schema::SchemaBuilder, AsNode};
+use crate::AsNode;
 use fancy_regex::Regex;
 use itertools::{self, EitherOrBoth, Itertools};
 use json::{

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -1489,13 +1489,6 @@ impl Shape {
             );
         };
     }
-
-    pub fn to_serde(self) -> Result<Value, serde_json::Error> {
-        let builder = SchemaBuilder::new(self);
-        let root_schema = builder.root_schema();
-
-        serde_json::to_value(root_schema)
-    }
 }
 
 // Sentinel Shape returned by locate(), which make take any value.

--- a/crates/doc/src/inference.rs
+++ b/crates/doc/src/inference.rs
@@ -1,5 +1,5 @@
 use super::{compare, ptr::Token, reduce, Annotation, Pointer, Schema, SchemaIndex};
-use crate::AsNode;
+use crate::{schema::SchemaBuilder, AsNode};
 use fancy_regex::Regex;
 use itertools::{self, EitherOrBoth, Itertools};
 use json::{
@@ -1488,6 +1488,13 @@ impl Shape {
                 out,
             );
         };
+    }
+
+    pub fn to_serde(self) -> Result<Value, serde_json::Error> {
+        let builder = SchemaBuilder::new(self);
+        let root_schema = builder.root_schema();
+
+        serde_json::to_value(root_schema)
     }
 }
 

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -99,6 +99,8 @@ pub use validation::{
 // Doc implementations may be reduced.
 pub mod reduce;
 
+pub mod schema;
+
 // Documents may be combined.
 #[cfg(feature = "combine")]
 pub mod combine;

--- a/crates/doc/src/schema.rs
+++ b/crates/doc/src/schema.rs
@@ -1,7 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet};
-
+use crate::inference::Shape;
 use json::schema::{
-    self, keywords,
+    keywords,
     types::{self, Set},
 };
 use schemars::{
@@ -9,8 +8,7 @@ use schemars::{
     schema::{InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec},
 };
 use serde_json::json;
-
-use crate::inference::Shape;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Default)]
 pub struct SchemaBuilder {

--- a/crates/flowctl/src/preview/mod.rs
+++ b/crates/flowctl/src/preview/mod.rs
@@ -1,5 +1,6 @@
 use crate::{dataplane, local_specs};
 use anyhow::Context;
+use doc::schema::to_schema;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt, TryStreamExt};
 use prost::Message;
@@ -384,8 +385,7 @@ where
         }
     }
 
-    Ok(inferred_shape
-        .map(|shape| serde_json::to_value(schema_inference::schema::to_schema(&shape)).unwrap()))
+    Ok(inferred_shape.map(|shape| serde_json::to_value(to_schema(&shape)).unwrap()))
 }
 
 fn status_to_anyhow(status: tonic::Status) -> anyhow::Error {

--- a/crates/flowctl/src/raw/suggest_schema.rs
+++ b/crates/flowctl/src/raw/suggest_schema.rs
@@ -5,14 +5,12 @@ use crate::{
 };
 use anyhow::anyhow;
 use bytelines::AsyncByteLines;
-use doc::{inference::Shape, FailedValidation, SchemaIndexBuilder};
+use doc::{inference::Shape, schema::SchemaBuilder, FailedValidation, SchemaIndexBuilder};
 use futures::{Stream, StreamExt, TryStreamExt};
 use json::schema::build::build_schema;
 use models::Schema;
 use proto_flow::ops::Log;
-use schema_inference::{
-    inference::infer_shape, json_decoder::JsonCodec, schema::SchemaBuilder, shape,
-};
+use schema_inference::{inference::infer_shape, json_decoder::JsonCodec, shape};
 use std::{io::ErrorKind, pin::Pin};
 use tokio::io::BufReader;
 use tokio_util::{codec::FramedRead, compat::FuturesAsyncReadCompatExt};

--- a/crates/schema-inference/src/analyze.rs
+++ b/crates/schema-inference/src/analyze.rs
@@ -1,9 +1,9 @@
+use doc::schema::SchemaBuilder;
 use schemars::schema::RootSchema;
 use serde_json::Value as JsonValue;
 use std::io::BufRead;
 
 use crate::inference::infer_shape;
-use crate::schema::SchemaBuilder;
 use crate::shape;
 
 type StreamResult = serde_json::Result<JsonValue>;

--- a/crates/schema-inference/src/lib.rs
+++ b/crates/schema-inference/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod analyze;
 pub mod inference;
 pub mod json_decoder;
-pub mod schema;
 pub mod server;
 pub mod shape;

--- a/crates/schema-inference/src/server.rs
+++ b/crates/schema-inference/src/server.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use crate::inference::infer_shape;
 use crate::json_decoder::{JsonCodec, JsonCodecError};
-use crate::schema::SchemaBuilder;
 use crate::shape;
 use bytesize::ByteSize;
+use doc::schema::SchemaBuilder;
 use serde_json::json;
 
 use anyhow::Context;

--- a/crates/schema-inference/src/snapshots/schema_inference__analyze__test__simple_schema_merging.snap
+++ b/crates/schema-inference/src/snapshots/schema_inference__analyze__test__simple_schema_merging.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/schema-inference/src/analyze.rs
-assertion_line: 123
 expression: schema
 ---
 {
@@ -29,8 +28,7 @@ expression: schema
           ]
         },
         "optional": {
-          "type": "array",
-          "items": []
+          "type": "array"
         }
       }
     },


### PR DESCRIPTION
Move SchemaBuilder from schema-inference to doc since doc needs to learn how to turn a Shape into the correct blob of JSON representing that Shape as a JSON schema. This logic used to live in schema-inference, but not only do we want to get rid of that crate eventually, it also already depends on doc indirectly, so introducing the doc->schema-inference dependency caused a circular dependency issue.

In addition to moving SchemaBuilder into doc, I also realized that it was missing quite a few translations between Shape and Schema. I added the ones I could find, but it's entirely possible that there are more missing. I will add some more tests, but it's likely that there are still options we aren't supporting correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1135)
<!-- Reviewable:end -->
