### PR TITLE
Updates to the stripe invoice generator

### DIFF
--- a/supabase/migrations/42_stripe_customers.sql
+++ b/supabase/migrations/42_stripe_customers.sql
@@ -1,0 +1,33 @@
+begin;
+
+create schema stripe;
+grant usage on schema stripe to postgres;
+
+-- Included here to match the shape of production database so that sqlx can infer queries properly.
+create table stripe.customers (
+    id text PRIMARY KEY,
+    address json,
+    "address/city" text,
+    "address/country" text,
+    "address/line1" text,
+    "address/line2" text,
+    "address/postal_code" text,
+    "address/state" text,
+    balance bigint,
+    created bigint,
+    currency text,
+    default_source text,
+    delinquent boolean,
+    description text,
+    email text,
+    invoice_prefix text,
+    invoice_settings json,
+    "invoice_settings/custom_fields" json,
+    "invoice_settings/default_payment_method" text,
+    metadata json,
+    name text,
+    phone text,
+    flow_document json NOT NULL
+);
+
+end;


### PR DESCRIPTION
**Description:**
* For tenants that do not have a credit card:
   * Skip generating invoices for tenants that have no data flowing in the billed month
   * Skip generating invoices for tenants that didn't have both an active capture _and_ an active materialization in the billed month
* Add stub stripe customers table to allow sqlx to properly infer query shapes
* Automatically remove existing draft invoices if a new rule has been introduced that would have skipped that invoice

@dyaffe Is the logic for active dataflow correct here? I interpreted it as being "had >0 active task hours for both capture and materialization task types during the billed month". But if you want it to be more granular, we could change it to check whether there are any capture and materialization task hours on the last day of the billed month?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1317)
<!-- Reviewable:end -->
