### PR TITLE
agent: return TestFailed status when tests fail

### DIFF
--- a/crates/agent/src/publications/builds.rs
+++ b/crates/agent/src/publications/builds.rs
@@ -149,8 +149,8 @@ pub async fn test_catalog(
     build_id: Id,
     tmpdir: &path::Path,
     catalog: &build::Output,
-) -> anyhow::Result<Vec<tables::Error>> {
-    let mut errors = Vec::new();
+) -> anyhow::Result<tables::Errors> {
+    let mut errors = tables::Errors::default();
 
     // The tmpdir path will always begin with a /, so we don't need to add one
     let broker_socket_path = tmpdir.join("gazette.sock");
@@ -203,7 +203,7 @@ pub async fn test_catalog(
         .context("activating derivation for test")
         {
             tracing::error!(error = ?err, derivation = %built.catalog_name(), "failed to activate derivation in temp-data-plane");
-            errors.push(tables::Error {
+            errors.insert(tables::Error {
                 error: anyhow::anyhow!(
                     "Test setup failed. View logs for details and reach out to support@estuary.dev"
                 ),
@@ -235,7 +235,7 @@ pub async fn test_catalog(
     .context("starting test runner")?;
 
     if !job.success() {
-        errors.push(tables::Error {
+        errors.insert(tables::Error {
             error: anyhow::anyhow!("One or more test cases failed. View logs for details."),
             scope: url::Url::parse("flow://publication/test/api/test").unwrap(),
         });
@@ -259,7 +259,7 @@ pub async fn test_catalog(
         .context("cleaning up derivation after test")
         {
             tracing::error!(?error, derivation = %built.catalog_name(), "failed to delete derivation from temp-data-plane");
-            errors.push(tables::Error {
+            errors.insert(tables::Error {
                 error: anyhow::anyhow!(
                     "Test cleanup failed. View logs for details and reach out to support@estuary.dev"
                 ),

--- a/crates/agent/src/publications/handler.rs
+++ b/crates/agent/src/publications/handler.rs
@@ -97,6 +97,7 @@ impl Publisher {
                         draft,
                         ..Default::default()
                     },
+                    tables::Errors::default(),
                     JobStatus::BuildFailed {
                         incompatible_collections: Vec::new(),
                         evolution_id: None,
@@ -178,6 +179,7 @@ impl Publisher {
                     draft,
                     ..Default::default()
                 },
+                tables::Errors::default(),
                 JobStatus::BuildFailed {
                     incompatible_collections: Vec::new(),
                     evolution_id: None,


### PR DESCRIPTION
**Description:**

Updates the publisher to store test errors separately from other types of errors, and to set the `TestFailed` status if any test errors are present. Previously, test failures would result in a `BuildFailed` status, which was unhelpful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1499)
<!-- Reviewable:end -->
