### PR TITLE
agent: use new pub_id when evolving materializations

### DIFF
--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -89,7 +89,6 @@ impl MaterializationStatus {
 
             if result.status.has_incompatible_collections() {
                 let PublicationResult {
-                    pub_id: publication_id,
                     built,
                     mut detail,
                     mut draft,
@@ -103,6 +102,8 @@ impl MaterializationStatus {
                     .with_maybe_retry(backoff_publication_failure(state.failures))
                     .context("applying evolution actions")?;
 
+                // Always use a new pub_id since we're modifying the model
+                let publication_id = control_plane.next_pub_id();
                 let new_result = control_plane
                     .publish(publication_id, detail, state.logs_token, draft)
                     .await


### PR DESCRIPTION
Ensure that the materialization controller will always use a new publication id when applying onIncompatibleSchemaChange actions. Previously, it would re-use the publication id of the one that had failed. That doesn't work if the failed publication was a "touch" publication. Applying `onIncompatibleSchemaChange` actions modifies the model, and so the publication id must be greater than `last_pub_id`. Generating a new id ensures that is always the case.

Also includes some minor cleanups that didn't make it into the previous pr (#1639) to eliminate the duplicated `is_touch` property in favor of just checking the draft rows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1641)
<!-- Reviewable:end -->
