### PR TITLE
Implement `tenants.trial_start` and associated calculations in billing report

### DIFF
--- a/supabase/migrations/26_free_trial.sql
+++ b/supabase/migrations/26_free_trial.sql
@@ -1,191 +1,80 @@
-
--- Always use a transaction, y'all.
 begin;
 
-alter table tenants add column free_trial_start timestamptz;
+alter table tenants add column trial_start date;
 
-create or replace function internal.compute_incremental_line_items(item_name text, item_unit text, item_unit_plural text, single_usage numeric, tiers integer[], running_usage_sum numeric)
+-- Compute a JSONB array of line-items detailing usage under a tenant's effective tiers.
+create or replace function tier_line_items(
+  -- Ammount of usage we're breaking out.
+  amount numeric,
+  -- Effective tenant tiers as ordered pairs of (quantity, cents), followed
+  -- by a final unpaired cents for unbounded usage beyond the final quantity.
+  tiers integer[],
+  -- Descriptive name of the tiered thing ("Data processing").
+  name text,
+  -- Unit of the tier ("GB" or "hour").
+  unit text
+)
 returns jsonb as $$
 declare
-  line_items jsonb = '[]';
-
-  -- Calculating tiered usage.
-  tier_rate    integer;
-  tier_pivot   integer;
+  o_line_items jsonb = '[]'; -- Output variable.
   tier_count   numeric;
-
-  running_tier_pivot integer = 0;
+  tier_pivot   integer;
+  tier_rate    integer;
 begin
-  -- Walk up the tiers
-  for tier_idx in 1..array_length(tiers,1) by 2 loop
-    tier_rate = tiers[tier_idx];
-    tier_pivot = tiers[tier_idx+1];
-    if tier_pivot is null then
-      -- No limits here, roll all of the remaining usage into this tier
-      tier_count = single_usage;
-      running_usage_sum = running_usage_sum + tier_count;
-      line_items = line_items || jsonb_build_object(
-        'description', format(
-          '%s (at %s/%s)',
-          item_name,
-          (tier_rate / 100.0)::money,
-          item_unit
-        ),
-        'count', tier_count,
-        'rate', tier_rate,
-        'subtotal_frac', tier_count * tier_rate
-      );
-    elsif tier_pivot > running_usage_sum then
-      running_tier_pivot = running_tier_pivot + tier_pivot;
-      -- We haven't already surpassed this tier's pivot
-      -- Calculate how much more usage we'd need to surpass this tier
-      tier_count = least(single_usage, running_tier_pivot - running_usage_sum);
-      single_usage = single_usage - tier_count;
-      running_usage_sum = running_usage_sum + tier_count;
-      line_items = line_items || jsonb_build_object(
-        'description', format(
-          case
-            when tier_idx = 1 then '%s (first %s%s at %s/%s)'
-            else '%s (next %s%s at %s/%s)'
-          end,
-          item_name,
-          tier_pivot,
-          item_unit_plural,
-          (tier_rate / 100.0)::money,
-          item_unit
-        ),
-        'count', tier_count,
-        'rate', tier_rate,
-        'subtotal_frac', tier_count * tier_rate
-      );
-    end if;
+
+  for idx in 1..array_length(tiers, 1) by 2 loop
+    tier_rate = tiers[idx];
+    tier_pivot = tiers[idx+1];
+    tier_count = least(amount, tier_pivot);
+    amount = amount - tier_count;
+
+    o_line_items = o_line_items || jsonb_build_object(
+      'description', format(
+        case
+          when tier_pivot is null then '%1$s (at %4$s/%2$s)'      -- Data processing (at $0.50/GB)
+          when idx = 1 then '%1s (first %3$s %2$ss at %4$s/%2$s)' -- Data processing (first 30 GBs at $0.50/GB)
+          else '%1$s (next %3$s %2$ss at %4$s/%2$s)'              -- Data processing (next 6 GBs at $0.25/GB)
+        end,
+        name,
+        unit,
+        tier_pivot,
+        (tier_rate / 100.0)::money
+      ),
+      'count', tier_count,
+      'rate', tier_rate,
+      'subtotal', round(tier_count * tier_rate)
+    );
   end loop;
 
-  return jsonb_build_object(
-    'line_items', line_items,
-    'running_usage_sum', running_usage_sum
-  );
+  return o_line_items;
+
 end
 $$ language plpgsql;
 
