### PR TITLE
Implement logic to move tenants into the free trial

### DIFF
--- a/crates/billing-integrations/src/stripe.rs
+++ b/crates/billing-integrations/src/stripe.rs
@@ -254,11 +254,12 @@ impl Invoice {
                     stripe::CreateInvoice {
                         customer: Some(customer.id.to_owned()),
                         // Stripe timestamps are measured in _seconds_ since epoch
-                        // Due date must be in the future
-                        due_date: if date_end_secs > timestamp_now { Some(date_end_secs) } else {Some(timestamp_now + 10)},
+                        // Due date must be in the future. Bill net-30, so 30 days from today
+                        due_date: Some((Utc::now() + Duration::days(30)).timestamp()),
                         description: Some(
                             format!(
-                                "Your Flow bill for the billing preiod between {date_start_human} - {date_end_human}"
+                                "Your Flow bill for the billing preiod between {date_start_human} - {date_end_human}. Tenant: {tenant}",
+                                tenant=self.billed_prefix.to_owned()
                             )
                             .as_str(),
                         ),

--- a/crates/billing-integrations/src/stripe.rs
+++ b/crates/billing-integrations/src/stripe.rs
@@ -264,7 +264,7 @@ impl Invoice {
                         due_date: Some((Utc::now() + Duration::days(30)).timestamp()),
                         description: Some(
                             format!(
-                                "Your Flow bill for the billing preiod between {date_start_human} - {date_end_human}. Tenant: {tenant}",
+                                "Your Flow bill for the billing period between {date_start_human} - {date_end_human}. Tenant: {tenant}",
                                 tenant=self.billed_prefix.to_owned()
                             )
                             .as_str(),

--- a/supabase/migrations/33_automate_trial_start.sql
+++ b/supabase/migrations/33_automate_trial_start.sql
@@ -1,24 +1,27 @@
 begin;
 
+-- Index that accelerates operator ^@ (starts-with) for catalog_stats and friends.
+create index catalog_stats_catalog_index_spgist on catalog_stats using spgist ((catalog_name::text));
+
 create or replace view internal.new_free_trial_tenants as
-with hrs_by_day as (
+with hours_by_day as (
   select
     tenants.tenant as tenant,
     ts,
     sum(catalog_stats_daily.usage_seconds / (60.0 * 60)) as daily_usage_hours
   from catalog_stats_daily
-  join tenants on tenants.tenant = split_part(catalog_stats_daily.catalog_name,'/',1)||'/'
+  join tenants on catalog_stats_daily.catalog_name ^@ tenants.tenant
   where tenants.trial_start is null
   group by tenants.tenant, ts
   having sum(catalog_stats_daily.usage_seconds / (60.0 * 60)) > (2 * 24)
 ),
-hrs_by_month as (
+hours_by_month as (
   select
     tenants.tenant as tenant,
     ts,
     sum(catalog_stats_monthly.usage_seconds / (60.0 * 60)) as monthly_usage_hours
   from catalog_stats_monthly
-  join tenants on tenants.tenant = split_part(catalog_stats_monthly.catalog_name,'/',1)||'/'
+  join tenants on catalog_stats_monthly.catalog_name ^@ tenants.tenant
   where tenants.trial_start is null
   group by tenants.tenant, ts
   having sum(catalog_stats_monthly.usage_seconds / (60.0 * 60)) > (24 * 31 * 2)
@@ -29,35 +32,26 @@ gbs_by_month as (
     ts,
     ceil(sum((catalog_stats_monthly.bytes_written_by_me + catalog_stats_monthly.bytes_read_by_me) / (1024.0 * 1024 * 1024))) as monthly_usage_gbs
   from catalog_stats_monthly
-  join tenants on tenants.tenant = split_part(catalog_stats_monthly.catalog_name,'/',1)||'/'
+  join tenants on catalog_stats_monthly.catalog_name ^@ tenants.tenant
   where tenants.trial_start is null
   group by tenants.tenant, ts
   having ceil(sum((catalog_stats_monthly.bytes_written_by_me + catalog_stats_monthly.bytes_read_by_me) / (1024.0 * 1024 * 1024))) > 10
 )
 select
     tenants.tenant as tenant,
-    max(hrs_by_day.daily_usage_hours) as max_daily_usage_hours,
-    max(hrs_by_month.monthly_usage_hours) as max_monthly_usage_hours,
+    max(hours_by_day.daily_usage_hours) as max_daily_usage_hours,
+    max(hours_by_month.monthly_usage_hours) as max_monthly_usage_hours,
     max(gbs_by_month.monthly_usage_gbs) as max_monthly_gb,
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') as today_captures,
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') as today_materializations
 from tenants
-left join hrs_by_day on hrs_by_day.tenant = tenants.tenant
-left join hrs_by_month on hrs_by_month.tenant = tenants.tenant
+left join hours_by_day on hours_by_day.tenant = tenants.tenant
+left join hours_by_month on hours_by_month.tenant = tenants.tenant
 left join gbs_by_month on gbs_by_month.tenant = tenants.tenant
 join live_specs on (split_part(live_specs.catalog_name,'/',1)||'/' = tenants.tenant and (live_specs.spec #>> '{shards,disable}')::boolean is not true)
 where tenants.trial_start is null
 group by tenants.tenant
-having (
-  (
-    max(hrs_by_day.daily_usage_hours) > (2 * 24) or
-    max(hrs_by_month.monthly_usage_hours) > (24 * 31 * 2) or
-    max(gbs_by_month.monthly_usage_gbs) > 10
-  ) and (
-    count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') > 0 or
-    count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') > 0
-  )
-);
+having count(hours_by_month) > 0 or count(hours_by_day) > 0 or count(gbs_by_month) > 0;
 
 create or replace function internal.set_new_free_trials()
 returns integer as $$

--- a/supabase/migrations/33_automate_trial_start.sql
+++ b/supabase/migrations/33_automate_trial_start.sql
@@ -1,24 +1,58 @@
 begin;
 
 create or replace view internal.new_free_trial_tenants as
+with hrs_by_day as (
+  select
+    tenants.tenant as tenant,
+    ts,
+    sum(catalog_stats_daily.usage_seconds / (60.0 * 60)) as daily_usage_hours
+  from catalog_stats_daily
+  join tenants on tenants.tenant = split_part(catalog_stats_daily.catalog_name,'/',1)||'/'
+  where tenants.trial_start is null
+  group by tenants.tenant, ts
+  having sum(catalog_stats_daily.usage_seconds / (60.0 * 60)) > (2 * 24)
+),
+hrs_by_month as (
+  select
+    tenants.tenant as tenant,
+    ts,
+    sum(catalog_stats_monthly.usage_seconds / (60.0 * 60)) as monthly_usage_hours
+  from catalog_stats_monthly
+  join tenants on tenants.tenant = split_part(catalog_stats_monthly.catalog_name,'/',1)||'/'
+  where tenants.trial_start is null
+  group by tenants.tenant, ts
+  having sum(catalog_stats_monthly.usage_seconds / (60.0 * 60)) > (24 * 31 * 2)
+),
+gbs_by_month as (
+  select
+    tenants.tenant as tenant,
+    ts,
+    ceil(sum((catalog_stats_monthly.bytes_written_by_me + catalog_stats_monthly.bytes_read_by_me) / (1024.0 * 1024 * 1024))) as monthly_usage_gbs
+  from catalog_stats_monthly
+  join tenants on tenants.tenant = split_part(catalog_stats_monthly.catalog_name,'/',1)||'/'
+  where tenants.trial_start is null
+  group by tenants.tenant, ts
+  having ceil(sum((catalog_stats_monthly.bytes_written_by_me + catalog_stats_monthly.bytes_read_by_me) / (1024.0 * 1024 * 1024))) > 10
+)
 select
     tenants.tenant as tenant,
-    max(daily_stats.usage_seconds / (60.0 * 60)) as max_daily_usage_hours,
-    max(monthly_stats.usage_seconds / (60.0 * 60)) as max_monthly_usage_hours,
-    max(ceil((monthly_stats.bytes_written_by_me + monthly_stats.bytes_read_by_me) / (1024.0 * 1024 * 1024))) as max_monthly_gb,
+    max(hrs_by_day.daily_usage_hours) as max_daily_usage_hours,
+    max(hrs_by_month.monthly_usage_hours) as max_monthly_usage_hours,
+    max(gbs_by_month.monthly_usage_gbs) as max_monthly_gb,
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') as today_captures,
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') as today_materializations
-from catalog_stats_monthly as monthly_stats
-join catalog_stats_daily as daily_stats on daily_stats.catalog_name = monthly_stats.catalog_name
-join tenants on tenants.tenant = split_part(monthly_stats.catalog_name,'/',1)||'/'
-join live_specs on (live_specs.catalog_name = monthly_stats.catalog_name and (live_specs.spec #>> '{shards,disable}')::boolean is not true)
+from tenants
+left join hrs_by_day on hrs_by_day.tenant = tenants.tenant
+left join hrs_by_month on hrs_by_month.tenant = tenants.tenant
+left join gbs_by_month on gbs_by_month.tenant = tenants.tenant
+join live_specs on (split_part(live_specs.catalog_name,'/',1)||'/' = tenants.tenant and (live_specs.spec #>> '{shards,disable}')::boolean is not true)
 where tenants.trial_start is null
 group by tenants.tenant
 having (
   (
-    max(daily_stats.usage_seconds / (60.0 * 60)) > (2 * 24) or
-    max(monthly_stats.usage_seconds / (60.0 * 60)) > (24 * 30 * 2) or
-    max((monthly_stats.bytes_written_by_me + monthly_stats.bytes_read_by_me) / (1024.0 * 1024 * 1024)) > 10
+    max(hrs_by_day.daily_usage_hours) > (2 * 24) or
+    max(hrs_by_month.monthly_usage_hours) > (24 * 31 * 2) or
+    max(gbs_by_month.monthly_usage_gbs) > 10
   ) and (
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') > 0 or
     count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') > 0

--- a/supabase/migrations/33_automate_trial_start.sql
+++ b/supabase/migrations/33_automate_trial_start.sql
@@ -1,0 +1,48 @@
+begin;
+
+create or replace view internal.new_free_trial_tenants as
+select
+    tenants.tenant as tenant,
+    max(daily_stats.usage_seconds / (60.0 * 60)) as max_daily_usage_hours,
+    max(monthly_stats.usage_seconds / (60.0 * 60)) as max_monthly_usage_hours,
+    max(ceil((monthly_stats.bytes_written_by_me + monthly_stats.bytes_read_by_me) / (1024.0 * 1024 * 1024))) as max_monthly_gb,
+    count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') as today_captures,
+    count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') as today_materializations
+from catalog_stats_monthly as monthly_stats
+join catalog_stats_daily as daily_stats on daily_stats.catalog_name = monthly_stats.catalog_name
+join tenants on tenants.tenant = split_part(monthly_stats.catalog_name,'/',1)||'/'
+join live_specs on (live_specs.catalog_name = monthly_stats.catalog_name and (live_specs.spec #>> '{shards,disable}')::boolean is not true)
+where tenants.trial_start is null
+group by tenants.tenant
+having (
+  (
+    max(daily_stats.usage_seconds / (60.0 * 60)) > (2 * 24) or
+    max(monthly_stats.usage_seconds / (60.0 * 60)) > (24 * 30 * 2) or
+    max((monthly_stats.bytes_written_by_me + monthly_stats.bytes_read_by_me) / (1024.0 * 1024 * 1024)) > 10
+  ) and (
+    count(distinct live_specs.id) filter (where live_specs.spec_type = 'capture') > 0 or
+    count(distinct live_specs.id) filter (where live_specs.spec_type = 'materialization') > 0
+  )
+)
+order by max_daily_usage_hours desc, max_monthly_usage_hours desc, max_monthly_gb desc;
+
+create or replace function internal.set_new_free_trials()
+returns integer as $$
+declare
+    tenant_row record;
+    update_count integer = 0;
+begin
+    for tenant_row in select tenant from internal.new_free_trial_tenants loop
+      update tenants set trial_start = date_trunc('day', now())
+      where tenants.tenant = tenant_row.tenant;
+
+      -- INSERT statements set FOUND true if at least one row is affected, false if no row is affected.
+      if found then
+        update_count = update_count + 1;
+      end if;
+    end loop;
+    return update_count;
+end
+$$ language plpgsql volatile;
+
+commit;


### PR DESCRIPTION
**Description:**

Rather than writing `internal.set_new_free_trials()` with a CTE, I thought it would be nice to be able to take a look and see which tenants are slated to be kicked into the free trial next time the cron job runs, so I made `internal.new_free_trial_tenants` a view. Any reason this would be a bad idea?

The criteria I came up with from coversations is: a tenant should be moved into the trial if
* They are not already a paying customer (i.e they don't have a free trial set) AND
* They have at least one active, not-disabled capture or materialization
* One of the following is true
  * Daily task usage time exceeds 2*24h
  * Monthly usage time exceeds 2*30d
  * Monthly data used exceeds 10gb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1215)
<!-- Reviewable:end -->
