### PR TITLE
dekaf: Refresh `Read`'s journal client auth token when it expires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-util",
+ "tonic",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -31,6 +31,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 crypto-common = { workspace = true }
+tonic = { workspace = true }
 deadpool = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
**Description:**

This is a follow-up to https://github.com/estuary/flow/pull/1725. I was still seeing some JWT expired errors, this time they looked like this:

```
WARN serve{...}: dekaf: error=status: Unauthenticated, message: "parsing jwt: token is expired by 12m4.003303197s", details: [], metadata: MetadataMap { headers: {} }
```

After some more digging, I realized that a sufficiently long-lived session containing a sufficiently long-lived `Read` could run into this issue, as the Read's journal client is never refreshed. This fixes that.

**Note:** I did consider whether it would be cleaner to refactor Read to just take a `flow_client::Client` and wholly manage its own journal client, but it didn't seem better enough to justify the bigger refactor. I'm low conviction on that though, happy to do that refactor if someone else feels more strongly about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1726)
<!-- Reviewable:end -->
