### PR TITLE
crates/json: don't validate strings with underscores as integers or numbers

### DIFF
--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -175,10 +175,11 @@ impl Format {
             Self::Integer => ValidationResult::from(
                 BigDecimal::from_str(val)
                     .map(|d| d.is_integer())
-                    .unwrap_or(false),
+                    .unwrap_or(false)
+                    && !val.contains("_"),
             ),
             Self::Number => ValidationResult::from(
-                BigDecimal::from_str(val).is_ok()
+                BigDecimal::from_str(val).is_ok() && !val.contains("_")
                     || ["NaN", "Infinity", "-Infinity"].contains(&val),
             ),
         }
@@ -264,14 +265,14 @@ mod test {
             ("integer", "1234", true),
             ("integer", "1234.00", true),
             ("integer", "-1234", true),
-            ("integer", "1_234", true),
+            ("integer", "1_234", false),
             ("integer", "1.234", false),
             ("integer", " 1234", false),
             ("uint32", "1234", true),
             ("uint64", "1234", true),
             ("number", "1234", true),
             ("number", "-1234", true),
-            ("number", "1_234", true),
+            ("number", "1_234", false),
             ("number", "1.234", true),
             ("number", "-1.234", true),
             ("number", " 1234", false),


### PR DESCRIPTION
**Description:**

Previously strings like `"1_234"`, `"123_"`, `"1__2"`, `" _123.3"` (etc.) positively validated as having a format of `integer` or `number`. This is problematic for many systems that will process these downstream that do not have such permissive handling for strings as integers/numbers. It is also a little questionable whether we should consider these strings as numeric values in the first place.

This changes those types of strings to not validate as `integer` or `number`, and will instead cause schema inference to consider them to be strings with no format annotation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1364)
<!-- Reviewable:end -->
