### PR TITLE
async-process: SIGKILL on drop and connector-init idle timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,6 @@ version = "0.0.0"
 dependencies = [
  "insta",
  "libc",
- "shared_child",
  "tokio",
  "tracing",
 ]
@@ -4426,16 +4425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "fmt",
 ] }
-shared_child = "1.0.0"
 zeroize = "1.6"
 
 unicode-bom = "1.1"

--- a/crates/async-process/Cargo.toml
+++ b/crates/async-process/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 
 [dependencies]
 libc = { workspace = true }
-shared_child = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/connector-init/src/capture.rs
+++ b/crates/connector-init/src/capture.rs
@@ -16,6 +16,9 @@ impl proto_grpc::capture::connector_server::Connector for Proxy {
         &self,
         request: tonic::Request<tonic::Streaming<Request>>,
     ) -> Result<tonic::Response<Self::CaptureStream>, tonic::Status> {
+        crate::inc(&crate::GRPC_SERVER_STARTED_TOTAL);
+        let guard = crate::IncOnDrop(&crate::GRPC_SERVER_HANDLED_TOTAL);
+
         Ok(tonic::Response::new(
             rpc::bidi::<Request, Response, _, _>(
                 rpc::new_command(&self.entrypoint),
@@ -26,6 +29,10 @@ impl proto_grpc::capture::connector_server::Connector for Proxy {
                 }),
                 ops::stderr_log_handler,
             )?
+            .map(move |response| {
+                let _ = &guard; // Owned by closure.
+                response
+            })
             .boxed(),
         ))
     }

--- a/crates/connector-init/src/materialize.rs
+++ b/crates/connector-init/src/materialize.rs
@@ -16,6 +16,9 @@ impl proto_grpc::materialize::connector_server::Connector for Proxy {
         &self,
         request: tonic::Request<tonic::Streaming<Request>>,
     ) -> Result<tonic::Response<Self::MaterializeStream>, tonic::Status> {
+        crate::inc(&crate::GRPC_SERVER_STARTED_TOTAL);
+        let guard = crate::IncOnDrop(&crate::GRPC_SERVER_HANDLED_TOTAL);
+
         Ok(tonic::Response::new(
             rpc::bidi::<Request, Response, _, _>(
                 rpc::new_command(&self.entrypoint),
@@ -26,6 +29,10 @@ impl proto_grpc::materialize::connector_server::Connector for Proxy {
                 }),
                 ops::stderr_log_handler,
             )?
+            .map(move |response| {
+                let _ = &guard;
+                response
+            })
             .boxed(),
         ))
     }


### PR DESCRIPTION
Simplify the async-process crate by having it send SIGKILL in its drop
handler, to make sure `docker run` invocations are stopped. This avoids
a wedge we've observed in production where `docker run` doesn't exit
when asked (via SIGTERM) and we later deadlock waiting for its stderr to
close (which never happens).

Since `docker run` is now SIGKILL'd, also add a timeout-based watchdog
to flow-connector-init which ensures that it reliably exits after a
period of inactivity. This lets us avoid relying on docker to proxy
shutdown signals correctly, which in my testing is an iffy proposition.

Testing:
 * Confirmed this resolves my (limited) reproduction of deadlocks observed in production.
 * Local stack:
   * In normal operation `flow-connector-init` continues to run indefinitely.
   * When a shard is re-assigned, I see the new connector container start and the old one exit a few seconds later.
   * When the reactor is stopped through Tilt, or via ctrl-C, its containers exit a few seconds later.

Fixes #1326

Also add in a discovery timeout exception for source-netsuite and friends.

**Workflow steps:**

* Docker containers more reliably clean themselves up.
* Discovery over source-netsuite is allowed to take up to five minutes.
* Revert discovery increase to one minute for _all_ connectors.
* No other new behavior.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1328)
<!-- Reviewable:end -->
