### PR TITLE
flowctl: fix panic in preview

### DIFF
--- a/crates/journal-client/src/read/uncommitted.rs
+++ b/crates/journal-client/src/read/uncommitted.rs
@@ -215,11 +215,12 @@ impl<R: Retry> Reader<R> {
     }
 
     fn continue_after_eof(&self) -> bool {
-        if self.read.end_offset > 0 {
-            self.read.offset < self.read.end_offset
-                || (self.read.offset >= self.target_write_head && !self.read.block)
+        let want_more = self.read.end_offset == 0 || self.read.offset < self.read.end_offset;
+
+        if self.read.block {
+            want_more
         } else {
-            self.read.offset < self.target_write_head
+            want_more && self.read.offset < self.target_write_head
         }
     }
 


### PR DESCRIPTION
**Description:**

Fixes a panic in `flowctl preview` that could happen after reading through the end of a source collection. Fixes the `continue_after_eof` function so that we no longer return `None` for blocking reads.

This ware reported in [this slack thread](https://estuary-dev.slack.com/archives/C01G7CFNA8K/p1701858388568069)

I was able to reproduce it locally by running `flowctl preview --source flow.yaml` with the following `flow.yaml`:

```yaml
materializations:
  phil/test/preview-mat:
    endpoint:
      connector:
        image: ghcr.io/estuary/materialize-sqlite:v1
        config: {}
    bindings:
     - source:
         name: phil/test/2023-11-13/webhook-data
       resource:
         table: webhook_data
```

Prior to this change, that command would return:

```
thread 'main' panicked at crates/flowctl/src/preview/journal_reader.rs:93:28:
all branches are disabled and there is no else branch
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After, it works normally, and I can go to the datasette web ui and see the data.

I also tested `flowctl collections read` both with and without the `--follow` argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1303)
<!-- Reviewable:end -->
