### PR TITLE
Update `billing_report_202308` to round quantities.

### DIFF
--- a/supabase/migrations/29_round_free_trial.sql
+++ b/supabase/migrations/29_round_free_trial.sql
@@ -1,0 +1,256 @@
+begin;
+
+-- Compute a JSONB array of line-items detailing usage under a tenant's effective tiers.
+create or replace function tier_line_items(
+  -- Ammount of usage we're breaking out.
+  amount numeric,
+  -- Effective tenant tiers as ordered pairs of (quantity, cents), followed
+  -- by a final unpaired cents for unbounded usage beyond the final quantity.
+  tiers integer[],
+  -- Descriptive name of the tiered thing ("Data processing").
+  name text,
+  -- Unit of the tier ("GB" or "hour").
+  unit text
+)
+returns jsonb as $$
+declare
+  o_line_items jsonb = '[]'; -- Output variable.
+  tier_count   numeric;
+  tier_pivot   integer;
+  tier_rate    integer;
+begin
+
+  for idx in 1..array_length(tiers, 1) by 2 loop
+    tier_rate = tiers[idx];
+    tier_pivot = tiers[idx+1];
+    tier_count = least(amount, tier_pivot);
+    amount = amount - tier_count;
+
+    o_line_items = o_line_items || jsonb_build_object(
+      'description', format(
+        case
+          when tier_pivot is null then '%1$s (at %4$s/%2$s)'      -- Data processing (at $0.50/GB)
+          when idx = 1 then '%1s (first %3$s %2$ss at %4$s/%2$s)' -- Data processing (first 30 GBs at $0.50/GB)
+          else '%1$s (next %3$s %2$ss at %4$s/%2$s)'              -- Data processing (next 6 GBs at $0.25/GB)
+        end,
+        name,
+        unit,
+        tier_pivot,
+        (tier_rate / 100.0)::money
+      ),
+      'count', tier_count,
+      'rate', tier_rate,
+      'subtotal', round(tier_count * tier_rate)
+    );
+  end loop;
+
+  return o_line_items;
+
+end
+$$ language plpgsql;
+
+
+-- Billing report which is effective August 2023.
+create or replace function billing_report_202308(billed_prefix catalog_prefix, billed_month timestamptz)
+returns jsonb as $$
+declare
+  -- Auth checks
+  has_admin_grant boolean;
+  has_bypassrls boolean;
+
+  -- Output variables.
+  o_daily_usage   jsonb;
+  o_data_gb       numeric;
+  o_line_items    jsonb = '[]';
+  o_recurring_fee integer;
+  o_subtotal      integer;
+  o_task_hours    numeric;
+  o_trial_credit  integer;
+  o_trial_start   date;
+  o_trial_range   daterange;
+  o_billed_range  daterange;
+begin
+
+  -- Ensure `billed_month` is the truncated start of the billed month.
+  billed_month = date_trunc('month', billed_month);
+
+  -- Verify that the user has an admin grant for the requested `billed_prefix`.
+  perform 1 from auth_roles('admin') as r where billed_prefix ^@ r.role_prefix;
+  has_admin_grant = found;
+
+  -- Check whether the real active role has bypassrls flag set.
+  -- Because this function is SECURITY DEFINER, both `current_user` and `current_role`
+  -- will be `postgres`, which does have bypassrls set. Instead we want the
+  -- role of the caller, which can be accessed like so according to:
+  -- https://www.postgresql.org/message-id/13906.1141711109%40sss.pgh.pa.us
+  perform * from pg_roles where rolname = current_setting('role') and rolbypassrls = true;
+  has_bypassrls = found;
+
+  if not has_admin_grant and not has_bypassrls then
+    -- errcode 28000 causes PostgREST to return an HTTP 403
+    -- see: https://www.postgresql.org/docs/current/errcodes-appendix.html
+    -- and: https://postgrest.org/en/stable/errors.html#status-codes
+    raise 'You are not authorized for the billed prefix %', billed_prefix using errcode = 28000;
+  end if;
+
+  with vars as (
+    select
+      t.data_tiers,
+      t.trial_start,
+      t.usage_tiers,
+      tstzrange(billed_month, billed_month  + '1 month', '[)') as billed_range,
+      case when t.trial_start is not null
+        then tstzrange(t.trial_start, t.trial_start + interval '1 month', '[)')
+        else 'empty' end as trial_range,
+      -- Reveal contract costs only when computing whole-tenant billing.
+      case when t.tenant = billed_prefix then t.recurring_usd_cents else 0 end as recurring_fee
+      from tenants t
+      where billed_prefix ^@ t.tenant -- Prefix starts with tenant.
+  ),
+  -- Roll up each day's incremental usage.
+  daily_stat_deltas as (
+    select
+      ts,
+      sum(bytes_written_by_me + bytes_read_by_me) / (1024.0 * 1024 * 1024) as data_gb,
+      sum(usage_seconds) / (60.0 * 60) as task_hours
+    from catalog_stats, vars
+      where catalog_name ^@ billed_prefix -- Name starts with prefix.
+      and grain = 'daily'
+      and billed_range @> ts
+      group by ts
+  ),
+  -- Map to cumulative daily usage.
+  -- Note sum(...) over (order by ts) yields the running sum of its aggregate.
+  daily_stats as (
+    select
+      ts,
+      ceil(sum(data_gb) over w) as data_gb,
+      ceil(sum(task_hours) over w) as task_hours
+    from daily_stat_deltas
+    window w as (order by ts)
+  ),
+  -- Extend with line items for each category for the period ending with the given day.
+  daily_line_items as (
+    select
+      daily_stats.*,
+      tier_line_items(data_gb, data_tiers, 'Data processing', 'GB') as data_line_items,
+      tier_line_items(task_hours, usage_tiers, 'Task usage', 'hour') as task_line_items
+    from daily_stats, vars
+  ),
+  -- Extend with per-category subtotals for the period ending with the given day.
+  daily_totals as (
+    select
+      daily_line_items.*,
+      data_subtotal,
+      task_subtotal
+    from daily_line_items,
+      lateral (select sum((li->>'subtotal')::numeric) as data_subtotal from jsonb_array_elements(data_line_items) li) l1,
+      lateral (select sum((li->>'subtotal')::numeric) as task_subtotal from jsonb_array_elements(task_line_items) li) l2
+  ),
+  -- Map cumulative totals to per-day deltas.
+  daily_deltas as (
+    select
+      ts,
+      data_gb       - (coalesce(lag(data_gb,         1) over w, 0)) as data_gb,
+      data_subtotal - (coalesce(lag(data_subtotal,   1) over w, 0)) as data_subtotal,
+      task_hours    - (coalesce(lag(task_hours,      1) over w, 0)) as task_hours,
+      task_subtotal - (coalesce(lag(task_subtotal,   1) over w, 0)) as task_subtotal
+      from daily_totals
+      window w as (order by ts)
+  ),
+  -- 1) Group daily_deltas into a JSON array
+  -- 2) Sum a trial credit from daily deltas that overlap with the trial period.
+  daily_array_and_trial_credit as (
+    select
+    jsonb_agg(jsonb_build_object(
+      'ts', ts,
+      'data_gb', data_gb,
+      'data_subtotal', data_subtotal,
+      'task_hours', task_hours,
+      'task_subtotal', task_subtotal
+    )) as daily_usage,
+    coalesce(sum(data_subtotal + task_subtotal) filter (where trial_range @>ts),0 ) as trial_credit
+    from daily_deltas, vars
+  ),
+  -- The last day captures the cumulative billed period.
+  last_day as (
+    select * from daily_line_items
+    order by ts desc limit 1
+  ),
+  -- If we're reporting for the whole tenant then gather billing adjustment line-items.
+  adjustments as (
+    select coalesce(jsonb_agg(
+      jsonb_build_object(
+        'description', detail,
+        'count', 1,
+        'rate', usd_cents,
+        'subtotal', usd_cents
+      )
+    ), '[]') as adjustment_line_items
+    from internal.billing_adjustments a
+    where a.tenant = billed_prefix and a.billed_month = billing_report_202308.billed_month
+  )
+  select into
+    -- Block of variables being selected into.
+    o_daily_usage,
+    o_data_gb,
+    o_line_items,
+    o_recurring_fee,
+    o_task_hours,
+    o_trial_credit,
+    o_trial_start,
+    o_trial_range,
+    o_billed_range
+    -- The actual selected columns.
+    daily_usage,
+    data_gb,
+    data_line_items || task_line_items || adjustment_line_items,
+    recurring_fee,
+    task_hours,
+    trial_credit,
+    trial_start,
+    trial_range,
+    billed_range
+  from daily_array_and_trial_credit, last_day, adjustments, vars;
+
+  -- Add line items for recurring service fee & free trial credit.
+  if o_recurring_fee != 0 then
+    o_line_items = jsonb_build_object(
+      'description', 'Recurring service charge',
+      'count', 1,
+      'rate', o_recurring_fee,
+      'subtotal', o_recurring_fee
+    ) || o_line_items;
+  end if;
+
+  -- Display a (possibly zero) free trial credit if the trial range overlaps the billed range
+  if o_trial_range && o_billed_range then
+    o_line_items = o_line_items || jsonb_build_object(
+      'description', format('Free trial credit (%s - %s)', lower(o_trial_range), (upper(o_trial_range) - interval '1 day')::date),
+      'count', 1,
+      'rate', -o_trial_credit,
+      'subtotal', -o_trial_credit
+    );
+  end if;
+
+  -- Roll up the final subtotal.
+  select into o_subtotal sum((l->>'subtotal')::numeric)
+    from jsonb_array_elements(o_line_items) l;
+
+  return jsonb_build_object(
+    'billed_month', billed_month,
+    'billed_prefix', billed_prefix,
+    'daily_usage', o_daily_usage,
+    'line_items', o_line_items,
+    'processed_data_gb', o_data_gb,
+    'recurring_fee', o_recurring_fee,
+    'subtotal', o_subtotal,
+    'task_usage_hours', o_task_hours,
+    'trial_credit', coalesce(o_trial_credit, 0),
+    'trial_start', o_trial_start
+  );
+
+end
+$$ language plpgsql volatile security definer;
+
+commit;

