### PR TITLE
dekaf: Refactor to support new agent auth mechanism

### DIFF
--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -17,6 +17,7 @@ doc = { path = "../doc" }
 flowctl = { path = "../flowctl" }
 gazette = { path = "../gazette" }
 labels = { path = "../labels" }
+models = { path = "../models" }
 ops = { path = "../ops" }
 proto-flow = { path = "../proto-flow" }
 proto-gazette = { path = "../proto-gazette" }

--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -40,6 +40,8 @@ async fn all_subjects(
             ..
         } = app.authenticate(auth.username(), auth.password()).await?;
 
+        let client = client.pg_client();
+
         super::fetch_all_collection_names(&client)
             .await
             .context("failed to list collections from the control plane")
@@ -95,7 +97,7 @@ async fn get_subject_latest(
         .with_context(|| format!("collection {collection} does not exist"))?;
 
         let (key_id, value_id) = collection
-            .registered_schema_ids(&client)
+            .registered_schema_ids(&client.pg_client())
             .await
             .context("failed to resolve registered Avro schemas")?;
 

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -31,7 +31,7 @@ struct PendingRead {
 
 pub struct Session {
     app: Arc<App>,
-    client: postgrest::Postgrest,
+    client: Option<flowctl::Client>,
     reads: HashMap<(TopicName, i32), PendingRead>,
     /// ID of the authenticated user
     user_id: Option<String>,
@@ -41,10 +41,9 @@ pub struct Session {
 
 impl Session {
     pub fn new(app: Arc<App>, secret: String) -> Self {
-        let client = app.anon_client.clone();
         Self {
             app,
-            client,
+            client: None,
             reads: HashMap::new(),
             user_id: None,
             config: None,
@@ -87,9 +86,9 @@ impl Session {
                 user_config,
                 claims,
             }) => {
-                self.client = client;
+                self.client.replace(client);
                 self.config.replace(user_config);
-                self.user_id.replace(claims.sub);
+                self.user_id.replace(claims.sub.to_string());
 
                 let mut response = messages::SaslAuthenticateResponse::default();
                 response.session_lifetime_ms = (1000
@@ -144,7 +143,14 @@ impl Session {
     async fn metadata_all_topics(
         &mut self,
     ) -> anyhow::Result<IndexMap<TopicName, MetadataResponseTopic>> {
-        let collections = fetch_all_collection_names(&self.client).await?;
+        let collections = fetch_all_collection_names(
+            &self
+                .client
+                .as_ref()
+                .ok_or(anyhow::anyhow!("Session not authenticated"))?
+                .pg_client(),
+        )
+        .await?;
 
         tracing::debug!(collections=?ops::DebugJson(&collections), "fetched all collections");
 
@@ -170,7 +176,10 @@ impl Session {
         &mut self,
         requests: Vec<messages::metadata_request::MetadataRequestTopic>,
     ) -> anyhow::Result<IndexMap<TopicName, MetadataResponseTopic>> {
-        let client = &self.client;
+        let client = &self
+            .client
+            .as_ref()
+            .ok_or(anyhow::anyhow!("Session not authenticated"))?;
 
         // Concurrently fetch Collection instances for all requested topics.
         let collections: anyhow::Result<Vec<(TopicName, Option<Collection>)>> =
@@ -247,7 +256,10 @@ impl Session {
         &mut self,
         request: messages::ListOffsetsRequest,
     ) -> anyhow::Result<messages::ListOffsetsResponse> {
-        let client = &self.client;
+        let client = &self
+            .client
+            .as_ref()
+            .ok_or(anyhow::anyhow!("Session not authenticated"))?;
 
         // Concurrently fetch Collection instances and offsets for all requested topics and partitions.
         // Map each "topic" into Vec<(Partition Index, Option<(Journal Offset, Timestamp))>.
@@ -342,7 +354,11 @@ impl Session {
             ..
         } = request;
 
-        let client = &self.client;
+        let client = &self
+            .client
+            .as_ref()
+            .ok_or(anyhow::anyhow!("Session not authenticated"))?;
+
         let timeout = tokio::time::sleep(std::time::Duration::from_millis(max_wait_ms as u64));
         let timeout = futures::future::maybe_done(timeout);
         tokio::pin!(timeout);
@@ -370,10 +386,11 @@ impl Session {
                     tracing::debug!(collection = ?&key.0, partition=partition_request.partition, "Partition doesn't exist!");
                     continue; // Partition doesn't exist.
                 };
-                let (key_schema_id, value_schema_id) =
-                    collection.registered_schema_ids(&client).await?;
+                let (key_schema_id, value_schema_id) = collection
+                    .registered_schema_ids(&client.pg_client())
+                    .await?;
 
-                let read = Read::new(
+                let read: Read = Read::new(
                     collection.journal_client.clone(),
                     &collection,
                     partition,

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use flowctl::fetch_collection_authorization;
 use futures::{StreamExt, TryStreamExt};
 use gazette::{broker, journal, uuid};
 use proto_flow::flow;
@@ -50,11 +51,9 @@ pub struct Partition {
 
 impl Collection {
     /// Build a Collection by fetching its spec, a authenticated data-plane access token, and its partitions.
-    pub async fn new(
-        client: &postgrest::Postgrest,
-        collection: &str,
-    ) -> anyhow::Result<Option<Self>> {
+    pub async fn new(client: &flowctl::Client, collection: &str) -> anyhow::Result<Option<Self>> {
         let not_before = uuid::Clock::default();
+        let pg_client = client.pg_client();
 
         // Build a journal client and use it to fetch partitions while concurrently
         // fetching the collection's metadata from the control plane.
@@ -64,7 +63,7 @@ impl Collection {
             Ok((journal_client, partitions))
         };
         let (spec, client_partitions): (anyhow::Result<_>, anyhow::Result<_>) =
-            futures::join!(Self::fetch_spec(&client, collection), client_partitions);
+            futures::join!(Self::fetch_spec(&pg_client, collection), client_partitions);
 
         let Some(spec) = spec? else { return Ok(None) };
         let (journal_client, partitions) = client_partitions?;
@@ -234,43 +233,12 @@ impl Collection {
 
     /// Build a journal client by resolving the collections data-plane gateway and an access token.
     async fn build_journal_client(
-        client: &postgrest::Postgrest,
+        client: &flowctl::Client,
         collection: &str,
     ) -> anyhow::Result<journal::Client> {
-        let body = serde_json::json!({
-            "prefixes": [collection],
-        })
-        .to_string();
+        let (_, journal_client) = fetch_collection_authorization(client, collection).await?;
 
-        #[derive(serde::Deserialize)]
-        struct Auth {
-            token: String,
-            gateway_url: String,
-        }
-
-        let [auth]: [Auth; 1] = client
-            .rpc("gateway_auth_token", body)
-            .build()
-            .send()
-            .await
-            .and_then(|r| r.error_for_status())
-            .context("requesting data plane gateway auth token")?
-            .json()
-            .await?;
-
-        tracing::debug!(
-            collection,
-            gateway = auth.gateway_url,
-            "fetched data-plane token"
-        );
-
-        let mut metadata = gazette::Metadata::default();
-        metadata.bearer_token(&auth.token)?;
-
-        let router = gazette::Router::new("dekaf");
-        let client = journal::Client::new(auth.gateway_url, metadata, router);
-
-        Ok(client)
+        Ok(journal_client)
     }
 
     async fn registered_schema_id(

--- a/crates/flowctl/src/client.rs
+++ b/crates/flowctl/src/client.rs
@@ -1,3 +1,11 @@
+use crate::{
+    api_exec,
+    config::{self, RefreshToken},
+    parse_jwt_claims,
+};
+use anyhow::Context;
+use models::authorizations::ControlClaims;
+
 /// Client encapsulates sub-clients for various control-plane
 /// and data-plane  services that `flowctl` interacts with.
 #[derive(Clone)]
@@ -6,10 +14,14 @@ pub struct Client {
     agent_endpoint: url::Url,
     // HTTP client to use for REST requests.
     http_client: reqwest::Client,
-    // PostgREST client.
-    pg_client: postgrest::Postgrest,
+    // PostgREST URL.
+    pg_url: url::Url,
+    // PostgREST access token.
+    pg_token: String,
     // User's access token, if authenticated.
     user_access_token: Option<String>,
+    // User's refresh token, if authenticated.
+    user_refresh_token: Option<RefreshToken>,
     // Base shard client which is cloned to build token-specific clients.
     shard_client: gazette::shard::Client,
     // Base journal client which is cloned to build token-specific clients.
@@ -19,15 +31,6 @@ pub struct Client {
 impl Client {
     /// Build a new Client from the Config.
     pub fn new(config: &crate::config::Config) -> Self {
-        let user_access_token = config.user_access_token.clone();
-
-        let mut pg_client = postgrest::Postgrest::new(config.get_pg_url().as_str())
-            .insert_header("apikey", config.get_pg_public_token());
-
-        if let Some(token) = user_access_token.as_ref() {
-            pg_client = pg_client.insert_header("Authorization", &format!("Bearer {token}"));
-        }
-
         // Build journal and shard clients with an empty default service address.
         // We'll use their with_endpoint_and_metadata() routines to cheaply clone
         // new clients using dynamic addresses and access tokens, while re-using
@@ -48,19 +51,107 @@ impl Client {
         Self {
             agent_endpoint: config.get_agent_url().clone(),
             http_client: reqwest::Client::new(),
+            pg_token: config.get_pg_public_token().to_owned(),
+            pg_url: config.get_pg_url().to_owned(),
             journal_client,
-            pg_client,
             shard_client,
-            user_access_token,
+            user_access_token: config.user_access_token.clone(),
+            user_refresh_token: config.user_refresh_token.clone(),
         }
     }
 
+    pub async fn refresh(&mut self) -> anyhow::Result<()> {
+        // Clear expired or soon-to-expire access token
+        if let Some(_) = &self.user_access_token {
+            let claims = self.claims()?;
+
+            let now = time::OffsetDateTime::now_utc();
+            let exp = time::OffsetDateTime::from_unix_timestamp(claims.exp as i64).unwrap();
+
+            // Refresh access tokens with plenty of time to spare if we have a
+            // refresh token. If not, allow refreshing right until the token expires
+            match ((now - exp).whole_seconds(), &self.user_refresh_token) {
+                (exp_seconds, Some(_)) if exp_seconds < 60 => self.user_access_token = None,
+                (exp_seconds, None) if exp_seconds <= 0 => self.user_access_token = None,
+                _ => {}
+            }
+        }
+
+        if self.user_access_token.is_some() && self.user_refresh_token.is_some() {
+            // Authorization is current: nothing to do.
+            Ok(())
+        } else if self.user_access_token.is_some() {
+            // We have an access token but no refresh token. Create one.
+            let refresh_token = api_exec::<config::RefreshToken>(
+                self.rpc(
+                    "create_refresh_token",
+                    serde_json::json!({"multi_use": true, "valid_for": "90d", "detail": "Created by flowctl"})
+                        .to_string(),
+                ),
+            )
+            .await?;
+
+            self.user_refresh_token = Some(refresh_token);
+
+            tracing::info!("created new refresh token");
+            Ok(())
+        } else if let Some(config::RefreshToken { id, secret }) = &self.user_refresh_token {
+            // We have a refresh token but no access token. Generate one.
+
+            #[derive(serde::Deserialize)]
+            struct Response {
+                access_token: String,
+                refresh_token: Option<config::RefreshToken>, // Set iff the token was single-use.
+            }
+            let Response {
+                access_token,
+                refresh_token: next_refresh_token,
+            } = api_exec::<Response>(self.rpc(
+                "generate_access_token",
+                serde_json::json!({"refresh_token_id": id, "secret": secret}).to_string(),
+            ))
+            .await
+            .context("failed to obtain access token")?;
+
+            if next_refresh_token.is_some() {
+                self.user_refresh_token = next_refresh_token;
+            }
+
+            self.user_access_token = Some(access_token);
+
+            tracing::info!("generated a new access token");
+            Ok(())
+        } else {
+            anyhow::bail!("Client not authenticated");
+        }
+    }
+
+    pub fn pg_client(&self) -> postgrest::Postgrest {
+        let pg_client = postgrest::Postgrest::new(self.pg_url.as_str())
+            .insert_header("apikey", self.pg_token.as_str());
+
+        if let Some(token) = &self.user_access_token {
+            return pg_client.insert_header("Authorization", &format!("Bearer {token}"));
+        }
+
+        pg_client
+    }
+
+    pub fn claims(&self) -> anyhow::Result<ControlClaims> {
+        parse_jwt_claims(
+            self.user_access_token
+                .as_ref()
+                .ok_or(anyhow::anyhow!("Client is not authenticated"))?
+                .as_str(),
+        )
+    }
+
     pub fn from(&self, table: &str) -> postgrest::Builder {
-        self.pg_client.from(table)
+        self.pg_client().from(table)
     }
 
     pub fn rpc(&self, function: &str, params: String) -> postgrest::Builder {
-        self.pg_client.rpc(function, params)
+        self.pg_client().rpc(function, params)
     }
 
     pub fn is_authenticated(&self) -> bool {

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -40,7 +40,7 @@ pub struct Config {
     api: Option<DeprecatedAPISection>,
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct RefreshToken {
     pub id: models::Id,
     pub secret: String,
@@ -158,6 +158,22 @@ impl Config {
         config.is_local = profile == "local";
 
         Ok(config)
+    }
+
+    pub fn from_refresh_token(refresh_token: &str) -> anyhow::Result<Self> {
+        Ok(Self {
+            agent_url: None,
+            dashboard_url: None,
+            draft: None,
+            pg_public_token: None,
+            pg_url: None,
+            user_access_token: None,
+            user_refresh_token: Some(
+                serde_json::from_str(refresh_token).context("Invalid refresh token")?,
+            ),
+            is_local: false,
+            api: None,
+        })
     }
 
     /// Write the config to the file corresponding to the given named `profile`.


### PR DESCRIPTION
This updates Dekaf to use `flowctl::Client`'s support for generating `gazette` clients using the new agent's `/authorize/user/collection` API. Draft because we're still talking about where this client should ultimately live.

Once #1642 is merged, will change base to master.
Fixes #1657

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1663)
<!-- Reviewable:end -->