-create or replace function internal.incremental_usage_report(requested_grain text, billed_prefix catalog_prefix, billed_month timestamptz)
-returns jsonb as $$
-declare
-  billed_range tstzrange;
-  -- Retrieved from tenants table.
-  data_tiers  integer[];
-  usage_tiers integer[];
-
-  granules jsonb = '[]';
-  returned_data_line_items jsonb = '{}';
-  returned_hours_line_items jsonb = '{}';
-  combined_line_items jsonb;
-
-  -- We can't round these subtotals yet because we might want to add them up later.
-  -- Rounding before adding will result in inconsistent subtotals between daily and monthly
-  -- granularities, since the monthly granularity by definition sums up all fractional
-  -- values, which we then round later on. In reality the discrepancies are tiny since
-  -- the maximum error per grain is 1 ($0.01), but better to be entirely exact when dealing with money.
-  subtotal_frac numeric;
-
-  running_gb_sum numeric = 0;
-  running_hour_sum numeric = 0;
-  line_items jsonb = '[]';
-begin
-  -- Because usage tiers reset at the beginning of every month, the logic defined here
-  -- is only correct when operating on at most a whole month.
-  billed_month = date_trunc('month', billed_month);
-  billed_range = tstzrange(billed_month, billed_month + '1 month', '[)');
-
-  select into data_tiers, usage_tiers
-    t.data_tiers,
-    t.usage_tiers
-  from tenants t
-  where billed_prefix ^@ t.tenant;
-
-  -- Get all stats records for the selected time period at the selected granularity
-  select into granules
-    (select json_agg(res.obj) from (
-        select jsonb_build_object(
-          'processed_data_gb', sum((bytes_written_by_me + bytes_read_by_me)) / (1024.0 * 1024 * 1024),
-          'task_usage_hours', sum(usage_seconds) / (60.0 * 60),
-          'ts', ts
-        ) as obj
-        from catalog_stats
-        where catalog_name ^@ billed_prefix
-        and grain = requested_grain
-        and billed_range @> ts
-        group by ts
-    ) as res)
-  ;
-
-  if granules is not null then
-    for idx in 0..jsonb_array_length(granules)-1 loop
-      returned_data_line_items = internal.compute_incremental_line_items('Data processing', 'GB', 'GB', (granules->idx->'processed_data_gb')::numeric, data_tiers, running_gb_sum);
-      running_gb_sum = (returned_data_line_items->'running_usage_sum')::numeric;
-
-      returned_hours_line_items = internal.compute_incremental_line_items('Task usage', 'hour', ' hours', (granules->idx->'task_usage_hours')::numeric, usage_tiers, running_hour_sum);
-      running_hour_sum = (returned_hours_line_items->'running_usage_sum')::numeric;
-
-      combined_line_items = (returned_data_line_items->'line_items')::jsonb || (returned_hours_line_items->'line_items')::jsonb;
-
-      select into subtotal_frac sum((item->'subtotal_frac')::numeric) from jsonb_array_elements(combined_line_items) as item;
-
-      line_items = line_items || jsonb_build_object(
-        'line_items', combined_line_items,
-        'subtotal_frac', subtotal_frac,
-        'processed_data_gb', (granules->idx->'processed_data_gb')::numeric,
-        'task_usage_hours', (granules->idx->'task_usage_hours')::numeric,
-        'ts', granules->idx->'ts'
-      );
-    end loop;
-  end if;
-
-  return line_items;
-end
-$$ language plpgsql;
 
 -- Billing report which is effective August 2023.
 create or replace function billing_report_202308(billed_prefix catalog_prefix, billed_month timestamptz)
 returns jsonb as $$
-#variable_conflict use_variable
 declare
   -- Auth checks
   has_admin_grant boolean;
   has_bypassrls boolean;
 
-  -- Computed
-  recurring_usd_cents integer;
-  free_trial_range tstzrange;
-  billed_range tstzrange;
-  free_trial_overlap tstzrange;
-
-  incremental_usage jsonb;
-  daily_usage jsonb;
-
-  free_trial_credit numeric;
-
-  -- Temporary line items holders for free trial calculations
-  task_usage_line_items jsonb = '[]';
-  data_usage_line_items jsonb = '[]';
-
-  -- Calculating adjustments.
-  adjustment   internal.billing_adjustments;
-
-  -- Aggregated outputs.
-  line_items jsonb = '[]';
-  subtotal_usd_cents integer;
-  processed_data_gb numeric;
-  task_usage_hours numeric;
-
-  -- Free trial outputs
-  free_trial_gb numeric;
-  free_trial_hours numeric;
+  -- Output variables.
+  o_daily_usage   jsonb;
+  o_data_gb       numeric;
+  o_line_items    jsonb = '[]';
+  o_recurring_fee integer;
+  o_subtotal      integer;
+  o_task_hours    numeric;
+  o_trial_credit  integer;
+  o_trial_start   date;
+  o_trial_range   daterange;
+  o_billed_range  daterange;
 begin
 
   -- Ensure `billed_month` is the truncated start of the billed month.
   billed_month = date_trunc('month', billed_month);
-  billed_range = tstzrange(billed_month, billed_month + '1 month', '[)');
 
   -- Verify that the user has an admin grant for the requested `billed_prefix`.
   perform 1 from auth_roles('admin') as r where billed_prefix ^@ r.role_prefix;
@@ -206,122 +95,164 @@ begin
     raise 'You are not authorized for the billed prefix %', billed_prefix using errcode = 28000;
   end if;
 
