### PR TITLE
materialize-mysql: datetime utc

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/mysql.md
+++ b/site/docs/reference/Connectors/materialization-connectors/mysql.md
@@ -54,6 +54,9 @@ Possible values:
 - `verify_identity`: Connect using an SSL connection, verify the server's
   certificate and the server's hostname. This is the most secure option. When using this mode, SSL Server
   CA must be provided.
+
+Optionally, SSL Client Certificate and Key can be provided if necessary to
+authorize the client.
  
 #### Bindings
 
@@ -128,6 +131,12 @@ You can find the host and port in the following locations in each platform's con
 
 This connector supports both standard (merge) and [delta updates](../../../concepts/materialization.md#delta-updates).
 The default is to use standard updates.
+
+## Date & times
+
+Date and time fields that are part of collections, which specify a `format:
+date-time` for the field, are automatically converted to UTC and
+persisted as UTC `DATETIME` in MySQL.
 
 ## Reserved words
 


### PR DESCRIPTION
**Description:**

Explicitly clarify that we write `DATETIME` fields in UTC timezone

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1168)
<!-- Reviewable:end -->
