### PR TITLE
flowctl: change to new --partitions argument

### DIFF
--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -1,7 +1,7 @@
 pub mod read;
 
 use crate::Timestamp;
-use assemble::percent_encode_partition_value;
+use anyhow::Context;
 use journal_client::{fragments, list};
 use proto_gazette::broker;
 use time::OffsetDateTime;
@@ -17,75 +17,39 @@ pub struct CollectionJournalSelector {
     /// The full name of the Flow collection
     #[clap(long)]
     pub collection: String,
-    /// Selects a logical partition to include. Partition selectors must be provided in the format
-    /// `<name>=<value>`. For example: `--include-partition userRegion=eu` would only include the
-    /// logical partition of the `userRegion` field with the value `eu`. This argument may be
-    /// provided multiple times to include multiple partitions. If this argument is provided, then
-    /// any other logical partitions will be excluded unless explicitly included here.
-    #[clap(long = "include-partition")]
-    pub include_partitions: Vec<Partition>,
-    /// Selects a logical partition to exclude. The syntax is the same as for `--include-partition`.
-    /// If this argument is provided, then all partitions will be implicitly included unless
-    /// explicitly excluded here.
-    #[clap(long = "exclude-partition")]
-    pub exclude_partitions: Vec<Partition>,
+    /// Selects a subset of collection partitions using the given selector.
+    /// The selector is provided as JSON matching the same shape that's used
+    /// in Flow catalog specs. For example:
+    /// '{"include": {"myField1":["value1", "value2"]}}'
+    #[clap(
+        long,
+        value_parser(parse_partition_selector),
+        conflicts_with_all(&["include-partition", "exclude-partition"])
+    )]
+    pub partitions: Option<models::PartitionSelector>,
+
+    /// Deprecated, use --partitions instead
+    #[clap(long = "include-partition", value_parser(parse_deprecated_selector))]
+    pub include_partitions: Vec<String>,
+    /// Deprecated, use --partitions instead
+    #[clap(long = "exclude-partition", value_parser(parse_deprecated_selector))]
+    pub exclude_partitions: Vec<String>,
+}
+
+fn parse_deprecated_selector(_: &str) -> Result<String, anyhow::Error> {
+    anyhow::bail!("this argument has been deprecated, and replaced by --partitions")
+}
+
+fn parse_partition_selector(arg: &str) -> Result<models::PartitionSelector, anyhow::Error> {
+    serde_json::from_str(arg).context("parsing `--partitions` argument value")
 }
 
 impl CollectionJournalSelector {
     pub fn build_label_selector(&self) -> broker::LabelSelector {
-        let mut include = Vec::with_capacity(1 + self.include_partitions.len());
-        include.push(broker::Label {
-            name: labels::COLLECTION.to_string(),
-            value: self.collection.clone(),
-        });
-        include.extend(self.include_partitions.iter().map(partition_field_label));
-        let mut exclude = self
-            .exclude_partitions
-            .iter()
-            .map(partition_field_label)
-            .collect::<Vec<_>>();
-
-        // LabelSets must be in sorted order.
-        include.sort_by(|l, r| (&l.name, &l.value).cmp(&(&r.name, &r.value)));
-        exclude.sort_by(|l, r| (&l.name, &l.value).cmp(&(&r.name, &r.value)));
-
-        broker::LabelSelector {
-            include: Some(broker::LabelSet { labels: include }),
-            exclude: Some(broker::LabelSet { labels: exclude }),
-        }
-    }
-}
-
-/// A selector of a logical partition, which can be either included or excluded from a read of a
-/// collection.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Partition {
-    pub name: String,
-    pub value: String,
-}
-
-impl std::str::FromStr for Partition {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some((key, value)) = s.split_once('=') {
-            Ok(Partition {
-                name: key.trim().to_string(),
-                value: value.trim().to_string(),
-            })
-        } else {
-            anyhow::bail!(
-                "invalid partition argument: '{}', must be in the format: '<key>:<json-value>'",
-                s
-            );
-        }
-    }
-}
-
-fn partition_field_label(part: &Partition) -> broker::Label {
-    broker::Label {
-        name: format!("{}{}", labels::FIELD_PREFIX, part.name),
-        value: percent_encode_partition_value(&part.value),
+        assemble::journal_selector(
+            &models::Collection::new(&self.collection),
+            self.partitions.as_ref(),
+        )
     }
 }
 
