### PR TITLE
CI: flowctl release uses ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/flowctl-release.yaml
+++ b/.github/workflows/flowctl-release.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             assetName: flowctl-x86_64-linux
           - os: macos-latest
             assetName: flowctl-multiarch-macos


### PR DESCRIPTION
Instead of ubuntu-latest (22.04).

This should improve compatibility with Linux boxes still running 20.04.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1297)
<!-- Reviewable:end -->
