### PR TITLE
control-plane: change authz grants of unchanged_draft_specs view

### DIFF
--- a/supabase/migrations/36_prune_unchanged_draft_specs.sql
+++ b/supabase/migrations/36_prune_unchanged_draft_specs.sql
@@ -100,7 +100,7 @@ create view unchanged_draft_specs as
       -- or the inferred schema hasn't changed since the last publication
       or inferred_schema_md5 is not distinct from live_inferred_schema_md5
     );
-alter view unchanged_draft_specs owner to authenticated;
+grant select on unchanged_draft_specs to authenticated;
 comment on view unchanged_draft_specs is
   'View of `draft_specs_ext` that is filtered to only include specs that are identical to the
  current `live_specs`. For collection specs that use schema inference, this will only include


### PR DESCRIPTION
**Description:**

Initially, the `unchanged_draft_specs` view was written as being owned by the `authenticated` role in postgres, to ensure that it always used the RLS policies of the caller. But Supabase has revoked the `superuser` attribute of the `postgres` role and no longer provides a way to authenticate as a superuser. This means that `alter view ... set owner to authenticated` no longer works because `authenticated` does not have the necessary permission to create a view. See [this thread](https://github.com/orgs/supabase/discussions/9314) for more.

In this case, we're able to work around this by granting select permission to the `authenticated` role. This works because both `draft_specs_ext` and `live_specs_ext` perform their own enforcement of authZ, so it's safe to bypass RLS.

Also changes the name of the migration to fix a conflict.

**Workflow steps:**

I re-tested authZ of the view by:

- create `aliceCo/` tenant and create a hello-world capture
- start editing that capture and hit the re-fresh button
- confirm that there's 2 rows in `unchanged_draft_specs`
- create `bobCo/` tenant and repeat the above steps
- confirm that there's 4 rows in `unchanged_draft_specs` when querying as superuser, but only 2 rows when using `flowctl raw get` to query as alice or bob.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1246)
<!-- Reviewable:end -->
