### PR TITLE
validation: allow unsatisfiable constraints on excluded fields

### DIFF
--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -536,7 +536,8 @@ fn walk_materialization_response(
         ) {
             // Selector / connector constraints conflict internally:
             (true, true, _) => panic!("included and excluded (should have been filtered)"),
-            (_, _, Type::Unsatisfiable) => Err(format!(
+            // Unsatisfiable is OK only if the field is explicitly excluded
+            (_, false, Type::Unsatisfiable) => Err(format!(
                 "connector reports as unsatisfiable with reason: {}",
                 reason
             )),

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -775,6 +775,69 @@ driver:
 }
 
 #[test]
+fn test_materialization_constraints_on_excluded_fields() {
+    let ((_, validations), errors) = run_test(
+        serde_yaml::from_str(
+            r#"
+test://example/catalog.yaml:
+  collections:
+    testing/constraints:
+      schema:
+        type: object
+        properties:
+          id: { type: string }
+          naughty_u: { type: string }
+          naughty_f: { type: string }
+        required: [id]
+      key: [/id]
+  materializations:
+    testing/db-views:
+      endpoint:
+        connector:
+          image: an/image:test
+          config: {}
+      bindings:
+        - source: testing/constraints
+          resource: {table: anything}
+          fields:
+            recommended: true
+            exclude:
+              - naughty_u
+              - naughty_f
+  storageMappings:
+    testing/:
+        stores: [{ provider: S3, bucket: data-bucket }]
+    recovery/testing/:
+        stores: [{ provider: GCS, bucket: recovery-bucket, prefix: some/ }]
+driver:
+  materializations:
+    testing/db-views:
+      connectorType: IMAGE
+      config:
+        image: an/image:test
+        config: {}
+      bindings:
+        - constraints:
+            flow_document: { type: 1, reason: "location required" }
+            id: { type: 1, reason: "location required" }
+            naughty_u: { type: 6, reason: "field unsatisfiable" }
+            naughty_f: { type: 5, reason: "field forbidden" }
+          resourcePath: [anything]
+"#,
+        )
+        .unwrap(),
+        "constraints-excluded-fields",
+    );
+    assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+
+    let fields = validations.built_materializations[0].spec.bindings[0]
+        .field_selection
+        .as_ref()
+        .unwrap();
+    assert!(!fields.values.iter().any(|f| f.starts_with("naughty_")));
+}
+
+#[test]
 fn test_schema_fragment_not_found() {
     let errors = run_test_errors(
         &GOLDEN,


### PR DESCRIPTION
**Description:**

Updates our valiation logic to only consider unsatisfiable constraints an error in the case that the field isn't explicitly excluded. This allows users to change the type of a field without needing to backfill, as long as they exclude the changed field.

**Workflow steps:**

- materialize a collection that has `fieldA: { type: string }`, using one of the database connectors
- Update the source collection schema to change to `fieldA: { type: integer }`
- The publication should fail due to the unsatisfiable constraint
- Explicitly exclude `fieldA` from the field selection
- Now, the publication should succeed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1375)
<!-- Reviewable:end -->