--- a/supabase/migrations/29_round_free_trial.sql
+++ b/supabase/migrations/29_round_free_trial.sql
@@ -15,7 +15,7 @@ create or replace function tier_line_items(
 returns jsonb as $$
 declare
   o_line_items jsonb = '[]'; -- Output variable.
-  tier_count   numeric;
+  tier_count   integer;
   tier_pivot   integer;
   tier_rate    integer;
 begin
@@ -23,7 +23,7 @@ begin
   for idx in 1..array_length(tiers, 1) by 2 loop
     tier_rate = tiers[idx];
     tier_pivot = tiers[idx+1];
-    tier_count = least(amount, tier_pivot);
+    tier_count = ceil(least(amount, tier_pivot));
     amount = amount - tier_count;
 
     o_line_items = o_line_items || jsonb_build_object(
@@ -40,7 +40,7 @@ begin
       ),
       'count', tier_count,
       'rate', tier_rate,
-      'subtotal', round(tier_count * tier_rate)
+      'subtotal', tier_count * tier_rate
     );
   end loop;
 
@@ -124,8 +124,8 @@ begin
   daily_stats as (
     select
       ts,
-      ceil(sum(data_gb) over w) as data_gb,
-      ceil(sum(task_hours) over w) as task_hours
+      sum(data_gb) over w as data_gb,
+      sum(task_hours) over w as task_hours
     from daily_stat_deltas
     window w as (order by ts)
   ),

