### PR TITLE
agent: fix pub status incompatible_collections

### DIFF
--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -457,7 +457,6 @@ mod test {
     use std::collections::{BTreeSet, VecDeque};
 
     use chrono::TimeZone;
-    use models::Capture;
 
     use super::*;
     use crate::controllers::materialization::SourceCaptureStatus;
@@ -486,6 +485,7 @@ mod test {
                         field: "a_field".to_string(),
                         reason: "do not like".to_string(),
                     }],
+                    resource_path: vec!["water".to_string()],
                 }],
             }])),
             errors: vec![Error {

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__materialization-status-round-trip.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__materialization-status-round-trip.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/agent/src/controllers/mod.rs
-expression: "StatusSnapshot { starting: status, json: as_json, parsed: round_tripped, }"
+expression: "StatusSnapshot { starting: status, json: as_json, parsed: round_tripped }"
 ---
 StatusSnapshot {
     starting: Materialization(
@@ -47,6 +47,9 @@ StatusSnapshot {
                                                         reason: "do not like",
                                                     },
                                                 ],
+                                                resource_path: [
+                                                    "water",
+                                                ],
                                             },
                                         ],
                                     },
@@ -73,7 +76,7 @@ StatusSnapshot {
             },
         },
     ),
-    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"dependency_hash\": \"abc12345\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\",\n          \"incompatible_collections\": [\n            {\n              \"collection\": \"snails/water\",\n              \"affected_materializations\": [\n                {\n                  \"name\": \"snails/materialize\",\n                  \"fields\": [\n                    {\n                      \"field\": \"a_field\",\n                      \"reason\": \"do not like\"\n                    }\n                  ]\n                }\n              ]\n            }\n          ]\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\"\n  }\n}",
+    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"dependency_hash\": \"abc12345\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\",\n          \"incompatible_collections\": [\n            {\n              \"collection\": \"snails/water\",\n              \"affected_materializations\": [\n                {\n                  \"name\": \"snails/materialize\",\n                  \"fields\": [\n                    {\n                      \"field\": \"a_field\",\n                      \"reason\": \"do not like\"\n                    }\n                  ],\n                  \"resource_path\": [\n                    \"water\"\n                  ]\n                }\n              ]\n            }\n          ]\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\"\n  }\n}",
     parsed: Materialization(
         MaterializationStatus {
             source_capture: Some(
@@ -117,6 +120,9 @@ StatusSnapshot {
                                                         field: "a_field",
                                                         reason: "do not like",
                                                     },
+                                                ],
+                                                resource_path: [
+                                                    "water",
                                                 ],
                                             },
                                         ],

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__status_json_schema.snap
@@ -25,6 +25,13 @@ expression: schema
         },
         "name": {
           "type": "string"
+        },
+        "resource_path": {
+          "description": "Identifies the specific binding that is affected. This can be used to differentiate in cases there are multiple bindings with the same source.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [


### PR DESCRIPTION
The `incompatible_collections` field on the publication `job_status` was not correctly accounting for disabled bindings, which caused it to output incorrect collection names in some cases. This corrects that.

Additionally, the `resource_path` of affected bindings was added to the `AffectedConsumer` struct, so that we can identify specific bindings in cases where there are multiple bindings with the same source collection. In the future, we can enhance `evolutions` to identify bindings by resource path instead of collection name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1683)
<!-- Reviewable:end -->