-  -- Fetch data & usage tiers for `billed_prefix`'s tenant.
-  select into free_trial_range
-      case
-      	when t.free_trial_start is null then 'empty'::tstzrange
-        -- Inclusive start, exclusive end
-       	else tstzrange(date_trunc('day', t.free_trial_start), date_trunc('day', t.free_trial_start) + '30 days', '[)')
-      end
-    from tenants t
-    where billed_prefix ^@ t.tenant
-  ;
-  -- Reveal contract costs only when the computing tenant-level billing.
-  select into recurring_usd_cents t.recurring_usd_cents
-    from tenants t
-    where billed_prefix = t.tenant
-  ;
+  with vars as (
+    select
+      t.data_tiers,
+      t.trial_start,
+      t.usage_tiers,
+      tstzrange(billed_month, billed_month  + '1 month', '[)') as billed_range,
+      case when t.trial_start is not null
+        then tstzrange(t.trial_start, t.trial_start + interval '1 month', '[)')
+        else 'empty' end as trial_range,
+      -- Reveal contract costs only when computing whole-tenant billing.
+      case when t.tenant = billed_prefix then t.recurring_usd_cents else 0 end as recurring_fee
+      from tenants t
+      where billed_prefix ^@ t.tenant -- Prefix starts with tenant.
+  ),
+  -- Roll up each day's incremental usage.
+  daily_stat_deltas as (
+    select
+      ts,
+      sum(bytes_written_by_me + bytes_read_by_me) / (1024.0 * 1024 * 1024) as data_gb,
+      sum(usage_seconds) / (60.0 * 60) as task_hours
+    from catalog_stats, vars
+      where catalog_name ^@ billed_prefix -- Name starts with prefix.
+      and grain = 'daily'
+      and billed_range @> ts
+      group by ts
+  ),
+  -- Map to cumulative daily usage.
+  -- Note sum(...) over (order by ts) yields the running sum of its aggregate.
+  daily_stats as (
+    select
+      ts,
+      sum(data_gb) over w as data_gb,
+      sum(task_hours) over w as task_hours
+    from daily_stat_deltas
+    window w as (order by ts)
+  ),
+  -- Extend with line items for each category for the period ending with the given day.
+  daily_line_items as (
+    select
+      daily_stats.*,
+      tier_line_items(data_gb, data_tiers, 'Data processing', 'GB') as data_line_items,
+      tier_line_items(task_hours, usage_tiers, 'Task usage', 'hour') as task_line_items
+    from daily_stats, vars
+  ),
+  -- Extend with per-category subtotals for the period ending with the given day.
+  daily_totals as (
+    select
+      daily_line_items.*,
+      data_subtotal,
+      task_subtotal
+    from daily_line_items,
+      lateral (select sum((li->>'subtotal')::numeric) as data_subtotal from jsonb_array_elements(data_line_items) li) l1,
+      lateral (select sum((li->>'subtotal')::numeric) as task_subtotal from jsonb_array_elements(task_line_items) li) l2
+  ),
+  -- Map cumulative totals to per-day deltas.
+  daily_deltas as (
+    select
+      ts,
+      data_gb       - (coalesce(lag(data_gb,         1) over w, 0)) as data_gb,
+      data_subtotal - (coalesce(lag(data_subtotal,   1) over w, 0)) as data_subtotal,
+      task_hours    - (coalesce(lag(task_hours,      1) over w, 0)) as task_hours,
+      task_subtotal - (coalesce(lag(task_subtotal,   1) over w, 0)) as task_subtotal
+      from daily_totals
+      window w as (order by ts)
+  ),
+  -- 1) Group daily_deltas into a JSON array
+  -- 2) Sum a trial credit from daily deltas that overlap with the trial period.
+  daily_array_and_trial_credit as (
+    select
+    jsonb_agg(jsonb_build_object(
+      'ts', ts,
+      'data_gb', data_gb,
+      'data_subtotal', data_subtotal,
+      'task_hours', task_hours,
+      'task_subtotal', task_subtotal
+    )) as daily_usage,
+    coalesce(sum(data_subtotal + task_subtotal) filter (where trial_range @>ts),0 ) as trial_credit
+    from daily_deltas, vars
+  ),
+  -- The last day captures the cumulative billed period.
+  last_day as (
+    select * from daily_line_items
+    order by ts desc limit 1
+  ),
+  -- If we're reporting for the whole tenant then gather billing adjustment line-items.
+  adjustments as (
+    select coalesce(jsonb_agg(
+      jsonb_build_object(
+        'description', detail,
+        'count', 1,
+        'rate', usd_cents,
+        'subtotal', usd_cents
+      )
+    ), '[]') as adjustment_line_items
+    from internal.billing_adjustments a
+    where a.tenant = billed_prefix and a.billed_month = billing_report_202308.billed_month
+  )
+  select into
+    -- Block of variables being selected into.
+    o_daily_usage,
+    o_data_gb,
+    o_line_items,
+    o_recurring_fee,
+    o_task_hours,
+    o_trial_credit,
+    o_trial_start,
+    o_trial_range,
+    o_billed_range
+    -- The actual selected columns.
+    daily_usage,
+    data_gb,
+    data_line_items || task_line_items || adjustment_line_items,
+    recurring_fee,
+    task_hours,
+    trial_credit,
+    trial_start,
+    trial_range,
+    billed_range
+  from daily_array_and_trial_credit, last_day, adjustments, vars;
 
-  -- Apply a recurring service cost, if defined.
-  if recurring_usd_cents != 0 then
-    line_items = line_items || jsonb_build_object(
+  -- Add line items for recurring service fee & free trial credit.
+  if o_recurring_fee != 0 then
+    o_line_items = jsonb_build_object(
       'description', 'Recurring service charge',
       'count', 1,
-      'rate', recurring_usd_cents,
-      'subtotal', recurring_usd_cents
-    );
+      'rate', o_recurring_fee,
+      'subtotal', o_recurring_fee
+    ) || o_line_items;
   end if;
 
