### PR TITLE
agent: add diagnostics for db connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "jsonwebtoken",
  "labels",
  "lazy_static",
+ "log",
  "md5",
  "models",
  "ops",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ librocksdb-sys = { version = "0.16.0", default-features = false, features = [
     "snappy",
     "rtti",
 ] }
+log = "0.4" # only used to configure logging of dependencies
 lz4 = "1.24.0"
 lz4_flex = "0.11.0"
 mime = "0.3"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -46,6 +46,7 @@ humantime-serde = { workspace = true }
 itertools = { workspace = true }
 jsonwebtoken = { workspace = true }
 lazy_static = { workspace = true }
+log = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }


### PR DESCRIPTION
- Adds periodic logging of connection pool size
- Sets the application name to the k8s pod name, to better correlate with pg_stat_activity
- Sets a connection acquisition timeout
- Configures logging of slow statements
- Pings the connection when returning it to the pool, so that we can detect and remove bad connections

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1717)
<!-- Reviewable:end -->
