### PR TITLE
runtime: hard code `materialize-bigquery` in `ser_policy`

### DIFF
--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -31,6 +31,7 @@ impl Task {
         // that don't handle large strings very well. This should be negotiated via connector protocol.
         // See go/runtime/materialize.go:135
         let ser_policy = if [
+            "ghcr.io/estuary/materialize-bigquery",
             "ghcr.io/estuary/materialize-snowflake",
             "ghcr.io/estuary/materialize-redshift",
             "ghcr.io/estuary/materialize-sqlite",


### PR DESCRIPTION
**Description:**

BigQuery actually has a limit of 20MiB on an individual row that can be returned via its Query API. Although we can store a row with a `flow_document` that large, we then can't read it back out using the conventional query mechanism the materialization connector currently uses.

This adds `materialize-bigquery` to the list of connectors that use `ser_policy`, which should generally reduce how often we store rows that are excessively large.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1610)
<!-- Reviewable:end -->
