### PR TITLE
crates/doc: relax `sum` inspection to allow numeric strings

### DIFF
--- a/crates/validation/tests/snapshots/scenario_tests__shape_inspections.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__shape_inspections.snap
@@ -17,7 +17,7 @@ expression: errors
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/schema,
-        error: /str has 'sum' reduction strategy, restricted to numbers, but has types "string",
+        error: /str has 'sum' reduction strategy (restricted to integers, numbers and strings with `format: integer` or `format: number`) but has types "string",
     },
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/key/0,
@@ -37,7 +37,7 @@ expression: errors
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/readSchema,
-        error: /str has 'sum' reduction strategy, restricted to numbers, but has types "string",
+        error: /str has 'sum' reduction strategy (restricted to integers, numbers and strings with `format: integer` or `format: number`) but has types "string",
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/key/0,

--- a/examples/reduction-types/sum.flow.yaml
+++ b/examples/reduction-types/sum.flow.yaml
@@ -6,9 +6,10 @@ collections:
       properties:
         key: { type: string }
         value:
-          # Sum only works with types "number" or "integer".
-          # Others will error at build time.
-          type: number
+          # Sum only works with numbers.
+          # Other types will error at build time.
+          type: [number, string]
+          format: number
           reduce: { strategy: sum }
       required: [key]
     key: [/key]
@@ -24,3 +25,12 @@ tests:
         collection: example/reductions/sum
         documents:
           - { key: "key", value: 3.8 }
+    - ingest:
+        collection: example/reductions/sum
+        documents:
+          - { key: "key", value: "2000000000000000000000" }
+          - { key: "key", value: "1000000000010000000000.00005" }
+    - verify:
+        collection: example/reductions/sum
+        documents:
+          - { key: "key", value: "3000000000010000000003.800050000000000" }


### PR DESCRIPTION
Improve the error message to relate that `format: number` may be used.

Update catalog test to provide coverage.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1481)
<!-- Reviewable:end -->
