### PR TITLE
fix: Properly render unsealed sops output when there are no keys with the encrypted suffix

### DIFF
--- a/crates/runtime/src/capture/local.rs
+++ b/crates/runtime/src/capture/local.rs
@@ -35,7 +35,8 @@ fn unseal(mut request: Request) -> Result<UnsealFuture<Request>, Request> {
             config: sealed_config,
             env,
             protobuf,
-        }) = endpoint else {
+        }) = endpoint
+        else {
             anyhow::bail!("task connector type has changed and is no longer an image")
         };
 


### PR DESCRIPTION
Change `decrypt_sops` to return `serde_json::Value` instead of `RawValue`. `RawValue`, by its nature of being represented as a string instead of a a big enum like `serde_json::Value`, was allowing differences in string representation to taint its output.
    
Specifically, the connector protocol expects all commands to live on a single line. `sops --decrypt` outputs pretty-printed JSON. This was flowing all the way through to the connector, where it was causing a failure because of the assumption that every command would live on a single line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1267)
<!-- Reviewable:end -->
