### PR TITLE
dekaf: Fix `Fetch` encoding issue for some versions of librdkafka

### DIFF
--- a/.github/workflows/dekaf.yaml
+++ b/.github/workflows/dekaf.yaml
@@ -14,8 +14,8 @@ on:
       - "Cargo.lock"
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+  build-dekaf:
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/crates/dekaf/Dockerfile
+++ b/crates/dekaf/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 WORKDIR /app
 COPY dekaf-bin /dekaf
 RUN --mount=type=cache,target=/var/cache/apt \


### PR DESCRIPTION
I wrongly assumed that `kafka-protocol` would do the right thing when passing `None` to a fetch response's records. It appears that it encodes this with a length of `-1`, but I found that caused issues when testing locally:

```
Protocol parse failure for Fetch v11 ... invalid MessageSetSize -1
```

It still reads documents when the chunk returns some, but otherwise it logs that error frequently. This fixes it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1693)
<!-- Reviewable:end -->
