### PR TITLE
Improve schema limits

### DIFF
--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -886,7 +886,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[serial_test::parallel]
+    #[serial_test::serial]
     async fn test_source_capture_validation() {
         let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
             .await

--- a/crates/agent/src/resource_configs.rs
+++ b/crates/agent/src/resource_configs.rs
@@ -80,7 +80,7 @@ pub fn pointer_for_schema(schema_json: &str) -> anyhow::Result<doc::Pointer> {
 
     for (ptr, _, prop_shape, _) in shape.locations() {
         if prop_shape.annotations.contains_key("x-collection-name") {
-            return Ok(doc::Pointer::from_str(&ptr));
+            return Ok(ptr);
         }
     }
     Err(anyhow::anyhow!(

--- a/crates/derive/src/combine_api.rs
+++ b/crates/derive/src/combine_api.rs
@@ -1,7 +1,7 @@
 use crate::{new_validator, DebugJson, DocCounter, JsonError, StatsAccumulator};
 use anyhow::Context;
 use bytes::Buf;
-use doc::shape::{limits::enforce_field_count_limits, schema::to_schema};
+use doc::shape::{limits::{enforce_shape_complexity_limit, DEFAULT_SCHEMA_COMPLEXITY_LIMIT}, schema::to_schema};
 use prost::Message;
 use proto_flow::flow::combine_api::{self, Code};
 
@@ -291,7 +291,7 @@ pub fn drain_chunk(
                 doc::LazyNode::Heap(h) => shape.widen(h),
             };
             if changed {
-                enforce_field_count_limits(shape, json::Location::Root);
+                enforce_shape_complexity_limit(shape, DEFAULT_SCHEMA_COMPLEXITY_LIMIT);
                 *did_change = true;
             }
         }
@@ -742,8 +742,8 @@ pub mod test {
 
                 // Test projection fields == their pointer.
                 flow::Projection {
-                    field: ptr.clone(),
-                    ptr: ptr,
+                    field: ptr.to_string(),
+                    ptr: ptr.to_string(),
                     inference: Some(flow::Inference {
                         default_json: shape
                             .default

--- a/crates/doc/src/ptr.rs
+++ b/crates/doc/src/ptr.rs
@@ -39,7 +39,7 @@ impl<'t> std::fmt::Display for Token {
 }
 
 /// Pointer is a parsed JSON pointer.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Pointer(pub Vec<Token>);
 
 impl Pointer {

--- a/crates/doc/src/reduce/schema.rs
+++ b/crates/doc/src/reduce/schema.rs
@@ -1,5 +1,9 @@
 use super::{count_nodes, Cursor, Error, Result};
-use crate::{shape::limits, shape::schema::to_schema, AsNode, HeapNode, Shape};
+use crate::{
+    shape::limits,
+    shape::{limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT, schema::to_schema},
+    AsNode, HeapNode, Shape,
+};
 use json::schema::index::IndexBuilder;
 
 pub fn json_schema_merge<'alloc, L: AsNode, R: AsNode>(
@@ -32,7 +36,7 @@ pub fn json_schema_merge<'alloc, L: AsNode, R: AsNode>(
     let right = shape_from_node(rhs).map_err(|e| Error::with_location(e, loc))?;
 
     let mut merged_shape = Shape::union(left, right);
-    limits::enforce_field_count_limits(&mut merged_shape, json::Location::Root);
+    limits::enforce_shape_complexity_limit(&mut merged_shape, DEFAULT_SCHEMA_COMPLEXITY_LIMIT);
 
     // Union together the LHS and RHS, and convert back from `Shape` into `HeapNode`.
     let merged_doc = serde_json::to_value(to_schema(merged_shape))

--- a/crates/doc/src/shape/limits.rs
+++ b/crates/doc/src/shape/limits.rs
@@ -1,63 +1,164 @@
 // This module defines limits which are used to simplify complex,
 // typically inferred schema Shapes.
 use super::*;
-use json::Location;
+use crate::{ptr::Token, Pointer};
+use itertools::Itertools;
+use std::cmp::Ordering;
 
-// Prune any locations in this shape that have more than the allowed fields,
-// squashing those fields into the `additionalProperties` subschema for that location.
-pub fn enforce_field_count_limits(slf: &mut Shape, loc: Location) {
-    // TODO: If we implement inference/widening of array tuple shapes
-    // then we'll need to also check that those aren't excessively large.
-    if slf.type_.overlaps(types::ARRAY) {
-        if let Some(array_shape) = slf.array.additional_items.as_mut() {
-            enforce_field_count_limits(array_shape, loc.push_item(0));
+fn resolve_shape_mut(shape: &mut Shape, field: Token) -> Option<&mut Shape> {
+    match field {
+        Token::Index(idx) => shape.array.tuple.get_mut(idx),
+        Token::Property(prop_name) if prop_name == "*" => {
+            shape.object.additional_properties.as_deref_mut()
         }
-    }
-
-    if !slf.type_.overlaps(types::OBJECT) {
-        return;
-    }
-
-    let limit = match loc {
-        Location::Root => MAX_ROOT_FIELDS,
-        _ => MAX_NESTED_FIELDS,
-    };
-
-    if slf.object.properties.len() > limit {
-        // Take all of the properties' shapes and
-        // union them into additionalProperties
-
-        let existing_additional_properties = slf
-            .object
-            .additional_properties
-            // `Shape::union` takes owned Shapes which is why we
-            // have to take ownership here.
-            .take()
-            .map(|boxed| *boxed)
-            .unwrap_or(Shape::nothing());
-
-        let merged_additional_properties = slf
+        Token::Property(prop_name) => shape
             .object
             .properties
-            // As part of squashing all known property shapes together into
-            // additionalProperties, we need to also remove those explicit properties.
-            .drain(..)
-            .fold(existing_additional_properties, |accum, mut prop| {
-                // Recur here to avoid excessively large `additionalProperties` shapes
-                enforce_field_count_limits(&mut prop.shape, loc.push_prop(&prop.name));
-                Shape::union(accum, prop.shape)
-            });
+            .iter_mut()
+            .find(|prop| *prop.name == *prop_name)
+            .map(|inner| &mut inner.shape),
+        Token::NextIndex => shape.array.additional_items.as_deref_mut(),
+    }
+}
 
-        slf.object.additional_properties = Some(Box::new(merged_additional_properties));
-    } else {
-        for prop in slf.object.properties.iter_mut() {
-            enforce_field_count_limits(&mut prop.shape, loc.push_prop(&prop.name))
+fn squash_location_inner(shape: &mut Shape, name: Token) {
+    match name {
+        Token::Index(idx) => {
+            // Remove location from parent properties
+            let shape_to_squash = shape.array.tuple.remove(idx);
+
+            if let Some(addl_items) = &shape.array.additional_items {
+                shape.array.additional_items =
+                    Some(Box::new(Shape::union(*addl_items.clone(), shape_to_squash)));
+            } else {
+                shape.array.additional_items = Some(Box::new(shape_to_squash));
+            }
+        }
+        Token::Property(prop_name) => {
+            let prop_position = shape
+                .object
+                .properties
+                .iter()
+                .position(|prop| *prop.name == *prop_name);
+
+            if let Some(prop_position) = prop_position {
+                // Remove location from parent properties
+                let ObjProperty {
+                    shape: shape_to_squash,
+                    ..
+                } = shape.object.properties.remove(prop_position);
+
+                // First check to see if it matches a pattern
+                // and if so squash into that pattern's shape
+                if let Some(pattern) = shape
+                    .object
+                    .pattern_properties
+                    .iter_mut()
+                    .find(|pattern| regex_matches(&pattern.re, &prop_name))
+                {
+                    pattern.shape = Shape::union(pattern.shape.clone(), shape_to_squash)
+                } else if let Some(addl_properties) = &shape.object.additional_properties {
+                    shape.object.additional_properties = Some(Box::new(Shape::union(
+                        *addl_properties.clone(),
+                        shape_to_squash,
+                    )));
+                } else {
+                    shape.object.additional_properties = Some(Box::new(shape_to_squash))
+                }
+            }
+        }
+        Token::NextIndex => {}
+    }
+}
+
+fn squash_location(shape: &mut Shape, location: Pointer) {
+    match &location.0.as_slice() {
+        [] => unreachable!(),
+        [first] => squash_location_inner(shape, first.to_owned()),
+        [first, last] => {
+            if let Some(parent) = resolve_shape_mut(shape, first.to_owned()) {
+                match last {
+                    // These represent the locations for array `additionalItems`, and object `additionalProperties`.
+                    // The only way I can figure out to reduce the complexity of these locations
+                    // is to simply "widen" their shapes to accept anything, thereby removing schema complexity.
+                    Token::NextIndex => {
+                        parent.array.additional_items = Some(Box::new(Shape::anything()))
+                    }
+                    Token::Property(prop_name) if prop_name == "*" => {
+                        parent.object.additional_properties = Some(Box::new(Shape::anything()))
+                    }
+                    _ => squash_location_inner(parent, last.to_owned()),
+                }
+            }
+        }
+        [first, more @ ..] => {
+            if let Some(inner) = resolve_shape_mut(shape, first.to_owned()) {
+                squash_location(inner, Pointer(more.to_vec()))
+            }
         }
     }
 }
 
-pub const MAX_ROOT_FIELDS: usize = 750;
-pub const MAX_NESTED_FIELDS: usize = 200;
+fn is_additionalx_field(token: &Token) -> bool {
+    match token {
+        Token::NextIndex => true,
+        Token::Property(prop_name) if prop_name == "*" => true,
+        _ => false,
+    }
+}
+
+/// Reduce the size/complexity of a shape while making sure that all
+/// objects that used to pass validation still do.
+pub fn enforce_shape_complexity_limit(shape: &mut Shape, limit: usize) {
+    let mut locations = shape
+        .locations()
+        .into_iter()
+        .filter_map(|(ptr, _, shape, _)| {
+            if ptr.0.len() > 0 {
+                Some((ptr, shape.clone()))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+
+    if locations.len() < limit {
+        return;
+    }
+
+    locations.sort_by(|(a_ptr, _), (b_ptr, _)| {
+        // make sure that all `additional*` fields are last
+        // AND that they are sorted by depth within their group
+        // then order by depth, then lexicographically
+        match (a_ptr.0.as_slice(), b_ptr.0.as_slice()) {
+            // Order additional* fields by depth within their group
+            ([.., a_token], [.., b_token])
+                if is_additionalx_field(a_token) && is_additionalx_field(b_token) =>
+            {
+                a_ptr.0.len().cmp(&b_ptr.0.len())
+            }
+            // Order additional* fields after all other fields
+            ([.., a_token], _) if is_additionalx_field(a_token) => Ordering::Less,
+            (_, [.., b_token]) if is_additionalx_field(b_token) => Ordering::Greater,
+            // Neither are additional*, now order by depth
+            _ => match a_ptr.0.len().cmp(&b_ptr.0.len()) {
+                // Same depth, stably sort lexicographically
+                Ordering::Equal => a_ptr.to_string().cmp(&b_ptr.to_string()),
+                depth => depth,
+            },
+        }
+    });
+
+    while locations.len() > limit {
+        let (location_ptr, _) = locations
+            .pop()
+            .expect("locations vec was just checked to be non-empty");
+
+        squash_location(shape, location_ptr);
+    }
+}
+
+pub const DEFAULT_SCHEMA_COMPLEXITY_LIMIT: usize = 2000;
 
 #[cfg(test)]
 mod test {
@@ -70,7 +171,7 @@ mod test {
         initial_schema: Option<&str>,
         expected_schema: &str,
         docs: &[serde_json::Value],
-        enforce_limits: bool,
+        enforce_limits: Option<usize>,
     ) -> Shape {
         let mut schema = match initial_schema {
             Some(initial) => shape_from(initial),
@@ -83,8 +184,8 @@ mod test {
 
         let expected = shape_from(expected_schema);
 
-        if enforce_limits {
-            enforce_field_count_limits(&mut schema, Location::Root);
+        if let Some(limit) = enforce_limits {
+            enforce_shape_complexity_limit(&mut schema, limit);
         }
 
         assert_eq!(expected, schema);
@@ -113,7 +214,7 @@ mod test {
                 maximum: 10000
             "#,
             dynamic_keys.as_slice(),
-            true,
+            Some(0),
         );
     }
 
@@ -149,7 +250,7 @@ mod test {
                         maximum: 10000
             "#,
             &[json!(root)],
-            true,
+            Some(2),
         );
     }
 
@@ -178,7 +279,7 @@ mod test {
                             maximum: 0
             "#,
             &[json!({ "container": nested })],
-            true,
+            Some(4),
         );
 
         for id in 0..300 {
@@ -200,7 +301,7 @@ mod test {
                         maximum: 10000
             "#,
             &[json!({ "container": nested })],
-            true,
+            Some(3),
         );
     }
 
@@ -223,9 +324,9 @@ mod test {
                         maxLength: 4
             "#,
             &[json!([{"key": "test"}])],
-            true,
+            Some(3),
         );
-        let dynamic_array_objects = (0..800)
+        let dynamic_array_objects = (0..8)
             .map(|id| {
                 json!([{
                     format!("key-{id}"): "test"
@@ -262,7 +363,7 @@ mod test {
                         maxLength: 4
                 "#,
             &dynamic_array_objects,
-            true,
+            Some(2),
         );
     }
 
@@ -294,7 +395,39 @@ mod test {
                     maximum: 0
             "#,
             dynamic_keys.as_slice(),
-            true,
+            Some(20),
+        );
+    }
+
+    #[test]
+    fn test_quickcheck_regression() {
+        widening_snapshot_helper(
+            None,
+            r#"
+            type: array
+            maxItems: 1
+            items:
+                type: object
+                additionalProperties: true
+            "#,
+            &[json!([{}])],
+            Some(0),
+        );
+    }
+
+    #[test]
+    fn test_quickcheck_regression_2() {
+        widening_snapshot_helper(
+            None,
+            r#"
+            type: object
+            additionalProperties:
+                type: array
+                items: false
+                maxItems: 0
+            "#,
+            &[json!({"foo":[]})],
+            Some(0),
         );
     }
 }

--- a/crates/doc/tests/shape_fuzz.rs
+++ b/crates/doc/tests/shape_fuzz.rs
@@ -1,6 +1,5 @@
-use doc::{shape::schema::to_schema, Shape, Validator};
 use itertools::Itertools;
-use quickcheck::{Arbitrary, Gen, QuickCheck};
+use quickcheck::Arbitrary;
 use serde_json::{Map, Number, Value};
 use std::{collections::BTreeMap, ops::Range};
 
@@ -80,11 +79,13 @@ fn gen_value(g: &mut quickcheck::Gen, n: usize) -> Value {
 }
 
 fn gen_array(g: &mut quickcheck::Gen, n: usize) -> Vec<Value> {
-    (0..gen_range(g, 2..20)).map(|_| gen_value(g, n)).collect()
+    (0..gen_range(g, 2..(n as u64) + 3))
+        .map(|_| gen_value(g, n))
+        .collect()
 }
 
 fn gen_map(g: &mut quickcheck::Gen, n: usize) -> Map<String, Value> {
-    (0..gen_range(g, 2..20))
+    (0..gen_range(g, 2..(n as u64) + 3))
         .map(|_| {
             (
                 <String as quickcheck::Arbitrary>::arbitrary(g),
@@ -94,55 +95,122 @@ fn gen_map(g: &mut quickcheck::Gen, n: usize) -> Map<String, Value> {
         .collect()
 }
 
-fn roundtrip_schema_widening_validation(vals: Vec<Value>) -> bool {
-    let mut shape = Shape::nothing();
-    for val in &vals {
-        shape.widen(val);
-    }
+#[cfg(test)]
+mod test {
+    use crate::ArbitraryValue;
+    use doc::{
+        shape::{limits::enforce_shape_complexity_limit, schema::to_schema},
+        Shape, Validator,
+    };
+    use itertools::Itertools;
+    use quickcheck::{Gen, QuickCheck, TestResult};
+    use serde_json::{json, Value};
 
-    let schema = json::schema::build::build_schema(
-        url::Url::parse("https://example").unwrap(),
-        &serde_json::to_value(to_schema(shape.clone())).unwrap(),
-    )
-    .unwrap();
+    fn assert_docs_fit_schema(docs: Vec<Value>, shape: Shape) -> bool {
+        let schema = json::schema::build::build_schema(
+            url::Url::parse("https://example").unwrap(),
+            &serde_json::to_value(to_schema(shape.clone())).unwrap(),
+        )
+        .unwrap();
 
-    let schema_yaml = serde_yaml::to_string(&to_schema(shape)).unwrap();
+        let schema_yaml = serde_yaml::to_string(&to_schema(shape)).unwrap();
 
-    let mut validator = Validator::new(schema).unwrap();
+        let mut validator = Validator::new(schema).unwrap();
 
-    for val in vals {
-        let res = validator.validate(None, &val);
-        if let Ok(validation) = res {
-            if validation.validator.invalid() {
-                let errs = validation
-                    .validator
-                    .outcomes()
-                    .iter()
-                    .map(|(outcome, _span)| format!("{}", outcome))
-                    .collect_vec()
-                    .join(r#","#);
+        for val in docs {
+            let res = validator.validate(None, &val);
+            if let Ok(validation) = res {
+                if validation.validator.invalid() {
+                    let errs = validation
+                        .validator
+                        .outcomes()
+                        .iter()
+                        .map(|(outcome, _span)| format!("{}", outcome))
+                        .collect_vec()
+                        .join(r#","#);
 
-                println!(
-                    r#"Schema {} failed validation for document {}: "{}\n"#,
-                    schema_yaml, val, errs
-                );
+                    println!(
+                        r#"Schema {} failed validation for document {}: "{}\n"#,
+                        schema_yaml, val, errs
+                    );
+                    return false;
+                }
+            } else {
                 return false;
             }
-        } else {
+        }
+        return true;
+    }
+
+    fn shape_limits(vals: Vec<Value>, limit: usize) -> bool {
+        let mut shape = Shape::nothing();
+        for val in &vals {
+            shape.widen(val);
+        }
+
+        let initial_locations = shape.locations().len();
+        let initial_schema_yaml = serde_yaml::to_string(&to_schema(shape.clone())).unwrap();
+
+        enforce_shape_complexity_limit(&mut shape, limit);
+
+        let enforced_locations = shape
+            .locations()
+            .iter()
+            .filter(|(ptr, pattern, _, _)| !pattern && ptr.0.len() > 0)
+            .collect_vec()
+            .len();
+
+        if enforced_locations > limit || !assert_docs_fit_schema(vals.clone(), shape.clone()) {
+            let schema_yaml = serde_yaml::to_string(&to_schema(shape)).unwrap();
+            println!("Started with {initial_locations} initial locations, enforced down to {enforced_locations}, limit was {limit}");
+            println!(
+                "start: {initial_schema_yaml}\nenforced down to: {schema_yaml}\ndocs:{vals:?}"
+            );
             return false;
+        } else {
+            return true;
         }
     }
-    return true;
-}
 
-#[test]
-fn fuzz_json() {
-    fn inner_test(av: Vec<ArbitraryValue>) -> bool {
-        let vals = av.into_iter().map(|v| v.0).collect_vec();
-        roundtrip_schema_widening_validation(vals)
+    fn roundtrip_schema_widening_validation(vals: Vec<Value>) -> bool {
+        let mut shape = Shape::nothing();
+        for val in &vals {
+            shape.widen(val);
+        }
+
+        assert_docs_fit_schema(vals, shape)
     }
 
-    QuickCheck::new()
-        .gen(Gen::new(20))
-        .quickcheck(inner_test as fn(Vec<ArbitraryValue>) -> bool);
+    #[test]
+    fn test_case_obj() {
+        assert_eq!(true, shape_limits(vec![json!({"":{"":55}})], 1));
+    }
+
+    #[test]
+    fn fuzz_roundtrip() {
+        fn inner_test(av: Vec<ArbitraryValue>) -> bool {
+            let vals = av.into_iter().map(|v| v.0).collect_vec();
+            roundtrip_schema_widening_validation(vals)
+        }
+
+        QuickCheck::new()
+            .gen(Gen::new(100))
+            .quickcheck(inner_test as fn(Vec<ArbitraryValue>) -> bool);
+    }
+
+    #[test]
+    fn fuzz_limiting() {
+        fn inner_test(av: Vec<ArbitraryValue>, limit: usize) -> TestResult {
+            if limit < 1 {
+                return TestResult::discard();
+            }
+            let vals = av.into_iter().map(|v| v.0).collect_vec();
+            TestResult::from_bool(shape_limits(vals, limit))
+        }
+
+        QuickCheck::new()
+            .gen(Gen::new(100))
+            .tests(1000)
+            .quickcheck(inner_test as fn(Vec<ArbitraryValue>, usize) -> TestResult);
+    }
 }

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -87,10 +87,10 @@ pub fn infer(schema: JsValue) -> Result<JsValue, JsValue> {
         .locations()
         .into_iter()
         .map(|(ptr, is_pattern, prop_shape, exists)| {
-            let name = if ptr.is_empty() || is_pattern {
+            let name = if ptr.0.is_empty() || is_pattern {
                 None
             } else {
-                Some((&ptr[1..]).to_string())
+                Some((&ptr.to_string()[1..]).to_string())
             };
             let types = prop_shape.type_.iter().map(|ty| ty.to_string()).collect();
 
@@ -109,7 +109,7 @@ pub fn infer(schema: JsValue) -> Result<JsValue, JsValue> {
                 title: prop_shape.title.clone().map(Into::into),
                 description: prop_shape.description.clone().map(Into::into),
                 reduction: reduce_description(prop_shape.reduction.clone()).to_string(),
-                pointer: ptr,
+                pointer: ptr.to_string(),
                 types,
                 enum_vals,
                 string_format,

--- a/crates/flowctl/src/raw/discover.rs
+++ b/crates/flowctl/src/raw/discover.rs
@@ -213,8 +213,7 @@ fn schema_to_sample_json(schema_shape: &Shape) -> Result<serde_json::Value, anyh
     let mut config = json!({});
     let locs = schema_shape.locations();
 
-    for (ptr, _is_pattern, shape, _exists) in locs.iter() {
-        let p = doc::Pointer::from_str(ptr);
+    for (p, _is_pattern, shape, _exists) in locs.iter() {
         let v = p
             .create_value(&mut config)
             .expect("structure must be valid");

--- a/crates/schemalate/src/markdown.rs
+++ b/crates/schemalate/src/markdown.rs
@@ -35,13 +35,18 @@ pub fn run(args: Args) -> anyhow::Result<()> {
     println!("|---|---|---|---|---|");
 
     for (ptr, pattern, shape, exists) in shape.locations() {
-        if args.exclude.contains(&ptr) {
+        let ptr_str = ptr.to_string();
+        if args.exclude.contains(&ptr_str) {
             continue;
         }
         let formatted_ptr = surround_if(
             exists.cannot(),
             "~~",
-            surround_if(exists.must(), "**", surround_if(pattern, "_", Code(&ptr))),
+            surround_if(
+                exists.must(),
+                "**",
+                surround_if(pattern, "_", Code(ptr_str.as_str())),
+            ),
         );
 
         let title = shape.title.as_deref().unwrap_or("");

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -288,11 +288,11 @@ fn walk_collection_projections(
     // Now add all statically inferred locations from the read-time JSON schema
     // which are not patterns or the document root.
     for (ptr, pattern, r_shape, r_exists) in effective_read_schema.shape.locations() {
-        if pattern || ptr.is_empty() {
+        if pattern || ptr.0.is_empty() {
             continue;
         }
         // Canonical-ize by stripping the leading "/".
-        let field = ptr[1..].to_string();
+        let field = ptr.to_string()[1..].to_string();
         // Special case to avoid creating a conflicting projection when the collection
         // schema contains a field with the same name as the default root projection.
         if field == FLOW_DOCUMENT {

--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -147,8 +147,9 @@ func (c *Capture) StartReadingMessages(
 	cp pf.Checkpoint,
 	_ *flow.Timepoint,
 	ch chan<- consumer.EnvelopeOrError,
+	enableSchemaInference bool,
 ) {
-	if err := c.startReadingMessages(shard, cp, ch); err != nil {
+	if err := c.startReadingMessages(shard, cp, ch, enableSchemaInference); err != nil {
 		ch <- consumer.EnvelopeOrError{Error: err}
 	}
 }
@@ -157,6 +158,7 @@ func (c *Capture) startReadingMessages(
 	shard consumer.Shard,
 	cp pf.Checkpoint,
 	ch chan<- consumer.EnvelopeOrError,
+	enableSchemaInference bool,
 ) error {
 	// A consumer.Envelope requires a JournalSpec, of which only the Name is actually
 	// used (for sequencing messages and producing checkpoints).
@@ -271,9 +273,7 @@ func (c *Capture) startReadingMessages(
 			binding.Collection.Key,
 			binding.Collection.PartitionFields,
 			binding.Collection.Projections,
-			// Enable schema inference for captures
-			// true,
-			false, // TODO(johnny): temporarily disable schema inference.
+			enableSchemaInference,
 		)
 	}
 

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -27,10 +27,11 @@ import (
 type FlowConsumerConfig struct {
 	runconsumer.BaseConfig
 	Flow struct {
-		BuildsRoot string `long:"builds-root" required:"true" env:"BUILDS_ROOT" description:"Base URL for fetching Flow catalog builds"`
-		BrokerRoot string `long:"broker-root" required:"true" env:"BROKER_ROOT" default:"/gazette/cluster" description:"Broker Etcd base prefix"`
-		Network    string `long:"network" description:"The Docker network that connector containers are given access to, defaults to the bridge network"`
-		TestAPIs   bool   `long:"test-apis" description:"Enable APIs exclusively used while running catalog tests"`
+		BuildsRoot            string `long:"builds-root" required:"true" env:"BUILDS_ROOT" description:"Base URL for fetching Flow catalog builds"`
+		BrokerRoot            string `long:"broker-root" required:"true" env:"BROKER_ROOT" default:"/gazette/cluster" description:"Broker Etcd base prefix"`
+		Network               string `long:"network" description:"The Docker network that connector containers are given access to, defaults to the bridge network"`
+		TestAPIs              bool   `long:"test-apis" description:"Enable APIs exclusively used while running catalog tests"`
+		EnableSchemaInference bool   `long:"enable-schema-inference" description:"Enable schema inference for capture tasks" `
 	} `group:"flow" namespace:"flow" env-namespace:"FLOW"`
 }
 
@@ -118,7 +119,7 @@ func (f *FlowConsumer) StartReadingMessages(shard consumer.Shard, store consumer
 	var tp = f.Timepoint.Now
 	f.Timepoint.Mu.Unlock()
 
-	store.(Application).StartReadingMessages(shard, checkpoint, tp, envOrErr)
+	store.(Application).StartReadingMessages(shard, checkpoint, tp, envOrErr, f.Config.Flow.EnableSchemaInference)
 }
 
 // ReplayRange delegates to the Application.

--- a/go/runtime/interfaces.go
+++ b/go/runtime/interfaces.go
@@ -20,7 +20,7 @@ type Application interface {
 	FinalizeTxn(consumer.Shard, *message.Publisher) error
 	FinishedTxn(consumer.Shard, consumer.OpFuture)
 
-	StartReadingMessages(consumer.Shard, pc.Checkpoint, *flow.Timepoint, chan<- consumer.EnvelopeOrError)
+	StartReadingMessages(consumer.Shard, pc.Checkpoint, *flow.Timepoint, chan<- consumer.EnvelopeOrError, bool)
 	ReplayRange(_ consumer.Shard, _ pb.Journal, begin, end pb.Offset) message.Iterator
 	ReadThrough(pb.Offsets) (pb.Offsets, error)
 }

--- a/go/runtime/task_term.go
+++ b/go/runtime/task_term.go
@@ -244,6 +244,8 @@ func (r *taskReader) StartReadingMessages(
 	cp pc.Checkpoint,
 	tp *flow.Timepoint,
 	ch chan<- consumer.EnvelopeOrError,
+	// We'll just ignore this here, we don't want to do schema inference when reading from collections
+	enableSchemaInference bool,
 ) {
 	shuffle.StartReadingMessages(shard.Context(), r.readBuilder, cp, tp, ch)
 }


### PR DESCRIPTION
**Description:**

* Replace per-subschema field limit with a global complexity limit, currently set at 1000 total fields.
* Add a `--flow.enable-schema-inference` flag to `flowctl-go serve consumer` to enable schema inference for capture tasks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1157)
<!-- Reviewable:end -->
