### PR TITLE
Phil/agent qos

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -12,13 +12,19 @@ pub async fn create(
     draft_id: Id,
     auto_evolve: bool,
     detail: String,
+    background: bool,
 ) -> sqlx::Result<Id> {
     let rec = sqlx::query!(
-            r#"insert into publications (user_id, draft_id, auto_evolve, detail) values ($1, $2, $3, $4) returning id as "id: Id";"#,
-            user_id as Uuid, draft_id as Id, auto_evolve, detail
-        )
-        .fetch_one(txn)
-        .await?;
+        r#"insert into publications (user_id, draft_id, auto_evolve, detail, background)
+            values ($1, $2, $3, $4, $5) returning id as "id: Id";"#,
+        user_id as Uuid,
+        draft_id as Id,
+        auto_evolve,
+        detail,
+        background
+    )
+    .fetch_one(txn)
+    .await?;
 
     Ok(rec.id)
 }
@@ -30,11 +36,12 @@ pub async fn create_with_user_email(
     draft_id: Id,
     auto_evolve: bool,
     detail: String,
+    background: bool,
 ) -> sqlx::Result<Id> {
     let rec = sqlx::query!(
-        r#"insert into publications (user_id, draft_id, auto_evolve, detail)
-        values ((select id from auth.users where email = $1), $2, $3, $4) returning id as "id: Id";"#,
-            user_email, draft_id as Id, auto_evolve, detail
+        r#"insert into publications (user_id, draft_id, auto_evolve, detail, background)
+        values ((select id from auth.users where email = $1), $2, $3, $4, $5) returning id as "id: Id";"#,
+            user_email, draft_id as Id, auto_evolve, detail, background
         )
         .fetch_one(txn)
         .await?;
@@ -54,9 +61,14 @@ pub struct Row {
     pub updated_at: DateTime<Utc>,
     pub user_id: Uuid,
     pub auto_evolve: bool,
+    pub background: bool,
 }
 
-pub async fn dequeue(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> sqlx::Result<Option<Row>> {
+#[tracing::instrument(level = "debug", skip(txn))]
+pub async fn dequeue(
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    allow_background: bool,
+) -> sqlx::Result<Option<Row>> {
     sqlx::query_as!(
         Row,
         r#"select
@@ -68,12 +80,15 @@ pub async fn dequeue(txn: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> sqlx::R
             id as "pub_id: Id",
             updated_at,
             user_id,
-            auto_evolve
-        from publications where job_status->>'type' = 'queued'
-        order by id asc
+            auto_evolve,
+            background
+        from publications
+        where job_status->>'type' = 'queued' and (background = $1 or background = false)
+        order by background asc, id asc
         limit 1
         for update of publications skip locked;
-        "#
+        "#,
+        allow_background
     )
     .fetch_optional(txn)
     .await

--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use super::{jobs, logs, Handler, HandlerStatus, Id};
+use super::{jobs, logs, HandleResult, Handler, Id};
 use agent_sql::connector_tags::Row;
 use anyhow::Context;
 use proto_flow::flow;
@@ -53,11 +53,15 @@ impl TagHandler {
 
 #[async_trait::async_trait]
 impl Handler for TagHandler {
-    async fn handle(&mut self, pg_pool: &sqlx::PgPool) -> anyhow::Result<HandlerStatus> {
+    async fn handle(
+        &mut self,
+        pg_pool: &sqlx::PgPool,
+        allow_background: bool,
+    ) -> anyhow::Result<HandleResult> {
         let mut txn = pg_pool.begin().await?;
 
-        let row: Row = match agent_sql::connector_tags::dequeue(&mut txn).await? {
-            None => return Ok(HandlerStatus::Idle),
+        let row: Row = match agent_sql::connector_tags::dequeue(&mut txn, allow_background).await? {
+            None => return Ok(HandleResult::NoJobs),
             Some(row) => row,
         };
 
@@ -67,7 +71,7 @@ impl Handler for TagHandler {
         agent_sql::connector_tags::resolve(id, status, &mut txn).await?;
         txn.commit().await?;
 
-        Ok(HandlerStatus::Active)
+        Ok(HandleResult::HadJob)
     }
 
     fn table_name(&self) -> &'static str {

--- a/crates/agent/src/directives/accept_demo_tenant.rs
+++ b/crates/agent/src/directives/accept_demo_tenant.rs
@@ -85,7 +85,10 @@ mod test {
         .unwrap();
 
         let mut handler = DirectiveHandler::default();
-        while let Some(row) = agent_sql::directives::dequeue(&mut txn).await.unwrap() {
+        while let Some(row) = agent_sql::directives::dequeue(&mut txn, false)
+            .await
+            .unwrap()
+        {
             let (id, status) = handler.process(row, &mut txn).await.unwrap();
             agent_sql::directives::resolve(id, status, &mut txn)
                 .await

--- a/crates/agent/src/directives/beta_onboard.rs
+++ b/crates/agent/src/directives/beta_onboard.rs
@@ -137,7 +137,10 @@ mod test {
         let mut handler = DirectiveHandler {
             accounts_user_email: "accounts@example.com".to_string(),
         };
-        while let Some(row) = agent_sql::directives::dequeue(&mut txn).await.unwrap() {
+        while let Some(row) = agent_sql::directives::dequeue(&mut txn, true)
+            .await
+            .unwrap()
+        {
             let (id, status) = handler.process(row, &mut txn).await.unwrap();
             agent_sql::directives::resolve(id, status, &mut txn)
                 .await

--- a/crates/agent/src/directives/click_to_accept.rs
+++ b/crates/agent/src/directives/click_to_accept.rs
@@ -77,7 +77,10 @@ mod test {
         .unwrap();
 
         let mut handler = DirectiveHandler::default();
-        while let Some(row) = agent_sql::directives::dequeue(&mut txn).await.unwrap() {
+        while let Some(row) = agent_sql::directives::dequeue(&mut txn, true)
+            .await
+            .unwrap()
+        {
             let (id, status) = handler.process(row, &mut txn).await.unwrap();
             agent_sql::directives::resolve(id, status, &mut txn)
                 .await

--- a/crates/agent/src/directives/grant.rs
+++ b/crates/agent/src/directives/grant.rs
@@ -127,7 +127,10 @@ mod test {
         .unwrap();
 
         let mut handler = DirectiveHandler::default();
-        while let Some(row) = agent_sql::directives::dequeue(&mut txn).await.unwrap() {
+        while let Some(row) = agent_sql::directives::dequeue(&mut txn, false)
+            .await
+            .unwrap()
+        {
             let (id, status) = handler.process(row, &mut txn).await.unwrap();
             agent_sql::directives::resolve(id, status, &mut txn)
                 .await

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -1,4 +1,4 @@
-use super::{draft, Handler, HandlerStatus, Id};
+use super::{draft, HandleResult, Handler, Id};
 use agent_sql::{
     evolutions::{Row, SpecRow},
     Capability,
@@ -61,11 +61,15 @@ fn error_status(err: impl Into<String>) -> anyhow::Result<JobStatus> {
 
 #[async_trait::async_trait]
 impl Handler for EvolutionHandler {
-    async fn handle(&mut self, pg_pool: &sqlx::PgPool) -> anyhow::Result<HandlerStatus> {
+    async fn handle(
+        &mut self,
+        pg_pool: &sqlx::PgPool,
+        allow_background: bool,
+    ) -> anyhow::Result<HandleResult> {
         let mut txn = pg_pool.begin().await?;
 
-        let Some(row) = agent_sql::evolutions::dequeue(&mut txn).await? else {
-            return Ok(HandlerStatus::Idle);
+        let Some(row) = agent_sql::evolutions::dequeue(&mut txn, allow_background).await? else {
+            return Ok(HandleResult::NoJobs);
         };
 
         let id: Id = row.id;
@@ -76,7 +80,7 @@ impl Handler for EvolutionHandler {
         agent_sql::evolutions::resolve(id, &status, &mut txn).await?;
         txn.commit().await?;
 
-        Ok(HandlerStatus::Active)
+        Ok(HandleResult::HadJob)
     }
 
     fn table_name(&self) -> &'static str {
@@ -84,7 +88,7 @@ impl Handler for EvolutionHandler {
     }
 }
 
-#[tracing::instrument(err, skip_all, fields(id=?row.id, draft_id=?row.draft_id))]
+#[tracing::instrument(err, skip_all, fields(?row.id, ?row.draft_id, %row.background))]
 async fn process_row(
     row: Row,
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -249,9 +253,15 @@ async fn process_row(
         );
         // So that we don't create an infinite loop in case there's continued errors.
         let auto_evolve = false;
-        let id =
-            agent_sql::publications::create(txn, row.user_id, row.draft_id, auto_evolve, detail)
-                .await?;
+        let id = agent_sql::publications::create(
+            txn,
+            row.user_id,
+            row.draft_id,
+            auto_evolve,
+            detail,
+            row.background,
+        )
+        .await?;
         Some(id)
     } else {
         None

--- a/crates/agent/src/evolution/test.rs
+++ b/crates/agent/src/evolution/test.rs
@@ -35,6 +35,7 @@ async fn test_collection_evolution() {
         user_id,
         collections: agent_sql::TextJson(input),
         auto_publish: true,
+        background: false,
     };
 
     let result = super::process_row(evolution_row, &mut txn)
@@ -70,7 +71,8 @@ async fn test_collection_evolution() {
             draft_id as "draft_id: Id",
             dry_run,
             user_id,
-            auto_evolve
+            auto_evolve,
+            background
         from publications where id = $1;"#,
         publication_id as Id
     )
@@ -82,6 +84,7 @@ async fn test_collection_evolution() {
     assert_eq!(user_id, publication.user_id);
     assert!(!publication.dry_run);
     assert!(!publication.auto_evolve);
+    assert!(!publication.background); // should match the value from the evolutions row
 }
 
 #[tokio::test]
@@ -121,6 +124,7 @@ async fn evolution_fails_when_collection_is_deleted() {
         user_id,
         collections: agent_sql::TextJson(input),
         auto_publish: false,
+        background: false,
     };
 
     let result = super::process_row(evolution_row, &mut txn)
@@ -173,6 +177,7 @@ async fn evolution_adds_collections_to_the_draft_if_necessary() {
         user_id,
         collections: agent_sql::TextJson(input),
         auto_publish: false,
+        background: false,
     };
 
     let result = super::process_row(evolution_row, &mut txn)
@@ -255,6 +260,7 @@ async fn evolution_preserves_changes_already_in_the_draft() {
         user_id,
         collections: agent_sql::TextJson(input),
         auto_publish: false,
+        background: false,
     };
 
     let result = super::process_row(evolution_row, &mut txn)
@@ -319,7 +325,7 @@ async fn evolution_affects_specific_materializations_when_requested() {
                       {"source": "evolution/CollectionC", "resource": {"targetThingy": "testTargetThingC"}}
                     ],
                     "endpoint": {"connector": {"image": "matImage:v1", "config": {}}}
-                }' :: json, 
+                }' :: json,
               'materialization', 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb'
             )
         ),
@@ -328,7 +334,7 @@ async fn evolution_affects_specific_materializations_when_requested() {
             (
               'a100000000000000', 'b333000000000000',
               'materialization'
-            ), 
+            ),
             (
               'a200000000000000', 'b333000000000000',
               'materialization'
@@ -350,6 +356,7 @@ async fn evolution_affects_specific_materializations_when_requested() {
         user_id,
         collections: agent_sql::TextJson(input),
         auto_publish: false,
+        background: false,
     };
 
     let result = super::process_row(evolution_row, &mut txn)

--- a/crates/agent/src/handlers.rs
+++ b/crates/agent/src/handlers.rs
@@ -253,6 +253,14 @@ where
                     tracing::debug!(%table_name, "got notification for handler table");
                     handler.status = Status::PollInteractive;
                 }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    tracing::debug!("polling all handlers, just in case we missed a notification");
+                    for handler in handlers_by_table.values_mut() {
+                        // No need to go through both interactive and background, since this is "extra"
+                        // and handlers should still dequeue interactive jobs even when `allow_background = true`.
+                        handler.status = Status::PollBackground;
+                    }
+                }
             }
         }
     }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -14,7 +14,7 @@ pub use connector_tags::TagHandler;
 pub use directives::DirectiveHandler;
 pub use discovers::DiscoverHandler;
 pub use evolution::EvolutionHandler;
-pub use handlers::{serve, Handler, HandlerStatus};
+pub use handlers::{serve, HandleResult, Handler};
 use lazy_static::lazy_static;
 pub use publications::PublishHandler;
 use regex::Regex;

--- a/crates/agent/src/logs.rs
+++ b/crates/agent/src/logs.rs
@@ -19,7 +19,7 @@ pub type Tx = tokio::sync::mpsc::Sender<Line>;
 
 // capture_job_logs consumes newline-delimited lines from the AsyncRead and
 // streams each as a Line to the channel Sender.
-#[tracing::instrument(err, skip(tx, reader))]
+#[tracing::instrument(level = "debug", err, skip(tx, reader))]
 pub async fn capture_lines<R>(
     tx: Tx,
     stream: String,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use derivative::Derivative;
 use futures::{FutureExt, TryFutureExt};
 use serde::Deserialize;
+use tracing_subscriber::fmt::format::FmtSpan;
 
 /// Agent is a daemon which runs server-side tasks of the Flow control-plane.
 #[derive(Derivative, Parser)]
@@ -50,7 +51,9 @@ struct Args {
 
 fn main() -> Result<(), anyhow::Error> {
     // Use reasonable defaults for printing structured logs to stderr.
+    // `FmtSpan::Close` emits a log at the end of each span, containing timing info.
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_span_events(FmtSpan::CLOSE)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");

--- a/crates/agent/src/publications/linked_materializations.rs
+++ b/crates/agent/src/publications/linked_materializations.rs
@@ -344,8 +344,9 @@ async fn create_publication(
         txn,
         agent_user_email,
         draft_id,
-        false,
+        false, // don't auto-evolve
         detail,
+        true, // run as a background job
     )
     .await?;
     Ok(pub_id)

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -465,12 +465,9 @@ pub async fn apply_updates_for_row(
     .context("insert live_spec_flow edges")?;
 
     if draft_spec.is_none() {
-        agent_sql::publications::delete_data_processing_alerts(
-            catalog_name,
-            txn,
-        )
-        .await
-        .context("delete alert_data_processing rows")?;
+        agent_sql::publications::delete_data_processing_alerts(catalog_name, txn)
+            .await
+            .context("delete alert_data_processing rows")?;
     }
 
     Ok(())
@@ -800,7 +797,10 @@ mod test {
 
         let mut results: Vec<ScenarioResult> = vec![];
 
-        while let Some(row) = agent_sql::publications::dequeue(&mut *txn).await.unwrap() {
+        while let Some(row) = agent_sql::publications::dequeue(&mut *txn, true)
+            .await
+            .unwrap()
+        {
             let row_draft_id = row.draft_id.clone();
             let (pub_id, status) = handler.process(row, &mut *txn, true).await.unwrap();
 

--- a/supabase/migrations/16_tenants.sql
+++ b/supabase/migrations/16_tenants.sql
@@ -7,7 +7,7 @@ create table tenants (
   tenant                  catalog_tenant unique not null,
 
   tasks_quota             integer        not null default 10,
-  collections_quota       integer        not null default 100
+  collections_quota       integer        not null default 500
 );
 alter table tenants enable row level security;
 

--- a/supabase/migrations/45_background_jobs.sql
+++ b/supabase/migrations/45_background_jobs.sql
@@ -1,0 +1,77 @@
+-- Introduces the ability to distinguish between background and interactive jobs. Interactive jobs
+-- are those that users may be actively awaiting. They are identified by having `background = false`,
+-- which is the default. The agent will process all jobs where `background = false` before it processes
+-- any that have `background = true`. Background jobs are expected to be things like auto-discovers,
+-- and the ultimate goal is to prevent things like auto-discovers causing delays in jobs that users
+-- are actively waiting on.
+begin;
+
+alter table internal._model_async add column background boolean not null default false;
+comment on column internal._model_async.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+alter table discovers add column background boolean not null default false;
+comment on column discovers.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+alter table publications add column background boolean not null default false;
+comment on column publications.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+alter table connector_tags add column background boolean not null default false;
+comment on column connector_tags.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+alter table applied_directives add column background boolean not null default false;
+comment on column applied_directives.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+alter table evolutions add column background boolean not null default false;
+comment on column evolutions.background is
+    'indicates whether this is a background job, which will be processed with a lower priority than interactive jobs';
+
+-- Previously defined in 20_auto_discovers.sql, and re-created here to set `background = true`.
+create or replace function internal.create_auto_discovers()
+returns integer as $$
+declare
+  support_user_id uuid = (select id from auth.users where email = 'support@estuary.dev');
+  next_row internal.next_auto_discovers;
+  total_created integer := 0;
+  tmp_draft_id flowid;
+  tmp_discover_id flowid;
+begin
+
+for next_row in select * from internal.next_auto_discovers
+loop
+  -- Create a draft, which we'll discover into
+  insert into drafts (user_id) values (support_user_id) returning id into tmp_draft_id;
+
+  insert into discovers (capture_name, draft_id, connector_tag_id, endpoint_config, update_only, auto_publish, auto_evolve, background)
+  values (
+    next_row.capture_name,
+    tmp_draft_id,
+    next_row.connector_tags_id,
+    next_row.endpoint_json,
+    not next_row.add_new_bindings,
+    true,
+    next_row.evolve_incompatible_collections,
+    true
+  ) returning id into tmp_discover_id;
+
+  -- This is just useful when invoking the function manually.
+  total_created := total_created + 1;
+end loop;
+
+return total_created;
+end;
+$$ language plpgsql security definer;
+
+comment on function internal.create_auto_discovers is
+'Creates discovers jobs for each capture that is due for an automatic discover. Each disocver will have auto_publish
+set to true. The update_only and auto_evolve columns of the discover will be set based on the addNewBindings and
+evolveIncompatibleCollections fields in the capture spec. This function is idempotent. Once a discover is created by
+this function, the next_auto_discovers view will no longer include that capture until its interval has passed again.
+So its safe to call this function at basically any frequency. The return value of the function is the count of newly
+created discovers jobs.';
+
+commit;


### PR DESCRIPTION
**Description:**

Implements the ideas discussed in #1378 to improve the latency of handling jobs that users may be waiting on. That discussion also covers the motivation. The commit messages have more detail.

There's no user-facing changes. Users should just notice improved latencies in job processing. The framing of `background` was intentional, because it allows the UI and flowctl to both remain ignorant of this change, since all jobs are considered interactive by default.

I updated some of the tracing instrumentation so that we can more easily check up on the timing of the `dequeue` functions. This was because we're potentially calling those functions somewhat more frequently, and I just wanted an easy way to make sure they don't bog things down.

**Notes for reviewers:**

The first commit rolls in an unrelated change to update the default `colections_quota`. That change was already applied in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1379)
<!-- Reviewable:end -->
