### PR TITLE
crate(gazette): Include the original error message when we log a `Transport` error warning

### DIFF
--- a/crates/gazette/src/journal/read.rs
+++ b/crates/gazette/src/journal/read.rs
@@ -29,7 +29,12 @@ impl Client {
                 match result {
                     Ok(()) => attempt = 0,
                     Err(Error::Transport(err)) => {
-                        tracing::warn!(%err, "broker transport error (will retry)");
+                        let source = std::error::Error::source(&err);
+                        if let Some(source) = source {
+                            tracing::warn!(%err, cause=%source, "broker transport error (will retry)");
+                        } else {
+                            tracing::warn!(%err, "broker transport error (will retry)");
+                        }
                     }
                     Err(Error::Grpc(status)) => {
                         tracing::warn!(%status, "broker stream error (will retry)");


### PR DESCRIPTION
**Description:**

Dekaf has been getting a bunch of `gazette::journal::read: broker transport error (will retry) err=transport error` errors recently. It doesn't seem to be causing any issues that I can tell --- all of my test dataflows are still flowing, but it is suspicious. It seems that this message indicates a `gazette::Error::Transport`, which wraps a `tonic::transport::Error` which gets mapped into by a whole bunch of things inside tonic.

<img width="1486" alt="Screen Shot 2024-08-28 at 12 34 51" src="https://github.com/user-attachments/assets/05f72ff1-b4bd-44fa-bb0d-44eaa8cf36fb">

I made this quick change to get some more details about the cause of the transport errors (of course they stopped as soon as I deployed the change, which is itself a hint) and wanted to get opinions before I do more. Should all of these cases include the source error message? Should it instead be an additional `tracing::debug!` message? I imagine the reason for not including it originally is to simplify the error messaging as it could be user facing. Thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1592)
<!-- Reviewable:end -->
