### PR TITLE
validation: fix bucket name validation for GCS and Azure

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -26,8 +26,8 @@ pub use derivation::{Derivation, DeriveUsing, Shuffle, ShuffleType, TransformDef
 pub use derive_sqlite::DeriveUsingSqlite;
 pub use derive_typescript::DeriveUsingTypescript;
 pub use journals::{
-    BucketAndPrefix, CompressionCodec, CustomStore, FragmentTemplate, JournalTemplate, StorageDef,
-    Store, BUCKET_RE,
+    CompressionCodec, CustomStore, FragmentTemplate, JournalTemplate, S3BucketAndPrefix,
+    StorageDef, Store, AZURE_CONTAINER_RE, AZURE_STORAGE_ACCOUNT_RE, GCS_BUCKET_RE, S3_BUCKET_RE,
 };
 pub use materializations::{
     MaterializationBinding, MaterializationDef, MaterializationEndpoint, MaterializationFields,


### PR DESCRIPTION
When validating storage configurations, we were previously using the same regex for all types of cloud storage. But it turns out that GCS is more permissive, and Azure is more restrictive.  This introduces separate regexes for each type of cloud storage provider.  For custom storage endpoints, the GCS regex is used, as it's the most permissive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1370)
<!-- Reviewable:end -->
