### PR TITLE
flowctl: allow specifying --network in `raw` commands

### DIFF
--- a/crates/flowctl/src/raw/capture.rs
+++ b/crates/flowctl/src/raw/capture.rs
@@ -22,6 +22,10 @@ pub struct Capture {
     /// Print the reduced checkpoint of the connector as it gets updated
     #[clap(long, action)]
     print_checkpoint: bool,
+
+    /// Docker network to run the connector
+    #[clap(long, default_value="bridge")]
+    network: String,
 }
 
 #[derive(Deserialize)]
@@ -40,6 +44,7 @@ pub async fn do_capture(
     ctx: &mut crate::CliContext,
     Capture {
         source,
+        network,
         print_checkpoint,
     }: &Capture,
 ) -> anyhow::Result<()> {
@@ -80,7 +85,7 @@ pub async fn do_capture(
         ..Default::default()
     };
 
-    let apply_output = docker_run(&cfg.image, apply)
+    let apply_output = docker_run(&cfg.image, &network, apply)
         .await
         .context("connector apply")?;
 
@@ -159,6 +164,7 @@ pub async fn do_capture(
     });
     let mut out_stream = docker_run_stream(
         &cfg.image,
+        &network,
         Box::pin(stream::once(async { open }).chain(in_stream)),
     )
     .await

--- a/crates/flowctl/src/raw/discover.rs
+++ b/crates/flowctl/src/raw/discover.rs
@@ -33,6 +33,10 @@ pub struct Discover {
     /// Should specs be written to the single specification file, or written in the canonical layout?
     #[clap(long)]
     flat: bool,
+
+    /// Docker network to run the connector
+    #[clap(long, default_value="bridge")]
+    network: String,
 }
 
 pub async fn do_discover(
@@ -42,6 +46,7 @@ pub async fn do_discover(
         prefix,
         overwrite,
         flat,
+        network,
     }: &Discover,
 ) -> anyhow::Result<()> {
     let connector_name = image
@@ -70,6 +75,7 @@ pub async fn do_discover(
     if let Some(config) = cfg {
         let discover_output = docker_run(
             image,
+            &network,
             Request {
                 discover: Some(request::Discover {
                     connector_type: ConnectorType::Image.into(),
@@ -150,6 +156,7 @@ pub async fn do_discover(
         // Otherwise send a Spec RPC and use that to write a sample config file
         let spec_output = docker_run(
             image,
+            &network,
             Request {
                 spec: Some(request::Spec {
                     connector_type: ConnectorType::Image.into(),


### PR DESCRIPTION
**Description:**

- Allow specifying `--network` in `flowctl raw` commands, helps with testing locally on endpoints run with docker

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1189)
<!-- Reviewable:end -->