-  -- Transform from `{"subtotal_frac": 1.98}` into `{"subtotal": 2}`
-  -- We can comfortably round here because we're loading the monthly granularity
-  -- meaning that summing has already happened.
-  select into line_items, processed_data_gb, task_usage_hours
-    line_items || (
-      select json_agg(
-              (item - 'subtotal_frac') ||
-              jsonb_build_object(
-                'subtotal', round((item->'subtotal_frac')::numeric)
-              )
-            )::jsonb
-      from jsonb_array_elements(report->0->'line_items') as item
-    ),
-    (report->0->'processed_data_gb')::numeric,
-    (report->0->'task_usage_hours')::numeric
-  from internal.incremental_usage_report('monthly', billed_prefix, billed_month) as report;
-
-  select into incremental_usage
-    report
-  from internal.incremental_usage_report('daily', billed_prefix, billed_month) as report;
-
-  -- Does the free trial range overlap the month in question?
-  if not isempty(free_trial_range) and (free_trial_range && billed_range) then
-    free_trial_overlap = billed_range * free_trial_range;
-    -- Sum up the fractional subtotals for each day in the portion of this
-    -- month covered by the free trial. Note that we don't want to round yet
-    -- since these are exact fractional values. Only after summing do we round.
-    select into
-      free_trial_credit coalesce(sum((line_item->>'subtotal_frac')::numeric), 0)
-    from
-      jsonb_array_elements(incremental_usage) as line_item
-    where free_trial_overlap @> (line_item->>'ts')::timestamptz;
-
-    line_items = line_items || jsonb_build_object(
-      'description', format('Free trial credit (%s to %s)', lower(free_trial_range)::date,upper(free_trial_range)::date),
+  -- Display a (possibly zero) free trial credit if the trial range overlaps the billed range
+  if o_trial_range && o_billed_range then
+    o_line_items = o_line_items || jsonb_build_object(
+      'description', format('Free trial credit (%s - %s)', lower(o_trial_range), (upper(o_trial_range) - interval '1 day')::date),
       'count', 1,
-      'rate', round(free_trial_credit) * -1,
-      'subtotal', round(free_trial_credit) * -1
+      'rate', -o_trial_credit,
+      'subtotal', -o_trial_credit
     );
   end if;
-
-  -- Apply any billing adjustments.
-  for adjustment in select * from internal.billing_adjustments a
-    where a.billed_month = billed_month and a.tenant = billed_prefix
-  loop
-    line_items = line_items || jsonb_build_object(
-      'description', adjustment.detail,
-      'count', 1,
-      'rate', adjustment.usd_cents,
-      'subtotal', adjustment.usd_cents
-    );
-  end loop;
 
   -- Roll up the final subtotal.
-  select into subtotal_usd_cents sum((l->>'subtotal')::numeric)
-    from jsonb_array_elements(line_items) l;
-
-  -- Build up a list of days and their usage, with a default of 0
-  select into daily_usage json_agg(
-    case
-      when usage is null then jsonb_build_object(
-          'line_items', '[]'::jsonb,
-          'subtotal', 0,
-          'processed_data_gb', 0,
-          'task_usage_hours', 0,
-          'ts', date_of_month
-        )
-      else (usage - 'subtotal_frac') || jsonb_build_object(
-          'subtotal', round((usage->'subtotal_frac')::numeric)
-      )
-    end
-  )
-  -- Despite the range being exclusive on the upper bound, upper() still returns the upper bound
-  -- See this thread https://www.postgresql.org/message-id/20150116152713.2582.10294@wrigleys.postgresql.org
-  from generate_series(lower(billed_range)::date, upper(billed_range)::date - interval '1 day', interval '1 day') as date_of_month
-  left join jsonb_array_elements(incremental_usage) as usage on (usage->>'ts')::date = date_of_month::date;
+  select into o_subtotal sum((l->>'subtotal')::numeric)
+    from jsonb_array_elements(o_line_items) l;
 
   return jsonb_build_object(
     'billed_month', billed_month,
     'billed_prefix', billed_prefix,
-    'line_items', line_items,
-    'processed_data_gb', processed_data_gb,
-    'recurring_fee', coalesce(recurring_usd_cents, 0),
-    'subtotal', subtotal_usd_cents,
-    'task_usage_hours', task_usage_hours,
-    'daily_usage', daily_usage
+    'daily_usage', o_daily_usage,
+    'line_items', o_line_items,
+    'processed_data_gb', o_data_gb,
+    'recurring_fee', o_recurring_fee,
+    'subtotal', o_subtotal,
+    'task_usage_hours', o_task_hours,
+    'trial_credit', coalesce(o_trial_credit, 0),
+    'trial_start', o_trial_start
   );
 
 end
 $$ language plpgsql volatile security definer;
 
 commit;
-

--- a/supabase/migrations/26_free_trial.sql
+++ b/supabase/migrations/26_free_trial.sql
@@ -1,0 +1,300 @@
+
+-- Always use a transaction, y'all.
+begin;
+
+alter table tenants add column free_trial_start timestamptz;
+
+create or replace function internal.compute_incremental_line_items(item_name text, item_unit text, item_unit_plural text, single_usage numeric, tiers integer[], running_usage_sum numeric)
+returns jsonb as $$
+declare
+  line_items jsonb = '[]';
+
+  -- Calculating tiered usage.
+  tier_rate    integer;
+  tier_pivot   integer;
+  tier_count   numeric;
+
+  running_tier_pivot integer = 0;
+begin
+  -- Walk up the tiers
+  for tier_idx in 1..array_length(tiers,1) by 2 loop
+    tier_rate = tiers[tier_idx];
+    tier_pivot = tiers[tier_idx+1];
+    if tier_pivot is null then
+      -- No limits here, roll all of the remaining usage into this tier
+      tier_count = single_usage;
+      running_usage_sum = running_usage_sum + tier_count;
+      line_items = line_items || jsonb_build_object(
+        'description', format(
+          '%s (at %s/%s)',
+          item_name,
+          (tier_rate / 100.0)::money,
+          item_unit
+        ),
+        'count', tier_count,
+        'rate', tier_rate,
+        'subtotal_frac', tier_count * tier_rate
+      );
+    elsif tier_pivot > running_usage_sum then
+      running_tier_pivot = running_tier_pivot + tier_pivot;
+      -- We haven't already surpassed this tier's pivot
+      -- Calculate how much more usage we'd need to surpass this tier
+      tier_count = least(single_usage, running_tier_pivot - running_usage_sum);
+      single_usage = single_usage - tier_count;
+      running_usage_sum = running_usage_sum + tier_count;
+      line_items = line_items || jsonb_build_object(
+        'description', format(
+          case
+            when tier_idx = 1 then '%s (first %s%s at %s/%s)'
+            else '%s (next %s%s at %s/%s)'
+          end,
+          item_name,
+          tier_pivot,
+          item_unit_plural,
+          (tier_rate / 100.0)::money,
+          item_unit
+        ),
+        'count', tier_count,
+        'rate', tier_rate,
+        'subtotal_frac', tier_count * tier_rate
+      );
+    end if;
+  end loop;
+
+  return jsonb_build_object(
+    'line_items', line_items,
+    'running_usage_sum', running_usage_sum
+  );
+end
+$$ language plpgsql;
+
+create or replace function internal.incremental_usage_report(requested_grain text, billed_prefix catalog_prefix, billed_range tstzrange)
+returns jsonb as $$
+declare
+  -- Retrieved from tenants table.
+  data_tiers  integer[];
+  usage_tiers integer[];
+
+  granules jsonb = '[]';
+  returned_data_line_items jsonb = '{}';
+  returned_hours_line_items jsonb = '{}';
+  combined_line_items jsonb;
+
+  -- We can't round these subtotals yet because we might want to add them up later.
+  -- Rounding before adding will result in inconsistent subtotals between daily and monthly
+  -- granularities, since the monthly granularity by definition sums up all fractional
+  -- values, which we then round later on. In reality the discrepancies are tiny since
+  -- the maximum error per grain is 1 ($0.01), but better to be entirely exact when dealing with money.
+  subtotal_frac numeric;
+
+  running_gb_sum numeric = 0;
+  running_hour_sum numeric = 0;
+  line_items jsonb = '[]';
+begin
+  -- Because usage tiers reset at the beginning of every month, the logic defined here
+  -- is only correct when operating on at most a whole month.
+  if upper(billed_range) > date_trunc('month', lower(billed_range)) + '1 month' then
+    raise 'Invalid input range, must span at most one month: %', billed_range;
+  end if;
+
+  select into data_tiers, usage_tiers
+    t.data_tiers,
+    t.usage_tiers
+  from tenants t
+  where billed_prefix ^@ t.tenant;
+
+  -- Get all stats records for the selected time period at the selected granularity
+  select into granules
+    (select json_agg(res.obj) from (
+        select jsonb_build_object(
+          'processed_data_gb', sum((bytes_written_by_me + bytes_read_by_me)) / (1024.0 * 1024 * 1024),
+          'task_usage_hours', sum(usage_seconds) / (60.0 * 60),
+          'ts', ts
+        ) as obj
+        from catalog_stats
+        where catalog_name ^@ billed_prefix
+        and grain = requested_grain
+        and billed_range @> ts
+        group by ts
+    ) as res)
+  ;
+
+  if granules is not null then
+    for idx in 0..jsonb_array_length(granules)-1 loop
+      returned_data_line_items = internal.compute_incremental_line_items('Data processing', 'GB', 'GB', (granules->idx->'processed_data_gb')::numeric, data_tiers, running_gb_sum);
+      running_gb_sum = (returned_data_line_items->'running_usage_sum')::numeric;
+
+      returned_hours_line_items = internal.compute_incremental_line_items('Task usage', 'hour', ' hours', (granules->idx->'task_usage_hours')::numeric, usage_tiers, running_hour_sum);
+      running_hour_sum = (returned_hours_line_items->'running_usage_sum')::numeric;
+
+      combined_line_items = (returned_data_line_items->'line_items')::jsonb || (returned_hours_line_items->'line_items')::jsonb;
+
+      select into subtotal_frac sum((item->'subtotal_frac')::numeric) from jsonb_array_elements(combined_line_items) as item;
+
+      line_items = line_items || jsonb_build_object(
+        'line_items', combined_line_items,
+        'subtotal_frac', subtotal_frac,
+        'processed_data_gb', (granules->idx->'processed_data_gb')::numeric,
+        'task_usage_hours', (granules->idx->'task_usage_hours')::numeric,
+        'ts', granules->idx->'ts'
+      );
+    end loop;
+  end if;
+
+  return line_items;
+end
+$$ language plpgsql;
+
+-- Billing report which is effective August 2023.
+create or replace function billing_report_202308(billed_prefix catalog_prefix, billed_month timestamptz)
+returns jsonb as $$
+#variable_conflict use_variable
+declare
+  -- Auth checks
+  has_admin_grant boolean;
+  has_bypassrls boolean;
+
+  -- Computed
+  recurring_usd_cents integer;
+  free_trial_range tstzrange;
+  billed_range tstzrange;
+  free_trial_overlap tstzrange;
+
+  free_trial_credit numeric;
+
+  -- Temporary line items holders for free trial calculations
+  task_usage_line_items jsonb = '[]';
+  data_usage_line_items jsonb = '[]';
+
+  -- Calculating adjustments.
+  adjustment   internal.billing_adjustments;
+
+  -- Aggregated outputs.
+  line_items jsonb = '[]';
+  subtotal_usd_cents integer;
+  processed_data_gb numeric;
+  task_usage_hours numeric;
+
+  -- Free trial outputs
+  free_trial_gb numeric;
+  free_trial_hours numeric;
+begin
+
+  -- Ensure `billed_month` is the truncated start of the billed month.
+  billed_month = date_trunc('month', billed_month);
+  billed_range = tstzrange(billed_month, billed_month + '1 month', '[)');
+
+  -- Verify that the user has an admin grant for the requested `billed_prefix`.
+  perform 1 from auth_roles('admin') as r where billed_prefix ^@ r.role_prefix;
+  has_admin_grant = found;
+
+  -- Check whether the real active role has bypassrls flag set.
+  -- Because this function is SECURITY DEFINER, both `current_user` and `current_role`
+  -- will be `postgres`, which does have bypassrls set. Instead we want the
+  -- role of the caller, which can be accessed like so according to:
+  -- https://www.postgresql.org/message-id/13906.1141711109%40sss.pgh.pa.us
+  perform * from pg_roles where rolname = current_setting('role') and rolbypassrls = true;
+  has_bypassrls = found;
+
+  if not has_admin_grant and not has_bypassrls then
+    -- errcode 28000 causes PostgREST to return an HTTP 403
+    -- see: https://www.postgresql.org/docs/current/errcodes-appendix.html
+    -- and: https://postgrest.org/en/stable/errors.html#status-codes
+    raise 'You are not authorized for the billed prefix %', billed_prefix using errcode = 28000;
+  end if;
+
+  -- Fetch data & usage tiers for `billed_prefix`'s tenant.
+  select into free_trial_range
+      case
+      	when t.free_trial_start is null then 'empty'::tstzrange
+        -- Inclusive start, exclusive end
+       	else tstzrange(date_trunc('day', t.free_trial_start), date_trunc('day', t.free_trial_start) + '1 month', '[)')
+      end
+    from tenants t
+    where billed_prefix ^@ t.tenant
+  ;
+  -- Reveal contract costs only when the computing tenant-level billing.
+  select into recurring_usd_cents t.recurring_usd_cents
+    from tenants t
+    where billed_prefix = t.tenant
+  ;
+
+  -- Apply a recurring service cost, if defined.
+  if recurring_usd_cents != 0 then
+    line_items = line_items || jsonb_build_object(
+      'description', 'Recurring service charge',
+      'count', 1,
+      'rate', recurring_usd_cents,
+      'subtotal', recurring_usd_cents
+    );
+  end if;
+
+  -- Transform from `{"subtotal_frac": 1.98}` into `{"subtotal": 2}`
+  -- We can comfortably round here because we're loading the monthly granularity
+  -- meaning that summing has already happened.
+  select into line_items, processed_data_gb, task_usage_hours
+    line_items || (
+      select json_agg(
+              (item - 'subtotal_frac') ||
+              jsonb_build_object(
+                'subtotal', round((item->'subtotal_frac')::numeric)
+              )
+            )::jsonb
+      from jsonb_array_elements(report->0->'line_items') as item
+    ),
+    (report->0->'processed_data_gb')::numeric,
+    (report->0->'task_usage_hours')::numeric
+  from internal.incremental_usage_report('monthly', billed_prefix, billed_range) as report;
+
+  -- Does the free trial range overlap the month in question?
+  if not isempty(free_trial_range) and (free_trial_range && billed_range) then
+    free_trial_overlap = billed_range * free_trial_range;
+    -- Sum up the fractional subtotals for each day in the portion of this
+    -- month covered by the free trial. Note that we don't want to round yet
+    -- since these are exact fractional values. Only after summing do we round.
+    select into
+      free_trial_credit coalesce(sum((line_item->>'subtotal_frac')::numeric), 0)
+    from
+      jsonb_array_elements(
+        internal.incremental_usage_report('daily', billed_prefix, free_trial_overlap)
+      ) as line_item;
+
+    line_items = line_items || jsonb_build_object(
+      'description', 'Free trial credit',
+      'count', 1,
+      'rate', round(free_trial_credit) * -1,
+      'subtotal', round(free_trial_credit) * -1
+    );
+  end if;
+
+  -- Apply any billing adjustments.
+  for adjustment in select * from internal.billing_adjustments a
+    where a.billed_month = billed_month and a.tenant = billed_prefix
+  loop
+    line_items = line_items || jsonb_build_object(
+      'description', adjustment.detail,
+      'count', 1,
+      'rate', adjustment.usd_cents,
+      'subtotal', adjustment.usd_cents
+    );
+  end loop;
+
+  -- Roll up the final subtotal.
+  select into subtotal_usd_cents sum((l->>'subtotal')::numeric)
+    from jsonb_array_elements(line_items) l;
+
+  return jsonb_build_object(
+    'billed_month', billed_month,
+    'billed_prefix', billed_prefix,
+    'line_items', line_items,
+    'processed_data_gb', processed_data_gb,
+    'recurring_fee', coalesce(recurring_usd_cents, 0),
+    'subtotal', subtotal_usd_cents,
+    'task_usage_hours', task_usage_hours
+  );
+
+end
+$$ language plpgsql volatile security definer;
+
+commit;
+

--- a/supabase/tests/billing.test.sql
+++ b/supabase/tests/billing.test.sql
@@ -193,19 +193,19 @@ begin
         "rate": 30,
         "count": 4,
         "subtotal": 120,
-        "description": "Data processing (first 4GB at $0.30/GB)"
+        "description": "Data processing (first 4 GBs at $0.30/GB)"
       },
       {
         "rate": 25,
         "count": 6,
         "subtotal": 150,
-        "description": "Data processing (next 6GB at $0.25/GB)"
+        "description": "Data processing (next 6 GBs at $0.25/GB)"
       },
       {
         "rate": 20,
         "count": 20,
         "subtotal": 400,
-        "description": "Data processing (next 20GB at $0.20/GB)"
+        "description": "Data processing (next 20 GBs at $0.20/GB)"
       },
       {
         "rate": 15,
@@ -253,7 +253,9 @@ begin
     "processed_data_gb": 43.125,
     "recurring_fee": 10000,
     "subtotal": 22044,
-    "task_usage_hours": 738.375
+    "task_usage_hours": 738.375,
+    "trial_credit": 0,
+    "trial_start": null
   }'::jsonb);
 
   set role postgres;
