### PR TITLE
agent: limit frequency of controller publications

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -1,9 +1,7 @@
 use super::{
-    backoff_data_plane_activate,
-    publication_status::{ActivationStatus, PendingPublication},
-    ControlPlane, ControllerErrorExt, ControllerState, NextRun,
+    backoff_data_plane_activate, ActivationStatus, ControlPlane, ControllerErrorExt,
+    ControllerState, NextRun, PendingPublication, PublicationStatus,
 };
-use crate::controllers::publication_status::PublicationStatus;
 use anyhow::Context;
 use itertools::Itertools;
 use schemars::JsonSchema;
@@ -83,7 +81,7 @@ impl CaptureStatus {
                 .context("failed to notify dependents")?;
         }
 
-        Ok(None)
+        Ok(dependencies.next_run)
     }
 }
 

--- a/crates/agent/src/controllers/catalog_test.rs
+++ b/crates/agent/src/controllers/catalog_test.rs
@@ -39,13 +39,13 @@ impl TestStatus {
             // return a terminal error if the publication failed
             result.error_for_status().do_not_retry()?;
             // TODO(phil): This would be a great place to trigger an alert if the publication failed
-        } else {
+        } else if dependencies.next_run.is_none() {
             // We're up-to-date with our dependencies, which means the test has been published successfully
             self.passing = true;
         }
 
         // Don't re-try when tests fail, because fixing them will likely require a change to either
         // the test itself or one of its dependencies.
-        Ok(None)
+        Ok(dependencies.next_run)
     }
 }

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -40,7 +40,7 @@ impl CollectionStatus {
                 format!("in response to publication of one or more depencencies"),
             );
             if !dependencies.deleted.is_empty() {
-                let add_detail = handle_deleted_dependencies(draft, state, dependencies);
+                let add_detail = handle_deleted_dependencies(draft, state, &dependencies);
                 pending_pub.update_pending_draft(add_detail);
             }
         }
@@ -85,7 +85,10 @@ impl CollectionStatus {
                 .await?;
         }
 
-        Ok(inferred_schema_next_run)
+        Ok(super::reduce_next_run(&[
+            inferred_schema_next_run,
+            dependencies.next_run,
+        ]))
     }
 }
 
