### PR TITLE
agent: sanitize null bytes in log lines

### DIFF
--- a/crates/agent/src/logs.rs
+++ b/crates/agent/src/logs.rs
@@ -47,6 +47,19 @@ where
     Ok(())
 }
 
+/// NULL is a perfectly valid thing to include in UTF8 bytes, but not according
+/// to postgres. It rejects `TEXT` values containing nulls. This replaces all
+/// null bytes with a space character. The space was chosen somewhat arbitrarily
+/// as a goodenuf replacement in this rare edge case.
+fn sanitize_null_bytes(line: String) -> String {
+    // Check to avoid copying the string if it doesn't contain the character.
+    if line.contains('\u{0000}') {
+        line.replace('\u{0000}', " ")
+    } else {
+        line
+    }
+}
+
 // serve_sink consumes log Lines from the receiver, streaming each
 // to the `logs` table of the database.
 #[tracing::instrument(ret, skip_all)]
@@ -75,7 +88,7 @@ pub async fn serve_sink(
                     trace!(%token, %stream, %line, "rx (initial)");
                     tokens.push(token);
                     streams.push(stream);
-                    lines.push(line);
+                    lines.push(sanitize_null_bytes(line));
                 }
                 None => {
                     debug!("rx (eof)");
@@ -102,7 +115,7 @@ pub async fn serve_sink(
             trace!(%token, %stream, %line, "rx (cont)");
             tokens.push(token);
             streams.push(stream);
-            lines.push(line);
+            lines.push(sanitize_null_bytes(line));
         }
 
         if let None = held_conn {


### PR DESCRIPTION
**Description:**

Sanitizes log lines before persisting them to `internal.log_lines`. We observed a failure in production due to a connector logging a null byte. Postgres does not allow nulls in `TEXT` columns, even though they are valid UTF-8, so this removes them before persisting to postgres. Log lines are left unchanged if they're not being saved to postgres.

**Notes for reviewers:**

I've tested that this doesn't completely break anything, but not that this actually allows us to work end to end with a connector that logs out null bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1257)
<!-- Reviewable:end -->
