### PR TITLE
go.sh: add explicit flag for c++17

### DIFF
--- a/.github/workflows/derive-typescript.yaml
+++ b/.github/workflows/derive-typescript.yaml
@@ -18,12 +18,9 @@ jobs:
           fetch-depth: 0
           submodules: false
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.72.0
-          default: true
-          target: x86_64-unknown-linux-musl
+          targets: x86_64-unknown-linux-musl
 
       - run: sudo apt install -y musl-tools
 

--- a/.github/workflows/flow-web.yaml
+++ b/.github/workflows/flow-web.yaml
@@ -18,17 +18,15 @@ on:
 jobs:
   buildAndPublish:
     runs-on: ubuntu-20.04
-    permissions: 
+    permissions:
       contents: read
-      packages: write 
+      packages: write
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen
         run: |
@@ -42,7 +40,7 @@ jobs:
         run: wasm-pack build --scope estuary crates/flow-web --out-name flow_web
 
       # Fix from: https://github.com/rustwasm/wasm-pack/issues/1039#issuecomment-1712491804
-      # We need to manually insert the main ref until this fix is published 
+      # We need to manually insert the main ref until this fix is published
       # https://github.com/rustwasm/wasm-pack/pull/1061
       - name: Manually update package.json
         run: |
@@ -58,5 +56,3 @@ jobs:
           wasm-pack publish --access=public --tag=dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-

--- a/.github/workflows/flowctl-release.yaml
+++ b/.github/workflows/flowctl-release.yaml
@@ -28,31 +28,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Linux build steps:
-      - name: Install Rust
-        if: matrix.config.os == 'ubuntu-20.04'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Build Linux
         if: matrix.config.os == 'ubuntu-20.04'
         run: |-
           cargo build -p flowctl --release && mv target/release/flowctl ${ASSET_NAME}
 
       # Mac build steps:
-      # We need multiple targets for mac builds, so they will be manually added
-      # during the build step.
-      - name: Install Rust
-        if: matrix.config.os == 'macos-latest'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Setup mac signing certificate
         if: matrix.config.os == 'macos-latest'
         env:

--- a/.github/workflows/flowctl-test.yaml
+++ b/.github/workflows/flowctl-test.yaml
@@ -23,9 +23,6 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo test -p flowctl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,7 @@ jobs:
         with:
           go-version: "1.21"
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          default: true
-          toolchain: 1.74.0
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -94,12 +90,9 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
-          default: true
-          target: x86_64-unknown-linux-musl
+          targets: x86_64-unknown-linux-musl
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/go.sh
+++ b/go.sh
@@ -12,6 +12,10 @@ else
 fi;
 export CGO_CPPFLAGS="-I $(pwd)/target/${CARGO_BUILD_TARGET}/${PROFILE}/librocksdb-exp/include"
 
+# RocksDB requires std::string_view, which is only available starting in C++17.
+# We currently build on Ubuntu 20.04, where C++17 isn't the default.
+export CGO_CXXFLAGS="-std=c++17"
+
 # Uncomment me if you'd like to grab the resolved, final variables.
 # Try placing them in your User VSCode settings, under `go.testEnvVars`.
 # env | grep CGO


### PR DESCRIPTION
We can remove this once off of Ubuntu 20.04

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1391)
<!-- Reviewable:end -->
