### PR TITLE
Draft collections eligible for deletion

### DIFF
--- a/supabase/migrations/44_draft_associated_collections.sql
+++ b/supabase/migrations/44_draft_associated_collections.sql
@@ -1,0 +1,66 @@
+begin;
+
+-- Update permissions for live_spec_flows to allow users to directly access it as long as they
+-- have access to at least one side. This may allow users to know the id of specifications that
+-- they are not authorized to, but nothing else.
+alter policy "Users must be authorized to referenced specifications" on live_spec_flows
+  rename to "Users must be authorized to one referenced specification";
+
+-- This policy is tecnically a little more permissive than we truly want, though that seems
+-- acceptable since it only allows clients to get the ids of connected specs, not anything else.
+-- If you have read-only access to a spec, then you can see the ids of all connected specs.
+-- Ideally, you'd only be able to select rows for which you have admin capability to at least
+-- one side, _or_ at least read capability to _both_ sides. Such a policy seems computationally
+-- expensive and complicated to write, though, so this is a compromise.
+alter policy "Users must be authorized to one referenced specification" on live_spec_flows
+  using (
+    source_id in (select id from live_specs) or
+    target_id in (select id from live_specs)
+  );
+grant select on live_spec_flows to authenticated;
+
+create or replace function draft_collections_eligible_for_deletion(capture_id flowid, draft_id flowid)
+returns void as $$
+begin
+
+  insert into draft_specs (draft_id, catalog_name, expect_pub_id, spec, spec_type)
+  with target_collections as (
+    select target_id from live_spec_flows
+      where source_id = capture_id
+  ),
+  collections_read as (
+    select target_collections.target_id from target_collections
+      join live_spec_flows lsf on target_collections.target_id = lsf.source_id
+  ),
+  collections_written as (
+    select target_collections.target_id from target_collections
+      join live_spec_flows lsf on target_collections.target_id = lsf.target_id and lsf.source_id <> capture_id
+  ),
+  ineligible_collections as (
+    select target_id from collections_read
+      union select target_id from collections_written
+  ),
+  eligible_collection_ids as (
+    select target_id from target_collections
+      except select target_id from ineligible_collections
+  ),
+  eligible_collections as (
+    select
+    ls.id,
+    ls.catalog_name,
+    ls.last_pub_id
+    from eligible_collection_ids
+    join live_specs ls on eligible_collection_ids.target_id = ls.id
+  )
+  select draft_id, catalog_name, last_pub_id, null, null from eligible_collections;
+
+end;
+$$ language plpgsql security invoker;
+
+comment on function draft_collections_eligible_for_deletion is '
+draft_collections_eligible_for_deletion facilitates the deletion of a capture and its associated collections
+in the same publication by populating the specified draft with the collections eligible for deletion.
+The specified draft should contain the capture pending deletion.
+';
+
+commit;

