### PR TITLE
runtime: fix flakey connector deadlock

### DIFF
--- a/crates/derive-typescript/src/main.rs
+++ b/crates/derive-typescript/src/main.rs
@@ -1,4 +1,4 @@
-use tracing_subscriber::{filter::LevelFilter, EnvFilter};
+use tracing_subscriber::EnvFilter;
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::fmt()

--- a/crates/runtime/src/image_connector.rs
+++ b/crates/runtime/src/image_connector.rs
@@ -1,7 +1,6 @@
 use super::container;
-use futures::future::BoxFuture;
-use futures::SinkExt;
-use futures::{channel::mpsc, Stream, StreamExt};
+use futures::{channel::mpsc, future::BoxFuture, SinkExt, Stream, TryStreamExt};
+use tokio::task::JoinHandle;
 
 /// Container is a description of a running Container instance.
 pub use proto_flow::runtime::Container;
@@ -37,23 +36,24 @@ pub type StartRpcFuture<Response> =
 ///   of each delegate container lifecycle.
 pub struct Connector<Request, Response, Requests, Unseal, StartRpc, Attach, L>
 where
+    Request: serde::Serialize,
+    Response: Send + Sync + 'static,
     Requests: Stream<Item = tonic::Result<Request>> + Send + Unpin + 'static,
     Unseal: Fn(Request) -> Result<UnsealFuture<Request>, Request>,
     StartRpc: Fn(tonic::transport::Channel, mpsc::Receiver<Request>) -> StartRpcFuture<Response>,
-    Attach: Fn(&mut Response, Container),
+    Attach: Fn(&mut Response, Container) + Clone + Send + Sync + 'static,
     L: Fn(&ops::Log) + Clone + Send + Sync + 'static,
 {
-    attach_container: Attach,
-    container: Option<Container>,
-    log_handler: L,
-    network: String,
-    request_rx: Requests,
-    response_tx: mpsc::Sender<tonic::Result<Response>>,
-    start_rpc: StartRpc,
-    state: State<Request, Response>,
-    task_name: String,
-    task_type: ops::TaskType,
-    unseal: Unseal,
+    attach_container: Attach, // Attaches a Container description to a response.
+    log_handler: L,           // Log handler.
+    network: String,          // Container network to use.
+    request_rx: Requests,     // Caller's input request stream.
+    response_tx: mpsc::Sender<tonic::Result<Response>>, // Caller's output response stream.
+    start_rpc: StartRpc,      // Begins RPC over a started container channel.
+    state: State<Request>,    // Current container state.
+    task_name: String,        // Name of this task, used to label container.
+    task_type: ops::TaskType, // Type of this task, for labeling container.
+    unseal: Unseal,           // Unseals a Request, or returns the Request if it doesn't unseal.
 }
 
 // TODO(johnny): This State can be extended with a Resumed variant when we
@@ -61,27 +61,27 @@ where
 // variant would introspect and hold the effective Request.Open of the resumed
 // container, which would then be matched with a current Open to either resume
 // or drain a recovered connector instance.
