### PR TITLE
materialize/transactor: cancel load before Destroy() if commit fails

### DIFF
--- a/go/protocols/materialize/lifecycle.go
+++ b/go/protocols/materialize/lifecycle.go
@@ -158,24 +158,11 @@ type LoadIterator struct {
 	request     *Request        // Request read into.
 	awaitDoneCh <-chan struct{} // Signaled when last commit acknowledgment has completed.
 	err         error           // Terminal error.
-	cancel      context.CancelFunc
 	ctx         context.Context
 }
 
 // Context returns the Context of this LoadIterator.
-func (it *LoadIterator) Context() context.Context { 
-	if it.ctx == nil {
-		it.ctx, it.cancel = context.WithCancel(it.stream.Context())
-	}
-
-	return it.ctx
-}
-
-func (it *LoadIterator) Cancel() {
-	if it.ctx != nil {
-		it.cancel()
-	}
-}
+func (it *LoadIterator) Context() context.Context { return it.ctx }
 
 // WaitForAcknowledged returns once the prior transaction has been fully acknowledged.
 // Importantly, upon its return a materialization connector is free to issues loads


### PR DESCRIPTION
**Description:**

- Currently there is a potential for deadlock if the `transactor.Destroy()` of a connector depends on cancellation of the Load phase. For example, this is the case for sqlserver and snowflake which wait for the database connection established for the load phase to be closed, and this closing of the connection blocks until existing operations are terminated. This can be reproduced by having a connector error during commit phase, while still processing its load phase (See [this commit](https://github.com/estuary/connectors/pull/1078/files) which emulates this situation).
- This happens as we do not cancel the load phase's context when there is a failure in the commit stage, this means any pending work in the load phase will never be terminated.
- This pull-request addresses this by allowing us to cancel the context used by the `LoadIterator`, so we can cancel it when an error is raised during commit phase

**Test steps:**

This has been tested by:
1. First reproducing the original issue by running a modified version of sqlserver which raises an error during commit phase, and ensures the Load phase is not terminated before this error is raised. This reliably reproduces the deadlock.
2. Then, the modified connector was updated to use this branch's transactor implementation, and the deadlock no longer happens. The load phase's context is cancelled and the error propagates up as expected, terminating the connector.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1287)
<!-- Reviewable:end -->
