### PR TITLE
flowctl: Batch draft spec upserts, rather than incorrectly attempting to paginate the response

### DIFF
--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -6,13 +6,9 @@ mod test;
 use crate::{
     api_exec, api_exec_paginated, controlplane,
     output::{to_table_row, CliOutput, JsonCell},
-    pagination::into_items,
 };
 use anyhow::Context;
-use futures::{
-    stream::{FuturesUnordered, StreamExt},
-    TryStreamExt,
-};
+use futures::stream::{FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use models::{CatalogType, RawValue};
 use serde::{Deserialize, Serialize};
@@ -262,7 +258,10 @@ where
                 // not the original builder. And also to clarify that we're not
                 // moving `batch` into the async block.
                 let builder = builder.clone().in_("catalog_name", batch);
-                async move { into_items::<T>(builder).try_collect::<Vec<T>>().await }
+                async move {
+                    // No need for pagination because we're paginating the inputs.
+                    api_exec::<Vec<T>>(builder).await
+                }
             })
             .collect::<FuturesUnordered<_>>();
         let mut rows = Vec::with_capacity(list.name_selector.name.len());
@@ -596,7 +595,7 @@ async fn do_draft(
     };
     tracing::debug!(?draft_spec, "inserting draft");
 
-    let rows: Vec<SpecSummaryItem> = api_exec_paginated(
+    let rows: Vec<SpecSummaryItem> = api_exec(
         ctx.controlplane_client()
             .await?
             .from("draft_specs")

--- a/crates/flowctl/src/pagination.rs
+++ b/crates/flowctl/src/pagination.rs
@@ -121,7 +121,9 @@ where
     ) -> PageTurnerOutput<Self, PaginationRequest> {
         let resp: Vec<Item> = api_exec::<Vec<Item>>(request.builder.clone()).await?;
 
-        if resp.len() == request.page_size
+        // Sometimes, it seems, we can get back more than the requested page size.
+        // So far I've only seen this on a request of 1,000 and a response of 1,001.
+        if resp.len() >= request.page_size
             // If the original builder had a limit set to the same value as page_size
             // this ensures that we stop right at the limit, instead of issuing an extra
             // request for 0 rows.


### PR DESCRIPTION
**Description:**

When pagination was originally introduced, this code-path was incorrectly switched to use it, despite it actually being an upsert which doesn't support pagination

https://github.com/estuary/flow/blob/f618926ccd4344233a9a972da7ec0907fc9c905c/crates/flowctl/src/draft/author.rs#L118-L124

Requests that don't support pagination just straight up ignore the `range` header. That wasn't a problem because the pagination logic only tried to fetch the next page if it got back _exactly_ the number of rows in its requested range:

https://github.com/estuary/flow/blob/f618926ccd4344233a9a972da7ec0907fc9c905c/crates/flowctl/src/pagination.rs#L124

So, this was an extremely rare edge case that would only get hit if you tried to publish exactly 1000 specs. **But**, I noticed that for requests that do respect pagination, sometimes postgrest will actually return one more row than was requested, so I updated this to a `>=` in #1516:

https://github.com/estuary/flow/blob/8c901416cff727bc99ace53af715546347c8a403/crates/flowctl/src/pagination.rs#L124-L126

Before that change is committed, any request that returns more rows than were requested will incorrectly cause pagination to think it has reached the end and result in an incomplete result set being returned. _After_ that change is committed, any attempt to publish >= 1000 specs will sit in an infinite loop attempting to load the next page of a request that doesn't support pagination.

This PR fixes both cases:
* It switches pagination to use `>=` check to correctly load paginated data where PostgREST returns more rows than the requested range
* It switches catalog publishes to batch their _inputs_ and not use pagination when making upsert queries.

### Testing:
Figuring out what was going on here was a bit complicated as the reason I thought my original PR fixed the issue was that I was working ontop of my branch in #1516 that had the pagination fix applied, but not the fix for `flowctl catalog publish`. So, after confirming that my locally-built flowctl is just ontop of this branch `jshearer/batch_drafts`, which is ontop of `master`:

```
$ flowctl catalog pull-specs --captures=true --collections=true --flat --target flow.yaml --prefix test/many_collections
Wrote 1734 specifications under file:///Users/js/Documents/estuary/test/flow.yaml.

$ flowctl catalog publish --source flow.yaml
Created draft: 0e...
Will publish the following 1734 specs:
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────╮
│ Name                                                                                                                            │ Type            │
╞═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╪═════════════════╡
│ test/many_collections/...                                                                                                       │ capture         │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
```
---

Also reverts `--name` back to its previous behavior since pagination doesn't make sense there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1629)
<!-- Reviewable:end -->
