### PR TITLE
examples: add derive pattern k/v pairs example

### DIFF
--- a/examples/derive-patterns/README.md
+++ b/examples/derive-patterns/README.md
@@ -120,3 +120,24 @@ paired with a reduced snapshot of the RHS accumulator at that time.
 
 See [join-one-sided.flow.yaml](join-one-sided.yaml).
 
+## Entity attribute values
+
+This is a common pattern where you have source data with key-value pairs
+relating to a specific entity, and you want to normalize it into a table-like format.
+In other words, you want to go from this:
+
+```
+{"entity_id": "1", "key": "first_name", "value": "Fred"}
+{"entity_id": "1", "key": "last_name", "value": "Flintstone"}
+```
+
+to this:
+
+```
+{"entity_id": "1", "first_name": "Fred", "last_name": "Flintstone"}
+```
+
+This is super easy to do in Flow. The key is to use `reduce: { strategy: merge }`
+in the derivation's schema.
+
+See [entity-attribute-values.flow.yaml](entity-attribute-values.flow.yaml)

--- a/examples/derive-patterns/entity-attribute-values.flow.yaml
+++ b/examples/derive-patterns/entity-attribute-values.flow.yaml
@@ -1,0 +1,72 @@
+collections:
+  patterns/entity-attribute-values:
+    key: [/entity_id]
+    schema:
+      type: object
+      properties:
+        entity_id: { type: string }
+        key: {type: string}
+        value: true
+      required: [entity_id, key, value]
+
+  patterns/normalized-entities:
+    key: [/entity_id]
+    schema:
+      type: object
+      properties:
+        entity_id: { type: string }
+        first_name: { type: string }
+        last_name: { type: string }
+        email: { type: string, format: email }
+      required: [entity_id]
+      reduce: { strategy: merge }
+    derive:
+      using:
+        sqlite: {}
+      transforms:
+        - name: fromKeyValuePairs
+          source: patterns/entity-attribute-values
+          shuffle: any
+          lambda: |
+            SELECT JSON_OBJECT(
+              'entity_id', $entity_id,
+              $key, $value
+            );
+
+tests:
+  patterns/normalizing-entity-attribute-values:
+    - ingest:
+        collection: patterns/entity-attribute-values
+        documents:
+          - { entity_id: "2", key: "email", value: "wilma@oldschooldialup.com"}
+          - { entity_id: "1", key: "email", value: "fred@oldschooldialup.com"}
+    - ingest:
+        collection: patterns/entity-attribute-values
+        documents:
+          - { entity_id: "1", key: "first_name", value: "Fred" }
+          - { entity_id: "2", key: "last_name", value: "Flintstone"}
+    - verify:
+        collection: patterns/normalized-entities
+        documents:
+          - entity_id: "1"
+            first_name: Fred
+            email: fred@oldschooldialup.com
+          - entity_id: "2"
+            last_name: Flintstone
+            email: wilma@oldschooldialup.com
+    - ingest:
+        collection: patterns/entity-attribute-values
+        documents:
+          - { entity_id: "2", key: "first_name", value: "Wilma" }
+          - { entity_id: "1", key: "last_name", value: "Flintstone"}
+    - verify:
+        collection: patterns/normalized-entities
+        documents:
+          - entity_id: "1"
+            first_name: Fred
+            last_name: Flintstone
+            email: fred@oldschooldialup.com
+          - entity_id: "2"
+            first_name: Wilma
+            last_name: Flintstone
+            email: wilma@oldschooldialup.com

--- a/examples/derive-patterns/flow.yaml
+++ b/examples/derive-patterns/flow.yaml
@@ -4,3 +4,4 @@ import:
   - join-one-sided.flow.yaml
   - join-outer.flow.yaml
   - summer.flow.yaml
+  - entity-attribute-values.flow.yaml


### PR DESCRIPTION
Adds an 'entity-attribute-values' example to derive-patterns, which shows how to normalize these values by rolling them up by entity id.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1164)
<!-- Reviewable:end -->
