### PR TITLE
agent: generate JSON schema for controller status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4440,14 +4440,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4565,13 +4565,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -4,16 +4,17 @@ use super::{
     ControlPlane, ControllerErrorExt, ControllerState, NextRun,
 };
 use crate::controllers::publication_status::PublicationStatus;
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Status of a capture
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+/// Status of a capture controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct CaptureStatus {
     // TODO: auto discovers are not yet implemented as controllers, but they should be soon.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_auto_discover: Option<DateTime<Utc>>,
+    // #[serde(default, skip_serializing_if = "Option::is_none")]
+    // #[schemars(schema_with = "super::datetime_schema")]
+    // pub next_auto_discover: Option<DateTime<Utc>>,
     #[serde(default)]
     pub publications: PublicationStatus,
     #[serde(default)]

--- a/crates/agent/src/controllers/catalog_test.rs
+++ b/crates/agent/src/controllers/catalog_test.rs
@@ -1,8 +1,9 @@
 use super::{publication_status::Dependencies, ControlPlane, ControllerState, NextRun};
 use crate::controllers::publication_status::PublicationStatus;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct TestStatus {
     pub passing: bool,
     #[serde(default)]

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -6,9 +6,11 @@ use super::{
 use crate::controllers::publication_status::PublicationStatus;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+/// The status of a collection controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct CollectionStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inferred_schema: Option<InferredSchemaStatus>,
@@ -117,10 +119,15 @@ fn handle_deleted_dependencies(
     )
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+/// Status of the inferred schema
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
 pub struct InferredSchemaStatus {
+    /// The time at which the inferred schema was last published. This will only
+    /// be present if the inferred schema was published at least once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "super::datetime_schema")]
     pub schema_last_updated: Option<DateTime<Utc>>,
+    /// The md5 sum of the inferred schema that was last published
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema_md5: Option<String>,
 }

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -10,11 +10,13 @@ use anyhow::Context;
 use itertools::Itertools;
 use models::{ModelDef, OnIncompatibleSchemaChange};
 use proto_flow::materialize::response::validated::constraint::Type as ConstraintType;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use tables::LiveRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+/// Status of a materialization controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct MaterializationStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_capture: Option<SourceCaptureStatus>,
@@ -277,10 +279,19 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+/// Status information about the `sourceCapture`
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct SourceCaptureStatus {
+    /// Whether the materialization bindings are up-to-date with respect to
+    /// the `sourceCapture` bindings. In normal operation, this should always
+    /// be `true`. Otherwise, there will be a controller `error` and the
+    /// publication status will contain details of why the update failed.
     #[serde(default, skip_serializing_if = "is_false")]
     pub up_to_date: bool,
+    /// If `up_to_date` is `false`, then this will contain the set of
+    /// `sourceCapture` collections that need to be added. This is provided
+    /// simply to aid in debugging in case the publication to add the bindings
+    /// fails.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub add_bindings: BTreeSet<models::Collection>,
 }

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
@@ -1,0 +1,509 @@
+---
+source: crates/agent/src/controllers/mod.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "definitions": {
+    "ActivationStatus": {
+      "description": "Status of the activation of the task in the data-plane",
+      "properties": {
+        "last_activated": {
+          "$ref": "#/definitions/Id",
+          "description": "The publication id that was last activated in the data plane. If this is less than the `last_pub_id` of the controlled spec, then an activation is still pending."
+        }
+      },
+      "type": "object"
+    },
+    "AffectedConsumer": {
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/RejectedField"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields",
+        "name"
+      ],
+      "type": "object"
+    },
+    "Collection": {
+      "description": "Collection names are paths of Unicode letters, numbers, '-', '_', or '.'. Each path component is separated by a slash '/', and a name may not begin or end in a '/'.",
+      "examples": [
+        "acmeCo/collection"
+      ],
+      "pattern": "^[\\p{Letter}\\p{Number}\\-_\\.]+(/[\\p{Letter}\\p{Number}\\-_\\.]+)*$",
+      "type": "string"
+    },
+    "Error": {
+      "properties": {
+        "catalog_name": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "scope": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "detail"
+      ],
+      "type": "object"
+    },
+    "Id": {
+      "type": "string"
+    },
+    "IncompatibleCollection": {
+      "properties": {
+        "affectedMaterializations": {
+          "items": {
+            "$ref": "#/definitions/AffectedConsumer"
+          },
+          "type": "array"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "requiresRecreation": {
+          "description": "Reasons why the collection would need to be re-created in order for a publication of the draft spec to succeed.",
+          "items": {
+            "$ref": "#/definitions/ReCreateReason"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "collection"
+      ],
+      "type": "object"
+    },
+    "InferredSchemaStatus": {
+      "description": "Status of the inferred schema",
+      "properties": {
+        "schema_last_updated": {
+          "description": "The time at which the inferred schema was last published. This will only be present if the inferred schema was published at least once.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "schema_md5": {
+          "description": "The md5 sum of the inferred schema that was last published",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "JobStatus": {
+      "description": "JobStatus is the possible outcomes of a handled publication.",
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "queued"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "evolution_id": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Id"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "incompatible_collections": {
+              "items": {
+                "$ref": "#/definitions/IncompatibleCollection"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "buildFailed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "testFailed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "publishFailed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "success"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Returned when there are no draft specs (after pruning unbound collections). There will not be any `draft_errors` in this case, because there's no `catalog_name` to associate with an error. And it may not be desirable to treat this as an error, depending on the scenario.",
+          "properties": {
+            "type": {
+              "enum": [
+                "emptyDraft"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "One or more expected `last_pub_id`s did not match the actual `last_pub_id`, indicating that specs have been changed since the draft was created.",
+          "properties": {
+            "failures": {
+              "items": {
+                "$ref": "#/definitions/LockFailure"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "expectPubIdMismatch"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LockFailure": {
+      "description": "Represents an optimistic lock failure when trying to update live specs.",
+      "properties": {
+        "catalog_name": {
+          "type": "string"
+        },
+        "expect_pub_id": {
+          "$ref": "#/definitions/Id"
+        },
+        "last_pub_id": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Id"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "catalog_name",
+        "expect_pub_id"
+      ],
+      "type": "object"
+    },
+    "PublicationInfo": {
+      "description": "Summary of a publication that was attempted by a controller.",
+      "properties": {
+        "completed": {
+          "description": "Time at which the publication was completed",
+          "format": "date-time",
+          "type": "string"
+        },
+        "created": {
+          "description": "Time at which the publication was initiated",
+          "format": "date-time",
+          "type": "string"
+        },
+        "detail": {
+          "description": "A brief description of the reason for the publication",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errors": {
+          "description": "Errors will be non-empty for publications that were not successful",
+          "items": {
+            "$ref": "#/definitions/Error"
+          },
+          "type": "array"
+        },
+        "id": {
+          "$ref": "#/definitions/Id"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JobStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The final result of the publication"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "PublicationStatus": {
+      "description": "Information on the publications performed by the controller. This does not include any information on user-initiated publications.",
+      "properties": {
+        "history": {
+          "description": "A limited history of publications performed by this controller",
+          "items": {
+            "$ref": "#/definitions/PublicationInfo"
+          },
+          "type": "array"
+        },
+        "max_observed_pub_id": {
+          "$ref": "#/definitions/Id",
+          "description": "The publication id at which the controller has last notified dependent specs. A publication of the controlled spec will cause the controller to notify the controllers of all dependent specs. When it does so, it sets `max_observed_pub_id` to the current `last_pub_id`, so that it can avoid notifying dependent controllers unnecessarily."
+        },
+        "target_pub_id": {
+          "$ref": "#/definitions/Id",
+          "description": "The largest `last_pub_id` among all of this spec's dependencies. For example, for materializations the dependencies are all of the collections of all enabled binding `source`s, as well as the `sourceCapture`. If any of these are published, it will increase the `target_pub_id` and the materialization will be published at `target_pub_id` in turn."
+        }
+      },
+      "required": [
+        "history"
+      ],
+      "type": "object"
+    },
+    "ReCreateReason": {
+      "description": "Reasons why a draft collection spec would need to be published under a new name.",
+      "oneOf": [
+        {
+          "description": "The collection key in the draft differs from that of the live spec.",
+          "enum": [
+            "keyChange"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "One or more collection partition fields in the draft differs from that of the live spec.",
+          "enum": [
+            "partitionChange"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "RejectedField": {
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "field",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "SourceCaptureStatus": {
+      "description": "Status information about the `sourceCapture`",
+      "properties": {
+        "add_bindings": {
+          "description": "If `up_to_date` is `false`, then this will contain the set of `sourceCapture` collections that need to be added. This is provided simply to aid in debugging in case the publication to add the bindings fails.",
+          "items": {
+            "$ref": "#/definitions/Collection"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "up_to_date": {
+          "description": "Whether the materialization bindings are up-to-date with respect to the `sourceCapture` bindings. In normal operation, this should always be `true`. Otherwise, there will be a controller `error` and the publication status will contain details of why the update failed.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Represents the internal state of a controller.",
+  "oneOf": [
+    {
+      "description": "Status of a capture controller",
+      "properties": {
+        "activation": {
+          "$ref": "#/definitions/ActivationStatus",
+          "default": {}
+        },
+        "publications": {
+          "$ref": "#/definitions/PublicationStatus",
+          "default": {
+            "history": []
+          }
+        },
+        "type": {
+          "enum": [
+            "Capture"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "description": "The status of a collection controller",
+      "properties": {
+        "activation": {
+          "$ref": "#/definitions/ActivationStatus",
+          "default": {}
+        },
+        "inferred_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InferredSchemaStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "publications": {
+          "$ref": "#/definitions/PublicationStatus",
+          "default": {
+            "history": []
+          }
+        },
+        "type": {
+          "enum": [
+            "Collection"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "description": "Status of a materialization controller",
+      "properties": {
+        "activation": {
+          "$ref": "#/definitions/ActivationStatus",
+          "default": {}
+        },
+        "publications": {
+          "$ref": "#/definitions/PublicationStatus",
+          "default": {
+            "history": []
+          }
+        },
+        "source_capture": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SourceCaptureStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Materialization"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "passing": {
+          "type": "boolean"
+        },
+        "publications": {
+          "$ref": "#/definitions/PublicationStatus",
+          "default": {
+            "history": []
+          }
+        },
+        "type": {
+          "enum": [
+            "Test"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "passing",
+        "type"
+      ],
+      "type": "object"
+    }
+  ],
+  "title": "Status"
+}

--- a/crates/agent/src/draft.rs
+++ b/crates/agent/src/draft.rs
@@ -5,9 +5,10 @@ use crate::publications::LockFailure;
 use super::Id;
 use agent_sql::{drafts as drafts_sql, CatalogType};
 use anyhow::Context;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
 pub struct Error {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub catalog_name: String,

--- a/crates/agent/src/publications/status.rs
+++ b/crates/agent/src/publications/status.rs
@@ -1,11 +1,12 @@
 use models::Id;
 use proto_flow::materialize::response::validated::constraint::Type as ConstraintType;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tables::BuiltRow;
 
 /// JobStatus is the possible outcomes of a handled publication.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum JobStatus {
     Queued,
@@ -63,7 +64,7 @@ impl JobStatus {
 }
 
 /// Represents an optimistic lock failure when trying to update live specs.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
 pub struct LockFailure {
     pub catalog_name: String,
     pub expect_pub_id: models::Id,
@@ -71,7 +72,7 @@ pub struct LockFailure {
 }
 
 /// Reasons why a draft collection spec would need to be published under a new name.
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ReCreateReason {
     /// The collection key in the draft differs from that of the live spec.
@@ -80,7 +81,7 @@ pub enum ReCreateReason {
     PartitionChange,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IncompatibleCollection {
     pub collection: String,
@@ -91,13 +92,13 @@ pub struct IncompatibleCollection {
     pub affected_materializations: Vec<AffectedConsumer>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 pub struct AffectedConsumer {
     pub name: String,
     pub fields: Vec<RejectedField>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 pub struct RejectedField {
     pub field: String,
     pub reason: String,


### PR DESCRIPTION
**Description:**

Adds an automatically generated json schema for the agent controller status objects. The goal is just to make it easier to consume status information.

Also updates the default publication history length from 3 to 5, which has just felt like a better number to ease debugging schema evolution issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1500)
<!-- Reviewable:end -->