@@ -277,7 +279,7 @@ begin
         "rate": 50,
         "count": 21.125,
         "subtotal": 1056,
-        "description": "Data processing (first 30GB at $0.50/GB)"
+        "description": "Data processing (first 30 GBs at $0.50/GB)"
       },
       {
         "rate": 20,
@@ -295,7 +297,9 @@ begin
     "processed_data_gb": 21.125,
     "recurring_fee": 0,
     "subtotal": 11856,
-    "task_usage_hours": 720
+    "task_usage_hours": 720,
+    "trial_credit": 0,
+    "trial_start": null
   }'::jsonb);
 
   -- We're authorized as Bob.
@@ -311,7 +315,7 @@ begin
   -- Switch tiers so usage spills over
   -- and set trial so half of August is covered
   update tenants set
-    free_trial_start='2022-08-15',
+    trial_start='2022-08-15',
     data_tiers = '{50, 5, 20}'
     where tenant = 'aliceCo/';
 
@@ -323,288 +327,24 @@ begin
     "billed_prefix": "aliceCo/aa/",
     "daily_usage": [
         {
-            "line_items": [
-                {
-                    "count": 5,
-                    "description": "Data processing (first 5GB at $0.50/GB)",
-                    "rate": 50,
-                    "subtotal_frac": 250
-                },
-                {
-                    "count": 13.125,
-                    "description": "Data processing (at $0.20/GB)",
-                    "rate": 20,
-                    "subtotal_frac": 262.5
-                },
-                {
-                    "count": 720,
-                    "description": "Task usage (at $0.15/hour)",
-                    "rate": 15,
-                    "subtotal_frac": 10800
-                }
-            ],
-            "processed_data_gb": 18.125,
-            "subtotal": 11313,
-            "task_usage_hours": 720,
+            "data_gb": 18.125,
+            "data_subtotal": 513,
+            "task_hours": 720,
+            "task_subtotal": 10800,
             "ts": "2022-08-01T00:00:00+00:00"
         },
         {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-02T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-03T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-04T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-05T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-06T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-07T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-08T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-09T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-10T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-11T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-12T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-13T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-14T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-15T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-16T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-17T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-18T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-19T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-20T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-21T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-22T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-23T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-24T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-25T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-26T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-27T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-28T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-29T00:00:00"
-        },
-        {
-            "line_items": [
-                {
-                    "count": 3,
-                    "description": "Data processing (at $0.20/GB)",
-                    "rate": 20,
-                    "subtotal_frac": 60
-                },
-                {
-                    "count": 0,
-                    "description": "Task usage (at $0.15/hour)",
-                    "rate": 15,
-                    "subtotal_frac": 0
-                }
-            ],
-            "processed_data_gb": 3,
-            "subtotal": 60,
-            "task_usage_hours": 0,
+            "data_gb": 3,
+            "data_subtotal": 60,
+            "task_hours": 0,
+            "task_subtotal": 0,
             "ts": "2022-08-30T00:00:00+00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-31T00:00:00"
         }
     ],
     "line_items": [
         {
             "count": 5,
-            "description": "Data processing (first 5GB at $0.50/GB)",
+            "description": "Data processing (first 5 GBs at $0.50/GB)",
             "rate": 50,
             "subtotal": 250
         },
@@ -622,7 +362,7 @@ begin
         },
         {
             "count": 1,
-            "description": "Free trial credit (2022-08-15 to 2022-09-14)",
+            "description": "Free trial credit (2022-08-15 - 2022-09-14)",
             "rate": -60,
             "subtotal": -60
         }
