### PR TITLE
docs/MySQL: Remove all mention of watermarks, plus other cleanups

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -14,11 +14,10 @@ This connector is available for use in the Flow web application. For local devel
 
 To use this connector, you'll need a MariaDB database setup with the following.
 
-- [`binlog_format`](https://mariadb.com/kb/en/binary-log-formats/)
-  system variable set to `ROW`.
-- [Binary log expiration period](https://mariadb.com/kb/en/using-and-maintaining-the-binary-log/#purging-log-files) set to at least 30 days (2592000 seconds) if at all possible.
-  - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
-    MariaDB's default value is 0 (no expiration).
+- The [`binlog_format`](https://mariadb.com/kb/en/binary-log-formats/)
+  system variable must be set to `ROW`.
+- The [binary log expiration period](https://mariadb.com/kb/en/using-and-maintaining-the-binary-log/#purging-log-files) should be at least 7 days.
+  - This value may be set lower if necessary, but we [discourage](#insufficient-binlog-retention) doing so as this may increase the likelihood of unrecoverable failures.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` [privileges](https://mariadb.com/docs/skysql/ref/es10.6/privileges/).
   - Permission to read the tables being captured.
@@ -47,7 +46,7 @@ GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
 ```
 
-2. Configure the binary log to retain data for 30 days, if previously set lower.
+2. Configure the binary log to retain data for at least 7 days. We recommend 30 days where possible.
 
 ```sql
 SET PERSIST binlog_expire_logs_seconds = 2592000;
@@ -217,18 +216,18 @@ Resolving this error requires fixing the `binlog_format` system variable, and th
 
 If your capture is failing with an `"unhandled query"` error, some SQL query is present in the binlog which the connector does not (currently) understand.
 
-In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to tear down and recreate the entire capture so that it restarts from a later point in the binlog.
+In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to backfill all collections to allow the capture to jump ahead to a later point in the binlog.
 
 ### Metadata Errors
 
 If your capture is failing with a `"metadata error"` then something has gone badly wrong with the capture's tracking of table metadata, such as column names or datatypes.
 
-This should never happen, and most likely means that the binlog itself is corrupt in some way. If this occurs, it can be resolved by removing the offending table(s) from the capture bindings list and then recreating the capture (generally into a new collection, as this process will cause the table to be re-captured in its entirety).
+This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by backfilling all collections from the source.
 
 ### Insufficient Binlog Retention
 
-If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value, and your capture would risk unrecoverable failure if it were paused or the server became unreachable for a nontrivial amount of time, such that the database expired a binlog segment that the capture was still reading from.
+If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value.
 
-(If this were to happen, then change events would be permanently lost and that particular capture would never be able to make progress without potentially producing incorrect data. Thus the capture would need to be torn down and recreated so that each table could be re-captured in its entirety, starting with a complete backfill of current contents.)
+The concern is that if a capture is disabled or the server becomes unreachable for longer than the binlog retention period, the database might delete a binlog segment which the capture isn't yet done with. If this happens then change events have been permanently lost, and the only way to get the capture running again is to skip ahead to a portion of the binlog which still exists. For correctness this requires backfilling the current contents of all tables from the source, and so we prefer to avoid it as much as possible. It's much easier to just set up your binlog retention with enough wiggle room to recover from temporary failures.
 
-The `"binlog retention period is too short"` error should normally be fixed by setting `binlog_expire_logs_seconds = 2592000` as described in the [Prerequisites](#prerequisites) section (and when running on a managed cloud platform additional steps may be required, refer to the managed cloud setup instructions above). However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
+The `"binlog retention period is too short"` error should normally be fixed by setting a longer retention period as described in these setup instructions. However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -97,7 +97,12 @@ GRANT SELECT ON *.* TO 'flow_capture';
 4. Note the instance's host under Server name, and the port under Connection Strings (usually `3306`).
    Together, you'll use the host:port as the `address` property when you configure the connector.
 
-### Setting the MariaDB time zone
+## Capturing from Read Replicas
+
+This connector supports capturing from a read replica of your database, provided that
+binary logging is enabled on the replica and all other requirements are met.
+
+## Setting the MariaDB time zone
 
 MariaDB's [`time_zone` server system variable](https://mariadb.com/kb/en/server-system-variables/#system_time_zone) is set to `SYSTEM` by default.
 Flow is not able to detect your time zone when it's set this way, so you must explicitly set the variable for your database.

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -159,7 +159,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database](https://mariadb.com/kb/en/understanding-mariadb-architecture/#databases) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                                 | string | Required         |
-| **`/syncMode`**  | Sync mode | Connection method. Always set to `incremental`.                                                                     | string | Required         |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.
@@ -186,7 +185,6 @@ captures:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
-          syncMode: incremental
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -14,11 +14,11 @@ This connector is available for use in the Flow web application. For local devel
 
 To use this connector, you'll need a MariaDB database setup with the following.
 
-- [`binlog_format`](https://mariadb.com/kb/en/binary-log-formats/)
-  system variable set to `ROW`.
-- [Binary log expiration period](https://mariadb.com/kb/en/using-and-maintaining-the-binary-log/#purging-log-files) set to at least 30 days (2592000 seconds) if at all possible.
-  - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
-    MariaDB's default value is 0 (no expiration).
+- The [`binlog_format`](https://mariadb.com/kb/en/binary-log-formats/)
+  system variable must be set to `ROW`.
+- The [binary log retention](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-stored-proc-configuring.html#mysql_rds_set_configuration-usage-notes.binlog-retention-hours)
+  period should be set to 168 hours (the maximum allowed by RDS).
+  - This value may be set lower if necessary, but we [discourage](#insufficient-binlog-retention) doing so as this may increase the likelihood of unrecoverable failures.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` [privileges](https://mariadb.com/docs/skysql/ref/es10.6/privileges/).
   - Permission to read the tables being captured.
@@ -187,18 +187,18 @@ Resolving this error requires fixing the `binlog_format` system variable, and th
 
 If your capture is failing with an `"unhandled query"` error, some SQL query is present in the binlog which the connector does not (currently) understand.
 
-In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to tear down and recreate the entire capture so that it restarts from a later point in the binlog.
+In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to backfill all collections to allow the capture to jump ahead to a later point in the binlog.
 
 ### Metadata Errors
 
 If your capture is failing with a `"metadata error"` then something has gone badly wrong with the capture's tracking of table metadata, such as column names or datatypes.
 
-This should never happen, and most likely means that the binlog itself is corrupt in some way. If this occurs, it can be resolved by removing the offending table(s) from the capture bindings list and then recreating the capture (generally into a new collection, as this process will cause the table to be re-captured in its entirety).
+This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by backfilling all collections from the source.
 
 ### Insufficient Binlog Retention
 
-If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value, and your capture would risk unrecoverable failure if it were paused or the server became unreachable for a nontrivial amount of time, such that the database expired a binlog segment that the capture was still reading from.
+If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value.
 
-(If this were to happen, then change events would be permanently lost and that particular capture would never be able to make progress without potentially producing incorrect data. Thus the capture would need to be torn down and recreated so that each table could be re-captured in its entirety, starting with a complete backfill of current contents.)
+The concern is that if a capture is disabled or the server becomes unreachable for longer than the binlog retention period, the database might delete a binlog segment which the capture isn't yet done with. If this happens then change events have been permanently lost, and the only way to get the capture running again is to skip ahead to a portion of the binlog which still exists. For correctness this requires backfilling the current contents of all tables from the source, and so we prefer to avoid it as much as possible. It's much easier to just set up your binlog retention with enough wiggle room to recover from temporary failures.
 
-The `"binlog retention period is too short"` error should normally be fixed by setting `binlog_expire_logs_seconds = 2592000` as described in the [Prerequisites](#prerequisites) section (and when running on a managed cloud platform additional steps may be required, refer to the managed cloud setup instructions above). However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
+The `"binlog retention period is too short"` error should normally be fixed by setting a longer retention period as described in these setup instructions. However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -19,13 +19,8 @@ To use this connector, you'll need a MariaDB database setup with the following.
 - [Binary log expiration period](https://mariadb.com/kb/en/using-and-maintaining-the-binary-log/#purging-log-files) set to at least 30 days (2592000 seconds) if at all possible.
   - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
     MariaDB's default value is 0 (no expiration).
-- A watermarks table. The watermarks table is a small "scratch space"
-  to which the connector occasionally writes a small amount of data (a UUID,
-  specifically) to ensure accuracy when backfilling preexisting table contents.
-  - The default name is `"flow.watermarks"`, but this can be overridden in `config.json`.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` [privileges](https://mariadb.com/docs/skysql/ref/es10.6/privileges/).
-  - Permission to insert, update, and delete on the watermarks table.
   - Permission to read the tables being captured.
   - Permission to read from `information_schema` tables, if automatic discovery is used.
 - If the table(s) to be captured include columns of type `DATETIME`, the `time_zone` system variable
@@ -83,17 +78,12 @@ To use this connector, you'll need a MariaDB database setup with the following.
 
    3. Reboot the replica to allow the changes to take effect.
 
-4. Switch to your MariaDB client. Run the following commands to create a new user for the capture with appropriate permissions,
-   and set up the watermarks table:
+4. Switch to your MariaDB client. Run the following commands to create a new user for the capture with appropriate permissions:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS flow;
-CREATE TABLE IF NOT EXISTS flow.watermarks (slot INTEGER PRIMARY KEY, watermark TEXT);
-CREATE USER IF NOT EXISTS flow_capture
-  IDENTIFIED BY 'secret'
+CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret'
 GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
-GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
 ```
 
 5. Run the following command to set the binary log retention to 7 days, the maximum value which RDS MariaDB permits:
@@ -128,7 +118,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
 | **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
-| `/advanced/watermarks_table`            | Watermarks Table Name              | The name of the table used for watermark writes. Must be fully-qualified in &#x27;&lt;schema&gt;.&lt;table&gt;&#x27; form.                                                                                                                                                                                                                                                              | string  | `"flow.watermarks"`        |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
 | `/advanced/node_id`                     | Node ID                            | Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn&#x27;t matter so long as it is unique. If unset or zero the connector will pick a value.                                                                                                                                                                             | integer |                            |
 | `/advanced/skip_backfills`              | Skip Backfills                     | A comma-separated list of fully-qualified table names which should not be backfilled.                                                                                                                                                                                                                                                                                                   | string  |                            |

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -130,7 +130,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database](https://mariadb.com/kb/en/understanding-mariadb-architecture/#databases) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                                 | string | Required         |
-| **`/syncMode`**  | Sync mode | Connection method. Always set to `incremental`.                                                                     | string | Required         |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.
@@ -157,7 +156,6 @@ captures:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
-          syncMode: incremental
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -24,10 +24,10 @@ Setup instructions are provided for the following platforms:
 
 To use this connector, you'll need a MySQL database setup with the following.
 
-- [`binlog_format`](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format)
-  system variable set to `ROW` (the default value).
-- [Binary log expiration period](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) set to MySQL's default value of 30 days (2592000 seconds) if at all possible.
-  - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
+- The [`binlog_format`](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_format)
+  system variable must be set to `ROW` (the default value).
+- The [binary log expiration period](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) should be at least 7 days.
+  - This value may be set lower if necessary, but we [discourage](#insufficient-binlog-retention) doing so as this may increase the likelihood of unrecoverable failures.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges.
   - Permission to read the tables being captured.
@@ -64,7 +64,7 @@ GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
 ```
 
-2. Configure the binary log to retain data for the default MySQL setting of 30 days, if previously set lower.
+2. Configure the binary log to retain data for at least 7 days. We recommend 30 days where possible.
 
 ```sql
 SET PERSIST binlog_expire_logs_seconds = 2592000;
@@ -292,21 +292,21 @@ Resolving this error requires fixing the `binlog_format` system variable, and th
 
 If your capture is failing with an `"unhandled query"` error, some SQL query is present in the binlog which the connector does not (currently) understand.
 
-In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to tear down and recreate the entire capture so that it restarts from a later point in the binlog.
+In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to backfill all collections to allow the capture to jump ahead to a later point in the binlog.
 
 ### Metadata Errors
 
 If your capture is failing with a `"metadata error"` then something has gone badly wrong with the capture's tracking of table metadata, such as column names or datatypes.
 
-This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by removing the offending table(s) from the capture bindings list and then recreating the capture (generally into a new collection, as this process will cause the table to be re-captured in its entirety).
+This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by backfilling all collections from the source.
 
 ### Insufficient Binlog Retention
 
-If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MySQL binlog retention period is set to a dangerously low value, and your capture would risk unrecoverable failure if it were paused or the server became unreachable for a nontrivial amount of time, such that the database expired a binlog segment that the capture was still reading from.
+If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value.
 
-(If this were to happen, then change events would be permanently lost and that particular capture would never be able to make progress without potentially producing incorrect data. Thus the capture would need to be torn down and recreated so that each table could be re-captured in its entirety, starting with a complete backfill of current contents.)
+The concern is that if a capture is disabled or the server becomes unreachable for longer than the binlog retention period, the database might delete a binlog segment which the capture isn't yet done with. If this happens then change events have been permanently lost, and the only way to get the capture running again is to skip ahead to a portion of the binlog which still exists. For correctness this requires backfilling the current contents of all tables from the source, and so we prefer to avoid it as much as possible. It's much easier to just set up your binlog retention with enough wiggle room to recover from temporary failures.
 
-The `"binlog retention period is too short"` error should normally be fixed by setting `binlog_expire_logs_seconds = 2592000` as described in the [Prerequisites](#prerequisites) section (and when running on a managed cloud platform additional steps may be required, refer to the managed cloud setup instructions above). However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
+The `"binlog retention period is too short"` error should normally be fixed by setting a longer retention period as described in these setup instructions. However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
 
 ### Empty Collection Key
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -235,7 +235,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
-| **`/syncMode`**  | Sync mode | Connection method. Always set to `incremental`.                                                                | string | Required         |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.
@@ -262,7 +261,6 @@ captures:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
-          syncMode: incremental
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -166,7 +166,12 @@ GRANT SELECT ON *.* TO 'flow_capture';
 4. Note the instance's host under Server name, and the port under Connection Strings (usually `3306`).
    Together, you'll use the host:port as the `address` property when you configure the connector.
 
-### Setting the MySQL time zone
+## Capturing from Read Replicas
+
+This connector supports capturing from a read replica of your database, provided that
+binary logging is enabled on the replica and all other requirements are met.
+
+## Setting the MySQL time zone
 
 MySQL's [`time_zone` server system variable](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_time_zone) is set to `SYSTEM` by default.
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -16,13 +16,8 @@ To use this connector, you'll need a MySQL database setup with the following.
   system variable set to `ROW` (the default value).
 - [Binary log expiration period](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) set to MySQL's default value of 30 days (2592000 seconds) if at all possible.
   - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
-- A watermarks table. The watermarks table is a small "scratch space"
-  to which the connector occasionally writes a small amount of data (a UUID,
-  specifically) to ensure accuracy when backfilling preexisting table contents.
-  - The default name is `"flow.watermarks"`, but this can be overridden in `config.json`.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges.
-  - Permission to insert, update, and delete on the watermarks table.
   - Permission to read the tables being captured.
   - Permission to read from `information_schema` tables, if automatic discovery is used.
 - If the table(s) to be captured include columns of type `DATETIME`, the `time_zone` system variable
@@ -73,18 +68,14 @@ To use this connector, you'll need a MySQL database setup with the following.
 
    3. Reboot the replica to allow the changes to take effect.
 
-4. Switch to your MySQL client. Run the following commands to create a new user for the capture with appropriate permissions,
-   and set up the watermarks table:
+4. Switch to your MySQL client. Run the following commands to create a new user for the capture with appropriate permissions:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS flow;
-CREATE TABLE IF NOT EXISTS flow.watermarks (slot INTEGER PRIMARY KEY, watermark TEXT);
 CREATE USER IF NOT EXISTS flow_capture
   IDENTIFIED BY 'secret'
   COMMENT 'User account for Flow MySQL data capture';
 GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
-GRANT INSERT, UPDATE, DELETE ON flow.watermarks TO 'flow_capture';
 ```
 
 5. Run the following command to set the binary log retention to 7 days, the maximum value which RDS MySQL permits:
@@ -147,7 +138,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
 | **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
-| `/advanced/watermarks_table`            | Watermarks Table Name              | The name of the table used for watermark writes. Must be fully-qualified in &#x27;&lt;schema&gt;.&lt;table&gt;&#x27; form.                                                                                                                                                                                                                                                              | string  | `"flow.watermarks"`        |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
 | `/advanced/node_id`                     | Node ID                            | Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn&#x27;t matter so long as it is unique. If unset or zero the connector will pick a value.                                                                                                                                                                             | integer |                            |
 | `/advanced/skip_backfills`              | Skip Backfills                     | A comma-separated list of fully-qualified table names which should not be backfilled.                                                                                                                                                                                                                                                                                                   | string  |                            |

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -48,28 +48,12 @@ To use this connector, you'll need a MySQL database setup with the following.
    2. [Modify the new parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBInstanceParamGroups.html#USER_WorkingWithParamGroups.Modifying) and update the following parameters:
 
       - binlog_format: ROW
-      - binlog_row_metadata: FULL
-      - read_only: 0
 
-   3. If using the primary instance (not recommended), [associate the parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBInstanceParamGroups.html#USER_WorkingWithParamGroups.Associating)
+   3. [Associate the parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBInstanceParamGroups.html#USER_WorkingWithParamGroups.Associating)
       with the database and set [Backup Retention Period](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.Enabling) to 7 days.
       Reboot the database to allow the changes to take effect.
 
-3. Create a read replica with the new parameter group applied (recommended).
-
-   1. [Create a read replica](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.Create)
-      of your MySQL database.
-
-   2. [Modify the replica](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
-      and set the following:
-
-      - **DB parameter group**: choose the parameter group you created previously
-      - **Backup retention period**: 7 days
-      - **Public access**: Publicly accessible
-
-   3. Reboot the replica to allow the changes to take effect.
-
-4. Switch to your MySQL client. Run the following commands to create a new user for the capture with appropriate permissions:
+3. Switch to your MySQL client. Run the following commands to create a new user for the capture with appropriate permissions:
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture
@@ -79,15 +63,33 @@ GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
 GRANT SELECT ON *.* TO 'flow_capture';
 ```
 
-5. Run the following command to set the binary log retention to 7 days, the maximum value which RDS MySQL permits:
+4. Run the following command to set the binary log retention to 7 days, the maximum value which RDS MySQL permits:
 
 ```sql
 CALL mysql.rds_set_configuration('binlog retention hours', 168);
 ```
 
-6. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+5. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
 
-### Setting the MySQL time zone
+## Capturing from Read Replicas
+
+This connector supports capturing from a read replica of your database, provided that
+binary logging is enabled on the replica and all other requirements are met. To create
+a read replica:
+
+1. Follow RDS instructions to [create a read replica](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.Create)
+   of your MySQL database.
+
+2. [Modify the replica](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
+   and set the following:
+
+   - **DB parameter group**: the parameter group you created previously
+   - **Backup retention period**: 7 days
+   - **Public access**: Publicly accessible
+
+3. Reboot the replica to allow the changes to take effect.
+
+## Setting the MySQL time zone
 
 MySQL's [`time_zone` server system variable](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_time_zone) is set to `SYSTEM` by default.
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -151,7 +151,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
-| **`/syncMode`**  | Sync mode | Connection method. Always set to `incremental`.                                                                | string | Required         |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.
@@ -178,7 +177,6 @@ captures:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
-          syncMode: incremental
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -123,7 +123,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
-| **`/syncMode`**  | Sync mode | Connection method. Always set to `incremental`.                                                                | string | Required         |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.
@@ -150,7 +149,6 @@ captures:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
-          syncMode: incremental
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -12,10 +12,10 @@ It is available for use in the Flow web application. For local development or op
 
 To use this connector, you'll need a MySQL database setup with the following.
 
-- [`binlog_format`](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format)
-  system variable set to `ROW` (the default value).
-- [Binary log expiration period](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) set to MySQL's default value of 30 days (2592000 seconds) if at all possible.
-  - This value may be set lower if necessary, but we [strongly discourage](#insufficient-binlog-retention) going below 7 days as this may increase the likelihood of unrecoverable failures.
+- The [`binlog_format`](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_format)
+  system variable must be set to `ROW` (the default value).
+- The [binary log expiration period](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds) should be at least 7 days.
+  - This value may be set lower if necessary, but we [discourage](#insufficient-binlog-retention) doing so as this may increase the likelihood of unrecoverable failures.
 - A database user with appropriate permissions:
   - `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges.
   - Permission to read the tables being captured.
@@ -36,7 +36,7 @@ To use this connector, you'll need a MySQL database setup with the following.
       - When you configure your connector as described in the [configuration](#configuration) section above, including the additional `networkTunnel` configuration to enable the SSH tunnel. See [Connecting to endpoints on secure networks](/concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
 
 2. Set the instance's `binlog_expire_logs_seconds` [flag](https://cloud.google.com/sql/docs/mysql/flags?_ga=2.8077298.-1359189752.1655241239&_gac=1.226418280.1655849730.Cj0KCQjw2MWVBhCQARIsAIjbwoOczKklaVaykkUiCMZ4n3_jVtsInpmlugWN92zx6rL5i7zTxm3AALIaAv6nEALw_wcB)
-   to `2592000`.
+   to `2592000` (30 days).
 
 3. Using [Google Cloud Shell](https://cloud.google.com/sql/docs/mysql/connect-instance-cloud-shell) or your preferred client,
    create the `flow_capture` user with replication permission, and the ability to read all tables.
@@ -180,21 +180,21 @@ Resolving this error requires fixing the `binlog_format` system variable, and th
 
 If your capture is failing with an `"unhandled query"` error, some SQL query is present in the binlog which the connector does not (currently) understand.
 
-In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to tear down and recreate the entire capture so that it restarts from a later point in the binlog.
+In general, this error suggests that the connector should be modified to at least recognize this type of query, and most likely categorize it as either an unsupported [DML Query](#data-manipulation-queries), an unsupported [Table Operation](#unsupported-operations), or something that can safely be ignored. Until such a fix is made the capture cannot proceed, and you will need to backfill all collections to allow the capture to jump ahead to a later point in the binlog.
 
 ### Metadata Errors
 
 If your capture is failing with a `"metadata error"` then something has gone badly wrong with the capture's tracking of table metadata, such as column names or datatypes.
 
-This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by removing the offending table(s) from the capture bindings list and then recreating the capture (generally into a new collection, as this process will cause the table to be re-captured in its entirety).
+This should never happen, and most likely means that the MySQL binlog itself is corrupt in some way. If this occurs, it can be resolved by backfilling all collections from the source.
 
 ### Insufficient Binlog Retention
 
-If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MySQL binlog retention period is set to a dangerously low value, and your capture would risk unrecoverable failure if it were paused or the server became unreachable for a nontrivial amount of time, such that the database expired a binlog segment that the capture was still reading from.
+If your capture fails with a `"binlog retention period is too short"` error, it is informing you that the MariaDB binlog retention period is set to a dangerously low value.
 
-(If this were to happen, then change events would be permanently lost and that particular capture would never be able to make progress without potentially producing incorrect data. Thus the capture would need to be torn down and recreated so that each table could be re-captured in its entirety, starting with a complete backfill of current contents.)
+The concern is that if a capture is disabled or the server becomes unreachable for longer than the binlog retention period, the database might delete a binlog segment which the capture isn't yet done with. If this happens then change events have been permanently lost, and the only way to get the capture running again is to skip ahead to a portion of the binlog which still exists. For correctness this requires backfilling the current contents of all tables from the source, and so we prefer to avoid it as much as possible. It's much easier to just set up your binlog retention with enough wiggle room to recover from temporary failures.
 
-The `"binlog retention period is too short"` error should normally be fixed by setting `binlog_expire_logs_seconds = 2592000` as described in the [Prerequisites](#prerequisites) section (and when running on a managed cloud platform additional steps may be required, refer to the managed cloud setup instructions above). However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
+The `"binlog retention period is too short"` error should normally be fixed by setting a longer retention period as described in these setup instructions. However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
 
 ### Empty Collection Key
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -55,7 +55,12 @@ GRANT SELECT ON *.* TO 'flow_capture';
 5. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `3306`.
    Together, you'll use the host:port as the `address` property when you configure the connector.
 
-### Setting the MySQL time zone
+## Capturing from Read Replicas
+
+This connector supports capturing from a read replica of your database, provided that
+binary logging is enabled on the replica and all other requirements are met.
+
+## Setting the MySQL time zone
 
 MySQL's [`time_zone` server system variable](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_time_zone) is set to `SYSTEM` by default.
 


### PR DESCRIPTION
**Description:**

This PR started out as just removing all mentions of watermark tables from our MySQL setup documentation, but then I couldn't help correcting a few other things where the docs were _really_ woefully out of date and/or simply incorrect, most notably softening our stance on binlog retention requirements and removing the bits where we officially recommended using a read replica as part of our RDS docs [1].

This is part of https://github.com/estuary/connectors/issues/1859

**Documentation links affected:**

- https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/
- https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql/
- https://docs.estuary.dev/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql/
- https://docs.estuary.dev/reference/Connectors/capture-connectors/MariaDB/
- https://docs.estuary.dev/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb/

**Notes for reviewers:**

[1] It's a good thing nobody ever reads the documentation, since the RDS instructions as written could never have worked for anyone. It's a bit ironic that I'm removing that recommendation as part of the "make capturing from read replicas possible" work, but really it's just because I haven't touched these docs in some time. My stance as reflected in these documentation changes is that read replicas are something we support and which we may provide cloud-provider-specific instructions for in some cases, but we have no official position on whether somebody should or shouldn't use one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1613)
<!-- Reviewable:end -->
