### PR TITLE
agent: backend support for updating storage mappings

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -34,6 +34,13 @@ RUN apt update -y \
 # Create a non-privileged "flow" user.
 RUN useradd flow --create-home --shell /usr/sbin/nologin
 
+# Install AWS CLI v2, taken from: https://lukewiwa.com/blog/add_the_aws_cli_to_a_dockerfile/
+COPY --from=amazon/aws-cli:latest /usr/local/aws-cli/ /usr/local/aws-cli/
+RUN ln -s /usr/local/aws-cli/v2/current/bin/aws \
+        /usr/local/bin/aws && \
+    ln -s /usr/local/aws-cli/v2/current/bin/aws_completer \
+        /usr/local/bin/aws_completer
+
 # Copy binaries & libraries to the image, owned by root.
 USER root
 COPY bin/* /usr/local/bin/

--- a/crates/agent-sql/src/directives/mod.rs
+++ b/crates/agent-sql/src/directives/mod.rs
@@ -8,6 +8,7 @@ use sqlx::types::Uuid;
 pub mod accept_demo_tenant;
 pub mod beta_onboard;
 pub mod grant;
+pub mod storage_mappings;
 
 // Row is the dequeued task shape of an applied directive operation. We don't currently have a use
 // for background directive applications, so the `background` column is omitted.

--- a/crates/agent-sql/src/directives/storage_mappings.rs
+++ b/crates/agent-sql/src/directives/storage_mappings.rs
@@ -1,0 +1,64 @@
+use crate::TextJson;
+use serde_json::value::RawValue;
+use sqlx::types::Uuid;
+
+pub async fn user_has_admin_capability(
+    user_id: Uuid,
+    catalog_prefix: &str,
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> sqlx::Result<bool> {
+    let row = sqlx::query!(
+        r#"select true as whatever_column from internal.user_roles($1, 'admin') where starts_with(role_prefix, $2)"#,
+        user_id,
+        catalog_prefix,
+    )
+    .fetch_optional(txn)
+    .await?;
+    Ok(row.is_some())
+}
+
+pub async fn upsert_storage_mapping<T: serde::Serialize + Send + Sync>(
+    detail: &str,
+    catalog_prefix: &str,
+    spec: T,
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> sqlx::Result<()> {
+    sqlx::query!(
+        r#"
+        insert into storage_mappings (detail, catalog_prefix, spec)
+        values ($1, $2, $3)
+        on conflict (catalog_prefix) do update set detail = $1, spec = $3"#,
+        detail as &str,
+        catalog_prefix as &str,
+        TextJson(spec) as TextJson<T>,
+    )
+    .execute(txn)
+    .await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct StorageMapping {
+    pub catalog_prefix: String,
+    pub spec: TextJson<Box<RawValue>>,
+}
+
+pub async fn fetch_storage_mappings(
+    catalog_prefix: &str,
+    recovery_prefix: &str,
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> sqlx::Result<Vec<StorageMapping>> {
+    sqlx::query_as!(
+        StorageMapping,
+        r#"select
+            catalog_prefix,
+            spec as "spec: TextJson<Box<RawValue>>"
+         from storage_mappings
+         where catalog_prefix = $1 or catalog_prefix = $2
+         for update of storage_mappings"#,
+        catalog_prefix,
+        recovery_prefix
+    )
+    .fetch_all(txn)
+    .await
+}

--- a/crates/agent/src/directives/accept_demo_tenant.rs
+++ b/crates/agent/src/directives/accept_demo_tenant.rs
@@ -83,8 +83,8 @@ mod test {
         .execute(&mut txn)
         .await
         .unwrap();
-
-        let mut handler = DirectiveHandler::default();
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(64);
+        let mut handler = DirectiveHandler::new("support@estuary.test".to_owned(), &logs_tx);
         while let Some(row) = agent_sql::directives::dequeue(&mut txn, false)
             .await
             .unwrap()

--- a/crates/agent/src/directives/beta_onboard.rs
+++ b/crates/agent/src/directives/beta_onboard.rs
@@ -134,9 +134,8 @@ mod test {
         .await
         .unwrap();
 
-        let mut handler = DirectiveHandler {
-            accounts_user_email: "accounts@example.com".to_string(),
-        };
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(64);
+        let mut handler = DirectiveHandler::new("accounts@example.com".to_owned(), &logs_tx);
         while let Some(row) = agent_sql::directives::dequeue(&mut txn, true)
             .await
             .unwrap()

--- a/crates/agent/src/directives/click_to_accept.rs
+++ b/crates/agent/src/directives/click_to_accept.rs
@@ -76,7 +76,8 @@ mod test {
         .await
         .unwrap();
 
-        let mut handler = DirectiveHandler::default();
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(64);
+        let mut handler = DirectiveHandler::new("support@estuary.test".to_owned(), &logs_tx);
         while let Some(row) = agent_sql::directives::dequeue(&mut txn, true)
             .await
             .unwrap()

--- a/crates/agent/src/directives/grant.rs
+++ b/crates/agent/src/directives/grant.rs
@@ -126,7 +126,8 @@ mod test {
         .await
         .unwrap();
 
-        let mut handler = DirectiveHandler::default();
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(64);
+        let mut handler = DirectiveHandler::new("support@estuary.test".to_owned(), &logs_tx);
         while let Some(row) = agent_sql::directives::dequeue(&mut txn, false)
             .await
             .unwrap()

--- a/crates/agent/src/directives/storage_mappings.rs
+++ b/crates/agent/src/directives/storage_mappings.rs
@@ -1,0 +1,294 @@
+use std::io::Write;
+
+use crate::{directives::JobStatus, logs};
+use agent_sql::directives::{
+    storage_mappings::{
+        fetch_storage_mappings, upsert_storage_mapping, user_has_admin_capability, StorageMapping,
+    },
+    Row,
+};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use sqlx::types::Uuid;
+use validator::Validate;
+
+#[derive(Debug, Deserialize, Serialize, Validate, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Directive {}
+
+#[derive(Debug, Deserialize, Serialize, Validate, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Claims {
+    add_store: models::Store,
+    catalog_prefix: models::Prefix,
+}
+
+#[tracing::instrument(skip_all, ret, err, fields(row.user_claims))]
+pub async fn apply(
+    _: Directive,
+    row: Row,
+    logs_tx: &logs::Tx,
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> anyhow::Result<JobStatus> {
+    let detail = format!(
+        "updated by user {} via applied directive {}",
+        row.user_id, row.apply_id
+    );
+    let (collection_data, recovery) = match validate(txn, logs_tx, row).await {
+        Ok(c) => c,
+        Err(err) => {
+            return Ok(JobStatus::invalid_claims(err));
+        }
+    };
+
+    let ProposedMapping {
+        catalog_prefix,
+        spec,
+    } = collection_data;
+    upsert_storage_mapping(&detail, &catalog_prefix, spec, txn).await?;
+    let ProposedMapping {
+        catalog_prefix,
+        spec,
+    } = recovery;
+    upsert_storage_mapping(&detail, &catalog_prefix, spec, txn).await?;
+
+    Ok(JobStatus::Success)
+}
+
+pub struct ProposedMapping {
+    catalog_prefix: String,
+    spec: models::StorageDef,
+}
+
+fn add_store(stores: &mut models::StorageDef, store: models::Store) {
+    // If there's already an equivalent store, then remove it so that we don't end up with
+    // duplicates. This could happen if someone added store A, then store B, then store A again.
+    stores.stores.retain(|s| s != &store);
+    stores.stores.insert(0, store);
+}
+
+async fn validate(
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    logs_tx: &logs::Tx,
+    row: Row,
+) -> anyhow::Result<(ProposedMapping, ProposedMapping)> {
+    let claims: Claims =
+        serde_json::from_str(row.user_claims.get()).context("parsing user_claims")?;
+
+    if !claims.catalog_prefix.ends_with('/') {
+        anyhow::bail!("invalid prefix, must end with '/'");
+    }
+
+    // Storage mappings can only be updated for an entire tenant. We may one day wish to support
+    // updates to narrower prefixes, but are trying to keep it simple for now.
+    if claims.catalog_prefix.matches('/').count() > 1 {
+        anyhow::bail!("catalog prefix contains too many path segments. Only top-level tenant prefixes can have storage mappings altered");
+    }
+
+    // Note: we must assert that user has admin capability for the _entire tenant_, even if in the
+    // future we allow for updating mappings of narrower prefixes. This is required because a new
+    // storage mapping for `a/b/` may implicitly override the existing mapping for `a/`.
+    let user_has_admin =
+        user_has_admin_capability(row.user_id, &claims.catalog_prefix, txn).await?;
+    anyhow::ensure!(
+        user_has_admin,
+        "user does not have required 'admin' capability to '{}'",
+        claims.catalog_prefix
+    );
+
+    // Check that we can actually access the storage bucket before fetching (and locking) the
+    // existing `storage_mappings` rows, since this check requires multiple network round trips.
+    check_bucket_access(row.logs_token, logs_tx, &claims.add_store).await?;
+
+    let recovery_prefix = format!("recovery/{}", claims.catalog_prefix);
+    let existing_mappings =
+        fetch_storage_mappings(&claims.catalog_prefix, &recovery_prefix, txn).await?;
+    let (mut collection_data, mut recovery_data) = parse_existing(existing_mappings)?;
+
+    let mut collection_store = claims.add_store.clone();
+    // The storage mapping for collection data should always have a `collection-data/` prefix in
+    // order to segregate it from recovery log data. This makes it easier to apply bucket lifecycle
+    // policies, since you can target just the `collection-data/` prefix. If the store already
+    // specifies a prefix, then we'll add `collection-data/` to the end.
+    collection_store
+        .prefix_mut()
+        .as_mut_string()
+        .push_str("collection-data/");
+    add_store(&mut collection_data.spec, collection_store);
+    // The recovery log store doesn't need a separate prefix because all recovery log journals
+    // already begin with `recovery/`.
+    add_store(&mut recovery_data.spec, claims.add_store.clone());
+
+    Ok((collection_data, recovery_data))
+}
+
+// This is a macro instead of a function to work around the fact that file paths are `OsStr`s
+// instead of regular `&str`s.
+macro_rules! check_command {
+    ($prog:expr, $($arg:expr),* $(; region $region:expr)?) => {{
+        let mut cmd = std::process::Command::new($prog);
+        $(
+            cmd.arg($arg);
+        )*
+        $(
+          if let Some(region_name) = $region {
+              cmd.arg("--region");
+              cmd.arg(region_name);
+          }
+        )?
+        cmd
+    } };
+}
+
+async fn check_bucket_access(
+    logs_token: Uuid,
+    logs_tx: &logs::Tx,
+    store: &models::Store,
+) -> anyhow::Result<()> {
+    let mut test_file = tempfile::NamedTempFile::new().context("creating temp file")?;
+    test_file
+        .write_all(TEST_FILE_CONTENT.as_bytes())
+        .context("writing test file content")?;
+    let test_file_path = test_file.path();
+
+    let commands = match store {
+        models::Store::S3(conf) => vec![
+            (
+                "put object",
+                check_command!(
+                    "aws",
+                    "s3",
+                    "cp",
+                    test_file_path,
+                    without_query(conf.as_url()).join(TEST_FILENAME)?.to_string()
+                    ; region conf.region.as_ref()),
+            ),
+            // List comes after put, so the prefix, if configured, is guaranteed to exist.
+            (
+                "list bucket",
+                check_command!("aws", "s3", "ls", without_query(conf.as_url()).to_string()
+                    ; region conf.region.as_ref()),
+            ),
+            (
+                "delete object",
+                check_command!(
+                    "aws",
+                    "s3",
+                    "rm",
+                    without_query(conf.as_url()).join(TEST_FILENAME)?.to_string()
+                    ; region conf.region.as_ref()
+                ),
+            ),
+        ],
+        models::Store::Gcs(conf) => vec![
+            (
+                "put object",
+                check_command!(
+                    "gcloud",
+                    "storage",
+                    "cp",
+                    test_file_path,
+                    without_query(conf.as_url())
+                        .join(TEST_FILENAME)?
+                        .to_string()
+                ),
+            ),
+            // List comes after put, so the prefix, if configured, is guaranteed to exist.
+            (
+                "list bucket",
+                check_command!(
+                    "gcloud",
+                    "storage",
+                    "ls",
+                    without_query(conf.as_url()).to_string()
+                ),
+            ),
+            (
+                "delete object",
+                check_command!(
+                    "gcloud",
+                    "storage",
+                    "rm",
+                    without_query(conf.as_url())
+                        .join(TEST_FILENAME)?
+                        .to_string()
+                ),
+            ),
+        ],
+        models::Store::Azure(_) => {
+            anyhow::bail!("checking access for azure cloud storage is not yet implemented")
+        }
+        models::Store::Custom(_) => {
+            anyhow::bail!("checking access for custom cloud storage is not supported")
+        }
+    };
+
+    for (desc, mut cmd) in commands {
+        tracing::info!(
+            %desc,
+            program = ?cmd.get_program(),
+            args = ?cmd.get_args(),
+            "running storage check"
+        );
+        let exit_status =
+            crate::jobs::run_without_removing_env(&desc, logs_tx, logs_token, &mut cmd)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to execute {desc} command: {:?} with: {:?}",
+                        cmd.get_program(),
+                        cmd.get_args()
+                    )
+                })?;
+        if !exit_status.success() {
+            anyhow::bail!("failed to {desc}, please check that permissions are set appropriately");
+        }
+    }
+
+    Ok(())
+}
+
+fn without_query(mut uri: url::Url) -> url::Url {
+    uri.set_query(None);
+    uri
+}
+
+fn parse_existing(
+    mut existing: Vec<StorageMapping>,
+) -> anyhow::Result<(ProposedMapping, ProposedMapping)> {
+    if existing.len() != 2 {
+        anyhow::bail!("expected 2 existing storage mappings, found: {existing:?}");
+    }
+    let Some(recovery_idx) = existing
+        .iter()
+        .position(|m| m.catalog_prefix.starts_with("recovery/"))
+    else {
+        anyhow::bail!("missing recovery/ storage mapping in {existing:?}");
+    };
+    let recovery = existing.remove(recovery_idx);
+    let recovery_storage: models::StorageDef = serde_json::from_str(recovery.spec.get())
+        .context("deserializing existing recovery/ storage mapping")?;
+
+    let collection_data = existing.remove(0);
+    let collection_store: models::StorageDef = serde_json::from_str(collection_data.spec.get())
+        .context("deserializing existing storage mapping")?;
+
+    Ok((
+        ProposedMapping {
+            catalog_prefix: collection_data.catalog_prefix,
+            spec: collection_store,
+        },
+        ProposedMapping {
+            catalog_prefix: recovery.catalog_prefix,
+            spec: recovery_storage,
+        },
+    ))
+}
+
+const TEST_FILENAME: &str = "estuary_test.txt";
+
+const TEST_FILE_CONTENT: &str = r#"Estuary storage test
+This file is written to your storage bucket in order to test that we have the necessary access
+permissions to create and delete objects. If you're seeing this file stick around, then it's
+likely because we lacked the necessary permissions to delete it. You may remove this file at
+any time, and doing so will not impact the function of Estuary."#;

--- a/crates/agent/src/directives/storage_mappings.rs
+++ b/crates/agent/src/directives/storage_mappings.rs
@@ -170,6 +170,21 @@ async fn check_bucket_access(
                     ; region conf.region.as_ref()),
             ),
             (
+                "get object",
+                // Copy to stdout to avoid needing to cleanup a temp file.
+                // Don't use /dev/null because the cli will exit non-zero even when it gets the file successfully.
+                check_command!(
+                    "aws",
+                    "s3",
+                    "cp",
+                    without_query(conf.as_url())
+                        .join(TEST_FILENAME)?
+                        .to_string(),
+                    "/dev/stdout"
+                    ; region conf.region.as_ref()
+                ),
+            ),
+            (
                 "delete object",
                 check_command!(
                     "aws",
@@ -201,6 +216,17 @@ async fn check_bucket_access(
                     "storage",
                     "ls",
                     without_query(conf.as_url()).to_string()
+                ),
+            ),
+            (
+                "get object",
+                check_command!(
+                    "gcloud",
+                    "storage",
+                    "cat",
+                    without_query(conf.as_url())
+                        .join(TEST_FILENAME)?
+                        .to_string()
                 ),
             ),
             (

--- a/crates/agent/src/logs.rs
+++ b/crates/agent/src/logs.rs
@@ -157,7 +157,9 @@ pub fn ops_handler(
             token: token.clone(),
             stream: stream.clone(),
             line: render_ops_log_for_ui(log),
-        }) else { return };
+        }) else {
+            return;
+        };
 
         // Perform an expensive "move" of all other tasks scheduled on the
         // current async executor thread, so that we can block until there's capacity.

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -134,7 +134,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
                 &logs_tx,
                 args.allow_local,
             )),
-            Box::new(agent::DirectiveHandler::new(args.accounts_email)),
+            Box::new(agent::DirectiveHandler::new(args.accounts_email, &logs_tx)),
             Box::new(agent::EvolutionHandler),
         ],
         pg_pool.clone(),

--- a/crates/models/src/journals.rs
+++ b/crates/models/src/journals.rs
@@ -408,6 +408,8 @@ lazy_static! {
 
 #[cfg(test)]
 mod test {
+    use schemars::gen::SchemaGenerator;
+
     use super::*;
 
     #[test]
@@ -499,5 +501,16 @@ mod test {
             "s3://test-bucket/test/?profile=testTenant&endpoint=http%3A%2F%2Fcanary.test%3A1234",
             &actual_url
         );
+    }
+
+    // The main catalog schema does not include storage definitions. This test ensures that the
+    // storage schemas are available in the snapshot and up-to-date, since we need them for the UI.
+    #[test]
+    fn storage_schemas() {
+        let mut settings = schemars::gen::SchemaSettings::draft2019_09();
+        settings.option_add_null_type = false;
+        let schema_gen = SchemaGenerator::new(settings);
+        let schema = schema_gen.into_root_schema_for::<StorageDef>();
+        insta::assert_json_snapshot!("storage-json-schema", schema);
     }
 }

--- a/crates/models/src/references.rs
+++ b/crates/models/src/references.rs
@@ -71,6 +71,10 @@ macro_rules! string_reference_types {
                 &$Regex
             }
 
+            pub fn as_mut_string(&mut self) -> &mut String {
+                &mut self.0
+            }
+
             fn schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
                 from_value(json!({
                     "type": "string",

--- a/crates/models/src/snapshots/models__journals__test__storage-json-schema.snap
+++ b/crates/models/src/snapshots/models__journals__test__storage-json-schema.snap
@@ -1,0 +1,203 @@
+---
+source: crates/models/src/journals.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "StorageDef",
+  "description": "Storage defines the backing cloud storage for journals.",
+  "type": "object",
+  "required": [
+    "stores"
+  ],
+  "properties": {
+    "stores": {
+      "title": "Stores for journal fragments under this prefix.",
+      "description": "Multiple stores may be specified, and all stores are periodically scanned to index applicable journal fragments. New fragments are always persisted to the first store in the list.\n\nThis can be helpful in performing bucket migrations: adding a new store to the front of the list causes ongoing data to be written to that location, while historical data continues to be read and served from the prior stores.\n\nWhen running `flowctl test`, stores are ignored and a local temporary directory is used instead.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Store"
+      }
+    }
+  },
+  "definitions": {
+    "Prefix": {
+      "description": "Prefixes are paths of Unicode letters, numbers, '-', '_', or '.'. Each path component is separated by a slash '/'. Prefixes may not begin in a '/', but must end in one.",
+      "examples": [
+        "acmeCo/widgets/"
+      ],
+      "type": "string",
+      "pattern": "^([\\p{Letter}\\p{Number}\\-_\\.]+/)*$"
+    },
+    "StorageEndpoint": {
+      "description": "An address for a custom storage endpoint",
+      "examples": [
+        "storage.example.com"
+      ],
+      "type": "string",
+      "pattern": "^^(http://|https://)?[a-z0-9]+[a-z0-9\\.:-]*[a-z0-9]+$"
+    },
+    "Store": {
+      "description": "A Store into which Flow journal fragments may be written.\n\nThe persisted path of a journal fragment is determined by composing the Store's bucket and prefix with the journal name and a content-addressed fragment file name.\n\nEg, given a Store to S3 with bucket \"my-bucket\" and prefix \"a/prefix\", along with a collection \"example/events\" having a logical partition \"region\", then a complete persisted path might be:\n\ns3://my-bucket/a/prefix/example/events/region=EU/utc_date=2021-10-25/utc_hour=13/000123-000456-789abcdef.gzip",
+      "examples": [
+        {
+          "bucket": "my-bucket",
+          "prefix": null,
+          "provider": "S3",
+          "region": null
+        }
+      ],
+      "oneOf": [
+        {
+          "title": "Amazon Simple Storage Service.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "prefix": null,
+              "region": null
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "$ref": "#/definitions/Prefix"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "S3"
+              ]
+            },
+            "region": {
+              "description": "AWS region of the S3 bucket. Uses the default value from the AWS credentials of the Gazette broker if unset.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "Google Cloud Storage.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "prefix": null
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^[a-z0-9][a-z0-9\\-_\\.]{1,60}[a-z0-9]$)"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "$ref": "#/definitions/Prefix"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "GCS"
+              ]
+            }
+          }
+        },
+        {
+          "title": "Azure object storage service.",
+          "examples": [
+            {
+              "account_tenant_id": "689f4ac1-038c-44cc-a1f9-8a65bc33386e",
+              "container_name": "containername",
+              "prefix": null,
+              "storage_account_name": "storageaccount"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "account_tenant_id",
+            "container_name",
+            "provider",
+            "storage_account_name"
+          ],
+          "properties": {
+            "account_tenant_id": {
+              "description": "The tenant ID that owns the storage account that we're writing into NOTE: This is not the tenant ID that owns the service principal",
+              "type": "string"
+            },
+            "container_name": {
+              "description": "In azure, blobs are stored inside of containers, which live inside accounts",
+              "type": "string"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "default": null,
+              "$ref": "#/definitions/Prefix"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "AZURE"
+              ]
+            },
+            "storage_account_name": {
+              "description": "Storage accounts in Azure are the equivalent to a \"bucket\" in S3",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "An S3-compatible endpoint",
+          "description": "Details of an s3-compatible storage endpoint, such as Minio or R2.",
+          "examples": [
+            {
+              "bucket": "my-bucket",
+              "endpoint": "storage.example.com"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "bucket",
+            "endpoint",
+            "provider"
+          ],
+          "properties": {
+            "bucket": {
+              "description": "Bucket into which Flow will store data.",
+              "type": "string",
+              "pattern": "(^[a-z0-9][a-z0-9\\-_\\.]{1,60}[a-z0-9]$)"
+            },
+            "endpoint": {
+              "description": "endpoint is required when provider is \"custom\", and specifies the address of an s3-compatible storage provider.",
+              "$ref": "#/definitions/StorageEndpoint"
+            },
+            "prefix": {
+              "description": "Optional prefix of keys written to the bucket.",
+              "$ref": "#/definitions/Prefix"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "CUSTOM"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/supabase/migrations/47_republish_prefix.sql
+++ b/supabase/migrations/47_republish_prefix.sql
@@ -1,0 +1,30 @@
+
+begin;
+
+-- Add the storageMappings directive
+insert into directives (catalog_prefix, spec) values ('ops/', '{"type": "storageMappings"}');
+
+create or replace function republish_prefix(prefix catalog_prefix)
+returns flowid as $$
+declare
+    draft_id flowid;
+    pub_id flowid;
+begin
+    insert into drafts default values returning id into draft_id;
+    insert into draft_specs (draft_id, catalog_name, spec_type, spec, expect_pub_id)
+        select draft_id, catalog_name, spec_type, spec, last_pub_id as expect_pub_id
+        from live_specs
+        where starts_with(catalog_name, prefix) and spec_type is not null;
+
+    insert into publications (draft_id) values (draft_id) returning id into pub_id;
+    return pub_id;
+end;
+$$ language plpgsql security invoker;
+
+comment on function republish_prefix is
+'Creates a publication of every task and collection under the given prefix. This will not modify any
+of the specs, and will set expect_pub_id to ensure that the publication does not overwrite changes
+from other publications. This is intended to be called after an update to the storage mappings of
+the prefix to apply the updated mappings.';
+
+commit;

--- a/supabase/migrations/48_storage_mapping_directive.sql
+++ b/supabase/migrations/48_storage_mapping_directive.sql
@@ -1,8 +1,9 @@
 
 begin;
 
--- Add the storageMappings directive
-insert into directives (catalog_prefix, spec) values ('ops/', '{"type": "storageMappings"}');
+-- Add the storageMappings directive, using a static token so that we can hard code the token in the UI.
+-- This token is not sensitive, and is safe to be shared publicly.
+insert into directives (catalog_prefix, spec, token) values ('ops/', '{"type": "storageMappings"}', 'dd1319b2-e72b-421c-ad2b-082352569bb1');
 
 create or replace function republish_prefix(prefix catalog_prefix)
 returns flowid as $$


### PR DESCRIPTION
**Description:**

Introduces two different pieces of backend functionality in support of a UI for updating storage mappings. The first is a directive for updating the actual storage mappings, including validating the new mapping by ensuring we have appropriate permissions to the bucket. The second is a postgres function that creates a publication of all the existing specs under a given prefix.

Only top-level tenant prefixes are supported at this time. It shouldn't be too hard to support adding new prefixes in the future, but it seemed wise to avoid the complexity for now.

The directive is meant to validate our access to the users storage buckets. It only supports GCS and S3 at this time, but it shouldn't be too hard to add support for azure and even custom storage endpoints. The checks are done by putting a file, listing it, and deleting it. This is somewhat more crude than checking our users permissions, but it works for any cloud provider and ensures that we're only requiring a minimal set of permissions.

The `republish_prefix` function is needed in order to apply the newly updated storage mappings. Stitching this together with the directive is being left as a UI responsibility for now.

**Workflow steps:**

The basic steps are (assume `--profile local` if running locally):

- `flowctl raw rpc --function exchange_directive_token --body '{"bearer_token": "<directive-token>"}'
- `update applied_directives set user_claims = '{"addStore": {"provider": "S3", "bucket": "estuary-test"}, "catalogPrefix": "phil/"}' where id = '<id-from-rpc>'`
- Observe applied directive status and storage mappings
- If directive was successful, `flowctl raw rpc --function republish_prefix --body '{"prefix": "phil/"}'` to publish everything under the tenant

I ran through these steps and tested a few different buckets and scenarios:

- add GCS bucket with and without a prefix
- add an S3 bucket with and without a prefix
- add an S3 bucket with an explicit region
- add a mapping that's already in the historical mappings, and ensure that it's not duplicated (should only be at index 0)

Some sad-path scenarios:

- catalog prefix in user claims is one that the user doens't admin results in `invalidClaims`
- catalog prefix that is not a top-level tenant prefix results in `invalidClaims`
- republish_prefix called with prefix that user doesn't have read access to (results in publication of empty draft)

**Documentation links affected:**

None yet, will document once we have UI done.

**Notes for reviewers:** n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1438)
<!-- Reviewable:end -->
