### PR TITLE
control-plane: exclude recently updated specs from next_auto_discovers

### DIFF
--- a/supabase/tests/auto_discovers.test.sql
+++ b/supabase/tests/auto_discovers.test.sql
@@ -18,7 +18,7 @@ begin
 	('12:34:56:78:87:65:43:21', 'captureImage', '{"en-US":"a title"}', '{"en-US":"a desc"}', '{"en-US":"a logo"}', 'http://foo.test');
   insert into connector_tags (connector_id, image_tag) values
 	('12:34:56:78:87:65:43:21', ':v0');
-  insert into live_specs (catalog_name, spec_type, spec, connector_image_name, connector_image_tag, created_at) values
+  insert into live_specs (catalog_name, spec_type, spec, connector_image_name, connector_image_tag, updated_at) values
 	('aliceCo/test-capture', 'capture', '{
       "autoDiscover": {"addNewBindings": true},
       "endpoint": {
@@ -31,7 +31,19 @@ begin
     }', 'captureImage', ':v0', now() - '3h'::interval),
 
 	-- This should show up in the initial next_auto_discovers output, but not after
-	-- we create a recent discover.
+	-- we bump the updated_at timestamp
+	('aliceCo/test-capture-recently-updated', 'capture', '{
+      "autoDiscover": {"evolveIncompatibleCollections": true},
+      "endpoint": {
+        "connector": {
+          "image": "does not matter",
+            "config": {"other": "config"}
+          }
+      },
+      "bindings": []
+    }', 'captureImage', ':v0', now() - '3h'::interval),
+	-- This should show up in the initial next_auto_discovers output, but not after
+	-- we create a discover
 	('aliceCo/test-capture-recently-discovered', 'capture', '{
       "autoDiscover": {"evolveIncompatibleCollections": true},
       "endpoint": {
@@ -76,12 +88,16 @@ begin
       "bindings": []
     }', 'captureImage', ':v0', now() - '3h'::interval);
 
-  -- assert that the recently-discovered capture shows up in the view before we
+  -- assert that the recently-updated capture shows up in the view before we
   -- insert the recent discover.
   return query select results_eq(
     $i$ select capture_name::text from internal.next_auto_discovers order by capture_name asc $i$,
-	$i$ values ('aliceCo/test-capture'),('aliceCo/test-capture-recently-discovered') $i$
+	$i$ values ('aliceCo/test-capture'),('aliceCo/test-capture-recently-discovered'),('aliceCo/test-capture-recently-updated') $i$
   );
+
+  -- bump the live_specs updated_at timestamp and create a discover for these two captures, which should
+  -- cause them to be excluded from the output.
+  update live_specs set updated_at = now() where catalog_name = 'aliceCo/test-capture-recently-updated';
 
   insert into drafts (user_id) select id from auth.users where email = 'support@estuary.dev' returning id into draft_id;
   insert into discovers (capture_name, connector_tag_id, draft_id, endpoint_config) values (


### PR DESCRIPTION
**Description:**

Fixes another bug in the next_auto_discovers view, where it would not respect the `auto_discover_interval` and would publish much more frequently if the publications were successful. This fixes it by considering the `updated_at` timestamp of the `live_specs` table when checking to see if a capture is due for another auto discover.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1149)
<!-- Reviewable:end -->
