### PR TITLE
.devcontainer/release.Dockerfile: switch to ubuntu:noble

### DIFF
--- a/.devcontainer/release.Dockerfile
+++ b/.devcontainer/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM ubuntu:noble
 
 # Pick run-time library packages which match the development packages
 # used by the ci-builder image. "curl" is included, to allow node-zone.sh


### PR DESCRIPTION
From debian:trixie-slim. The package index is subtly different (docker-cli is required for CLI tools on debian now). Make the release image consistent with our CI environment.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1598)
<!-- Reviewable:end -->
