### PR TITLE
flow-client: Make sure to remove any potentially expired JWT from the client used to exchange a refresh token for an access token in `refresh_authorizations()`

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -72,7 +72,7 @@ impl Authenticated {
             self.client = self
                 .client
                 .clone()
-                .with_creds(Some(access))
+                .with_user_access_token(Some(access))
                 .with_fresh_gazette_client();
         }
 
@@ -98,7 +98,7 @@ impl App {
         let client = self
             .client_base
             .clone()
-            .with_creds(Some(access.clone()))
+            .with_user_access_token(Some(access.clone()))
             .with_fresh_gazette_client();
 
         let claims = flow_client::client::client_claims(&client)?;

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -59,16 +59,9 @@ impl Client {
         }
     }
 
-    pub fn with_creds(self, user_access_token: Option<String>) -> Self {
+    pub fn with_user_access_token(self, user_access_token: Option<String>) -> Self {
         Self {
-            user_access_token: user_access_token.or(self.user_access_token),
-            ..self
-        }
-    }
-
-    pub fn as_anonymous(self) -> Self {
-        Self {
-            user_access_token: None,
+            user_access_token,
             ..self
         }
     }
@@ -319,7 +312,7 @@ pub async fn refresh_authorizations(
         (Some(access), None) => {
             // We have an access token but no refresh token. Create one.
             let refresh_token = api_exec::<RefreshToken>(
-                client.clone().with_creds(Some(access.to_owned())).rpc(
+                client.clone().with_user_access_token(Some(access.to_owned())).rpc(
                     "create_refresh_token",
                     serde_json::json!({"multi_use": true, "valid_for": "90d", "detail": "Created by flowctl"})
                         .to_string(),
@@ -346,7 +339,7 @@ pub async fn refresh_authorizations(
             let Response {
                 access_token,
                 refresh_token: next_refresh_token,
-            } = api_exec::<Response>(client.clone().as_anonymous().rpc(
+            } = api_exec::<Response>(client.clone().with_user_access_token(None).rpc(
                 "generate_access_token",
                 serde_json::json!({"refresh_token_id": id, "secret": secret}).to_string(),
             ))

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -148,7 +148,7 @@ impl Cli {
                 config.user_access_token = Some(access.to_owned());
                 config.user_refresh_token = Some(refresh.to_owned());
 
-                anon_client.with_creds(Some(access))
+                anon_client.with_user_access_token(Some(access))
             }
             Err(err) => {
                 tracing::debug!(?err, "Error refreshing credentials");


### PR DESCRIPTION
While running down some issues with Dekaf, namely frequent consumer group rebalances, I noticed that these rebalances correlated with Dekaf errors such as:

```
dekaf: error=failed to obtain access token

Caused by:
    Unauthorized: {"code":"PGRST301","details":null,"hint":null,"message":"JWT expired"}
```

I then realized that Dekaf was passing a client containing an expired access token to `refresh_authorizations`. Since `generate_access_token` RPC performs its own authentication internally by way of the provided refresh token, it shouldn't be called with an authorization header.

This isn't a critical bug as it should just disconnect the session, causing a new connection to be created that'll have a freshly authenticated client, but nevertheless it's good to fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1725)
<!-- Reviewable:end -->
