### PR TITLE
build: add SystemConfiguration framework CGO flag for Darwin builds

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -7,6 +7,7 @@ if [ "$(uname)" == "Darwin" ]; then
   export CGO_CFLAGS="-I $(pwd)/target/${CARGO_BUILD_TARGET}/${PROFILE}/librocksdb-exp/include -I $(brew --prefix)/include -I $(brew --prefix)/opt/sqlite3/include"
   export CC="$(brew --prefix)/opt/llvm/bin/clang"
   export CXX="$(brew --prefix)/opt/llvm/bin/clang"
+  export CGO_LDFLAGS="${CGO_LDFLAGS} -framework SystemConfiguration"
 else
   export CGO_CFLAGS="-I $(pwd)/target/${CARGO_BUILD_TARGET}/${PROFILE}/librocksdb-exp/include"
 fi;


### PR DESCRIPTION
**Description:**

This is required for building on ARM macs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1470)
<!-- Reviewable:end -->
