### PR TITLE
flowctl: fix preview hanging on error

### DIFF
--- a/crates/flowctl/src/main.rs
+++ b/crates/flowctl/src/main.rs
@@ -1,12 +1,15 @@
 use clap::Parser;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), anyhow::Error> {
     // Colorization support for Win 10.
     #[cfg(windows)]
     let _ = colored_json::enable_ansi_support();
 
     let cli = flowctl::Cli::parse();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to start runtime");
 
     // Use reasonable defaults for printing structured logs to stderr.
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
@@ -15,5 +18,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
 
-    cli.run().await
+    let result = runtime.block_on(async move { cli.run().await });
+
+    // We must call `shutdown_background()` because otherwise an incomplete spawned future
+    // could block indefinitely.
+    runtime.shutdown_background();
+    result
 }

--- a/crates/flowctl/src/preview/mod.rs
+++ b/crates/flowctl/src/preview/mod.rs
@@ -19,7 +19,7 @@ pub struct Preview {
     /// Collection is required if there are multiple derivations in --source specifications.
     #[clap(long)]
     collection: Option<String>,
-    /// When exiting (for example, upon Ctrl-C), should we update the derivation schema
+    /// When exiting (for example, upon Ctrl-D), should we update the derivation schema
     /// based on observed output documents?
     #[clap(long)]
     infer_schema: bool,


### PR DESCRIPTION
**Description:**

`flowctl preview` would hang indefinitely when an error was encountered running the derivation. This fixes that to return immediately. In order to do that, we needed to explicitly shutdown the runtime, because the reason it was hanging was due to the runtime blocking on a future (reading stdin) that would never complete.

**Workflow steps:**

Run `flowctl preview` on a spec that results in a validation error. Previously, it would hang indefinitely. Now it'll return the error immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1147)
<!-- Reviewable:end -->
