### PR TITLE
Phil/discover merge updates

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -527,6 +527,7 @@ pub async fn update_published_live_spec(
     sqlx::query!(
         r#"
         update live_specs set
+            built_spec = null,
             catalog_name = $2::text::catalog_name,
             connector_image_name = $3,
             connector_image_tag = $4,

--- a/crates/agent-sql/tests/connector_tags.rs
+++ b/crates/agent-sql/tests/connector_tags.rs
@@ -1,0 +1,77 @@
+use agent_sql::Id;
+use serde_json::value::RawValue;
+use sqlx::Connection;
+
+const FIXED_DATABASE_URL: &str = "postgresql://postgres:postgres@localhost:5432/postgres";
+
+#[tokio::test]
+async fn resource_path_pointers_cannot_be_changed() {
+    let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+        .await
+        .expect("connect");
+
+    let mut txn = conn.begin().await.unwrap();
+
+    let row = sqlx::query!(
+      r#"
+      with setup_connectors as (
+        insert into connectors (image_name, external_url, title, short_description, logo_url)
+          values ('foo/image', 'http://test.test', '{"en-US": "foo"}', '{"en-US": "foo"}', '{"en-US": "foo"}')
+          returning id
+      )
+      insert into connector_tags (connector_id, image_tag) select id, ':test' as image_tag from setup_connectors
+      returning id as "id: Id"
+      "#
+	).fetch_one(&mut txn).await.unwrap();
+
+    let id = row.id;
+
+    let doc_url = "http://test-docs.test".to_string();
+    let endpoint_schema = RawValue::from_string(r#"{"x-test":"endpoint"}"#.to_string()).unwrap();
+    let protocol = "capture".to_string();
+    let resource_schema = RawValue::from_string(r#"{"x-test":"resource"}"#.to_string()).unwrap();
+    let resource_path_pointers = vec!["/ptr_one".to_string(), "/ptr_two".to_string()];
+
+    let result_one = agent_sql::connector_tags::update_tag_fields(
+        id,
+        doc_url.clone(),
+        endpoint_schema.clone(),
+        protocol.clone(),
+        resource_schema.clone(),
+        resource_path_pointers.clone(),
+        &mut txn,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        result_one,
+        "update_tag_fields should return true when existing resource_path_pointers is null"
+    );
+
+    let new_row = sqlx::query!(
+        r#"select resource_path_pointers as "resource_path_pointers!: Vec<String>" from connector_tags where id = $1"#,
+        id as Id,
+    ).fetch_one(&mut txn).await.unwrap();
+    assert_eq!(resource_path_pointers, new_row.resource_path_pointers);
+
+    let result_two = agent_sql::connector_tags::update_tag_fields(
+        id,
+        doc_url,
+        endpoint_schema,
+        protocol,
+        resource_schema,
+        vec!["/new_pointer".to_string()],
+        &mut txn,
+    )
+    .await
+    .expect("update_tag_fields succeeds");
+    assert!(!result_two, "update_tag_fields should return false when existing resource_path_pointers would be changed");
+
+    // assert that the pointers were not changed
+    let new_row = sqlx::query!(
+        r#"select resource_path_pointers as "resource_path_pointers!: Vec<String>" from connector_tags where id = $1"#,
+        id as Id,
+    ).fetch_one(&mut txn).await.unwrap();
+    assert_eq!(resource_path_pointers, new_row.resource_path_pointers);
+}

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -21,9 +21,9 @@ pub fn parse_response(
     for binding in &mut bindings {
         binding.recommended_name = normalize_recommended_name(&binding.recommended_name);
     }
-    if bindings.iter().any(|b| b.resource_path.is_empty()) {
+    if bindings.iter().any(|b| !b.resource_path.is_empty()) {
         tracing::warn!(%image_name, %image_tag,
-            "connector discovered response omits resource_path, this is OK for now but will become an error in a future release");
+            "connector discovered response includes deprecated field 'resource_path'");
     }
 
     Ok((
@@ -66,7 +66,7 @@ type ResourcePath = Vec<String>;
 
 /// Extracts the value of each of the given `resource_path_pointers` and encodes
 /// them into a `ResourcePath`. Each pointed-to location must be either a string
-/// value, null, or undefines. Null and undefined values are _not_ included in
+/// value, null, or undefined. Null and undefined values are _not_ included in
 /// the resulting path, and are thus treated as equivalent. Resource path values
 /// other than strings will result in an error.
 fn resource_path(

--- a/crates/agent/src/publications/validation.rs
+++ b/crates/agent/src/publications/validation.rs
@@ -1,14 +1,33 @@
+use std::collections::HashSet;
+
 use futures::{FutureExt, TryFutureExt};
 
 #[derive(Clone)]
 pub struct ControlPlane {
     pool: Option<sqlx::PgPool>,
+    /// A kludge to make sure we don't resolve collection specs that are being
+    /// deleted by the current publication. Ideally, the validation logic would
+    /// be aware that these collections were being deleted, and wouldn't ask for
+    /// them in the first place. But this should work in the meantime.
+    deleted_collections: HashSet<String>,
 }
 
 impl ControlPlane {
     pub fn new(pool: Option<&sqlx::PgPool>) -> Self {
         Self {
             pool: pool.cloned(),
+            deleted_collections: HashSet::new(),
+        }
+    }
+
+    /// Returns a copy of the `ControlPlane` that will filter out the given collections
+    /// when resolving collections and inferred schemas. This is a hopefully temporary
+    /// hack to ensure that we don't allow deleting collections that are still being used
+    /// by an active task.
+    pub fn with_deleted_collections(&self, deleted_collections: HashSet<String>) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            deleted_collections,
         }
     }
 }
@@ -19,9 +38,13 @@ impl validation::ControlPlane for ControlPlane {
         collections: Vec<models::Collection>,
     ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<proto_flow::flow::CollectionSpec>>> {
         let Some(pool) = self.pool.clone() else {
-            return validation::NoOpControlPlane.resolve_collections(collections)
+            return validation::NoOpControlPlane.resolve_collections(collections);
         };
-        let collections = collections.into_iter().map(Into::into).collect();
+        let collections = collections
+            .into_iter()
+            .filter(|c| !self.deleted_collections.contains(c.as_str()))
+            .map(Into::into)
+            .collect();
 
         agent_sql::publications::resolve_collections(collections, pool)
             .map_err(Into::into)
@@ -41,9 +64,13 @@ impl validation::ControlPlane for ControlPlane {
         anyhow::Result<std::collections::BTreeMap<models::Collection, validation::InferredSchema>>,
     > {
         let Some(pool) = self.pool.clone() else {
-            return validation::NoOpControlPlane.get_inferred_schemas(collections)
+            return validation::NoOpControlPlane.get_inferred_schemas(collections);
         };
-        let collections = collections.into_iter().map(Into::into).collect();
+        let collections = collections
+            .into_iter()
+            .filter(|c| !self.deleted_collections.contains(c.as_str()))
+            .map(Into::into)
+            .collect();
 
         agent_sql::publications::get_inferred_schemas(collections, pool)
             .map_err(Into::into)


### PR DESCRIPTION
**Description:**

Rolls up a number of updates and fixes to the agent. Best to review commit by commit.

**Workflow steps:**

- Tested creating captures in the ui and then trying to delete the collection spec. Prior to this change, I was able to do so. After, it returns an error complaining about the existing capture binding that references the collection.
- Tested to ensure that the `built_spec` is properly updated as specs are published, and nulled out when specs are deleted.
- Manually update `resource_path_pointers` and ensure that a subsequent `connector_tags` job fails due to the change.
- Ensure that `connector_tags` jobs work when `resource_path_pointers` haven't changed.
- Ensure that discovers output the same results before and after this change.

**Notes for reviewers:**

This should not get merged/deployed until after estuary/connectors#1110 is merged, so that it doesn't prevent the `resource_path_pointers` from being updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1304)
<!-- Reviewable:end -->
