### PR TITLE
flowctl: fix draft pruning

### DIFF
--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -290,7 +290,7 @@ pub async fn remove_unchanged(client: &Client, draft_id: &str) -> anyhow::Result
         catalog_name: String,
     }
 
-    let params = serde_json::to_string(&serde_json::json!({ "draft_id": draft_id })).unwrap();
+    let params = serde_json::to_string(&serde_json::json!({ "prune_draft_id": draft_id })).unwrap();
     // We don't use an explicit select of `catalog_name` because we want the other fields to appear
     // in the response when trace logging is enabled. This may be something we wish to change once
     // we gain more confidence in the spec pruning feature.


### PR DESCRIPTION
**Description:**

The `prune_unchanged_draft_specs` function had a last-minute rename of the argument parameter, which was not reflected at the callsite in flowctl, resulting in failure to publish.
This just updates the parameter to match, which fixes publication failure.

**Workflow steps:**

- `flowctl catalog publish --source flow.yaml`

On master, this fails with:

```
Error: pruning unchanged specs

Caused by:
    404 Not Found: {"code":"PGRST202","details":"Searched for the function public.prune_unchanged_draft_specs with parameter draft_id or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache.","hint":"Perhaps you meant to call the function public.prune_unchanged_draft_specs(prune_draft_id)","message":"Could not find the function public.prune_unchanged_draft_specs(draft_id) in the schema cache"}
```

This fixes it.

**Notes for reviewers:**

Thankfully, this was caught before a public release went out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1262)
<!-- Reviewable:end -->
