### PR TITLE
rust coroutines and derivation inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "coroutines"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,7 +2316,6 @@ dependencies = [
  "futures",
  "futures-core",
  "lazy_static",
- "pin-project",
  "proto-gazette",
  "proto-grpc",
  "reqwest",
@@ -3884,6 +3893,7 @@ dependencies = [
  "bytes",
  "clap 3.2.24",
  "connector-init",
+ "coroutines",
  "derive-sqlite",
  "doc",
  "extractors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ pathfinding = "3.0"
 pbjson = "0.5.1"
 pbjson-types = "0.5.1"
 percent-encoding = "2.1"
-pin-project = "1.0.12"
+pin-project-lite = "0.2"
 postgrest = { git = "https://github.com/jshearer/postgrest-rs", branch = "joseph/combined_changes_rebased" }
 page-turner = "0.8.2"
 prost = "0.11"

--- a/crates/bindings/src/service.rs
+++ b/crates/bindings/src/service.rs
@@ -290,9 +290,9 @@ pub fn drop<S: Service>(ch: *mut Channel) {
     });
 
     // Drop svc_impl, arena, out, and tracing subscriber.
-    unsafe { Box::from_raw(svc_impl as *mut S) };
-    unsafe { Vec::<u8>::from_raw_parts(arena_ptr, arena_len, arena_cap) };
-    unsafe { Vec::<Out>::from_raw_parts(out_ptr, out_len, out_cap) };
-    unsafe { String::from_raw_parts(err_ptr, err_len, err_cap) };
-    unsafe { Box::from_raw(tracing_dispatch as *mut tracing::Dispatch) };
+    _ = unsafe { Box::from_raw(svc_impl as *mut S) };
+    _ = unsafe { Vec::<u8>::from_raw_parts(arena_ptr, arena_len, arena_cap) };
+    _ = unsafe { Vec::<Out>::from_raw_parts(out_ptr, out_len, out_cap) };
+    _ = unsafe { String::from_raw_parts(err_ptr, err_len, err_cap) };
+    _ = unsafe { Box::from_raw(tracing_dispatch as *mut tracing::Dispatch) };
 }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -238,7 +238,9 @@ pub fn generate_files(
     let mut files = BTreeMap::new();
 
     for row in validations.built_collections.iter() {
-        let Some(validated) = &row.validated else { continue };
+        let Some(validated) = &row.validated else {
+            continue;
+        };
 
         for (url, content) in &validated.generated_files {
             if let Ok(url) = url::Url::parse(&url) {
@@ -408,8 +410,7 @@ where
                     .runtime
                     .clone()
                     .unary_derive(request, CONNECTOR_TIMEOUT)
-                    .await
-                    .map_err(status_to_anyhow)?)
+                    .await?)
             }
         }
         .boxed()

--- a/crates/coroutines/Cargo.toml
+++ b/crates/coroutines/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "coroutines"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+futures-core = { workspace = true }
+pin-project-lite = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+futures = { workspace = true }

