### PR TITLE
flowctl: use max build_id for validating local specs

### DIFF
--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -88,8 +88,8 @@ async fn validate(
     } else {
         build::validate(
             models::Id::new([0xff; 8]), // Must be larger than all real last_pub_id's.
-            models::Id::new([1; 8]),
-            true, // Allow local connectors.
+            models::Id::new([0xff; 8]), // Must be larger than all real last_build_id's.
+            true,                       // Allow local connectors.
             network,
             ops::tracing_log_handler,
             noop_captures,


### PR DESCRIPTION
The validation logic was changed in a prior commit to error if the `last_build_id` of a live spec is greater than the current build id. This change was supposed to go along with that, but got missed. Using the maximum id value ensures that we never get errors due to the build id being superseded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1636)
<!-- Reviewable:end -->