--- a/supabase/tests/billing.test.sql
+++ b/supabase/tests/billing.test.sql
@@ -161,7 +161,25 @@ begin
     ('aliceCo/aa/hello', 'daily', '2022-08-01T00:00:00Z', '{}', 5.125 * 1024 * 1024 * 1024, 0, 3600 * 720),
     ('aliceCo/aa/big',   'daily', '2022-08-01T00:00:00Z', '{}', 6::bigint * 1024 * 1024 * 1024, 7::bigint * 1024 * 1024 * 1024, 0),
     ('aliceCo/aa/big',   'daily', '2022-08-30T00:00:00Z', '{}', 1::bigint * 1024 * 1024 * 1024, 2::bigint * 1024 * 1024 * 1024, 0),
-    ('aliceCo/bb/world', 'daily', '2022-08-01T00:00:00Z', '{}', 0, 22::bigint * 1024 * 1024 * 1024, 3600 * 18.375)
+    ('aliceCo/bb/world', 'daily', '2022-08-01T00:00:00Z', '{}', 0, 22::bigint * 1024 * 1024 * 1024, 3600 * 18.375),
+    ('aliceCo/cc/round', 'daily', '2022-07-01T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-02T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-03T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-04T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-05T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-06T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-07T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-08T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-09T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-10T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-11T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-12T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-13T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-14T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-15T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-16T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-17T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0),
+    ('aliceCo/cc/round', 'daily', '2022-07-18T00:00:00Z', '{}', 0, 0.1 * 1024 * 1024 * 1024, 0)
   ;
 
   insert into internal.billing_adjustments (
@@ -206,8 +224,8 @@ begin
       },
       {
         "rate": 15,
-        "count": 13.125,
-        "subtotal": 197,
+        "count": 14,
+        "subtotal": 210,
         "description": "Data processing (at $0.15/GB)"
       },
       {
@@ -230,8 +248,8 @@ begin
       },
       {
         "rate": 14,
-        "count": 438.375,
-        "subtotal": 6137,
+        "count": 439,
+        "subtotal": 6146,
         "description": "Task usage (at $0.14/hour)"
       },
       {
@@ -247,10 +265,10 @@ begin
         "description": "An extra charge for some reason"
       }
     ],
