### PR TITLE
fix: `simd-doc` build on MacOS (am I the only one getting this?)

### DIFF
--- a/crates/simd-doc/src/ffi/simd-doc.hpp
+++ b/crates/simd-doc/src/ffi/simd-doc.hpp
@@ -2,6 +2,7 @@
 
 #include "simdjson.h"
 #include "rust/cxx.h"
+#include <bit>
 
 using namespace simdjson;
 


### PR DESCRIPTION
I've been having to patch my local `simd-doc.hpp` for a while now in order to get anything to build. Not sure why nobody else has encountered this (or maybe everyone has just been silently patching it like me!). Any reason we shouldn't do this?

Build error:
```
cargo:warning=In file included from /Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/sources/simd-doc/src/ffi/mod.rs.cc:1:
  cargo:warning=/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/crate/simd-doc/src/ffi/simd-doc.hpp:15:10: error: no member named 'endian' in namespace 'std'
  cargo:warning=    std::endian::native == std::endian::little,
  cargo:warning=    ~~~~~^
  cargo:warning=/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/crate/simd-doc/src/ffi/simd-doc.hpp:15:33: error: no member named 'endian' in namespace 'std'
  cargo:warning=    std::endian::native == std::endian::little,
  cargo:warning=                           ~~~~~^
  cargo:warning=2 errors generated.
  exit status: 1
  cargo:warning=ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "-mmacosx-version-min=12.6" "-std=c++2a" "-I" "/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/include" "-I" "/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/crate" "-Wall" "-Wextra" "-DNDEBUG" "-DSIMDJSON_DISABLE_DEPRECATED_API=1" "-DSIMDJSON_EXCEPTIONS=1" "-DSIMDJSON_IMPLEMENTATION_WESTMERE=0" "-DSIMDJSON_IMPLEMENTATION_PPC64=0" "-o" "/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/9f2f475b8bf3e6cb-mod.rs.o" "-c" "/Users/js/Documents/estuary/flow/target/release/build/simd-doc-2758ffc3fafe2976/out/cxxbridge/sources/simd-doc/src/ffi/mod.rs.cc" with args c++ did not execute successfully (status code exit status: 1).
```

FWIW I'm still on MacOS 12.7.6, so it's possible that this is because I haven't updated in a while.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1719)
<!-- Reviewable:end -->
