### PR TITLE
agent: switch to jemalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ version = "0.0.0"
 dependencies = [
  "activate",
  "agent-sql",
+ "allocator",
  "anyhow",
  "async-process",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ humantime-serde = "1.1"
 itertools = "0.10"
 indexmap = { version = "1.8", features = ["serde"] }
 iri-string = "0.6.0"
-jemallocator = "0.3"
+jemallocator = { version = "0.3", features = ["profiling"] }
 jemalloc-ctl = "0.3"
 json-patch = "0.3"
 js-sys = "0.3.60"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [dependencies]
 activate = { path = "../activate" }
 agent-sql = { path = "../agent-sql" }
+allocator = { path = "../allocator" }
 async-process = { path = "../async-process" }
 build = { path = "../build" }
 doc = { path = "../doc" }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -1,3 +1,6 @@
+// Links in the allocator crate, which sets the global allocator to jemalloc
+extern crate allocator;
+
 use agent::publications::Publisher;
 use anyhow::Context;
 use clap::Parser;


### PR DESCRIPTION
**Description:**

Switches `agent` to use `jemalloc` from the allocator crate. This is being done in order to facilitate debugging of memory issues using jemalloc's built-in profiling features.

This enables the use of the `_RJEM_MALLOC_CONF` env variable for selectively enabling profiling. For example: `_RJEM_MALLOC_CONF=prof_leak:true,lg_prof_sample:0,prof_final:true`, which is recommended in the [jemalloc docs on leak detection](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Leak-Checking). (The `_RJEM_` prefix is added by the `jemalloc-sys` crate.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1559)
<!-- Reviewable:end -->
