### PR TITLE
Fix BumpVec test after change to u128 alignment

### DIFF
--- a/crates/doc/src/bump_vec.rs
+++ b/crates/doc/src/bump_vec.rs
@@ -359,7 +359,7 @@ mod test {
         assert_eq!((2, 8, 4), BumpVec::<u16>::sizes());
         assert_eq!((4, 8, 4), BumpVec::<u32>::sizes());
         assert_eq!((8, 8, 8), BumpVec::<u64>::sizes());
-        assert_eq!((16, 8, 8), BumpVec::<u128>::sizes());
+        assert_eq!((16, 16, 16), BumpVec::<u128>::sizes());
 
         let alloc = bumpalo::Bump::new();
 


### PR DESCRIPTION
**Description:**

There was a recent change in the rust compiler that changed the aligmnent of u128 values. See: https://blog.rust-lang.org/2024/03/30/i128-layout-update.html This updates a BumpVec test that had asserted the old values, so that the test now hopefully passes.

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1430)
<!-- Reviewable:end -->
