### PR TITLE
control-plane: use btree index for log_lines

### DIFF
--- a/supabase/migrations/30_log_lines_index.sql
+++ b/supabase/migrations/30_log_lines_index.sql
@@ -1,0 +1,11 @@
+
+-- The previous BRIN index on internal.log_lines is ineffective for queries that don't 
+-- supply a where condition on the `logged_at` timestamp. Currently, that represents
+-- all queries against that table. This drops the old BRIN index in favor of a regular
+-- btree index, which is effective when queries only provide the `token`.
+
+begin;
+create index idx_logs_token on internal.log_lines (token);
+drop index internal.idx_logs_token_logged_at;
+commit;
+


### PR DESCRIPTION
**Description:**

Replaces the current BRIN index on the `internal.log_lines` table with a btree index.  The BRIN index would require queries to use the `logged_at` timestamp in the where clause in order for it to be effective.  Neither the UI or flowctl do that currently. The btree index works well when only filtering on token, so this changes to just using that.

**Notes for reviewers:**

The main issue this is seeking to address is that clients are getting HTTP 500 responses when they try to fetch log lines during a publication or discover. Another option that might also work to address this would be to add `where logged_at > (now() - '1h'::interval)` to the query in the `view_logs` RPC. I decided to use the btree index instead because it felt somewhat less hacky.

BUT, we may still want a brin index on (only) `logged_at`, so that we can use it in a `pg_cron` job to clean out old logs. I've opted to ignore this for the time being, and address that in a future PR along with the cron job to delete the logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1197)
<!-- Reviewable:end -->
