### PR TITLE
flowctl: don't require sops unless we actually need it

### DIFF
--- a/crates/runtime/src/unseal/mod.rs
+++ b/crates/runtime/src/unseal/mod.rs
@@ -3,9 +3,6 @@ use zeroize::Zeroizing;
 
 /// Decrypt a `sops`-protected document using `sops` and application default credentials.
 pub async fn decrypt_sops(config: &models::RawValue) -> anyhow::Result<models::RawValue> {
-    let jq = locate_bin::locate("jq").context("failed to locate sops")?;
-    let sops = locate_bin::locate("sops").context("failed to locate sops")?;
-
     // Only objects can be `sops` documents.
     let dom = config.to_value();
     if !dom.is_object() {
@@ -30,6 +27,9 @@ pub async fn decrypt_sops(config: &models::RawValue) -> anyhow::Result<models::R
     let Some(Sops{encrypted_suffix}) = doc.sops else {
         return Ok(config.to_owned())
     };
+
+    let jq = locate_bin::locate("jq").context("failed to locate jq")?;
+    let sops = locate_bin::locate("sops").context("failed to locate sops")?;
 
     // Note that input_output() pre-allocates an output buffer as large as its input buffer,
     // and our decrypted result will never be larger than its input.


### PR DESCRIPTION
**Description:**

The `runtime::unseal` module was a little aggressive about checking to make sure `sops` and `jq` are both on the path.  This would cause errors, even in cases where the connector configuration wasn't actually sops-enctypted.  This moves those checks to be performed only after it's determined that the config needs to be decrypted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1264)
<!-- Reviewable:end -->
