### PR TITLE
fix: `combined_grants_ext` already shows only the authorized user's grants, no need to filter by `user_id`

### DIFF
--- a/supabase/functions/billing/index.ts
+++ b/supabase/functions/billing/index.ts
@@ -39,7 +39,7 @@ serve(async (req) => {
                 throw new Error("User not found");
             }
 
-            const grants = await supabaseClient.from("combined_grants_ext").select("*").eq("capability", "admin").eq("user_id", user.id);
+            const grants = await supabaseClient.from("combined_grants_ext").select("*").eq("capability", "admin");
 
             if (!(grants.data ?? []).find((grant) => grant.object_role === requested_tenant)) {
                 res = [JSON.stringify({ error: `Not authorized to requested grant` }), {


### PR DESCRIPTION
Problem is, `user_id` is null when showing grants that come from `role_grants`, such as `estuary_support`/.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1228)
<!-- Reviewable:end -->
