### PR TITLE
dekaf: Swap to `lz4_flex` from `lz4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "itertools 0.10.5",
  "kafka-protocol",
  "labels",
+ "lz4_flex",
  "md5",
  "metrics",
  "metrics-prometheus",
@@ -3293,9 +3294,8 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3201cc84e70fc4e24b0ebf4dac3eb2a8d3460ec3f2b29fd197fa8051fc0db41c"
+version = "0.12.0"
+source = "git+https://github.com/tychedelia/kafka-protocol-rs.git?rev=cabe835#cabe835a9cc87fe8ea64649ff599d96a61e1fb66"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3565,19 +3565,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "a231296ca742e418c43660cb68e082486ff2538e8db432bc818580f3965025ed"
 dependencies = [
- "libc",
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "fcb44a01837a858d47e5a630d2ccf304c8efcc4b83b8f9f75b7a9ee4fcc6e57d"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ flate2 = "1.0"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
-fxhash = "0.2" # Used in `json` crate. Replace with xxhash.
+fxhash = "0.2"                                               # Used in `json` crate. Replace with xxhash.
 hex = "0.4.3"
 hexdump = "0.1"
 humantime = "2.1"
@@ -72,7 +72,9 @@ jemalloc-ctl = "0.3"
 json-patch = "0.3"
 jsonwebtoken = { version = "9", default-features = false }
 js-sys = "0.3.60"
-kafka-protocol = "0.11.0"
+# TODO(jshearer): Swap back after 0.13.0 is released, which includes
+# https://github.com/tychedelia/kafka-protocol-rs/pull/81
+kafka-protocol = { git = "https://github.com/tychedelia/kafka-protocol-rs.git", rev = "cabe835" }
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "0.16.0", default-features = false, features = [
@@ -80,6 +82,7 @@ librocksdb-sys = { version = "0.16.0", default-features = false, features = [
     "rtti",
 ] }
 lz4 = "1.24.0"
+lz4_flex = "0.11.0"
 mime = "0.3"
 memchr = "2.5"
 metrics = "0.23.0"

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -37,6 +37,7 @@ hex = { workspace = true }
 hexdump = { workspace = true }
 itertools = { workspace = true }
 kafka-protocol = { workspace = true }
+lz4_flex = { workspace = true }
 md5 = { workspace = true }
 metrics = { workspace = true }
 metrics-prometheus = { workspace = true }


### PR DESCRIPTION
While investigating the cause of LZ4 compression issues related to franz-go (https://github.com/estuary/flow/pull/1651#issuecomment-2369322939), I found [`lz4_flex`](https://github.com/PSeitz/lz4_flex) which is a pure-Rust lz4 implementation which appears to be safer and faster than `lz4`/`lz4-sys` that `kafka-protocol` is using. 

Now that https://github.com/tychedelia/kafka-protocol-rs/pull/81 allows us to use our own compression, and `lz4`'s configuration of block checksums is broken (fix here https://github.com/10XGenomics/lz4-rs/pull/52), I thought it would be a good time to swap to `lz4_flex`.

I've confirmed that this change _also_ fixes the issue with block checksums, mainly because `lz4_flex`'s block checksums are actually off by default (unfortunately, turning them on reproduces the issue).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1653)
<!-- Reviewable:end -->
