### PR TITLE
feature: Introduce `get-tenant-invoice` API request to fetch the invoice metadata for a particular tenant and month

### DIFF
--- a/supabase/functions/billing/get_tenant_invoice_data.ts
+++ b/supabase/functions/billing/get_tenant_invoice_data.ts
@@ -1,0 +1,51 @@
+import { customerQuery, StripeClient } from "./shared.ts";
+
+export interface getTenantPaymentMethodsParams {
+    tenant: string;
+    month: string;
+    type: "Usage" | "Manual";
+}
+
+const INVOICE_TYPE_KEY = "estuary.dev/invoice_type";
+const BILLING_PERIOD_START_KEY = "estuary.dev/period_start";
+
+export async function getTenantInvoiceData(
+    req_body: getTenantPaymentMethodsParams,
+    full_req: Request,
+): Promise<ConstructorParameters<typeof Response>> {
+    const customer = (await StripeClient.customers.search({ query: customerQuery(req_body.tenant) })).data[0];
+    const parsed_date = new Date(req_body.month);
+
+    const year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(parsed_date);
+    const month = new Intl.DateTimeFormat("en", { month: "2-digit" }).format(parsed_date);
+
+    // We always start on the first of the month
+    const metadata_date = `${year}-${month}-01`;
+
+    if (customer) {
+        const query =
+            `customer:"${customer.id}" AND metadata["${INVOICE_TYPE_KEY}"]:"${req_body.type}" AND metadata["${BILLING_PERIOD_START_KEY}"]:"${metadata_date}" AND -status:"draft"`;
+        const resp = await StripeClient.invoices.search({
+            query,
+        });
+
+        if (resp.data[0]) {
+            const limited_invoice = {
+                id: resp.data[0].id,
+                amount_due: resp.data[0].amount_due,
+                invoice_pdf: resp.data[0].invoice_pdf,
+                hosted_invoice_url: resp.data[0].hosted_invoice_url,
+            };
+
+            return [JSON.stringify({ invoice: limited_invoice }), {
+                headers: { "Content-Type": "application/json" },
+                status: 200,
+            }];
+        }
+    }
+
+    return [JSON.stringify({ invoice: null }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+    }];
+}

--- a/supabase/functions/billing/get_tenant_invoice_data.ts
+++ b/supabase/functions/billing/get_tenant_invoice_data.ts
@@ -9,7 +9,7 @@ export interface getTenantPaymentMethodsParams {
 const INVOICE_TYPE_KEY = "estuary.dev/invoice_type";
 const BILLING_PERIOD_START_KEY = "estuary.dev/period_start";
 
-export async function getTenantInvoiceData(
+export async function getTenantInvoice(
     req_body: getTenantPaymentMethodsParams,
     full_req: Request,
 ): Promise<ConstructorParameters<typeof Response>> {

--- a/supabase/functions/billing/get_tenant_invoice_data.ts
+++ b/supabase/functions/billing/get_tenant_invoice_data.ts
@@ -35,6 +35,7 @@ export async function getTenantInvoiceData(
                 amount_due: resp.data[0].amount_due,
                 invoice_pdf: resp.data[0].invoice_pdf,
                 hosted_invoice_url: resp.data[0].hosted_invoice_url,
+                status: resp.data[0].status,
             };
 
             return [JSON.stringify({ invoice: limited_invoice }), {

--- a/supabase/functions/billing/index.ts
+++ b/supabase/functions/billing/index.ts
@@ -5,6 +5,7 @@ import { getTenantPaymentMethods } from "./get_tenant_payment_methods.ts";
 import { deleteTenantPaymentMethod } from "./delete_tenant_payment_method.ts";
 import { setTenantPrimaryPaymentMethod } from "./set_tenant_primary_payment_method.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.0.5";
+import { getTenantInvoiceData } from "./get_tenant_invoice_data.ts";
 
 // Now that the supabase CLI supports multiple edge functions,
 // we should refactor this into individual functions instead
@@ -54,6 +55,8 @@ serve(async (req) => {
                     res = await deleteTenantPaymentMethod(request, req);
                 } else if (request.operation === "set-tenant-primary-payment-method") {
                     res = await setTenantPrimaryPaymentMethod(request, req);
+                } else if (request.operation === "get-tenant-invoice") {
+                    res = await getTenantInvoiceData(request, req);
                 } else {
                     res = [JSON.stringify({ error: "unknown_operation" }), {
                         headers: { "Content-Type": "application/json" },

--- a/supabase/functions/billing/index.ts
+++ b/supabase/functions/billing/index.ts
@@ -5,7 +5,7 @@ import { getTenantPaymentMethods } from "./get_tenant_payment_methods.ts";
 import { deleteTenantPaymentMethod } from "./delete_tenant_payment_method.ts";
 import { setTenantPrimaryPaymentMethod } from "./set_tenant_primary_payment_method.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.0.5";
-import { getTenantInvoiceData } from "./get_tenant_invoice_data.ts";
+import { getTenantInvoice } from "./get_tenant_invoice_data.ts";
 
 // Now that the supabase CLI supports multiple edge functions,
 // we should refactor this into individual functions instead
@@ -56,7 +56,7 @@ serve(async (req) => {
                 } else if (request.operation === "set-tenant-primary-payment-method") {
                     res = await setTenantPrimaryPaymentMethod(request, req);
                 } else if (request.operation === "get-tenant-invoice") {
-                    res = await getTenantInvoiceData(request, req);
+                    res = await getTenantInvoice(request, req);
                 } else {
                     res = [JSON.stringify({ error: "unknown_operation" }), {
                         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
This introduces a new operation in the billing RPC that allows you to look up invoices in Stripe for a tenant that you have access to. This is to enable downloading invoice PDFs, or linking to Stripe's hosted invoice payment page. 

We return a limited subset of the invoice data from Stripe as a security precaution:

```json
{
    "id": "in_1NrnHeL0ioq4FQU8SNVFOpiQ",
    "amount_due": 64,
    "invoice_pdf": "https://pay.stripe.com/invoice/acct_1...pdf",
    "hosted_invoice_url": "https://invoice.stripe.com/i/acct_1..."
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1192)
<!-- Reviewable:end -->
