### PR TITLE
Disable use of `realtime`

### DIFF
--- a/supabase/migrations/06_connectors.sql
+++ b/supabase/migrations/06_connectors.sql
@@ -71,7 +71,6 @@ create table connector_tags (
     check (image_tag like ':%' or image_tag like '@sha256:')
 );
 -- Public, no RLS.
-alter publication supabase_realtime add table connector_tags;
 
 create trigger "Notify agent about changes to connector_tags" after insert or update on connector_tags
 for each statement execute procedure internal.notify_agent();

--- a/supabase/migrations/08_discovers.sql
+++ b/supabase/migrations/08_discovers.sql
@@ -12,7 +12,6 @@ create table discovers (
   auto_evolve       boolean  not null default false
 );
 alter table discovers enable row level security;
-alter publication supabase_realtime add table discovers;
 
 create trigger "Notify agent about changes to discover requests" after insert or update on discovers
 for each statement execute procedure internal.notify_agent();

--- a/supabase/migrations/09_publications.sql
+++ b/supabase/migrations/09_publications.sql
@@ -12,7 +12,6 @@ create table publications (
   auto_evolve boolean not null default false
 );
 alter table publications enable row level security;
-alter publication supabase_realtime add table publications;
 
 create trigger "Notify agent about changes to publication" after insert or update on publications
 for each statement execute procedure internal.notify_agent();

--- a/supabase/migrations/15_directives.sql
+++ b/supabase/migrations/15_directives.sql
@@ -74,7 +74,6 @@ create table applied_directives (
   user_claims   json_obj
 );
 alter table applied_directives enable row level security;
-alter publication supabase_realtime add table applied_directives;
 
 create trigger "Notify agent of applied directive" after insert or update on applied_directives
 for each statement execute procedure internal.notify_agent();

--- a/supabase/migrations/19_evolutions.sql
+++ b/supabase/migrations/19_evolutions.sql
@@ -27,7 +27,6 @@ comment on column evolutions.auto_publish is
   'whether to automatically publish the results of the evolution, if successful';
 
 alter table evolutions enable row level security;
-alter publication supabase_realtime add table evolutions;
 
 create trigger "Notify agent about changes to evolution" after insert or update on evolutions
 for each statement execute procedure internal.notify_agent();


### PR DESCRIPTION
**Description:**

Since we now using polling for discovers we no longer rely on the Supabase realtime capabilities. I have been keeping an eye on the project but I have a feeling they will [never guarantee messages](https://github.com/supabase/realtime#does-this-server-guarantee-message-delivery). This means all solutions we think about in the UI are based around using polling and I believe we can disable this functionality as we are not using it.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

We can manually disable these settings in Supabase dashboard to cause these changes right now. This will keep that setting from getting flipped back on later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1211)
<!-- Reviewable:end -->
