### PR TITLE
flowctl: initialize rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,7 @@ dependencies = [
  "reqwest",
  "runtime",
  "rusqlite",
+ "rustls 0.23.10",
  "rustyline",
  "serde",
  "serde-transcode",

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -53,6 +53,7 @@ postgrest = { workspace = true }
 prost = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
+rustls = { workspace = true }
 rustyline = { workspace = true }
 serde = { workspace = true }
 serde-transcode = { workspace = true }

--- a/crates/flowctl/src/main.rs
+++ b/crates/flowctl/src/main.rs
@@ -4,6 +4,12 @@ use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 fn main() -> Result<(), anyhow::Error> {
     let cli = flowctl::Cli::parse();
 
+    // Required in order for libraries to use `rustls` for TLS.
+    // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install default crypto provider");
+
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::WARN.into()) // Otherwise it's ERROR.
         .from_env_lossy();


### PR DESCRIPTION
Add the required initialization for the `rustls` crypto provider to the beginning of the agent main function, so that TLS will work again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1692)
<!-- Reviewable:end -->