-    "processed_data_gb": 43.125,
+    "processed_data_gb": 44,
     "recurring_fee": 10000,
-    "subtotal": 22044,
-    "task_usage_hours": 738.375,
+    "subtotal": 22066,
+    "task_usage_hours": 739,
     "trial_credit": 0,
     "trial_start": null
   }'::jsonb);
@@ -274,8 +292,8 @@ begin
     "line_items": [
       {
         "rate": 50,
-        "count": 21.125,
-        "subtotal": 1056,
+        "count": 22,
+        "subtotal": 1100,
         "description": "Data processing (first 30 GBs at $0.50/GB)"
       },
       {
@@ -291,9 +309,9 @@ begin
         "description": "Task usage (at $0.15/hour)"
       }
     ],
-    "processed_data_gb": 21.125,
+    "processed_data_gb": 22,
     "recurring_fee": 0,
-    "subtotal": 11856,
+    "subtotal": 11900,
     "task_usage_hours": 720,
     "trial_credit": 0,
     "trial_start": null
@@ -324,8 +342,8 @@ begin
     "billed_prefix": "aliceCo/aa/",
     "daily_usage": [
         {
-            "data_gb": 18.125,
-            "data_subtotal": 513,
+            "data_gb": 19,
+            "data_subtotal": 530,
             "task_hours": 720,
             "task_subtotal": 10800,
             "ts": "2022-08-01T00:00:00+00:00"
@@ -346,10 +364,10 @@ begin
             "subtotal": 250
         },
         {
-            "count": 16.125,
+            "count": 17,
             "description": "Data processing (at $0.20/GB)",
             "rate": 20,
-            "subtotal": 323
+            "subtotal": 340
         },
         {
             "count": 720,
@@ -364,9 +382,9 @@ begin
             "subtotal": -60
         }
     ],
-    "processed_data_gb": 21.125,
+    "processed_data_gb": 22,
     "recurring_fee": 0,
-    "subtotal": 11313,
+    "subtotal": 11330,
     "task_usage_hours": 720,
     "trial_credit": 60,
     "trial_start": "2022-08-15"
