### PR TITLE
Phil/evolutions backfill

### DIFF
--- a/crates/agent-sql/src/evolutions.rs
+++ b/crates/agent-sql/src/evolutions.rs
@@ -90,46 +90,97 @@ where
     Ok(())
 }
 
-pub struct DraftSpecRow {
-    pub draft_spec_id: Id,
-    pub live_spec_id: Option<Id>,
+pub struct SpecRow {
     pub catalog_name: String,
+    /// The id of the draft spec, or None if it is not already in the draft
+    pub draft_spec_id: Option<Id>,
+    /// The id of the live spec, or None if the spec was never published (which
+    /// will be surfaced as an error)
+    pub live_spec_id: Option<Id>,
+    /// The current value of `expect_pub_id` from the draft spec, if drafted
     pub expect_pub_id: Option<Id>,
+    /// The last publication id that updated the live spec
     pub last_pub_id: Option<Id>,
-    pub draft_spec: Option<Json<Box<RawValue>>>,
-    pub draft_type: Option<CatalogType>,
-    pub live_type: Option<CatalogType>,
+    pub spec: Option<Json<Box<RawValue>>>,
+    pub spec_type: Option<CatalogType>,
 }
 
-pub async fn fetch_draft_specs(
-    draft_id: Id,
+/// Fetches the initial set of specs that are needed for an evolutions job. The `collection_names` must be only the _current_ names of affected collections. It should not include the new names of collections requested to be re-created.
+/// The set of returned specs will include:
+/// - All draft_specs for the given `draft_id`
+/// - live_specs rows for any of the `collection_names` that _aren't_ already drafted
+///
+/// The reason for including all draft specs is that the evolution may end
+/// up affecting them, but we cannot know for certain until we check all of their
+/// bindings. Technically, we could implement that filtering as part of the sql
+/// query, but the extra complexity doesn't seem warranted at this time.
+pub async fn resolve_specs(
     user_id: Uuid,
+    draft_id: Id,
+    collection_names: Vec<String>,
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-) -> sqlx::Result<Vec<DraftSpecRow>> {
+) -> sqlx::Result<Vec<SpecRow>> {
     sqlx::query_as!(
-        DraftSpecRow,
+        SpecRow,
         r#"
+        with drafted as (
+            select
+                ds.catalog_name,
+                ds.id as draft_spec_id,
+                ls.id as live_spec_id,
+                ds.expect_pub_id,
+                ls.last_pub_id as last_pub_id,
+                ds.spec as spec,
+                ds.spec_type as spec_type
+            from draft_specs ds
+            left join live_specs ls
+                on ds.catalog_name = ls.catalog_name
+                -- filter out live_specs rows that the user does not have admin access to
+                and exists (select 1 from internal.user_roles($2, 'admin') r where ls.catalog_name ^@ r.role_prefix)
+            where ds.draft_id = $1
+        ),
+        not_drafted as (
+            select catalog_name from unnest($3::text[]) as names(catalog_name)
+            except
+            select catalog_name from drafted
+        ),
+        live as (
+            select 
+                ls.catalog_name,
+                ls.spec,
+                ls.spec_type,
+                ls.last_pub_id,
+                ls.id
+            from not_drafted
+            join live_specs ls on not_drafted.catalog_name = ls.catalog_name
+            where
+                -- filter out live_specs rows that the user does not have admin access to
+                exists (select 1 from internal.user_roles($2, 'admin') r where ls.catalog_name ^@ r.role_prefix)
+        )
         select
-            draft_specs.id as "draft_spec_id: Id",
-            draft_specs.catalog_name,
-            draft_specs.expect_pub_id as "expect_pub_id: Id",
-            draft_specs.spec as "draft_spec: Json<Box<RawValue>>",
-            draft_specs.spec_type as "draft_type: CatalogType",
-            live_specs.spec_type as "live_type: CatalogType",
-            live_specs.last_pub_id as "last_pub_id: Option<Id>",
-            live_specs.id as "live_spec_id: Option<Id>"
-        from drafts
-        left join draft_specs on drafts.id = draft_specs.draft_id
-        left join live_specs
-            on draft_specs.catalog_name = live_specs.catalog_name
-            -- Ensure that `live_spec_id` is `None` if the user does not have admin access to the spec.
-            and exists (select 1 from internal.user_roles($2, 'admin') r where live_specs.catalog_name ^@ r.role_prefix)
-        where drafts.id = $1 and drafts.user_id = $2
+            catalog_name as "catalog_name!: String",
+            draft_spec_id as "draft_spec_id: Id",
+            live_spec_id as "live_spec_id: Id",
+            expect_pub_id as "expect_pub_id: Id",
+            last_pub_id as "last_pub_id: Id",
+            spec as "spec: Json<Box<RawValue>>",
+            spec_type as "spec_type: CatalogType"
+        from drafted
+        union all
+        select 
+            catalog_name as "catalog_name!: String",
+            null as "draft_spec_id: Id",
+            id as "live_spec_id: Id",
+            null as "expect_pub_id: Id",
+            last_pub_id as "last_pub_id: Id",
+            spec as "spec: Json<Box<RawValue>>",
+            spec_type as "spec_type: CatalogType"
+        from live
         "#,
         draft_id as Id,
         user_id as Uuid,
-    )
-    .fetch_all(txn)
+        collection_names as Vec<String>,
+    ).fetch_all(txn)
     .await
 }
 

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -423,6 +423,12 @@ fn evolve_collection(
             for binding in new_spec.bindings.iter_mut() {
                 if &binding.target == &old_collection {
                     binding.target = new_name.clone();
+                    // When re-creating collections, it's quite likely that
+                    // users will also want to trigger a new backfill. Unlike
+                    // materializations, capture connectors will only backfill
+                    // when the counter is incremented, not when only the
+                    // collection name is changed.
+                    binding.backfill += 1;
                 }
             }
         }

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
@@ -18,6 +18,7 @@ expression: new_draft
                         "target": String("evolution/CollectionA"),
                     },
                     Object {
+                        "backfill": Number(1),
                         "resource": Object {
                             "thingy": String("bar"),
                         },
@@ -48,6 +49,7 @@ expression: new_draft
                         "target": String("evolution/CollectionC"),
                     },
                     Object {
+                        "backfill": Number(1),
                         "resource": Object {
                             "thingy": String("qux"),
                         },

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
@@ -121,11 +121,12 @@ expression: new_draft
             Object {
                 "bindings": Array [
                     Object {
+                        "backfill": Number(1),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("aThing_v2"),
+                            "targetThingy": String("aThing"),
                         },
                         "source": String("evolution/CollectionA"),
                     },
@@ -157,11 +158,12 @@ expression: new_draft
             Object {
                 "bindings": Array [
                     Object {
+                        "backfill": Number(10),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("cThing_v2"),
+                            "targetThingy": String("cThing"),
                         },
                         "source": String("evolution/CollectionC"),
                     },

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__collection_evolution-2.snap
@@ -131,11 +131,12 @@ expression: new_draft
                         "source": String("evolution/CollectionA"),
                     },
                     Object {
+                        "backfill": Number(1),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("NewCollectionB"),
+                            "targetThingy": String("bThing"),
                         },
                         "source": String("evolution/NewCollectionB"),
                     },
@@ -168,11 +169,12 @@ expression: new_draft
                         "source": String("evolution/CollectionC"),
                     },
                     Object {
+                        "backfill": Number(1),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("NewCollectionD"),
+                            "targetThingy": String("dThing"),
                         },
                         "source": String("evolution/NewCollectionD"),
                     },
