### PR TITLE
dekaf: Always make sure we're using fresh tokens

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -57,7 +57,7 @@ pub struct Authenticated {
 }
 
 impl Authenticated {
-    pub async fn get_client(&mut self) -> anyhow::Result<&flow_client::Client> {
+    pub async fn authenticated_client(&mut self) -> anyhow::Result<&flow_client::Client> {
         let (access, refresh) = refresh_authorizations(
             &self.client,
             Some(self.access_token.to_owned()),
@@ -65,7 +65,7 @@ impl Authenticated {
         )
         .await?;
 
-        if access.ne(&self.access_token) {
+        if access != self.access_token {
             self.access_token = access.clone();
             self.refresh_token = refresh;
 

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -144,7 +144,6 @@ async fn main() -> anyhow::Result<()> {
             api_key,
             api_endpoint,
             None,
-            None
         )
     });
 

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -139,7 +139,7 @@ impl Session {
                 .auth
                 .as_mut()
                 .ok_or(anyhow::anyhow!("Session not authenticated"))?
-                .get_client()
+                .authenticated_client()
                 .await?
                 .pg_client(),
         )
@@ -173,7 +173,7 @@ impl Session {
             .auth
             .as_mut()
             .ok_or(anyhow::anyhow!("Session not authenticated"))?
-            .get_client()
+            .authenticated_client()
             .await?;
 
         // Concurrently fetch Collection instances for all requested topics.
@@ -260,7 +260,7 @@ impl Session {
             .auth
             .as_mut()
             .ok_or(anyhow::anyhow!("Session not authenticated"))?
-            .get_client()
+            .authenticated_client()
             .await?;
 
         // Concurrently fetch Collection instances and offsets for all requested topics and partitions.
@@ -360,7 +360,7 @@ impl Session {
             .auth
             .as_mut()
             .ok_or(anyhow::anyhow!("Session not authenticated"))?
-            .get_client()
+            .authenticated_client()
             .await?;
 
         let timeout_at =

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -13,8 +13,6 @@ pub struct Client {
     http_client: reqwest::Client,
     // User's access token, if authenticated.
     user_access_token: Option<String>,
-    // User's refresh token, if authenticated.
-    user_refresh_token: Option<RefreshToken>,
     // Base shard client which is cloned to build token-specific clients.
     shard_client: gazette::shard::Client,
     // Base journal client which is cloned to build token-specific clients.
@@ -32,7 +30,6 @@ impl Client {
         pg_api_token: String,
         pg_url: Url,
         user_access_token: Option<String>,
-        user_refresh_token: Option<RefreshToken>,
     ) -> Self {
         // Build journal and shard clients with an empty default service address.
         // We'll use their with_endpoint_and_metadata() routines to cheaply clone
@@ -59,18 +56,12 @@ impl Client {
             journal_client,
             shard_client,
             user_access_token,
-            user_refresh_token,
         }
     }
 
-    pub fn with_creds(
-        self,
-        user_access_token: Option<String>,
-        user_refresh_token: Option<RefreshToken>,
-    ) -> Self {
+    pub fn with_creds(self, user_access_token: Option<String>) -> Self {
         Self {
             user_access_token: user_access_token.or(self.user_access_token),
-            user_refresh_token: user_refresh_token.or(self.user_refresh_token),
             ..self
         }
     }

--- a/crates/flowctl/src/config.rs
+++ b/crates/flowctl/src/config.rs
@@ -187,7 +187,6 @@ impl Config {
             self.get_pg_public_token().to_string(),
             self.get_pg_url().clone(),
             None,
-            None,
         )
     }
 

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -147,7 +147,7 @@ impl Cli {
             config.user_access_token = Some(access.to_owned());
             config.user_refresh_token = Some(refresh.to_owned());
 
-            anon_client.with_creds(Some(access), Some(refresh))
+            anon_client.with_creds(Some(access))
         } else {
             tracing::warn!("You are not authenticated. Run `auth login` to login to Flow.");
             anon_client


### PR DESCRIPTION
I was noticing a bunch of `ExpiredSignature` errors, and realized that if a client didn't close its connection on read errors (which it appears is sometimes the case), a new access token would never get created. This ensures that every time we get a `flow_client::Client`, we call `refresh_authorizations()` to make sure it's using valid tokens. This is cheap in the common case that the tokens aren't expired.

Also removes refresh token from `flow_client::Client`, as refreshing is a concern that should live outside of the Client (and indeed, `refresh_token` was no longer user anywhere).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1689)
<!-- Reviewable:end -->
