### PR TITLE
Fix `rust-analyzer` adding spaces to `use` statements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,6 @@
     "deno.config": "./deno.jsonc",
     "deno.importMap": "./supabase/functions/import-map.json",
     "deno.lint": true,
-    "deno.path": ".build/package/bin/deno"
+    "deno.path": ".build/package/bin/deno",
+    "rust-analyzer.imports.group.enable": false
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "One"


### PR DESCRIPTION
Rust analyzer was adding undesired newlines to automatically-generated import statements. Pretty sure this fixes it, at least on my machine 👀 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1136)
<!-- Reviewable:end -->
