### PR TITLE
control-plane: fix pruning of unchanged specs

### DIFF
--- a/supabase/migrations/57_prune_unchanged_draft_specs_inferred_schemas.sql
+++ b/supabase/migrations/57_prune_unchanged_draft_specs_inferred_schemas.sql
@@ -1,0 +1,19 @@
+begin;
+
+create or replace view unchanged_draft_specs as
+  select
+    draft_id,
+    catalog_name,
+    spec_type,
+    live_spec_md5,
+    draft_spec_md5,
+    inferred_schema_md5,
+    live_inferred_schema_md5
+  from draft_specs_ext d
+    where draft_spec_md5 = live_spec_md5;
+grant select on unchanged_draft_specs to authenticated;
+comment on view unchanged_draft_specs is
+  'View of `draft_specs_ext` that is filtered to only include specs that are identical to the
+ current `live_specs`.';
+
+commit;

--- a/supabase/tests/prune_unchanged_draft_specs.test.sql
+++ b/supabase/tests/prune_unchanged_draft_specs.test.sql
@@ -3,18 +3,14 @@ create function tests.test_prune_unchanged_draft_specs()
 returns setof text as $$
 declare
   draft_id flowid;
-  si_collection_spec json = '{"writeSchema":{},"readSchema": {"$ref":"flow://inferred-schema"},"key":["/id"]}'::json;
-  reg_collection_spec json = '{"schema":{},"key":["/id"]}'::json;
+  collection_spec json = '{"schema":{},"key":["/id"]}'::json;
 begin
-  
+
   insert into user_grants (user_id, object_role, capability) values
     ('11111111-1111-1111-1111-111111111111', 'aliceCo/', 'admin');
-    
+
   insert into inferred_schemas (collection_name, schema, flow_document) values
     ('aliceCo/collA', '{"description": "collA has a schema"}', '{}'),
-    ('aliceCo/collC', '{"description": "collC has a schema"}', '{}'),
-    ('aliceCo/collD', '{"description": "collD has a schema"}', '{}'),
-    ('aliceCo/collE', '{"description": "collE has a schema"}', '{}'),
     ('aliceCo/collG', '{"description": "collG has a schema"}', '{}');
 
   insert into live_specs (catalog_name, spec_type, spec, inferred_schema_md5) values
@@ -45,13 +41,8 @@ begin
       },
       "bindings": []
     }', null),
-    ('aliceCo/collA', 'collection', reg_collection_spec, 'different md5 that should be ignored'),
-    ('aliceCo/collB', 'collection', si_collection_spec, null),
-    ('aliceCo/collC', 'collection', si_collection_spec,
-      (select md5 from inferred_schemas where collection_name = 'aliceCo/collC')),
-    ('aliceCo/collD', 'collection', si_collection_spec, null),
-    ('aliceCo/collE', 'collection', si_collection_spec, 'mock stale md5'),
-    ('aliceCo/collG', 'collection', si_collection_spec,
+    ('aliceCo/collA', 'collection', collection_spec, 'different md5 that should be ignored'),
+    ('aliceCo/collG', 'collection', collection_spec,
       (select md5 from inferred_schemas where collection_name = 'aliceCo/collG'));
 
 
@@ -81,35 +72,24 @@ begin
       },
       "bindings": []
     }'),
-    -- should be pruned because spec is identical. Note that the inferred schema
-    -- is still setup above so we can assert it is ignored when the spec does not
-    -- $ref it.
-    (draft_id, 'aliceCo/collA', 'collection', reg_collection_spec),
-    -- should prune because spec is idential and inferred schema is still null/missing
-    (draft_id, 'aliceCo/collB', 'collection', si_collection_spec),
-    -- should prune because spec is identical and inferred schema md5 is the same
-    (draft_id, 'aliceCo/collC', 'collection', si_collection_spec),
-    -- should keep because inferred schema md5 changed from null to some
-    (draft_id, 'aliceCo/collD', 'collection', si_collection_spec),
-    -- should keep because inferrred schema md5 changed
-    (draft_id, 'aliceCo/collE', 'collection', si_collection_spec),
+    -- should be pruned because spec is identical.
+    (draft_id, 'aliceCo/collA', 'collection', collection_spec),
     -- should keep because it is new
-    (draft_id, 'aliceCo/collF', 'collection', si_collection_spec),
-    -- should keep because spec changed (whitespace after "writeSchema" to document that behavior)
+    (draft_id, 'aliceCo/collF', 'collection', collection_spec),
+    -- should keep because spec changed (whitespace only change, in order to document that behavior)
     (draft_id, 'aliceCo/collG', 'collection', '{
-      "writeSchema":{},
-      "readSchema": {"$ref": "flow://inferred-schema"},
+      "schema":{ },
       "key": ["/id"]
     }');
-    
+
   return query select set_eq(
     $i$ select catalog_name from prune_unchanged_draft_specs('$i$ || draft_id || $i$') $i$,
-	'{aliceCo/capA, aliceCo/collA, aliceCo/collB, aliceCo/collC}'::text[]
+	'{aliceCo/capA, aliceCo/collA}'::text[]
   );
 
   return query select results_eq(
     $i$ select catalog_name::text from draft_specs where draft_id = '$i$ || draft_id || $i$' order by catalog_name $i$,
-	$i$ values ('aliceCo/capB'),('aliceCo/collD'),('aliceCo/collE'),('aliceCo/collF'),('aliceCo/collG') $i$
+	$i$ values ('aliceCo/capB'),('aliceCo/collF'),('aliceCo/collG') $i$
   );
 
 end;


### PR DESCRIPTION
This is a quick fix for the pruning of unchanged draft specs. It stops trying to account for inferred schema changes, since those are now part of the spec itself, and the `inferred_schema_md5` column is no longer used. (We can remove it in a subsequent migration).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1561)
<!-- Reviewable:end -->
