### PR TITLE
go/shuffle: lower the read channel capacity

### DIFF
--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -377,7 +377,7 @@ func (r *read) sendReadResult(resp *pr.ShuffleResponse, err error, wakeCh chan<-
 
 	var queue, cap = len(r.ch), cap(r.ch)
 	if queue == cap {
-		r.log(ops.Log_warn,
+		r.log(ops.Log_debug,
 			"cancelling shuffle read due to full channel timeout",
 			"queue", queue,
 			"cap", cap,
@@ -696,8 +696,8 @@ func pickHRW(h uint32, from []shuffleMember, start, stop int) int {
 }
 
 // readChannelCapacity is sized so that sendReadResult will overflow and
-// cancel the read after ~35 minutes of no progress (1<<20 + 1<<19 + 1<<18 ... millis).
-var readChannelCapacity = 22
+// cancel the read after ~2 minutes of no progress (1<<16 + 1<<15 + 1<<14 ... millis).
+var readChannelCapacity = 18
 
 func backoff(attempt int) time.Duration {
 	// The choices of backoff time reflect that we're usually waiting for the


### PR DESCRIPTION
Time out and cancel reads after about a couple minutes of inactivity, rather than 35 minutes.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1405)
<!-- Reviewable:end -->