@@ -94,7 +97,7 @@ impl CollectionStatus {
 fn handle_deleted_dependencies(
     draft: &mut tables::DraftCatalog,
     state: &ControllerState,
-    dependencies: Dependencies,
+    dependencies: &Dependencies,
 ) -> String {
     let drafted = draft
         .collections

--- a/crates/agent/src/controllers/handler.rs
+++ b/crates/agent/src/controllers/handler.rs
@@ -1,6 +1,5 @@
 use agent_sql::controllers::{dequeue, update};
 use anyhow::Context;
-use chrono::{DateTime, Utc};
 
 use crate::{
     controlplane::{ControlPlane, PGControlPlane},

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__materialization-status-round-trip.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__materialization-status-round-trip.snap
@@ -16,6 +16,8 @@ StatusSnapshot {
                 },
             ),
             publications: PublicationStatus {
+                last_publication_time: None,
+                min_publication_interval: 300s,
                 target_pub_id: 0102030405060708,
                 max_observed_pub_id: 0102030405060708,
                 history: [
@@ -69,7 +71,7 @@ StatusSnapshot {
             },
         },
     ),
-    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"target_pub_id\": \"0102030405060708\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\",\n          \"incompatible_collections\": [\n            {\n              \"collection\": \"snails/water\",\n              \"affected_materializations\": [\n                {\n                  \"name\": \"snails/materialize\",\n                  \"fields\": [\n                    {\n                      \"field\": \"a_field\",\n                      \"reason\": \"do not like\"\n                    }\n                  ]\n                }\n              ]\n            }\n          ]\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\"\n  }\n}",
+    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"min_publication_interval\": \"5m\",\n    \"target_pub_id\": \"0102030405060708\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\",\n          \"incompatible_collections\": [\n            {\n              \"collection\": \"snails/water\",\n              \"affected_materializations\": [\n                {\n                  \"name\": \"snails/materialize\",\n                  \"fields\": [\n                    {\n                      \"field\": \"a_field\",\n                      \"reason\": \"do not like\"\n                    }\n                  ]\n                }\n              ]\n            }\n          ]\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\"\n  }\n}",
     parsed: Materialization(
         MaterializationStatus {
             source_capture: Some(
@@ -83,6 +85,8 @@ StatusSnapshot {
                 },
             ),
             publications: PublicationStatus {
+                last_publication_time: None,
+                min_publication_interval: 300s,
                 target_pub_id: 0102030405060708,
                 max_observed_pub_id: 0102030405060708,
                 history: [

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
@@ -316,9 +316,23 @@ expression: schema
           },
           "type": "array"
         },
+        "last_publication_time": {
+          "description": "Time of the last controller-initiated publication",
+          "format": "date-time",
+          "type": "string"
+        },
         "max_observed_pub_id": {
           "$ref": "#/definitions/Id",
           "description": "The publication id at which the controller has last notified dependent specs. A publication of the controlled spec will cause the controller to notify the controllers of all dependent specs. When it does so, it sets `max_observed_pub_id` to the current `last_pub_id`, so that it can avoid notifying dependent controllers unnecessarily."
+        },
+        "min_publication_interval": {
+          "default": "30m",
+          "description": "The minimim time to wait between controller-initiated publications.",
+          "pattern": "^\\d+(s|m|h)$",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_pub_id": {
           "$ref": "#/definitions/Id",
@@ -395,7 +409,8 @@ expression: schema
         "publications": {
           "$ref": "#/definitions/PublicationStatus",
           "default": {
-            "history": []
+            "history": [],
+            "min_publication_interval": "30m"
           }
         },
         "type": {
@@ -430,7 +445,8 @@ expression: schema
         "publications": {
           "$ref": "#/definitions/PublicationStatus",
           "default": {
-            "history": []
+            "history": [],
+            "min_publication_interval": "30m"
           }
         },
         "type": {
@@ -455,7 +471,8 @@ expression: schema
         "publications": {
           "$ref": "#/definitions/PublicationStatus",
           "default": {
-            "history": []
+            "history": [],
+            "min_publication_interval": "30m"
           }
         },
         "source_capture": {
@@ -488,7 +505,8 @@ expression: schema
         "publications": {
           "$ref": "#/definitions/PublicationStatus",
           "default": {
-            "history": []
+            "history": [],
+            "min_publication_interval": "30m"
           }
         },
         "type": {

--- a/crates/agent/src/integration_tests/null_bytes.rs
+++ b/crates/agent/src/integration_tests/null_bytes.rs
@@ -1,7 +1,5 @@
 use super::harness::{draft_catalog, md5_hash, TestHarness};
-use crate::{controllers::ControllerState, publications::JobStatus, ControlPlane};
-use agent_sql::Capability;
-use models::{CatalogType, Id};
+use crate::publications::JobStatus;
 use tables::InferredSchema;
 
 #[tokio::test]

--- a/crates/agent/src/integration_tests/schema_evolution.rs
+++ b/crates/agent/src/integration_tests/schema_evolution.rs
@@ -215,6 +215,18 @@ async fn test_schema_evolution() {
         },
     );
 
+    harness
+        .move_back_last_pub_time(vec![
+            ("goats/materializeBackfill", CatalogType::Materialization),
+            (
+                "goats/materializeDisableBinding",
+                CatalogType::Materialization,
+            ),
+            ("goats/materializeMixed", CatalogType::Materialization),
+            ("goats/totes", CatalogType::Collection),
+        ])
+        .await;
+
     harness.run_pending_controllers(None).await;
     // All consumers should have been published
     harness.control_plane().assert_activations(
@@ -249,6 +261,17 @@ async fn test_schema_evolution() {
         .await;
     harness
         .fast_forward_inferred_schema_update("goats/totes")
+        .await;
+    harness
+        .move_back_last_pub_time(vec![
+            ("goats/materializeBackfill", CatalogType::Materialization),
+            (
+                "goats/materializeDisableBinding",
+                CatalogType::Materialization,
+            ),
+            ("goats/materializeMixed", CatalogType::Materialization),
+            ("goats/totes", CatalogType::Collection),
+        ])
         .await;
     harness.run_pending_controller("goats/totes").await;
     harness.run_pending_controllers(None).await;
@@ -299,6 +322,18 @@ async fn test_schema_evolution() {
         .await;
     harness
         .fast_forward_inferred_schema_update("goats/totes")
+        .await;
+
+    harness
+        .move_back_last_pub_time(vec![
+            ("goats/materializeBackfill", CatalogType::Materialization),
+            (
+                "goats/materializeDisableBinding",
+                CatalogType::Materialization,
+            ),
+            ("goats/materializeMixed", CatalogType::Materialization),
+            ("goats/totes", CatalogType::Collection),
+        ])
         .await;
     harness.run_pending_controller("goats/totes").await;
     harness.run_pending_controllers(None).await;

--- a/crates/agent/src/integration_tests/user_publications.rs
+++ b/crates/agent/src/integration_tests/user_publications.rs
@@ -244,6 +244,9 @@ async fn test_user_publications() {
         &mut harness,
     )
     .await;
+    harness
+        .move_back_last_pub_time(vec![("dogs/materialize", CatalogType::Materialization)])
+        .await;
 
     harness.run_pending_controllers(None).await;
     harness.control_plane().assert_activations(

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -2,7 +2,6 @@ use super::{LockFailure, UncommittedBuild};
 use agent_sql::publications::{LiveRevision, LiveSpecUpdate};
 use agent_sql::Capability;
 use anyhow::Context;
-use itertools::Itertools;
 use models::{split_image_tag, Id, ModelDef};
 use serde_json::value::RawValue;
 use sqlx::types::Uuid;
@@ -965,7 +964,6 @@ pub async fn add_built_specs_to_draft_specs(
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_null_bytes_in_json() {


### PR DESCRIPTION
**Description:**

Fixes #1520 

We've observed a scenario where there's a very large capture with hundreds of collections all using schema inference. Among all of the collections, publications due to inferred schema updates are quite frequent. Because each collection publication results in a subsequent publication of the capture and materialization, it results in extremely frequent publications of those tasks, which has two important consequences:

- It can prevent user-initiated publications from completing successfully due to `PublicationSuperceded` or `ExpectPubIdNotMatched` errors.
- It can prevent the materialization from making progress, because every time it's activated it must re-start any in-progress reads of source journals. There may also be a data-plane bug that's affecting this, but the frequent publications are certainly a factor.

So we've decided to slow down the rate of controller-initiated publications to try to alleviate those symptoms. This introduces two new fields to the publication status: `last_publication_time` and `min_publication_interval`. Controllers will now wait at least `min_publication_interval` since the `last_publication_time` before publishing a spec in response to publication of dependencies.

The default value of `min_publication_interval` is 30 minutes, which is somewhat arbitrary, but aligns with the default `update_delay` of materializations. Since this value is part of the controller status, we can update it on a per-task basis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1532)
<!-- Reviewable:end -->
