### PR TITLE
Phil/sneaky spec expansion

### DIFF
--- a/crates/validation/src/reference.rs
+++ b/crates/validation/src/reference.rs
@@ -10,19 +10,19 @@ pub fn gather_referenced_collections<'a>(
     let mut out = BTreeSet::new();
 
     for capture in captures {
-        for binding in &capture.spec.bindings {
+        for binding in capture.spec.bindings.iter().filter(|b| !b.disable) {
             out.insert(&binding.target);
         }
     }
     for collection in collections {
         let Some(derive) = &collection.spec.derive else { continue };
 
-        for transform in &derive.transforms {
+        for transform in derive.transforms.iter().filter(|b| !b.disable) {
             out.insert(&transform.source.collection());
         }
     }
     for materialization in materializations {
-        for binding in &materialization.spec.bindings {
+        for binding in materialization.spec.bindings.iter().filter(|b| !b.disable) {
             out.insert(&binding.source.collection());
         }
     }

--- a/supabase/migrations/37_cleanup_built_specs.sql
+++ b/supabase/migrations/37_cleanup_built_specs.sql
@@ -1,0 +1,7 @@
+-- There's been a bug that resulted in the `built_spec` being populated for deleted collections.
+-- The agent code has been updated to fix the issue, and this just cleans up any affected rows.
+begin;
+
+update live_specs set built_spec = null where spec is null and spec_type is null;
+
+commit;


### PR DESCRIPTION
**Description:**

This rolls up a few related bug fixes that were identified in the course of troubleshooting a panic in the agent:

- Stop adding built specs to `live_specs` rows when the corresponding `draft_specs` row represents a deletion
- Migration to remove all the `built_specs` that aren't supposed to be there
- Stop resolving remote collections for bindings that are disabled

The individual commit messages have move details. [This slack thread](https://estuaryworkspace.slack.com/archives/C012S5U0WP2/p1697719643581899) contains this summary:

The steps to reproduce are simple:
- Create hello-world capture
- Disable hello-world and publish
- Delete the events collections and publish, which triggers the panic due to trying to add the built_spec to live_specs after the spec_type is set to null :boom:

So why is there a built_spec that it would be adding to collections?
- The draft starts out with only the events collection (with null spec/type)
- Spec expansion expands to include the hello-world capture. This is not actually a bug, because we still want to show the connected collections for tasks that are disabled.
- The draft catalog is built, containing only the source-hello-world capture
- When building, we again [don't check for disabled tasks or bindings](https://github.com/estuary/flow/blob/3a1700b7dbeae3448b91d182720f31d0335a1192/crates/validation/src/reference.rs#L4) when we resolve referenced collections, so the collection spec (which we're currently deleting) gets pulled into the build, and subsequently output in `built_collections`


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1252)
<!-- Reviewable:end -->
