### PR TITLE
runtime: increase maximum message size for dialed containers

### DIFF
--- a/crates/runtime/src/capture/connector.rs
+++ b/crates/runtime/src/capture/connector.rs
@@ -34,6 +34,8 @@ pub async fn start<L: LogHandler>(
     ) -> crate::image_connector::StartRpcFuture<Response> {
         async move {
             proto_grpc::capture::connector_client::ConnectorClient::new(channel)
+                .max_decoding_message_size(crate::MAX_MESSAGE_SIZE)
+                .max_encoding_message_size(usize::MAX)
                 .capture(rx)
                 .await
         }

--- a/crates/runtime/src/derive/connector.rs
+++ b/crates/runtime/src/derive/connector.rs
@@ -34,6 +34,8 @@ pub async fn start<L: LogHandler>(
     ) -> crate::image_connector::StartRpcFuture<Response> {
         async move {
             proto_grpc::derive::connector_client::ConnectorClient::new(channel)
+                .max_decoding_message_size(crate::MAX_MESSAGE_SIZE)
+                .max_encoding_message_size(usize::MAX)
                 .derive(rx)
                 .await
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -261,3 +261,6 @@ where
         }
     })
 }
+
+// Maximum accepted message size.
+const MAX_MESSAGE_SIZE: usize = 1 << 26; // 64MB.

--- a/crates/runtime/src/materialize/connector.rs
+++ b/crates/runtime/src/materialize/connector.rs
@@ -34,6 +34,8 @@ pub async fn start<L: LogHandler>(
     ) -> crate::image_connector::StartRpcFuture<Response> {
         async move {
             proto_grpc::materialize::connector_client::ConnectorClient::new(channel)
+                .max_decoding_message_size(crate::MAX_MESSAGE_SIZE)
+                .max_encoding_message_size(usize::MAX)
                 .materialize(rx)
                 .await
         }


### PR DESCRIPTION
From 4MB => 64MB.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1312)
<!-- Reviewable:end -->