--- a/supabase/tests/draft_collections_eligible_for_deletion.test.sql
+++ b/supabase/tests/draft_collections_eligible_for_deletion.test.sql
@@ -1,0 +1,168 @@
+create function tests.test_draft_collections_eligible_for_deletion()
+returns setof text as $$
+declare
+  target_capture_id flowid;
+  target_draft_id flowid;
+
+  collection_a_id flowid;
+  collection_b_id flowid;
+  collection_c_id flowid;
+  collection_d_id flowid;
+  collection_e_id flowid;
+  collection_f_id flowid;
+
+  capture_consumer_id flowid;
+  materialization_consumer_b_id flowid;
+  materialization_consumer_f_id flowid;
+  derivation_consumer_c_id flowid;
+  derivation_consumer_d_id flowid;
+begin
+
+  -- Bob will have read-only access to carol's collections, and materializes one of them.
+  -- We'll later assert that the collection Bob is materializing does _not_ get deleted,
+  -- even though Carol doesn't have any access to it.
+  insert into user_grants (user_id, object_role, capability) values
+    ('22222222-2222-2222-2222-222222222222', 'bobCo/', 'admin'),
+    ('33333333-3333-3333-3333-333333333333', 'carolCo/', 'admin');
+
+  insert into role_grants (subject_role, object_role, capability) values
+    ('carolCo/', 'carolCo/', 'admin'),
+    ('bobCo/', 'bobCo/', 'admin'),
+    ('bobCo/', 'carolCo/', 'read');
+
+  insert into live_specs (catalog_name, spec_type, spec, writes_to, reads_from) values
+    ('carolCo/capture/pending-deletion', 'capture', '{
+        "endpoint": {
+          "connector": {
+            "image": "some image",
+              "config": {"some": "config"}
+            }
+        },
+        "bindings": []
+      }',
+      array[
+        'carolCo/pending-deletion/collection-A',
+        'carolCo/pending-deletion/collection-B',
+        'carolCo/pending-deletion/collection-C',
+        'carolCo/pending-deletion/collection-D',
+        'carolCo/pending-deletion/collection-E',
+        'carolCo/pending-deletion/collection-F'
+      ],
+      null),
+    ('carolCo/pending-deletion/collection-A', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/pending-deletion/collection-B', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/pending-deletion/collection-C', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/pending-deletion/collection-D', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/pending-deletion/collection-E', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/pending-deletion/collection-F', 'collection', '{"schema":{},"key":["/id"]}', null, null),
+    ('carolCo/capture/consumes-collection-A', 'capture', '{
+        "endpoint": {
+          "connector": {
+            "image": "some image",
+              "config": {"some": "config"}
+            }
+        },
+        "bindings": []
+      }',
+      array['carolCo/pending-deletion/collection-A'],
+      null),
+    ('carolCo/materialization/consumes-collection-B', 'materialization', '{
+        "endpoint": {
+          "connector": {
+            "image": "some image",
+              "config": {"some": "config"}
+            }
+        },
+        "bindings": []
+      }',
+      null,
+      array['carolCo/pending-deletion/collection-B']),
+    ('carolCo/derivation/consumes-collection-C', 'collection', '{
+        "using": {
+          "sqlite": {
+            "migrations": []
+            }
+        },
+        "transforms": []
+      }',
+      array['carolCo/pending-deletion/collection-C'],
+      null),
+    ('carolCo/derivation/consumes-collection-D', 'collection', '{
+        "using": {
+          "sqlite": {
+            "migrations": []
+            }
+        },
+        "transforms": []
+      }',
+      null,
+      array['carolCo/pending-deletion/collection-D']),
+    ('bobCo/materialization/consumes-collection-F', 'materialization', '{
+        "endpoint": {
+          "connector": {
+            "image": "some image",
+              "config": {"some": "config"}
+            }
+        },
+        "bindings": []
+      }',
+      null,
+      array['carolCo/pending-deletion/collection-F']);
+
+  target_capture_id := (select id from live_specs where catalog_name = 'carolCo/capture/pending-deletion');
+
+  collection_a_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-A');
+  capture_consumer_id := (select id from live_specs where catalog_name = 'carolCo/capture/consumes-collection-A');
+
+  collection_b_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-B');
+  materialization_consumer_b_id := (select id from live_specs where catalog_name = 'carolCo/materialization/consumes-collection-B');
+
+  collection_c_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-C');
+  derivation_consumer_c_id := (select id from live_specs where catalog_name = 'carolCo/derivation/consumes-collection-C');
+
+  collection_d_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-D');
+  derivation_consumer_d_id := (select id from live_specs where catalog_name = 'carolCo/derivation/consumes-collection-D');
+
+  collection_e_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-E');
+
+  collection_f_id := (select id from live_specs where catalog_name = 'carolCo/pending-deletion/collection-F');
+  materialization_consumer_f_id := (select id from live_specs where catalog_name = 'carolCo/materialization/consumes-collection-B');
+
+  insert into live_spec_flows (source_id, target_id, flow_type) values
+    (target_capture_id, collection_a_id, 'capture'),
+    (target_capture_id, collection_b_id, 'capture'),
+    (target_capture_id, collection_c_id, 'capture'),
+    (target_capture_id, collection_d_id, 'capture'),
+    (target_capture_id, collection_e_id, 'capture'),
+    (target_capture_id, collection_f_id, 'capture'),
+    (capture_consumer_id, collection_a_id, 'capture'),
+    (collection_b_id, materialization_consumer_b_id, 'materialization'),
+    (collection_f_id, materialization_consumer_f_id, 'materialization'),
+    (derivation_consumer_c_id, collection_c_id, 'collection'),
+    (collection_d_id, derivation_consumer_d_id, 'collection');
+
+  insert into drafts (user_id, detail) values ('33333333-3333-3333-3333-333333333333', 'carolCo/capture/pending-deletion') returning id into target_draft_id;
+
+  insert into draft_specs (draft_id, catalog_name, spec_type, spec) values
+    (target_draft_id, 'carolCo/capture/pending-deletion', null, null);
+
+  -- Drop privilege to `authenticated` and authorize as Carol.
+  perform set_authenticated_context('33333333-3333-3333-3333-333333333333');
+
+  perform draft_collections_eligible_for_deletion(target_capture_id, target_draft_id);
+
+  return query select results_eq(
+    $i$ select catalog_name, spec_type from draft_specs where draft_id = '$i$ || target_draft_id || $i$' $i$,
+    $i$ values (
+      'carolCo/capture/pending-deletion'::catalog_name,
+      null::catalog_spec_type
+      ),
+      (
+        'carolCo/pending-deletion/collection-E'::catalog_name,
+        null::catalog_spec_type
+      );
+    $i$
+  );
+
+end;
+$$ language plpgsql;


### PR DESCRIPTION
**Description:**

Facilitate the deletion of a capture and its associated collections in the UI by populating a specified draft with the collections eligible for deletion. A collection is eligible for deletion if it is not consumed by an active task.

**Workflow steps:**

1. Initialize a draft with a capture pending deletion.

1. Execute the `draft_collections_eligible_for_deletion` procedure, supplying the live spec ID of the capture of interest and the ID of the draft created in the previous step.

1. Observe that the collections that are not consumed by another active task in the system are added to the draft and slated for deletion.

**Documentation links affected:**

N/A

**Notes for reviewers:**

This is a dependency of `ui` [issue 939](https://github.com/estuary/ui/issues/939). Integration of the procedure can be found in [PR 978](https://github.com/estuary/ui/pull/978).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1377)
<!-- Reviewable:end -->
