### PR TITLE
docs: add resource-level schema to materialize snowflake

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -87,14 +87,14 @@ Use the below properties to configure a Snowflake materialization, which will di
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/account`** | Account | The Snowflake account identifier | string | Required |
-| **`/database`** | Database | Name of the Snowflake database to which to materialize | string | Required |
 | **`/host`** | Host URL | The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol). | string | Required |
-| **`/password`** | Password | Snowflake user password | string | Required |
-| `/role` | Role | Role assigned to the user | string |  |
-| **`/schema`** | Schema | Snowflake schema within the database to which to materialize | string | Required |
+| **`/account`** | Account | The Snowflake account identifier | string | Required |
 | **`/user`** | User | Snowflake username | string | Required |
+| **`/password`** | Password | Snowflake user password | string | Required |
+| **`/database`** | Database | Name of the Snowflake database to which to materialize | string | Required |
+| **`/schema`** | Schema | Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables | string | Required |
 | `/warehouse` | Warehouse | Name of the data warehouse that contains the database | string |  |
+| `/role` | Role | Role assigned to the user | string |  |
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/updateDelay`     | Update Delay    | Potentially reduce active warehouse time by increasing the delay between updates. | string  |  |
 
@@ -102,8 +102,9 @@ Use the below properties to configure a Snowflake materialization, which will di
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean |  |
 | **`/table`** | Table | Table name | string | Required |
+| `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean |  |
+| `/schema` | Alternative Schema | Alternative schema for this table (optional). Overrides schema set in endpoint configuration | string |  |
 
 ### Sample
 


### PR DESCRIPTION

**Description:**

Adds the resource-level schema configuration to `materialize-snowflake` docs. Also re-orders the properties to be in the same order as the connector spec. See https://github.com/estuary/connectors/pull/980

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1208)
<!-- Reviewable:end -->
