### PR TITLE
fix: Make `runtime::Binding` public

### DIFF
--- a/crates/runtime/src/combine/mod.rs
+++ b/crates/runtime/src/combine/mod.rs
@@ -10,7 +10,7 @@ impl<T: Stream<Item = anyhow::Result<Request>> + Send + Unpin + 'static> Request
 pub trait ResponseStream: Stream<Item = anyhow::Result<Response>> + Send + 'static {}
 impl<T: Stream<Item = anyhow::Result<Response>> + Send + 'static> ResponseStream for T {}
 
-struct Binding {
+pub struct Binding {
     key: Vec<doc::Extractor>,
     ser_policy: doc::SerPolicy,
     uuid_ptr: Option<doc::Pointer>,


### PR DESCRIPTION
This fixes a build error: `can't leak private type`

```
error[E0446]: private type `combine::Binding` in public interface
  --> crates/runtime/src/combine/protocol.rs:6:1
   |
6  | / pub fn recv_client_open(
7  | |     open: Request,
8  | | ) -> anyhow::Result<(doc::combine::Accumulator, Vec<Binding>)...
   | |______________________________________________________________^ can't leak private type
   |
  ::: crates/runtime/src/combine/mod.rs:13:1
   |
13 |   struct Binding {
   |   -------------- `combine::Binding` declared as private
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1321)
<!-- Reviewable:end -->
