### PR TITLE
Phil/agent logs

### DIFF
--- a/crates/agent-sql/src/drafts.rs
+++ b/crates/agent-sql/src/drafts.rs
@@ -20,7 +20,7 @@ pub async fn create(
     Ok(row.id)
 }
 
-#[tracing::instrument(err, skip(spec, txn))]
+#[tracing::instrument(err, level = "debug", skip(spec, txn))]
 pub async fn upsert_spec<S>(
     draft_id: Id,
     catalog_name: &str,

--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -65,8 +65,9 @@ impl Handler for TagHandler {
             Some(row) => row,
         };
 
+        let time_queued = chrono::Utc::now().signed_duration_since(row.updated_at);
         let (id, status) = self.process(row, &mut txn).await?;
-        info!(%id, ?status, "finished");
+        info!(%id, %time_queued, ?status, "finished");
 
         agent_sql::connector_tags::resolve(id, status, &mut txn).await?;
         txn.commit().await?;

--- a/crates/agent/src/directives/mod.rs
+++ b/crates/agent/src/directives/mod.rs
@@ -71,8 +71,9 @@ impl Handler for DirectiveHandler {
             Some(row) => row,
         };
 
+        let time_queued = chrono::Utc::now().signed_duration_since(row.apply_updated_at);
         let (id, status) = self.process(row, &mut txn).await?;
-        info!(%id, ?status, "finished");
+        info!(%id, %time_queued, ?status, "finished");
 
         agent_sql::directives::resolve(id, status, &mut txn).await?;
         txn.commit().await?;

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -65,8 +65,9 @@ impl Handler for DiscoverHandler {
             Some(row) => row,
         };
 
+        let time_queued = chrono::Utc::now().signed_duration_since(row.updated_at);
         let (id, status) = self.process(row, &mut txn).await?;
-        tracing::info!(%id, ?status, "finished");
+        tracing::info!(%id, %time_queued, ?status, "finished");
 
         agent_sql::discovers::resolve(id, status, &mut txn).await?;
         txn.commit().await?;

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -72,11 +72,12 @@ impl Handler for EvolutionHandler {
             return Ok(HandleResult::NoJobs);
         };
 
+        let time_queued = chrono::Utc::now().signed_duration_since(row.updated_at);
         let id: Id = row.id;
         let status = process_row(row, &mut txn).await?;
         let status = serde_json::to_value(status)?;
 
-        tracing::info!(%id, %status, "evolution finished");
+        tracing::info!(%id, %time_queued, %status, "evolution finished");
         agent_sql::evolutions::resolve(id, &status, &mut txn).await?;
         txn.commit().await?;
 

--- a/crates/agent/src/jobs.rs
+++ b/crates/agent/src/jobs.rs
@@ -54,7 +54,7 @@ pub async fn run(
 }
 
 /// Does the same thing as `run`, but doesn't modify the environment given in `cmd`.
-#[tracing::instrument(err, skip(logs_tx, cmd))]
+#[tracing::instrument(err, level = "debug", skip(logs_tx, cmd))]
 pub async fn run_without_removing_env(
     name: &str,
     logs_tx: &logs::Tx,
@@ -72,7 +72,7 @@ pub async fn run_without_removing_env(
 // run_with_output spawns the provided Command, capturing its stderr
 // into the provided logs_tx identified by |logs_token|
 // and returning its stdout.
-#[tracing::instrument(err, skip(logs_tx, cmd))]
+#[tracing::instrument(err, level = "debug", skip(logs_tx, cmd))]
 pub async fn run_with_output(
     name: &str,
     logs_tx: &logs::Tx,
@@ -93,7 +93,7 @@ pub async fn run_with_output(
 // run_with_input_output spawns the provided Command, capturing its stderr
 // into the provided logs_tx identified by |logs_token| and returning its stdout.
 // stdin is copied into the Command.
-#[tracing::instrument(err, skip(logs_tx, stdin, cmd))]
+#[tracing::instrument(err, level = "debug", skip(logs_tx, stdin, cmd))]
 pub async fn run_with_input_output<I>(
     name: &str,
     logs_tx: &logs::Tx,

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -116,8 +116,10 @@ impl Handler for PublishHandler {
             None
         };
 
+        let time_queued = chrono::Utc::now().signed_duration_since(row.updated_at);
+
         let (id, status) = self.process(row, &mut txn, false).await?;
-        info!(%id, ?status, "finished");
+        info!(%id, %time_queued, ?status, "finished");
 
         agent_sql::publications::resolve(id, &status, &mut txn).await?;
         txn.commit().await?;


### PR DESCRIPTION
**Description:**

estuary/flow#1379 changed our `tracing_subscriber` configuration to log at the close of each span. That required updating some `#[instrument]` attributes to include `level = "debug"`, since the default level of spans is `INFO`. Apparently I missed a couple, so here we are. Production is currently logging pretty noisily, and this should help tone it down.

Also, I added `time_queued` log field to each async job handler, so we can get a sense of end-to-end processing latency. In retrospect, I wish I would have done this _before_ making all these improvements to it, but 🤷

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1388)
<!-- Reviewable:end -->
