### PR TITLE
fixes for reverted runtime release

### DIFF
--- a/crates/runtime/src/rocksdb.rs
+++ b/crates/runtime/src/rocksdb.rs
@@ -9,6 +9,9 @@ use tokio::runtime::Handle;
 pub struct RocksDB {
     db: Arc<rocksdb::DB>,
     _tmp: Option<tempfile::TempDir>,
+    // TODO(johnny): Remove after RocksDB cut-over.
+    migrate_connector_state: std::sync::atomic::AtomicBool,
+    migrate_checkpoint: std::sync::atomic::AtomicBool,
 }
 
 impl RocksDB {
@@ -16,7 +19,7 @@ impl RocksDB {
     pub async fn open(desc: Option<RocksDbDescriptor>) -> anyhow::Result<Self> {
         let (opts, path, _tmp) = unpack_descriptor(desc)?;
 
-        let db = Handle::current()
+        let (db, migrate) = Handle::current()
             .spawn_blocking(move || Self::open_blocking(opts, path))
             .await
             .unwrap()?;
@@ -24,13 +27,39 @@ impl RocksDB {
         Ok(Self {
             db: Arc::new(db),
             _tmp,
+            migrate_connector_state: migrate.into(),
+            migrate_checkpoint: migrate.into(),
         })
     }
 
     fn open_blocking(
         mut opts: rocksdb::Options,
         path: std::path::PathBuf,
-    ) -> anyhow::Result<rocksdb::DB> {
+    ) -> anyhow::Result<(rocksdb::DB, bool)> {
+        // TODO(johnny): Remove after RocksDB cut-over.
+        // Is the recovered state.json more recent than the database?
+        // If so, we'll initially prefer it over DB-stored values.
+        let migrate = match (
+            std::fs::metadata(&path.join("state.json")),
+            std::fs::metadata(&path.join("CURRENT")),
+        ) {
+            (Ok(state), Ok(current)) => {
+                let state = state.modified().context("mtime")?;
+                let current = current.modified().context("mtime")?;
+                let migrate = state > current;
+
+                tracing::warn!(
+                    ?current,
+                    ?state,
+                    migrate,
+                    "rocks migration: CURRENT and state.json both exist",
+                );
+
+                migrate
+            }
+            _ => false,
+        };
+
         // RocksDB requires that all column families be explicitly passed in on open
         // or it will fail. We don't currently use column families, but have in the
         // past and may in the future. Flexibly open the DB by explicitly listing,
@@ -64,7 +93,7 @@ impl RocksDB {
         let db = rocksdb::DB::open_cf_descriptors(&opts, &path, cf_descriptors)
             .context("failed to open RocksDB")?;
 
-        Ok(db)
+        Ok((db, migrate))
     }
 
     /// Perform an async get_opt using a blocking background thread.
@@ -113,6 +142,16 @@ impl RocksDB {
 
     /// Load a persisted runtime Checkpoint.
     pub async fn load_checkpoint(&self) -> anyhow::Result<consumer::Checkpoint> {
+        // TODO(johnny): Remove after RocksDB cut-over.
+        if self
+            .migrate_checkpoint
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            // Ignore a DB-stored value and return an empty checkpoint.
+            // The Go runtime will then prefer its legacy, state.json value.
+            return Ok(consumer::Checkpoint::default());
+        }
+
         match self
             .get_opt(Self::CHECKPOINT_KEY, rocksdb::ReadOptions::default())
             .await
@@ -130,17 +169,27 @@ impl RocksDB {
         &self,
         initial: models::RawValue,
     ) -> anyhow::Result<models::RawValue> {
-        if let Some(state) = self
-            .get_opt(Self::CONNECTOR_STATE_KEY, rocksdb::ReadOptions::default())
-            .await
-            .context("failed to load connector state")?
+        // TODO(johnny): Remove after RocksDB cut-over.
+        if self
+            .migrate_connector_state
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
         {
-            let state = String::from_utf8(state).context("decoding connector state as UTF-8")?;
-            let state = models::RawValue::from_string(state).context("decoding state as JSON")?;
+            // Fall through to immediately persist the value populated by state.json
+        } else {
+            if let Some(state) = self
+                .get_opt(Self::CONNECTOR_STATE_KEY, rocksdb::ReadOptions::default())
+                .await
+                .context("failed to load connector state")?
+            {
+                let state =
+                    String::from_utf8(state).context("decoding connector state as UTF-8")?;
+                let state =
+                    models::RawValue::from_string(state).context("decoding state as JSON")?;
 
-            tracing::debug!(state=?ops::DebugJson(&state), "loaded a persisted connector state");
-            return Ok(state);
-        };
+                tracing::debug!(state=?ops::DebugJson(&state), "loaded a persisted connector state");
+                return Ok(state);
+            };
+        }
 
         let mut wo = rocksdb::WriteOptions::default();
         wo.set_sync(true);

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,8 @@ require (
 	github.com/stretchr/testify v1.8.3
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.89.1-0.20231208174009-79690d5b892a
+	go.gazette.dev/core v0.89.1-0.20231211195355-128bdd7af87d
 	golang.org/x/net v0.14.0
-	golang.org/x/sync v0.3.0
 	google.golang.org/api v0.126.0
 	google.golang.org/grpc v1.59.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -92,6 +91,7 @@ require (
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -382,10 +382,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20231121115006-0fa83a6cc072 h1:AtrxzZXkoUDfjXq7arxx5MKo+GsM3tPxRsakMIp9UQo=
-go.gazette.dev/core v0.89.1-0.20231121115006-0fa83a6cc072/go.mod h1:pUISSIdKXHoL5AJHBMrlPS20SF6TrManQlFbu6oV/84=
-go.gazette.dev/core v0.89.1-0.20231208174009-79690d5b892a h1:HWve8J8eXGZVrHHrR4lQdCJtqmiJWuSKuVLrM1C39oE=
-go.gazette.dev/core v0.89.1-0.20231208174009-79690d5b892a/go.mod h1:pUISSIdKXHoL5AJHBMrlPS20SF6TrManQlFbu6oV/84=
+go.gazette.dev/core v0.89.1-0.20231211195355-128bdd7af87d h1:o9dqLJOjiar+ixIpBf7J6sF073/6wnRlD7qjPV8Zpt8=
+go.gazette.dev/core v0.89.1-0.20231211195355-128bdd7af87d/go.mod h1:pUISSIdKXHoL5AJHBMrlPS20SF6TrManQlFbu6oV/84=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -33,9 +33,6 @@ update auth.users set
   updated_at = now()
 ;
 
-insert into auth.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
-select id, id, json_build_object('sub', id), 'email', now(), now(), now() from auth.users;
-
 -- Public directive which allows a new user to provision a new tenant.
 insert into directives (catalog_prefix, spec, token) values
   ('ops/', '{"type":"clickToAccept"}', 'd4a37dd7-1bf5-40e3-b715-60c4edd0f6dc'),

--- a/tests/snapshots/capture_hello_world__basic__stdout.json
+++ b/tests/snapshots/capture_hello_world__basic__stdout.json
@@ -19,5 +19,19 @@
       "message": "Hello 2!",
       "ts": "redacted-timestamp"
     }
+  ],
+  [
+    "acmeCo/events",
+    {
+      "message": "Hello 3!",
+      "ts": "redacted-timestamp"
+    }
+  ],
+  [
+    "acmeCo/events",
+    {
+      "message": "Hello 4!",
+      "ts": "redacted-timestamp"
+    }
   ]
 ]

--- a/tests/test_capture_hello_world.py
+++ b/tests/test_capture_hello_world.py
@@ -10,7 +10,7 @@ def test_basic(request, snapshot):
             "--source",
             request.config.rootdir + "/tests/test_capture_hello_world.flow.yaml",
             "--sessions",
-            "3",
+            "3,2",
         ],
         stdout=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
Bug fixes for reverted runtime release:

* Fix `consumer.Store` vs `*Materialize` et all nil checks.
* Update gazette pin to bring in relaxed FSM property handling.
* Add a modification-time-based migration for `state.json` vs RocksDB selection for initial checkpoint and connector state.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1310)
<!-- Reviewable:end -->
