### PR TITLE
docs: we no longer require us-east-1 S3 buckets

### DIFF
--- a/site/docs/getting-started/installation.mdx
+++ b/site/docs/getting-started/installation.mdx
@@ -104,7 +104,6 @@ You'll need to grant Estuary Flow access to your GCS bucket.
 
 ### Amazon S3 buckets
 
-Your bucket must be in the us-east-1 [region](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html).
 You'll need to grant Estuary Flow access to your S3 bucket.
 
 1. [Create a bucket to use with Flow](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html), if you haven't already.


### PR DESCRIPTION
Updates docs to reflect the fact that we no longer require S3 buckets to be in the us-east-1 region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1591)
<!-- Reviewable:end -->
