### PR TITLE
Phil/discover timeouts

### DIFF
--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -87,12 +87,19 @@ func (cmd apiDiscover) Execute(_ []string) error {
 
 	var timeout = time.Second * 30
 
-	// Temporary exception for the Netsuite connector.
+	// Temporary exceptions for connectors that are known to have very slow discover
+	// operations.
 	// TODO(johnny): Allow larger timeouts across the board, after resolving
 	// progress and UX issues of long-running discover operations.
-	if strings.HasPrefix(cmd.Image, "ghcr.io/estuary/source-netsuite") {
-		timeout = time.Minute * 5
+	for _, image := range []string{
+		"ghcr.io/estuary/source-salesforce",
+		"ghcr.io/estuary/source-netsuite",
+	} {
+		if strings.HasPrefix(cmd.Image, image) {
+			timeout = time.Minute * 5
+		}
 	}
+
 	var ctx, cancelFn = context.WithTimeout(context.Background(), timeout)
 	defer cancelFn()
 


### PR DESCRIPTION
**Description:**

Adds another exception to our discover timeout for the `source-salesforce` connector, which is routinely timing out in production.

Allows flowctl-go to read the discover timeout from an env variable, so that we can change it without needing to re-build. The env var is `FLOW_DISCOVER_TIMEOUT`, and it's value will be used as the default timeout, which is overridden by the exception cases.

**Workflow steps:**

Do a discover with the source-saleforce connector, and it is now allowed to take up to 5 minutes before timing out.

**Notes for reviewers:**

`FLOW_DISCOVER_TIMEOUT` is not necessarily meant to be a permanent solution, though it may be fine for us to keep using that env variable. But there's a desire to change the default timeout based on observed failures in production, and seems likely that we'll tweak it more than once, so it seemed worthwhile to just use an env var.

I tested this by manually running some `flowctl-go api discover` commands and observing the logged timeout value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1338)
<!-- Reviewable:end -->
