### PR TITLE
Inserting `type` and `main` into `package.json` for flow-web

### DIFF
--- a/.github/workflows/flow-web.yaml
+++ b/.github/workflows/flow-web.yaml
@@ -39,7 +39,15 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build flow-web
-        run: wasm-pack build --scope estuary crates/flow-web
+        run: wasm-pack build --scope estuary crates/flow-web --out-name flow_web
+
+      # Fix from: https://github.com/rustwasm/wasm-pack/issues/1039#issuecomment-1712491804
+      # We need to manually insert the main ref until this fix is published 
+      # https://github.com/rustwasm/wasm-pack/pull/1061
+      - name: Manually update package.json
+        run: |
+          npm pkg set type='module' --prefix crates/flow-web/pkg
+          npm pkg set main='flow_web.js' --prefix crates/flow-web/pkg
 
       - name: Publish flow-web
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "flow-web"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "doc",

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flow-web"
 
 # wasm-pack isn't yet fully compatible with workspace inheritance, so we can't use that for these fields
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Estuary developers  <engineering@estuary.dev>"]
 edition = "2021"
 license = "BSL"


### PR DESCRIPTION
**Description:**
To import `flow-web` into vitest we need to set the `type` and `main` in the `package.json` file. Right now `wasm-pack` is not including these but there is a PR has merged that should fix this. 

Also hard cording the name for the output to `flow_web` to ensure these new props are set correctly.

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

As called out in the comment in the YAML - this is kind of hacky but is a known hack that folks have been doing to work around the issue. We should probably keep an eye on `wasm-pack` to see when it releases a new version (hopefully with the fix for this)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1371)
<!-- Reviewable:end -->
