### PR TITLE
feature: Introduce `quickcheck`-based fuzzing for `Shape::widen()`, and fix two bugs that it found

### DIFF
--- a/crates/doc/src/shape/widen.rs
+++ b/crates/doc/src/shape/widen.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 impl StringShape {
     fn widen(&mut self, val: &str, is_first: bool) -> bool {
         if is_first {
-            let (min, max) = length_bounds(val.len());
+            let (min, max) = length_bounds(val.chars().count());
             self.format = Format::detect(val);
             self.max_length = Some(max);
             self.min_length = min;
@@ -32,14 +32,14 @@ impl StringShape {
             }
         }
 
-        if self.min_length as usize > val.len() {
-            self.min_length = length_bounds(val.len()).0;
+        if self.min_length as usize > val.chars().count() {
+            self.min_length = length_bounds(val.chars().count()).0;
             changed = true;
         }
 
         if let Some(max) = &mut self.max_length {
-            if (*max as usize) < val.len() {
-                *max = length_bounds(val.len()).1;
+            if (*max as usize) < val.chars().count() {
+                *max = length_bounds(val.chars().count()).1;
                 changed = true;
             }
         }
@@ -264,12 +264,16 @@ impl Shape {
             return self.widen_enum(node);
         }
 
+        // is_first doesn’t mean “the first time i’ve seen this location”,
+        // it’s “the first time i’ve seen this location with this type”
         let mut apply_type = |type_| -> bool {
-            let is_first = self.type_ & type_ == types::INVALID;
-            if is_first {
+            if self.type_ & type_ != type_ {
+                // Handle INT_OR_FRACT correctly. We could have partial overlap with type_.
+                let is_first = self.type_ & type_ == types::INVALID;
                 self.type_ = self.type_ | type_;
+                return is_first;
             }
-            is_first
+            false
         };
 
         match node.as_node() {

--- a/crates/doc/tests/shape_fuzz.rs
+++ b/crates/doc/tests/shape_fuzz.rs
@@ -1,0 +1,165 @@
+use doc::{shape::schema::to_schema, Shape, Validator};
+use itertools::Itertools;
+use quickcheck::*;
+use serde_json::{Map, Number, Value};
+use std::{collections::BTreeMap, ops::Range};
+
+#[derive(Clone, Debug)]
+struct ArbitraryValue(Value);
+
+impl quickcheck::Arbitrary for ArbitraryValue {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        Self(gen_value(g, 10))
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        match self.0.clone() {
+            Value::Null => quickcheck::empty_shrinker(),
+            Value::Bool(b) => Box::new(b.shrink().map(|v| Self(Value::Bool(v)))),
+            Value::Number(n) if n.is_f64() => {
+                Box::new(n.as_f64().unwrap_or(0.0).shrink().map(|v| {
+                    Self(Value::Number(
+                        Number::from_f64(v).unwrap_or(Number::from_f64(0.0).unwrap()),
+                    ))
+                }))
+            }
+            Value::Number(n) if n.is_u64() => Box::new(
+                n.as_u64()
+                    .unwrap()
+                    .shrink()
+                    .map(|v| Self(Value::Number(Number::from(v)))),
+            ),
+            Value::Number(n) if n.is_i64() => Box::new(
+                n.as_i64()
+                    .unwrap()
+                    .shrink()
+                    .map(|v| Self(Value::Number(Number::from(v)))),
+            ),
+            Value::Number(_) => unreachable!(),
+            Value::String(ref s) => Box::new(s.shrink().map(|v| Self(Value::String(v)))),
+            Value::Array(ref v) => Box::new(
+                v.into_iter()
+                    .map(|val| Self(val.to_owned()))
+                    .collect_vec()
+                    .shrink()
+                    .map(|v| Self(Value::Array(v.into_iter().map(|av| av.0).collect_vec()))),
+            ),
+            Value::Object(ref m) => {
+                let btreetmap = m
+                    .iter()
+                    .map(|(k, v)| (k.to_owned(), Self(v.clone())))
+                    .collect::<BTreeMap<_, _>>();
+                Box::new(btreetmap.shrink().map(|v| {
+                    Self(Value::Object(Map::from_iter(
+                        v.into_iter().map(|(k, v)| (k, v.0)),
+                    )))
+                }))
+            }
+        }
+    }
+}
+
+fn gen_range(gen: &mut quickcheck::Gen, range: Range<u64>) -> u64 {
+    u64::arbitrary(gen) % (range.end - range.start) + range.start
+}
+
+fn gen_value(g: &mut quickcheck::Gen, n: usize) -> Value {
+    match gen_range(g, 0..if n != 0 { 8 } else { 6 }) {
+        0 => Value::Null,
+        1 => Value::Bool(bool::arbitrary(g)),
+        2 => Value::Number(Number::from(i64::arbitrary(g).min(2 ^ 53).max(2 ^ 53 * -1))),
+        3 => Value::Number(Number::from(u64::arbitrary(g).min(2 ^ 53))),
+        4 => Number::from_f64(f64::arbitrary(g))
+            .map(|v| Value::Number(v))
+            .unwrap_or(Value::Number(Number::from(0))),
+        5 => Value::String(<String as quickcheck::Arbitrary>::arbitrary(g)),
+        6 => Value::Array(gen_array(g, n / 2)),
+        7 => Value::Object(gen_map(g, n / 2)),
+        _ => unreachable!(),
+    }
+}
+
+fn gen_array(g: &mut quickcheck::Gen, n: usize) -> Vec<Value> {
+    (0..gen_range(g, 2..20)).map(|_| gen_value(g, n)).collect()
+}
+
+fn gen_map(g: &mut quickcheck::Gen, n: usize) -> Map<String, Value> {
+    (0..gen_range(g, 2..20))
+        .map(|_| {
+            (
+                <String as quickcheck::Arbitrary>::arbitrary(g),
+                gen_value(g, n),
+            )
+        })
+        .collect()
+}
+
+fn roundtrip_schema_widening_validation(vals: Vec<Value>) -> bool {
+    let mut shape = Shape::nothing();
+    for val in &vals {
+        shape.widen(val);
+    }
+
+    let schema = json::schema::build::build_schema(
+        url::Url::parse("https://example").unwrap(),
+        &serde_json::to_value(to_schema(shape.clone())).unwrap(),
+    )
+    .unwrap();
+
+    let schema_yaml = serde_yaml::to_string(&to_schema(shape)).unwrap();
+
+    let mut validator = Validator::new(schema).unwrap();
+
+    for val in vals {
+        let res = validator.validate(None, &val);
+        if let Ok(validation) = res {
+            if validation.validator.invalid() {
+                let errs = validation
+                    .validator
+                    .outcomes()
+                    .iter()
+                    .map(|(outcome, _span)| format!("{}", outcome))
+                    .collect_vec()
+                    .join(r#","#);
+
+                println!(
+                    r#"Schema {} failed validation for document {}: "{}\n"#,
+                    schema_yaml, val, errs
+                );
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Cases detected by quickcheck:
+#[test]
+fn test_unicode_multibyte_widening() {
+    assert_eq!(
+        roundtrip_schema_widening_validation(vec![serde_json::json!("ࠀ")]),
+        true
+    )
+}
+
+#[test]
+fn test_widening_floats() {
+    assert_eq!(
+        roundtrip_schema_widening_validation(vec![serde_json::json!([0.0, 71113157.14749053])]),
+        true
+    )
+}
+
+#[test]
+fn fuzz_json() {
+    fn inner_test(av: Vec<ArbitraryValue>) -> bool {
+        let vals = av.into_iter().map(|v| v.0).collect_vec();
+        roundtrip_schema_widening_validation(vals)
+    }
+
+    QuickCheck::new()
+        .gen(Gen::new(20))
+        .quickcheck(inner_test as fn(Vec<ArbitraryValue>) -> bool);
+}

--- a/crates/doc/tests/shape_fuzz.rs
+++ b/crates/doc/tests/shape_fuzz.rs
@@ -1,6 +1,6 @@
 use doc::{shape::schema::to_schema, Shape, Validator};
 use itertools::Itertools;
-use quickcheck::*;
+use quickcheck::{Arbitrary, Gen, QuickCheck};
 use serde_json::{Map, Number, Value};
 use std::{collections::BTreeMap, ops::Range};
 
@@ -133,23 +133,6 @@ fn roundtrip_schema_widening_validation(vals: Vec<Value>) -> bool {
         }
     }
     return true;
-}
-
-// Cases detected by quickcheck:
-#[test]
-fn test_unicode_multibyte_widening() {
-    assert_eq!(
-        roundtrip_schema_widening_validation(vec![serde_json::json!("ࠀ")]),
-        true
-    )
-}
-
-#[test]
-fn test_widening_floats() {
-    assert_eq!(
-        roundtrip_schema_widening_validation(vec![serde_json::json!([0.0, 71113157.14749053])]),
-        true
-    )
 }
 
 #[test]


### PR DESCRIPTION
1. We were widening strings using `.len()`, which returns different results than `.chars().count()`. [JSON Schema](https://json-schema.org/draft/2020-12/json-schema-validation.html#section-6.3) says:
   > The length of a string instance is defined as the number of its characters [..]
2. Fixed a bug inferring from `integer` -> `number`. The problem is that `NUMBER` is really a composite of `INTEGER | FRACTIONAL`, so if it’s already `INTEGER`, then the test of `type_ & INTEGER | FRACTIONAL` is `INTEGER`, not `INVALID`.

I'm somewhat conflicted on code organization here: I would kind of like to put all of the widen tests in one place inside `widen.rs`, but I also want to put the quickcheck stuff together, and don't want to smoosh all of it inside of `widen.rs`. So for now I left it where it is

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1151)
<!-- Reviewable:end -->
