### PR TITLE
Updating SQL Server wording to correctly talk about which databases we support

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -11,7 +11,7 @@ It’s available for use in the Flow web application. For local development or o
 
 ## Supported versions and platforms
 
-This connector supports SQL Server 2017 and later on major cloud providers.
+This connector will work on both hosted deployments and all major cloud providers.  It is designed for databases using any version of SQL Server which has CDC support, and is regularly tested against SQL Server 2017 and up.
 
 ## Prerequisites
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -11,7 +11,7 @@ It’s available for use in the Flow web application. For local development or o
 
 ## Supported versions and platforms
 
-This connector will work on both hosted deployments and all major cloud providers.  It is designed for databases using any version of SQL Server which has CDC support, and is regularly tested against SQL Server 2017 and up.
+This connector designed for databases using any version of SQL Server which has CDC support, and is regularly tested against SQL Server 2017 and up.
 
 ## Prerequisites
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -9,7 +9,7 @@ It’s available for use in the Flow web application. For local development or o
 
 ## Supported versions and platforms
 
-This connector supports SQL Server 2017 and later.
+This connector is designed for databases using any version of SQL Server which has CDC support, and is regularly tested against SQL Server 2017 and up.
 
 ## Prerequisites
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -9,8 +9,8 @@ It’s available for use in the Flow web application. For local development or o
 
 ## Supported versions and platforms
 
-This connector supports SQL Server 2017 and later on major cloud providers,
-as well as self-hosted instances.
+This connector will work on both hosted deployments and all major cloud providers.  It is designed for databases using any version of SQL Server which has CDC support, and is regularly tested against SQL Server 2017 and up.
+
 Setup instructions are provided for the following platforms:
 
 * [Self-hosted SQL Server](#self-hosted-sql-server)


### PR DESCRIPTION
**Description:**

Updating SQL Server wording to correctly talk about which databases we support since we support earlier than 2017.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1398)
<!-- Reviewable:end -->
