### PR TITLE
flowctl: enable self-service task logs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -92,8 +92,13 @@ DPG_TLS_KEY_PATH='%s/local-tls-private-key.pem' % DPG_REPO
 
 local_resource('dpg-tls-cert',
     dir='%s/data-plane-gateway' % REPO_BASE,
+    # These incantations create a non-CA self-signed certificate which is
+    # valid for localhost and its subdomains. rustls is quite fiddly about
+    # accepting self-signed certificates so all of these are required.
     cmd='[ -f %s ] || openssl req -x509 -nodes -days 365 \
-        -subj  "/C=CA/ST=QC/O=Estuary/CN=localhost:28318" \
+        -subj  "/ST=QC/O=Estuary/CN=localhost" \
+        -addext basicConstraints=critical,CA:FALSE,pathlen:1 \
+        -addext "subjectAltName=DNS:localhost,DNS:*.localhost,IP:127.0.0.1" \
         -newkey rsa:2048 -keyout "%s" \
         -out "%s"' % (DPG_TLS_KEY_PATH, DPG_TLS_KEY_PATH, DPG_TLS_CERT_PATH))
 

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -21,23 +21,8 @@ pub struct CollectionJournalSelector {
     /// The selector is provided as JSON matching the same shape that's used
     /// in Flow catalog specs. For example:
     /// '{"include": {"myField1":["value1", "value2"]}}'
-    #[clap(
-        long,
-        value_parser(parse_partition_selector),
-        conflicts_with_all(&["include-partition", "exclude-partition"])
-    )]
+    #[clap(long, value_parser(parse_partition_selector))]
     pub partitions: Option<models::PartitionSelector>,
-
-    /// Deprecated, use --partitions instead
-    #[clap(long = "include-partition", value_parser(parse_deprecated_selector))]
-    pub include_partitions: Vec<String>,
-    /// Deprecated, use --partitions instead
-    #[clap(long = "exclude-partition", value_parser(parse_deprecated_selector))]
-    pub exclude_partitions: Vec<String>,
-}
-
-fn parse_deprecated_selector(_: &str) -> Result<String, anyhow::Error> {
-    anyhow::bail!("this argument has been deprecated, and replaced by --partitions")
 }
 
 fn parse_partition_selector(arg: &str) -> Result<models::PartitionSelector, anyhow::Error> {

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -98,22 +98,8 @@ pub enum Command {
     /// They can be edited, developed, and tested while still a draft.
     /// Then when you're ready, publish your draft to make your changes live.
     Draft(draft::Draft),
-    /// This command does not (yet) work for end users
-    ///
-    /// Note: We're still working on allowing users access to task logs, and this command will not work until we do.
-    /// Prints the runtime logs of a task (capture, derivation, or materialization).
-    /// Reads contents from the `ops.<data-plane>/logs` collection, selecting the partition
-    /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
-    /// `flowctl collections read --collection ops.<data-plane>/logs --include-partition estuary.dev/field/name=<task> --uncommitted`
+    /// Read operational logs of your tasks (captures, derivations, and materializations).
     Logs(ops::Logs),
-    /// This command does not (yet) work for end users
-    ///
-    /// Note: We're still working on allowing users access to task stats, and this command will not work until we do.
-    /// Prints the runtime stats of a task (capture, derivation, or materialization).
-    /// Reads contents from the `ops.<data-plane>/stats` collection, selecting the partition
-    /// that corresponds to the selected task. This command is essentially equivalent to the much longer:
-    /// `flowctl collections read --collection ops.<data-plane>/stats --include-partition estuary.dev/field/name=<task>`
-    Stats(ops::Stats),
     /// Advanced, low-level, and experimental commands which are less common.
     Raw(raw::Advanced),
 }
@@ -194,7 +180,6 @@ impl Cli {
             Command::Preview(preview) => preview.run(&mut context).await,
             Command::Draft(draft) => draft.run(&mut context).await,
             Command::Logs(logs) => logs.run(&mut context).await,
-            Command::Stats(stats) => stats.run(&mut context).await,
             Command::Raw(advanced) => advanced.run(&mut context).await,
         }?;
 


### PR DESCRIPTION
* Update local-stack certificate generation to create certs that work with rustls, when used with:

  SSL_CERT_FILE=~/estuary/data-plane-gateway/local-tls-cert.pem

* When reading ops logs, obtain a DPG token which is authorized for the task name, rather than the ops collection.

* Drop stats for now to remove flowctl surface area.

* Remove deprecated include-partition / exclude-partition (began to panic with auth_prefixes addition to ReadArgs for unknown reasons).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1347)
<!-- Reviewable:end -->
