### PR TITLE
runtime: when polling capture, wait for OpFuture to resolve

### DIFF
--- a/go/protocols/flow/re_exports.go
+++ b/go/protocols/flow/re_exports.go
@@ -34,13 +34,7 @@ var MustLabelSet = pb.MustLabelSet
 // OpFuture represents an operation which is executing in the background. The
 // operation has completed when Done selects. Err may be invoked to determine
 // whether the operation succeeded or failed.
-// This is copied from gazette's `client` package.
-type OpFuture interface {
-	// Done selects when operation background execution has finished.
-	Done() <-chan struct{}
-	// Err blocks until Done() and returns the final error of the OpFuture.
-	Err() error
-}
+type OpFuture = client.OpFuture
 
 // AsyncOperation is a simple, minimal implementation of the OpFuture interface.
 type AsyncOperation = client.AsyncOperation


### PR DESCRIPTION
We must wait for the OpFuture to resolve successfully before polling for the next capture transaction.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1565)
<!-- Reviewable:end -->
