### PR TITLE
source-mongodb: make it explicit that we require database permission

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/mongodb.md
+++ b/site/docs/reference/Connectors/capture-connectors/mongodb.md
@@ -32,7 +32,9 @@ You'll need:
       reliability, and possibility of capturing multiple databases in the same
       task. However, if access to all databases is not possible, you can
       give us access to a single database and we will watch a change stream on
-      that specific database.
+      that specific database. Note that we require access on the _database_ and
+      not individual collections. This is to so that we can run a change stream on
+      the database which allows for better consistency guarantees.
     
     In order to create a user with access to all databases, use a command like so:
     ```
@@ -44,7 +46,7 @@ You'll need:
    })
     ```
     
-    If you are using a userw ith access to all databases, then in your mongodb
+    If you are using a user with access to all databases, then in your mongodb
     address, you must specify `?authSource=admin` parameter so that
     authentication is done through your admin database.
 


### PR DESCRIPTION
**Description:**

- We had a user hit this. They gave us collection permissions for change stream but that does not work for us. We need access on the database.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1335)
<!-- Reviewable:end -->