@@ -630,7 +370,9 @@ begin
     "processed_data_gb": 21.125,
     "recurring_fee": 0,
     "subtotal": 11313,
-    "task_usage_hours": 720
+    "task_usage_hours": 720,
+    "trial_credit": 60,
+    "trial_start": "2022-08-15"
   }'::jsonb);
 
   -- aliceCo/bb has a free trial set, but has no usage in the trial period
@@ -639,277 +381,18 @@ begin
     "billed_month": "2022-08-01T00:00:00+00:00",
     "billed_prefix": "aliceCo/bb/",
     "daily_usage": [
-        {
-            "line_items": [
-                {
-                    "count": 5,
-                    "description": "Data processing (first 5GB at $0.50/GB)",
-                    "rate": 50,
-                    "subtotal_frac": 250
-                },
-                {
-                    "count": 17,
-                    "description": "Data processing (at $0.20/GB)",
-                    "rate": 20,
-                    "subtotal_frac": 340
-                },
-                {
-                    "count": 18.375,
-                    "description": "Task usage (at $0.15/hour)",
-                    "rate": 15,
-                    "subtotal_frac": 275.625
-                }
-            ],
-            "processed_data_gb": 22,
-            "subtotal": 866,
-            "task_usage_hours": 18.375,
-            "ts": "2022-08-01T00:00:00+00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-02T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-03T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-04T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-05T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-06T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-07T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-08T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-09T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-10T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-11T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-12T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-13T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-14T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-15T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-16T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-17T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-18T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-19T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-20T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-21T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-22T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-23T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-24T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-25T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-26T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-27T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-28T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-29T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-30T00:00:00"
-        },
-        {
-            "line_items": [
-            ],
-            "processed_data_gb": 0,
-            "subtotal": 0,
-            "task_usage_hours": 0,
-            "ts": "2022-08-31T00:00:00"
-        }
+      {
+        "ts": "2022-08-01T00:00:00+00:00",
+        "data_gb": 22,
+        "task_hours": 18.375,
+        "data_subtotal": 590,
+        "task_subtotal": 276
+      }
     ],
     "line_items": [
         {
             "count": 5,
-            "description": "Data processing (first 5GB at $0.50/GB)",
+            "description": "Data processing (first 5 GBs at $0.50/GB)",
             "rate": 50,
             "subtotal": 250
         },
@@ -927,7 +410,7 @@ begin
         },
         {
             "count": 1,
-            "description": "Free trial credit (2022-08-15 to 2022-09-14)",
+            "description": "Free trial credit (2022-08-15 - 2022-09-14)",
             "rate": 0,
             "subtotal": 0
         }
