### PR TITLE
fix: Differentiate between an object that has a literal `*` field, and a pointer to an object's `additionalProperties` shape.

### DIFF
--- a/crates/doc/src/ptr.rs
+++ b/crates/doc/src/ptr.rs
@@ -215,8 +215,7 @@ impl Pointer {
                         arr.last_mut().unwrap()
                     }
                     // Cannot match (attempt to query property of an array).
-                    Token::Property(_) => return None,
-                    Token::NextProperty => return None,
+                    Token::Property(_) | Token::NextProperty => return None,
                 },
                 Value::Number(_) | Value::Bool(_) | Value::String(_) => {
                     return None; // Cannot match (attempt to take child of scalar).
@@ -275,8 +274,7 @@ impl Pointer {
                         arr.last_mut().unwrap()
                     }
                     // Cannot match (attempt to query property of an array).
-                    Token::Property(_) => return None,
-                    Token::NextProperty => return None,
+                    Token::Property(_) | Token::NextProperty => return None,
                 },
                 HeapNode::Bool(_)
                 | HeapNode::Bytes(_)
@@ -517,6 +515,7 @@ mod test {
         for case in [
             "/foo/2/a/3", // Attempt to index string scalar.
             "/foo/bar",   // Attempt to take property of array.
+            "/foo/-",     // Attempt to take property of array
         ]
         .iter()
         {

--- a/crates/doc/src/ptr.rs
+++ b/crates/doc/src/ptr.rs
@@ -54,12 +54,11 @@ impl Pointer {
     /// ```
     /// use doc::ptr::{Pointer, Token};
     ///
-    /// let pointer = Pointer::from_str("/foo/ba~1ar/3/-");
+    /// let pointer = Pointer::from_str("/foo/ba~1ar/3");
     /// let expected_tokens = vec![
     ///     Token::Property("foo".to_string()),
     ///     Token::Property("ba/ar".to_string()),
     ///     Token::Index(3),
-    ///     Token::NextIndex,
     /// ];
     /// assert_eq!(expected_tokens, pointer.0);
     /// ```
@@ -362,12 +361,11 @@ mod test {
         use Token::*;
 
         // Basic example.
-        let ptr = Pointer::from("/p1/2/p3/-");
+        let ptr = Pointer::from("/p1/2/p3");
         assert!(vec![
             Property("p1".to_string()),
             Index(2),
-            Property("p3".to_string()),
-            NextIndex
+            Property("p3".to_string())
         ]
         .iter()
         .eq(ptr.iter()));
@@ -392,13 +390,12 @@ mod test {
         );
 
         // Handles disallowed integer representations.
-        let ptr = Pointer::from("/01/+2/-3/4/-");
+        let ptr = Pointer::from("/01/+2/-3/4");
         assert!(vec![
             Property("01".to_string()),
             Property("+2".to_string()),
             Property("-3".to_string()),
-            Index(4),
-            NextIndex,
+            Index(4)
         ]
         .iter()
         .eq(ptr.iter()));
@@ -490,10 +487,9 @@ mod test {
             ("/foo/2/a", json!("hello")),
             // Add property to existing object.
             ("/foo/2/b", json!(3)),
-            ("/foo/0", json!(false)),   // Update existing Null.
-            ("/bar", json!(null)),      // Add property to doc root.
-            ("/foo/0", json!(true)),    // Update from 'false'.
-            ("/foo/-", json!("world")), // NextIndex extends Array.
+            ("/foo/0", json!(false)), // Update existing Null.
+            ("/bar", json!(null)),    // Add property to doc root.
+            ("/foo/0", json!(true)),  // Update from 'false'.
             // Index token is interpreted as property because object exists.
             ("/foo/2/4", json!(5)),
             // NextIndex token is also interpreted as property.
@@ -510,7 +506,7 @@ mod test {
         }
 
         let expect = json!({
-            "foo": [true, null, {"-": false, "a": "hello", "b": 3, "4": 5}, "world"],
+            "foo": [true, null, {"-": false, "a": "hello", "b": 3, "4": 5}],
             "bar": null,
         });
 

--- a/crates/doc/src/ptr.rs
+++ b/crates/doc/src/ptr.rs
@@ -524,6 +524,13 @@ mod test {
             assert!(ptr.create_value(&mut root_value).is_none());
             assert!(ptr.create_heap_node(&mut root_heap_doc, &alloc).is_none());
         }
+
+        let next_index_ptr = Pointer::from_iter(
+            vec![Token::Property("foo".to_string()), Token::NextProperty].into_iter(),
+        );
+
+        let res = next_index_ptr.create_value(&mut root_value);
+        assert_eq!(res, None);
     }
 
     #[test]

--- a/crates/doc/src/shape/limits.rs
+++ b/crates/doc/src/shape/limits.rs
@@ -28,7 +28,7 @@ fn squash_location_inner(shape: &mut Shape, name: &Token) {
         // Squashing of `additional*` fields is not possible here because we don't
         // have access to the parent shape
         Token::NextIndex => unreachable!(),
-        Token::Property(prop) if prop == "*" => unreachable!(),
+        Token::AdditionalProperties => unreachable!(),
 
         Token::Index(_) => {
             // Pop the last element from the array tuple shape to avoid
@@ -99,15 +99,13 @@ fn squash_location(shape: &mut Shape, location: &[Token]) {
     match location {
         [] => unreachable!(),
         [Token::NextIndex] => unreachable!(),
-        [Token::Property(prop_name)] if prop_name == "*" => unreachable!(),
+        [Token::AdditionalProperties] => unreachable!(),
 
         [first] => squash_location_inner(shape, first),
         [first, more @ ..] => {
             let inner = match first {
                 Token::NextIndex => shape.array.additional_items.as_deref_mut(),
-                Token::Property(prop_name) if prop_name == "*" => {
-                    shape.object.additional_properties.as_deref_mut()
-                }
+                Token::AdditionalProperties => shape.object.additional_properties.as_deref_mut(),
                 Token::Index(idx) => shape.array.tuple.get_mut(*idx),
                 Token::Property(prop_name) => shape
                     .object
@@ -136,7 +134,7 @@ pub fn enforce_shape_complexity_limit(shape: &mut Shape, limit: usize) {
             // but we don't want to include those locations that are leaf nodes, since
             // leaf node recursion is squashed every time we squash a concrete property.
             [.., Token::NextIndex] => None,
-            [.., Token::Property(prop_name)] if prop_name == "*" => None,
+            [.., Token::AdditionalProperties] => None,
             [] => None,
             _ => Some(ptr),
         })
@@ -450,6 +448,35 @@ mod test {
                 additionalItems: false
             "#,
             &[json!({"foo":[]})],
+            Some(0),
+        );
+    }
+
+    #[test]
+    fn test_quickcheck_regression_3() {
+        widening_snapshot_helper(
+            Some(
+                r#"
+                type: object
+                required:
+                  - ""
+                  - "*"
+                properties:
+                  "":
+                    type: "null"
+                  "*":
+                    type: string
+                    maxLength: 0
+                additionalProperties: false
+            "#,
+            ),
+            r#"
+            type: object
+            additionalProperties:
+                type: ["null", "string"]
+                maxLength: 0
+            "#,
+            &[],
             Some(0),
         );
     }

--- a/crates/doc/src/shape/limits.rs
+++ b/crates/doc/src/shape/limits.rs
@@ -28,7 +28,7 @@ fn squash_location_inner(shape: &mut Shape, name: &Token) {
         // Squashing of `additional*` fields is not possible here because we don't
         // have access to the parent shape
         Token::NextIndex => unreachable!(),
-        Token::AdditionalProperties => unreachable!(),
+        Token::NextProperty => unreachable!(),
 
         Token::Index(_) => {
             // Pop the last element from the array tuple shape to avoid
@@ -99,13 +99,13 @@ fn squash_location(shape: &mut Shape, location: &[Token]) {
     match location {
         [] => unreachable!(),
         [Token::NextIndex] => unreachable!(),
-        [Token::AdditionalProperties] => unreachable!(),
+        [Token::NextProperty] => unreachable!(),
 
         [first] => squash_location_inner(shape, first),
         [first, more @ ..] => {
             let inner = match first {
                 Token::NextIndex => shape.array.additional_items.as_deref_mut(),
-                Token::AdditionalProperties => shape.object.additional_properties.as_deref_mut(),
+                Token::NextProperty => shape.object.additional_properties.as_deref_mut(),
                 Token::Index(idx) => shape.array.tuple.get_mut(*idx),
                 Token::Property(prop_name) => shape
                     .object
@@ -134,7 +134,7 @@ pub fn enforce_shape_complexity_limit(shape: &mut Shape, limit: usize) {
             // but we don't want to include those locations that are leaf nodes, since
             // leaf node recursion is squashed every time we squash a concrete property.
             [.., Token::NextIndex] => None,
-            [.., Token::AdditionalProperties] => None,
+            [.., Token::NextProperty] => None,
             [] => None,
             _ => Some(ptr),
         })

--- a/crates/doc/src/shape/limits.rs
+++ b/crates/doc/src/shape/limits.rs
@@ -27,9 +27,7 @@ fn squash_location_inner(shape: &mut Shape, name: &Token) {
     match name {
         // Squashing of `additional*` fields is not possible here because we don't
         // have access to the parent shape
-        Token::NextIndex => unreachable!(),
-        Token::NextProperty => unreachable!(),
-
+        Token::NextIndex | Token::NextProperty => unreachable!(),
         Token::Index(_) => {
             // Pop the last element from the array tuple shape to avoid
             // shifting the indexes of any other tuple shapes

--- a/crates/doc/src/shape/location.rs
+++ b/crates/doc/src/shape/location.rs
@@ -340,7 +340,7 @@ mod test {
             (&arr1, "/3", ("addl-item", Exists::May)),
             (&arr1, "/9", ("addl-item", Exists::May)),
             (&arr1, "/10", ("addl-item", Exists::Cannot)),
-            (&arr1, "/-", ("addl-item", Exists::Cannot)),
+            (&arr1, "/-", ("<missing>", Exists::Cannot)),
             (&arr2, "/0", ("0", Exists::May)),
             (&arr2, "/1", ("1", Exists::May)),
             (&arr2, "/123", ("<missing>", Exists::Implicit)),

--- a/crates/doc/src/shape/location.rs
+++ b/crates/doc/src/shape/location.rs
@@ -118,7 +118,7 @@ impl Shape {
                 Exists::Cannot,
             ),
 
-            Token::AdditionalProperties if self.type_.overlaps(types::OBJECT) => (
+            Token::NextProperty if self.type_.overlaps(types::OBJECT) => (
                 self.object
                     .additional_properties
                     .as_ref()
@@ -143,7 +143,7 @@ impl Shape {
             Token::Index(_) => (&SENTINEL_SHAPE, Exists::Cannot),
             Token::NextIndex => (&SENTINEL_SHAPE, Exists::Cannot),
             Token::Property(_) => (&SENTINEL_SHAPE, Exists::Cannot),
-            Token::AdditionalProperties => (&SENTINEL_SHAPE, Exists::Cannot),
+            Token::NextProperty => (&SENTINEL_SHAPE, Exists::Cannot),
         }
     }
 
@@ -221,7 +221,7 @@ impl Shape {
 
         if let Some(child) = &self.object.additional_properties {
             child.locations_inner(
-                location.push_additional_properties(),
+                location.push_next_property(),
                 exists.extend(Exists::May),
                 true,
                 out,

--- a/crates/doc/src/shape/location.rs
+++ b/crates/doc/src/shape/location.rs
@@ -118,6 +118,15 @@ impl Shape {
                 Exists::Cannot,
             ),
 
+            Token::AdditionalProperties if self.type_.overlaps(types::OBJECT) => (
+                self.object
+                    .additional_properties
+                    .as_ref()
+                    .map(AsRef::as_ref)
+                    .unwrap_or(&SENTINEL_SHAPE),
+                Exists::Cannot,
+            ),
+
             Token::Property(property) if self.type_.overlaps(types::OBJECT) => {
                 self.obj_property_location(property)
             }
@@ -134,6 +143,7 @@ impl Shape {
             Token::Index(_) => (&SENTINEL_SHAPE, Exists::Cannot),
             Token::NextIndex => (&SENTINEL_SHAPE, Exists::Cannot),
             Token::Property(_) => (&SENTINEL_SHAPE, Exists::Cannot),
+            Token::AdditionalProperties => (&SENTINEL_SHAPE, Exists::Cannot),
         }
     }
 
@@ -211,7 +221,7 @@ impl Shape {
 
         if let Some(child) = &self.object.additional_properties {
             child.locations_inner(
-                location.push_prop("*"),
+                location.push_additional_properties(),
                 exists.extend(Exists::May),
                 true,
                 out,

--- a/crates/doc/src/shape/mod.rs
+++ b/crates/doc/src/shape/mod.rs
@@ -268,11 +268,10 @@ fn shape_from(schema_yaml: &str) -> Shape {
 
 #[cfg(test)]
 mod test {
-    use super::{ArrayShape, ObjShape, Shape, StringShape};
-
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn shape_size_regression() {
+        use super::{ArrayShape, ObjShape, Shape, StringShape};
         assert_eq!(std::mem::size_of::<ObjShape>(), 56);
         assert_eq!(std::mem::size_of::<StringShape>(), 48);
         assert_eq!(std::mem::size_of::<ArrayShape>(), 48);

--- a/crates/json/src/lib.rs
+++ b/crates/json/src/lib.rs
@@ -57,7 +57,7 @@ pub enum Location<'a> {
     Property(LocatedProperty<'a>),
     Item(LocatedItem<'a>),
     EndOfArray(&'a Location<'a>),
-    AdditionalProperties(&'a Location<'a>),
+    NextProperty(&'a Location<'a>),
 }
 
 impl<'a> Location<'a> {
@@ -89,8 +89,8 @@ impl<'a> Location<'a> {
     }
 
     // Returns a new Location that extends this one with a pointer to the object's additionalProperties ("*").
-    pub fn push_additional_properties(&'a self) -> Location<'a> {
-        Location::AdditionalProperties(self)
+    pub fn push_next_property(&'a self) -> Location<'a> {
+        Location::NextProperty(self)
     }
 
     /// Returns a struct that implements `std::fmt::Display` to provide a string representation of
@@ -134,7 +134,7 @@ impl<'a> Location<'a> {
             Location::EndOfArray(parent) => {
                 acc = parent.fold_inner(acc, fun);
             }
-            Location::AdditionalProperties(parent) => {
+            Location::NextProperty(parent) => {
                 acc = parent.fold_inner(acc, fun);
             }
         }
@@ -190,7 +190,7 @@ impl<'a> fmt::Display for PointerStr<'a> {
                 }
                 Location::Item(LocatedItem { index, .. }) => write!(f, "/{}", index),
                 Location::EndOfArray(_) => write!(f, "/-"),
-                Location::AdditionalProperties(_) => write!(f, "/*"),
+                Location::NextProperty(_) => write!(f, "/*"),
             })
         })
     }
@@ -219,7 +219,7 @@ impl<'a> fmt::Display for UrlEscaped<'a> {
                 }
                 Location::Item(LocatedItem { index, .. }) => write!(f, "/{}", index),
                 Location::EndOfArray(_) => write!(f, "/-"),
-                Location::AdditionalProperties(_) => write!(f, "/*"),
+                Location::NextProperty(_) => write!(f, "/*"),
             })
         })
     }

--- a/crates/json/src/lib.rs
+++ b/crates/json/src/lib.rs
@@ -57,6 +57,7 @@ pub enum Location<'a> {
     Property(LocatedProperty<'a>),
     Item(LocatedItem<'a>),
     EndOfArray(&'a Location<'a>),
+    AdditionalProperties(&'a Location<'a>),
 }
 
 impl<'a> Location<'a> {
@@ -85,6 +86,11 @@ impl<'a> Location<'a> {
     // Returns a new Location that extends this one with a non-existent, trailing array item ("-").
     pub fn push_end_of_array(&'a self) -> Location<'a> {
         Location::EndOfArray(self)
+    }
+
+    // Returns a new Location that extends this one with a pointer to the object's additionalProperties ("*").
+    pub fn push_additional_properties(&'a self) -> Location<'a> {
+        Location::AdditionalProperties(self)
     }
 
     /// Returns a struct that implements `std::fmt::Display` to provide a string representation of
@@ -126,6 +132,9 @@ impl<'a> Location<'a> {
                 acc = item.parent.fold_inner(acc, fun);
             }
             Location::EndOfArray(parent) => {
+                acc = parent.fold_inner(acc, fun);
+            }
+            Location::AdditionalProperties(parent) => {
                 acc = parent.fold_inner(acc, fun);
             }
         }
@@ -181,6 +190,7 @@ impl<'a> fmt::Display for PointerStr<'a> {
                 }
                 Location::Item(LocatedItem { index, .. }) => write!(f, "/{}", index),
                 Location::EndOfArray(_) => write!(f, "/-"),
+                Location::AdditionalProperties(_) => write!(f, "/*"),
             })
         })
     }
@@ -209,6 +219,7 @@ impl<'a> fmt::Display for UrlEscaped<'a> {
                 }
                 Location::Item(LocatedItem { index, .. }) => write!(f, "/{}", index),
                 Location::EndOfArray(_) => write!(f, "/-"),
+                Location::AdditionalProperties(_) => write!(f, "/*"),
             })
         })
     }

--- a/crates/parser/src/decorate.rs
+++ b/crates/parser/src/decorate.rs
@@ -67,6 +67,7 @@ pub fn display_ptr(ptr: &Pointer) -> String {
             Token::Property(p) => buf.push_str(p),
             Token::Index(i) => write!(&mut buf, "{}", i).unwrap(),
             Token::NextIndex => buf.push('-'),
+            Token::NextProperty => buf.push('*'),
         }
     }
     buf


### PR DESCRIPTION
This flake was caught by quickcheck (only sometimes) and was causing Flow CI to intermittently fail.

The one thing I'm not confident on is calling this variant `AdditionalProperties`, since the variant for array's `additionalItems` is called `Token::NextIndex`, not `Token::AdditionalItems`. Thoughts @jgraettinger?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1200)
<!-- Reviewable:end -->
