### PR TITLE
sources: remove imports of inlined resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,6 +4530,7 @@ dependencies = [
  "serde-transcode",
  "serde_json",
  "serde_yaml",
+ "superslice",
  "tables",
  "thiserror",
  "tracing",

--- a/crates/flowctl/src/generate/mod.rs
+++ b/crates/flowctl/src/generate/mod.rs
@@ -49,6 +49,7 @@ impl Generate {
         Ok(())
     }
 }
+
 // Generates stubs for all missing connector configuration files,
 // returning tuples of:
 // * The missing config file URL.

--- a/crates/flowctl/src/raw/discover.rs
+++ b/crates/flowctl/src/raw/discover.rs
@@ -54,7 +54,12 @@ pub async fn do_discover(
 
     // Inline a clone of the capture spec for use with the discover RPC.
     let mut spec_clone = capture.spec.clone();
-    sources::inline_capture(&capture.scope, &mut spec_clone, &sources.resources);
+    sources::inline_capture(
+        &capture.scope,
+        &mut spec_clone,
+        &mut sources.imports,
+        &sources.resources,
+    );
 
     let discover = match &spec_clone.endpoint {
         models::CaptureEndpoint::Connector(config) => capture::request::Discover {

--- a/crates/sources/Cargo.toml
+++ b/crates/sources/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde-transcode = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+superslice = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/sources/src/bundle_schema_test.yaml
+++ b/crates/sources/src/bundle_schema_test.yaml
@@ -38,6 +38,10 @@ test://example/catalog.yaml:
       schema: test://example/NonCanonical
       key: [/int]
 
+    testing/seven:
+      schema: schema.Simple
+      key: [/int]
+
 test://example/schema.A:
   type: object
   properties:
@@ -52,7 +56,7 @@ test://example/schema.B:
   $defs:
     nested:
       properties:
-        something: {const: something}
+        something: { const: something }
 
 test://external/Canonical:
   $id: test://external/Canonical
@@ -68,3 +72,8 @@ test://example/NonCanonical:
   type: object
   properties:
     some: { const: stuff }
+
+test://example/schema.Simple:
+  properties:
+    int: { type: integer }
+    str: { type: string }

--- a/crates/sources/src/indirect.rs
+++ b/crates/sources/src/indirect.rs
@@ -428,7 +428,18 @@ fn indirect_materialization(
                 threshold,
             )
         }
-        _ => {}
+        models::MaterializationEndpoint::Local(models::LocalConfig { config, .. }) => indirect_dom(
+            Scope::new(scope)
+                .push_prop("endpoint")
+                .push_prop("local")
+                .push_prop("config"),
+            config,
+            ContentType::Config,
+            format!("{base}.config"),
+            imports,
+            resources,
+            threshold,
+        ),
     }
 
     for (index, models::MaterializationBinding { resource, .. }) in bindings.iter_mut().enumerate()

--- a/crates/sources/src/scenarios/mod.rs
+++ b/crates/sources/src/scenarios/mod.rs
@@ -28,11 +28,14 @@ mod test {
             tables.fetches = tables::Fetches::new();
             tables.resources = tables::Resources::new();
 
-            // Clear implicit imports, leaving only explicit catalog imports.
-            tables.imports.retain(|import| import.scope.fragment().unwrap().starts_with("/import"));
-
             // Verify shape of inline specs.
 			insta::assert_debug_snapshot!(tables);
+
+            // Most implicit imports were removed. Some remain:
+            // * References between JSON schemas (but not from a collection to a schema).
+            // * Imports which were not found and thus could not be inlined.
+            // Clear remaining implicit imports, leaving only explicit catalog imports.
+            tables.imports.retain(|import| import.scope.fragment().unwrap().starts_with("/import"));
 
             // Now indirect specs again, and verify the updated specs and indirect'd resources.
             crate::indirect_large_files(&mut tables, 32);

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations-2.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__endpoints_captures_materializations-2.snap
@@ -102,7 +102,28 @@ Sources {
     collections: [],
     errors: [],
     fetches: [],
-    imports: [],
+    imports: [
+        Import {
+            scope: test://example/catalog.yaml#/captures/capture~1config-missing/bindings/0/resource,
+            to_resource: test://example/resource/not/found.yaml,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/captures/capture~1config-missing/endpoint/connector/config,
+            to_resource: test://example/config/not/found.yaml,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/materializations/materialization~1missing-config/bindings/0/resource,
+            to_resource: test://example/referenced/not/found.yaml,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/materializations/materialization~1missing-config/endpoint/connector/config,
+            to_resource: test://example/config/not/found.yaml,
+        },
+        Import {
+            scope: test://example/catalog.yaml#/materializations/materialization~1with-config-fragment/endpoint/connector/config,
+            to_resource: test://example/referenced/config.yaml#/bad/fragment,
+        },
+    ],
     materializations: [
         Materialization {
             scope: test://example/catalog.yaml#/materializations/a~1materialization,

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__schema_with_references-2.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__schema_with_references-2.snap
@@ -18,7 +18,16 @@ Sources {
     ],
     errors: [],
     fetches: [],
-    imports: [],
+    imports: [
+        Import {
+            scope: test://external/a#/$defs/a/$ref,
+            to_resource: test://external/b,
+        },
+        Import {
+            scope: test://external/b#/$defs/c/$ref,
+            to_resource: test://external/c,
+        },
+    ],
     materializations: [],
     resources: [],
     storage_mappings: [],

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case-2.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__test_case-2.snap
@@ -16,6 +16,10 @@ Sources {
             scope: test://example/catalog.yaml#/import/1,
             to_resource: test://example/catalog-err-not-an-object.yaml,
         },
+        Import {
+            scope: test://example/catalog.yaml#/tests/acmeCo~1errors~1test/1/documents,
+            to_resource: test://example/not-found.json,
+        },
     ],
     materializations: [],
     resources: [],

--- a/crates/sources/src/snapshots/sources__bundle_schema__test__bundle_generation.snap
+++ b/crates/sources/src/snapshots/sources__bundle_schema__test__bundle_generation.snap
@@ -63,6 +63,13 @@ testing/one:
   required:
     - int
   type: object
+testing/seven:
+  $id: "test://example/schema.Simple"
+  properties:
+    int:
+      type: integer
+    str:
+      type: string
 testing/six:
   $id: "test://external/ActualCanonicalURI"
   properties:

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -6246,10 +6246,6 @@ All {
     ],
     imports: [
         Import {
-            scope: test://example/array-key#/collections/testing~1array-key/schema,
-            to_resource: test://example/array-key.schema,
-        },
-        Import {
             scope: test://example/catalog.yaml#/import/0,
             to_resource: test://example/int-string,
         },
@@ -6298,56 +6294,16 @@ All {
             to_resource: test://example/array-key,
         },
         Import {
-            scope: test://example/int-halve#/collections/testing~1int-halve/derive/using/typescript/module,
-            to_resource: test://example/int-halve.ts,
-        },
-        Import {
-            scope: test://example/int-halve#/collections/testing~1int-halve/schema,
-            to_resource: test://example/int-string-len.schema,
-        },
-        Import {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/derive/using/typescript/module,
-            to_resource: test://example/int-reverse.ts,
-        },
-        Import {
-            scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
             scope: test://example/int-reverse#/import/0,
             to_resource: test://example/int-string,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string-inferred-not-found/writeSchema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string-inferred/writeSchema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string-rw/readSchema,
-            to_resource: test://example/int-string-len.schema,
-        },
-        Import {
-            scope: test://example/int-string#/collections/testing~1int-string-rw/writeSchema,
-            to_resource: test://example/int-string.schema,
         },
         Import {
             scope: test://example/int-string#/collections/testing~1int-string.v2/schema/$ref,
             to_resource: test://example/int-string.schema,
         },
         Import {
-            scope: test://example/int-string#/collections/testing~1int-string/schema,
-            to_resource: test://example/int-string.schema,
-        },
-        Import {
             scope: test://example/int-string#/import/0,
             to_resource: test://example/int-halve,
-        },
-        Import {
-            scope: test://example/int-string-captures#/captures/testing~1db-cdc/endpoint/connector/config,
-            to_resource: test://example/cdc-config.yaml,
         },
         Import {
             scope: test://example/int-string-captures#/import/0,
@@ -6372,10 +6328,6 @@ All {
         Import {
             scope: test://example/webhook-deliveries#/import/1,
             to_resource: test://example/int-halve,
-        },
-        Import {
-            scope: test://example/webhook-deliveries#/materializations/testing~1webhook~1deliveries/endpoint/connector/config,
-            to_resource: test://example/webhook-config.yaml,
         },
     ],
     materializations: [


### PR DESCRIPTION
When inlining catalog specs, remove the imports of inlined schemas and config resources. These resources are no longer "imported" (they've been inlined), and pragmatically this makes inlining an idempotent operation.

This fixes a current bug in `flowctl generate` where it may attempt to inline a schema twice, producing an invalid JSON schema bundle.

Also add a missing symmetrical case for indirection of local materialization endpoint configs.

Tested:
 * All `sources` scenario tests are round-tripped through inlining and then indirection.
 * Tested with a substantive real-world catalog as well.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1218)
<!-- Reviewable:end -->
