### PR TITLE
Phil/discover name validation

### DIFF
--- a/crates/agent-sql/src/drafts.rs
+++ b/crates/agent-sql/src/drafts.rs
@@ -20,6 +20,7 @@ pub async fn create(
     Ok(row.id)
 }
 
+#[tracing::instrument(err, skip(spec, txn))]
 pub async fn upsert_spec<S>(
     draft_id: Id,
     catalog_name: &str,
@@ -53,7 +54,6 @@ where
     )
     .fetch_one(&mut *txn)
     .await?;
-
     Ok(())
 }
 

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -248,6 +248,25 @@ impl DiscoverHandler {
             specs::parse_response(endpoint_config, image_name, image_tag, discover_output)
                 .context("converting discovery response into specs")?;
 
+        if discovered_bindings
+            .iter()
+            .any(|b| b.recommended_name.is_empty())
+        {
+            tracing::error!(
+                ?discovered_bindings,
+                %capture_name,
+                %draft_id,
+                %image_name,
+                %image_tag,
+                "connector discovered response includes a binding with an empty recommended_name"
+            );
+            return Ok(Err(vec![draft::Error {
+                catalog_name: capture_name.to_string(),
+                scope: None,
+                detail: "connector protocol error: a binding was missing 'recommended_name'. Please contact support for assistance".to_string(),
+            }]));
+        }
+
         // Catalog we'll build up with the merged capture and collections.
         let mut catalog = models::Catalog::default();
 

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -289,10 +289,10 @@ pub fn merge_collections(
 }
 
 fn normalize_recommended_name(name: &str) -> String {
-    let parts: Vec<_> = models::Collection::regex()
+    use itertools::Itertools;
+    let mut parts = models::Collection::regex()
         .find_iter(name)
-        .map(|m| m.as_str())
-        .collect();
+        .map(|m| models::collate::normalize(m.as_str().chars()).collect::<String>());
 
     parts.join("_")
 }
@@ -681,8 +681,10 @@ mod tests {
         for (name, expect) in [
             ("Foo", "Foo"),
             ("foo/bar", "foo/bar"),
+            ("Faſt/Carſ", "Fast/Cars"), // First form is denormalized, assert that it gets NFKC normalized
+            ("/", ""),                  // just documenting a weird edge case
             ("/foo/bar//baz/", "foo/bar_baz"), // Invalid leading, middle, & trailing slash.
-            ("#੫൬    , bar-_!", "੫൬_bar-_"),   // Invalid leading, middle, & trailing chars.
+            ("#੫൬    , bar-_!", "੫൬_bar-_"), // Invalid leading, middle, & trailing chars.
             ("One! two/_three", "One_two/_three"),
         ] {
             assert_eq!(


### PR DESCRIPTION
**Description:**

Addresses a bug I found while troubleshooting a production issue, and adds better logging in case we try to insert another draft spec with an invalid name. The lack of normalization was not the cause of the issue we saw last week, but it certainly would present similarly if a connector returned a recommended collection name that wasn't normalized, since nfkc normalization is required by our postgres constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1365)
<!-- Reviewable:end -->
