### PR TITLE
tenants: "hide_preview" column to hide collection data preview

### DIFF
--- a/supabase/migrations/49_tenant_hide_preview.sql
+++ b/supabase/migrations/49_tenant_hide_preview.sql
@@ -2,4 +2,8 @@ begin;
 
 alter table tenants add column hide_preview boolean not null default false;
 
+comment on column tenants.hide_preview is '
+Hide data preview in the collections page for this tenant, used as a measure for preventing users with access to this tenant from viewing sensitive data in collections
+';
+
 commit;

--- a/supabase/migrations/49_tenant_hide_preview.sql
+++ b/supabase/migrations/49_tenant_hide_preview.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table tenants add column hide_preview boolean not null default false;
+
+commit;


### PR DESCRIPTION
**Description:**

- Tested with https://github.com/estuary/ui/pull/1100 and it works as expected 👍🏽 
<img width="1674" alt="image" src="https://github.com/estuary/flow/assets/2807772/ea9138d1-357e-44f3-91fd-418ac92017df">

<img width="1698" alt="image" src="https://github.com/estuary/flow/assets/2807772/005bbc1e-9467-46d2-80b9-887fb6fae46e">


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1455)
<!-- Reviewable:end -->
