### PR TITLE
flowctl-go: api discover should pass-through config directly

### DIFF
--- a/go/flowctl-go/cmd-api-discover.go
+++ b/go/flowctl-go/cmd-api-discover.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 	pb "go.gazette.dev/core/broker/protocol"
 	mbp "go.gazette.dev/core/mainboilerplate"
-	"gopkg.in/yaml.v3"
 )
 
 type apiDiscover struct {
@@ -34,7 +33,7 @@ type apiDiscover struct {
 }
 
 func (cmd apiDiscover) execute(ctx context.Context) (*pc.Response_Discovered, error) {
-	var config, err = readConfig(cmd.Config)
+	var config, err = os.ReadFile(cmd.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -142,18 +141,4 @@ func (cmd apiDiscover) Execute(_ []string) error {
 	} else {
 		panic(cmd.Output)
 	}
-}
-
-func readConfig(path string) (raw json.RawMessage, err error) {
-	var iface interface{}
-
-	if r, err := os.Open(path); err != nil {
-		return nil, fmt.Errorf("opening config: %w", err)
-	} else if err = yaml.NewDecoder(r).Decode(&iface); err != nil {
-		return nil, fmt.Errorf("decoding config: %w", err)
-	} else if raw, err = json.Marshal(iface); err != nil {
-		return nil, fmt.Errorf("encoding JSON config: %w", err)
-	}
-
-	return raw, nil
 }


### PR DESCRIPTION
We no longer use YAML here (this whole subcommand is vistigial) and can directly thread through bytes without any potential for re-ordering (which breaks SOPS MACs).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1475)
<!-- Reviewable:end -->
