### PR TITLE
uuid Clocks preserve low bits of precision when mapped into Unix timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
  "json-patch",
  "lz4",
  "pretty_assertions",
+ "proto-gazette",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -3751,6 +3752,8 @@ dependencies = [
  "prost-build",
  "proto-build",
  "serde",
+ "thiserror",
+ "uuid 1.10.0",
 ]
 
 [[package]]

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 json = { path = "../json" }
+proto-gazette = { path = "../proto-gazette" }
 tuple = { path = "../tuple" }
 
 base64 = { workspace = true }

--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -99,9 +99,15 @@ impl Extractor {
                     )
                     .ok()
                 }) {
+                    // Use a custom format and not time::format_description::well_known::Rfc3339,
+                    // because date-times must be right-padded out to the nanosecond to ensure
+                    // that lexicographic ordering matches temporal ordering.
+                    let format = time::macros::format_description!(
+                        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
+                    );
                     return Err(Cow::Owned(serde_json::Value::String(
                         date_time
-                            .format(&time::format_description::well_known::Rfc3339)
+                            .format(format)
                             .expect("rfc3339 format always succeeds"),
                     )));
                 }
@@ -250,6 +256,7 @@ mod test {
                 "85bad119-15f2-11ee-8401-43f05f562888",
                 "1878923d-162a-11ee-8401-43f05f562888",
                 // These differ only in counter bits.
+                "66285dbc-543d-11ef-8001-69ef5bf77016", // Counter is zero.
                 "66285dbc-543d-11ef-8401-69ef5bf77016",
                 "66285dbc-543d-11ef-8801-69ef5bf77016",
                 // Does not parse.
@@ -275,6 +282,7 @@ mod test {
             Extractor::for_uuid_v1_date_time("/uuid-ts/2"),
             Extractor::for_uuid_v1_date_time("/uuid-ts/3"),
             Extractor::for_uuid_v1_date_time("/uuid-ts/4"),
+            Extractor::for_uuid_v1_date_time("/uuid-ts/5"),
             Extractor::for_uuid_v1_date_time("/missing"),
             Extractor::for_uuid_v1_date_time("/fals"),
             Extractor::new("/long-str", &policy),
@@ -316,16 +324,19 @@ mod test {
                 b"\x5b\x22foo\x22\x5d",
             ),
             String(
-                "2023-06-28T20:29:46.4945945Z",
+                "2023-06-28T20:29:46.494594504Z",
             ),
             String(
-                "2023-06-29T03:07:35.0056509Z",
+                "2023-06-29T03:07:35.005650904Z",
             ),
             String(
-                "2024-08-06T21:46:55.5434428Z",
+                "2024-08-06T21:46:55.543442800Z",
             ),
             String(
-                "2024-08-06T21:46:55.5434428Z",
+                "2024-08-06T21:46:55.543442804Z",
+            ),
+            String(
+                "2024-08-06T21:46:55.543442808Z",
             ),
             String(
                 "6d304974-1631-11ee-8401-whoops",

--- a/crates/doc/src/shape/limits.rs
+++ b/crates/doc/src/shape/limits.rs
@@ -2,7 +2,6 @@
 // typically inferred schema Shapes.
 use super::*;
 use crate::ptr::Token;
-use itertools::Itertools;
 use std::cmp::Ordering;
 
 // Potential future improvement: currently this squashes any non-INVALID `additional*`

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -1,8 +1,7 @@
-pub use proto_gazette::{broker, consumer};
+pub use proto_gazette::{broker, consumer, uuid};
 
 pub mod journal;
 pub mod shard;
-pub mod uuid;
 
 mod router;
 pub use router::Router;

--- a/crates/proto-gazette/Cargo.toml
+++ b/crates/proto-gazette/Cargo.toml
@@ -21,6 +21,8 @@ pbjson = { workspace = true }
 pbjson-types = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
 
 [build-dependencies]
 proto-build = { path = "../proto-build", optional = true }

--- a/crates/proto-gazette/src/lib.rs
+++ b/crates/proto-gazette/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod consumer;
 mod protocol;
 pub mod recoverylog;
+pub mod uuid;
 
 // The `protocol` package is publicly exported as `broker`.
 pub mod broker {

--- a/crates/proto-gazette/src/uuid.rs
+++ b/crates/proto-gazette/src/uuid.rs
@@ -109,7 +109,7 @@ impl Default for Clock {
 impl Flags {
     #[inline]
     pub fn is_ack(&self) -> bool {
-        self.0 & (proto_gazette::message_flags::ACK_TXN as u16) != 0
+        self.0 & (crate::message_flags::ACK_TXN as u16) != 0
     }
 }
 

--- a/crates/runtime/src/uuid.rs
+++ b/crates/runtime/src/uuid.rs
@@ -26,7 +26,7 @@ mod test {
 
         assert_eq!(producer.as_bytes(), &[8, 6, 7, 5, 3, 9]);
         assert_eq!(clock.to_g1582_ns100(), 0x1eac6a39f2952f32);
-        assert_eq!(clock.to_unix(), (1594821664, 47589100));
+        assert_eq!(clock.to_unix(), (1594821664, 47589108));
         assert_eq!(flags.0, 0x02);
 
         let u2 = gazette::uuid::build(producer, clock, flags);


### PR DESCRIPTION
**Description:**

See commits. 

**Workflow steps:**

`flow_published_at` will now produce RFC-3339 date-times which preserve total order.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1548)
<!-- Reviewable:end -->
