### PR TITLE
agent: add logging and errors around null built_specs

### DIFF
--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -274,7 +274,10 @@ impl ControlPlane for PGControlPlane {
                 continue;
             };
             let scope = tables::synthetic_scope(catalog_type, &row.catalog_name);
-            let built_spec_json = row.built_spec.as_ref().unwrap().deref();
+            let built_spec_json = row.built_spec.as_ref().ok_or_else(|| {
+                tracing::warn!(catalog_name = %row.catalog_name, id = %row.id, "got row with spec but not built_spec");
+                anyhow::anyhow!("missing built_spec for {:?}, but spec is non-null", row.catalog_name)
+            })?.deref();
 
             live.add_spec(
                 catalog_type,

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -693,7 +693,7 @@ pub async fn resolve_live_specs(
             let catalog_type: models::CatalogType = spec_row.spec_type.unwrap().into();
             let scope = tables::synthetic_scope(catalog_type, &spec_row.catalog_name);
             live.add_spec(
-                spec_row.spec_type.unwrap().into(),
+                catalog_type,
                 &spec_row.catalog_name,
                 scope,
                 spec_row.last_pub_id.into(),
@@ -701,7 +701,9 @@ pub async fn resolve_live_specs(
                 &spec_row
                     .built_spec
                     .as_ref()
-                    .expect("must have built spec if spec exists"),
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("row has non-null spec, but null built_spec: catalog_name: {:?}, live_spec_id: {}", &spec_row.catalog_name, spec_row.id)
+                    })?,
             )
             .with_context(|| format!("adding live spec for {:?}", spec_row.catalog_name))?;
         }

--- a/supabase/migrations/51_backfill_controllers.sql
+++ b/supabase/migrations/51_backfill_controllers.sql
@@ -8,7 +8,11 @@ with insert_controller_jobs(live_spec_id) as (
 	insert into controller_jobs (live_spec_id)
 	select id from live_specs
 	where id not in (select live_spec_id from controller_jobs)
-	limit 1000
+	and (
+		(built_spec is not null and spec is not null)
+		or (built_spec is null and spec is null)
+	)
+	limit 100
 	-- on conflict can't hurt anything and I just can't be bothered to go through
 	-- the read-committed docs right now to prove to myself that it isn't necessary.
 	on conflict(live_spec_id) do nothing


### PR DESCRIPTION
Adds some logging and better errors when failures occur due to `built_spec` being null

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1503)
<!-- Reviewable:end -->
