### PR TITLE
agent: fix materialization sourceCapture updates

### DIFF
--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -365,8 +365,9 @@ impl SourceCaptureStatus {
                 model: Some(model.clone()),
                 is_touch: false, // We intend to update the model
             });
+        // In case the spec was already drafted as a touch operation, ensure it's a regular publication now
+        draft_row.is_touch = false;
 
-        // Failures here are terminal
         update_linked_materialization(
             collection_name_pointer,
             &self.add_bindings,


### PR DESCRIPTION
When updating the materialization spec in response to new bindings on the `sourceCapture`, ensure that `is_touch` is set to false. Otherwise, the publication will fail because the model has been changed.

This fixes a bug where controllers will fail to update the materialization because the publication fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1639)
<!-- Reviewable:end -->
