### PR TITLE
models/journals: region configuration for S3 storage mappings

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -26,8 +26,8 @@ pub use derivation::{Derivation, DeriveUsing, Shuffle, ShuffleType, TransformDef
 pub use derive_sqlite::DeriveUsingSqlite;
 pub use derive_typescript::DeriveUsingTypescript;
 pub use journals::{
-    CompressionCodec, CustomStore, FragmentTemplate, JournalTemplate, S3BucketAndPrefix,
-    StorageDef, Store, AZURE_CONTAINER_RE, AZURE_STORAGE_ACCOUNT_RE, GCS_BUCKET_RE, S3_BUCKET_RE,
+    CompressionCodec, CustomStore, FragmentTemplate, JournalTemplate, S3StorageConfig, StorageDef,
+    Store, AZURE_CONTAINER_RE, AZURE_STORAGE_ACCOUNT_RE, GCS_BUCKET_RE, S3_BUCKET_RE,
 };
 pub use materializations::{
     MaterializationBinding, MaterializationDef, MaterializationEndpoint, MaterializationFields,

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings-2.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings-2.snap
@@ -18,7 +18,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "root-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },
@@ -34,7 +35,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "s3-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings-3.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings-3.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sources/src/scenarios/mod.rs
-assertion_line: 42
 expression: tables
 ---
 Sources {
@@ -19,7 +18,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "root-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },
@@ -35,7 +35,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "s3-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },

--- a/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings.snap
+++ b/crates/sources/src/scenarios/snapshots/sources__scenarios__test__storage_mappings.snap
@@ -30,7 +30,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "root-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },
@@ -46,7 +47,8 @@ Sources {
               {
                 "provider": "S3",
                 "bucket": "s3-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },

--- a/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__golden_all_visits.snap
@@ -6972,7 +6972,8 @@ All {
               {
                 "provider": "S3",
                 "bucket": "data-bucket",
-                "prefix": null
+                "prefix": null,
+                "region": null
               }
             ],
         },


### PR DESCRIPTION
**Description:**

Allows setting the region for S3 storage mappings, for buckets that are not in the `us-east-1` region.

See also: https://github.com/gazette/core/pull/365. We will need to be running on this version of Gazette prior to deploying the changes here.

Closes https://github.com/estuary/flow/issues/1409

**Workflow steps:**

Create a storage mapping like this, and it will now work:

```json
{
  "stores": [
    {
      "provider": "S3",
      "bucket": "my-bucket-in-us-west-2",
      "region": "us-west-2",
      "prefix": "collection-data/"
    }
  ]
}
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1410)
<!-- Reviewable:end -->
