### PR TITLE
agent: use a timeout when shutting down the runtime

### DIFF
--- a/crates/agent/src/handlers.rs
+++ b/crates/agent/src/handlers.rs
@@ -28,9 +28,10 @@ pub struct AgentNotification {
 }
 
 /// Handler is the principal trait implemented by the various task-specific
-/// event handlers that the agent runs.
+/// event handlers that the agent runs. They need to be `Send` because we
+/// spawn the handler invocations on a multithreaded runtime.
 #[async_trait::async_trait]
-pub trait Handler {
+pub trait Handler: Send {
     async fn handle(&mut self, pg_pool: &sqlx::PgPool) -> anyhow::Result<HandlerStatus>;
 
     fn table_name(&self) -> &'static str;


### PR DESCRIPTION
We've observed cases where the agent hangs when shutting down the runtime after an error occurs. This changes it to use the same pattern that's used elsewhere in our code base for shutting down the tokio runtime with a timeout, to prevent it from hanging indefinitely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1334)
<!-- Reviewable:end -->
