### PR TITLE
reactor: show original error when document parse fails

### DIFF
--- a/crates/derive/src/extract_api.rs
+++ b/crates/derive/src/extract_api.rs
@@ -12,7 +12,7 @@ pub enum Error {
     Url(#[from] url::ParseError),
     #[error("schema index")]
     SchemaIndex(#[from] json::schema::index::Error),
-    #[error("failed to parse JSON document")]
+    #[error("failed to parse JSON document: {0:?}")]
     Json(std::io::Error),
     #[error("invalid document UUID: {value:?}")]
     InvalidUuid { value: Option<serde_json::Value> },


### PR DESCRIPTION
Allows us to see the actual cause of these errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1704)
<!-- Reviewable:end -->
