### PR TITLE
doc::combine: multiple bindings, support iteration, and move up validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,6 @@ dependencies = [
  "base64 0.13.1",
  "bumpalo",
  "bytes",
- "criterion",
  "fancy-regex",
  "futures",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bitvec = "0.19"
 bytecount = { version = "0.6.3", features = ["runtime-dispatch-simd"] }
 bytes = "1.2"
 bytesize = "1.1.0"
-bumpalo = { version = "3.11", features = ["collections"] }
+bumpalo = { version = "3.14", features = ["collections"] }
 bytelines = "2.4"
 byteorder = "1.4"
 caseless = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ rust-musl-test:
 .PHONY: go-test-fast
 go-test-fast: $(GO_BUILD_DEPS) | ${PKGDIR}/bin/deno ${PKGDIR}/bin/etcd ${PKGDIR}/bin/sops
 	PATH=${PKGDIR}/bin:$$PATH ;\
-	./go.sh test -p ${NPROC} --tags "${GO_BUILD_TAGS}" ./go/...
+	./go.sh test -p ${NPROC} --tags "${GO_BUILD_TAGS}" --count=1 ./go/...
 
 .PHONY: go-test-ci
 go-test-ci:

--- a/crates/derive/src/combine_api.rs
+++ b/crates/derive/src/combine_api.rs
@@ -288,24 +288,28 @@ pub fn drain_chunk(
     // Convert target from a delta to an absolute target length of the arena.
     let target_length = target_length + arena.len();
 
-    drainer.drain_while(|_binding, doc, fully_reduced| {
+    while let Some(drained) = drainer.next() {
+        let doc::combine::DrainedDoc {
+            binding: _, // Always zero.
+            reduced,
+            root,
+        } = drained?;
+
         if let Some(ref mut shape) = shape {
-            let changed = match &doc {
-                doc::LazyNode::Node(n) => shape.widen(*n),
-                doc::LazyNode::Heap(h) => shape.widen(h),
-            };
-            if changed {
+            if shape.widen_owned(&root) {
                 enforce_shape_complexity_limit(shape, DEFAULT_SCHEMA_COMPLEXITY_LIMIT);
                 *did_change = true;
             }
         }
+
         // Send serialized document.
         let begin = arena.len();
         let w: &mut Vec<u8> = &mut *arena;
-        serde_json::to_writer(w, &doc).expect("encoding cannot fail");
-        // Only here do we know the actual length of the document in its serialized form.
+        serde_json::to_writer(w, &root).expect("encoding cannot fail");
+
+        // Only now do we know the actual length of the document in its serialized form.
         stats.increment(arena.len() - begin);
-        if fully_reduced {
+        if reduced {
             cgo::send_bytes(Code::DrainedReducedDocument as u32, begin, arena, out);
         } else {
             cgo::send_bytes(Code::DrainedCombinedDocument as u32, begin, arena, out);
@@ -314,24 +318,26 @@ pub fn drain_chunk(
         // Send packed key followed by packed additional fields.
         for (code, extractors) in [(Code::DrainedKey, key_ex), (Code::DrainedFields, fields_ex)] {
             let begin = arena.len();
-            match &doc {
-                doc::LazyNode::Heap(n) => {
+            match &root {
+                doc::OwnedNode::Heap(n) => {
                     for ex in extractors {
-                        ex.extract(n, arena).unwrap();
+                        ex.extract(n.get(), arena).unwrap();
                     }
                 }
-                doc::LazyNode::Node(n) => {
+                doc::OwnedNode::Archived(n) => {
                     for ex in extractors {
-                        ex.extract(*n, arena).unwrap();
+                        ex.extract(n.get(), arena).unwrap();
                     }
                 }
             }
             cgo::send_bytes(code as u32, begin, arena, out);
         }
 
-        // Keep going if we have remaining arena length.
-        Ok::<_, doc::combine::Error>(arena.len() < target_length)
-    })
+        if arena.len() > target_length {
+            return Ok(true); // There's more but yield now.
+        }
+    }
+    return Ok(false); // All done.
 }
 
 #[cfg(test)]

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -34,7 +34,6 @@ uuid = { workspace = true }
 [dev-dependencies]
 allocator = { path = "../allocator" }
 
-criterion = { workspace = true }
 hexdump = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/doc/src/combine/memtable.rs
+++ b/crates/doc/src/combine/memtable.rs
@@ -270,9 +270,6 @@ impl MemTable {
             %mem_used,
             %reduce_bytes,
             %combine_bytes,
-            // TODO(johnny): remove when `mem_used` calculation is accurate.
-            mem_alloc=%alloc.allocated_bytes(),
-            mem_cap=%alloc.chunk_capacity(),
             "spilled MemTable to disk segment",
         );
         std::mem::drop(alloc); // Now safe to drop.

--- a/crates/doc/src/combine/mod.rs
+++ b/crates/doc/src/combine/mod.rs
@@ -92,9 +92,6 @@ impl Accumulator {
             unreachable!("memtable is always Some");
         };
 
-        // TODO(johnny): This is somewhat broken because chunk_capacity() is broken.
-        // Currently this means the mem_used value is very quantized and doubles ~quadratically.
-        // See: https://github.com/fitzgen/bumpalo/issues/185
         let mem_used = memtable.alloc().allocated_bytes() - memtable.alloc().chunk_capacity();
         if mem_used > SPILL_THRESHOLD {
             let spec = self
@@ -274,7 +271,7 @@ fn smash<'alloc>(
 //
 // There may be hypothetical use cases that benefit from more in-memory reduction.
 // At the moment, I suspect this would still be pretty marginal.
-const SPILL_THRESHOLD: usize = 8 * (1 << 28) / 10; // 80% of 256MB.
+const SPILL_THRESHOLD: usize = 1 << 28; // 256MB.
 
 // The chunk target determines the amortization of archiving and
 // compressing documents. We want chunks to be:

--- a/crates/doc/src/combine/spill.rs
+++ b/crates/doc/src/combine/spill.rs
@@ -1,11 +1,13 @@
-use super::{Error, Spec, FLAG_REDUCED};
-use crate::{ArchivedDoc, ArchivedNode, Extractor, HeapDoc, HeapNode, LazyNode};
+use super::{bump_mem_used, DrainedDoc, Error, HeapEntry, Spec, BUMP_THRESHOLD};
+use crate::owned::OwnedArchivedNode;
+use crate::{Extractor, LazyNode, OwnedHeapNode, OwnedNode};
+use bumpalo::Bump;
+use bytes::Buf;
 use rkyv::ser::Serializer;
-use std::cmp;
 use std::collections::BinaryHeap;
-use std::io;
 use std::ops::Range;
 use std::sync::Arc;
+use std::{cmp, io};
 
 /// SpillWriter writes segments of sorted documents to a spill file,
 /// and tracks each of the written segment range offsets within the file.
@@ -34,66 +36,67 @@ impl<F: io::Read + io::Write + io::Seek> SpillWriter<F> {
     /// of the given size, and are then written in-order to the spill file.
     /// Each chunks is compressed using LZ4.
     /// The written size of the segment is returned.
-    pub fn write_segment<'alloc>(
+    pub fn write_segment(
         &mut self,
-        mut segment: &[HeapDoc<'alloc>],
+        entries: &[HeapEntry<'_>],
         chunk_target_size: Range<usize>,
     ) -> Result<u64, io::Error> {
-        if segment.is_empty() {
+        if entries.is_empty() {
             return Ok(0);
         }
-        // Estimate an initial bytes per document from the first document. This
-        // can change as we process the segment - consider a grouping key over
-        // a user's union type that bakes in a "kind of document" component.
-        let mut last_bytes_per_doc = segment[0].root.to_archive().len();
 
         let begin = self.spill.seek(io::SeekFrom::Current(0))?;
-        let mut ser = rkyv::ser::serializers::AllocSerializer::<8192>::default();
-        let mut lz4_buf = Vec::new();
 
-        while !segment.is_empty() {
-            // Project `last_bytes_per_doc` into a number of documents for this chunk,
-            // in order to achieve an archived size equal to `chunk_target_size.begin`.
-            // It can't be larger than the remaining documents, and can't be smaller than one.
-            let chunk_docs = cmp::min(
-                cmp::max(1, chunk_target_size.start / last_bytes_per_doc),
-                segment.len(),
+        let mut last_chunk_index = 0;
+        let mut lz4_buf = Vec::new();
+        let mut raw_buf = rkyv::AlignedVec::with_capacity(11 * chunk_target_size.start / 10);
+        let mut rkyv_scratch = Default::default();
+
+        for (
+            index,
+            HeapEntry {
+                binding,
+                reduced,
+                root,
+            },
+        ) in entries.iter().enumerate()
+        {
+            let offset = raw_buf.len();
+
+            // Pack `reduced` into binding by setting its high bit.
+            let binding = binding | if *reduced { 1 << 31 } else { 0 };
+            // Write binding header.
+            raw_buf.extend_from_slice(&u32::to_le_bytes(binding));
+            // Reserve space for document size header.
+            raw_buf.extend_from_slice(&[0; 4]);
+
+            // Re-constitute an rkyv serializer around `raw_buf`.
+            let mut wrapped_buf = rkyv::ser::serializers::AlignedSerializer::new(raw_buf);
+            let mut rkyver = rkyv::ser::serializers::AllocSerializer::<8192>::new(
+                wrapped_buf,
+                rkyv_scratch,
+                Default::default(), // We don't use shared smart pointers, so this is always empty.
             );
 
-            // Archive chunk into uncompressed "raw" buffer.
-            ser.serialize_unsized_value(&segment[..chunk_docs])
-                .expect("serialize of HeapDoc to memory always succeeds");
-            let (raw_buf, scratch, _shared) = ser.into_components();
-            let mut raw_buf = raw_buf.into_inner();
+            _ = rkyver
+                .serialize_value(root)
+                .expect("serialize of HeapNode to memory always succeeds");
 
-            let cur_bytes_per_doc = raw_buf.len() / chunk_docs;
+            // Disassemble `rkyver` to recover `raw_buf`.
+            (wrapped_buf, rkyv_scratch, _) = rkyver.into_components();
+            raw_buf = wrapped_buf.into_inner();
 
-            // If `raw_buf` is outside of our upper `chunk_target_size` range
-            // and it's possible to make it smaller, then do so. This check lets
-            // us bound how much a reader must keep in memory when later
-            // processing a current chunk across all segments.
-            if chunk_docs > 1 && raw_buf.len() > chunk_target_size.end {
-                tracing::debug!(
-                    chunk_docs,
-                    %cur_bytes_per_doc,
-                    %last_bytes_per_doc,
-                    raw_buf_len = %raw_buf.len(),
-                    "archived buffer is too large (trying again)",
-                );
+            // Update header with the final document length, excluding header.
+            let doc_len = raw_buf.len() - offset - 8;
+            raw_buf[offset + 4..offset + 8].copy_from_slice(&u32::to_le_bytes(doc_len as u32));
 
-                // We allocated an over-large `raw_buf`: don't re-use it.
-                // This should be rare.
-                ser = Default::default();
-
-                // By construction, `cur_bytes_per_doc` must be larger that before.
-                // Otherwise we wouldn't be here. Update and try again.
-                assert!(cur_bytes_per_doc > last_bytes_per_doc);
-                last_bytes_per_doc = cur_bytes_per_doc;
+            // If this isn't the last element and our chunk is under threshold then continue accruing documents.
+            if index != entries.len() - 1 && raw_buf.len() < chunk_target_size.start {
                 continue;
             }
+            // We have a complete chunk. Next we compress and write it to the spill file.
 
-            // Prepare a buffer to hold the compressed result, reserving the leading eight bytes for the chunk header.
-            lz4_buf.clear();
+            // Prepare `lz4_buf` to hold the compressed result, reserving leading bytes for a chunk header.
             lz4_buf.reserve(8 + lz4::block::compress_bound(raw_buf.len())?);
             unsafe { lz4_buf.set_len(lz4_buf.capacity()) };
 
@@ -116,24 +119,17 @@ impl<F: io::Read + io::Write + io::Seek> SpillWriter<F> {
             self.spill.write_all(&lz4_buf)?;
 
             tracing::trace!(
-                chunk_docs,
-                bytes_per_doc = %cur_bytes_per_doc,
+                chunk_docs = %(index - last_chunk_index),
+                bytes_per_doc = (raw_buf.len() / (index - last_chunk_index)),
                 raw_len = %raw_buf.len(),
                 lz4_len = %lz4_buf.len(),
-                remaining = %(segment.len() - chunk_docs),
+                remaining = %(entries.len() - index),
                 "wrote chunk",
             );
 
-            // Re-compose the `rkyv` serializer, preserving allocated capacity of `raw_buf`.
+            last_chunk_index = index;
+            lz4_buf.clear();
             raw_buf.clear();
-            ser = rkyv::ser::serializers::CompositeSerializer::new(
-                rkyv::ser::serializers::AlignedSerializer::new(raw_buf),
-                scratch,
-                Default::default(),
-            );
-
-            last_bytes_per_doc = cur_bytes_per_doc;
-            segment = &segment[chunk_docs..];
         }
 
         let end = self.spill.seek(io::SeekFrom::Current(0))?;
@@ -153,22 +149,73 @@ impl<F: io::Read + io::Write + io::Seek> SpillWriter<F> {
     }
 }
 
+// Entry is a parsed document entry of a spill file.
+struct Entry {
+    binding: u32,
+    reduced: bool,
+    root: OwnedArchivedNode,
+}
+
+impl Entry {
+    // Parse the next Entry from a SpillWriter chunk.
+    fn parse(mut chunk: bytes::Bytes) -> Result<(Self, bytes::Bytes), io::Error> {
+        if chunk.len() < 8 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "corrupt segment: chunk length is smaller than header: {}",
+                    chunk.len()
+                ),
+            ));
+        }
+
+        // Parse entry header.
+        let reduced_binding = u32::from_le_bytes(chunk[0..4].try_into().unwrap());
+        let doc_len = u32::from_le_bytes(chunk[4..8].try_into().unwrap()) as usize;
+        chunk.advance(8); // Consume header.
+
+        // Decompose `reduced_binding` into its parts.
+        let reduced = reduced_binding & 1 << 31 != 0;
+        let binding = reduced_binding & ((1 << 31) - 1);
+
+        if chunk.len() < doc_len {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "corrupt segment: chunk is smaller than document length: {} vs {doc_len}",
+                    chunk.len(),
+                ),
+            ));
+        }
+
+        let rest = chunk.split_off(doc_len);
+        let root = unsafe { OwnedArchivedNode::new(chunk) };
+
+        Ok((
+            Self {
+                binding,
+                reduced,
+                root,
+            },
+            rest,
+        ))
+    }
+}
+
 /// Segment is a segment region of a spill file which is being incrementally read.
-/// As documents are written to the spill file in sorted order within a segment,
-/// this iterator-like object will also yield documents in ascending key order.
-pub struct Segment {
-    docs: &'static [ArchivedDoc],
-    keys: Arc<Box<[Box<[Extractor]>]>>,
-    next: Range<u64>,
-    zz_backing: rkyv::AlignedVec,
+/// Entries are written to the spill file in sorted order within a segment,
+/// so this iterator-like object will yield entries in ascending order.
+struct Segment {
+    head: Entry,                   // Next Entry of Segment.
+    keys: Arc<[Box<[Extractor]>]>, // Keys for comparing Entries across Segments.
+    next: Range<u64>,              // Next chunk of this Segment.
+    tail: bytes::Bytes,            // Remainder of the current chunk.
 }
 
 impl Segment {
     /// Build a new Segment covering the given range of the spill file.
-    /// The given AlignedVec buffer, which may have pre-allocated capacity,
-    /// is used to back the archived documents read from the spill file.
-    pub fn new<R: io::Read + io::Seek>(
-        keys: Arc<Box<[Box<[Extractor]>]>>,
+    fn new<R: io::Read + io::Seek>(
+        keys: Arc<[Box<[Extractor]>]>,
         r: &mut R,
         range: Range<u64>,
     ) -> Result<Self, io::Error> {
@@ -184,10 +231,12 @@ impl Segment {
 
         // Compute implied next chunk range and ensure it remains valid.
         let next = range.start + 8 + lz4_len..range.end;
-        assert!(
-            next.start <= next.end,
-            "read header len {lz4_len} which is outside of region {next:?}"
-        );
+        if next.start > next.end {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("read header len {lz4_len} which is outside of region {next:?}"),
+            ));
+        }
 
         // Allocate and read compressed chunk into `lz4_buf`.
         // Safety: we're immediately reading into allocated memory, overwriting its uninitialized content.
@@ -195,78 +244,76 @@ impl Segment {
         unsafe { lz4_buf.set_len(lz4_len as usize) }
         r.read_exact(&mut lz4_buf)?;
 
-        // Allocate and decompress into `backing`.
+        // Allocate and decompress into `raw_buf`.
         // Safety: we're immediately decompressing into allocated memory, overwriting its uninitialized content.
-        let mut backing = rkyv::AlignedVec::with_capacity(raw_len as usize);
-        unsafe { backing.set_len(raw_len as usize) }
+        let mut raw_buf = rkyv::AlignedVec::with_capacity(raw_len as usize);
+        unsafe { raw_buf.set_len(raw_len as usize) }
 
-        assert_eq!(
-            lz4::block::decompress_to_buffer(&lz4_buf, Some(raw_len as i32), &mut backing)?,
-            backing.len(),
-            "bytes actually decompressed don't match the length encoded in the chunk header"
-        );
+        let decompressed_bytes =
+            lz4::block::decompress_to_buffer(&lz4_buf, Some(raw_len as i32), &mut raw_buf)?;
 
-        // Cast `backing` into its archived type.
-        let docs = unsafe { rkyv::archived_unsized_root::<[HeapDoc]>(&backing) };
+        if decompressed_bytes != raw_buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("corrupt segment: decompressed chunk bytes don't match the length encoded in the chunk header: {decompressed_bytes} vs {}", raw_buf.len()),
+            ));
+        }
 
-        // Transmute from the implied Self lifetime of backing to &'static lifetime.
-        // Safety: Segment is a guard which maintains the lifetime of `backing`
-        // alongside its borrowed `docs` reference.
-        let docs: &[ArchivedDoc] = unsafe { std::mem::transmute(docs) };
-        assert_ne!(docs.len(), 0);
+        let chunk: bytes::Bytes = raw_buf.into_vec().into();
+        let (head, tail) = Entry::parse(chunk)?;
 
         Ok(Self {
-            zz_backing: backing,
-            docs,
+            head,
             keys,
             next,
+            tail,
         })
     }
 
-    /// Head is the next ordered document of the Segment.
-    /// Despite the static lifetime, the head() document cannot be referenced
-    /// after a subsequent call to next().
-    pub fn head(&self) -> &'static ArchivedDoc {
-        &self.docs[0]
-    }
-
-    /// Next is called after the current head() has been fully processed.
-    /// It is unsafe to access a previous head() after calling next().
-    /// If no more documents remain in the Segment then Ok(None) is returned.
-    pub fn next<R: io::Read + io::Seek>(self, r: &mut R) -> Result<Option<Self>, io::Error> {
+    // Pop the head Entry of the Segment, returning ownership to the caller,
+    // as well as a Segment Option if any further Entries remain.
+    fn pop_head<R: io::Read + io::Seek>(
+        self,
+        r: &mut R,
+    ) -> Result<(Entry, Option<Self>), io::Error> {
         let Segment {
-            docs,
+            head: popped,
             keys,
             next,
-            zz_backing,
+            tail,
         } = self;
 
-        if docs.len() != 1 {
-            Ok(Some(Segment {
-                docs: &docs[1..],
-                keys,
-                next,
-                zz_backing,
-            }))
+        if !tail.is_empty() {
+            let (head, tail) = Entry::parse(tail)?;
+
+            Ok((
+                popped,
+                Some(Self {
+                    head,
+                    keys,
+                    next,
+                    tail,
+                }),
+            ))
         } else if !next.is_empty() {
-            Ok(Some(Self::new(keys, r, next)?))
+            Ok((popped, Some(Self::new(keys, r, next)?)))
         } else {
-            Ok(None)
+            Ok((popped, None))
         }
     }
 }
 
 impl Ord for Segment {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let (lhs, rhs) = (self.head(), other.head());
+        let (lhs, rhs) = (&self.head, &other.head);
 
         lhs.binding
             .cmp(&rhs.binding)
             .then_with(|| {
                 Extractor::compare_key(
-                    &self.keys[lhs.binding.value() as usize],
-                    &lhs.root,
-                    &rhs.root,
+                    &self.keys[lhs.binding as usize],
+                    lhs.root.get(),
+                    rhs.root.get(),
                 )
             })
             .then_with(||
@@ -288,14 +335,122 @@ impl PartialEq for Segment {
 impl Eq for Segment {}
 
 /// SpillDrainer drains documents across all segments of a spill file,
-/// yielding one document per key in ascending order.
-pub struct SpillDrainer<F: io::Read + io::Write + io::Seek> {
+/// yielding drained entries (one per binding & key) in ascending order.
+pub struct SpillDrainer<F: io::Read + io::Seek> {
     heap: BinaryHeap<cmp::Reverse<Segment>>,
     spec: Spec,
     spill: F,
+    // Allocator for reductions, which is not referenced by other internal state of SpillDrainer.
+    alloc: Arc<Bump>,
 }
 
-impl<F: io::Read + io::Write + io::Seek> SpillDrainer<F> {
+// Safety: SpillDrainer is safe to Send because its iterators never have lent references,
+// and we're sending them and their backing Bump allocator together.
+unsafe impl<F: io::Read + io::Seek> Send for SpillDrainer<F> {}
+
+impl<F: io::Read + io::Seek> Iterator for SpillDrainer<F> {
+    type Item = Result<DrainedDoc, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut inner = || {
+            let Some(cmp::Reverse(cur_segment)) = self.heap.pop() else { return Ok(None) };
+
+            let (
+                Entry {
+                    binding,
+                    mut reduced,
+                    root: owned_root,
+                },
+                cur_segment,
+            ) = cur_segment.pop_head(&mut self.spill)?;
+
+            let key = &self.spec.keys[binding as usize];
+            let (validator, ref schema) = &mut self.spec.validators[binding as usize];
+
+            // LazyNode root which is updated as reductions occur.
+            let mut root = LazyNode::Node(owned_root.get());
+
+            // Poll the heap to find additional documents in other segments which share root's key.
+            // Note that there can be at-most one instance of a key within a single segment,
+            // so we don't need to re-heap `cur_segment` just yet.
+            while matches!(self.heap.peek(), Some(cmp::Reverse(peek))
+                if binding == peek.head.binding
+                    && Extractor::compare_key_lazy(
+                        key,
+                        &root,
+                        &LazyNode::Node(peek.head.root.get())
+                    ).is_eq())
+            {
+                let other_segment = self.heap.pop().unwrap().0;
+
+                let (
+                    Entry {
+                        binding: _,
+                        reduced: rhs_reduced,
+                        root: rhs_root,
+                    },
+                    other_segment,
+                ) = other_segment.pop_head(&mut self.spill)?;
+
+                let smashed = super::smash(
+                    &self.alloc,
+                    root,
+                    reduced,
+                    LazyNode::Node(rhs_root.get()),
+                    rhs_reduced,
+                    schema.as_ref(),
+                    validator,
+                )?;
+                (root, reduced) = (LazyNode::Heap(smashed.0), smashed.1);
+
+                // Re-heap `other_segment`.
+                if let Some(other) = other_segment {
+                    self.heap.push(cmp::Reverse(other));
+                }
+            }
+
+            // Re-heap `cur_segment`.
+            if let Some(segment) = cur_segment {
+                self.heap.push(cmp::Reverse(segment));
+            }
+
+            // Map `root` into an owned variant.
+            let root = match root {
+                LazyNode::Node(_) => {
+                    // Already validated (no reduction occurred).
+                    OwnedNode::Archived(owned_root)
+                }
+                LazyNode::Heap(root) => {
+                    // We built `doc` via reduction and must re-validate it.
+                    validator
+                        .validate(schema.as_ref(), &root)
+                        .map_err(Error::SchemaError)?
+                        .ok()
+                        .map_err(Error::FailedValidation)?;
+
+                    // Safety: we allocated `root` out of `self.alloc`.
+                    let root = unsafe { OwnedHeapNode::new(root, self.alloc.clone()) };
+
+                    // Safety: we must hold `alloc` constant for all reductions of a yielded entry.
+                    if bump_mem_used(&self.alloc) > BUMP_THRESHOLD {
+                        self.alloc = Arc::new(Bump::new());
+                    }
+
+                    OwnedNode::Heap(root)
+                }
+            };
+
+            Ok(Some(DrainedDoc {
+                binding,
+                reduced,
+                root,
+            }))
+        };
+        inner().transpose()
+    }
+}
+
+impl<F: io::Read + io::Seek> SpillDrainer<F> {
     /// Build a new SpillDrainer which drains the given segment ranges previously
     /// written to the spill file.
     pub fn new(spec: Spec, mut spill: F, ranges: &[Range<u64>]) -> Result<Self, std::io::Error> {
@@ -306,124 +461,43 @@ impl<F: io::Read + io::Write + io::Seek> SpillDrainer<F> {
             heap.push(cmp::Reverse(segment));
         }
 
-        Ok(Self { heap, spec, spill })
+        Ok(Self {
+            alloc: Arc::new(Bump::new()),
+            heap,
+            spec,
+            spill,
+        })
     }
 
     pub fn into_parts(self) -> (Spec, F) {
         let Self {
+            alloc: _,
             heap: _,
             spec,
             spill,
         } = self;
         (spec, spill)
     }
-
-    /// Drain documents from this SpillDrainer by invoking the given callback.
-    /// Documents passed to the callback MUST NOT be accessed after it returns.
-    /// The callback returns true if it would like to be called further, or false
-    /// if a present call to drain_while() should return, yielding back to the caller.
-    ///
-    /// A future call to drain_while() can then resume the drain operation at
-    /// its next ordered document. drain_while() returns true while documents
-    /// remain to drain, and false only after all documents have been drained.
-    pub fn drain_while<C, CE>(&mut self, mut callback: C) -> Result<bool, CE>
-    where
-        C: for<'alloc> FnMut(
-            u32,
-            LazyNode<'alloc, 'static, ArchivedNode>,
-            bool,
-        ) -> Result<bool, CE>,
-        CE: From<Error>,
-    {
-        while let Some(cmp::Reverse(cur)) = self.heap.pop() {
-            let alloc = HeapNode::new_allocator();
-
-            let binding = cur.head().binding.value();
-            let (validator, ref schema) = &mut self.spec.validators[binding as usize];
-
-            let mut flags = cur.head().flags;
-            let mut doc = LazyNode::Node(&cur.head().root);
-
-            // All documents are validated when spilled to disk.
-            // We must only validate again if a reduction occurs.
-            let mut must_validate = false;
-
-            // Poll the heap to find additional documents in other segments which share doc's key.
-            // Note that there can be at-most one instance of a key within a single segment,
-            // so we don't need to also check Segment `cur`.
-            while matches!(self.heap.peek(), Some(cmp::Reverse(peek))
-                if binding == peek.head().binding.value()
-                    && Extractor::compare_key_lazy(
-                        &self.spec.keys[binding as usize],
-                        &doc,
-                        &LazyNode::Node(&peek.head().root)
-                    ).is_eq())
-            {
-                let other = self.heap.pop().unwrap().0;
-
-                let ArchivedDoc {
-                    binding: _,
-                    flags: rhs_flags,
-                    root: rhs_doc,
-                } = other.head();
-
-                let out = super::smash(
-                    &alloc,
-                    binding,
-                    doc,
-                    flags,
-                    LazyNode::Node(rhs_doc),
-                    *rhs_flags,
-                    schema.as_ref(),
-                    validator,
-                )?;
-                (doc, flags) = (LazyNode::Heap(out.root), out.flags);
-
-                if let Some(other) = other.next(&mut self.spill).map_err(Error::SpillIO)? {
-                    self.heap.push(cmp::Reverse(other));
-                }
-                must_validate = true;
-            }
-
-            if must_validate {
-                doc.validate_ok(validator, schema.as_ref())
-                    .map_err(Error::SchemaError)?
-                    .map_err(Error::FailedValidation)?;
-            }
-
-            let done = !callback(binding, doc, flags & FLAG_REDUCED != 0)?;
-
-            if let Some(segment) = cur.next(&mut self.spill).map_err(Error::SpillIO)? {
-                self.heap.push(cmp::Reverse(segment));
-            }
-
-            if done {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{combine::CHUNK_MAX_LEN, validation::build_schema, AsNode, Validator};
+    use crate::{combine::CHUNK_MAX_LEN, validation::build_schema, HeapNode, Validator};
+    use itertools::Itertools;
     use serde_json::{json, Value};
 
     #[test]
     fn test_spill_writes_to_segments() {
-        let alloc = HeapNode::new_allocator();
-        let segment = segment_fixture(
-            &[
-                (0, json!({"key": "aaa", "v": "apple"}), 0),
-                (1, json!({"key": "bbb", "v": "banana"}), FLAG_REDUCED),
-                (2, json!({"key": "ccc", "v": "carrot"}), FLAG_REDUCED),
-            ],
-            &alloc,
-        );
-        let keys: Arc<Box<[Box<[Extractor]>]>> =
-            Arc::new(vec![vec![Extractor::new("/key")].into()].into());
+        let fixture = &[
+            (0, json!({"key": "aaa", "v": "apple"}), false),
+            (1, json!({"key": "bbb", "v": "banana"}), true),
+            (2, json!({"key": "ccc", "v": "carrot"}), true),
+        ];
+        let alloc = Bump::new();
+        let segment = segment_fixture(fixture, &alloc);
+        // We're not using a SpillDrainer and are not comparing keys.
+        let keys: Arc<[Box<[Extractor]>]> = Vec::new().into();
 
         // Write segment fixture into a SpillWriter.
         let mut spill = SpillWriter::new(io::Cursor::new(Vec::new())).unwrap();
@@ -433,84 +507,56 @@ mod test {
         let (mut spill, ranges) = spill.into_parts();
 
         // Assert we wrote the expected range and regression fixture.
-        assert_eq!(ranges, vec![0..191]);
+        assert_eq!(ranges, vec![0..186]);
 
         insta::assert_snapshot!(to_hex(&spill.get_ref()), @r###"
-        |67000000 98000000 f1006b65 79000000| g.........key... 00000000
-        |00030800 00006161 610c0000 05001076| ......aaa......v 00000010
-        |05003100 00011800 7070706c 65000005| ..1.....ppple... 00000020
-        |11000830 00306262 62130010 03050008| ...0.0bbb....... 00000030
-        |30008062 616e616e 61000618 00000500| 0..banana....... 00000040
-        |509cffff ff020d00 07020000 180017b4| P............... 00000050
-        |18001301 040080d0 ffffff02 00000048| ...............H 00000060
-        |00000050 000000f1 006b6579 00000000| ...P.....key.... 00000070
-        |03080000 00636363 0c000005 00107605| .....ccc......v. 00000080
-        |00310000 01180070 6172726f 74000611| .1.....parrot... 00000090
-        |00000500 50ccffff ff020d00 30000000| ....P.......0... 000000a0
-        |0800c001 000000e8 ffffff01 000000|   ...............  000000b0
-                                                               000000bf
+        |68000000 90000000 b0000000 00400000| h............@.. 00000000
+        |006b6579 0b008103 08000000 6161610c| .key........aaa. 00000010
+        |00000500 10760500 31000001 18007070| .....v..1.....pp 00000020
+        |706c6500 00051100 90060000 00ccffff| ple............. 00000030
+        |ff020d00 7c000000 01000080 48003062| ....|.......H.0b 00000040
+        |62621c00 10030500 08480061 62616e61| bb.......H.abana 00000050
+        |6e614300 01050003 48005000 00000000| naC.....H.P..... 00000060
+        |42000000 48000000 f1080200 00804000| B...H.........@. 00000070
+        |00006b65 79000000 00030800 00006363| ..key.........cc 00000080
+        |630c0000 05001076 05003100 00011800| c......v..1..... 00000090
+        |70617272 6f740006 11000005 00c0ccff| parrot.......... 000000a0
+        |ffff0200 00000000 0000|              ..........       000000b0
+                                                               000000ba
         "###);
 
         // Parse the region as a Segment.
-        let mut actual = Vec::new();
         let mut segment = Segment::new(keys, &mut spill, ranges[0].clone()).unwrap();
 
         // First chunk has two documents.
-        assert_eq!(segment.docs.len(), 2);
-        assert_eq!(segment.zz_backing.len(), 152);
-        assert_eq!(segment.next, 111..191);
+        assert_eq!(segment.head.binding, 0);
+        assert_eq!(segment.head.reduced, false);
+        assert!(crate::compare(segment.head.root.get(), &fixture[0].1).is_eq());
+        assert!(!segment.tail.is_empty());
+        assert_eq!(segment.next, 112..186);
 
-        actual.push((
-            segment.head().binding.value(),
-            serde_json::to_value(&segment.head().root.as_node()).unwrap(),
-        ));
+        let (_, next_segment) = segment.pop_head(&mut spill).unwrap();
+        segment = next_segment.unwrap();
 
-        segment = segment.next(&mut spill).unwrap().unwrap();
-        actual.push((
-            segment.head().binding.value(),
-            serde_json::to_value(&segment.head().root.as_node()).unwrap(),
-        ));
+        assert_eq!(segment.head.binding, 1);
+        assert_eq!(segment.head.reduced, true);
+        assert!(crate::compare(segment.head.root.get(), &fixture[1].1).is_eq());
+        assert!(segment.tail.is_empty()); // Chunk is empty.
+        assert_eq!(segment.next, 112..186);
 
         // Next chunk is read and has one document.
-        segment = segment.next(&mut spill).unwrap().unwrap();
+        let (_, next_segment) = segment.pop_head(&mut spill).unwrap();
+        segment = next_segment.unwrap();
 
-        assert_eq!(segment.docs.len(), 1);
-        assert_eq!(segment.zz_backing.len(), 80);
-        assert_eq!(segment.next, 191..191);
-
-        actual.push((
-            segment.head().binding.value(),
-            serde_json::to_value(&segment.head().root.as_node()).unwrap(),
-        ));
+        assert_eq!(segment.head.binding, 2);
+        assert_eq!(segment.head.reduced, true);
+        assert!(crate::compare(segment.head.root.get(), &fixture[2].1).is_eq());
+        assert!(segment.tail.is_empty()); // Chunk is empty.
+        assert_eq!(segment.next, 186..186);
 
         // Stepping the segment again consumes it, as no chunks remain.
-        assert!(segment.next(&mut spill).unwrap().is_none());
-
-        insta::assert_json_snapshot!(actual, @r###"
-        [
-          [
-            0,
-            {
-              "key": "aaa",
-              "v": "apple"
-            }
-          ],
-          [
-            1,
-            {
-              "key": "bbb",
-              "v": "banana"
-            }
-          ],
-          [
-            2,
-            {
-              "key": "ccc",
-              "v": "carrot"
-            }
-          ]
-        ]
-        "###);
+        let (_, next_segment) = segment.pop_head(&mut spill).unwrap();
+        assert!(next_segment.is_none());
     }
 
     #[test]
@@ -541,30 +587,30 @@ mod test {
             .take(3),
         );
 
-        let alloc = HeapNode::new_allocator();
+        let alloc = Bump::new();
         let fixtures = vec![
             segment_fixture(
                 &[
-                    (0, json!({"key": "aaa", "v": ["apple"]}), FLAG_REDUCED),
-                    (0, json!({"key": "bbb", "v": ["banana"]}), 0),
-                    (1, json!({"key": "ccc", "v": ["carrot"]}), 0),
+                    (0, json!({"key": "aaa", "v": ["apple"]}), true),
+                    (0, json!({"key": "bbb", "v": ["banana"]}), false),
+                    (1, json!({"key": "ccc", "v": ["carrot"]}), false),
                 ],
                 &alloc,
             ),
             segment_fixture(
                 &[
-                    (0, json!({"key": "bbb", "v": ["avocado"]}), FLAG_REDUCED),
-                    (1, json!({"key": "bbb", "v": ["apricot"]}), FLAG_REDUCED),
-                    (1, json!({"key": "ccc", "v": ["raisin"]}), FLAG_REDUCED),
-                    (2, json!({"key": "ddd", "v": ["tomato"]}), FLAG_REDUCED),
+                    (0, json!({"key": "bbb", "v": ["avocado"]}), true),
+                    (1, json!({"key": "bbb", "v": ["apricot"]}), true),
+                    (1, json!({"key": "ccc", "v": ["raisin"]}), true),
+                    (2, json!({"key": "ddd", "v": ["tomato"]}), true),
                 ],
                 &alloc,
             ),
             segment_fixture(
                 &[
-                    (1, json!({"key": "ccc", "v": ["dill"]}), 0),
-                    (2, json!({"key": "ddd", "v": ["pickle"]}), 0),
-                    (2, json!({"key": "eee", "v": ["squash"]}), 0),
+                    (1, json!({"key": "ccc", "v": ["dill"]}), false),
+                    (2, json!({"key": "ddd", "v": ["pickle"]}), false),
+                    (2, json!({"key": "eee", "v": ["squash"]}), false),
                 ],
                 &alloc,
             ),
@@ -577,20 +623,18 @@ mod test {
 
         // Map from SpillWriter => SpillDrainer.
         let (spill, ranges) = spill.into_parts();
-        let mut drainer = SpillDrainer::new(spec, spill, &ranges).unwrap();
+        let drainer = SpillDrainer::new(spec, spill, &ranges).unwrap();
 
-        let mut actual = Vec::new();
-        loop {
-            if !drainer
-                .drain_while(|binding, node, full| {
-                    actual.push((binding, serde_json::to_value(&node).unwrap(), full));
-                    Ok::<_, Error>(actual.len() % 2 != 0)
-                })
-                .unwrap()
-            {
-                break;
-            }
-        }
+        let actual = drainer
+            .map_ok(|doc| {
+                (
+                    doc.binding,
+                    serde_json::to_value(&doc.root).unwrap(),
+                    doc.reduced,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         insta::assert_json_snapshot!(actual, @r###"
         [
@@ -674,50 +718,6 @@ mod test {
         assert_eq!(alloc.chunk_capacity(), 36800 - s.len());
     }
 
-    #[test]
-    fn test_spill_chunk_too_large() {
-        let alloc = HeapNode::new_allocator();
-        let segment = segment_fixture(
-            &[
-                (0, json!("one"), 0),
-                (0, json!("twotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwotwo"), 0),
-                (0, json!("three"), 0),
-                (0, json!("four"), 0),
-                (0, json!("five"), 0),
-            ],
-            &alloc,
-        );
-
-        let mut spill = SpillWriter::new(io::Cursor::new(Vec::new())).unwrap();
-        spill.write_segment(&segment, 109..110).unwrap();
-        let (mut spill, ranges) = spill.into_parts();
-
-        let mut segment = Segment::new(Arc::new([].into()), &mut spill, ranges[0].clone()).unwrap();
-
-        // First chunk is retried until its narrowed to a single document.
-        assert_eq!(segment.docs.len(), 1);
-        assert_eq!(segment.zz_backing.len(), 32);
-        segment = segment.next(&mut spill).unwrap().unwrap();
-
-        // Second chunk can only proceed by encoding the document by itself.
-        // It's still too large given our maximum chunk size, but we let it through.
-        assert_eq!(segment.docs.len(), 1);
-        assert_eq!(segment.zz_backing.len(), 120);
-        segment = segment.next(&mut spill).unwrap().unwrap();
-
-        // Third chunk is very conservative because `last_bytes_per_doc` is so large,
-        // but then re-sets the expectation for the fourth chunk.
-        assert_eq!(segment.docs.len(), 1);
-        assert_eq!(segment.zz_backing.len(), 32);
-        segment = segment.next(&mut spill).unwrap().unwrap();
-
-        // Fourth chunk includes multiple documents.
-        assert_eq!(segment.docs.len(), 2);
-        assert_eq!(segment.zz_backing.len(), 56);
-        segment = segment.next(&mut spill).unwrap().unwrap();
-        assert!(segment.next(&mut spill).unwrap().is_none());
-    }
-
     fn to_hex(b: &[u8]) -> String {
         hexdump::hexdump_iter(b)
             .map(|line| format!("{line}"))
@@ -726,14 +726,14 @@ mod test {
     }
 
     fn segment_fixture<'alloc>(
-        fixture: &[(u32, Value, u8)],
+        fixture: &[(u32, Value, bool)],
         alloc: &'alloc bumpalo::Bump,
-    ) -> Vec<HeapDoc<'alloc>> {
+    ) -> Vec<HeapEntry<'alloc>> {
         fixture
             .into_iter()
-            .map(|(binding, value, flags)| HeapDoc {
+            .map(|(binding, value, reduced)| HeapEntry {
                 binding: *binding,
-                flags: *flags,
+                reduced: *reduced,
                 root: HeapNode::from_node(value, &alloc),
             })
             .collect()

--- a/crates/doc/src/combine/spill.rs
+++ b/crates/doc/src/combine/spill.rs
@@ -668,14 +668,10 @@ mod test {
         assert_eq!(alloc.chunk_capacity(), 36800);
 
         // Allocation which fits within the current chunk.
-        alloc.alloc_str("hello world");
+        let s = alloc.alloc_str("hello world");
 
         // Expect chunk capacity is lower than before, because of the allocation.
-        // TODO(johnny): This is broken currently.
-        // Filed issue: https://github.com/fitzgen/bumpalo/issues/185
-        // I'm leaving this test in to identify when it's fixed,
-        // because we'll want to update our MemTable spill logic to reflect the new behavior.
-        assert_eq!(alloc.chunk_capacity(), 36800); // <- Should be assert_ne!().
+        assert_eq!(alloc.chunk_capacity(), 36800 - s.len());
     }
 
     #[test]

--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -1,4 +1,4 @@
-use crate::{compare::compare, ArchivedNode, AsNode, LazyNode, Node, Pointer};
+use crate::{compare::compare, AsNode, LazyNode, Node, OwnedNode, Pointer};
 use bytes::BufMut;
 use std::borrow::Cow;
 use tuple::TuplePack;
@@ -99,15 +99,15 @@ impl Extractor {
         out.split().freeze()
     }
 
-    /// Extract a packed tuple representation from an instance of doc::LazyNode.
-    pub fn extract_all_lazy<'alloc>(
-        doc: &LazyNode<'alloc, 'static, ArchivedNode>,
+    /// Extract a packed tuple representation from an instance of doc::OwnedNode.
+    pub fn extract_all_owned<'alloc>(
+        doc: &OwnedNode,
         extractors: &[Self],
         out: &mut bytes::BytesMut,
     ) -> bytes::Bytes {
         match doc {
-            LazyNode::Heap(doc) => Self::extract_all(doc, extractors, out),
-            LazyNode::Node(doc) => Self::extract_all(*doc, extractors, out),
+            OwnedNode::Heap(n) => Self::extract_all(n.get(), extractors, out),
+            OwnedNode::Archived(n) => Self::extract_all(n.get(), extractors, out),
         }
     }
 

--- a/crates/doc/src/heap.rs
+++ b/crates/doc/src/heap.rs
@@ -4,10 +4,12 @@ use super::{AsNode, BumpStr, BumpVec, Field, Fields, Node};
 #[derive(Debug, rkyv::Archive, rkyv::Serialize)]
 #[archive(archived = "ArchivedDoc")]
 pub struct HeapDoc<'alloc> {
-    /// Root node of the document.
-    pub root: HeapNode<'alloc>,
+    /// Binding to which this HeapDoc belongs.
+    pub binding: u32,
     /// Arbitrary flags used to persist document processing status.
     pub flags: u8,
+    /// Root node of the document.
+    pub root: HeapNode<'alloc>,
 }
 
 /// HeapNode is a document node representation stored in the heap.

--- a/crates/doc/src/heap.rs
+++ b/crates/doc/src/heap.rs
@@ -1,17 +1,5 @@
 use super::{AsNode, BumpStr, BumpVec, Field, Fields, Node};
 
-/// HeapDoc is a document representation stored in the heap.
-#[derive(Debug, rkyv::Archive, rkyv::Serialize)]
-#[archive(archived = "ArchivedDoc")]
-pub struct HeapDoc<'alloc> {
-    /// Binding to which this HeapDoc belongs.
-    pub binding: u32,
-    /// Arbitrary flags used to persist document processing status.
-    pub flags: u8,
-    /// Root node of the document.
-    pub root: HeapNode<'alloc>,
-}
-
 /// HeapNode is a document node representation stored in the heap.
 // The additional archive bounds are required to satisfy the compiler due to
 // the recursive nature of this structure. For more explanation see:

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -45,9 +45,9 @@ pub trait Field<'a, N: AsNode> {
 // an ArchivedNode serialized by the `rkyv` crate,
 // and an implementation upon serde_json::Value.
 mod archived;
-pub use archived::{ArchivedDoc, ArchivedField, ArchivedNode};
+pub use archived::{ArchivedField, ArchivedNode};
 pub mod heap;
-pub use heap::{HeapDoc, HeapField, HeapNode};
+pub use heap::{HeapField, HeapNode};
 mod value;
 
 // BumpStr is a low-level String type built upon a Bump allocator.
@@ -85,6 +85,10 @@ pub mod walker;
 // Optimized conversions from AsNode implementations into HeapNode.
 pub mod lazy;
 pub use lazy::LazyNode;
+
+// OwnedNode owns its HeapNode or ArchivedNode.
+mod owned;
+pub use owned::{OwnedArchivedNode, OwnedHeapNode, OwnedNode};
 
 // JSON-schema annotation extensions supported by Flow documents.
 mod annotation;

--- a/crates/doc/src/owned.rs
+++ b/crates/doc/src/owned.rs
@@ -1,0 +1,86 @@
+use super::{ArchivedNode, HeapNode};
+use crate::AsNode;
+use std::sync::Arc;
+
+/// OwnedNode is an enum over OwnedArchivedNode and OwnedHeapNode.
+pub enum OwnedNode {
+    Archived(OwnedArchivedNode),
+    Heap(OwnedHeapNode),
+}
+
+impl serde::Serialize for OwnedNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Archived(archived) => archived.get().as_node().serialize(serializer),
+            Self::Heap(heap) => heap.get().as_node().serialize(serializer),
+        }
+    }
+}
+
+/// OwnedArchivedNode is an owned, aligned Bytes buffer holding an ArchivedNode.
+pub struct OwnedArchivedNode(bytes::Bytes);
+
+impl OwnedArchivedNode {
+    /// Build an OwnedArchivedNode around a serialized buffer.
+    /// The caller must ensure the buffer is aligned and a valid ArchivedNode.
+    pub unsafe fn new(buf: bytes::Bytes) -> Self {
+        const EXPECT_ALIGN: usize = core::mem::align_of::<ArchivedNode>();
+        let actual_align = (buf.as_ptr() as usize) & (EXPECT_ALIGN - 1);
+
+        assert_eq!(
+            actual_align, 0,
+            "ArchivedNode requires that buffers be aligned to {}",
+            EXPECT_ALIGN
+        );
+
+        Self(buf)
+    }
+
+    #[inline]
+    pub fn get<'s>(&'s self) -> &'s ArchivedNode {
+        // Cast `backing` into its archived type.
+        unsafe { rkyv::archived_root::<HeapNode>(&self.0) }
+    }
+
+    pub fn bytes(&self) -> &bytes::Bytes {
+        &self.0
+    }
+}
+
+pub struct OwnedHeapNode {
+    node: HeapNode<'static>,
+    _zz_alloc: Arc<bumpalo::Bump>,
+}
+
+impl OwnedHeapNode {
+    /// Build an OwnedHeapNode around a HeapNode and its backing Bump allocator.
+    /// The caller must ensure the HeapNode is entirely allocated within the argument Bump.
+    pub unsafe fn new<'s>(node: HeapNode<'s>, alloc: Arc<bumpalo::Bump>) -> Self {
+        // Safety: `node` is backed by `alloc`, which is an owned reference
+        // to the Bump and is stored alongside `node`.
+        let node = unsafe { std::mem::transmute::<HeapNode<'s>, HeapNode<'static>>(node) };
+
+        Self {
+            node,
+            _zz_alloc: alloc,
+        }
+    }
+
+    #[inline]
+    pub fn get<'s>(&'s self) -> &'s HeapNode<'s> {
+        &self.node
+    }
+}
+
+// impl Drop to disallow destructuring of OwnedHeapNode,
+// because that can separate the lifetimes of `node` and `_alloc`.
+impl Drop for OwnedHeapNode {
+    fn drop(&mut self) {}
+}
+
+// OwnedHeapNode is Send because we maintain a coupled lifetime between HeapNode
+// and its backing allocator, and they're sent together.
+unsafe impl Send for OwnedHeapNode {}

--- a/crates/doc/src/shape/widen.rs
+++ b/crates/doc/src/shape/widen.rs
@@ -2,7 +2,7 @@
 // of a Shape as needed, to allow a given document to properly validate.
 // It's used as a base operation for schema inference.
 use super::*;
-use crate::{AsNode, Node};
+use crate::{AsNode, Node, OwnedNode};
 use std::cmp::Ordering;
 
 impl StringShape {
@@ -310,6 +310,14 @@ impl Shape {
                 self.object.widen::<N>(fields, is_first)
             }
             Node::String(s) => self.string.widen(s, apply_type(types::STRING)),
+        }
+    }
+
+    #[inline]
+    pub fn widen_owned(&mut self, node: &OwnedNode) -> bool {
+        match node {
+            OwnedNode::Heap(n) => self.widen(n.get()),
+            OwnedNode::Archived(n) => self.widen(n.get()),
         }
     }
 

--- a/crates/doc/tests/combiner_perf.rs
+++ b/crates/doc/tests/combiner_perf.rs
@@ -163,18 +163,11 @@ pub fn combiner_perf() {
     let mut drained: usize = 0;
     let mut shape = doc::Shape::nothing();
 
-    let mut drainer = accum.into_drainer().unwrap();
-    while drainer
-        .drain_while(|_binding, entry, _reduce| {
-            drained += 1;
-            match entry {
-                doc::LazyNode::Heap(entry) => shape.widen(&entry),
-                doc::LazyNode::Node(entry) => shape.widen(entry),
-            };
-            Ok::<_, doc::combine::Error>(true)
-        })
-        .unwrap()
-    {}
+    for drained_doc in accum.into_drainer().unwrap() {
+        let drained_doc = drained_doc.unwrap();
+        drained += 1;
+        shape.widen_owned(&drained_doc.root);
+    }
 
     let duration = begin.elapsed();
     let trough_stats = allocator::current_mem_stats();

--- a/crates/doc/tests/spill_merge_fuzz.rs
+++ b/crates/doc/tests/spill_merge_fuzz.rs
@@ -98,30 +98,26 @@ fn run_sequence(seq: Vec<(u8, u8, bool)>) -> Result<(), FuzzError> {
     // Spill final MemTable and begin to drain.
     let spec = memtable.spill(&mut spill, chunk_target.clone()).unwrap();
     let (spill, ranges) = spill.into_parts();
-    let mut drainer = combine::SpillDrainer::new(spec, spill, &ranges).unwrap();
+    let drainer = combine::SpillDrainer::new(spec, spill, &ranges).unwrap();
 
-    let mut count = 0;
     let mut expect_it = expect.into_iter();
 
-    while drainer.drain_while(|_binding, node, reduced| {
-        count += 1;
-
-        let actual = json!([node, reduced]);
+    for drained_doc in drainer {
+        let drained_doc = drained_doc?;
+        let actual = json!([drained_doc.root, drained_doc.reduced]);
 
         match expect_it.next() {
             Some((key, (values, reduced))) => {
                 let expect = json!([{"key": key, "arr": values}, reduced]);
                 // eprintln!("key {key} values {values:?}");
 
-                if actual == expect {
-                    Ok(count % 13 == 0) // Restart drain_while() periodically.
-                } else {
-                    Err(FuzzError::Mismatch { actual, expect })
+                if actual != expect {
+                    return Err(FuzzError::Mismatch { actual, expect });
                 }
             }
-            None => Err(FuzzError::Unexpected(actual)),
+            None => return Err(FuzzError::Unexpected(actual)),
         }
-    })? {}
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Description:**

This is a series of loosely coupled, incremental refactors detailed in individual commit messages.

* Support multiple bindings via a single combiner.

This allows a single combiner to support materialization and capture workflows operating over multiple bindings simultaneously, with a much tighter bound over memory usage when there are many bindings because they share a common MemTable.
 
* Validate documents when spilling to disk.

This is expected to increase end-to-end throughput for warehouse connectors because it makes the Store phase of the transaction -- when connectors can't do other useful parallel work -- much shorter when draining a SpillDrainer.

* Removing `drain_while` and adding an owned impl Iterator for MemDrainer / SpillDrainer.

This makes the API much more ergonomic when integrating with Streams and whatnot.

Performance:

At each step I was evaluating impacts using the `combiner_perf` benchmark. The only change which made an impact was moving up document validation, because it increase the total number of validations which are performed. While it impacts that benchmark (which performs a large number of reductions) given the parallel nature of the Load phase of the transaction I expect overall performance to increase.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1210)
<!-- Reviewable:end -->