@@ -277,42 +241,4 @@ async fn do_list_journals(
     let journals = list::list_journals(&mut client, &args.build_label_selector()).await?;
 
     ctx.write_all(journals, ())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn partition_specs_are_parsed() {
-        let cases = vec![
-            (
-                r#"str_field=bar"#,
-                Partition {
-                    name: "str_field".to_string(),
-                    value: "bar".to_string(),
-                },
-            ),
-            (
-                r#"int_field=7"#,
-                Partition {
-                    name: "int_field".to_string(),
-                    value: "7".to_string(),
-                },
-            ),
-            (
-                r#"bool_field=true"#,
-                Partition {
-                    name: "bool_field".to_string(),
-                    value: "true".to_string(),
-                },
-            ),
-        ];
-        for (input, expected) in cases {
-            let actual = input.parse().unwrap_or_else(|error| {
-                panic!("failed to parse input: '{}', error: {:?}", input, error);
-            });
-            assert_eq!(expected, actual, "invalid output for input: '{}'", input);
-        }
-    }
 }

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -22,10 +22,6 @@ pub async fn get_collection_inferred_schema(
     ctx: &mut crate::CliContext,
     args: &SchemaInferenceArgs,
 ) -> anyhow::Result<()> {
-    if args.selector.exclude_partitions.len() > 0 || args.selector.include_partitions.len() > 0 {
-        anyhow::bail!("flowctl is not yet able to read from partitioned collections (coming soon)");
-    }
-
     let cp_client = ctx.controlplane_client().await?;
     let token = fetch_data_plane_access_token(cp_client, vec![args.selector.collection.clone()])
         .await

--- a/crates/flowctl/src/ops.rs
+++ b/crates/flowctl/src/ops.rs
@@ -1,6 +1,8 @@
+use serde_json::Value;
+
 use crate::collection::{
     read::{read_collection, ReadArgs, ReadBounds},
-    CollectionJournalSelector, Partition,
+    CollectionJournalSelector,
 };
 
 #[derive(clap::Args, Debug)]
@@ -73,13 +75,19 @@ pub fn read_args(
     // Once we implement federated data planes, we'll need to update this to
     // fetch the name of the data plane based on the tenant.
     let collection = format!("ops.us-central1.v1/{logs_or_stats}");
+
+    let mut include = std::collections::BTreeMap::new();
+    include.insert(
+        "name".to_string(),
+        vec![Value::String(task_name.to_string())],
+    );
     let selector = CollectionJournalSelector {
         collection,
-        include_partitions: vec![Partition {
-            name: "name".to_string(),
-            value: task_name.to_string(),
-        }],
-        exclude_partitions: Vec::new(),
+        partitions: Some(models::PartitionSelector {
+            include,
+            exclude: Default::default(),
+        }),
+        ..Default::default()
     };
     ReadArgs {
         selector,


### PR DESCRIPTION
**Description:**

Replaces the --include-partition and --exclude-partition arguments of `flowctl collections read|list-journals|list-fragments` with a new `--partitions` argument. The new argument accepts a JSON object, which is deserialized into a `models::PartitionSelector`, and thus matches the shape of the selector that's used in catalog specs.

The motivation for this is that the old arguments didn't allow for reading from partitions where the value was a json `null`. When it was written, we didn't allow partitioning on nullable fields. Now that we do, the json syntax seemed desirable as it allows distinguishing between json types, so that `null` can be differentiated from the string `"null"`.

**Workflow steps:**

If you'd previously used `--include-partition foo=bar`, then you'll now have to use `--partitions '{"include": {"foo": ["bar"]}}'`

**Documentation links affected:**

This isn't documented, except in the CLI help.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1174)
<!-- Reviewable:end -->