@@ -935,7 +418,9 @@ begin
     "processed_data_gb": 22,
     "recurring_fee": 0,
     "subtotal": 866,
-    "task_usage_hours": 18.375
+    "task_usage_hours": 18.375,
+    "trial_start": "2022-08-15",
+    "trial_credit": 0
   }'::jsonb);
 
 end

--- a/supabase/tests/billing.test.sql
+++ b/supabase/tests/billing.test.sql
@@ -158,12 +158,9 @@ begin
   insert into catalog_stats (
     catalog_name, grain, ts, flow_document, bytes_written_by_me, bytes_read_by_me, usage_seconds
   ) values
-    ('aliceCo/aa/hello', 'monthly', '2022-08-01T00:00:00Z', '{}', 5.125 * 1024 * 1024 * 1024, 0, 3600 * 720),
     ('aliceCo/aa/hello', 'daily', '2022-08-01T00:00:00Z', '{}', 5.125 * 1024 * 1024 * 1024, 0, 3600 * 720),
-    ('aliceCo/aa/big',   'monthly', '2022-08-01T00:00:00Z', '{}', 7::bigint * 1024 * 1024 * 1024, 9::bigint * 1024 * 1024 * 1024, 0),
     ('aliceCo/aa/big',   'daily', '2022-08-01T00:00:00Z', '{}', 6::bigint * 1024 * 1024 * 1024, 7::bigint * 1024 * 1024 * 1024, 0),
     ('aliceCo/aa/big',   'daily', '2022-08-30T00:00:00Z', '{}', 1::bigint * 1024 * 1024 * 1024, 2::bigint * 1024 * 1024 * 1024, 0),
