### PR TITLE
agent: add built specs to draft (bugfix)

### DIFF
--- a/crates/agent/src/publications/handler.rs
+++ b/crates/agent/src/publications/handler.rs
@@ -42,6 +42,11 @@ impl Handler for Publisher {
 
             let (status, draft_errors, final_pub_id) = match self.process(row).await {
                 Ok(result) => {
+                    if dry_run {
+                        specs::add_built_specs_to_draft_specs(draft_id, &result.built, &self.db)
+                            .await
+                            .context("adding built specs to draft")?;
+                    }
                     let errors = result.draft_errors();
                     let final_id = if result.status.is_success() {
                         Some(result.pub_id)


### PR DESCRIPTION
Fixes a bug that was introduced during the publciations refactor, where the `built` and `validated` columns of `draft_specs` were no longer populated after a `dry_run` publication. This adds that back in, so that the "Field Selection" UI will work again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1687)
<!-- Reviewable:end -->