@@ -381,9 +399,9 @@ begin
       {
         "ts": "2022-08-01T00:00:00+00:00",
         "data_gb": 22,
-        "task_hours": 18.375,
+        "task_hours": 19,
         "data_subtotal": 590,
-        "task_subtotal": 276
+        "task_subtotal": 285
       }
     ],
     "line_items": [
@@ -400,10 +418,10 @@ begin
             "subtotal": 340
         },
         {
-            "count": 18.375,
+            "count": 19,
             "description": "Task usage (at $0.15/hour)",
             "rate": 15,
-            "subtotal": 276
+            "subtotal": 285
         },
         {
             "count": 1,
@@ -414,11 +432,174 @@ begin
     ],
     "processed_data_gb": 22,
     "recurring_fee": 0,
-    "subtotal": 866,
-    "task_usage_hours": 18.375,
+    "subtotal": 875,
+    "task_usage_hours": 19,
     "trial_start": "2022-08-15",
     "trial_credit": 0
   }'::jsonb);
+
+  -- aliceCo/cc has a free trial set, but has no usage in the trial period
+  -- and multiple days of fractional usage. Let's see if they round correctly
+  return query select is(billing_report_202308('aliceCo/cc/', '2022-07-20T13:00:00Z'), '{
+    "billed_month": "2022-07-01T00:00:00+00:00",
+    "billed_prefix": "aliceCo/cc/",
+    "daily_usage": [
+        {
+            "data_gb": 1,
+            "data_subtotal": 50,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-01T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-02T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-03T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-04T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-05T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-06T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-07T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-08T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-09T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-10T00:00:00+00:00"
+        },
+        {
+            "data_gb": 1,
+            "data_subtotal": 50,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-11T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-12T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-13T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-14T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-15T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-16T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-17T00:00:00+00:00"
+        },
+        {
+            "data_gb": 0,
+            "data_subtotal": 0,
+            "task_hours": 0,
+            "task_subtotal": 0,
+            "ts": "2022-07-18T00:00:00+00:00"
+        }
+    ],
+    "line_items": [
+        {
+            "count": 2,
+            "description": "Data processing (first 5 GBs at $0.50/GB)",
+            "rate": 50,
+            "subtotal": 100
+        },
+        {
+            "count": 0,
+            "description": "Data processing (at $0.20/GB)",
+            "rate": 20,
+            "subtotal": 0
+        },
+        {
+            "count": 0,
+            "description": "Task usage (at $0.15/hour)",
+            "rate": 15,
+            "subtotal": 0
+        }
+    ],
+    "processed_data_gb": 2,
+    "recurring_fee": 0,
+    "subtotal": 100,
+    "task_usage_hours": 0,
+    "trial_credit": 0,
+    "trial_start": "2022-08-15"
+  }'::jsonb);
+
+
 
 end
 $$ language plpgsql;

--- a/supabase/tests/billing.test.sql
+++ b/supabase/tests/billing.test.sql
@@ -265,10 +265,10 @@ begin
         "description": "An extra charge for some reason"
       }
     ],
-    "processed_data_gb": 44,
+    "processed_data_gb": 43.125,
     "recurring_fee": 10000,
     "subtotal": 22066,
-    "task_usage_hours": 739,
+    "task_usage_hours": 738.375,
     "trial_credit": 0,
     "trial_start": null
   }'::jsonb);
@@ -309,7 +309,7 @@ begin
         "description": "Task usage (at $0.15/hour)"
       }
     ],
-    "processed_data_gb": 22,
+    "processed_data_gb": 21.125,
     "recurring_fee": 0,
     "subtotal": 11900,
     "task_usage_hours": 720,
@@ -342,7 +342,7 @@ begin
     "billed_prefix": "aliceCo/aa/",
     "daily_usage": [
         {
-            "data_gb": 19,
+            "data_gb": 18.125,
             "data_subtotal": 530,
             "task_hours": 720,
             "task_subtotal": 10800,
@@ -382,7 +382,7 @@ begin
             "subtotal": -60
         }
     ],
-    "processed_data_gb": 22,
+    "processed_data_gb": 21.125,
     "recurring_fee": 0,
     "subtotal": 11330,
     "task_usage_hours": 720,
