### PR TITLE
Phil/no key changes

### DIFF
--- a/crates/agent-sql/src/live_specs.rs
+++ b/crates/agent-sql/src/live_specs.rs
@@ -31,7 +31,7 @@ pub struct LiveSpec {
     pub catalog_name: String,
     pub spec_type: Option<CatalogType>,
     pub spec: Option<TextJson<Box<RawValue>>>,
-    pub built_spec: Option<Json<Box<RawValue>>>,
+    pub built_spec: Option<TextJson<Box<RawValue>>>,
     pub inferred_schema_md5: Option<String>,
     // User's capability to the specification `catalog_name`.
     pub user_capability: Option<Capability>,
@@ -56,7 +56,7 @@ pub async fn fetch_live_specs(
             names as "catalog_name!: String",
             ls.spec_type as "spec_type?: CatalogType",
             ls.spec as "spec: TextJson<Box<RawValue>>",
-            ls.built_spec as "built_spec: Json<Box<RawValue>>",
+            ls.built_spec as "built_spec: TextJson<Box<RawValue>>",
             ls.inferred_schema_md5,
             (
                 select max(capability) from internal.user_roles($1) r
@@ -135,7 +135,7 @@ pub async fn fetch_expanded_live_specs(
             ls.catalog_name,
             ls.spec_type as "spec_type?: CatalogType",
             ls.spec as "spec: TextJson<Box<RawValue>>",
-            ls.built_spec as "built_spec: Json<Box<RawValue>>",
+            ls.built_spec as "built_spec: TextJson<Box<RawValue>>",
             ls.inferred_schema_md5,
             (
                 select max(capability) from internal.user_roles($1) r

--- a/crates/models/src/references.rs
+++ b/crates/models/src/references.rs
@@ -222,7 +222,7 @@ impl RelativeUrl {
 
 /// Ordered JSON-Pointers which define how a composite key may be extracted from
 /// a collection document.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq)]
 #[schemars(example = "CompositeKey::example")]
 pub struct CompositeKey(Vec<JsonPointer>);
 


### PR DESCRIPTION
**Description:**

Re-introduces the prior behavior of rejecting any changes to the key or
logical partitioning of a collection spec. We'd eventually like to allow
these changes, but it seems our first go was a bit premature, since we
don't yet have another way to respect `evolveIncompatibleCollections:
false` if the key does change.

I tried to keep this change relatively localized and easy to rip out.

**Workflow steps:**

Publish an existing collection with a different key or logical partitioning.
It should now fail and return `incompatible_collections`.

**Documentation links affected:**

n/a

**Notes for reviewers:**

Also includes a minor cleanup in agent-sql.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1506)
<!-- Reviewable:end -->
