### PR TITLE
agent: don't disable linked materialization bindings

### DIFF
--- a/crates/agent/src/publications/linked_materializations/snapshots/agent__publications__linked_materializations__test__capture_only_published.snap
+++ b/crates/agent/src/publications/linked_materializations/snapshots/agent__publications__linked_materializations__test__capture_only_published.snap
@@ -113,4 +113,48 @@ expression: results
             },
         ),
     },
+    Record {
+        catalog_name: "acmeCo/matC/already-matching",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "disable": Bool(true),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {},
+                        "source": String("acmeCo/captureA/c1"),
+                    },
+                    Object {
+                        "disable": Bool(true),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {},
+                        "source": String("acmeCo/captureA/c3"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("c4"),
+                        },
+                        "source": String("acmeCo/captureA/c4"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("matImage:v1"),
+                    },
+                },
+                "sourceCapture": String("acmeCo/captureA/source-happy"),
+            },
+        ),
+    },
 ]

--- a/crates/agent/src/publications/test_resources/linked_materializations.sql
+++ b/crates/agent/src/publications/test_resources/linked_materializations.sql
@@ -87,9 +87,10 @@ setup_live_specs as (
     }'::json, null, 'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'),
     ('1600000000000000', 'acmeCo/matC/already-matching', '{
       "endpoint": {"connector":{"image":"matImage:v1","config":{}}},
-      "sourceCapture": "acmeCo/captureC/source-empty",
+      "sourceCapture": "acmeCo/captureA/source-happy",
       "bindings": [
-        {"source": "acmeCo/captureC/c1","disable": true}
+        {"source": "acmeCo/captureA/c1","disable": true, "resource": {}},
+        {"source": "acmeCo/captureA/c3","disable": true, "resource": {}}
       ]
     }'::json, null, 'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'),
 


### PR DESCRIPTION
**Description:**

This updates the handling of materialization `sourceCapture`s in the publications handler, to no longer disable materialization bindings. The agent will now only ever add bindings to linked materializations, and will never disable them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1187)
<!-- Reviewable:end -->
