### PR TITLE
dekaf: Swap to sending control messages that count for consumer offsets

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -229,8 +229,8 @@ impl Read {
                 // Control Message keys are always 4 bytes:
                 // Version: 0i16
                 buf.put_i16(0);
-                // ControlMessageType: >1 i16
-                buf.put_i16(2);
+                // ControlMessageType: != 0 or 1 i16
+                buf.put_i16(-1);
                 record_bytes += buf.len();
                 Some(buf.split().freeze())
             } else {


### PR DESCRIPTION
**Description:**

We were translating acks into entirely invalid Kafka control messages in order to still send them and have consumers know about them, but filter them out from the documents a client sees. It turns out this translation was a bit too invalid, and the messages were getting filtered before their offsets were being counted for consumer group committed offsets.

This changes the translation to use a valid control message version (0), but an invalid message _type_, which has the effect of causing the message to be a no-op, but still get counted for offset tracking.

Relevant librdkafka section here: https://github.com/confluentinc/librdkafka/blob/master/src/rdkafka_msgset_reader.c#L768-L903

Deployed to `dekaf-dev` and testing shows this works as intended. Before change, the caught-up consumer will report being behind the reported gazette write head by 69 bytes:

![Screen Shot 2024-10-22 at 13 24 43](https://github.com/user-attachments/assets/1a2983d6-9615-4132-ab21-7874ada8d37d)

And after the deploy, the caught-up consumer's committed offset matches the write_head exactly:
![Screen Shot 2024-10-22 at 13 24 52](https://github.com/user-attachments/assets/7a5cc549-ccba-4ec6-b13e-6416849ab9c5)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1728)
<!-- Reviewable:end -->