-    ('aliceCo/bb/world', 'monthly', '2022-08-01T00:00:00Z', '{}', 0, 22::bigint * 1024 * 1024 * 1024, 3600 * 18.375),
     ('aliceCo/bb/world', 'daily', '2022-08-01T00:00:00Z', '{}', 0, 22::bigint * 1024 * 1024 * 1024, 3600 * 18.375)
   ;
 


### PR DESCRIPTION
Update billing to support free trials. Fundamentally, the idea is to generate a list of all dates in the specified month along with their usage and subtotal. If there is a free trial, then sum up the subtotals for the days that are included in the free trial period, and provide a credit for that sum. 

One wrinkle here is that originally, we were dealing with monthly stats. This meant that we could comfortably multiply usage by rate and `round()` the result. Now that we're potentially dealing with summing up daily stats, the `round()`ing _must_ happen after summing, since `round(sum([list_of_real_numbers]))` != `sum(round([list_of_real_numbers]))`. Mechanically this is all fine, but it's a subtlety worth mentioning, and explains why `internal.incremental_usage_report()` must return `{"subtotal_frac": 1.234, ..}` and not `subtotal`. 

I ended up refactoring this into a couple different functions to ~preserve my sanity~ improve readability:

* **internal.compute_incremental_line_items()** deals with converting usage and usage tiers to line items incrementally. That is, rather than generating line items all at once, we can compute only the line items for the difference in usage (for a particular day, for example) while still keeping track of the total usage so far in order to determine which tier we're currently in.
* **internal.incremental_usage_report** is responsible for computing all incremental line items over a specified range, essentially driving `internal.compute_incremental_line_items()` with data from `catalog_stats`. **Note** that because we've defined `data_tiers` and `usage_tiers` as covering a specific month and then resetting, this function is inherently limited to a range of at most one month.
* **billing_report_202308** is no longer responsible for computing line items for usage. Instead, in addition to keeping its existing logic around adjustments and recurring fixed costs, it calls out to `internal.incremental_usage_report()` using the `monthly` granularity to generate the usage-based line items, and uses the `daily` granularity to calculate the free trial credit. It also now includes the list of incremental usage reports generated by `internal.incremental_usage_report` for each day of the month, with an empty fallback if no stats were recorded on that day. 

**Question:** Currently, the output of `billing_report_202308` includes line items in its per-day usage list. I'm visualizing these as mapping to different sections of a bar in a bar chart of daily usage, like this: <img width="435" alt="Screen Shot 2023-09-05 at 17 16 19" src="https://github.com/estuary/flow/assets/4368270/dd288dcd-642f-4bcf-9ba8-fd6d8413c451">

That being said, the mapping isn't 1:1. For example, I would not expect to care about different billing _tiers_ when displaying that bar chart, which implies that maybe line items aren't actually what we want here and they should be left out in favor of some unspecified future work to break down billing by category (SKU? SKU grouping?) rather than line item. 

Additionally, getting rid of it would be nice because I couldn't think of a way to expose rounded subtotals in the daily line items that all add up to the final subtotal, because of the above-mentioned "round-before-sum != sum-before-round" problem. Thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1166)
<!-- Reviewable:end -->
