### PR TITLE
runtime: fix schema inference for derivations

### DIFF
--- a/crates/runtime/src/derive/protocol.rs
+++ b/crates/runtime/src/derive/protocol.rs
@@ -223,6 +223,7 @@ pub fn send_client_published(
     txn.combined_stats.bytes_total += doc_json.len() as u64;
 
     if shape.widen_owned(&root) {
+        txn.updated_inference = true;
         doc::shape::limits::enforce_shape_complexity_limit(
             shape,
             doc::shape::limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT,


### PR DESCRIPTION
**Description:**

A user reported a problem with continuous schema inference not working for their derivation. This seems to have been caused by the change to the new derive runtime, which was missing a line to set the `updated_inference` flag when the shape was widened.

I tested this locally by running a derivation. Prior to this change, there were no `inferred schema updated` messages in the task logs. After, those logs appear as expected.