### PR TITLE
agent: use 5 minute timeout for spec runs

### DIFF
--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use super::{jobs, logs, HandleResult, Handler, Id};
 use agent_sql::connector_tags::Row;
 use anyhow::Context;
@@ -216,7 +214,7 @@ async fn spec_materialization(
     };
 
     let spec = runtime
-        .unary_materialize(req, SPEC_TIMEOUT)
+        .unary_materialize(req, build::CONNECTOR_TIMEOUT)
         .await?
         .spec
         .ok_or_else(|| anyhow::anyhow!("connector didn't send expected Spec response"))?;
@@ -262,7 +260,7 @@ async fn spec_capture(
     };
 
     let spec = runtime
-        .unary_capture(req, SPEC_TIMEOUT)
+        .unary_capture(req, build::CONNECTOR_TIMEOUT)
         .await?
         .spec
         .ok_or_else(|| anyhow::anyhow!("connector didn't send expected Spec response"))?;
@@ -294,5 +292,3 @@ async fn spec_capture(
         oauth2: oauth,
     })
 }
-
-const SPEC_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
**Description:**

Use the `build::CONNECTOR_TIMEOUT` for spec requests, since the 10 second timeout was likely causing more failures than necessary with how long docker image pulling can take. Currently `build::CONNECTOR_TIMEOUT` is set to 5 minutes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1401)
<!-- Reviewable:end -->
