### PR TITLE
dekaf: Detect and handle requests for documents in a limited range directly before the write-head of a collection

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -194,6 +194,7 @@ async fn handle_api(
             // https://github.com/confluentinc/librdkafka/blob/e03d3bb91ed92a38f38d9806b8d8deffe78a1de5/src/rdkafka_request.c#L2823
             let (header, request) = dec_request(frame, version)?;
             tracing::debug!(client_id=?header.client_id, "Got client ID!");
+            session.client_id = header.client_id.clone().map(|id| id.to_string());
             Ok(enc_resp(out, &header, session.api_versions(request).await?))
         }
         ApiKey::SaslHandshakeKey => {

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -12,16 +12,12 @@ use futures::{FutureExt, TryStreamExt};
 use rsasl::config::SASLConfig;
 use rustls::pki_types::CertificateDer;
 use std::{
-    collections::HashMap,
     fs::File,
     io,
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
-    sync::RwLock,
-};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 use url::Url;
 

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -117,8 +117,6 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     tracing::info!("Starting dekaf");
 
-    let offset_map = Arc::new(RwLock::new(HashMap::new()));
-
     let (api_endpoint, api_key) = if cli.local {
         (LOCAL_PG_URL.to_owned(), LOCAL_PG_PUBLIC_TOKEN.to_string())
     } else {
@@ -225,7 +223,7 @@ async fn main() -> anyhow::Result<()> {
                         continue
                     };
 
-                    tokio::spawn(serve(Session::new(app.clone(), cli.encryption_secret.to_owned(), offset_map.clone()), socket, addr, stop.clone()));
+                    tokio::spawn(serve(Session::new(app.clone(), cli.encryption_secret.to_owned()), socket, addr, stop.clone()));
                 }
                 _ = &mut stop => break,
             }
@@ -246,7 +244,7 @@ async fn main() -> anyhow::Result<()> {
                     };
                     socket.set_nodelay(true)?;
 
