### PR TITLE
dekaf: Temporarily disable record LZ4 compression

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -252,7 +252,7 @@ impl Read {
         }
 
         let opts = RecordEncodeOptions {
-            compression: Compression::Lz4,
+            compression: Compression::None,
             version: 2,
         };
         RecordBatchEncoder::encode(&mut buf, records.iter(), &opts)


### PR DESCRIPTION
**Description:**

So, this was crazy. @danthelion reported to me this morning that ClickHouse wasn't able to read from Dekaf. I spent a bunch of time digging into it, and found that long story short, Clickhouse's Kafka consumer was acting as if we were reporting bad data -- issuing a Fetch request, and then throwing the response away and re-issuing a Fetch request for the same offset, over and over.

I initially thought it was related to the change I had made to [treat Flow acks as Kafka control messages](https://github.com/estuary/flow/pull/1516/commits/e127a5c1794ce4935565f9004ea72d7adc19092e), but backing that out had no effect. I tried a bunch of other things unsuccessfully until I finally took a wild guess and disabled LZ4 compression... which immediately completely fixed the problem.

This _isn't_ the first time that client/server compression compatibility has broken Dekaf. I ran into a similar issue before which was fixed [here](https://github.com/tychedelia/kafka-protocol-rs/pull/59), but this time I'm not able to reproduce this issue in any local testing. 

I'd like to get this merged ASAP to unblock the Dekaf release (at least for Clickhouse) happening early next week, but ultimately I intend to make compression configurable as part of a Dekaf-type materialization's endpoint config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1651)
<!-- Reviewable:end -->
