### PR TITLE
agent: fix panic on collection deletion

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -160,7 +160,7 @@ pub async fn add_inferred_schema_md5(
     sqlx::query!(
         r#"
         update live_specs set inferred_schema_md5 = $1
-        where id = $2 and spec_type = 'collection'
+        where id = $2
         returning 1 as "must_exist"
         "#,
         inferred_schema_md5 as Option<String>,


### PR DESCRIPTION
**Description:**

When deleting a collection, the `add_inferred_schema_md5` function is still called. This panics because that function included a condition on `spec_type = 'collection'`, which is no longer true for collections being deleted. This results in panic because we explicitly expect one row to always be updated. This removes the condition, so that the live spec is updated by id only.

**Workflow steps:**

This bug can be reproduced by deleting any collection spec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1247)
<!-- Reviewable:end -->
