### PR TITLE
flowctl-go: discover timeout exception for redshift

### DIFF
--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -101,6 +101,7 @@ func (cmd apiDiscover) Execute(_ []string) error {
 	for _, image := range []string{
 		"ghcr.io/estuary/source-salesforce",
 		"ghcr.io/estuary/source-netsuite",
+		"ghcr.io/estuary/source-redshift",
 	} {
 		if strings.HasPrefix(cmd.Image, image) && timeout < (time.Minute*5) {
 			timeout = time.Minute * 5


### PR DESCRIPTION
Adds an exception to our growing list of discover timeout exceptions. I'm sure eventually we'll thread through some configuration of this from the `connector_tags` table 😉 but not today

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1355)
<!-- Reviewable:end -->
