### PR TITLE
Bigsum reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ version = "0.0.0"
 dependencies = [
  "allocator",
  "base64 0.13.1",
+ "bigdecimal",
  "bumpalo",
  "bytes",
  "fancy-regex",

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -30,6 +30,7 @@ time = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+bigdecimal.workspace = true
 
 [dev-dependencies]
 allocator = { path = "../allocator" }

--- a/crates/doc/src/reduce/mod.rs
+++ b/crates/doc/src/reduce/mod.rs
@@ -26,6 +26,8 @@ pub enum Error {
     SumNumericOverflow,
     #[error("'sum' strategy expects numbers")]
     SumWrongType,
+    #[error("'big-sum' strategy could not parse text as number: {detail}")]
+    BigSumParserError { detail: String },
     #[error(
         "'json-schema-merge' strategy expects objects containing valid JSON schemas: {detail}"
     )]

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -46,6 +46,7 @@ fn reduce_description(reduce: Reduction) -> &'static str {
         Reduction::Strategy(Strategy::Minimize(_)) => "minimize",
         Reduction::Strategy(Strategy::Set(_)) => "set",
         Reduction::Strategy(Strategy::Sum) => "sum",
+        Reduction::Strategy(Strategy::BigSum) => "big-sum",
         Reduction::Unset => "unset",
     }
 }

--- a/site/docs/reference/reduction-strategies/README.md
+++ b/site/docs/reference/reduction-strategies/README.md
@@ -18,6 +18,7 @@ The available strategies are:
 * [minimize and maximize](minimize-and-maximize.md)
 * [set](set.md)
 * [sum](sum.md)
+* [bigSum](big-sum.md)
 
 When no other strategy is specified in a schema, Flow defaults to `lastWriteWins`.  For even more customization, you can use [conditional statements](composing-with-conditionals.md).&#x20;
 

--- a/site/docs/reference/reduction-strategies/big-sum.md
+++ b/site/docs/reference/reduction-strategies/big-sum.md
@@ -1,0 +1,37 @@
+---
+description: Using the bigSum reduction strategy
+sidebar_position: 6
+---
+
+# bigSum
+
+`big-sum` reduces two numbers or integers by adding their values.
+
+```yaml
+collections:
+  - name: example/reductions/bigSum
+    schema:
+      type: object
+      reduce: { strategy: merge }
+      properties:
+        key: { type: string }
+        value:
+          # BigSum accepts strings and integers,
+          # but will always output strings.
+          type: string
+          reduce: { strategy: bigSum }
+      required: [key]
+    key: [/key]
+
+tests:
+  "Expect we can sum two numbers":
+    - ingest:
+        collection: example/reductions/sum
+        documents:
+          - { key: "key", value: 5 }
+          - { key: "key", value: "-1.2" }
+    - verify:
+        collection: example/reductions/sum
+        documents:
+          - { key: "key", value: "3.8" }
+```

--- a/site/docs/reference/reduction-strategies/big-sum.md
+++ b/site/docs/reference/reduction-strategies/big-sum.md
@@ -26,12 +26,12 @@ collections:
 tests:
   "Expect we can sum two numbers":
     - ingest:
-        collection: example/reductions/sum
+        collection: example/reductions/bigSum
         documents:
           - { key: "key", value: 5 }
           - { key: "key", value: "-1.2" }
     - verify:
-        collection: example/reductions/sum
+        collection: example/reductions/bigSum
         documents:
           - { key: "key", value: "3.8" }
 ```


### PR DESCRIPTION
**Description:**

Our use case requires summing up big numbers (mainly unsigned 256 bit integers), which is not currently supported.

**Workflow steps:**

Use like this:
```
{ "reduce": { "strategy": "bigSum" } }
```

Inputs need to be string-formatted integers or numbers. I excluded floats for now, mainly because there were some funky precision errors and we don't need them to work.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)
* Added a `bigSum` page to the reduction strategies section (slightly edited version of `sum`)

**Notes for reviewers:**

This is very much a draft. I haven't previously contributed to this project and I'm fairly new to Rust, so this is just my quick attempt at making it work. It is heavily inspired by the `sum` strategy, just using the most downloaded big decimal library under the hood. Happy to hear any feedback on this implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1476)
<!-- Reviewable:end -->
