### PR TITLE
flowctl: fix cataglog delete

### DIFF
--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -1,4 +1,4 @@
-use crate::{api_exec_paginated, catalog, draft, CliContext};
+use crate::{api_exec, catalog, draft, CliContext};
 use anyhow::Context;
 use serde::Serialize;
 
@@ -124,7 +124,7 @@ pub async fn do_delete(
         })
         .collect::<Vec<DraftSpec>>();
 
-    api_exec_paginated::<Vec<serde_json::Value>>(
+    api_exec::<Vec<serde_json::Value>>(
         ctx.controlplane_client()
             .await?
             .from("draft_specs")


### PR DESCRIPTION
**Description:**

fixes #1213
`flowctl catalog delete` was broken by the change to pagination. It doesn't make sense to use pagination for this request anyway, since it's a POST and the response body is empty. This changes it to just use `api_exec`, which works as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1214)
<!-- Reviewable:end -->
