### PR TITLE
task_service: hack to work around container signal failures

### DIFF
--- a/go/bindings/task_service.go
+++ b/go/bindings/task_service.go
@@ -146,7 +146,8 @@ func (s *TaskService) Drop() {
 		// Block until log read loop reads error or EOF.
 		// This happens only after all Rust references of the Pipe have been
 		// dropped and the descriptor has been closed.
-		<-s.lwaCh
+		// TODO: uncomment after fixing #1326
+		// <-s.lwaCh
 		s.lwaCh = nil
 	}
 	_ = os.Remove(s.config.UdsPath) // Best effort.


### PR DESCRIPTION
The long explanation can be found in [this slack
thread](https://estuaryworkspace.slack.com/archives/C03Q9A3GFEE/p1703378797225919). The short explanation is that not waiting for the log file to close may be a useful short term crutch.

Created the issue #1326 to track the underlying issue. We should revert this PR once we have a long term solve for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1327)
<!-- Reviewable:end -->
