### PR TITLE
Fix task failures sending over-large blocks to Slack

### DIFF
--- a/ops-catalog/notify-failure-logs.sql
+++ b/ops-catalog/notify-failure-logs.sql
@@ -38,7 +38,7 @@ WITH return_values as (
             'ts',ts,
             'level',level,
             'message',message,
-            'formatted_message',SUBSTR('[ts='||ts||' level='||level||']: '||message,0,2500)
+            'formatted_message','[ts='||ts||' level='||level||']: '||message
         ))
         FROM related_log_lines
         WHERE shard=$name
@@ -155,8 +155,7 @@ RETURNING
                         'type','section',
                         'text',JSON_OBJECT(
                             'type', 'mrkdwn',
-                            'text', '```'||(SELECT group_concat(value->>'formatted_message', CHAR(10)) from json_each(return_values.log_lines))||'```'
-                            -- 'text', '```'||(SELECT group_concat(value->'message', CHAR(10)) from json_each(return_values.log_lines))||'```'
+                            'text', '```'||(SELECT SUBSTR(group_concat(value->>'formatted_message', CHAR(10)), 0,2900) from json_each(return_values.log_lines))||'```'
                         )
                     )
                 END,


### PR DESCRIPTION
Limit message blocks generated by `ops.us-central1.v1/failure-notifications/v1` to be under the 3000 character limit.

This was deployed, but never committed so got rolled back. I deployed this again just now, so this is already live

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1159)
<!-- Reviewable:end -->
