### PR TITLE
Phil/schema bundling

### DIFF
--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -218,10 +218,7 @@ fn update_inferred_schema(
         let Some(read_schema) = model.read_schema.as_ref() else {
             anyhow::bail!("model is missing read schema");
         };
-        let Some(write_schema) = model.write_schema.as_ref() else {
-            anyhow::bail!("model is missing write schema");
-        };
-        models::Schema::extend_read_bundle(read_schema, write_schema, Some(inferred_schema))
+        models::Schema::extend_read_bundle(read_schema, None, Some(inferred_schema))
     };
 
     model.read_schema = Some(new_read_schema);

--- a/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__merge_collection.snap
+++ b/crates/agent/src/discovers/snapshots/agent__discovers__specs__tests__merge_collection.snap
@@ -48,14 +48,14 @@ expression: "serde_json::to_string_pretty(&out).unwrap()"
   },
   "case/5": {
     "writeSchema": {"const":"write!","x-infer-schema":true},
-    "readSchema": {"$defs":{"flow://inferred-schema":{"$id":"flow://inferred-schema","properties":{"_meta":{"properties":{"inferredSchemaIsNotAvailable":{"const":true,"description":"An inferred schema is not yet available because no documents have been written to this collection.\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready."}},"required":["inferredSchemaIsNotAvailable"]}},"required":["_meta"]},"flow://write-schema":{"$id":"flow://write-schema","const":"write!","x-infer-schema":true}},"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},
+    "readSchema": {"$defs":{"flow://inferred-schema":{"$id":"flow://inferred-schema","properties":{"_meta":{"properties":{"inferredSchemaIsNotAvailable":{"const":true,"description":"An inferred schema is not yet available because no documents have been written to this collection.\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready."}},"required":["inferredSchemaIsNotAvailable"]}},"required":["_meta"]}},"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},
     "key": [
       "/key"
     ]
   },
   "case/6": {
     "writeSchema": {"const":"write!","x-infer-schema":true},
-    "readSchema": {"$defs":{"flow://inferred-schema":{"$id":"flow://inferred-schema","properties":{"_meta":{"properties":{"inferredSchemaIsNotAvailable":{"const":true,"description":"An inferred schema is not yet available because no documents have been written to this collection.\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready."}},"required":["inferredSchemaIsNotAvailable"]}},"required":["_meta"]},"flow://write-schema":{"$id":"flow://write-schema","const":"write!","x-infer-schema":true}},"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},
+    "readSchema": {"$defs":{"flow://inferred-schema":{"$id":"flow://inferred-schema","properties":{"_meta":{"properties":{"inferredSchemaIsNotAvailable":{"const":true,"description":"An inferred schema is not yet available because no documents have been written to this collection.\nThis place-holder causes document validations to fail at read time, so that the task can be updated once an inferred schema is ready."}},"required":["inferredSchemaIsNotAvailable"]}},"required":["_meta"]}},"allOf":[{"$ref":"flow://write-schema"},{"$ref":"flow://inferred-schema"}]},
     "key": [
       "/key"
     ]

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -272,7 +272,7 @@ pub fn merge_collections(
             // This is either a new collection, or else discovery has just started asking for
             // the inferred schema. In either case, we must initialize the read schema with the
             // inferred schema placeholder.
-            let read_schema = models::Schema::default_inferred_read_schema(&document_schema);
+            let read_schema = models::Schema::default_inferred_read_schema();
             collection.read_schema = Some(read_schema);
             collection.write_schema = Some(document_schema);
             collection.schema = None;

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -144,7 +144,7 @@ pub fn extend_read_bundle(input: JsValue) -> Result<JsValue, JsValue> {
     } = serde_json::from_value(input)
         .map_err(|err| JsValue::from_str(&format!("invalid input: {:?}", err)))?;
 
-    let output = models::Schema::extend_read_bundle(&read, &write, inferred.as_ref());
+    let output = models::Schema::extend_read_bundle(&read, Some(&write), inferred.as_ref());
 
     serde_wasm_bindgen::to_value(&output).map_err(|err| JsValue::from_str(&format!("{err:?}")))
 }

--- a/crates/flow-web/tests/web.rs
+++ b/crates/flow-web/tests/web.rs
@@ -200,6 +200,37 @@ fn test_end_to_end_extend_read_bundle() {
           "maxProperties": 10,
         })
     );
+
+    let input: JsValue = to_js_value(&json!({
+      "read": {
+        "allOf": [
+            {"$ref": "flow://inferred-schema"},
+            {"$ref": "flow://write-schema"},
+        ]
+      },
+      "inferred": {
+        "$id": "flow://inferred-schema",
+        "x-canary-annotation": true
+      }
+    }));
+
+    let output = flow_web::extend_read_bundle(input).expect("extend first bundle");
+    let output: serde_json::Value = from_js_value(output).expect("failed to deserialize output");
+    assert_eq!(
+        output,
+        json!({
+            "$defs": {
+                "flow://inferred-schema": {
+                    "$id": "flow://inferred-schema",
+                    "x-canary-annotation": true
+                }
+            },
+            "allOf": [
+                {"$ref": "flow://inferred-schema"},
+                {"$ref": "flow://write-schema"},
+            ]
+        })
+    );
 }
 
 fn to_js_value(val: &serde_json::Value) -> JsValue {

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -33,6 +33,10 @@ impl std::ops::DerefMut for Schema {
     }
 }
 
+type Skim = BTreeMap<String, RawValue>;
+const KEYWORD_DEF: &str = "$defs";
+const KEYWORD_ID: &str = "$id";
+
 impl Schema {
     pub fn new(v: RawValue) -> Self {
         Self(v)
@@ -96,11 +100,7 @@ impl Schema {
         write_bundle: Option<&Self>,
         inferred_bundle: Option<&Self>,
     ) -> Self {
-        const KEYWORD_DEF: &str = "$defs";
-        const KEYWORD_ID: &str = "$id";
-
         use serde_json::{value::to_raw_value, Value};
-        type Skim = BTreeMap<String, RawValue>;
 
         let mut read_schema: Skim = serde_json::from_str(read_bundle.get()).unwrap();
         let mut read_defs: Skim = read_schema
@@ -179,6 +179,32 @@ impl Schema {
             serde_json::value::to_raw_value(&read_defs).unwrap().into(),
         );
         Self(to_raw_value(&read_schema).unwrap().into())
+    }
+
+    /// Removes the bundled write schema from the `$defs` of `self`, returning
+    /// a new schema with the value removed, and a boolean indicating whether the write
+    /// schema def was actually present. We used to bundle the write schema as part of the
+    /// read schema, just like the inferred schema. We're no longer doing that because it's
+    /// confusing to users, so this function removes the bundled write schema. This function
+    /// should only be needed for long enough to update all the inferred schemas, and can then
+    /// be safely removed.
+    pub fn remove_bundled_write_schema(&self) -> (bool, Self) {
+        use serde_json::value::to_raw_value;
+
+        let mut read_schema: Skim = serde_json::from_str(self.0.get()).unwrap();
+        let mut read_defs: Skim = read_schema
+            .get(KEYWORD_DEF)
+            .map(|d| serde_json::from_str(d.get()).unwrap())
+            .unwrap_or_default();
+        let had_write_schema = read_defs.remove(Schema::REF_WRITE_SCHEMA_URL).is_some();
+        read_schema.insert(
+            KEYWORD_DEF.to_string(),
+            to_raw_value(&read_defs).unwrap().into(),
+        );
+        (
+            had_write_schema,
+            Self(to_raw_value(&read_schema).unwrap().into()),
+        )
     }
 }
 
@@ -361,5 +387,65 @@ mod test {
           "maxProperties": 10
         }
         "###);
+    }
+
+    #[test]
+    fn test_removing_bundled_write_schema() {
+        let read_schema = Schema::new(RawValue::from_value(&json!({
+            "$defs": {
+                "existing://def": {"type": "array"},
+            },
+            "maxProperties": 10,
+            "allOf": [
+                {"$ref": "flow://inferred-schema"},
+                {"$ref": "flow://write-schema"},
+            ]
+        })));
+        let write_schema = Schema::new(RawValue::from_value(&json!({
+            "$id": "old://value",
+            "required": ["a_key"],
+        })));
+        let inferred_schema = Schema::new(RawValue::from_value(&json!({
+            "$id": "old://value",
+            "minProperties": 5,
+        })));
+
+        let bundle =
+            Schema::extend_read_bundle(&read_schema, Some(&write_schema), Some(&inferred_schema));
+        assert_eq!(
+            3,
+            bundle.get().matches(Schema::REF_WRITE_SCHEMA_URL).count(),
+            "schema should contain 'flow://write-schema' 3 times, for $ref, $defs key, and $id"
+        );
+        let (was_removed, new_bundle) = bundle.remove_bundled_write_schema();
+        assert!(was_removed);
+        insta::assert_json_snapshot!(new_bundle.to_value(), @r###"
+        {
+          "$defs": {
+            "existing://def": {
+              "type": "array"
+            },
+            "flow://inferred-schema": {
+              "$id": "flow://inferred-schema",
+              "minProperties": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "flow://inferred-schema"
+            },
+            {
+              "$ref": "flow://write-schema"
+            }
+          ],
+          "maxProperties": 10
+        }
+        "###);
+
+        let (was_removed, _) = new_bundle.remove_bundled_write_schema();
+        assert!(
+            !was_removed,
+            "expected write schema to have already been removed"
+        );
     }
 }

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -99,8 +99,11 @@ fn walk_collection(
 
             // Potentially extend the user's read schema with definitions
             // for the collection's current write and inferred schemas.
-            let read_bundle =
-                models::Schema::extend_read_bundle(read_bundle, write_bundle, inferred_bundle);
+            let read_bundle = models::Schema::extend_read_bundle(
+                read_bundle,
+                Some(write_bundle),
+                inferred_bundle,
+            );
 
             let read_schema =
                 walk_collection_schema(scope.push_prop("readSchema"), &read_bundle, errors);


### PR DESCRIPTION
**Description:**

This affects only the json schema bundling that's used when updating collection models to bundle in the inferred schemas. Previously, this function would bundle in the write schema, too. This makes that optional so that we no longer inline the write schema as part of the read schema `$defs`.

**Workflow steps:**

No change to what users _do_, only what they see as part of collection specs. Once this is deployed, controllers will start to remove bundled write schemas from every collection that uses schema inference. The periodic controller runs for such collections are every 3-4 hours, so after ~4 hours all collections should be updated.

**Notes for reviewers:**

The idea is to revert the entire second commit after we're satisfied that all the collections have been updated.

One other note is that I checked the existing `live_specs` and confirmed that all existing collection specs have either 0, 1, or 3 occurrences of the substring `flow://write-schema`. So that hacky check in `read_schema_bundles_write_schema` seems like it'll probably work OK.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1540)
<!-- Reviewable:end -->
