### PR TITLE
Add schema inference `L1` and `L2` collections, as well as materializing them to the database

### DIFF
--- a/ops-catalog/schema-inference.flow.yaml
+++ b/ops-catalog/schema-inference.flow.yaml
@@ -1,0 +1,35 @@
+collections:
+  ops.us-central1.v1/inferred-schemas/L1:
+    derive:
+      using:
+        sqlite: {}
+      transforms:
+        - name: logs
+          source:
+            name: ops.us-central1.v1/logs
+          shuffle:
+            key: [/shard/name] # Use partition-based shuffle.
+          lambda: |
+            select
+              $fields->>'collection_name' as collection_name,
+              $fields->'schema' as schema
+            where $message = 'inferred schema updated';
+    key: [/collection_name]
+    schema: schema-inference.schema.yaml
+
+  # A direct-copy of L1, but enables us to add more L1s
+  # as we create more data planes.
+  ops.us-central1.v1/inferred-schemas/L2:
+    schema: schema-inference.schema.yaml
+    key: [/collection_name]
+    derive:
+      using:
+        sqlite: {}
+      # The idea with this L2 collection is to merge
+      # all data planes' L1 collections together
+      transforms:
+        - name: from-ops.us-central1.v1
+          source: ops.us-central1.v1/inferred-schemas/L1
+          shuffle:
+            key: [/collection_name]
+          lambda: select json($flow_document);

--- a/ops-catalog/schema-inference.schema.yaml
+++ b/ops-catalog/schema-inference.schema.yaml
@@ -1,0 +1,15 @@
+type: object
+reduce:
+  strategy: merge
+required:
+  - collection_name
+  - schema
+properties:
+  collection_name:
+    type: string
+    description: The name of the collection that this schema was inferred for
+  schema:
+    type: object
+    description: The inferred schema
+    reduce:
+      strategy: jsonSchemaMerge

--- a/ops-catalog/schema-inference.test.flow.yaml
+++ b/ops-catalog/schema-inference.test.flow.yaml
@@ -1,0 +1,52 @@
+tests:
+  ops.us-central1.v1/inferred-schemas/test:
+    - ingest:
+        collection: ops.us-central1.v1/logs
+        documents:
+          - shard: &shard
+              kind: capture
+              name: tenant/test/cap
+              keyBegin: "aabbccdd"
+              rClockBegin: "00112233"
+            ts: "2022-04-03T02:02:03.45678Z"
+            level: info
+            message: inferred schema updated
+            fields:
+              collection_name: acmeCo/integers
+              schema:
+                type: integer
+                minimum: 32
+                maximum: 42
+
+          - shard: *shard
+            ts: "2022-04-03T02:02:04Z"
+            level: info
+            message: inferred schema updated
+            fields:
+              collection_name: acmeCo/integers
+              schema:
+                type: integer
+                minimum: 42
+                maximum: 52
+
+          - shard: *shard
+            ts: "2022-04-03T02:02:05Z"
+            level: info
+            message: inferred schema updated
+            fields:
+              collection_name: acmeCo/booleans
+              schema:
+                type: boolean
+
+    - verify:
+        collection:
+          name: ops.us-central1.v1/inferred-schemas/L2
+        documents:
+          - collection_name: acmeCo/booleans
+            schema:
+              type: boolean
+          - collection_name: acmeCo/integers
+            schema:
+              type: integer
+              minimum: 32
+              maximum: 52

--- a/ops-catalog/template-common.flow.yaml
+++ b/ops-catalog/template-common.flow.yaml
@@ -1,4 +1,5 @@
 import:
+  - schema-inference.flow.yaml
   - task-failures.flow.yaml
 
 collections:

--- a/ops-catalog/template-local.flow.yaml
+++ b/ops-catalog/template-local.flow.yaml
@@ -9,6 +9,15 @@ materializations:
         config: stats-local-endpoint.sops.yaml
 
     bindings:
+      - source: ops.us-central1.v1/inferred-schemas/L2
+        resource:
+          table: inferred_schemas
+        fields:
+          recommended: false
+          include:
+            collection_name: {}
+            schema: {}
+            flow_document: {}
       - source: ops.us-central1.v1/catalog-stats-L2
         resource:
           table: catalog_stats

--- a/ops-catalog/template-prod.flow.yaml
+++ b/ops-catalog/template-prod.flow.yaml
@@ -9,6 +9,15 @@ materializations:
         config: stats-production-endpoint.sops.yaml
 
     bindings:
+      - source: ops.us-central1.v1/inferred-schemas/L2
+        resource:
+          table: inferred_schemas
+        fields:
+          recommended: false
+          include:
+            collection_name: {}
+            schema: {}
+            flow_document: {}
       - source: ops.us-central1.v1/catalog-stats-L2
         resource:
           table: catalog_stats

--- a/ops-catalog/tests.flow.yaml
+++ b/ops-catalog/tests.flow.yaml
@@ -3,6 +3,7 @@
 
 import:
   - template-common.flow.yaml
+  - schema-inference.test.flow.yaml
 
 tests:
   ops.us-central1.v1/catalog-stats:
@@ -134,6 +135,8 @@ tests:
                 - ops.us-central1.v1/catalog-stats-L1
                 - ops.us-central1.v1/catalog-stats-L2
                 - ops.us-central1.v1/failure-notifications/v1
+                - ops.us-central1.v1/inferred-schemas/L1
+                - ops.us-central1.v1/inferred-schemas/L2
                 - ops.us-central1.v1/logs
                 - ops.us-central1.v1/stats
 


### PR DESCRIPTION
Per convo with @jgraettinger, I added `L1` under `ops.us-central1.v1/private` and `L2` under `estuary/global`

Closes #1140. It works!

<img width="1450" alt="Screen Shot 2023-08-08 at 14 21 43" src="https://github.com/estuary/flow/assets/4368270/4183f0d4-bdb9-4934-a0fc-e11f46b9f718">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1141)
<!-- Reviewable:end -->
