### PR TITLE
docs: add update delay and resource-level schema to sql materializations

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -70,12 +70,14 @@ For a complete introduction to resource organization in Bigquery, see the [BigQu
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
 | **`/project_id`**| Project ID | The project ID for the Google Cloud Storage bucket and BigQuery dataset.| String | Required |
-| `/billing_project_id` | Billing project ID | The project ID to which these operations are billed in BigQuery. Typically, you want this to be the same as `project_id` (the default). | String | Same as `project_id` |
-| **`/dataset`** | Dataset | Name of the target BigQuery dataset. | String | Required |
+| **`/credentials_json`** | Service Account JSON | The JSON credentials of the service account to use for authorization. | String | Required |
 | **`/region`** | Region | The GCS region. | String | Required |
+| **`/dataset`** | Dataset | BigQuery dataset for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables. | String | Required |
 | **`/bucket`** | Bucket | Name of the GCS bucket. | String | Required |
 | `/bucket_path` | Bucket path | Base path within the GCS bucket. Also called "Folder" in the GCS console. | String | |
-| **`/credentials_json`** | Service Account JSON | The JSON credentials of the service account to use for authorization. | String | Required |
+| `/billing_project_id` | Billing project ID | The project ID to which these operations are billed in BigQuery. Typically, you want this to be the same as `project_id` (the default). | String | Same as `project_id` |
+| `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
+| `/advanced/updateDelay`     | Update Delay    | Potentially reduce compute time by increasing the delay between updates. Defaults to 30 minutes if unset. | string  |  |
 
 To learn more about project billing, [see the BigQuery docs](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled).
 
@@ -83,7 +85,8 @@ To learn more about project billing, [see the BigQuery docs](https://cloud.googl
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/table`** | Table | Table name. | string | Required |
+| **`/table`** | Table | Table in the BigQuery dataset to store materialized result in." | string | Required |
+| `/dataset` | Table | Alternative dataset for this table. Must be located in the region set in the endpoint configuration. | string |  |
 | `/delta_updates` | Delta updates. | Whether to use standard or [delta updates](#delta-updates) | boolean | false |
 
 ### Sample

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -92,7 +92,7 @@ Use the below properties to configure a Snowflake materialization, which will di
 | **`/host`** | Host URL | The Snowflake Host used for the connection. Example: orgname-accountname.snowflakecomputing.com (do not include the protocol). | string | Required |
 | **`/password`** | Password | Snowflake user password | string | Required |
 | `/role` | Role | Role assigned to the user | string |  |
-| **`/schema`** | Schema | Snowflake schema within the database to which to materialize | string | Required |
+| **`/schema`** | Schema | Database schema for bound collection tables (unless overridden within the binding resource configuration) as well as associated materialization metadata tables | string | Required |
 | **`/user`** | User | Snowflake username | string | Required |
 | `/warehouse` | Warehouse | Name of the data warehouse that contains the database | string |  |
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
@@ -102,8 +102,9 @@ Use the below properties to configure a Snowflake materialization, which will di
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean |  |
 | **`/table`** | Table | Table name | string | Required |
+| `/schema` | Alternative Schema | Alternative schema for this table | string |  |
+| `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean |  |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-redshift.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-redshift.md
@@ -49,7 +49,8 @@ more of your Flow collections to your desired tables in the database.
 | **`/bucket`**             | S3 Staging Bucket | Name of the S3 bucket to use for staging data loads.                                                                                                             | string | Required         |
 | **`/region`**             | Region            | Region of the S3 staging bucket. For optimal performance this should be in the same region as the Redshift database cluster.                                     | string | Required         |
 | `/bucketPath`             | Bucket Path       | A prefix that will be used to store objects in S3.                                                                                                               | string |                  |
-
+| `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
+| `/advanced/updateDelay`     | Update Delay    | Potentially reduce active cluster time by increasing the delay between updates. Defaults to 30 minutes if unset. | string  |  |
 
 #### Bindings
 


### PR DESCRIPTION
**Description:**

Adds resource-level schema configuration (or equivalent) to `materialize-snowflake` and `materialize-bigquery`, and also adds the `advanced: updateDelay` configuration where it was missing.

See https://github.com/estuary/connectors/pull/992 and https://github.com/estuary/connectors/pull/980

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

