### PR TITLE
flowctl: resurrect stats subcommand under raw

### DIFF
--- a/crates/flowctl/src/ops.rs
+++ b/crates/flowctl/src/ops.rs
@@ -31,6 +31,7 @@ impl Logs {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum OpsCollection {
     Logs,
+    Stats,
 }
 
 pub fn read_args(
@@ -41,6 +42,7 @@ pub fn read_args(
 ) -> ReadArgs {
     let logs_or_stats = match collection {
         OpsCollection::Logs => "logs",
+        OpsCollection::Stats => "stats",
     };
     // Once we implement federated data planes, we'll need to update this to
     // fetch the name of the data plane based on the tenant.

--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -1,4 +1,8 @@
-use crate::local_specs;
+use crate::{
+    collection::read::{read_collection, ReadBounds},
+    local_specs,
+    ops::{OpsCollection, TaskSelector},
+};
 use anyhow::Context;
 use doc::combine;
 use std::{
@@ -56,6 +60,8 @@ pub enum Command {
     Oauth(oauth::Oauth),
     /// Emit the Flow specification JSON-Schema.
     JsonSchema,
+    /// Read stats collection documents
+    Stats(Stats),
 }
 
 #[derive(Debug, clap::Args)]
@@ -131,6 +137,34 @@ pub struct Combine {
     collection: String,
 }
 
+#[derive(clap::Args, Debug)]
+pub struct Stats {
+    #[clap(flatten)]
+    pub task: TaskSelector,
+
+    #[clap(flatten)]
+    pub bounds: ReadBounds,
+
+    /// Read raw data from stats journals, including possibly uncommitted or rolled back transactions.
+    /// This flag is currently required, but will be made optional in the future as we add support for
+    /// committed reads, which will become the default.
+    #[clap(long)]
+    pub uncommitted: bool,
+}
+
+impl Stats {
+    pub async fn run(&self, ctx: &mut crate::CliContext) -> anyhow::Result<()> {
+        let read_args = crate::ops::read_args(
+            &self.task.task,
+            OpsCollection::Stats,
+            &self.bounds,
+            self.uncommitted,
+        );
+        read_collection(ctx, &read_args).await?;
+        Ok(())
+    }
+}
+
 impl Advanced {
     pub async fn run(&self, ctx: &mut crate::CliContext) -> anyhow::Result<()> {
         match &self.cmd {
@@ -150,6 +184,7 @@ impl Advanced {
                 let schema = models::Catalog::root_json_schema();
                 Ok(serde_json::to_writer_pretty(std::io::stdout(), &schema)?)
             }
+            Command::Stats(stats) => stats.run(ctx).await,
         }
     }
 }


### PR DESCRIPTION
`flowctl stats` was removed a few months ago due to concerns about UX. I've really missed having it, though, because the process for finding and reading from the stats journal using `flowctl-go` and port-forwarding is a pain. So this adds the subcommand back in, but moves it under `flowctl raw` to address the UX issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1432)
<!-- Reviewable:end -->
