### PR TITLE
doc: make LazyNode::Heap and reduction by-reference

### DIFF
--- a/crates/doc/src/bump_str.rs
+++ b/crates/doc/src/bump_str.rs
@@ -5,6 +5,9 @@ use std::{fmt, mem, ops, ptr::NonNull};
 /// as a leading u32 of a pointed-to allocated memory region.
 /// This is unlike Rust's "fat" &str reference which includes the
 /// length within the reference handle (see test_sizes()).
+// BumpStr doesn't provide mutable access to its backing memory,
+// and is trivially copy-safe.
+#[derive(Copy, Clone)]
 pub struct BumpStr<'alloc> {
     ptr: NonNull<u8>,
     marker: std::marker::PhantomData<&'alloc str>,

--- a/crates/doc/src/bump_vec.rs
+++ b/crates/doc/src/bump_vec.rs
@@ -28,11 +28,6 @@ struct RawVec<T> {
     data: [T],
 }
 
-pub struct IntoIter<'alloc, T> {
-    inner: BumpVec<'alloc, T>,
-    next: u32,
-}
-
 impl<'alloc, T> BumpVec<'alloc, T> {
     pub fn new() -> Self {
         Self {
@@ -45,20 +40,29 @@ impl<'alloc, T> BumpVec<'alloc, T> {
         if capacity == 0 {
             return Self::new(); // Don't allocate an empty array.
         }
+        Self {
+            ptr: Some(Self::allocate_inline(capacity, alloc).0),
+            marker: Default::default(),
+        }
+    }
 
-        // Allocate space for a RawVec with the correct size and alignment.
-        let (size_of_elem, size_of_header, align) = Self::sizes();
-        let size = size_of_header + capacity.checked_mul(size_of_elem).expect("too large");
-        let layout = unsafe { std::alloc::Layout::from_size_align_unchecked(size, align) };
-        let ptr = alloc.alloc_layout(layout);
+    pub fn with_contents<I>(alloc: &'alloc bumpalo::Bump, iter: I) -> Self
+    where
+        I: ExactSizeIterator<Item = T>,
+    {
+        if iter.len() == 0 {
+            return Self::new();
+        }
+        let (ptr, raw) = Self::allocate_inline(iter.len(), alloc);
 
-        // Initialize the allocated RawVec.
-        let raw =
-            unsafe { std::mem::transmute::<(NonNull<u8>, usize), &mut RawVec<T>>((ptr, capacity)) };
-
-        raw.cap = u32::try_from(capacity).expect("capacity is too large");
-        raw.len = 0;
-        // raw.data is left uninitialized.
+        for value in iter {
+            // Safety: we just allocated this memory to the exact size of this iterator.
+            unsafe {
+                let end = raw.data.as_mut_ptr().add(raw.len as usize);
+                ptr::write(end, value);
+                raw.len += 1;
+            }
+        }
 
         Self {
             ptr: Some(ptr),
@@ -66,15 +70,27 @@ impl<'alloc, T> BumpVec<'alloc, T> {
         }
     }
 
-    #[inline]
-    pub fn as_slice(&self) -> &[T] {
+    pub fn len(&self) -> usize {
+        match self.raw() {
+            Some(raw) => raw.len as usize,
+            None => 0,
+        }
+    }
+
+    pub fn cap(&self) -> usize {
+        match self.raw() {
+            Some(raw) => raw.cap as usize,
+            None => 0,
+        }
+    }
+
+    pub fn as_slice(&self) -> &'alloc [T] {
         match self.raw() {
             Some(raw) => &raw.data[..raw.len as usize],
             None => &[],
         }
     }
 
-    #[inline]
     pub fn push(&mut self, value: T, alloc: &'alloc bumpalo::Bump) {
         let raw = match self.raw() {
             Some(raw) if raw.len != raw.cap => raw,
@@ -144,47 +160,54 @@ impl<'alloc, T> BumpVec<'alloc, T> {
         ret
     }
 
-    #[inline]
-    pub fn len(&self) -> usize {
-        match self.raw() {
-            Some(raw) => raw.len as usize,
-            None => 0,
-        }
-    }
-
-    #[inline]
-    pub fn cap(&self) -> usize {
-        match self.raw() {
-            Some(raw) => raw.cap as usize,
-            None => 0,
-        }
-    }
-
     pub fn extend<I: Iterator<Item = T>>(&mut self, it: I, alloc: &'alloc bumpalo::Bump) {
         for value in it {
             self.push(value, alloc)
         }
     }
 
-    pub fn into_iter(self) -> IntoIter<'alloc, T> {
-        IntoIter {
-            inner: self,
-            next: 0,
-        }
+    // Allocate space for a RawVec with the correct size and alignment.
+    fn allocate(capacity: usize, alloc: &'alloc bumpalo::Bump) -> (NonNull<u8>, &mut RawVec<T>) {
+        Self::allocate_inline(capacity, alloc)
     }
 
-    #[inline]
+    #[inline(always)]
+    fn allocate_inline(
+        capacity: usize,
+        alloc: &'alloc bumpalo::Bump,
+    ) -> (NonNull<u8>, &mut RawVec<T>) {
+        let cap = u32::try_from(capacity).expect("capacity is too large");
+        let (size_of_elem, size_of_header, align) = Self::sizes();
+        let size = size_of_header + capacity * size_of_elem; // Cannot overflow (cap is u32).
+
+        // Safety: we know `align` is a non-zero power of two, and capacity fits within u32.
+        // Using unchecked has a small, persistent effect in benchmarks.
+        let layout = unsafe { std::alloc::Layout::from_size_align_unchecked(size, align) };
+        let ptr = alloc.alloc_layout(layout);
+
+        // Initialize the allocated RawVec by building a "fat" reference to the !Sized RawVec.
+        // Fat references include the length of the pointed-to slice.
+        let raw =
+            unsafe { std::mem::transmute::<(NonNull<u8>, usize), &mut RawVec<T>>((ptr, capacity)) };
+
+        raw.cap = cap;
+        raw.len = 0;
+        // raw.data is left uninitialized.
+
+        (ptr, raw)
+    }
+
     fn raw(&self) -> Option<&'alloc mut RawVec<T>> {
         let Some(ptr) = self.ptr else {
             return None;
         };
         unsafe {
-            // We know that the allocated slice capacity is a leading u32.
-            let len = std::mem::transmute::<NonNull<u8>, &u32>(ptr);
-            // Construct a "fat" pointer using the "thin" pointer and length.
+            // We know that the allocated slice capacity is the first u32 of RawVec.
+            let cap = std::mem::transmute::<NonNull<u8>, &u32>(ptr);
+            // Recover a "fat" reference to the !Sized RawVec which includes its capacity.
             let raw = std::mem::transmute::<(NonNull<u8>, usize), &'alloc mut RawVec<T>>((
                 ptr,
-                *len as usize,
+                *cap as usize,
             ));
             Some(raw)
         }
@@ -192,12 +215,13 @@ impl<'alloc, T> BumpVec<'alloc, T> {
 
     fn grow(&mut self, additional: u32, alloc: &'alloc bumpalo::Bump) -> &mut RawVec<T> {
         let Some(src) = self.raw() else {
-            *self = Self::with_capacity_in(cmp::max(additional, 4) as usize, alloc);
-            return self.raw().unwrap();
+            let (ptr, raw) = Self::allocate(cmp::max(additional, 4) as usize, alloc);
+            self.ptr = Some(ptr);
+            return raw;
         };
 
-        *self = Self::with_capacity_in(cmp::max(additional, 2 * src.cap) as usize, alloc);
-        let dst = self.raw().unwrap();
+        let (ptr, dst) = Self::allocate(cmp::max(additional, 2 * src.cap) as usize, alloc);
+        self.ptr = Some(ptr);
 
         unsafe {
             ptr::copy(
@@ -237,14 +261,12 @@ impl<'alloc, T> BumpVec<'alloc, T> {
 impl<'alloc, T> ops::Deref for BumpVec<'alloc, T> {
     type Target = [T];
 
-    #[inline]
     fn deref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
 impl<'alloc, T> ops::DerefMut for BumpVec<'alloc, T> {
-    #[inline]
     fn deref_mut(&mut self) -> &mut [T] {
         match self.raw() {
             Some(raw) => &mut raw.data[..raw.len as usize],
@@ -255,45 +277,20 @@ impl<'alloc, T> ops::DerefMut for BumpVec<'alloc, T> {
 
 impl<'alloc, T: Copy> BumpVec<'alloc, T> {
     pub fn from_slice(slice: &[T], alloc: &'alloc bumpalo::Bump) -> Self {
-        let v = Self::with_capacity_in(slice.len(), alloc);
-
-        let raw = v.raw().unwrap();
+        let (ptr, raw) = Self::allocate_inline(slice.len(), alloc);
         raw.data.copy_from_slice(slice);
         raw.len = raw.cap;
 
-        v
+        Self {
+            ptr: Some(ptr),
+            marker: Default::default(),
+        }
     }
 }
 
 impl<'alloc, T: fmt::Debug> fmt::Debug for BumpVec<'alloc, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_slice().fmt(f)
-    }
-}
-
-impl<'alloc, T> Iterator for IntoIter<'alloc, T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let Some(raw) = self.inner.raw() else {
-            return None;
-        };
-
-        if raw.len == self.next {
-            return None;
-        }
-
-        let ret;
-        unsafe {
-            // The place we are taking from.
-            let ptr = raw.data.as_mut_ptr().add(self.next as usize);
-            // Copy it out, unsafely having a copy of the value on
-            // the stack and in the vector at the same time.
-            ret = ptr::read(ptr);
-        }
-        self.next += 1;
-
-        Some(ret)
     }
 }
 
@@ -349,7 +346,7 @@ mod test {
         assert_eq!(b.as_slice(), &[9, 0, 3, 5, 7, 6, 8]);
 
         // We can convert BumpVec into an Iterator.
-        let v = b.into_iter().collect::<Vec<_>>();
+        let v = b.iter().copied().collect::<Vec<_>>();
         assert_eq!(v.as_slice(), &[9, 0, 3, 5, 7, 6, 8]);
     }
 

--- a/crates/doc/src/combine/memtable.rs
+++ b/crates/doc/src/combine/memtable.rs
@@ -101,9 +101,9 @@ impl Entries {
                 let next = queued.next().unwrap();
                 (cur.root, cur.reduced) = super::smash(
                     alloc,
-                    LazyNode::Heap(cur.root),
+                    LazyNode::Heap(&cur.root),
                     cur.reduced,
-                    LazyNode::Heap(next.root),
+                    LazyNode::Heap(&next.root),
                     next.reduced,
                     schema.as_ref(),
                     validator,
@@ -116,9 +116,9 @@ impl Entries {
                 let prev = sorted.next().unwrap();
                 (cur.root, cur.reduced) = super::smash(
                     alloc,
-                    LazyNode::Heap(prev.root),
+                    LazyNode::Heap(&prev.root),
                     prev.reduced,
-                    LazyNode::Heap(cur.root),
+                    LazyNode::Heap(&cur.root),
                     cur.reduced,
                     schema.as_ref(),
                     validator,
@@ -337,9 +337,9 @@ impl Iterator for MemDrainer {
 
                             let (root, reduced) = super::smash(
                                 &self.zz_alloc,
-                                LazyNode::Heap(lhs_root),
+                                LazyNode::Heap(&lhs_root),
                                 lhs_reduced,
-                                LazyNode::Heap(rhs_root),
+                                LazyNode::Heap(&rhs_root),
                                 rhs_reduced,
                                 schema.as_ref(),
                                 validator,

--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -1,4 +1,4 @@
-use crate::{compare::compare, AsNode, LazyNode, Node, OwnedNode, Pointer};
+use crate::{compare::compare, AsNode, Node, OwnedNode, Pointer};
 use bytes::BufMut;
 use std::borrow::Cow;
 use tuple::TuplePack;
@@ -133,20 +133,6 @@ impl Extractor {
             })
             .find(|o| *o != Ordering::Equal)
             .unwrap_or(Ordering::Equal)
-    }
-
-    /// Compare the deep ordering of `lhs` and `rhs` with respect to a composite key.
-    pub fn compare_key_lazy<'alloc, 'l, 'r, L: AsNode, R: AsNode>(
-        key: &[Self],
-        lhs: &LazyNode<'alloc, 'l, L>,
-        rhs: &LazyNode<'alloc, 'r, R>,
-    ) -> std::cmp::Ordering {
-        match (lhs, rhs) {
-            (LazyNode::Heap(lhs), LazyNode::Heap(rhs)) => Self::compare_key(key, lhs, rhs),
-            (LazyNode::Heap(lhs), LazyNode::Node(rhs)) => Self::compare_key(key, lhs, *rhs),
-            (LazyNode::Node(lhs), LazyNode::Heap(rhs)) => Self::compare_key(key, *lhs, rhs),
-            (LazyNode::Node(lhs), LazyNode::Node(rhs)) => Self::compare_key(key, *lhs, *rhs),
-        }
     }
 }
 

--- a/crates/doc/src/lazy.rs
+++ b/crates/doc/src/lazy.rs
@@ -1,103 +1,77 @@
 use super::{
-    AsNode, BumpStr, BumpVec, FailedValidation, Field, Fields, HeapField, HeapNode, Node, Valid,
-    Validator,
+    AsNode, BumpStr, FailedValidation, Field, Fields, HeapField, HeapNode, Node, Valid, Validator,
 };
 
 /// LazyNode is either a HeapNode, or is an AsNode which may be promoted to a HeapNode.
 pub enum LazyNode<'alloc, 'n, N: AsNode> {
     Node(&'n N),
-    Heap(HeapNode<'alloc>),
+    Heap(&'n HeapNode<'alloc>),
 }
 
 /// LazyArray is either a [AsNode] slice, or is a vec of HeapNode.
 pub enum LazyArray<'alloc, 'n, N: AsNode> {
     Node(&'n [N]),
-    Heap(BumpVec<'alloc, HeapNode<'alloc>>),
+    Heap(&'n [HeapNode<'alloc>]),
 }
 
 /// LazyObject is either an AsNode::Fields, or is a vec of HeapField.
-pub enum LazyObject<'alloc, 'n, N: AsNode + 'n> {
+pub enum LazyObject<'alloc, 'n, N: AsNode> {
     Node(&'n N::Fields),
-    Heap(BumpVec<'alloc, HeapField<'alloc>>),
+    Heap(&'n [HeapField<'alloc>]),
+}
+
+/// LazyField is either an AsNode::Fields::Field, or is a HeapField.
+pub enum LazyField<'alloc, 'n, N: AsNode + 'n> {
+    Node(<N::Fields as Fields<N>>::Field<'n>),
+    Heap(&'n HeapField<'alloc>),
 }
 
 /// LazyDestructured is an unpacked Node or HeapNode.
 pub enum LazyDestructured<'alloc, 'n, N: AsNode> {
     Array(LazyArray<'alloc, 'n, N>),
     ScalarNode(Node<'n, N>),
-    ScalarHeap(HeapNode<'alloc>),
+    ScalarHeap(&'n HeapNode<'alloc>),
     Object(LazyObject<'alloc, 'n, N>),
 }
 
-/// LazyField is either an AsNode::Fields::Field, or is a HeapField.
-pub enum LazyField<'alloc, 'n, N: AsNode + 'n> {
-    Node(<N::Fields as Fields<N>>::Field<'n>),
-    Heap(HeapField<'alloc>),
-}
-
-impl<'alloc> HeapNode<'alloc> {
-    // from_node builds a HeapNode from another AsNode implementation.
-    pub fn from_node<N: AsNode>(node: &N, alloc: &'alloc bumpalo::Bump) -> Self {
-        match node.as_node() {
-            Node::Array(arr) => {
-                let mut vec = BumpVec::with_capacity_in(arr.len(), alloc);
-                vec.extend(arr.iter().map(|item| Self::from_node(item, alloc)), alloc);
-                HeapNode::Array(vec)
-            }
-            Node::Bool(b) => HeapNode::Bool(b),
-            Node::Bytes(b) => HeapNode::Bytes(BumpVec::from_slice(b, alloc)),
-            Node::Null => HeapNode::Null,
-            Node::Float(n) => HeapNode::Float(n),
-            Node::PosInt(n) => HeapNode::PosInt(n),
-            Node::NegInt(n) => HeapNode::NegInt(n),
-            Node::Object(fields) => {
-                let mut vec = BumpVec::with_capacity_in(fields.len(), alloc);
-                vec.extend(
-                    fields.iter().map(|field| HeapField {
-                        property: BumpStr::from_str(field.property(), alloc),
-                        value: Self::from_node(field.value(), alloc),
-                    }),
-                    alloc,
-                );
-                HeapNode::Object(vec)
-            }
-            Node::String(s) => HeapNode::String(BumpStr::from_str(s, alloc)),
-        }
-    }
-}
-
 impl<'alloc, 'n, N: AsNode> LazyNode<'alloc, 'n, N> {
-    pub fn unwrap_node(self) -> &'n N {
-        match self {
-            Self::Node(n) => n,
-            Self::Heap(_) => panic!("not a LazyNode::Node"),
-        }
-    }
-
-    pub fn unwrap_heap(self) -> HeapNode<'alloc> {
-        match self {
-            Self::Node(_) => panic!("not a LazyNode::Heap"),
-            Self::Heap(n) => n,
-        }
-    }
-
+    // Map this LazyNode into an owned HeapNode, either by re-hydrating a non-heap Node,
+    // or by taking a shallow copy of a HeapNode. Note that the returned HeapNode may
+    // reference structure which is shared with other HeapNodes.
     pub fn into_heap_node(self, alloc: &'alloc bumpalo::Bump) -> HeapNode<'alloc> {
         match self {
             Self::Node(doc) => HeapNode::from_node(doc, alloc),
-            Self::Heap(doc) => doc,
+            Self::Heap(doc) => Self::borrow(doc),
         }
     }
 
-    pub fn destructure(self) -> LazyDestructured<'alloc, 'n, N> {
+    fn borrow(doc: &'n HeapNode<'alloc>) -> HeapNode<'alloc> {
+        // Directly transmute &HeapNode into an owned HeapNode by bit-copy.
+        //
+        // Safety: LazyNode holds immutable references of documents being
+        // built up using append-only reduction. By design, and enforced
+        // through its immutability, all built up HeapNode structure is
+        // allocated into new memory, though it may reference borrowed
+        // HeapNodes without the possibility of mutating them.
+        //
+        // Recursive HeapNode references are exclusively backed by a shared
+        // bump allocator having lifetime 'alloc, and are freed as a unit,
+        // meaning a use-after-free due to disjoint lifetimes isn't possible.
+        unsafe { std::mem::transmute_copy::<HeapNode, HeapNode>(&doc) }
+    }
+
+    pub fn destructure(&self) -> LazyDestructured<'alloc, 'n, N> {
         match self {
             Self::Node(doc) => match doc.as_node() {
                 Node::Array(arr) => LazyDestructured::Array(LazyArray::Node(arr)),
                 Node::Object(fields) => LazyDestructured::Object(LazyObject::Node(fields)),
                 doc @ _ => LazyDestructured::ScalarNode(doc),
             },
-            Self::Heap(HeapNode::Array(arr)) => LazyDestructured::Array(LazyArray::Heap(arr)),
+            Self::Heap(HeapNode::Array(arr)) => {
+                LazyDestructured::Array(LazyArray::Heap(arr.as_slice()))
+            }
             Self::Heap(HeapNode::Object(fields)) => {
-                LazyDestructured::Object(LazyObject::Heap(fields))
+                LazyDestructured::Object(LazyObject::Heap(fields.as_slice()))
             }
             Self::Heap(doc) => LazyDestructured::ScalarHeap(doc),
         }
@@ -107,28 +81,14 @@ impl<'alloc, 'n, N: AsNode> LazyNode<'alloc, 'n, N> {
     /// AsNode and then attempts to extract a Valid outcome. This is helpful
     /// because a Validation is generic over the AsNode type but Valid erases
     /// it, allowing for single-path handle for the Self::Heap and Self::Node cases.
-    pub fn validate_ok<'doc, 'v>(
-        &'doc self,
+    pub fn validate_ok<'v>(
+        &self,
         validator: &'v mut Validator,
         schema: Option<&'v url::Url>,
     ) -> Result<Result<Valid<'static, 'v>, FailedValidation>, json::schema::index::Error> {
         match self {
-            Self::Heap(n) => Ok(validator.validate(schema, n)?.ok()),
+            Self::Heap(n) => Ok(validator.validate(schema, *n)?.ok()),
             Self::Node(n) => Ok(validator.validate(schema, *n)?.ok()),
-        }
-    }
-}
-
-impl<'alloc, 'n, N: AsNode> LazyDestructured<'alloc, 'n, N> {
-    /// restructure the LazyDestructured into either a HeapNode or Node.
-    pub fn restructure(self) -> Result<HeapNode<'alloc>, Node<'n, N>> {
-        match self {
-            Self::Array(LazyArray::Node(arr)) => Err(Node::Array(arr)),
-            Self::Array(LazyArray::Heap(arr)) => Ok(HeapNode::Array(arr)),
-            Self::Object(LazyObject::Node(fields)) => Err(Node::Object(fields)),
-            Self::Object(LazyObject::Heap(fields)) => Ok(HeapNode::Object(fields)),
-            Self::ScalarNode(doc) => Err(doc),
-            Self::ScalarHeap(doc) => Ok(doc),
         }
     }
 }
@@ -144,13 +104,13 @@ impl<'alloc, 'n, N: AsNode> LazyArray<'alloc, 'n, N> {
     pub fn into_iter(self) -> impl Iterator<Item = LazyNode<'alloc, 'n, N>> {
         let (it1, it2) = match self {
             Self::Node(arr) => (Some(arr.iter().map(|d| LazyNode::Node(d))), None),
-            Self::Heap(arr) => (None, Some(arr.into_iter().map(LazyNode::Heap))),
+            Self::Heap(arr) => (None, Some(arr.iter().map(LazyNode::Heap))),
         };
         it1.into_iter().flatten().chain(it2.into_iter().flatten())
     }
 }
 
-impl<'alloc, 'n, N: AsNode> LazyObject<'alloc, 'n, N> {
+impl<'alloc, 'n, N: AsNode + 'n> LazyObject<'alloc, 'n, N> {
     pub fn len(&self) -> usize {
         match self {
             Self::Node(fields) => fields.len(),
@@ -161,7 +121,7 @@ impl<'alloc, 'n, N: AsNode> LazyObject<'alloc, 'n, N> {
     pub fn into_iter(self) -> impl Iterator<Item = LazyField<'alloc, 'n, N>> {
         let (it1, it2) = match self {
             Self::Node(fields) => (Some(fields.iter().map(LazyField::Node)), None),
-            Self::Heap(fields) => (None, Some(fields.into_iter().map(LazyField::Heap))),
+            Self::Heap(fields) => (None, Some(fields.iter().map(LazyField::Heap))),
         };
         it1.into_iter().flatten().chain(it2.into_iter().flatten())
     }
@@ -171,17 +131,23 @@ impl<'alloc, 'n, N: AsNode> LazyField<'alloc, 'n, N> {
     pub fn property(&self) -> &str {
         match self {
             LazyField::Node(field) => field.property(),
-            LazyField::Heap(field) => field.property(),
+            LazyField::Heap(field) => &field.property,
         }
     }
 
+    // Map this LazyField into an owned HeapField, either by re-hydrating a non-heap Field,
+    // or by taking a shallow copy of a HeapField. Note that the returned HeapField may
+    // reference structure which is shared with other HeapNodes.
     pub fn into_heap_field(self, alloc: &'alloc bumpalo::Bump) -> HeapField<'alloc> {
         match self {
             Self::Node(field) => HeapField {
                 property: BumpStr::from_str(field.property(), alloc),
                 value: HeapNode::from_node(field.value(), alloc),
             },
-            Self::Heap(field) => field,
+            Self::Heap(HeapField { property, value }) => HeapField {
+                property: *property,
+                value: LazyNode::<N>::borrow(value),
+            },
         }
     }
 
@@ -190,7 +156,7 @@ impl<'alloc, 'n, N: AsNode> LazyField<'alloc, 'n, N> {
     pub fn into_parts(self) -> (Result<&'n str, BumpStr<'alloc>>, LazyNode<'alloc, 'n, N>) {
         match self {
             Self::Node(field) => (Ok(field.property()), LazyNode::Node(field.value())),
-            Self::Heap(field) => (Err(field.property), LazyNode::Heap(field.value)),
+            Self::Heap(field) => (Err(field.property), LazyNode::Heap(&field.value)),
         }
     }
 }

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -26,7 +26,7 @@ pub trait Fields<N: AsNode> {
     where
         Self: 'a;
 
-    type Iter<'a>: Iterator<Item = Self::Field<'a>>
+    type Iter<'a>: ExactSizeIterator<Item = Self::Field<'a>>
     where
         Self: 'a;
 

--- a/crates/doc/src/reduce/schema.rs
+++ b/crates/doc/src/reduce/schema.rs
@@ -25,11 +25,11 @@ pub fn json_schema_merge<'alloc, L: AsNode, R: AsNode>(
     // Ensure that we're working with objects on both sides
     // Question: Should we actually relax this to support
     // reducing valid schemas like "true" and "false"?
-    let (
-        lhs @ HeapNode::Object(_),
-        rhs @ HeapNode::Object(_)
-    ) = (lhs, rhs) else {
-        return Err(Error::with_location(Error::JsonSchemaMergeWrongType { detail: None }, loc) )
+    let (lhs @ HeapNode::Object(_), rhs @ HeapNode::Object(_)) = (lhs, rhs) else {
+        return Err(Error::with_location(
+            Error::JsonSchemaMergeWrongType { detail: None },
+            loc,
+        ));
     };
 
     let left = shape_from_node(lhs).map_err(|e| Error::with_location(e, loc))?;

--- a/crates/doc/src/reduce/set.rs
+++ b/crates/doc/src/reduce/set.rs
@@ -41,7 +41,7 @@ impl<'alloc, 'l, 'r, L: AsNode, R: AsNode> Destructured<'alloc, 'l, 'r, L, R> {
         // Unwrap required Objects on each side.
         let (lhs, rhs) = match (lhs.destructure(), rhs.destructure()) {
             (LazyDestructured::Object(lhs), LazyDestructured::Object(rhs)) => (lhs, rhs),
-            (lhs, rhs) => return Err(Error::with_details(Error::SetWrongType, loc, lhs, rhs)),
+            _ => return Err(Error::with_details(Error::SetWrongType, loc, lhs, rhs)),
         };
 
         // Extract "add", "intersect", and "remove" properties & values
@@ -190,7 +190,7 @@ impl<'alloc> Builder<'alloc, '_, '_> {
             Box::new(
                 itertools::merge_join_by(left, right, |l, r| match l {
                     LazyNode::Node(l) => compare_key(key, *l, *r),
-                    LazyNode::Heap(l) => compare_key(key, l, *r),
+                    LazyNode::Heap(l) => compare_key(key, *l, *r),
                 })
                 .filter_map(move |eob| match eob {
                     EitherOrBoth::Left(l) if !naught => Some(l),

--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -175,7 +175,7 @@ impl Strategy {
                 Ok(HeapNode::Null)
             }
 
-            (lhs, rhs) => Err(Error::with_details(Error::AppendWrongType, loc, lhs, rhs)),
+            _ => Err(Error::with_details(Error::AppendWrongType, loc, lhs, rhs)),
         }
     }
 
@@ -273,21 +273,19 @@ impl Strategy {
             alloc: _,
         } = cur;
 
-        let (lhs, rhs) = (lhs.destructure(), rhs.destructure());
-
-        let ln = match &lhs {
-            LazyDestructured::ScalarNode(Node::PosInt(n)) => json::Number::Unsigned(*n),
-            LazyDestructured::ScalarNode(Node::NegInt(n)) => json::Number::Signed(*n),
-            LazyDestructured::ScalarNode(Node::Float(n)) => json::Number::Float(*n),
+        let ln = match lhs.destructure() {
+            LazyDestructured::ScalarNode(Node::PosInt(n)) => json::Number::Unsigned(n),
+            LazyDestructured::ScalarNode(Node::NegInt(n)) => json::Number::Signed(n),
+            LazyDestructured::ScalarNode(Node::Float(n)) => json::Number::Float(n),
             LazyDestructured::ScalarHeap(HeapNode::PosInt(n)) => json::Number::Unsigned(*n),
             LazyDestructured::ScalarHeap(HeapNode::NegInt(n)) => json::Number::Signed(*n),
             LazyDestructured::ScalarHeap(HeapNode::Float(n)) => json::Number::Float(*n),
             _ => return Err(Error::with_details(Error::SumWrongType, loc, lhs, rhs)),
         };
-        let rn = match &rhs {
-            LazyDestructured::ScalarNode(Node::PosInt(n)) => json::Number::Unsigned(*n),
-            LazyDestructured::ScalarNode(Node::NegInt(n)) => json::Number::Signed(*n),
-            LazyDestructured::ScalarNode(Node::Float(n)) => json::Number::Float(*n),
+        let rn = match rhs.destructure() {
+            LazyDestructured::ScalarNode(Node::PosInt(n)) => json::Number::Unsigned(n),
+            LazyDestructured::ScalarNode(Node::NegInt(n)) => json::Number::Signed(n),
+            LazyDestructured::ScalarNode(Node::Float(n)) => json::Number::Float(n),
             LazyDestructured::ScalarHeap(HeapNode::PosInt(n)) => json::Number::Unsigned(*n),
             LazyDestructured::ScalarHeap(HeapNode::NegInt(n)) => json::Number::Signed(*n),
             LazyDestructured::ScalarHeap(HeapNode::Float(n)) => json::Number::Float(*n),
@@ -403,7 +401,7 @@ impl Strategy {
                 Ok(HeapNode::Null)
             }
 
-            (lhs, rhs) => Err(Error::with_details(Error::MergeWrongType, loc, lhs, rhs)),
+            _ => Err(Error::with_details(Error::MergeWrongType, loc, lhs, rhs)),
         }
     }
 }

--- a/crates/doc/src/ser.rs
+++ b/crates/doc/src/ser.rs
@@ -9,7 +9,7 @@ impl<'n, N: AsNode> serde::Serialize for Node<'n, N> {
         S: ::serde::Serializer,
     {
         match self {
-            Node::Array(arr) => serializer.collect_seq(arr.into_iter().map(|d| d.as_node())),
+            Node::Array(arr) => serializer.collect_seq(arr.iter().map(AsNode::as_node)),
             Node::Bool(b) => serializer.serialize_bool(*b),
             Node::Bytes(b) => {
                 if serializer.is_human_readable() {
@@ -35,7 +35,7 @@ impl<'n, N: AsNode> serde::Serialize for Node<'n, N> {
     }
 }
 
-impl<'alloc, 'n, N: AsNode> serde::Serialize for LazyNode<'alloc, 'n, N> {
+impl<N: AsNode> serde::Serialize for LazyNode<'_, '_, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,


### PR DESCRIPTION
LazyNode::Heap no longer owns its HeapNode, and instead takes its value by-reference. This makes reduction non-destructive: it's now possible to perform part of a reduction, realize that the operation cannot complete, and backtrack without destroying its input documents.

No changes to function or semantics in this commit. It's laying groundwork for allowing the combiner to handle non-associative reductions.

BumpStr is marked as Copy (it always has been).

BumpVec is not, but it is safe to re-use its structure -- as LazyNode does when promoting a reference into a HeapNode -- subject to certain conditions (if you mutate a reduced HeapNode, the changes may be visible to other HeapNodes). LazyNode::Heap takes an immutable reference, making it impossible to do this accidentally in the context of reductions, which instead always reduce into newly allocated memory.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1250)
<!-- Reviewable:end -->
