### PR TITLE
parser: error logs when parsing failes and limit is exceeded

### DIFF
--- a/crates/parser/src/format/character_separated/error_buffer.rs
+++ b/crates/parser/src/format/character_separated/error_buffer.rs
@@ -71,7 +71,7 @@ impl<I: Iterator<Item = ParseResult>> ParseErrorBuffer<I> {
     fn buffer_next(&mut self) -> bool {
         if let Some(item) = self.inner.next() {
             if let Err(err) = item.as_ref() {
-                tracing::warn!(error=err.to_string(), "failed to parse row");
+                tracing::warn!(error=err.to_string(), "failed to parse row, but ignoring due to error threshold");
                 self.errors_in_buffer += 1;
             }
             self.total_records += 1;
@@ -105,7 +105,7 @@ impl<I: Iterator<Item = ParseResult>> Iterator for ParseErrorBuffer<I> {
             } else {
                 let item = self.advance()?;
                 if let Err(err) = item.as_ref() {
-                    tracing::warn!(error=err.to_string(), "failed to parse row");
+                    tracing::warn!(error=err.to_string(), "failed to parse row, but ignoring due to error threshold");
                     continue;
                 } else {
                     return Some(item);

--- a/crates/parser/src/format/mod.rs
+++ b/crates/parser/src/format/mod.rs
@@ -45,8 +45,8 @@ pub enum ParseError {
     #[error("unable to decompress input: {0}")]
     Decompression(#[from] CompressionError),
 
-    #[error("error limit exceeded")]
-    ErrorLimitExceeded(ErrorThreshold),
+    #[error("error limit exceeded: {1}")]
+    ErrorLimitExceeded(ErrorThreshold, String),
 
     #[error("failed to sanitize documents: {0}")]
     SanitizeError(#[from] sanitize::SanitizeError),

--- a/crates/parser/src/format/mod.rs
+++ b/crates/parser/src/format/mod.rs
@@ -7,7 +7,7 @@ pub mod sanitize;
 use crate::config::ErrorThreshold;
 use crate::decorate::{AddFieldError, Decorator};
 use crate::input::{detect_compression, CompressionError, Input};
-use crate::{Compression, Format, ParseConfig};
+use crate::{Compression, Format, ParseConfig, JsonPointer};
 
 use serde_json::Value;
 use std::io::{self, Write};
@@ -106,6 +106,10 @@ pub fn parse(
 ) -> Result<(), ParseError> {
     let (resolved_format, resolved_compression, content) = resolve_config(config, content)?;
     tracing::debug!(format = ?resolved_format, compression = %resolved_compression, "resolved config");
+    
+    // Add the /_meta/filename to the span so we can track which files are associated with logs
+    let span = tracing::span!(tracing::Level::ERROR, "parsing", filename = config.add_values.get(&JsonPointer("/_meta/file".to_string())).and_then(|v| v.as_str()));
+    let _enter = span.enter();
 
     let parser = parser_for(resolved_format);
 


### PR DESCRIPTION
**Description:**

- This fixes an issue where if during `prefill_buffer` we would already hit the error limit, we would not log any of the errors.
- Moreover, makes the error limit exceeded exception include the first error in the buffer to make it more informative
- One thing that I find missing though is having the file name that is failing as part of the errors, that makes it a lot more useful for users. Looking at how the plumbing works, I think we need to make that change in `filesource` library in connectors repo to include the file name, but it's a bit tricky given that the parser logs the error and `filesource` abstains from logging anything to leave the parser error as the last log line

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1333)
<!-- Reviewable:end -->
