### PR TITLE
doc: fix numeric bounds in schema reductions

### DIFF
--- a/crates/doc/src/reduce/mod.rs
+++ b/crates/doc/src/reduce/mod.rs
@@ -414,11 +414,18 @@ pub mod test {
             match expect {
                 Ok(expect) => {
                     let (reduced, _delete) = reduced.unwrap();
+
+                    // Assert that the serialized string representations are identical.
+                    // This catches differences like `1.0` vs `1`, which `compare` would
+                    // ignore.
+                    let expect_str = serde_json::to_string(&expect).unwrap();
+                    let actual_str =
+                        serde_json::to_string(&SerPolicy::noop().on(&reduced)).unwrap();
                     assert_eq!(
-                        crate::compare(&reduced, &expect),
-                        std::cmp::Ordering::Equal,
-                        "reduced: {reduced:?} expected: {expect:?}",
+                        expect_str, actual_str,
+                        "comparison failed:\nreduced:\n{actual_str}\nexpected:\n{expect_str}\n"
                     );
+
                     lhs = Some(reduced)
                 }
                 Err(expect) => {

--- a/crates/json/src/number.rs
+++ b/crates/json/src/number.rs
@@ -101,6 +101,13 @@ impl PartialEq for Number {
 impl Eq for Number {}
 
 impl Number {
+    pub fn is_float(&self) -> bool {
+        match self {
+            Float(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_multiple_of(&self, d: &Self) -> bool {
         use Number::*;
 


### PR DESCRIPTION
**Description:**

This fix addresses the following scenario with inferred schemas:
- The captured data has a mix of integer and float values.
- The `minimum` and `maximum` values in the inferred schemas thus also have a mix of integer and float values, where the values themselves are equal except for some have a `.0` decimal and others do not.
- When we reduce the inferred schemas, the result will arbitrarily select either the decimal or integer value, as it considers them to be equal.

A consequence of that behavior is that it's possible for an inferred schema to flip back and forth between the decimal and integer representations, causing unnecessary publications of the inferred schema.

The fix is to adjust the behavior of `NumericShape::union`, which is used for schema reductions. This updates it to always prefer a decimal value over an integer value in cases where the two are equal. This makes it consistent with the widening behavior of considering `number` to be "wider" than `integer` types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1555)
<!-- Reviewable:end -->
