### PR TITLE
models: when not found, use an inferred schema sentinel

### DIFF
--- a/crates/validation/tests/model.yaml
+++ b/crates/validation/tests/model.yaml
@@ -75,6 +75,14 @@ test://example/int-string:
           - { $ref: flow://inferred-schema }
       key: [/int]
 
+    testing/int-string-inferred-not-found:
+      writeSchema: test://example/int-string.schema
+      readSchema:
+        allOf:
+          - { $ref: flow://write-schema }
+          - { $ref: flow://inferred-schema }
+      key: [/int]
+
 test://example/int-string-captures:
   import:
     - test://example/int-string

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -3870,6 +3870,239 @@ All {
             },
         },
         BuiltCollection {
+            scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found,
+            collection: testing/int-string-inferred-not-found,
+            validated: NULL,
+            spec: CollectionSpec {
+                name: "testing/int-string-inferred-not-found",
+                write_schema_json: "{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string.schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}",
+                read_schema_json: "{\"$defs\":{\"flow://inferred-schema\":{\"$id\":\"flow://inferred-schema\",\"properties\":{\n                    \"_meta\": {\n                        \"properties\": {\n                            \"inferredSchemaIsNotAvailable\": {\n                                \"const\": true,\n                                \"description\": \"An inferred schema is not yet available because no documents have been written to this collection.\\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready.\"\n                            }\n                        },\n                        \"required\": [\"inferredSchemaIsNotAvailable\"]\n                    }\n                },\"required\":[\"_meta\"]},\"flow://write-schema\":{\"$defs\":{\"anAnchor\":{\"$anchor\":\"AnAnchor\",\"properties\":{\"one\":{\"type\":\"string\"},\"two\":{\"type\":\"integer\"}},\"required\":[\"one\"],\"type\":\"object\"}},\"$id\":\"flow://write-schema\",\"properties\":{\"bit\":{\"type\":\"boolean\"},\"int\":{\"type\":\"integer\"},\"str\":{\"type\":\"string\"}},\"required\":[\"int\",\"str\",\"bit\"],\"type\":\"object\"}},\"$id\":\"test://example/int-string?ptr=/collections/testing~1int-string-inferred-not-found/readSchema\",\"allOf\":[{\"$ref\":\"flow://write-schema\"},{\"$ref\":\"flow://inferred-schema\"}]}",
+                key: [
+                    "/int",
+                ],
+                uuid_ptr: "/_meta/uuid",
+                partition_fields: [],
+                projections: [
+                    Projection {
+                        ptr: "/_meta",
+                        field: "_meta",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "array",
+                                    "boolean",
+                                    "null",
+                                    "number",
+                                    "object",
+                                    "string",
+                                ],
+                                string: Some(
+                                    String {
+                                        content_type: "",
+                                        format: "",
+                                        content_encoding: "",
+                                        max_length: 0,
+                                    },
+                                ),
+                                title: "",
+                                description: "",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/_meta/inferredSchemaIsNotAvailable",
+                        field: "_meta/inferredSchemaIsNotAvailable",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "boolean",
+                                ],
+                                string: None,
+                                title: "",
+                                description: "An inferred schema is not yet available because no documents have been written to this collection.\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready.",
+                                default_json: "",
+                                secret: false,
+                                exists: May,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/bit",
+                        field: "bit",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "boolean",
+                                ],
+                                string: None,
+                                title: "",
+                                description: "",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "",
+                        field: "flow_document",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "object",
+                                ],
+                                string: None,
+                                title: "",
+                                description: "",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/_meta/uuid",
+                        field: "flow_published_at",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "string",
+                                ],
+                                string: Some(
+                                    String {
+                                        content_type: "",
+                                        format: "date-time",
+                                        content_encoding: "uuid",
+                                        max_length: 0,
+                                    },
+                                ),
+                                title: "Flow Publication Time",
+                                description: "Flow publication date-time of this document",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/int",
+                        field: "int",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: true,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "integer",
+                                ],
+                                string: None,
+                                title: "",
+                                description: "",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                    Projection {
+                        ptr: "/str",
+                        field: "str",
+                        explicit: false,
+                        is_partition_key: false,
+                        is_primary_key: false,
+                        inference: Some(
+                            Inference {
+                                types: [
+                                    "string",
+                                ],
+                                string: Some(
+                                    String {
+                                        content_type: "",
+                                        format: "",
+                                        content_encoding: "",
+                                        max_length: 0,
+                                    },
+                                ),
+                                title: "",
+                                description: "",
+                                default_json: "",
+                                secret: false,
+                                exists: Must,
+                            },
+                        ),
+                    },
+                ],
+                ack_template_json: "{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                partition_template: Some(
+                    JournalSpec {
+                        name: "testing/int-string-inferred-not-found",
+                        replication: 3,
+                        labels: Some(
+                            LabelSet {
+                                labels: [
+                                    Label {
+                                        name: "app.gazette.dev/managed-by",
+                                        value: "estuary.dev/flow",
+                                    },
+                                    Label {
+                                        name: "content-type",
+                                        value: "application/x-ndjson",
+                                    },
+                                    Label {
+                                        name: "estuary.dev/build",
+                                        value: "a-build-id",
+                                    },
+                                    Label {
+                                        name: "estuary.dev/collection",
+                                        value: "testing/int-string-inferred-not-found",
+                                    },
+                                ],
+                            },
+                        ),
+                        fragment: Some(
+                            Fragment {
+                                length: 536870912,
+                                compression_codec: Gzip,
+                                stores: [
+                                    "s3://data-bucket/",
+                                ],
+                                refresh_interval: Some(
+                                    Duration {
+                                        seconds: 300,
+                                        nanos: 0,
+                                    },
+                                ),
+                                retention: None,
+                                flush_interval: None,
+                                path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                            },
+                        ),
+                        flags: 4,
+                        max_append_rate: 4194304,
+                    },
+                ),
+                derivation: None,
+            },
+        },
+        BuiltCollection {
             scope: test://example/int-string#/collections/testing~1int-string-rw,
             collection: testing/int-string-rw,
             validated: NULL,
@@ -5885,6 +6118,17 @@ All {
             },
         },
         Collection {
+            scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found,
+            collection: testing/int-string-inferred-not-found,
+            spec: {
+              "writeSchema": {"$defs":{"anAnchor":{"$anchor":"AnAnchor","properties":{"one":{"type":"string"},"two":{"type":"integer"}},"required":["one"],"type":"object"}},"$id":"test://example/int-string.schema","properties":{"bit":{"type":"boolean"},"int":{"type":"integer"},"str":{"type":"string"}},"required":["int","str","bit"],"type":"object"},
+              "readSchema": {"$id":"test://example/int-string?ptr=/collections/testing~1int-string-inferred-not-found/readSchema","allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},
+              "key": [
+                "/int"
+              ]
+            },
+        },
+        Collection {
             scope: test://example/int-string#/collections/testing~1int-string-rw,
             collection: testing/int-string-rw,
             spec: {
@@ -6072,6 +6316,10 @@ All {
         Import {
             scope: test://example/int-reverse#/import/0,
             to_resource: test://example/int-string,
+        },
+        Import {
+            scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found/writeSchema,
+            to_resource: test://example/int-string.schema,
         },
         Import {
             scope: test://example/int-string#/collections/testing~1int-string-inferred/writeSchema,
@@ -6272,7 +6520,7 @@ All {
             resource: test://example/int-string,
             content_type: "CATALOG",
             content: ".. binary ..",
-            content_dom: {"collections":{"testing/int-string":{"key":["/int"],"projections":{"Int":"/int","bit":{"location":"/bit","partition":true}},"schema":"test://example/int-string.schema"},"testing/int-string-inferred":{"key":["/int"],"readSchema":{"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},"writeSchema":"test://example/int-string.schema"},"testing/int-string-rw":{"key":["/int"],"projections":{"Int":"/int","Len":"/len","Str":"/str","bit":{"location":"/bit","partition":true}},"readSchema":"test://example/int-string-len.schema","writeSchema":"test://example/int-string.schema"},"testing/int-string.v2":{"journals":{"fragments":{"compressionCodec":"ZSTANDARD"}},"key":["/int"],"schema":{"$id":"test://inlined/canonical/id","$ref":"test://example/int-string.schema"}}},"import":["test://example/int-halve"]},
+            content_dom: {"collections":{"testing/int-string":{"key":["/int"],"projections":{"Int":"/int","bit":{"location":"/bit","partition":true}},"schema":"test://example/int-string.schema"},"testing/int-string-inferred":{"key":["/int"],"readSchema":{"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},"writeSchema":"test://example/int-string.schema"},"testing/int-string-inferred-not-found":{"key":["/int"],"readSchema":{"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},"writeSchema":"test://example/int-string.schema"},"testing/int-string-rw":{"key":["/int"],"projections":{"Int":"/int","Len":"/len","Str":"/str","bit":{"location":"/bit","partition":true}},"readSchema":"test://example/int-string-len.schema","writeSchema":"test://example/int-string.schema"},"testing/int-string.v2":{"journals":{"fragments":{"compressionCodec":"ZSTANDARD"}},"key":["/int"],"schema":{"$id":"test://inlined/canonical/id","$ref":"test://example/int-string.schema"}}},"import":["test://example/int-halve"]},
         },
         Resource {
             resource: test://example/int-string-captures,

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
@@ -24,6 +24,14 @@ expression: errors
         error: location /int accepts "number", "object" in schema test://example/int-string#/collections/testing~1int-string-inferred/readSchema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
+        scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found/key/0,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found/key/0,
+        error: location /int accepts "number", "object" in schema test://example/int-string#/collections/testing~1int-string-inferred-not-found/readSchema, but locations used as keys may only be null-able integers, strings, or booleans,
+    },
+    Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/key/0,
         error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },

--- a/crates/validation/tests/snapshots/scenario_tests__storage_mappings_not_found.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__storage_mappings_not_found.snap
@@ -28,6 +28,10 @@ expression: errors
         error: could not map collection testing/int-string-inferred into a storage mapping; did you mean TestinG/ defined at test://example/int-string#/storageMappings/TestinG~1?,
     },
     Error {
+        scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found,
+        error: could not map collection testing/int-string-inferred-not-found into a storage mapping; did you mean TestinG/ defined at test://example/int-string#/storageMappings/TestinG~1?,
+    },
+    Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw,
         error: could not map collection testing/int-string-rw into a storage mapping; did you mean TestinG/ defined at test://example/int-string#/storageMappings/TestinG~1?,
     },


### PR DESCRIPTION
The sentinel purpose is two-fold:
* It explicitly marks that an inferred schemas was not available.
* It causes downstream tasks to fail on the very first read document, so that they can be re-published with an updated inferred schema.

Tested: end-to-end on a local stack with `source-postgres-batch`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1212)
<!-- Reviewable:end -->
