### PR TITLE
ci: revert build image to ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   gnu-binaries:
-    runs-on: ubuntu-2404-large
+    runs-on: ubuntu-2004-large
 
     steps:
       - uses: actions/checkout@v2
@@ -64,8 +64,6 @@ jobs:
       - run: make print-versions
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "2404"
 
       - name: Cache/Restore Go dependencies.
         uses: actions/cache@v2
@@ -92,7 +90,7 @@ jobs:
             target/x86_64-unknown-linux-gnu/release/librocksdb-exp/
 
   musl-binaries:
-    runs-on: ubuntu-2404-large
+    runs-on: ubuntu-2004-large
 
     steps:
       - uses: actions/checkout@v2
@@ -112,8 +110,6 @@ jobs:
       - run: make print-versions
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "2404"
 
       - run: go mod download
       - run: make rust-musl-test
@@ -127,7 +123,7 @@ jobs:
             .build/package/bin/*
 
   assembly:
-    runs-on: ubuntu-2404-large
+    runs-on: ubuntu-2004-large
     needs: [gnu-binaries, musl-binaries]
 
     services:


### PR DESCRIPTION
The version we build on is effectively the minimum OS version we can support with our pre-built binaries. So this reverts it back to 20.04 so that our binaries can run on systems with older glibc versions.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

