### PR TITLE
Phil/fix auto evolve

### DIFF
--- a/crates/agent-sql/src/evolutions.rs
+++ b/crates/agent-sql/src/evolutions.rs
@@ -5,28 +5,26 @@ use serde_json::value::RawValue;
 use sqlx::types::Uuid;
 
 pub async fn create(
-    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    pool: &sqlx::PgPool,
     user_id: Uuid,
     draft_id: Id,
     collections: Vec<serde_json::Value>,
     auto_publish: bool,
     detail: String,
-    background: bool,
 ) -> sqlx::Result<Id> {
     let rec = sqlx::query!(
         r#"
         insert into evolutions
             ( user_id, draft_id, collections, auto_publish, detail, background)
-        values ( $1, $2, $3, $4, $5, $6 ) returning id as "id: Id"
+        values ( $1, $2, $3, $4, $5, true ) returning id as "id: Id"
         "#,
         user_id as Uuid,
         draft_id as Id,
         serde_json::Value::Array(collections),
         auto_publish,
         detail,
-        background,
     )
-    .fetch_one(txn)
+    .fetch_one(pool)
     .await?;
     Ok(rec.id)
 }

--- a/crates/agent/src/publications/handler.rs
+++ b/crates/agent/src/publications/handler.rs
@@ -64,7 +64,7 @@ impl Handler for Publisher {
             // As a separate transaction, delete the draft. Note that the user technically could
             // have inserted or updated draft specs after we started the publication, and those
             // would still be removed by this.
-            if (status.is_success() || status.is_empty_draft()) && !dry_run {
+            if status.is_success() && !dry_run {
                 agent_sql::publications::delete_draft(draft_id, pg_pool).await?;
             }
             return Ok(HandleResult::HadJob);


### PR DESCRIPTION
**Description:**

Rolls up two agent fixes, best reviewed independently.
First is a fix for evolutions in auto-discovers.
Second is a fix for auto-discovers happening too frequently.