### PR TITLE
connector-init: set connector_type on protocol check Spec

### DIFF
--- a/crates/connector-init/src/lib.rs
+++ b/crates/connector-init/src/lib.rs
@@ -92,7 +92,7 @@ async fn check_protocol(entrypoint: &[String], codec: Codec) -> anyhow::Result<(
         codec,
         proto_flow::capture::Request {
             spec: Some(proto_flow::capture::request::Spec {
-                connector_type: 0,
+                connector_type: proto_flow::flow::capture_spec::ConnectorType::Image as i32,
                 config_json: String::new(),
             }),
             ..Default::default()


### PR DESCRIPTION
It's not valid to leave it as zero (INVALID).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1400)
<!-- Reviewable:end -->
