### PR TITLE
ops-catalog: use v5 for postgres materialization

### DIFF
--- a/ops-catalog/template-prod.flow.yaml
+++ b/ops-catalog/template-prod.flow.yaml
@@ -8,7 +8,7 @@ materializations:
       minTxnDuration: "10s"
     endpoint:
       connector:
-        image: ghcr.io/estuary/materialize-postgres:v4
+        image: ghcr.io/estuary/materialize-postgres:v5
         config: stats-production-endpoint.sops.yaml
 
     bindings:


### PR DESCRIPTION
**Description:**

This connector version has been bumped to v5, so use the latest one in the ops catalog publication that runs on production.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1577)
<!-- Reviewable:end -->