--- a/crates/coroutines/src/lib.rs
+++ b/crates/coroutines/src/lib.rs
@@ -1,0 +1,293 @@
+use std::{
+    cell::UnsafeCell,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// Start a coroutine using the provide asynchronous function.
+/// The function is invoked with a Suspend instance through which
+/// the coroutine yields values and receives sent resumption values.
+/// Coroutines can be directly driven via calls to start() and then
+/// resume(), or if it returns (), it may also be accessed as an
+/// instance of futures::Stream.
+pub fn coroutine<Fut, Yield, Resume, Done>(
+    fut: impl FnOnce(Suspend<Yield, Resume>) -> Fut,
+) -> Coroutine<Fut, Yield, Resume>
+where
+    Fut: Future<Output = Done>,
+{
+    let mailbox = Arc::new(Mailbox {
+        yield_: UnsafeCell::new(None),
+        resume: UnsafeCell::new(None),
+    });
+    let fut = fut(Suspend {
+        mailbox: mailbox.clone(),
+    });
+    Coroutine { mailbox, fut }
+}
+
+/// Start a coroutine using the provide asynchronous function,
+/// which must return a Result with Ok(()). The function is
+/// invoked with a Suspend instance through which the coroutine
+/// yields values.
+///
+/// try_coroutine is well suited for creating a `futures::stream::TryStream`.
+/// Unlike `coroutine()`, `try_coroutine()` maps a completion
+/// of the Future with a Result::Error into a corresponding
+/// TryStream Error item.
+pub fn try_coroutine<Fut, Yield, Resume, Error>(
+    fut: impl FnOnce(Suspend<Yield, Resume>) -> Fut,
+) -> TryCoroutine<Fut, Yield, Resume>
+where
+    Fut: Future<Output = Result<(), Error>>,
+{
+    let inner = Arc::new(Mailbox {
+        yield_: UnsafeCell::new(None),
+        resume: UnsafeCell::new(None),
+    });
+    let fut = fut(Suspend {
+        mailbox: inner.clone(),
+    });
+    TryCoroutine {
+        inner: Coroutine {
+            mailbox: inner,
+            fut,
+        },
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// Coroutine is a Future which acts as an asynchronous coroutine,
+    /// yielding values at arbitrary suspension points and resuming
+    /// with sent values.
+    pub struct Coroutine<Fut, Yield, Resume> {
+        mailbox: Arc<Mailbox<Yield, Resume>>,
+        #[pin]
+        fut: Fut,
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// TryCoroutine is a Coroutine whose Future::Output is a Result,
+    /// and maps into a futures::stream::TryStream.
+    pub struct TryCoroutine<Fut, Yield, Resume>{
+        #[pin]
+        inner: Coroutine<Fut, Yield, Resume>
+    }
+}
+
+/// ResumeResult is the result of a Coroutine resumption,
+/// which either yields a value or completes.
+pub enum ResumeResult<Yield, Done> {
+    Yielded(Yield),
+    Done(Done),
+}
+
+/// Suspend is passed by-value into a Coroutine Future,
+/// and is used to suspend the coroutine by yielding a
+/// value and awaiting a received resumption value.
+pub struct Suspend<Yield, Resume> {
+    mailbox: Arc<Mailbox<Yield, Resume>>,
+}
+
+/// Mailbox is shared between a Coroutine, the Suspend passed by-value to its Future.
+/// Though contained by an Arc, these are the only two references allowed to exist.
+struct Mailbox<Yield, Resume> {
+    yield_: UnsafeCell<Option<Yield>>,
+    resume: UnsafeCell<Option<Resume>>,
+}
+
+// Safety: all references to Mailbox are held within Coroutine,
+// either directly or within its owned Future, and are always accessed
+// through polling functions that require &mut self.
+unsafe impl<Y: Send + Sync, R: Send + Sync> Sync for Mailbox<Y, R> {}
+
+impl<Fut, Yield, Resume, Done> Coroutine<Fut, Yield, Resume>
+where
+    Fut: Future<Output = Done>,
+{
+    // Poll the Future of the Coroutine to resume it.
+    // If it yields a value or returns, then this poll completes with its Ready(ResumeResult).
+    fn poll_resume(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ResumeResult<Yield, Done>> {
+        let me = self.project();
+        match me.fut.poll(cx) {
+            Poll::Pending => {
+                // Safety: `me.fut` is the only other reference to the mailbox, and just returned.
+                if let Some(value) = unsafe { (&mut *me.mailbox.yield_.get()).take() } {
+                    Poll::Ready(ResumeResult::Yielded(value))
+                } else {
+                    Poll::Pending
+                }
+            }
+            Poll::Ready(done) => Poll::Ready(ResumeResult::Done(done)),
+        }
+    }
+
+    /// Start this Coroutine, waiting for it to yield its first value or complete.
+    /// NOTE: Calls to start() after the first will never complete.
+    /// Use resume() to resume an already-started Coroutine.
+    pub async fn start(self: &mut Pin<&mut Self>) -> ResumeResult<Yield, Done> {
+        std::future::poll_fn(move |cx| self.as_mut().poll_resume(cx)).await
+    }
+
+    /// Send a value to resume this suspended Coroutine, and wait for it to yield
+    /// its next value or complete.
+    /// NOTE: Calls to resume() an un-started Coroutine will start it,
+    /// but the sent value will be Dropped without ever being received by the Coroutine.
+    pub async fn resume(self: &mut Pin<&mut Self>, value: Resume) -> ResumeResult<Yield, Done> {
+        // Safety: we hold an exclusive &mut Coroutine reference.
+        *unsafe { &mut *self.mailbox.resume.get() } = Some(value);
+        self.start().await
+    }
+}
+
+impl<Yield, Resume> Suspend<Yield, Resume> {
+    /// Suspend this Coroutine by yielding a value and then waiting to receive
+    /// a corresponding resumption value, which is returned.
+    pub async fn yield_(&mut self, yielded: Yield) -> Resume {
+        {
+            // Safety: we are within a polling of the Coroutine future,
+            // which is only possible from a &mut reference, and we hold a &mut reference
+            // to its inner Suspend instance.
+            let cell = unsafe { &mut *self.mailbox.yield_.get() };
+            assert!(
+                cell.is_none(),
+                "yield holds &mut self, so its not possible to call twice without awaiting"
+            );
+            *cell = Some(yielded);
+        }
+
+        std::future::poll_fn(|_| {
+            if let Some(value) = unsafe { (&mut *self.mailbox.resume.get()).take() } {
+                Poll::Ready(value)
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+}
+
+impl<Fut, Yield> futures_core::Stream for Coroutine<Fut, Yield, ()>
+where
+    Fut: Future<Output = ()>,
+{
+    type Item = Yield;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let resume = self.mailbox.resume.get();
+
+        match Self::poll_resume(self, cx) {
+            Poll::Ready(ResumeResult::Yielded(yielded)) => {
+                // Send a resumption now so the Coroutine can be immediately polled again.
+                // Safety: we previously held a &mut Coroutine, and just returned
+                // from polling it (to which we transferred our &mut reference).
+                *unsafe { &mut *resume } = Some(());
+                Poll::Ready(Some(yielded))
+            }
+            Poll::Ready(ResumeResult::Done(())) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// The implementation for TryCoroutine matches a Result::Ok to end-of-stream,
+// but a Result::Err becomes a Stream Item instance.
+impl<Fut, Ok, Error> futures_core::Stream for TryCoroutine<Fut, Ok, ()>
+where
+    Fut: Future<Output = Result<(), Error>>,
+{
+    type Item = Result<Ok, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let resume = self.inner.mailbox.resume.get();
+
+        match Coroutine::<Fut, Ok, ()>::poll_resume(self.project().inner, cx) {
+            Poll::Ready(ResumeResult::Yielded(yielded)) => {
+                // Send a resumption now so the Coroutine can be immediately polled again.
+                // Safety: we previously held a &mut Coroutine, and just returned
+                // from polling it (to which we transferred our &mut reference).
+                *unsafe { &mut *resume } = Some(());
+                Poll::Ready(Some(Ok(yielded)))
+            }
+            Poll::Ready(ResumeResult::Done(Ok(()))) => Poll::Ready(None),
+            Poll::Ready(ResumeResult::Done(Err(error))) => Poll::Ready(Some(Err(error))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::{StreamExt, TryStreamExt};
+
+    #[tokio::test]
+    async fn test_coroutine_yield_and_resume() {
+        let mut cr = std::pin::pin!(coroutine(|mut yielder| async move {
+            let mut i = 1;
+            while let Some(next) = yielder.yield_(i).await {
+                i = next;
+            }
+            i + 1
+        }));
+
+        let ResumeResult::Yielded(foo) = cr.start().await else {
+            unreachable!()
+        };
+        assert_eq!(foo, 1);
+
+        let ResumeResult::Yielded(foo) = cr.resume(Some(foo * 2)).await else {
+            unreachable!()
+        };
+        assert_eq!(foo, 2);
+
+        let ResumeResult::Yielded(foo) = cr.resume(Some(foo * 2)).await else {
+            unreachable!()
+        };
+        assert_eq!(foo, 4);
+
+        let ResumeResult::Done(foo) = cr.resume(None).await else {
+            unreachable!()
+        };
+        assert_eq!(foo, 5);
+    }
+
+    #[tokio::test]
+    async fn test_as_stream() {
+        let stream = coroutine(|mut yielder| async move {
+            () = yielder.yield_(42).await;
+            () = yielder.yield_(52).await;
+            () = yielder.yield_(62).await;
+        });
+
+        let out = stream.collect::<Vec<_>>().await;
+        assert_eq!(out, vec![42, 52, 62]);
+    }
+
+    #[tokio::test]
+    async fn test_as_try_stream_ok() {
+        let stream = try_coroutine(|mut yielder| async move {
+            () = yielder.yield_(42).await;
+            () = yielder.yield_(52).await;
+            () = yielder.yield_(62).await;
+            Ok::<_, bool>(())
+        });
+
+        let out = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(out, vec![42, 52, 62]);
+    }
+
+    #[tokio::test]
+    async fn test_as_try_stream_error() {
+        let stream = try_coroutine(|mut yielder| async move {
+            () = yielder.yield_(42).await;
+            return Err(true);
+        });
+
+        let out = stream.try_collect::<Vec<_>>().await.unwrap_err();
+        assert_eq!(out, true);
+    }
+}

--- a/crates/flowctl/src/generate/mod.rs
+++ b/crates/flowctl/src/generate/mod.rs
@@ -188,7 +188,10 @@ async fn generate_missing_collection_configs(
         spec: models::CollectionDef { derive, .. },
     } = collection;
 
-    let Some(models::Derivation { using, transforms, ..  }) = derive else {
+    let Some(models::Derivation {
+        using, transforms, ..
+    }) = derive
+    else {
         return Ok(Vec::new()); // Not a derivation.
     };
 
@@ -244,8 +247,7 @@ async fn generate_missing_collection_configs(
         },
         build::CONNECTOR_TIMEOUT,
     )
-    .await
-    .map_err(crate::status_to_anyhow)?
+    .await?
     .spec
     .context("connector didn't send expected Spec response")?;
 

--- a/crates/flowctl/src/preview/mod.rs
+++ b/crates/flowctl/src/preview/mod.rs
@@ -157,14 +157,12 @@ impl Preview {
             "preview".to_string(),
         )
         .serve_derive(request_rx)
-        .await
-        .map_err(crate::status_to_anyhow)?;
+        .await?;
 
         let _opened = responses_rx
             .next()
             .await
-            .context("expected Opened, not EOF")?
-            .map_err(crate::status_to_anyhow)?
+            .context("expected Opened, not EOF")??
             .opened
             .context("expected Opened")?;
 
@@ -238,7 +236,7 @@ async fn read_journal(
     mut cancel_rx: broadcast::Receiver<()>,
     journal: broker::JournalSpec,
     transform: usize,
-    mut request_tx: mpsc::Sender<tonic::Result<derive::Request>>,
+    mut request_tx: mpsc::Sender<anyhow::Result<derive::Request>>,
     client: journal_client::Client,
 ) -> anyhow::Result<()> {
     use futures::AsyncBufReadExt;
@@ -290,7 +288,7 @@ async fn read_journal(
 
 async fn tick_flushes(
     mut cancel_rx: broadcast::Receiver<()>,
-    mut request_tx: mpsc::Sender<tonic::Result<derive::Request>>,
+    mut request_tx: mpsc::Sender<anyhow::Result<derive::Request>>,
     flush_interval: Option<&humantime::Duration>,
 ) -> anyhow::Result<()> {
     let period = flush_interval
@@ -344,13 +342,11 @@ async fn output<R>(
     infer_schema: bool,
 ) -> anyhow::Result<Option<serde_json::Value>>
 where
-    R: futures::Stream<Item = tonic::Result<derive::Response>> + Unpin,
+    R: futures::Stream<Item = anyhow::Result<derive::Response>> + Unpin,
 {
     let mut inferred_shape = doc::Shape::nothing();
 
-    while let Some(response) = responses_rx.next().await {
-        let response = response.map_err(crate::status_to_anyhow)?;
-
+    while let Some(response) = responses_rx.try_next().await? {
         let internal = response
             .get_internal()
             .context("failed to decode internal runtime.DeriveResponseExt")?;

--- a/crates/journal-client/Cargo.toml
+++ b/crates/journal-client/Cargo.toml
@@ -26,6 +26,5 @@ serde = { workspace = true }
 async-compression = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
-pin-project = { workspace = true }
 exponential-backoff = { workspace = true }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 async-process = { path = "../async-process" }
 connector-init = { path = "../connector-init"  }
+coroutines = { path = "../coroutines"  }
 derive-sqlite = { path = "../derive-sqlite" }
 doc = { path = "../doc" }
 extractors = { path = "../extractors" }

--- a/crates/runtime/src/derive/combine.rs
+++ b/crates/runtime/src/derive/combine.rs
@@ -1,6 +1,5 @@
-use crate::anyhow_to_status;
 use anyhow::Context;
-use futures::{channel::mpsc, Future, SinkExt, Stream, StreamExt, TryStreamExt};
+use futures::{channel::mpsc, SinkExt, Stream, StreamExt, TryStreamExt};
 use proto_flow::derive::{request, response, Request, Response};
 use proto_flow::flow::{self, collection_spec, CollectionSpec};
 use proto_flow::ops;
@@ -10,283 +9,273 @@ use std::time::SystemTime;
 pub fn adapt_requests<R>(
     _peek_request: &Request,
     request_rx: R,
-) -> anyhow::Result<(impl Stream<Item = tonic::Result<Request>> + Unpin, Backward)>
+) -> anyhow::Result<(impl Stream<Item = anyhow::Result<Request>>, ResponseArgs)>
 where
-    R: Stream<Item = tonic::Result<Request>> + Send + Unpin + 'static,
+    R: Stream<Item = anyhow::Result<Request>>,
 {
-    let (open_tx, open_rx) = mpsc::channel(1);
-    let (flush_tx, flush_rx) = mpsc::channel(1);
+    // Maximum UUID Clock value observed in request::Read documents.
+    let mut max_clock = 0;
+    // Statistics for read documents, passed to the response stream on flush.
+    let mut read_stats: Vec<ops::stats::DocsAndBytes> = Vec::new();
+    // Time at which the current transaction was started.
+    let mut started_at: Option<SystemTime> = None;
+    // Channel for passing request::Open to the response stream.
+    let (mut open_tx, open_rx) = mpsc::channel(1);
+    // Channel for passing statistics to the response stream on request::Flush.
+    let (mut flush_tx, flush_rx) = mpsc::channel(1);
 
-    let mut fwd = Forward {
-        max_clock: 0,
-        read_stats: Vec::new(),
-        started_at: None,
-        open_tx,
-        flush_tx,
-    };
+    let request_rx = coroutines::try_coroutine(move |mut co| async move {
+        let mut request_rx = std::pin::pin!(request_rx);
 
-    Ok((
-        Box::pin(request_rx.and_then(move |request| fwd.on_request(request))),
-        Backward {
-            open_rx,
-            flush_rx,
-            maybe_state: None,
-        },
-    ))
+        while let Some(request) = request_rx.try_next().await? {
+            if let Some(open) = &request.open {
+                // Tell the response loop about the request::Open.
+                // It will inspect it upon a future response::Opened message.
+                open_tx
+                    .feed(open.clone())
+                    .await
+                    .context("failed to send request::Open to response stream")?;
+            } else if let Some(_flush) = &request.flush {
+                // Tell the response loop about our flush statistics.
+                // It will inspect it upon a future response::Flushed message.
+                let flush = (
+                    max_clock,
+                    std::mem::take(&mut read_stats),
+                    started_at.take().unwrap_or_else(|| SystemTime::now()),
+                );
+                flush_tx
+                    .feed(flush)
+                    .await
+                    .context("failed to send request::Flush to response stream")?;
+            } else if let Some(read) = &request.read {
+                // Track start time of the transaction as time of first Read.
+                if started_at.is_none() {
+                    started_at = Some(SystemTime::now());
+                }
+                // Track the largest document clock that we've observed.
+                match &read.uuid {
+                    Some(flow::UuidParts { clock, .. }) if *clock > max_clock => max_clock = *clock,
+                    _ => (),
+                }
+                // Accumulate metrics over reads for our transforms.
+                if read.transform as usize >= read_stats.len() {
+                    read_stats.resize(read.transform as usize + 1, Default::default());
+                }
+                let read_stats = &mut read_stats[read.transform as usize];
+                read_stats.docs_total += 1;
+                read_stats.bytes_total += read.doc_json.len() as u64;
+            }
+
+            co.yield_(request).await; // Forward all requests.
+        }
+        Ok(())
+    });
+
+    Ok((request_rx, ResponseArgs { open_rx, flush_rx }))
 }
 
-struct Forward {
-    flush_tx: mpsc::Sender<(u64, Vec<ops::stats::DocsAndBytes>, SystemTime)>,
-    max_clock: u64,
-    open_tx: mpsc::Sender<request::Open>,
-    read_stats: Vec<ops::stats::DocsAndBytes>,
-    started_at: Option<SystemTime>,
-}
-
-pub struct Backward {
+pub struct ResponseArgs {
     open_rx: mpsc::Receiver<request::Open>,
     flush_rx: mpsc::Receiver<(u64, Vec<ops::stats::DocsAndBytes>, SystemTime)>,
-    maybe_state: Option<State>,
 }
 
-impl Forward {
-    fn on_request(&mut self, request: Request) -> impl Future<Output = tonic::Result<Request>> {
-        // Build an intent to tell the response loop about a request::Open.
-        // The response loop will inspect it upon a future Opened message.
-        let open_intent = request
-            .open
-            .clone()
-            .map(|open| (self.open_tx.clone(), open));
+pub fn adapt_responses<R>(
+    args: ResponseArgs,
+    response_rx: R,
+) -> impl Stream<Item = anyhow::Result<Response>>
+where
+    R: Stream<Item = anyhow::Result<Response>>,
+{
+    let ResponseArgs {
+        mut flush_rx,
+        mut open_rx,
+    } = args;
 
-        if let Some(read) = &request.read {
-            // Track start time of the transaction as time of first Read.
-            if self.started_at.is_none() {
-                self.started_at = Some(SystemTime::now());
-            }
-            // Track the largest document clock that we've observed.
-            match &read.uuid {
-                Some(flow::UuidParts { clock, .. }) if *clock > self.max_clock => {
-                    self.max_clock = *clock
-                }
-                _ => (),
-            }
-            // Accumulate metrics over reads for our transforms.
-            if read.transform as usize >= self.read_stats.len() {
-                self.read_stats
-                    .resize(read.transform as usize + 1, Default::default());
-            }
-            let read_stats = &mut self.read_stats[read.transform as usize];
-            read_stats.docs_total += 1;
-            read_stats.bytes_total += read.doc_json.len() as u64;
-        }
+    // Statistics for documents published by us when draining.
+    let mut drain_stats: ops::stats::DocsAndBytes = Default::default();
+    // Inferred shape of published documents.
+    let mut inferred_shape: doc::Shape = doc::Shape::nothing();
+    // Did `inferred_shape` change during the current transaction?
+    let mut inferred_shape_changed: bool = false;
+    // State of an opened derivation.
+    let mut maybe_opened: Option<Opened> = None;
+    // Statistics for documents published by the wrapped delegate.
+    let mut publish_stats: ops::stats::DocsAndBytes = Default::default();
 
-        // Build an intent to tell the response loop about a request::Flush.
-        // The response loop will inspect it upon a future Flushed message.
-        let flush_intent = request.flush.as_ref().map(|_flush| {
-            (
-                self.flush_tx.clone(),
-                (
-                    self.max_clock,
-                    std::mem::take(&mut self.read_stats),
-                    self.started_at.take().unwrap_or_else(|| SystemTime::now()),
-                ),
-            )
-        });
+    coroutines::try_coroutine(move |mut co| async move {
+        let mut response_rx = std::pin::pin!(response_rx);
 
-        // Async block performing possible blocking sends to open_tx and flush_tx.
-        // Note the returned future doesn't close over a reference to `self`.
-        async move {
-            if let Some((mut tx, item)) = open_intent {
-                tx.send(item)
+        while let Some(response) = response_rx.try_next().await? {
+            if let Some(_opened) = &response.opened {
+                let open = open_rx
+                    .next()
                     .await
-                    .context("failed to send Open to response loop")
-                    .map_err(anyhow_to_status)?;
-            }
-            if let Some((mut tx, item)) = flush_intent {
-                tx.send(item)
+                    .context("failed to receive request::Open from request loop")?;
+
+                maybe_opened = Some(Opened::build(open)?);
+                co.yield_(response).await; // Forward.
+            } else if let Some(published) = &response.published {
+                let opened = maybe_opened
+                    .as_mut()
+                    .context("connector sent Published before Opened")?;
+
+                opened.combine_right(&published)?;
+                publish_stats.docs_total += 1;
+                publish_stats.bytes_total += published.doc_json.len() as u64;
+                // Not forwarded.
+            } else if let Some(_flushed) = &response.flushed {
+                let mut opened = maybe_opened
+                    .take()
+                    .context("connector sent Flushed before Opened")?;
+
+                let (max_clock, read_stats, started_at) = flush_rx
+                    .next()
                     .await
-                    .context("failed to send Flush to response loop")
-                    .map_err(anyhow_to_status)?;
-            }
-            Ok(request)
-        }
-    }
-}
+                    .context("failed to receive on request::Flush from request loop")?;
 
-impl Backward {
-    pub fn adapt_responses<R>(
-        self,
-        inner_response_rx: R,
-    ) -> impl Stream<Item = tonic::Result<Response>>
-    where
-        R: Stream<Item = tonic::Result<Response>> + Send + 'static,
-    {
-        let (mut response_tx, response_rx) = mpsc::channel(crate::CHANNEL_BUFFER);
+                // Drain Combiner into Published responses.
+                let doc::Combiner::Accumulator(accumulator) = opened.combiner else {
+                    unreachable!()
+                };
 
-        // TODO(johnny): We could avoid the spawn by using try_unfold.
-        tokio::spawn(async move {
-            if let Err(err) = self.loop_(inner_response_rx, &mut response_tx).await {
-                _ = response_tx.send(Err(anyhow_to_status(err))).await;
-            }
-        });
+                let mut drainer = accumulator
+                    .into_drainer()
+                    .context("preparing to drain combiner")?;
+                let mut buf = bytes::BytesMut::new();
 
-        response_rx
-    }
+                while let Some(drained) = drainer.next() {
+                    let doc::combine::DrainedDoc {
+                        binding: _, // Always zero.
+                        reduced: _, // Always false.
+                        root,
+                    } = drained?;
 
-    async fn loop_<R>(
-        mut self,
-        inner_response_rx: R,
-        response_tx: &mut mpsc::Sender<tonic::Result<Response>>,
-    ) -> anyhow::Result<()>
-    where
-        R: Stream<Item = tonic::Result<Response>> + Send + 'static,
-    {
-        tokio::pin!(inner_response_rx);
-
-        loop {
-            let mut response = match inner_response_rx.next().await {
-                Some(Ok(response)) => response,
-                None => {
-                    // This may be a clean EOF, or it may be unexpected.
-                    // We don't bother distinguishing here and just forward EOF to our client.
-                    return Ok(());
-                }
-                Some(Err(status)) => {
-                    // Forward terminal error and exit.
-                    let () = response_tx.send(Err(status)).await?;
-                    return Ok(());
-                }
-            };
-
-            let Response {
-                spec: _,
-                validated: _,
-                opened,
-                published,
-                flushed,
-                started_commit: _,
-                internal: _,
-            } = &mut response;
-
-            let forward = match (opened, published, flushed.take()) {
-                (Some(_opened), None, None) => {
-                    let open = self
-                        .open_rx
-                        .next()
-                        .await
-                        .context("connector sent Opened before Open")?;
-
-                    self.maybe_state = Some(State::build(open, self.maybe_state.take())?);
-                    true
-                }
-                (None, Some(published), None) => {
-                    let state = self
-                        .maybe_state
-                        .as_mut()
-                        .context("connector sent Published before Opened")?;
-
-                    state.combine_right(&published)?;
-                    false
-                }
-                (None, None, Some(flushed)) => {
-                    let mut state = self
-                        .maybe_state
-                        .take()
-                        .context("connector sent Flushed before Opened")?;
-
-                    let (max_clock, read_stats, started_at) = self
-                        .flush_rx
-                        .next()
-                        .await
-                        .context("connector sent Flushed before Flush")?;
-
-                    // Drain combiner into Published responses.
-                    let doc::Combiner::Accumulator(accumulator) = state.combiner else { unreachable!() };
-                    let mut drainer = accumulator.into_drainer()?;
-                    let mut buf = bytes::BytesMut::new();
-
-                    while let Some(drained) = drainer.next() {
-                        let doc::combine::DrainedDoc {
-                            binding: _, // Always zero.
-                            reduced: _, // Always false.
-                            root,
-                        } = drained?;
-
-                        let doc_json = serde_json::to_string(&root)
-                            .expect("document serialization cannot fail");
-
-                        state.drain_stats.docs_total += 1;
-                        state.drain_stats.bytes_total += doc_json.len() as u64;
-
-                        let key_packed = doc::Extractor::extract_all_owned(
-                            &root,
-                            &state.key_extractors,
-                            &mut buf,
+                    if inferred_shape.widen_owned(&root) {
+                        doc::shape::limits::enforce_shape_complexity_limit(
+                            &mut inferred_shape,
+                            doc::shape::limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT,
                         );
-                        let partitions_packed = doc::Extractor::extract_all_owned(
-                            &root,
-                            &state.partition_extractors,
-                            &mut buf,
-                        );
-
-                        let published = Response {
-                            published: Some(response::Published { doc_json }),
-                            ..Default::default()
-                        }
-                        .with_internal_buf(&mut buf, |internal| {
-                            internal.published = Some(derive_response_ext::Published {
-                                max_clock,
-                                key_packed,
-                                partitions_packed,
-                            });
-                        });
-
-                        let () = response_tx.feed(Ok(published)).await?;
+                        inferred_shape_changed = true;
                     }
 
-                    // Combiner is drained and ready to accumulate again.
-                    state.combiner = doc::Combiner::Accumulator(drainer.into_new_accumulator()?);
+                    let key_packed =
+                        doc::Extractor::extract_all_owned(&root, &opened.key_extractors, &mut buf);
+                    let partitions_packed = doc::Extractor::extract_all_owned(
+                        &root,
+                        &opened.partition_extractors,
+                        &mut buf,
+                    );
 
-                    // Now send the delegate's Flushed response extended with accumulated stats.
-                    let () = response_tx
-                        .send(Ok(state.flushed(started_at, read_stats, flushed)))
-                        .await?;
+                    let doc_json =
+                        serde_json::to_string(&root).expect("document serialization cannot fail");
+                    drain_stats.docs_total += 1;
+                    drain_stats.bytes_total += doc_json.len() as u64;
 
-                    self.maybe_state = Some(state);
-                    false
+                    let published = Response {
+                        published: Some(response::Published { doc_json }),
+                        ..Default::default()
+                    }
+                    .with_internal_buf(&mut buf, |internal| {
+                        internal.published = Some(derive_response_ext::Published {
+                            max_clock,
+                            key_packed,
+                            partitions_packed,
+                        });
+                    });
+                    co.yield_(published).await;
                 }
-                // Forward everything else.
-                _ => true,
-            };
+                // Combiner is now drained and is ready to accumulate again.
+                opened.combiner = doc::Combiner::Accumulator(drainer.into_new_accumulator()?);
 
-            if forward {
-                let () = response_tx.send(Ok(response)).await?;
+                // Next we build up statistics to yield with our own response::Flushed.
+                let duration = started_at.elapsed().unwrap_or_default();
+
+                let transforms = opened
+                    .transforms
+                    .iter()
+                    .zip(read_stats.into_iter())
+                    .filter_map(|((name, source), read_stats)| {
+                        if read_stats.docs_total == 0 && read_stats.bytes_total == 0 {
+                            None
+                        } else {
+                            Some((
+                                name.clone(),
+                                ops::stats::derive::Transform {
+                                    input: Some(read_stats),
+                                    source: source.clone(),
+                                },
+                            ))
+                        }
+                    })
+                    .collect();
+
+                let stats = ops::Stats {
+                    capture: Default::default(),
+                    derive: Some(ops::stats::Derive {
+                        transforms,
+                        published: maybe_counts(&mut publish_stats),
+                        out: maybe_counts(&mut drain_stats),
+                    }),
+                    interval: None,
+                    materialize: Default::default(),
+                    meta: Some(ops::Meta {
+                        uuid: crate::UUID_PLACEHOLDER.to_string(),
+                    }),
+                    open_seconds_total: duration.as_secs_f64(),
+                    shard: Some(opened.shard.clone()),
+                    timestamp: Some(proto_flow::as_timestamp(started_at)),
+                    txn_count: 1,
+                };
+
+                // Now send the delegate's Flushed response extended with accumulated stats.
+                co.yield_(response.with_internal(|internal| {
+                    internal.flushed = Some(derive_response_ext::Flushed { stats: Some(stats) });
+                }))
+                .await;
+
+                // If the inferred doc::Shape was updated, log it out for continuous schema inference.
+                if inferred_shape_changed {
+                    inferred_shape_changed = false;
+
+                    let serialized = serde_json::to_value(&doc::shape::schema::to_schema(
+                        inferred_shape.clone(),
+                    ))
+                    .expect("shape serialization should never fail");
+
+                    tracing::info!(
+                        schema = ?::ops::DebugJson(serialized),
+                        collection_name = %opened.shard.name,
+                        "inferred schema updated"
+                    );
+                }
+
+                maybe_opened = Some(opened);
+            } else {
+                // All other request types are forwarded.
+                co.yield_(response).await;
             }
         }
-    }
+        Ok(())
+    })
 }
 
-pub struct State {
+pub struct Opened {
     // Combiner of published documents.
     combiner: doc::Combiner,
-    // Key components of derived documents.
-    key_extractors: Vec<doc::Extractor>,
     // JSON pointer to the derived document UUID.
     document_uuid_ptr: Option<doc::Pointer>,
+    // Key components of derived documents.
+    key_extractors: Vec<doc::Extractor>,
     // Partitions to extract when draining the Combiner.
     partition_extractors: Vec<doc::Extractor>,
-    // Statistics for published documents.
-    publish_stats: ops::stats::DocsAndBytes,
-    // Statistics for published documents.
-    drain_stats: ops::stats::DocsAndBytes,
-    // Ordered transform (transform-name, source-collection).
-    transforms: Vec<(String, String)>,
     // Shard of this derivation.
     shard: ops::ShardRef,
+    // Ordered transform (transform-name, source-collection).
+    transforms: Vec<(String, String)>,
 }
 
-impl State {
-    pub fn build(open: request::Open, _prev: Option<State>) -> anyhow::Result<State> {
+impl Opened {
+    pub fn build(open: request::Open) -> anyhow::Result<Opened> {
         let request::Open {
             collection,
             range,
@@ -359,13 +348,11 @@ impl State {
 
         Ok(Self {
             combiner,
-            key_extractors,
             document_uuid_ptr,
+            key_extractors,
             partition_extractors,
-            publish_stats: Default::default(),
-            drain_stats: Default::default(),
+            shard: shard,
             transforms,
-            shard: shard.into(),
         })
     }
 
@@ -392,65 +379,7 @@ impl State {
         }
         memtable.add(0, doc, false)?;
 
-        self.publish_stats.docs_total += 1;
-        self.publish_stats.bytes_total += published.doc_json.len() as u64;
-
         Ok(())
-    }
-
-    pub fn flushed(
-        &mut self,
-        started_at: std::time::SystemTime,
-        read_stats: Vec<ops::stats::DocsAndBytes>,
-        flushed: response::Flushed,
-    ) -> Response {
-        let duration = started_at.elapsed().unwrap_or_default();
-
-        let transforms = self
-            .transforms
-            .iter()
-            .zip(read_stats.into_iter())
-            .filter_map(|((name, source), read_stats)| {
-                if read_stats.docs_total == 0 && read_stats.bytes_total == 0 {
-                    None
-                } else {
-                    Some((
-                        name.clone(),
-                        ops::stats::derive::Transform {
-                            input: Some(read_stats),
-                            source: source.clone(),
-                        },
-                    ))
-                }
-            })
-            .collect();
-
-        // Extend Flushed response with our output stats.
-        let stats = ops::Stats {
-            meta: Some(ops::Meta {
-                uuid: crate::UUID_PLACEHOLDER.to_string(),
-            }),
-            shard: Some(self.shard.clone()),
-            timestamp: Some(proto_flow::as_timestamp(started_at)),
-            open_seconds_total: duration.as_secs_f64(),
-            txn_count: 1,
-            capture: Default::default(),
-            derive: Some(ops::stats::Derive {
-                transforms,
-                published: maybe_counts(&mut self.publish_stats),
-                out: maybe_counts(&mut self.drain_stats),
-            }),
-            materialize: Default::default(),
-            interval: None,
-        };
-
-        Response {
-            flushed: Some(flushed),
-            ..Default::default()
-        }
-        .with_internal(|internal| {
-            internal.flushed = Some(derive_response_ext::Flushed { stats: Some(stats) });
-        })
     }
 }
 

--- a/crates/runtime/src/derive/mod.rs
+++ b/crates/runtime/src/derive/mod.rs
@@ -13,14 +13,12 @@ mod image;
 mod local;
 mod rocksdb;
 
-pub type BoxStream = futures::stream::BoxStream<'static, tonic::Result<Response>>;
-
 #[tonic::async_trait]
 impl<H> proto_grpc::derive::connector_server::Connector for Runtime<H>
 where
     H: Fn(&ops::Log) + Send + Sync + Clone + 'static,
 {
-    type DeriveStream = BoxStream;
+    type DeriveStream = futures::stream::BoxStream<'static, tonic::Result<Response>>;
 
     async fn derive(
         &self,
@@ -31,9 +29,17 @@ where
             .get::<tonic::transport::server::UdsConnectInfo>();
         tracing::debug!(?request, ?conn_info, "started derive request");
 
-        let response_rx = self.clone().serve_derive(request.into_inner()).await?;
+        let request_rx = crate::stream_status_to_error(request.into_inner());
 
-        Ok(tonic::Response::new(response_rx))
+        let response_rx = self
+            .clone()
+            .serve_derive(request_rx)
+            .await
+            .map_err(crate::anyhow_to_status)?;
+
+        Ok(tonic::Response::new(
+            crate::stream_error_to_status(response_rx).boxed(),
+        ))
     }
 }
 
@@ -41,15 +47,18 @@ impl<H> Runtime<H>
 where
     H: Fn(&ops::Log) + Send + Sync + Clone + 'static,
 {
-    pub async fn serve_derive<In>(self, request_rx: In) -> tonic::Result<BoxStream>
+    pub async fn serve_derive<In>(
+        self,
+        request_rx: In,
+    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<Response>> + Send>
     where
-        In: futures::Stream<Item = tonic::Result<Request>> + Send + Unpin + 'static,
+        In: Stream<Item = anyhow::Result<Request>> + Send + Unpin + 'static,
     {
         let mut request_rx = request_rx.peekable();
 
         let mut peek_request = match Pin::new(&mut request_rx).peek().await {
             Some(Ok(peek)) => peek.clone(),
-            Some(Err(status)) => return Err(status.clone()),
+            Some(Err(_status)) => return Err(request_rx.try_next().await.unwrap_err()),
             None => return Ok(futures::stream::empty().boxed()),
         };
         let (endpoint, _) = extract_endpoint(&mut peek_request).map_err(crate::anyhow_to_status)?;
@@ -98,16 +107,16 @@ where
                 );
 
                 // Response interceptor for stateful RocksDB storage.
-                let response_rx = rocks_back.adapt_responses(response_rx);
+                let response_rx = rocksdb::adapt_responses(rocks_back, response_rx);
                 // Response interceptor for combining over documents.
-                let response_rx = combine_back.adapt_responses(response_rx);
+                let response_rx = combine::adapt_responses(combine_back, response_rx);
 
                 response_rx.boxed()
             }
             models::DeriveUsing::Local(_) if !self.allow_local => {
-                return Err(tonic::Status::failed_precondition(
+                Err(tonic::Status::failed_precondition(
                     "Local connectors are not permitted in this context",
-                ))
+                ))?
             }
             models::DeriveUsing::Local(_) => {
                 // Request interceptor for stateful RocksDB storage.
@@ -118,9 +127,9 @@ where
                 let response_rx = local::connector(self.log_handler, request_rx);
 
                 // Response interceptor for stateful RocksDB storage.
-                let response_rx = rocks_back.adapt_responses(response_rx);
+                let response_rx = rocksdb::adapt_responses(rocks_back, response_rx);
                 // Response interceptor for combining over documents.
-                let response_rx = combine_back.adapt_responses(response_rx);
+                let response_rx = combine::adapt_responses(combine_back, response_rx);
 
                 response_rx.boxed()
             }
@@ -129,7 +138,7 @@ where
                 let response_rx = ::derive_sqlite::connector(&peek_request, request_rx)?;
 
                 // Response interceptor for combining over documents.
-                let response_rx = combine_back.adapt_responses(response_rx);
+                let response_rx = combine::adapt_responses(combine_back, response_rx);
 
                 response_rx.boxed()
             }
@@ -143,12 +152,18 @@ where
 fn adjust_log_level<R>(
     request_rx: R,
     set_log_level: Option<Arc<dyn Fn(ops::log::Level) + Send + Sync>>,
-) -> impl Stream<Item = tonic::Result<Request>>
+) -> impl Stream<Item = anyhow::Result<Request>>
 where
-    R: Stream<Item = tonic::Result<Request>> + Send + 'static,
+    R: Stream<Item = anyhow::Result<Request>> + Send + 'static,
 {
     request_rx.inspect_ok(move |request| {
-        let Ok(DeriveRequestExt{labels: Some(ops::ShardLabeling { log_level, .. }), ..}) = request.get_internal() else { return };
+        let Ok(DeriveRequestExt {
+            labels: Some(ops::ShardLabeling { log_level, .. }),
+            ..
+        }) = request.get_internal()
+        else {
+            return;
+        };
 
         if let (Some(log_level), Some(set_log_level)) =
             (ops::log::Level::from_i32(log_level), &set_log_level)

--- a/ops-catalog/schema-inference.flow.yaml
+++ b/ops-catalog/schema-inference.flow.yaml
@@ -9,19 +9,17 @@ collections:
         - name: logs
           source:
             name: ops.us-central1.v1/logs
+            notBefore: 2023-10-01T00:00:00Z
             partitions:
               include:
                 kind:
                   - capture
+                  - derivation
               exclude:
                 name:
                   # Don't read our own inferences.
                   - ops.us-central1.v1/inferred-schemas/L1
                   - ops.us-central1.v1/inferred-schemas/L2
-
-                  # NOTE(johnny): In production, I've temporarily held back
-                  # a number of other task logs for $reasons. Do not publish
-                  # directly from ./ops-catalog/ into production quite yet.
 
           shuffle:
             key: [/shard/name] # Use partition-based shuffle.


### PR DESCRIPTION
Add a `coroutine` crate to enhance the ergonomics of writing complex stream transformations in Rust.

Begin refactors of the `runtime` crate to use them, and begin transitioning to `anyhow::Result` as the primary stream item type.

Add inferred schema shape tracking, widening, and logging for derivations.

See individual commits for more detail.

Testing:
 - End to end on a local stack to verify derivation inference
 - With `flowctl preview` of high-volume production derivations (wikipedia sampled)
 
**Workflow steps:**

Derivations automatically produce inferred schemas.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1220)
<!-- Reviewable:end -->
