### PR TITLE
agent: default evolveIncompatibleCollections for new captures

### DIFF
--- a/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_create.snap
+++ b/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__capture_merge_create.snap
@@ -6,7 +6,7 @@ expression: json!(out)
   {
     "autoDiscover": {
       "addNewBindings": true,
-      "evolveIncompatibleCollections": false
+      "evolveIncompatibleCollections": true
     },
     "bindings": [
       {

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -132,7 +132,7 @@ pub fn merge_capture(
             models::ShardTemplate::default(),
             Some(models::AutoDiscover {
                 add_new_bindings: true,
-                evolve_incompatible_collections: false,
+                evolve_incompatible_collections: true,
             }),
         ),
     };


### PR DESCRIPTION
Resolves #1348
Updates the default value of `evolveIncompatibleCollections` in the discovers handler. This affects new captures only. Now that evolutions only increment the backfill counter in typical cases, the previous default seems overly conservative and inconvenient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1349)
<!-- Reviewable:end -->
