### PR TITLE
Phil/agent fixes

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -4,6 +4,7 @@ use super::{
     ControlPlane, ControllerErrorExt, ControllerState, NextRun,
 };
 use crate::controllers::publication_status::PublicationStatus;
+use anyhow::Context;
 use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -67,7 +68,7 @@ impl CaptureStatus {
                 .publications
                 .finish_pending_publication(state, control_plane)
                 .await
-                .expect("failed to execute publish")
+                .context("failed to execute publish")?
                 .error_for_status()
                 .with_maybe_retry(backoff_publication_failure(state.failures))?;
         } else {
@@ -80,7 +81,7 @@ impl CaptureStatus {
             self.publications
                 .notify_dependents(state, control_plane)
                 .await
-                .expect("failed to notify dependents");
+                .context("failed to notify dependents")?;
         }
 
         Ok(None)

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -4,6 +4,7 @@ use super::{
     ControlPlane, ControllerErrorExt, ControllerState, NextRun,
 };
 use crate::controllers::publication_status::PublicationStatus;
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use schemars::JsonSchema;
@@ -150,7 +151,7 @@ impl InferredSchemaStatus {
         let maybe_inferred_schema = control_plane
             .get_inferred_schema(collection_name.clone())
             .await
-            .expect("failed to fetch inferred schema");
+            .context("fetching inferred schema")?;
 
         if let Some(inferred_schema) = maybe_inferred_schema {
             let tables::InferredSchema {
@@ -186,8 +187,7 @@ impl InferredSchemaStatus {
                 // Don't retry publications, since they're unlikely to succeed.
                 let pub_result = publication_status
                     .finish_pending_publication(state, control_plane)
-                    .await
-                    .expect("failed to execute publication")
+                    .await?
                     .error_for_status()?;
 
                 self.schema_md5 = Some(md5);

--- a/crates/agent/src/controllers/handler.rs
+++ b/crates/agent/src/controllers/handler.rs
@@ -107,11 +107,8 @@ impl Handler for ControllerHandler {
     async fn handle(
         &mut self,
         pg_pool: &sqlx::PgPool,
-        allow_background: bool,
+        _allow_background: bool,
     ) -> anyhow::Result<HandleResult> {
-        if !allow_background {
-            return Ok(HandleResult::NoJobs);
-        }
         let prev_state = self.try_run_next(pg_pool).await?;
         let result = if prev_state.is_some() {
             HandleResult::HadJob

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -85,7 +85,7 @@ impl MaterializationStatus {
                 .publications
                 .finish_pending_publication(state, control_plane)
                 .await
-                .expect("failed to execute publication");
+                .context("failed to execute publication")?;
 
             if result.status.has_incompatible_collections() {
                 let PublicationResult {
@@ -106,7 +106,7 @@ impl MaterializationStatus {
                 let new_result = control_plane
                     .publish(publication_id, detail, state.logs_token, draft)
                     .await
-                    .expect("failed to execute publication");
+                    .context("failed to execute publication")?;
                 self.publications
                     .record_result(PublicationInfo::observed(&new_result));
                 if !new_result.status.is_success() {
@@ -327,7 +327,7 @@ impl SourceCaptureStatus {
         let connector_spec = control_plane
             .get_connector_spec(config.image.clone())
             .await
-            .expect("failed to fetch connector spec");
+            .context("failed to fetch connector spec")?;
         let collection_name_pointer = crate::resource_configs::pointer_for_schema(
             connector_spec.resource_config_schema.get(),
         )?;

--- a/crates/agent/src/integration_tests/mod.rs
+++ b/crates/agent/src/integration_tests/mod.rs
@@ -5,6 +5,7 @@
 mod dependencies_and_activations;
 pub mod harness;
 mod locking_retries;
+mod null_bytes;
 mod quotas;
 mod schema_evolution;
 mod source_captures;

--- a/crates/agent/src/integration_tests/null_bytes.rs
+++ b/crates/agent/src/integration_tests/null_bytes.rs
@@ -1,0 +1,119 @@
+use super::harness::{draft_catalog, md5_hash, TestHarness};
+use crate::{controllers::ControllerState, publications::JobStatus, ControlPlane};
+use agent_sql::Capability;
+use models::{CatalogType, Id};
+use tables::InferredSchema;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_specs_with_null_bytes() {
+    let mut harness = TestHarness::init("specs_with_null_bytes").await;
+
+    let user_id = harness.setup_tenant("possums").await;
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "possums/bugs": {
+                "writeSchema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    },
+                    "required": ["id"]
+                },
+                "readSchema": {
+                    "allOf": [
+                        {"$ref": "flow://write-schema"},
+                        {"$ref": "flow://inferred-schema"}
+                    ]
+                },
+                "key": ["/id"]
+            }
+        },
+        "captures": {
+            "possums/capture": {
+                "endpoint": {
+                    "connector": {
+                        "image": "source/test:test",
+                        "config": {}
+                    }
+                },
+                "bindings": [
+                    {
+                        "resource": { "a": "thing" },
+                        "target": "possums/bugs"
+                    }
+                ]
+            }
+        },
+    }));
+    let first_pub_result = harness
+        .user_publication(user_id, format!("initial publication"), draft)
+        .await;
+    assert!(
+        first_pub_result.status.is_success(),
+        "expected success, got {:?}, errors: {:?}",
+        first_pub_result.status,
+        first_pub_result.errors
+    );
+
+    let naughty_draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "possums/bugs": {
+                "writeSchema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "naughty\u{0000}Property": { "type": "string" },
+                    },
+                    "required": ["id"]
+                },
+                "readSchema": {
+                    "allOf": [
+                        {"$ref": "flow://write-schema"},
+                        {"$ref": "flow://inferred-schema"}
+                    ]
+                },
+                "key": ["/id"]
+            }
+        },
+    }));
+
+    let result = harness
+        .user_publication(user_id, format!("publish spec with nulls"), naughty_draft)
+        .await;
+    assert_eq!(JobStatus::PublishFailed, result.status);
+
+    insta::assert_debug_snapshot!(result.errors, @r###"
+    [
+        (
+            "",
+            "committing publication: a string in the spec contains a disallowed unicode null escape (\\x00 or \\u0000)",
+        ),
+    ]
+    "###);
+
+    let schema: models::Schema = serde_json::from_value(serde_json::json!({
+        "type": "object",
+        "properties": {
+            "a naughty \u{0000} property": { "type": "integer" }
+        },
+    }))
+    .unwrap();
+    let md5 = md5_hash(&schema);
+    harness
+        .upsert_inferred_schema(InferredSchema {
+            collection_name: models::Collection::new("possums/bugs"),
+            schema,
+            md5,
+        })
+        .await;
+
+    harness.run_pending_controllers(None).await;
+    let state = harness.get_controller_state("possums/bugs").await;
+
+    insta::assert_debug_snapshot!(state.error, @r###"
+    Some(
+        "a string in the spec contains a disallowed unicode null escape (\\x00 or \\u0000)",
+    )
+    "###);
+}


### PR DESCRIPTION
**Description:**

Rolls up a few different fixes for agent:

- Prevent null bytes from getting into live/built specs
- Handle errors in publications and controllers more gracefully
- Process controller jobs sooner

Individual commit messages have more details.

**Notes for reviewers:**

The default backoff for controller errors is pretty steep, and also uses a very large random jitter. This is to prevent thundering herd scenarios in case there's a widespread problem that causes a large proportion of controller jobs to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1510)
<!-- Reviewable:end -->
