### PR TITLE
Stripe invoice generator updates

### DIFF
--- a/crates/billing-integrations/src/stripe.rs
+++ b/crates/billing-integrations/src/stripe.rs
@@ -269,7 +269,7 @@ impl Invoice {
                             )
                             .as_str(),
                         ),
-                        collection_method: Some(stripe::CollectionMethod::SendInvoice),
+                        collection_method: Some(stripe::CollectionMethod::ChargeAutomatically),
                         auto_advance: Some(false),
                         custom_fields: Some(vec![
                             stripe::CreateInvoiceCustomFields {


### PR DESCRIPTION
**Description:**

* Add a `--charge-type` flag: 
  ```
  --charge-type <CHARGE_TYPE>
      Whether to attempt to automatically charge the invoice or send it to be paid manually.
      
      NOTE: Invoices are still created as drafts and require approval, this setting only
      changes what happens once the invoice is approved.
      
      [default: auto-charge]
      [possible values: auto-charge, send-invoice]
  ```
* Print out invoice stats after the run (example numbers)
  ```
   INFO Fetching billing data for October 2023
   INFO Processing 1234 usage-based invoices, and 243 manually-entered invoices.
   INFO [  29 invoices]: Updated existing invoice                                              $1,234.36
   INFO [ 124 invoices]: Published new invoice                                                 $12,345.67
   INFO [1123 invoices]: Skipping invoice with no usage                                        $0.00
   INFO [   7 invoices]: Skipping invoice ending before free trial start date                  $0.00
   INFO [  48 invoices]: Skipping invoice for less than the minimum chargable amount ($0.50)   $0.00
   INFO [ 193 invoices]: Skipping usage invoice for tenant in free tier                        $0.00
  ```
**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1270)
<!-- Reviewable:end -->
