### PR TITLE
Correcting Hubspot to HubSpot

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/capture-connectors/hubspot.md
@@ -50,35 +50,8 @@ The following data resources are supported for pro accounts (set **Subscription 
 
 ## Prerequisites
 
-There are two ways to authenticate with HubSpot when capturing data: using OAuth2, and manually, with a private app access token.
-Their prerequisites differ.
+OAuth2 is required for authentication and capturing data with HubSpot. A HubSpot account is required before continuing.
 
-OAuth is recommended for simplicity in the Flow web app;
-the access token method is the only supported method using the command line.
-
-### Using OAuth2 to authenticate with HubSpot in the Flow web app
-
-* A HubSpot account
-
-### Configuring the connector specification manually
-
-* A HubSpot account
-
-* The access token for an appropriately configured [private app](https://developers.hubspot.com/docs/api/private-apps) on the HubSpot account.
-
-#### Setup
-
-To create a private app in HubSpot and generate its access token, do the following.
-
-1. Ensure that your HubSpot user account has [super admin](https://knowledge.hubspot.com/settings/hubspot-user-permissions-guide#super-admin) privileges.
-
-2. In HubSpot, create a [new private app](https://developers.hubspot.com/docs/api/private-apps#create-a-private-app).
-
-   1. Name the app "Estuary Flow," or choose another name that is memorable to you.
-
-   2. Grant the new app **Read** access for all available scopes.
-
-   3. Copy the access token for use in the connector configuration.
 
 ## Configuration
 
@@ -93,9 +66,6 @@ The following properties reflect the access token authentication method.
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| **`/credentials`** | Private Application | Authenticate with a private app access token | object | Required |
-| **`/credentials/access_token`** | Access Token | HubSpot Access token. | string | Required |
-| **`/credentials/credentials_title`** | Credentials | Name of the credentials set | string | Required, `"Private App Credentials"` |
 | **`/start_date`** | Start Date | UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated. | string | Required |
 | `/subscription_type` | Your HubSpot account subscription type | Some streams are only available to certain subscription packages, we use this information to select which streams to pull data from. | string | `"starter"` |
 
@@ -116,8 +86,11 @@ captures:
         image: ghcr.io/estuary/source-hubspot:dev
           config:
             credentials:
-              credentials_title: Private App Credentials
-              access_token: <secret>
+              client_id_sops: <client-id>
+              client_secret_sops: <client-secret>
+              credentials_title: OAuth Credentials
+              refresh_token_sops: <refresh-token>
+            start_date: 2023-11-07T00:00:00Z
       bindings:
         - resource:
             stream: companies

--- a/site/docs/reference/Connectors/capture-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/capture-connectors/hubspot.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 3
 ---
-# Hubspot
+# HubSpot
 
-This connector captures data from a Hubspot account.
+This connector captures data from a HubSpot account.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-hubspot:dev`](https://ghcr.io/estuary/source-hubspot:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
@@ -13,7 +13,7 @@ but keep in mind that the two versions may be significantly different.
 
 ## Supported data resources
 
-By default, each resource associated with your Hubspot account is mapped to a Flow collection through a separate binding.
+By default, each resource associated with your HubSpot account is mapped to a Flow collection through a separate binding.
 
 The following data resources are supported for all subscription levels:
 
@@ -50,29 +50,29 @@ The following data resources are supported for pro accounts (set **Subscription 
 
 ## Prerequisites
 
-There are two ways to authenticate with Hubspot when capturing data: using OAuth2, and manually, with a private app access token.
+There are two ways to authenticate with HubSpot when capturing data: using OAuth2, and manually, with a private app access token.
 Their prerequisites differ.
 
 OAuth is recommended for simplicity in the Flow web app;
 the access token method is the only supported method using the command line.
 
-### Using OAuth2 to authenticate with Hubspot in the Flow web app
+### Using OAuth2 to authenticate with HubSpot in the Flow web app
 
-* A Hubspot account
+* A HubSpot account
 
 ### Configuring the connector specification manually
 
-* A Hubspot account
+* A HubSpot account
 
-* The access token for an appropriately configured [private app](https://developers.hubspot.com/docs/api/private-apps) on the Hubspot account.
+* The access token for an appropriately configured [private app](https://developers.hubspot.com/docs/api/private-apps) on the HubSpot account.
 
 #### Setup
 
-To create a private app in Hubspot and generate its access token, do the following.
+To create a private app in HubSpot and generate its access token, do the following.
 
-1. Ensure that your Hubspot user account has [super admin](https://knowledge.hubspot.com/settings/hubspot-user-permissions-guide#super-admin) privileges.
+1. Ensure that your HubSpot user account has [super admin](https://knowledge.hubspot.com/settings/hubspot-user-permissions-guide#super-admin) privileges.
 
-2. In Hubspot, create a [new private app](https://developers.hubspot.com/docs/api/private-apps#create-a-private-app).
+2. In HubSpot, create a [new private app](https://developers.hubspot.com/docs/api/private-apps#create-a-private-app).
 
    1. Name the app "Estuary Flow," or choose another name that is memorable to you.
 
@@ -83,7 +83,7 @@ To create a private app in Hubspot and generate its access token, do the followi
 ## Configuration
 
 You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
-See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Hubspot source connector.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the HubSpot source connector.
 
 ### Properties
 
@@ -125,6 +125,6 @@ captures:
           target: ${PREFIX}/${COLLECTION_NAME}
 ```
 Your configuration will have many more bindings representing all supported [resources](#supported-data-resources)
-in your Hubspot account.
+in your HubSpot account.
 
 [Learn more about capture definitions.](../../../concepts/captures.md#pull-captures)


### PR DESCRIPTION
**Description:**
HubSpot docs updated for compliance for HubSpot App Marketplace

HubSpot does not allow for non-OAuth connections. Therefore, we had to remove:

- Option for access token in prerequisites
- Properties relevant to access tokens
- Sample file references to access token

**If we want to be listed on their marketplace we should remove the options for access token configuration from the Flow UI**

Documentation links affected:

https://docs.estuary.dev/reference/Connectors/capture-connectors/hubspot/#using-oauth2-to-authenticate-with-hubspot-in-the-flow-web-app

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1277)
<!-- Reviewable:end -->