@@ -399,7 +399,7 @@ begin
       {
         "ts": "2022-08-01T00:00:00+00:00",
         "data_gb": 22,
-        "task_hours": 19,
+        "task_hours": 18.375,
         "data_subtotal": 590,
         "task_subtotal": 285
       }
@@ -433,7 +433,7 @@ begin
     "processed_data_gb": 22,
     "recurring_fee": 0,
     "subtotal": 875,
-    "task_usage_hours": 19,
+    "task_usage_hours": 18.375,
     "trial_start": "2022-08-15",
     "trial_credit": 0
   }'::jsonb);
@@ -441,162 +441,162 @@ begin
   -- aliceCo/cc has a free trial set, but has no usage in the trial period
   -- and multiple days of fractional usage. Let's see if they round correctly
   return query select is(billing_report_202308('aliceCo/cc/', '2022-07-20T13:00:00Z'), '{
-    "billed_month": "2022-07-01T00:00:00+00:00",
-    "billed_prefix": "aliceCo/cc/",
-    "daily_usage": [
-        {
-            "data_gb": 1,
-            "data_subtotal": 50,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-01T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-02T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-03T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-04T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-05T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-06T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-07T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-08T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-09T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-10T00:00:00+00:00"
-        },
-        {
-            "data_gb": 1,
-            "data_subtotal": 50,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-11T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-12T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-13T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-14T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-15T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-16T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-17T00:00:00+00:00"
-        },
-        {
-            "data_gb": 0,
-            "data_subtotal": 0,
-            "task_hours": 0,
-            "task_subtotal": 0,
-            "ts": "2022-07-18T00:00:00+00:00"
-        }
-    ],
-    "line_items": [
-        {
-            "count": 2,
-            "description": "Data processing (first 5 GBs at $0.50/GB)",
-            "rate": 50,
-            "subtotal": 100
-        },
-        {
-            "count": 0,
-            "description": "Data processing (at $0.20/GB)",
-            "rate": 20,
-            "subtotal": 0
-        },
-        {
-            "count": 0,
-            "description": "Task usage (at $0.15/hour)",
-            "rate": 15,
-            "subtotal": 0
-        }
-    ],
-    "processed_data_gb": 2,
-    "recurring_fee": 0,
-    "subtotal": 100,
-    "task_usage_hours": 0,
-    "trial_credit": 0,
-    "trial_start": "2022-08-15"
+   "subtotal":100,
+   "line_items":[
+      {
+         "rate":50,
+         "count":2,
+         "subtotal":100,
+         "description":"Data processing (first 5 GBs at $0.50/GB)"
+      },
+      {
+         "rate":20,
+         "count":0,
+         "subtotal":0,
+         "description":"Data processing (at $0.20/GB)"
+      },
+      {
+         "rate":15,
+         "count":0,
+         "subtotal":0,
+         "description":"Task usage (at $0.15/hour)"
+      }
+   ],
+   "daily_usage":[
+      {
+         "ts":"2022-07-01T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":50,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-02T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-03T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-04T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-05T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-06T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-07T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-08T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-09T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-10T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-11T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":50,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-12T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-13T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-14T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-15T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-16T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-17T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      },
+      {
+         "ts":"2022-07-18T00:00:00+00:00",
+         "data_gb":0.09999999962747097015,
+         "task_hours":0.00000000000000000000,
+         "data_subtotal":0,
+         "task_subtotal":0
+      }
+   ],
+   "trial_start":"2022-08-15",
+   "billed_month":"2022-07-01T00:00:00+00:00",
+   "trial_credit":0,
+   "billed_prefix":"aliceCo/cc/",
+   "recurring_fee":0,
+   "task_usage_hours":0.00000000000000000000,
+   "processed_data_gb":1.79999999329447746270
   }'::jsonb);
 
 


### PR DESCRIPTION
Rounded quantities end up adding to the correct usage ± 1 in the end:

`daily_stats`: `0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1`
`daily_line_items`: `1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2`
`daily_deltas`: `1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0`
Trial credit is computed from daily deltas
Line items come from the last `daily_line_items` of the month, which has everything rolled into it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1190)
<!-- Reviewable:end -->
