### PR TITLE
Allow authorized users to set the `update_only` column on `discovers`

### DIFF
--- a/supabase/migrations/08_discovers.sql
+++ b/supabase/migrations/08_discovers.sql
@@ -22,7 +22,7 @@ create policy "Users access their discovers"
   using (draft_id in (select id from drafts));
 
 grant select on discovers to authenticated;
-grant insert (capture_name, connector_tag_id, draft_id, endpoint_config)
+grant insert (capture_name, connector_tag_id, draft_id, endpoint_config, update_only)
   on discovers to authenticated;
 
 comment on table discovers is


### PR DESCRIPTION
**Description:**

The UI needs to set the `update_only` column during capture edit.

This is in support of : https://github.com/estuary/ui/pull/955

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1360)
<!-- Reviewable:end -->
