### PR TITLE
simd-doc: allow for continued parsing after errors

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -95,10 +95,10 @@ impl Read {
                 ReadJsonLine::Doc { root, next_offset } => (root, next_offset),
             };
             let Some(doc::ArchivedNode::String(uuid)) = self.uuid_ptr.query(root.get()) else {
-                anyhow::bail!(gazette::Error::Parsing(
-                    self.offset,
-                    std::io::Error::other("document does not have a valid UUID"),
-                ));
+                anyhow::bail!(
+                    "document at offset {} does not have a valid UUID",
+                    self.offset
+                );
             };
             let (producer, clock, flags) = gazette::uuid::parse_str(uuid.as_str())?;
 

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -27,8 +27,12 @@ pub enum Error {
     BrokerStatus(broker::Status),
     #[error("unexpected consumer status: {0:?}")]
     ConsumerStatus(consumer::Status),
-    #[error("failed to parse document near journal offset {0}")]
-    Parsing(i64, #[source] std::io::Error),
+    #[error("failed to parse document at journal offset range {location:?}")]
+    Parsing {
+        location: std::ops::Range<i64>,
+        #[source]
+        err: std::io::Error,
+    },
     #[error("{0}")]
     Protocol(&'static str),
     #[error(transparent)]

--- a/crates/simd-doc/src/tests/fuzz.rs
+++ b/crates/simd-doc/src/tests/fuzz.rs
@@ -1,66 +1,109 @@
 use quickcheck::quickcheck;
 use serde_json::Value;
+use std::hash::Hasher;
+use xxhash_rust::xxh3::Xxh3;
 
 use super::ArbitraryValue;
 
 quickcheck! {
     fn transcode_matches_fallback_fuzz(input: Vec<ArbitraryValue>) -> bool {
-        let (simd, fallback) = super::transcoded_and_fallback(&mut build_fixture(input));
+        let (simd, fallback) = super::transcoded_and_fallback(&mut extend_fixture(Vec::new(), input));
         return fallback.v.as_slice() == simd.v.as_slice();
     }
 
     fn parse_matches_fallback_fuzz(input: Vec<ArbitraryValue>) -> bool {
         let alloc = doc::Allocator::new();
-        let (simd, fallback) = super::parsed_and_fallback(&mut build_fixture(input), &alloc);
+        let (simd, fallback) = super::parsed_and_fallback(&mut extend_fixture(Vec::new(), input), &alloc);
         return simd.iter().zip(fallback.iter()).all(|((l_d, l_o), (r_d, r_o))| l_o == r_o && doc::compare(l_d, r_d).is_eq());
     }
 
-    fn incremental_parse_splits_fuzz(input: Vec<ArbitraryValue>, s1: u16, s2: u16) -> bool {
-        incremental_parse_splits_case(input, s1, s2)
+    fn parse_and_transcode_with_errors( in1: Vec<ArbitraryValue>, in2: Vec<ArbitraryValue>, in3: Vec<ArbitraryValue>, s1: u16, s2: u16) -> bool {
+        parse_and_transcode_with_errors_case(in1, in2, in3, s1, s2)
     }
 }
 
-fn incremental_parse_splits_case(input: Vec<ArbitraryValue>, s1: u16, s2: u16) -> bool {
-    if input.is_empty() {
-        return true; // Cannot modulo on len().
-    }
-    let input = build_fixture(input);
+fn parse_and_transcode_with_errors_case(
+    in1: Vec<ArbitraryValue>,
+    in2: Vec<ArbitraryValue>,
+    in3: Vec<ArbitraryValue>,
+    s1: u16,
+    s2: u16,
+) -> bool {
+    let mut input = extend_fixture(Vec::new(), in1);
+    input.extend_from_slice(b"{error one}\n");
+    input = extend_fixture(input, in2);
+    input.extend_from_slice(b"{error: two}\n");
+    input = extend_fixture(input, in3);
 
     let mut p1 = crate::Parser::new();
     let mut p2 = crate::Parser::new();
+    let mut p3 = crate::Parser::new();
 
-    use std::hash::Hasher;
-    let mut h1 = xxhash_rust::xxh3::Xxh3::with_seed(0);
+    let mut h1 = Xxh3::with_seed(0);
     let mut h2 = h1.clone();
+    let mut h3 = h1.clone();
 
-    for (p, s, h) in [(&mut p1, s1, &mut h1), (&mut p2, s2, &mut h2)] {
-        let s = (s as usize) % input.len();
+    drive_parse(&mut p1, &input, s1 as usize, &mut h1);
+    drive_transcode(&mut p2, &input, s2 as usize, &mut h2);
+    drive_parse(&mut p3, &input, 0, &mut h3);
 
-        let out = p
-            .transcode_chunk(&input[..s], 0, Default::default())
-            .unwrap();
-
-        for (doc, next_offset) in out.iter() {
-            h.write_i64(next_offset);
-            h.update(doc);
-        }
-
-        let out = p
-            .transcode_chunk(&input[s..], s as i64, out.into_inner())
-            .unwrap();
-
-        for (doc, next_offset) in out.iter() {
-            h.write_i64(next_offset);
-            h.update(doc);
-        }
-    }
-
-    return h1.digest() == h2.digest();
+    return h1.digest() == h2.digest() && h1.digest() == h3.digest();
 }
 
-fn build_fixture(it: Vec<ArbitraryValue>) -> Vec<u8> {
-    let mut b = Vec::new();
+fn drive_transcode(p: &mut crate::Parser, input: &[u8], split: usize, hash: &mut Xxh3) {
+    let split = split % input.len();
+    let mut scratch = Default::default();
 
+    for (chunk, chunk_offset) in [(&input[..split], 0), (&input[split..], split as i64)] {
+        () = p.chunk(chunk, chunk_offset).unwrap();
+
+        scratch = loop {
+            match p.transcode_many(scratch) {
+                Ok(out) if out.is_empty() => break out.into_inner(),
+                Ok(out) => {
+                    for (doc, next_offset) in out.iter() {
+                        let doc = doc::ArchivedNode::from_archive(doc);
+                        let doc = serde_json::to_string(&doc::SerPolicy::noop().on(doc)).unwrap();
+                        hash.write(doc.as_bytes());
+                        hash.write_i64(next_offset);
+                    }
+                    scratch = out.into_inner();
+                }
+                Err((err, location)) => {
+                    hash.write(format!("{err} @ {location:?}").as_bytes());
+                    scratch = Default::default();
+                }
+            }
+        };
+    }
+}
+
+fn drive_parse(p: &mut crate::Parser, input: &[u8], split: usize, hash: &mut Xxh3) {
+    let split = split % input.len();
+    let mut alloc = doc::Allocator::new();
+
+    for (chunk, chunk_offset) in [(&input[..split], 0), (&input[split..], split as i64)] {
+        () = p.chunk(chunk, chunk_offset).unwrap();
+
+        loop {
+            alloc.reset();
+
+            match p.parse_many(&alloc) {
+                Ok((_begin, drained)) if drained.len() == 0 => break,
+                Ok((_begin, drained)) => {
+                    for (doc, next_offset) in drained {
+                        let doc = serde_json::to_string(&doc::SerPolicy::noop().on(&doc)).unwrap();
+                        hash.write(doc.as_bytes());
+                        hash.write_i64(next_offset);
+                    }
+                }
+                Err((err, location)) => hash.write(format!("{err} @ {location:?}").as_bytes()),
+            }
+        }
+    }
+}
+
+fn extend_fixture(mut b: Vec<u8>, it: Vec<ArbitraryValue>) -> Vec<u8> {
     for doc in it {
         serde_json::to_writer(
             &mut b,

--- a/crates/simd-doc/src/tests/mod.rs
+++ b/crates/simd-doc/src/tests/mod.rs
@@ -12,7 +12,9 @@ fn transcoded_and_fallback(input: &mut Vec<u8>) -> (crate::Transcoded, crate::Tr
     };
     () = crate::transcode_simd(input, &mut simd, &mut crate::ffi::new_parser(1_000_000)).unwrap();
 
-    let fallback = crate::transcode_fallback(&input, Default::default()).unwrap();
+    let (_consumed, fallback, maybe_err) = crate::transcode_fallback(&input, 0, Default::default());
+    assert_eq!(None, maybe_err.map(|(err, _location)| err.to_string()));
+
     let fallback = crate::Transcoded {
         v: fallback,
         offset: 0,
@@ -36,7 +38,8 @@ fn parsed_and_fallback<'a>(
     .unwrap();
 
     let mut fallback = Vec::new();
-    () = crate::parse_fallback(input, 123_000_000, alloc, &mut fallback).unwrap();
+    let (_consumed, maybe_err) = crate::parse_fallback(input, 123_000_000, alloc, &mut fallback);
+    assert_eq!(None, maybe_err.map(|(err, _location)| err.to_string()));
 
     (simd, fallback)
 }

--- a/crates/simd-doc/src/transcoded.rs
+++ b/crates/simd-doc/src/transcoded.rs
@@ -8,6 +8,10 @@ pub struct Transcoded {
 }
 
 impl Transcoded {
+    pub fn is_empty(&self) -> bool {
+        self.v.is_empty()
+    }
+
     pub fn iter<'s>(&'s self) -> IterOut<'s> {
         IterOut {
             v: self.v.as_slice(),


### PR DESCRIPTION
Update Parser to support continued parsing after an error in parsing a JSON document. Use a polling-based design, where a caller can add one or more chunk()'s to a Parser and then repeatedly poll it to drain all parsed or transcoded documents and errors.

Also update error tracking to provide fine-grain localization of exactly where, in the input stream, the erroring document is located.

Enhance fuzz tests to mix in errors alongside valid documents, and verify that parsing and transcoding give exactly the same outcomes.

Resolves #1584

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1589)
<!-- Reviewable:end -->
