### PR TITLE
json: fix ordering of integers greater than i64::MAX

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -28,7 +28,7 @@ RUN apt update -y \
      jq \
      nodejs \
      docker-ce-cli \
-     google-cloud-sdk \
+     google-cloud-cli \
      && rm -rf /var/lib/apt/lists/*
 
 # Create a non-privileged "flow" user.


### PR DESCRIPTION
Fixes a bug in the ordering of JSON numbers that are greater than the maximum signed 64 bit integer.  The previous ordering logic would convert the unsigned integer to signed, which would overflow if the value was larger than `i64::MAX`, leading to an incorrect ordering result.  This fixes that by adding in special cases for comparisons between negative signed integers and unsigned integers. The casts from `u64 -> i64` were replaced with casts from `i64 ->
u64`, relying on the previous checks to ensure that the `i64` value is not negative.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1367)
<!-- Reviewable:end -->
