### PR TITLE
Update `runtime::container::start()` to take a new `allow_local` flag

### DIFF
--- a/crates/runtime/src/capture/connector.rs
+++ b/crates/runtime/src/capture/connector.rs
@@ -57,6 +57,7 @@ pub async fn start<L: LogHandler>(
                 start_rpc,
                 &runtime.task_name,
                 ops::TaskType::Capture,
+                runtime.allow_local,
             )
             .await?
             .boxed()

--- a/crates/runtime/src/derive/connector.rs
+++ b/crates/runtime/src/derive/connector.rs
@@ -57,6 +57,7 @@ pub async fn start<L: LogHandler>(
                 start_rpc,
                 &runtime.task_name,
                 ops::TaskType::Derivation,
+                runtime.allow_local,
             )
             .await?
             .boxed()

--- a/crates/runtime/src/image_connector.rs
+++ b/crates/runtime/src/image_connector.rs
@@ -20,6 +20,7 @@ pub async fn serve<Request, Response, StartRpc, Attach>(
     start_rpc: StartRpc,      // Begins RPC over a started container channel.
     task_name: &str,          // Name of this task, used to label container.
     task_type: ops::TaskType, // Type of this task, for labeling container.
+    allow_local: bool,        // Whether we're running in local dev or not.
 ) -> anyhow::Result<impl Stream<Item = anyhow::Result<Response>> + Send>
 where
     Request: serde::Serialize + Send + 'static,
@@ -36,6 +37,7 @@ where
         &network,
         &task_name,
         task_type,
+        allow_local,
     )
     .await?;
 

--- a/crates/runtime/src/materialize/connector.rs
+++ b/crates/runtime/src/materialize/connector.rs
@@ -57,6 +57,7 @@ pub async fn start<L: LogHandler>(
                 start_rpc,
                 &runtime.task_name,
                 ops::TaskType::Materialization,
+                runtime.allow_local,
             )
             .await?
             .boxed()


### PR DESCRIPTION
**Description:**

This should fix an issue encountered by people running a local Flow stack under WSL. The problem is that in that case, Docker containers run in a separate VM to the one hosting the Linux VM, meaning that the container IP address exposed via `docker inspect` is not accessible from the "host". The solution here is to ask Docker to bind a port on the host to the corresponding port inside the container.

In order to prevent binding every task to a host port in production (which runs Linux), we ended up turning off host-port mapping on Linux entirely because we didn't have a better way to identify local vs prod environments.

We have since introduced an `allow_local` flag, and can condition host-port mapping on that, enabling Flow to run inside WSL.

**Notes for reviewers:**

I did also add a [debug log](https://github.com/estuary/flow/compare/jshearer/allow_local_host_port_mapping?expand=1#diff-9d708463ecd20353c6191614214a991691678d344871d15cc5958b192f73e144R148) so we can see the real `docker run` invocation. This might be noisy (but also, if you turn on debug logging noisy is kind of expected), but it's something I've reached for _every_ time I've had to debug why this piece of code isn't working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1361)
<!-- Reviewable:end -->
