### PR TITLE
Add `pays_externally` flag to tenants

### DIFF
--- a/supabase/migrations/34_tenants_pay_externally.sql
+++ b/supabase/migrations/34_tenants_pay_externally.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table tenants add column "pays_externally" boolean default false;
+
+commit;

--- a/supabase/migrations/34_tenants_pay_externally.sql
+++ b/supabase/migrations/34_tenants_pay_externally.sql
@@ -1,5 +1,14 @@
 begin;
 
-alter table tenants add column "pays_externally" boolean default false;
+create type payment_provider_type as enum (
+  'stripe',
+  'external'
+);
+
+comment on type payment_provider_type is '
+Enumeration of which payment provider this tenant is using.
+';
+
+alter table tenants add column "payment_provider" payment_provider_type default 'stripe';
 
 commit;


### PR DESCRIPTION
**Description:**

This allows us to flag tenants that pay outside of Stripe (or whatever payment system we might use in the future). We shouldn't show these tenants billing alerts in the UI because it's expected that they won't have billing information entered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1232)
<!-- Reviewable:end -->
