### PR TITLE
refactor: Update our OAuth flow to be more secure

### DIFF
--- a/supabase/migrations/41_store_oauth_state.sql
+++ b/supabase/migrations/41_store_oauth_state.sql
@@ -1,0 +1,14 @@
+
+begin;
+
+create table oauth_flows (
+    "state" 				text primary key,
+    "connector_id" 			flowid,
+    "code_verifier" 		text not null,
+    "code_challenge" 		text not null,
+    "code_challenge_method" text not null,
+	"extra"					jsonb
+);
+
+commit;
+


### PR DESCRIPTION
**Description:**

The impetus for this change is that while I was implementing Airtable OAuth (before I realized that it uses expiring refresh tokens and we had a whole slack conversation concluding that we shouldn't do it for now), I realized that we were doing a naughty. The OAuth authorize flow uses a concept of [state](https://auth0.com/docs/secure/attack-protection/state-parameters) to represent a particular request for authorization. You're supposed to generate a secret "challenge" (we do this), store it internally along with the state key (we _don't_ do this), send a hash of that secret to the provider (we do this), and then use the returned state value and challenge hash to look up the secret and verify that it matches (also don't do this), thereby validating that you haven't been MITM'd. 

The state key is supposed to be a random string, but in practice any string is usually fine. As it turns out, we were using a base64-encoded JSON object containing some metadata about the request (the connector ID, specifically). Airtable has a particularly strict implementation of OAuth, and they intentionally [only allow a few ranges of characters](https://airtable.com/developers/web/api/oauth-reference#authorization-parameter-rules), specifically excluding the `=` character, which usually shows up at the end of a base64-encoded string.

This change has us do the "right thing" by keeping track of ongoing OAuth flows, their state keys, challenge secrets, and connector IDs, and actually doing the challenge validation. That being said, it's not strictly necessary since we are still holding off on Airtable OAuth. I pushed it up because I did the work to implement it and I think it's a good security precaution to have.

* One thought I just had is that we really ought to clear out `oauth_flows` after the flow is finished, but we could also just have a cron job clear out old flows every day.
* The other annoying thing is that in order for the supabase SDK to be able to read the table, it _must_ be in the `public` schema, per Supabase [limitations](https://github.com/orgs/supabase/discussions/1222). I would have preferred to put it in `internal`, but so long as we don't grant `authenticated` to read it, it should be fine...?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1301)
<!-- Reviewable:end -->
