### PR TITLE
agent: setup rustls CryptoProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "regex",
  "reqwest",
  "runtime",
+ "rustls 0.23.10",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -49,6 +49,7 @@ lazy_static = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -51,6 +51,12 @@ struct Args {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    // Required in order for libraries to use `rustls` for TLS.
+    // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install default crypto provider");
+
     // Use reasonable defaults for printing structured logs to stderr.
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())


### PR DESCRIPTION
Fixes a crash in `agent` due to missing a `CryptoProvider` for `rustls` TLS connections.

I was able to reproduce this locally, and confirmed that the fix is working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1688)
<!-- Reviewable:end -->
