### PR TITLE
Adding in what tenant was being fetched with the payment

### DIFF
--- a/supabase/functions/billing/get_tenant_payment_methods.ts
+++ b/supabase/functions/billing/get_tenant_payment_methods.ts
@@ -12,12 +12,20 @@ export async function getTenantPaymentMethods(
     if (customer) {
         const methods = (await StripeClient.customers.listPaymentMethods(customer.id)).data;
 
-        return [JSON.stringify({ payment_methods: methods, primary: customer.invoice_settings.default_payment_method }), {
+        return [JSON.stringify({ 
+            payment_methods: methods,
+            primary: customer.invoice_settings.default_payment_method,
+            tenant: req_body.tenant
+        }), {
             headers: { "Content-Type": "application/json" },
             status: 200,
         }];
     } else {
-        return [JSON.stringify({ payment_methods: [], primary: null }), {
+        return [JSON.stringify({ 
+            payment_methods: [],
+            primary: null,
+            tenant: req_body.tenant
+        }), {
             headers: { "Content-Type": "application/json" },
             status: 200,
         }];


### PR DESCRIPTION
**Description:**

To make life easy on the UI we are not passing back what tenant was used when getting the payment methods.

**Workflow steps:**
N/A

**Documentation links affected:**
N/A

**Notes for reviewers:**
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1229)
<!-- Reviewable:end -->