-enum State<Request, Response> {
-    // We're ready to start a container.
+enum State<Request> {
     Idle,
+    // We're ready to start a container.
+    Starting {
+        unseal: UnsealFuture<Request>,
+    },
     // Container has an active bidirectional stream.
     Running {
-        container_rx: tonic::Streaming<Response>,
+        container_status: JoinHandle<tonic::Result<()>>,
         container_tx: mpsc::Sender<Request>,
-        guard: container::Guard,
     },
     // We must restart a new container. We've sent the current one EOF,
     // and are waiting to see its EOF before we begin a new instance.
     Restarting {
-        container_rx: tonic::Streaming<Response>,
-        _guard: container::Guard,
+        container_status: JoinHandle<tonic::Result<()>>,
         unseal: UnsealFuture<Request>,
     },
     // Requests reach EOF. We've sent EOF into the container and are
     // draining its final responses.
     Draining {
-        container_rx: tonic::Streaming<Response>,
-        _guard: container::Guard,
+        container_status: JoinHandle<tonic::Result<()>>,
     },
 }
 
@@ -89,10 +89,11 @@ impl<Request, Response, Requests, Unseal, StartRpc, Attach, L>
     Connector<Request, Response, Requests, Unseal, StartRpc, Attach, L>
 where
     Request: serde::Serialize,
+    Response: Send + Sync + 'static,
     Requests: Stream<Item = tonic::Result<Request>> + Send + Unpin + 'static,
     Unseal: Fn(Request) -> Result<UnsealFuture<Request>, Request>,
     StartRpc: Fn(tonic::transport::Channel, mpsc::Receiver<Request>) -> StartRpcFuture<Response>,
-    Attach: Fn(&mut Response, Container),
+    Attach: Fn(&mut Response, Container) + Clone + Send + Sync + 'static,
     L: Fn(&ops::Log) + Clone + Send + Sync + 'static,
 {
     pub fn new(
@@ -111,12 +112,11 @@ where
             Self {
                 attach_container,
                 unseal,
-                container: None,
                 network: network.to_string(),
                 request_rx,
                 start_rpc,
                 response_tx,
-                state: State::<Request, Response>::Idle,
+                state: State::<Request>::Idle,
                 task_name: task_name.to_string(),
                 log_handler,
                 task_type,
@@ -128,192 +128,144 @@ where
     /// Run the Connector until it's complete.
     pub async fn run(mut self) {
         loop {
-            // Select over the next request or the next container response.
-            // We use Result as a semantic "either" type.
-            let rx = match &mut self.state {
-                // We're only reading requests.
-                State::Idle => Err(self.request_rx.next().await),
-                // We're reading requests and container responses.
-                State::Running { container_rx, .. } => tokio::select! {
-                    rx = container_rx.next() => Ok(rx),
-                    rx = self.request_rx.next() => Err(rx),
-                },
-                // We're only reading container responses.
-                State::Restarting { container_rx, .. } | State::Draining { container_rx, .. } => {
-                    Ok(container_rx.next().await)
+            if let Err(status) = self.step().await {
+                if status.code() == tonic::Code::Ok {
+                    // Clean EOF.
+                } else if let Err(send_error) = self.response_tx.send(Err(status.clone())).await {
+                    tracing::warn!(%status, %send_error, "encountered terminal error but receiver is gone");
                 }
-            };
-
-            if !match rx {
-                Ok(Some(Ok(rx))) => self.container_rx(rx).await,
-                Ok(Some(Err(status))) => self.on_error(status).await,
-                Ok(None) => self.container_eof().await,
-                Err(Some(Ok(rx))) => self.request_rx(rx).await,
-                Err(Some(Err(status))) => self.on_error(status).await,
-                Err(None) => self.request_eof().await,
-            } {
                 break;
             }
         }
     }
 
-    async fn spawn_container(
-        &mut self,
-        Unsealed {
-            image,
-            log_level,
-            request,
-        }: Unsealed<Request>,
-    ) -> bool {
-        assert!(matches!(&self.state, State::Idle));
+    async fn step(&mut self) -> tonic::Result<()> {
+        let state = std::mem::replace(&mut self.state, State::Idle);
 
-        let (mut container_tx, container_rx) = mpsc::channel(crate::CHANNEL_BUFFER);
-        () = container_tx
-            .try_send(request)
-            .expect("can always send first request into buffered channel");
-
-        let started = container::start(
-            &image,
-            self.log_handler.clone(),
-            log_level,
-            &self.network,
-            &self.task_name,
-            self.task_type,
-        )
-        .await;
-
-        let (container, channel, guard) = match started {
-            Ok(ok) => ok,
-            Err(err) => return self.on_error(crate::anyhow_to_status(err)).await,
-        };
-
-        let container_rx = match (self.start_rpc)(channel, container_rx).await {
-            Ok(ok) => ok,
-            Err(status) => return self.on_error(status).await,
-        }
-        .into_inner();
-
-        self.state = State::Running {
-            container_rx,
-            container_tx,
-            guard,
-        };
-        self.container = Some(container);
-
-        true
-    }
-
-    async fn container_rx(&mut self, mut rx: Response) -> bool {
-        // Attach Container to the first Response of a delegate container session.
-        if let Some(container) = self.container.take() {
-            (self.attach_container)(&mut rx, container);
-        }
-
-        if let Err(send_error) = self.response_tx.send(Ok(rx)).await {
-            tracing::warn!(%send_error, "failed to forward container response");
-            false // All done. Container is cancelled via Drop.
-        } else {
-            true
-        }
-    }
-
-    async fn request_rx(&mut self, rx: Request) -> bool {
-        match (self.unseal)(rx) {
-            Ok(unseal) => match std::mem::replace(&mut self.state, State::Idle) {
-                State::Idle => match unseal.await {
-                    Ok(unsealed) => self.spawn_container(unsealed).await,
-                    Err(error) => self.on_error(crate::anyhow_to_status(error)).await,
-                },
-                State::Running {
-                    container_rx,
-                    container_tx: _, // Send EOF.
-                    guard,
-                } => {
-                    self.state = State::Restarting {
-                        container_rx,
-                        _guard: guard,
-                        unseal,
-                    };
-                    true
-                }
-                State::Restarting { .. } => unreachable!("not reading requests while restarting"),
-                State::Draining { .. } => unreachable!("not reading requests while draining"),
-            },
-            Err(rx) => match &mut self.state {
-                State::Idle => {
-                    self.on_error(tonic::Status::invalid_argument(format!(
-                        "invalid Request when no image container is running: {}",
-                        serde_json::to_string(&rx).unwrap()
-                    )))
-                    .await
-                }
-                State::Running { container_tx, .. } => match container_tx.send(rx).await {
-                    Ok(()) => true,
-                    Err(_send_error) => {
-                        self.on_error(tonic::Status::internal(
-                            "connector unexpectedly closed its running request stream",
-                        ))
-                        .await
+        Ok(match state {
+            State::Idle => {
+                let Some(request) = self.request_rx.try_next().await? else {
+                    return Err(tonic::Status::ok("EOF")); // All done.
+                };
+                match (self.unseal)(request) {
+                    Ok(unseal) => {
+                        self.state = State::Starting { unseal };
                     }
-                },
-                State::Restarting { .. } => unreachable!("not reading requests while restarting"),
-                State::Draining { .. } => unreachable!("not reading requests while draining"),
-            },
-        }
-    }
+                    Err(request) => {
+                        return Err(tonic::Status::invalid_argument(format!(
+                            "invalid initial Request: {}",
+                            serde_json::to_string(&request).unwrap()
+                        )));
+                    }
+                }
+            }
+            State::Starting { unseal } => {
+                let Unsealed {
+                    image,
+                    log_level,
+                    request,
+                } = unseal.await.map_err(crate::anyhow_to_status)?;
 
-    async fn container_eof(&mut self) -> bool {
-        match std::mem::replace(&mut self.state, State::Idle) {
-            State::Idle => unreachable!("not reading responses while idle"),
+                let (mut container_tx, container_rx) = mpsc::channel(crate::CHANNEL_BUFFER);
+                () = container_tx
+                    .try_send(request)
+                    .expect("can always send first request into buffered channel");
+
+                let (container, channel, guard) = container::start(
+                    &image,
+                    self.log_handler.clone(),
+                    log_level,
+                    &self.network,
+                    &self.task_name,
+                    self.task_type,
+                )
+                .await
+                .map_err(crate::anyhow_to_status)?;
+
+                // Start RPC over the container's gRPC `channel`.
+                let mut container_rx = (self.start_rpc)(channel, container_rx).await?.into_inner();
+
+                // Spawn task which reads and forwards connector responses.
+                let mut attach = Some((container, self.attach_container.clone()));
+                let mut response_tx = self.response_tx.clone();
+
+                let container_status = tokio::spawn(async move {
+                    let _guard = guard; // Hold guard while still reading responses.
+
+                    while let Some(mut response) = container_rx.try_next().await? {
+                        if let Some((container, attach)) = attach.take() {
+                            (attach)(&mut response, container);
+                        }
+                        if let Err(_) = response_tx.send(Ok(response)).await {
+                            return Err(tonic::Status::cancelled(
+                                "failed to forward response because receiver is gone",
+                            ));
+                        }
+                    }
+                    Ok(())
+                });
+
+                self.state = State::Running {
+                    container_status,
+                    container_tx,
+                };
+            }
             State::Running {
-                container_rx: _,
-                container_tx: _,
-                guard: _,
+                mut container_status,
+                mut container_tx,
             } => {
-                self.on_error(tonic::Status::aborted(
-                    "connector unexpectedly closed its response stream while the request stream was still open")).await
+                // Wait for a next request or for the container to exit.
+                let request = tokio::select! {
+                    status = &mut container_status => {
+                        () = status.unwrap()?;
+
+                        return Err(tonic::Status::aborted(
+                            "connector unexpectedly closed its output stream while its input stream is still open"
+                        ))
+                    },
+                    request = self.request_rx.try_next() => request?,
+                };
+
+                match request.map(|request| (self.unseal)(request)) {
+                    // A non-sealed request that we simply forward.
+                    Some(Err(request)) => {
+                        container_tx.feed(request).await.map_err(|_send_err| {
+                            tonic::Status::internal(
+                                "connector unexpectedly closed its input stream",
+                            )
+                        })?;
+
+                        self.state = State::Running {
+                            container_status,
+                            container_tx,
+                        };
+                    }
+                    // Sealed request which requires that we restart the container.
+                    Some(Ok(unseal)) => {
+                        let _drop_to_send_eof = container_tx;
+                        self.state = State::Restarting {
+                            container_status,
+                            unseal,
+                        };
+                    }
+                    // End of input.
+                    None => {
+                        let _drop_to_send_eof = container_tx;
+                        self.state = State::Draining { container_status };
+                    }
+                }
             }
             State::Restarting {
-                container_rx: _,
-                _guard: _,
+                container_status,
                 unseal,
             } => {
-                // Previous delegate has completed; start the next one.
-                match unseal.await {
-                    Ok(unsealed) => self.spawn_container(unsealed).await,
-                    Err(error) => self.on_error(crate::anyhow_to_status(error)).await,
-                }
+                () = container_status.await.unwrap()?;
+                self.state = State::Starting { unseal };
             }
-            State::Draining {
-                container_rx: _,
-                _guard: _,
-            } => false, // `request_rx` has already EOF'd. All done.
-        }
-    }
-
-    async fn request_eof(&mut self) -> bool {
-        match std::mem::replace(&mut self.state, State::Idle) {
-            State::Idle => false, // No running container. All done.
-            State::Running {
-                container_rx,
-                container_tx: _, // Send EOF.
-                guard,
-            } => {
-                self.state = State::Draining {
-                    container_rx,
-                    _guard: guard,
-                };
-                true // Wait for EOF from container.
+            State::Draining { container_status } => {
+                () = container_status.await.unwrap()?;
+                return Err(tonic::Status::ok("EOF")); // All done.
             }
-            State::Restarting { .. } => unreachable!("not reading requests"),
-            State::Draining { .. } => unreachable!("not reading requests"),
-        }
-    }
-
-    async fn on_error(&mut self, status: tonic::Status) -> bool {
-        if let Err(send_error) = self.response_tx.send(Err(status.clone())).await {
-            tracing::warn!(%status, %send_error, "encountered terminal error but response stream is cancelled");
-        }
-        false // All done. If a container is running, it's cancelled via Drop.
+        })
     }
 }


### PR DESCRIPTION
Image connectors can deadlock at high volumes of requests and response due to channel stuffing. Specifically it's not okay to await a send into the container while not concurrently polling for container responses.

Re-work the state machine to forward non-error responses using a separate spawned task, which is joined over only upon terminal error or completion.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1188)
<!-- Reviewable:end -->
