### PR TITLE
Allow `data_plane_name` column insertions on select tables

### DIFF
--- a/supabase/migrations/61_insert_data_plane_name.sql
+++ b/supabase/migrations/61_insert_data_plane_name.sql
@@ -1,0 +1,8 @@
+begin;
+
+grant insert (draft_id, dry_run, detail, data_plane_name) on publications to authenticated;
+
+grant insert (capture_name, connector_tag_id, data_plane_name, draft_id, endpoint_config, update_only)
+  on discovers to authenticated;
+
+commit;


### PR DESCRIPTION
**Description:**

Extend the insert grant on the `discovers` and `publications` tables by including the `data_plane_name` column. This is a dependency for a feature that will add a data plane selector to client workflows (ref: [issue 1239](https://github.com/estuary/ui/issues/1239)).

**Issues:**

The issues directly below are completely resolved by this PR:
https://github.com/estuary/flow/issues/1620

**Workflow steps:**

Execute a SQL query that inserts a value into the `data_plane_name` column of the `discovers` or `publications` table.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1621)
<!-- Reviewable:end -->
