### PR TITLE
control-plane: add 'resolved' keyword to alert resolution emails

### DIFF
--- a/supabase/functions/alert-data-processing/index.ts
+++ b/supabase/functions/alert-data-processing/index.ts
@@ -97,7 +97,7 @@ const formatConfirmationEmail = ({
     arguments: { emails, spec_type },
     catalog_name,
 }: AlertRecord): EmailConfig => {
-    const subject = `Estuary Flow: Alert for ${spec_type} ${catalog_name}`;
+    const subject = `Estuary Flow: Alert resolved for ${spec_type} ${catalog_name}`;
 
     const detailsPageURL = getTaskDetailsPageURL(catalog_name, spec_type);
 


### PR DESCRIPTION
**Description:**

Adding this keyword to the subject allows it to work with a Zenduty feature to automatically resolve alerts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1302)
<!-- Reviewable:end -->
