### PR TITLE
doc: defer validation of reduced documents on spill

### DIFF
--- a/crates/doc/tests/spill_merge_fuzz.rs
+++ b/crates/doc/tests/spill_merge_fuzz.rs
@@ -55,7 +55,7 @@ fn run_sequence(seq: Vec<(u8, u8, bool)>) -> Result<(), FuzzError> {
     );
 
     let mut spill = combine::SpillWriter::new(std::io::Cursor::new(Vec::new())).unwrap();
-    let chunk_target = (1 << 20)..(1 << 21);
+    let chunk_target = 1 << 20;
     let mut memtable = combine::MemTable::new(spec);
     let mut expect = BTreeMap::new();
 
@@ -63,7 +63,7 @@ fn run_sequence(seq: Vec<(u8, u8, bool)>) -> Result<(), FuzzError> {
     for (i, (seq_key, seq_value, mut is_reduce)) in seq.into_iter().enumerate() {
         // Produce an empirically reasonable number of spills, given quickcheck's defaults.
         if i % 15 == 0 {
-            let spec = memtable.spill(&mut spill, chunk_target.clone()).unwrap();
+            let spec = memtable.spill(&mut spill, chunk_target).unwrap();
             memtable = combine::MemTable::new(spec);
         }
 
@@ -96,7 +96,7 @@ fn run_sequence(seq: Vec<(u8, u8, bool)>) -> Result<(), FuzzError> {
     }
 
     // Spill final MemTable and begin to drain.
-    let spec = memtable.spill(&mut spill, chunk_target.clone()).unwrap();
+    let spec = memtable.spill(&mut spill, chunk_target).unwrap();
     let (spill, ranges) = spill.into_parts();
     let drainer = combine::SpillDrainer::new(spec, spill, &ranges).unwrap();
 


### PR DESCRIPTION
Typically such documents will be reduced with another document, meaning that a validation-on-spill is wasted work because we'll need to re-validate the reduced output.

Cleanup CHUNK_TARGET_SIZE range which no longer had meaning as a range. No functional changes here, this is just a cleanup.

Add new tests of MemTable::spill and SpillDrainer covering validation of reduced and !reduced documents.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1239)
<!-- Reviewable:end -->
