### PR TITLE
docs: instructions on building flowctl from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ ${RUSTBIN}/agent:
 	cargo build --release --locked -p agent
 
 .PHONY: ${RUSTBIN}/flowctl
-${RUSTBIN}/flowctl:
+flow-cli: ${RUSTBIN}/flowctl
 	cargo build --release --locked -p flowctl
 
 # Statically linked binaries using MUSL:

--- a/crates/flowctl/README.md
+++ b/crates/flowctl/README.md
@@ -55,3 +55,21 @@ flowctl draft create
 flowctl draft author --source ~/estuary/flow/examples/citi-bike/flow.yaml
 flowctl draft publish
 ```
+
+## Building from source
+
+First, make sure have rust installed.
+
+```
+make flow-cli
+```
+
+Now the binary is available at `target/release/flowctl`.
+
+Note that if you are using a recent version of git with `index.skipHash` enabled you may need to set this value to false in order to build. To fix this, without any changes in your local staging, run:
+
+```shell
+git config index.skipHash false
+rm .git/index
+git reset --hard
+```


### PR DESCRIPTION
**Description:**
Add documentation + associated make command to easily build flowctl from source.

**Workflow steps:**

`make flow-cli`

**Documentation links affected:**
N/A

**Notes for reviewers:**
Not sure the `skipHash` issue is a more global issue and should be documented elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1227)
<!-- Reviewable:end -->
