### PR TITLE
agent: use touch publications for expanded draft specs

### DIFF
--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -18,6 +18,10 @@ use tempfile::tempdir;
 
 const FIXED_DATABASE_URL: &str = "postgresql://postgres:postgres@localhost:5432/postgres";
 
+pub fn set_of(names: &[&str]) -> BTreeSet<String> {
+    names.into_iter().map(|n| n.to_string()).collect()
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)] // Suppress lints for fields used only in test snapshots
 pub struct LiveSpec {

--- a/crates/agent/src/publications/handler.rs
+++ b/crates/agent/src/publications/handler.rs
@@ -201,16 +201,13 @@ impl Publisher {
                 anyhow::bail!("missing spec for expanded row: {:?}", exp.catalog_name);
             };
             let scope = tables::synthetic_scope(spec_type, &exp.catalog_name);
-            // TODO(phil): currently we set `is_touch: false`, which is consistent with the prior
-            // behavior when publishing. It seems to make more sense to only "touch" expanded
-            // specs, but I'm holding off until a subsequent commit.
             if let Err(e) = draft.add_spec(
                 spec_type,
                 &exp.catalog_name,
                 scope,
                 Some(exp.last_pub_id.into()),
                 Some(&model_json),
-                false, // !is_touch
+                true, // is_touch
             ) {
                 draft.errors.push(e);
             }


### PR DESCRIPTION
**Description:**

Touch publications are kind of a perfect fit for expanded specs in user-initiated publications. Expanded specs are never modified by the publication, and it's annoying to add publication specs for things that users haven't intended to publish. Using `is_touch: true` on expanded specs prevents the creation of unnecessary publication specs. It also avoids unnecessary modification of `last_pub_id`, so there will be less chance of `ExpectPubIdMismatch` errors. The touched specs are still validated, which serves the original purpose of spec expansion.

Resolves #1643


**Workflow steps:**

- Create a capture into one or more collections, and a materialization.
- Publish a change to only the collection using flowctl
- Observe that the `last_pub_id` of the capture and materialization have not changed, but the `last_build_id` has
- No `publication_specs` are added for the capture and materialization, only the collection

**Notes for reviewers:**

This is a follow up change from #1629 , which added the "touch" capability. I wanted to break this out as a separate PR just to limit the scope of changes in any one deployment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1645)
<!-- Reviewable:end -->
