### PR TITLE
thread through `--allow-local` argument when running locally

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -50,6 +50,7 @@ local_resource('gazette', serve_cmd='%s/flow/.build/package/bin/gazette serve \
     ))
 
 local_resource('reactor', serve_cmd='%s/flow/.build/package/bin/flowctl-go serve consumer \
+    --flow.allow-local \
     --broker.address http://localhost:8080 \
     --broker.cache.size 128 \
     --consumer.host localhost \
@@ -71,6 +72,7 @@ local_resource('reactor', serve_cmd='%s/flow/.build/package/bin/flowctl-go serve
 
 local_resource('agent', serve_cmd='%s/flow/.build/package/bin/agent \
     --connector-network supabase_network_flow \
+    --allow-local \
     --bin-dir %s/flow/.build/package/bin' % (REPO_BASE, REPO_BASE),
     deps=[],
     resource_deps=['reactor', 'gazette'])

--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -38,13 +38,15 @@ impl JobStatus {
 pub struct TagHandler {
     connector_network: String,
     logs_tx: logs::Tx,
+    allow_local: bool,
 }
 
 impl TagHandler {
-    pub fn new(connector_network: &str, logs_tx: &logs::Tx) -> Self {
+    pub fn new(connector_network: &str, logs_tx: &logs::Tx, allow_local: bool) -> Self {
         Self {
             connector_network: connector_network.to_string(),
             logs_tx: logs_tx.clone(),
+            allow_local,
         }
     }
 }
@@ -122,7 +124,7 @@ impl TagHandler {
         let log_handler =
             logs::ops_handler(self.logs_tx.clone(), "spec".to_string(), row.logs_token);
         let runtime = Runtime::new(
-            false, // Don't allow local
+            self.allow_local,
             self.connector_network.clone(),
             log_handler,
             None, // no need to change log level

--- a/crates/agent/src/jobs.rs
+++ b/crates/agent/src/jobs.rs
@@ -107,11 +107,11 @@ where
     let mut child = spawn(name, cmd)?;
     let stdout = child.stdout.take().unwrap();
 
-    Ok(futures::try_join!(
+    futures::try_join!(
         wait(name, logs_tx, logs_token, stdin, child),
         read_stdout(stdout)
     )
-    .map_err(|err| Error::detail(err, name, cmd))?)
+    .map_err(|err| Error::detail(err, name, cmd))
 }
 
 /// spawn a command with the provided job name, returning its created Child.

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -44,7 +44,7 @@ struct Args {
     #[clap(long = "accounts-email", default_value = "support@estuary.dev")]
     accounts_email: String,
     /// Allow local connectors. True for local stacks, and false otherwise.
-    #[clap(long = "allow-local", default_value = "false")]
+    #[clap(long = "allow-local")]
     allow_local: bool,
 }
 
@@ -120,11 +120,16 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
                 &logs_tx,
                 Some(&pg_pool),
             )),
-            Box::new(agent::TagHandler::new(&args.connector_network, &logs_tx)),
+            Box::new(agent::TagHandler::new(
+                &args.connector_network,
+                &logs_tx,
+                args.allow_local,
+            )),
             Box::new(agent::DiscoverHandler::new(
                 &args.connector_network,
                 &bindir,
                 &logs_tx,
+                args.allow_local,
             )),
             Box::new(agent::DirectiveHandler::new(args.accounts_email)),
             Box::new(agent::EvolutionHandler),

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -48,7 +48,7 @@ pub async fn start(
     network: &str,
     task_name: &str,
     task_type: ops::TaskType,
-    allow_local: bool,
+    publish_ports: bool,
 ) -> anyhow::Result<(runtime::Container, tonic::transport::Channel, Guard)> {
     // Many operational contexts only allow for docker volume mounts
     // from certain locations:
@@ -126,7 +126,7 @@ pub async fn start(
         format!("--label=task-type={}", task_type.as_str_name()),
     ];
 
-    if allow_local {
+    if publish_ports {
         docker_args.append(&mut vec![
             // Support Docker Desktop in non-production contexts (for example, `flowctl`)
             // where the container IP is not directly addressable. As an alternative,

--- a/crates/runtime/src/image_connector.rs
+++ b/crates/runtime/src/image_connector.rs
@@ -20,7 +20,7 @@ pub async fn serve<Request, Response, StartRpc, Attach>(
     start_rpc: StartRpc,      // Begins RPC over a started container channel.
     task_name: &str,          // Name of this task, used to label container.
     task_type: ops::TaskType, // Type of this task, for labeling container.
-    allow_local: bool,        // Whether we're running in local dev or not.
+    publish_ports: bool,      // Whether to expose container ports. Must be true on mac/windoze.
 ) -> anyhow::Result<impl Stream<Item = anyhow::Result<Response>> + Send>
 where
     Request: serde::Serialize + Send + 'static,
@@ -37,7 +37,7 @@ where
         &network,
         &task_name,
         task_type,
-        allow_local,
+        publish_ports,
     )
     .await?;
 

--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -30,6 +30,7 @@ type apiDiscover struct {
 	Name        string                `long:"name" description:"The Docker container name."`
 	Config      string                `long:"config" description:"Path to the connector endpoint configuration"`
 	Output      string                `long:"output" choice:"json" choice:"proto" default:"json"`
+	AllowLocal  bool                  `long:"allow-local" description:"basically dev mode"`
 }
 
 func (cmd apiDiscover) execute(ctx context.Context) (*pc.Response_Discovered, error) {
@@ -53,7 +54,7 @@ func (cmd apiDiscover) execute(ctx context.Context) (*pc.Response_Discovered, er
 		pr.TaskServiceConfig{
 			TaskName:         cmd.Name,
 			ContainerNetwork: cmd.Network,
-			AllowLocal:       false, // TODO(johnny)?
+			AllowLocal:       cmd.AllowLocal,
 		},
 		ops.NewLocalPublisher(ops.ShardLabeling{TaskName: cmd.Name}),
 	)


### PR DESCRIPTION
**Description:**

When running locally using `tilt up` on a mac, I noticed I was unable to run any connectors.  This turned out to be caused by a recent change to have the runtime expose ports based on the presence of that flag, instead of being based on the host OS type.  When running on mac, exposing the ports is required, or else the runtime itself can't connect to the containers.  So this carries on the previous work, and threads through the `--allow-local` argument in the couple of places where it was missing.  The end result is that running locally once again works on mac.

**Workflow steps:**

Run `tilt up` ;)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1374)
<!-- Reviewable:end -->
