### PR TITLE
AlloyDB and Cloud SQL SQL Server Documentation Fixes

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/alloydb.md
+++ b/site/docs/reference/Connectors/capture-connectors/alloydb.md
@@ -76,7 +76,7 @@ See the table below and the [sample config](#sample).
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/address`** | Address | The host or host:port at which the database can be reached. Set to 127.0.0.1:5432 to enable SSH tunneling. | string | Required |
+| **`/address`** | Address | The host or host:port at which the database can be reached. | string | Required |
 | **`/database`** | Database | Logical database name to capture from. | string | Required, `"postgres"` |
 | **`/user`** | User | The database user to authenticate as. | string | Required, `"flow_capture"` |
 | **`/password`** | Password | Password for the specified database user. | string | Required |

--- a/site/docs/reference/Connectors/capture-connectors/google-cloud-sql-sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-cloud-sql-sqlserver.md
@@ -48,7 +48,7 @@ USE <database>;
 -- Enable CDC for the database.
 EXEC msdb.dbo.gcloudsql_cdc_enable_db '<database>';
 -- Create user and password for use with the connector.
-CREATE LOGIN flow_capture WITH PASSWORD = 'secret';
+CREATE LOGIN flow_capture WITH PASSWORD = 'Secret123!';
 CREATE USER flow_capture FOR LOGIN flow_capture;
 -- Grant the user permissions on the CDC schema and schemas with data.
 -- This assumes all tables to be captured are in the default schema, `dbo`.

--- a/site/docs/reference/Connectors/materialization-connectors/google-cloud-sql-sqlserver.md
+++ b/site/docs/reference/Connectors/materialization-connectors/google-cloud-sql-sqlserver.md
@@ -28,7 +28,7 @@ Use the below properties to configure a SQLServer materialization, which will di
 | Property                    | Title                  | Description                                                                                | Type   | Required/Default |
 |-----------------------------|------------------------|--------------------------------------------------------------------------------------------|--------|------------------|
 | **`/database`**             | Database               | Name of the logical database to materialize to.                                            | string | Required         |
-| **`/address`**              | Address                | Host and port of the database. If only the host is specified, port will default to `3306`. | string | Required         |
+| **`/address`**              | Address                | Host and port of the database. If only the host is specified, port will default to `1433`. | string | Required         |
 | **`/password`**             | Password               | Password for the specified database user.                                                  | string | Required         |
 | **`/user`**                 | User                   | Database user to connect as.                                                               | string | Required         |
 


### PR DESCRIPTION
1.  Updates Cloud SQL documentation to support SQL Server password complexity requirements: https://learn.microsoft.com/en-us/sql/relational-databases/security/password-policy?view=sql-server-ver16#password-complexity
2. Modifies the documentation describing the default port for Cloud SQL SQL Server
3. Removed local IP description for SSH tunneling in AlloyDB Docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1258)
<!-- Reviewable:end -->
