### PR TITLE
validation: add inferred schema placeholder if needed

### DIFF
--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -102,11 +102,8 @@ fn walk_collection(
 
             // Potentially extend the user's read schema with definitions
             // for the collection's current write schema.
-            let read_bundle = if model_read_schema.references_write_schema() {
-                models::Schema::bundle_write_schema_def(model_read_schema, model_write_schema)
-            } else {
-                model_read_schema.clone()
-            };
+            let read_bundle =
+                models::Schema::build_read_schema_bundle(model_read_schema, model_write_schema);
 
             let read_schema =
                 walk_collection_schema(scope.push_prop("readSchema"), &read_bundle, errors);


### PR DESCRIPTION
This fixes a bug in `flowctl`, where it would fail to load catalog specs that were missing an inlined `flow://inferred-schema` definition.

Commit 7190b42faf made the agent update collection inferred schemas as part of the initialization of a draft publication instead of updating the inferred schema as part of validation. Unfortunately, validation is called in other contexts as well, such as `flowctl::local_specs`, where it would be undesirable to have the caller need to inject the inferred schema placeholder. So this adds the inlining of the inferred schema back into the `validation` crate, but only in cases where there isn't already an existing `$defs` entry for it. In other words, it will only ever inject the placeholder, and only if necessary in order to resolve references within the schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1698)
<!-- Reviewable:end -->
