### PR TITLE
go/runtime: activate string truncation feature for select connectors

### DIFF
--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -1,12 +1,12 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/estuary/flow/go/bindings"
@@ -135,8 +135,12 @@ func (m *Materialize) RestoreCheckpoint(shard consumer.Shard) (cp pf.Checkpoint,
 		// TODO(johnny): Hack to address string truncation for these common materialization connectors
 		// that don't handle large strings very well. This should be negotiated via connector protocol.
 		var serPolicy = &pf.SerPolicy{}
-		for _, suffix := range []string{"/materialize-snowflake", "/materialize-redshift", "/materialize-sqlite"} {
-			if strings.HasSuffix(m.materialization.Name.String(), suffix) {
+		for _, needle := range []string{
+			"ghcr.io/estuary/materialize-snowflake",
+			"ghcr.io/estuary/materialize-redshift",
+			"ghcr.io/estuary/materialize-sqlite",
+		} {
+			if bytes.Contains(m.materialization.ConfigJson, []byte(needle)) {
 				serPolicy.StrTruncateAfter = 1 << 16 // Truncate at 64KB.
 			}
 		}


### PR DESCRIPTION
Look for a connector image match in the config, rather than a task name suffix, as not all tasks have that suffix.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1253)
<!-- Reviewable:end -->
