### PR TITLE
Removed Aurora docs recommending replica/reader

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL.md
@@ -144,8 +144,7 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 
 ### Amazon Aurora
 
-You must apply some of the settings to the entire Aurora DB cluster, and others to a database instance within the cluster
-(we recommend you use a [replica, or reader instance](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.html) to connect with Flow).
+You must apply some of the settings to the entire Aurora DB cluster, and others to a database instance within the cluster.
 For each step, take note of which entity you're working with.
 
 1. Allow connections between the database and Estuary Flow. There are two ways to do this: by granting direct access to Flow's IP or by creating an SSH tunnel.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL.md
@@ -143,8 +143,7 @@ and set up the watermarks table and publication.
 
 ### Amazon Aurora
 
-You must apply some of the settings to the entire Aurora DB cluster, and others to a database instance within the cluster
-(typically, you'll want to use a [replica, or reader instance](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.html)).
+You must apply some of the settings to the entire Aurora DB cluster, and others to a database instance within the cluster.
 For each step, take note of which entity you're working with.
 
 


### PR DESCRIPTION
Removed recommendations to use a reader or replica in MySQL and PostgreSQL for Aurora. Flow connection must happen with the primary database to enable watermark table writing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1261)
<!-- Reviewable:end -->
