### PR TITLE
Fix `flowctl auth ...` not properly exchanging access token for refresh token

### DIFF
--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -312,7 +312,7 @@ pub async fn refresh_authorizations(
         (Some(access), None) => {
             // We have an access token but no refresh token. Create one.
             let refresh_token = api_exec::<RefreshToken>(
-                client.rpc(
+                client.clone().with_creds(Some(access.to_owned())).rpc(
                     "create_refresh_token",
                     serde_json::json!({"multi_use": true, "valid_for": "90d", "detail": "Created by flowctl"})
                         .to_string(),


### PR DESCRIPTION
**Description:**

This bug was introduced in https://github.com/estuary/flow/pull/1665. I tested the `flowctl auth` flow as part of that PR, but apparently didn't exercise the branch used when we have an access token, but no refresh token (i.e authenticating for the first time). This fixes that branch by always ensuring the client used to create the refresh token is authenticated, and also makes sure to generate and store a refresh token on the `Config` as part of  the `auth` subcommand.

Also tested `auth token`, which was similarly broken and is similarly fixed.

Fixes https://github.com/estuary/flow/issues/1703

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1705)
<!-- Reviewable:end -->
