### PR TITLE
Phil/inferred schemas now

### DIFF
--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -649,26 +649,6 @@ impl TestHarness {
         draft_id
     }
 
-    pub async fn fast_forward_inferred_schema_update(&mut self, collection_name: &str) {
-        sqlx::query!(
-            r#"update controller_jobs
-            set status = jsonb_set(
-                status::jsonb,
-                array['inferred_schema', 'schema_last_updated'],
-                -- set to at least 5 minutes in the past
-                to_jsonb(now() - '6m'::interval),
-                -- do not create if missing
-                false
-            )::json
-            where live_spec_id = (select id from live_specs where catalog_name = $1)
-            returning 1 as "must_exist: bool";"#,
-            collection_name
-        )
-        .fetch_one(&self.pool)
-        .await
-        .expect("fast forward inferred schema update failed");
-    }
-
     pub async fn upsert_inferred_schema(&mut self, schema: tables::InferredSchema) {
         let tables::InferredSchema {
             collection_name,

--- a/crates/agent/src/integration_tests/schema_evolution.rs
+++ b/crates/agent/src/integration_tests/schema_evolution.rs
@@ -187,9 +187,6 @@ async fn test_schema_evolution() {
     harness
         .upsert_inferred_schema(mock_inferred_schema("goats/pasture", 2))
         .await;
-    harness
-        .fast_forward_inferred_schema_update("goats/pasture")
-        .await;
     harness.run_pending_controller("goats/pasture").await;
 
     // Simulate an unsatisfiable constraint on the next publications of the materializations
@@ -247,9 +244,6 @@ async fn test_schema_evolution() {
     harness
         .upsert_inferred_schema(mock_inferred_schema("goats/totes", 1))
         .await;
-    harness
-        .fast_forward_inferred_schema_update("goats/totes")
-        .await;
     harness.run_pending_controller("goats/totes").await;
     harness.run_pending_controllers(None).await;
     harness.control_plane().assert_activations(
@@ -296,9 +290,6 @@ async fn test_schema_evolution() {
     );
     harness
         .upsert_inferred_schema(mock_inferred_schema("goats/totes", 2))
-        .await;
-    harness
-        .fast_forward_inferred_schema_update("goats/totes")
         .await;
     harness.run_pending_controller("goats/totes").await;
     harness.run_pending_controllers(None).await;

--- a/supabase/migrations/55_inferred_schema_triggers.sql
+++ b/supabase/migrations/55_inferred_schema_triggers.sql
@@ -1,0 +1,37 @@
+-- Introduces a trigger that runs collection controllers in response to an inferred schema
+-- update, so that inferred schemas are published promptly in response.
+begin;
+
+create or replace function internal.on_inferred_schema_update()
+returns trigger as $$
+begin
+
+-- The least function is necessary in order to avoid delaying a controller job in scenarios
+-- where there is a backlog of controller runs that are due.
+update live_specs set controller_next_run = least(controller_next_run, now())
+where catalog_name = new.collection_name and spec_type = 'collection';
+
+return null;
+end;
+$$ language plpgsql security definer;
+
+comment on function internal.on_inferred_schema_update is
+    'Schedules a run of the controller in response to an inferred_schemas change.';
+
+-- We need two separate triggers because we want to reference the
+-- `old` row so we can avoid triggering the controller in response to
+-- no-op updates, which happen frequently.
+create or replace trigger inferred_schema_controller_update
+after update on inferred_schemas
+for each row
+when (old.md5 is distinct from new.md5)
+execute function internal.on_inferred_schema_update();
+
+create or replace trigger inferred_schema_controller_insert
+after insert on inferred_schemas
+for each row
+execute function internal.on_inferred_schema_update();
+
+-- There's no `on delete` trigger because we only delete inferred_schemas by cascade from the
+-- live_specs deletion.
+commit;


### PR DESCRIPTION
**Description:**

Introduces _much_ faster updates to inferred schemas by adding a database trigger that schedules a controller run in response to each insert/update on the `inferred_schemas` table.

This replaces the periodic checks as a mechanism for updating inferred schemas. I did leave a very infrequent periodic check in place, though, as a fallback in case the triggers get bypassed or disabled somehow. Note that removing the frequent periodic check is not required for correctness, and serves mainly to reduce the load on our agents and database. Thus the main functionality should work just fine with the current agent version after applying the migration, and deploying the agent itself would just be to reduce the frequency of (now unnecessary) controller runs.

The trigger fires for each row, because the postgres materialization will execute a prepared statement for each insert/update, and thus there's no benefit to using a statement-level trigger.

One risk to call out is that the `stats_view` materialization might contend with publications over updates to `live_specs` rows. This doesn't seem likely because the materialization should use pretty short-lived transactions when performing the inserts/updates. If that does turn out to be an issue, then it might be possible to work around it by introducing a `controller_triggers` table, and staging the updates there and having a cron job that updates `live_specs.controller_next_run`.

**Testing:**

I've been testing this out locally using a mongodb capture with 200 collections, all using schema inference, and a postgres materialization. Then running a few variations on this script in `mongosh` to repeatedly insert documents with new properties into each of the collections:

```
for (let r = 2; true; r++) {
  let propName = "p_" + r; 
  for (let i = 0; i < 200; i++) {
    let name = "c_" + i;
    let d = {"cname": name};
    d[propName] = true;
    db.getCollection(name).insertOne(d);
    printjson(d);
    sleep(2000);
  }
}
```

As expected, the materialization will stop essentially all progress while that script is running, because it continuously hits schema validation errors. Once the script is stopped and all pending controllers have run, the materialization starts working again.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1514)
<!-- Reviewable:end -->
