### PR TITLE
supabase: add `inferred_schemas` migration and final fixes

### DIFF
--- a/ops-catalog/schema-inference.flow.yaml
+++ b/ops-catalog/schema-inference.flow.yaml
@@ -1,5 +1,7 @@
 collections:
   ops.us-central1.v1/inferred-schemas/L1:
+    schema: schema-inference.schema.yaml
+    key: [/collection_name]
     derive:
       using:
         sqlite: {}
@@ -7,6 +9,20 @@ collections:
         - name: logs
           source:
             name: ops.us-central1.v1/logs
+            partitions:
+              include:
+                kind:
+                  - capture
+              exclude:
+                name:
+                  # Don't read our own inferences.
+                  - ops.us-central1.v1/inferred-schemas/L1
+                  - ops.us-central1.v1/inferred-schemas/L2
+
+                  # NOTE(johnny): In production, I've temporarily held back
+                  # a number of other task logs for $reasons. Do not publish
+                  # directly from ./ops-catalog/ into production quite yet.
+
           shuffle:
             key: [/shard/name] # Use partition-based shuffle.
           lambda: |
@@ -14,8 +30,6 @@ collections:
               $fields->>'collection_name' as collection_name,
               $fields->'schema' as schema
             where $message = 'inferred schema updated';
-    key: [/collection_name]
-    schema: schema-inference.schema.yaml
 
   # A direct-copy of L1, but enables us to add more L1s
   # as we create more data planes.

--- a/supabase/migrations/22_inferred_schemas.sql
+++ b/supabase/migrations/22_inferred_schemas.sql
@@ -1,0 +1,28 @@
+begin;
+
+create table inferred_schemas (
+    collection_name  catalog_name not null,
+    "schema"         json not null,
+    flow_document    json not null,
+    primary key (collection_name)
+);
+alter table inferred_schemas enable row level security;
+
+create policy "Users must be authorized to the collection name"
+  on inferred_schemas as permissive for select
+  using (exists(
+    select 1 from auth_roles('read') r where collection_name ^@ r.role_prefix
+  ));
+grant select on inferred_schemas to authenticated;
+
+comment on table inferred_schemas is
+    'Inferred schemas of Flow collections';
+comment on column inferred_schemas.collection_name is
+    'Collection which is inferred';
+comment on column inferred_schemas.schema is
+    'Inferred JSON schema of collection documents.';
+
+-- stats_loader loads directly to the inferred_schemas table.
+alter table inferred_schemas owner to stats_loader;
+
+commit;

--- a/supabase/tests/inferred_schemas.test.sql
+++ b/supabase/tests/inferred_schemas.test.sql
@@ -1,0 +1,29 @@
+create function tests.test_inferred_schemas()
+returns setof text as $$
+begin
+
+  insert into user_grants (user_id, object_role, capability) values
+    ('11111111-1111-1111-1111-111111111111', 'aliceCo/', 'admin'),
+    ('22222222-2222-2222-2222-222222222222', 'bobCo/', 'admin')
+  ;
+
+  -- The `stats_loader` user materializes directly into the inferred_schemas table.
+  set role stats_loader;
+  insert into inferred_schemas (
+    collection_name, schema, flow_document
+  ) values
+    ( 'aliceCo/hello', '{"const": "aliceCo"}', '{"alice":1}' ),
+    ( 'bobCo/world',   '{"const": "bobCo"}',   '{"bob":1}' )
+  ;
+
+  -- Drop privilege to `authenticated` and authorize as Alice.
+  perform set_authenticated_context('11111111-1111-1111-1111-111111111111');
+
+  return query select results_eq(
+    $i$ select collection_name::text, schema::text, flow_document::text from inferred_schemas $i$,
+    $i$ values ('aliceCo/hello', '{"const": "aliceCo"}', '{"alice":1}') $i$,
+    'alice can read alice stats only'
+  );
+
+end;
+$$ language plpgsql;


### PR DESCRIPTION
New `inferred_schemas` table is much like `catalog_stats`, and is loaded by the same stats_loader task.

Also add a partition selector to the inferred-schemas L1 derivation, to read only capture logs (for now: in the future we'll add derivations) and to exclude it's own schema inferrences.

Finally, improve `flowctl preview` error when a selector is not matched to explicitly tell the user that no journals were found, and what the evaluated selector was.

**Workflow steps:**

New table / API `inferred_schemas` is available.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

This migration has already been applied in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1146)
<!-- Reviewable:end -->
