### PR TITLE
doc: fix panic in `SerPolicy`

### DIFF
--- a/crates/doc/src/ser.rs
+++ b/crates/doc/src/ser.rs
@@ -97,7 +97,13 @@ impl<'p, N: AsNode> serde::Serialize for SerNode<'p, N> {
             })),
             Node::String(mut s) => {
                 if s.len() > self.policy.str_truncate_after {
-                    s = &s[..self.policy.str_truncate_after];
+                    // Find the greatest index that is <= `str_truncate_after` and falls at a utf8
+                    // character boundary
+                    let mut truncate_at = self.policy.str_truncate_after;
+                    while !s.is_char_boundary(truncate_at) {
+                        truncate_at -= 1;
+                    }
+                    s = &s[..truncate_at];
                 }
                 serializer.serialize_str(s)
             }


### PR DESCRIPTION
The `SerPolicy` was panicking due to attempting to split a string in the middle of a utf8 character. Updates the policy to instead truncate strings at the nearest character boundary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1283)
<!-- Reviewable:end -->
