### PR TITLE
flowctl(preview): multiple bindings may read from one collection

### DIFF
--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -80,7 +80,7 @@ async fn validate(
 
     let (sources, mut validations) = build::validate(
         true, // Allow local connectors.
-        "local-build",
+        "localbuild",
         network,
         &Resolver { client },
         false, // Don't generate ops collections.

--- a/crates/flowctl/src/preview/mod.rs
+++ b/crates/flowctl/src/preview/mod.rs
@@ -66,8 +66,12 @@ pub struct Preview {
     initial_state: String,
 
     /// Output state updates
-    #[clap(long, default_value_t=false)]
+    #[clap(long, action)]
     output_state: bool,
+
+    /// Output apply RPC description
+    #[clap(long, action)]
+    output_apply: bool,
 }
 
 impl Preview {
@@ -82,6 +86,7 @@ impl Preview {
             network,
             initial_state,
             output_state,
+            output_apply,
         } = self;
 
         let source = build::arg_source_to_url(source, false)?;
@@ -169,6 +174,7 @@ impl Preview {
                 state_dir.path(),
                 timeout,
                 *output_state,
+                *output_apply,
             )
             .await;
         }
@@ -231,6 +237,7 @@ impl Preview {
                     state_dir.path(),
                     timeout,
                     *output_state,
+                    *output_apply,
                 )
                 .await;
             } else {
@@ -243,6 +250,7 @@ impl Preview {
                     state_dir.path(),
                     timeout,
                     *output_state,
+                    *output_apply,
                 )
                 .await;
             }
@@ -261,9 +269,10 @@ async fn preview_capture<L: runtime::LogHandler>(
     state_dir: &std::path::Path,
     timeout: std::time::Duration,
     output_state: bool,
+    output_apply: bool,
 ) -> anyhow::Result<()> {
     let responses_rx =
-        runtime::harness::run_capture(delay, runtime, sessions, &spec, state, state_dir, timeout);
+        runtime::harness::run_capture(delay, runtime, sessions, &spec, state, state_dir, timeout, output_apply);
     tokio::pin!(responses_rx);
 
     while let Some(response) = responses_rx.try_next().await? {
@@ -358,9 +367,10 @@ async fn preview_materialization<L: runtime::LogHandler>(
     state_dir: &std::path::Path,
     timeout: std::time::Duration,
     output_state: bool,
+    output_apply: bool,
 ) -> anyhow::Result<()> {
     let responses_rx = runtime::harness::run_materialize(
-        reader, runtime, sessions, &spec, state, state_dir, timeout,
+        reader, runtime, sessions, &spec, state, state_dir, timeout, output_apply,
     );
     tokio::pin!(responses_rx);
 

--- a/crates/json/src/number.rs
+++ b/crates/json/src/number.rs
@@ -192,6 +192,7 @@ mod test {
         assert_eq!(from("1234"), Unsigned(1234));
         assert_eq!(from("-1234"), Signed(-1234));
         assert_eq!(from("12.34"), Float(12.34));
+        assert_eq!(from("18446744073709551615"), Unsigned(18446744073709551615));
 
         // Signed / unsigned integer conversions always succeed.
         expect_eq(Unsigned(1234), 1234 as u64);

--- a/crates/runtime/src/harness/fixture.rs
+++ b/crates/runtime/src/harness/fixture.rs
@@ -99,7 +99,7 @@ impl Reader {
                     for (binding, ptr) in bindings {
                         // Add a UUID fixture with a synthetic publication time.
                         let seconds = 3600 * txn + offset; // Synthetic timestamp of the document.
-                        let uuid = crate::uuid::build_uuid(
+                        let uuid = crate::uuid::build(
                             producer,
                             crate::uuid::Clock::from_unix(seconds as u64, 0),
                             crate::uuid::Flags(0),

--- a/crates/runtime/src/harness/materialize.rs
+++ b/crates/runtime/src/harness/materialize.rs
@@ -16,6 +16,7 @@ pub fn run_materialize<L: LogHandler>(
     mut state: models::RawValue,
     state_dir: &std::path::Path,
     timeout: std::time::Duration,
+    output_apply: bool,
 ) -> impl ResponseStream {
     let spec = spec.clone();
     let state_dir = state_dir.to_owned();
@@ -43,6 +44,7 @@ pub fn run_materialize<L: LogHandler>(
                 &mut state,
                 target_transactions,
                 timeout,
+                output_apply,
             )
             .await?;
         }
@@ -88,6 +90,7 @@ async fn run_session(
     state: &mut models::RawValue,
     target_transactions: usize,
     timeout: std::time::Duration,
+    output_apply: bool,
 ) -> anyhow::Result<()> {
     let labeling = crate::parse_shard_labeling(spec.shard_template.as_ref())?;
 
@@ -112,6 +115,9 @@ async fn run_session(
     // Receive Applied.
     match response_rx.try_next().await? {
         Some(applied) if applied.applied.is_some() => {
+            if output_apply {
+                print!("[\"applied.actionDescription\", {:?}]\n", applied.applied.as_ref().unwrap().action_description);
+            }
             () = co.yield_(applied).await;
         }
         response => return verify("runtime", "Applied").fail(response),


### PR DESCRIPTION
**Description:**

- The existing implementation only supported cases where bindings had a 1:1 relation with collections, but multiple bindings may read from the same collection, and we use this in our materialization integration tests. This pull-request introduces the ability to have multiple bindings read from the same collection.
- Added the `output_state` and `output_apply` options to preview so that the state and action description of a connector may also be output by `flowctl preview`, these are useful for materialization integration tests
- Required by https://github.com/estuary/connectors/pull/1571

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1466)
<!-- Reviewable:end -->