@@ -195,11 +197,12 @@ expression: new_draft
             Object {
                 "bindings": Array [
                     Object {
+                        "backfill": Number(1),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("NewCollectionB"),
+                            "targetThingy": String("CollectionB"),
                         },
                         "source": String("evolution/NewCollectionB"),
                     },

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
@@ -1,0 +1,135 @@
+---
+source: crates/agent/src/evolution/test.rs
+expression: draft_specs
+---
+[
+    Record {
+        catalog_name: "evolution/CaptureB",
+        spec_type: Some(
+            Capture,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "resource": Object {
+                            "thingy": String("baz"),
+                        },
+                        "target": String("evolution/CollectionC_v2"),
+                    },
+                    Object {
+                        "resource": Object {
+                            "thingy": String("qux"),
+                        },
+                        "target": String("evolution/CollectionD"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("captureImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+    Record {
+        catalog_name: "evolution/CollectionC_v2",
+        spec_type: Some(
+            Collection,
+        ),
+        spec: Some(
+            Object {
+                "key": Array [
+                    String("id"),
+                ],
+                "schema": Object {
+                    "properties": Object {
+                        "id": Object {
+                            "type": String("string"),
+                        },
+                    },
+                    "required": Array [
+                        String("id"),
+                    ],
+                    "type": String("object"),
+                    "x-infer-schema": Bool(true),
+                },
+            },
+        ),
+    },
+    Record {
+        catalog_name: "evolution/MaterializationA",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "backfill": Number(1),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("aThing"),
+                        },
+                        "source": String("evolution/CollectionA"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("bThing"),
+                        },
+                        "source": String("evolution/CollectionB"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("matImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+    Record {
+        catalog_name: "evolution/MaterializationB",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "backfill": Number(9),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("CollectionC_v2"),
+                        },
+                        "source": String("evolution/CollectionC_v2"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("dThing"),
+                        },
+                        "source": String("evolution/CollectionD"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("matImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+]

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
@@ -12,6 +12,7 @@ expression: draft_specs
             Object {
                 "bindings": Array [
                     Object {
+                        "backfill": Number(1),
                         "resource": Object {
                             "thingy": String("baz"),
                         },

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary-2.snap
@@ -104,12 +104,12 @@ expression: draft_specs
             Object {
                 "bindings": Array [
                     Object {
-                        "backfill": Number(9),
+                        "backfill": Number(10),
                         "fields": Object {
                             "recommended": Bool(true),
                         },
                         "resource": Object {
-                            "targetThingy": String("CollectionC_v2"),
+                            "targetThingy": String("cThing"),
                         },
                         "source": String("evolution/CollectionC_v2"),
                     },

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_adds_collections_to_the_draft_if_necessary.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agent/src/evolution/test.rs
+expression: evolved_collections
+---
+- old_name: evolution/CollectionA
+  new_name: evolution/CollectionA
+  updated_materializations:
+    - evolution/MaterializationA
+  updated_captures: []
+- old_name: evolution/CollectionC
+  new_name: evolution/CollectionC_v2
+  updated_materializations:
+    - evolution/MaterializationB
+  updated_captures:
+    - evolution/CaptureB
+

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_affects_specific_materializations_when_requested-2.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_affects_specific_materializations_when_requested-2.snap
@@ -1,0 +1,44 @@
+---
+source: crates/agent/src/evolution/test.rs
+expression: draft_specs
+---
+[
+    Record {
+        catalog_name: "evolution/MaterializationD",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "backfill": Number(10),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("testTargetThingA"),
+                        },
+                        "source": String("evolution/CollectionA"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("testTargetThingC"),
+                        },
+                        "source": String("evolution/CollectionC"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {},
+                        "image": String("matImage:v1"),
+                    },
+                },
+            },
+        ),
+        expect_pub_id: None,
+    },
+]

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_affects_specific_materializations_when_requested.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_affects_specific_materializations_when_requested.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agent/src/evolution/test.rs
+expression: evolved_collections
+---
+[
+    EvolvedCollection {
+        old_name: "evolution/CollectionA",
+        new_name: "evolution/CollectionA",
+        updated_materializations: [
+            "evolution/MaterializationD",
+        ],
+        updated_captures: [],
+    },
+]

--- a/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_preserves_changes_already_in_the_draft.snap
+++ b/crates/agent/src/evolution/snapshots/agent__evolution__test__evolution_preserves_changes_already_in_the_draft.snap
@@ -1,0 +1,48 @@
+---
+source: crates/agent/src/evolution/test.rs
+expression: draft_specs
+---
+[
+    Record {
+        catalog_name: "evolution/MaterializationA",
+        spec_type: Some(
+            Materialization,
+        ),
+        spec: Some(
+            Object {
+                "bindings": Array [
+                    Object {
+                        "backfill": Number(12),
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "new": String("stuff"),
+                            "targetThingy": String("newThing"),
+                        },
+                        "source": String("evolution/CollectionA"),
+                    },
+                    Object {
+                        "fields": Object {
+                            "recommended": Bool(true),
+                        },
+                        "resource": Object {
+                            "targetThingy": String("bThing"),
+                        },
+                        "source": String("evolution/CollectionB"),
+                    },
+                ],
+                "endpoint": Object {
+                    "connector": Object {
+                        "config": Object {
+                            "new": Object {
+                                "stuff": String("here"),
+                            },
+                        },
+                        "image": String("matImage:v1"),
+                    },
+                },
+            },
+        ),
+    },
+]

--- a/crates/agent/src/evolution/test.rs
+++ b/crates/agent/src/evolution/test.rs
@@ -286,3 +286,100 @@ async fn evolution_preserves_changes_already_in_the_draft() {
     // (even though it's already larger than the value in live_specs).
     insta::assert_debug_snapshot!(draft_specs);
 }
+
+#[tokio::test]
+#[serial_test::parallel]
+async fn evolution_affects_specific_materializations_when_requested() {
+    let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+        .await
+        .unwrap();
+    let mut txn = conn.begin().await.unwrap();
+
+    let draft_id = Id::from_hex("2230000000000000").unwrap();
+    let user_id = uuid::Uuid::parse_str("43a18a3e-5a59-11ed-9b6a-0242ac188888").unwrap();
+    sqlx::query(include_str!("test_setup.sql"))
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    // Add another materialization, so we can assert that only the requested one gets updated
+    sqlx::query(r##"
+        with clear_draft as (
+            delete from draft_specs where draft_id = '2230000000000000'
+        ),
+        ls as (
+            insert into live_specs (id, catalog_name, spec, spec_type, last_build_id, last_pub_id) values
+            (
+              'b333000000000000', 'evolution/MaterializationD',
+              '{
+                    "bindings": [
+                      {"source": "evolution/CollectionA", "backfill": 9, "resource": {"targetThingy": "testTargetThingA"}},
+                      {"source": "evolution/CollectionC", "resource": {"targetThingy": "testTargetThingC"}}
+                    ],
+                    "endpoint": {"connector": {"image": "matImage:v1", "config": {}}}
+                }' :: json, 
+              'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
+            )
+        ),
+        flows as (
+            insert into live_spec_flows (source_id, target_id, flow_type) values
+            (
+              'a100000000000000', 'b333000000000000',
+              'materialization'
+            ), 
+            (
+              'a200000000000000', 'b333000000000000',
+              'materialization'
+            )
+        ) select 1
+    "##).execute(&mut txn).await.unwrap();
+
+    let input = serde_json::value::to_raw_value(&serde_json::json!([
+        {"old_name": "evolution/CollectionA", "materializations": ["evolution/MaterializationD"]},
+    ]))
+    .unwrap();
+    let evolution_row = Row {
+        id: Id::from_hex("f100000000000000").unwrap(),
+        created_at: Utc::now(),
+        detail: None,
+        draft_id,
+        logs_token: uuid::Uuid::new_v4(),
+        updated_at: Utc::now(),
+        user_id,
+        collections: agent_sql::TextJson(input),
+        auto_publish: false,
+    };
+
+    let result = super::process_row(evolution_row, &mut txn)
+        .await
+        .expect("process row should succeed");
+
+    let JobStatus::Success {
+        evolved_collections,
+        publication_id,
+    } = result
+    else {
+        panic!("unexpected job status: {result:?}, expected success");
+    };
+    assert!(publication_id.is_none());
+
+    insta::assert_debug_snapshot!(evolved_collections);
+
+    let draft_specs = sqlx::query!(
+        r#"
+        select catalog_name, spec_type as "spec_type: CatalogType", spec, expect_pub_id as "expect_pub_id: Id"
+        from draft_specs
+        where draft_id = '2230000000000000'
+        order by catalog_name asc
+    "#
+    )
+    .fetch_all(&mut txn)
+    .await
+    .expect("querying draft_specs");
+
+    // We're looking for the new endpoint and resource configs, which ought to
+    // be preserved, and for the backfill counter to have been incremented still
+    // (even though it's already larger than the value in live_specs). Also looking
+    // for the expect_pub_id from the draft spec to be preserved.
+    insta::assert_debug_snapshot!(draft_specs);
+}

--- a/crates/agent/src/evolution/test.rs
+++ b/crates/agent/src/evolution/test.rs
@@ -41,7 +41,11 @@ async fn test_collection_evolution() {
         .await
         .expect("process row should succeed");
 
-    let JobStatus::Success { evolved_collections, publication_id } = result else {
+    let JobStatus::Success {
+        evolved_collections,
+        publication_id,
+    } = result
+    else {
         panic!("unexpected job status: {result:?}, expected success");
     };
     let publication_id = publication_id.expect("publication id should be set in status");
@@ -78,4 +82,207 @@ async fn test_collection_evolution() {
     assert_eq!(user_id, publication.user_id);
     assert!(!publication.dry_run);
     assert!(!publication.auto_evolve);
+}
+
+#[tokio::test]
+#[serial_test::parallel]
+async fn evolution_fails_when_collection_is_deleted() {
+    let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+        .await
+        .unwrap();
+    let mut txn = conn.begin().await.unwrap();
+
+    let draft_id = Id::from_hex("2230000000000000").unwrap();
+    let user_id = uuid::Uuid::parse_str("43a18a3e-5a59-11ed-9b6a-0242ac188888").unwrap();
+    sqlx::query(include_str!("test_setup.sql"))
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    // Simulate CollectionA being deleted in the draft
+    sqlx::query(
+        "update draft_specs set spec = null, spec_type = null where id = '1111000000000000'",
+    )
+    .execute(&mut txn)
+    .await
+    .unwrap();
+
+    let input = serde_json::value::to_raw_value(&serde_json::json!([
+        {"old_name": "evolution/CollectionA"},
+    ]))
+    .unwrap();
+    let evolution_row = Row {
+        id: Id::from_hex("f100000000000000").unwrap(),
+        created_at: Utc::now(),
+        detail: None,
+        draft_id,
+        logs_token: uuid::Uuid::new_v4(),
+        updated_at: Utc::now(),
+        user_id,
+        collections: agent_sql::TextJson(input),
+        auto_publish: false,
+    };
+
+    let result = super::process_row(evolution_row, &mut txn)
+        .await
+        .expect("process row should succeed");
+
+    let JobStatus::EvolutionFailed { error } = result else {
+        panic!("unexpected job status: {result:?}, expected failure");
+    };
+
+    assert_eq!(
+        "cannot evolve collection 'evolution/CollectionA' which was already deleted in the draft",
+        error
+    );
+}
+
+#[tokio::test]
+#[serial_test::parallel]
+async fn evolution_adds_collections_to_the_draft_if_necessary() {
+    let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+        .await
+        .unwrap();
+    let mut txn = conn.begin().await.unwrap();
+
+    let draft_id = Id::from_hex("2230000000000000").unwrap();
+    let user_id = uuid::Uuid::parse_str("43a18a3e-5a59-11ed-9b6a-0242ac188888").unwrap();
+    sqlx::query(include_str!("test_setup.sql"))
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    // Clear the draft of any specs, so we can assert that they get added as necessary
+    sqlx::query("delete from draft_specs where draft_id = '2230000000000000'")
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    let input = serde_json::value::to_raw_value(&serde_json::json!([
+        {"old_name": "evolution/CollectionA"},
+        {"old_name": "evolution/CollectionC", "new_name": "evolution/CollectionC_v2"},
+    ]))
+    .unwrap();
+    let evolution_row = Row {
+        id: Id::from_hex("f100000000000000").unwrap(),
+        created_at: Utc::now(),
+        detail: None,
+        draft_id,
+        logs_token: uuid::Uuid::new_v4(),
+        updated_at: Utc::now(),
+        user_id,
+        collections: agent_sql::TextJson(input),
+        auto_publish: false,
+    };
+
+    let result = super::process_row(evolution_row, &mut txn)
+        .await
+        .expect("process row should succeed");
+
+    let JobStatus::Success {
+        evolved_collections,
+        publication_id,
+    } = result
+    else {
+        panic!("unexpected job status: {result:?}, expected success");
+    };
+    assert!(publication_id.is_none());
+
+    insta::assert_yaml_snapshot!(evolved_collections);
+
+    let draft_specs = sqlx::query!(
+        r#"
+        select catalog_name, spec_type as "spec_type: CatalogType", spec
+        from draft_specs
+        where draft_id = '2230000000000000'
+        order by catalog_name asc
+    "#
+    )
+    .fetch_all(&mut txn)
+    .await
+    .expect("querying draft_specs");
+    insta::assert_debug_snapshot!(draft_specs);
+}
+
+#[tokio::test]
+#[serial_test::parallel]
+async fn evolution_preserves_changes_already_in_the_draft() {
+    let mut conn = sqlx::postgres::PgConnection::connect(&FIXED_DATABASE_URL)
+        .await
+        .unwrap();
+    let mut txn = conn.begin().await.unwrap();
+
+    let draft_id = Id::from_hex("2230000000000000").unwrap();
+    let user_id = uuid::Uuid::parse_str("43a18a3e-5a59-11ed-9b6a-0242ac188888").unwrap();
+    sqlx::query(include_str!("test_setup.sql"))
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    // Clear the draft, so it only contains the materialization
+    sqlx::query("delete from draft_specs where draft_id = '2230000000000000'")
+        .execute(&mut txn)
+        .await
+        .unwrap();
+    sqlx::query(r##"insert into draft_specs (draft_id, catalog_name, spec_type, spec) values (
+            '2230000000000000',
+            'evolution/MaterializationA',
+            'materialization',
+            '{
+                "bindings": [
+                    {"source": "evolution/CollectionA", "backfill": 11, "resource": {"targetThingy": "newThing", "new": "stuff"}},
+                    {"source": "evolution/CollectionB", "resource": {"targetThingy": "bThing"}}
+                ],
+                "endpoint": {"connector": {"image": "matImage:v1", "config": {"new": {"stuff": "here"}}}}
+            }'::json
+        )"##)
+        .execute(&mut txn)
+        .await
+        .unwrap();
+
+    let input = serde_json::value::to_raw_value(&serde_json::json!([
+        {"old_name": "evolution/CollectionA"}
+    ]))
+    .unwrap();
+    let evolution_row = Row {
+        id: Id::from_hex("f100000000000000").unwrap(),
+        created_at: Utc::now(),
+        detail: None,
+        draft_id,
+        logs_token: uuid::Uuid::new_v4(),
+        updated_at: Utc::now(),
+        user_id,
+        collections: agent_sql::TextJson(input),
+        auto_publish: false,
+    };
+
+    let result = super::process_row(evolution_row, &mut txn)
+        .await
+        .expect("process row should succeed");
+
+    let JobStatus::Success {
+        evolved_collections: _,
+        publication_id,
+    } = result
+    else {
+        panic!("unexpected job status: {result:?}, expected success");
+    };
+    assert!(publication_id.is_none());
+
+    let draft_specs = sqlx::query!(
+        r#"
+        select catalog_name, spec_type as "spec_type: CatalogType", spec
+        from draft_specs
+        where draft_id = '2230000000000000'
+        order by catalog_name asc
+    "#
+    )
+    .fetch_all(&mut txn)
+    .await
+    .expect("querying draft_specs");
+
+    // We're looking for the new endpoint and resource configs, which ought to
+    // be preserved, and for the backfill counter to have been incremented still
+    // (even though it's already larger than the value in live_specs).
+    insta::assert_debug_snapshot!(draft_specs);
 }

--- a/crates/agent/src/evolution/test_setup.sql
+++ b/crates/agent/src/evolution/test_setup.sql
@@ -83,7 +83,7 @@ with s1 as (
       'a900000000000000', 'evolution/MaterializationB', 
       '{
             "bindings": [
-                {"source": "evolution/CollectionC", "resource": {"targetThingy": "cThing"}},
+                {"source": "evolution/CollectionC", "backfill": 9, "resource": {"targetThingy": "cThing"}},
                 {"source": "evolution/CollectionD", "resource": {"targetThingy": "dThing"}}
             ],
             "endpoint": {"connector": {"image": "matImage:v1", "config": {}}}

--- a/crates/agent/src/evolution/test_setup.sql
+++ b/crates/agent/src/evolution/test_setup.sql
@@ -266,44 +266,6 @@ s8 as (
       '43a18a3e-5a59-11ed-9b6a-0242ac188888', 
       'evolution/', 'admin'
     )
-), 
-s9 as (
-  insert into connectors (
-    id, external_url, image_name, title, 
-    short_description, logo_url
-  ) 
-  values 
-    (
-      '5555555555555555', 'http://example.com', 
-      'captureImage', '{"en-US": "foo"}' :: json, 
-      '{"en-US": "foo"}' :: json, '{"en-US": "foo"}' :: json
-    ), 
-    (
-      '6666666666666666', 'http://example.com', 
-      'matImage', '{"en-US": "foo"}' :: json, 
-      '{"en-US": "foo"}' :: json, '{"en-US": "foo"}' :: json
-    )
-),
-s10 as (
-  -- Evolution requires the resource_spec_schema in order to get the location
-  -- of the `x-collection-name` annotation.
-  insert into connector_tags (
-    connector_id, image_tag, protocol, 
-    resource_spec_schema
-  ) 
-  values 
-    (
-      '6666666666666666', ':v1', 'materialize', 
-      '{
-            "type": "object",
-            "properties": {
-                "targetThingy": {
-                    "type": "string",
-                    "x-collection-name": true
-                }
-            }
-      }'
-    )
-) 
+)
 select 1;
 

--- a/crates/agent/src/publications/linked_materializations.rs
+++ b/crates/agent/src/publications/linked_materializations.rs
@@ -300,10 +300,9 @@ async fn update_linked_materialization(
         let mut resource_spec = serde_json::json!({});
         let collection_name_ptr = resource_pointer_cache.get_pointer(txn, &conn.image).await?;
         crate::resource_configs::update_materialization_resource_spec(
-            materialization_name,
             &mut resource_spec,
             &collection_name_ptr,
-            Some(collection_name.to_string()),
+            collection_name,
         )?;
 
         let binding = MaterializationBinding {

--- a/site/docs/concepts/advanced/evolutions.md
+++ b/site/docs/concepts/advanced/evolutions.md
@@ -66,17 +66,17 @@ Alternatively, you could manually update all the specs to agree to your edit, bu
 
 Evolutions can prevent errors resulting from mismatched specs in two ways:
 
-* **Materialize data to a new resource in the endpoint system**: The evolution updates all materialization binding that from the collection to write to a new resource (database table, for example) in the endpoint system. This is done by updating the materialization's *binding specification*. For example, if the collection was previously materialized into a database table called `my_table`, the evolution would update it to instead materialize into `my_table_v2`. The Flow collection itself remains unchanged.
+* **Materialize data to a new resource in the endpoint system**: The evolution updates the affected materialization bindings to increment their `backfill` counter, which causes the materialization to re-create the resource (database table, for example) and backfill it from the beginning.
 
    This is a simpler change, and how evolutions work in most cases.
 
-* **Re-create the Flow collection with a new name**: The evolution creates a completely new collection with numerical suffix, such as `_v2`. This collection starts out empty and backfills from the source. The evolution also updates all captures and materializations that reference the old collection to instead reference the new collection. This also updates any materializations to materialize the new collection into a new resource.
+* **Re-create the Flow collection with a new name**: The evolution creates a completely new collection with numerical suffix, such as `_v2`. This collection starts out empty and backfills from the source. The evolution also updates all captures and materializations that reference the old collection to instead reference the new collection, and increments their `backfill` counters.
 
-   This is a more complicated change, and evolutions only work this way when necessary: when the collection key or logical partition changes, or when a schema change would cause the endpoint system to reject the materialized data.
+   This is a more complicated change, and evolutions only work this way when necessary: when the collection key or logical partitioning changes.
 
-:::info
-Evolutions will soon support the re-creation of materialization resources, such as tables, while keeping the same names.
-:::
+In either case, the names of the destination resources will remain the same. For example, a materialization to Postgres would drop and re-create the affected tables with the same names they had previously.
+
+Also in either case, only the specific bindings that had incompatible changes will be affected. Other bindings will remain untouched, and will not re-backfill.
 
 ## What causes breaking schema changes?
 


### PR DESCRIPTION
**Description:**

This updates the evolutions handler to increment the backfill counter instead of re-naming resources. Best to review commit by commit. The individual commit messages have more details.

To summarize the new behavior of the evolutions handler:

- It will never add a version suffix to materialization resource names
- It will always increment the backfill counter for affected materializations
- It can optionally limit the evolution to only affect a subset of materializations
- It now sets the `expect_pub_id` column on `draft_specs` that it modifies
- It will increment the backfill counter of affected captures when re-creating collections (but not otherwise)

**Workflow steps:**

Some test cases:

- Changing primary key of a captured table when published via the UI
- Incompatible change to a database column (I just dropped and re-created the source table)
- Incompatible column change published via auto-discover
- Inferred schema changing when publishing a capture via the UI
- Inferred schema changing when publishing a materialization via the UI
- Inferred schema change published due to auto-discover

I tested each of these in an end-to-end fashion by starting with a postgres or webhook capture and a postgres materialization, then publishing a change that gets rejected, and subsequently triggering an evolution.

**Documentation links affected:**

I updated two docs pages in the last commit.

**Notes for reviewers:**

I'm working on wrapping up a related UI PR, and will link that once it's ready. The scenario where an incompatible inferred schema change is observed when publishing a materialization will break the current UI, and that'll be fixed in the UI PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1346)
<!-- Reviewable:end -->