-                    tokio::spawn(serve(Session::new(app.clone(), cli.encryption_secret.to_owned(), offset_map.clone()), socket, addr, stop.clone()));
+                    tokio::spawn(serve(Session::new(app.clone(), cli.encryption_secret.to_owned()), socket, addr, stop.clone()));
                 }
                 _ = &mut stop => break,
             }

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -23,7 +23,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     time::{SystemTime, UNIX_EPOCH},
 };
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration, cmp::max};
 use tracing::instrument;
 
 struct PendingRead {
@@ -491,7 +491,10 @@ impl Session {
                                     Some(partition_request.fetch_offset - 1),
                                 )
                                 .next_batch(
-                                    crate::read::ReadTarget::Docs(diff as usize + 1),
+                                    // Have to read at least 2 docs, as the very last doc
+                                    // will probably be a control document and will be
+                                    // ignored by the consumer, looking like 0 docs were read
+                                    crate::read::ReadTarget::Docs(max(diff as usize, 2)),
                                     std::time::Instant::now() + timeout,
                                 ),
                             )

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1261,7 +1261,9 @@ impl Session {
             .fetch_partition_offset(partition as usize, -1)
             .await?
         {
-            if latest_offset - fetch_offset < 13 {
+            // If fetch_offset is > latest_offset, this is a caught-up consumer
+            // polling for new documents, not a data preview request.
+            if fetch_offset <= latest_offset && latest_offset - fetch_offset < 13 {
                 tracing::debug!(
                     latest_offset,
                     diff = latest_offset - fetch_offset,

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1,10 +1,12 @@
 use super::{App, Collection, Read};
 use crate::{
-    from_downstream_topic_name, from_upstream_topic_name, read::BatchResult,
-    to_downstream_topic_name, to_upstream_topic_name, topology::fetch_all_collection_names,
+    from_downstream_topic_name, from_upstream_topic_name,
+    read::BatchResult,
+    to_downstream_topic_name, to_upstream_topic_name,
+    topology::{fetch_all_collection_names, PartitionOffset},
     Authenticated,
 };
-use anyhow::Context;
+use anyhow::{bail, Context};
 use bytes::{BufMut, Bytes, BytesMut};
 use kafka_protocol::{
     error::{ParseResponseErrorCode, ResponseError},
@@ -18,10 +20,7 @@ use kafka_protocol::{
     protocol::{buf::ByteBuf, Decodable, Encodable, Message, StrBytes},
 };
 use std::{
-    collections::{
-        hash_map::{Entry, OccupiedEntry},
-        HashMap,
-    },
+    collections::{hash_map::Entry, HashMap},
     time::{SystemTime, UNIX_EPOCH},
 };
 use std::{sync::Arc, time::Duration};
@@ -33,12 +32,19 @@ struct PendingRead {
     handle: tokio_util::task::AbortOnDropHandle<anyhow::Result<(Read, BatchResult)>>,
 }
 
+#[derive(Clone, Debug)]
+enum SessionDataPreviewState {
+    Unknown,
+    NotDataPreview,
+    DataPreview(HashMap<(TopicName, i32), PartitionOffset>),
+}
+
 pub struct Session {
     app: Arc<App>,
     reads: HashMap<(TopicName, i32), PendingRead>,
     secret: String,
     auth: Option<Authenticated>,
-    data_preview_offsets: HashMap<(TopicName, i32), Option<(i64, i64)>>,
+    data_preview_state: SessionDataPreviewState,
     pub client_id: Option<String>,
 }
 
@@ -50,7 +56,7 @@ impl Session {
             auth: None,
             secret,
             client_id: None,
-            data_preview_offsets: HashMap::new(),
+            data_preview_state: SessionDataPreviewState::Unknown,
         }
     }
 
@@ -271,48 +277,46 @@ impl Session {
             .await?;
 
         // Concurrently fetch Collection instances and offsets for all requested topics and partitions.
-        // Map each "topic" into Vec<(Partition Index, Option<(Journal Offset, Timestamp))>.
-        let collections: anyhow::Result<
-            Vec<(TopicName, Vec<(i32, i64, Option<(i64, i64, i64)>)>)>,
-        > = futures::future::try_join_all(request.topics.into_iter().map(|topic| async move {
-            let maybe_collection = Collection::new(
-                client,
-                from_downstream_topic_name(topic.name.clone()).as_str(),
-            )
-            .await?;
+        // Map each "topic" into Vec<(Partition Index, Option<PartitionOffset>.
+        let collections: anyhow::Result<Vec<(TopicName, Vec<(i32, Option<PartitionOffset>)>)>> =
+            futures::future::try_join_all(request.topics.into_iter().map(|topic| async move {
+                let maybe_collection = Collection::new(
+                    client,
+                    from_downstream_topic_name(topic.name.clone()).as_str(),
+                )
+                .await?;
 
-            let Some(collection) = maybe_collection else {
-                return Ok((
-                    topic.name,
-                    topic
-                        .partitions
-                        .iter()
-                        .map(|p| (p.partition_index, p.timestamp, None))
-                        .collect(),
-                ));
-            };
-            let collection = &collection;
+                let Some(collection) = maybe_collection else {
+                    return Ok((
+                        topic.name,
+                        topic
+                            .partitions
+                            .iter()
+                            .map(|p| (p.partition_index, None))
+                            .collect(),
+                    ));
+                };
+                let collection = &collection;
 
-            // Concurrently fetch requested offset for each named partition.
-            let offsets: anyhow::Result<_> = futures::future::try_join_all(
-                topic.partitions.into_iter().map(|partition| async move {
-                    Ok((
-                        partition.partition_index,
-                        partition.timestamp,
-                        collection
-                            .fetch_partition_offset(
-                                partition.partition_index as usize,
-                                partition.timestamp, // In millis.
-                            )
-                            .await?,
-                    ))
-                }),
-            )
+                // Concurrently fetch requested offset for each named partition.
+                let offsets: anyhow::Result<_> = futures::future::try_join_all(
+                    topic.partitions.into_iter().map(|partition| async move {
+                        Ok((
+                            partition.partition_index,
+                            collection
+                                .fetch_partition_offset(
+                                    partition.partition_index as usize,
+                                    partition.timestamp, // In millis.
+                                )
+                                .await?,
+                        ))
+                    }),
+                )
+                .await;
+
+                Ok((topic.name, offsets?))
+            }))
             .await;
-
-            Ok((topic.name, offsets?))
-        }))
-        .await;
 
         let collections = collections?;
 
@@ -326,8 +330,13 @@ impl Session {
             .map(|(topic_name, offsets)| {
                 let partitions = offsets
                     .into_iter()
-                    .map(|(partition_index, request_timestamp, maybe_offset)| {
-                        let Some((offset, fragment_start, timestamp)) = maybe_offset else {
+                    .map(|(partition_index, maybe_offset)| {
+                        let Some(PartitionOffset {
+                            offset,
+                            mod_time: timestamp,
+                            ..
+                        }) = maybe_offset
+                        else {
                             return ListOffsetsPartitionResponse::default()
                                 .with_partition_index(partition_index)
                                 .with_error_code(ResponseError::UnknownTopicOrPartition.code());
@@ -376,7 +385,8 @@ impl Session {
             .as_mut()
             .ok_or(anyhow::anyhow!("Session not authenticated"))?
             .authenticated_client()
-            .await?;
+            .await?
+            .clone();
 
         let timeout = std::time::Duration::from_millis(max_wait_ms as u64);
 
@@ -388,42 +398,56 @@ impl Session {
                 key.1 = partition_request.partition;
                 let fetch_offset = partition_request.fetch_offset;
 
-                let data_preview_params: Option<(i64, i64)> = match self
-                    .data_preview_offsets
-                    .entry(key.to_owned())
+                let data_preview_params: Option<PartitionOffset> = match self
+                    .data_preview_state
+                    .to_owned()
                 {
-                    Entry::Occupied(entry) => match entry.get() {
-                        Some((offset, fragment_start)) => {
-                            tracing::debug!(collection=?key.0,partition=key.1, offset, fragment_start, fetch_offset, "Session already marked as data-preview for this partition");
-                            Some((*offset, *fragment_start))
-                        }
-                        None => {
-                            tracing::debug!(collection=?key.0,partition=key.1, "Session already marked as not data-preview for this partition");
-                            None
-                        }
-                    },
-                    Entry::Vacant(entry) => {
-                        tracing::debug!(collection=?key.0,partition=key.1, fetch_offset,"Loading latest offset for this partition to check if session is data-preview");
-                        let collection = Collection::new(&client, key.0.as_str())
-                            .await?
-                            .ok_or(anyhow::anyhow!("Collection {} not found", key.0.as_str()))?;
-
-                        if let Some((latest_offset, fragment_start, _)) = collection
-                            .fetch_partition_offset(key.1 as usize, -1)
+                    // On the first Fetch call, check to see whether it is considered a data-preview
+                    // fetch or not. If so, flag the whole session as being tainted, and also keep track
+                    // of the neccesary offset data in order to serve the rewritten data preview responses.
+                    SessionDataPreviewState::Unknown => {
+                        if let Some(state) = self
+                            .is_fetch_data_preview(key.0.to_string(), key.1, fetch_offset)
                             .await?
                         {
-                            if latest_offset - fetch_offset < 13 {
-                                tracing::debug!(collection=?key.0,partition=key.1, fetch_offset, latest_offset, diff=latest_offset - fetch_offset, "Marking session as data-preview for this partition");
-                                let diff = Some((latest_offset, fragment_start));
-                                entry.insert(diff);
-                                diff
-                            } else {
-                                tracing::debug!(collection=?key.0,partition=key.1, fetch_offset, latest_offset, diff=latest_offset - fetch_offset, "Marking session as not data-preview for this partition");
-                                entry.insert(None);
-                                None
-                            }
+                            let mut data_preview_state = HashMap::new();
+                            data_preview_state.insert(key.to_owned(), state);
+                            self.data_preview_state =
+                                SessionDataPreviewState::DataPreview(data_preview_state);
+                            Some(state)
                         } else {
+                            self.data_preview_state = SessionDataPreviewState::NotDataPreview;
                             None
+                        }
+                    }
+                    // If the first Fetch request in a session was not considered for data preview,
+                    // then skip all further checks in order to avoid slowing down fetches.
+                    SessionDataPreviewState::NotDataPreview => None,
+                    SessionDataPreviewState::DataPreview(mut state) => {
+                        match state.entry(key.to_owned()) {
+                            // If a session is marked as being used for data preview, and this Fetch request
+                            // is for a topic/partition that we've already loaded the offsets for, re-use them
+                            // so long as the request is still a data preview request. If not, bail out
+                            Entry::Occupied(entry) => {
+                                let data_preview_state = entry.get();
+                                if data_preview_state.offset - fetch_offset > 12 {
+                                    bail!("Session was used for fetching preview data, cannot be used for fetching non-preview data.")
+                                }
+                                Some(data_preview_state.to_owned())
+                            }
+                            // Otherwise, load the offsets for this new topic/partition, and also ensure that this is
+                            // still a data-preview request. If not, bail out.
+                            Entry::Vacant(entry) => {
+                                if let Some(state) = self
+                                    .is_fetch_data_preview(key.0.to_string(), key.1, fetch_offset)
+                                    .await?
+                                {
+                                    entry.insert(state);
+                                    Some(state)
+                                } else {
+                                    bail!("Session was used for fetching preview data, cannot be used for fetching non-preview data.")
+                                }
+                            }
                         }
                     }
                 };
@@ -431,7 +455,7 @@ impl Session {
                 if matches!(self.reads.get(&key), Some(pending) if pending.offset == fetch_offset) {
                     continue; // Common case: fetch is at the pending offset.
                 }
-                let Some(collection) = Collection::new(client, &key.0).await? else {
+                let Some(collection) = Collection::new(&client, &key.0).await? else {
                     tracing::debug!(collection = ?&key.0, "Collection doesn't exist!");
                     continue; // Collection doesn't exist.
                 };
@@ -450,9 +474,11 @@ impl Session {
                     last_write_head: fetch_offset,
                     handle: tokio_util::task::AbortOnDropHandle::new(match data_preview_params {
                         // Startree: 0, Tinybird: 12
-                        Some((latest_offset, fragment_start))
-                            if latest_offset - fetch_offset <= 12 =>
-                        {
+                        Some(PartitionOffset {
+                            fragment_start,
+                            offset: latest_offset,
+                            ..
+                        }) if latest_offset - fetch_offset <= 12 => {
                             let diff = latest_offset - fetch_offset;
                             tokio::spawn(
                                 Read::new(
@@ -1200,6 +1226,59 @@ impl Session {
             to_downstream_topic_name(TopicName(StrBytes::from_string(name)))
         } else {
             TopicName(StrBytes::from_string(name))
+        }
+    }
+
+    /// If the fetched offset is within a fixed number of offsets from the end of the journal,
+    /// return Some with a PartitionOffset containing the beginning and end of the latest fragment.
+    #[tracing::instrument(skip(self))]
+    async fn is_fetch_data_preview(
+        &mut self,
+        collection_name: String,
+        partition: i32,
+        fetch_offset: i64,
+    ) -> anyhow::Result<Option<PartitionOffset>> {
+        let client = self
+            .auth
+            .as_mut()
+            .ok_or(anyhow::anyhow!("Session not authenticated"))?
+            .authenticated_client()
+            .await?;
+
+        tracing::debug!(
+            "Loading latest offset for this partition to check if session is data-preview"
+        );
+        let collection = Collection::new(&client, collection_name.as_str())
+            .await?
+            .ok_or(anyhow::anyhow!("Collection {} not found", collection_name))?;
+
+        if let Some(
+            partition_offset @ PartitionOffset {
+                offset: latest_offset,
+                ..
+            },
+        ) = collection
+            .fetch_partition_offset(partition as usize, -1)
+            .await?
+        {
+            if latest_offset - fetch_offset < 13 {
+                tracing::debug!(
+                    latest_offset,
+                    diff = latest_offset - fetch_offset,
+                    "Marking session as data-preview"
+                );
+                Ok(Some(partition_offset))
+            } else {
+                tracing::debug!(
+                    fetch_offset,
+                    latest_offset,
+                    diff = latest_offset - fetch_offset,
+                    "Marking session as non-data-preview"
+                );
+                Ok(None)
+            }
+        } else {
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
**Background:**

Dekaf fetches documents by reading bytes from a Gazette journal starting at the requested Kafka offset., skipping past partial documents if the requested offset is not on a document boundary. On the other hand, it returns records with their offsets pointing at the _last_ inclusive byte in a document for a couple of good reasons:
https://github.com/estuary/flow/blob/7780a8488ddaab40d517346393dc7a9f1cd828b3/crates/dekaf/src/read.rs#L247-L260

Unfortunately, this breaks a (surprisingly not very important) assumption inherent in the Kafka protocol: a record at offset X should be fetchable by issuing a `Fetch` starting at offset X - 1. 

The reason this isn't very important is that normally, consumers will either want to fetch all of the historical documents in a topic, or they'll want to poll the topic for new documents as they come in. In both of those cases, the consumer will first issue a `ListOffsets` request which we will always answer with an offset known to be the beginning of a document (or rather really the end of the previous document since fetches start at the returned offset + 1).

The case where this assumption becomes relevant is when consumers try to do things like ask for "the last N documents". Normally, the flow should work like this:
* Consumer asks for the latest readable offset in a partition by issuing a `ListOffsets` with a `timestamp` of -1, which is the sentinel value for "largest readable offset"
* The consumer will then subtract the number of latest documents they want to read from the returned offset, and issue a`Fetch` starting at that offset
* Because offsets are usually densely packed, the broker will then serve documents starting at the requested offset through the last readable offset, providing the consumer with the "last N documents"

Since Dekaf uses byte offsets instead of sequential record counters, that `Fetch` request will almost always point at a byte offset in the middle of a document. Dekaf will then skip past that document and, since the request was a small offset before the end of the journal, will find no more documents to read and return an empty record set.

**Problem:**

This is fine under normal circumstances: the consumer will see no records through the end of the partition, and either finish, or start polling for new documents. Where things break down is when this request actually needs to get the last n documents. We've found two such integration partners whose data preview UIs break when unable to fetch recent documents:

* Tinybird's data preview UI will eventually give up after failing to fetch documents, but it will result in the new dataflow/table starting out with a barebones schema, rather than the AVRO-derived schema of the documents in the collection.
* Startree's data preview UI, as it turns out, won't even let you proceed to create the dataflow at all if it's unable to load preview documents.

**Solution:**

Eventually, this will be solved by implementing committed read logic in Rust, and transitioning Dekaf to use it. That'll let Dekaf return dense document offsets instead of sparse byte offsets. There's a bunch of logic to get right here, and some unanswered questions, such as: what do we do when a consumer asks for an arbitrary document offset? Do we have to read the whole preceding fragment? Do we have to keep a stateful index of document->byte offsets in order to read through less data to get to the desired offset? etc.

In the meantime, we're making the assumption that the limited subset of requests that we can reliably identify as "fetch latest N documents" don't actually need to be served the _latest_ N documents, and rather just need to see _some_ representative documents from the collection. As such, this PR implements logic to detect these requests and serve some easily readable documents from the beginning of the latest fragment, with their offsets rewritten to be in the requested range. 

This satisfies the consumer's request and in my testing, unblocks both Tinybird's and Startree's data preview UIs, while still allowing normal request flows to proceed as usual.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1701)
<!-- Reviewable:end -->
