### PR TITLE
flowctl: build using clang instead of gcc

### DIFF
--- a/.github/workflows/flowctl-release.yaml
+++ b/.github/workflows/flowctl-release.yaml
@@ -33,6 +33,9 @@ jobs:
       # Linux build steps:
       - name: Build Linux
         if: matrix.config.os == 'ubuntu-20.04'
+        env:
+          CC: clang
+          CXX: clang++
         run: |-
           cargo build -p flowctl --release && mv target/release/flowctl ${ASSET_NAME}
 


### PR DESCRIPTION
Switches to using clang instead of GCC in order to work around a compilation error in one of our dependencies, which is due to a bug in GCC 9. See:
https://github.com/rustls/rustls/issues/1967

Unfortunately, I can't think of a way to test this locally, since there's no way to pull the github runner image. I think we'll just need to merge and try the release again and see whether it works :grimacing:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1699)
<!-- Reviewable:end -->
