### PR TITLE
agent: delete built-specs for real this time

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -527,6 +527,7 @@ pub async fn update_published_live_spec(
     sqlx::query!(
         r#"
         update live_specs set
+            built_spec = null,
             catalog_name = $2::text::catalog_name,
             connector_image_name = $3,
             connector_image_tag = $4,


### PR DESCRIPTION
**Description:**

A previous commit updated the agent to stop adding `built_spec`s to `live_specs` rows when specs are being deleted. Somehow, this seems to have not accounted for `built_spec`s that were already present before `add_build_output_to_live_specs` was called. This commit explicitly sets `built_spec` to null earlier in the build process. It will be updated again as part of `add_build_output_to_live_specs` for specs that are not being deleted.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I'm still working on some testing of this, and hoping to also find an explanation to why this ever "worked" in the previous tests. There's also another possible approach that might be worth considering. We could just set `built_spec` to null as part of `add_build_output_to_live_specs` if the drafted spec represents a deletion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1256)
<!-- Reviewable:end -->
