### PR TITLE
dekaf: Add metrics to track fetch request counts by topic and partition

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1321,7 +1321,7 @@ impl Session {
             // If fetch_offset is > latest_offset, this is a caught-up consumer
             // polling for new documents, not a data preview request.
             if fetch_offset <= latest_offset && latest_offset - fetch_offset < 13 {
-                tracing::debug!(
+                tracing::info!(
                     latest_offset,
                     diff = latest_offset - fetch_offset,
                     "Marking session as data-preview"


### PR DESCRIPTION
**Description:**

In order to debug what's happening with infrequent consumer lags, we want to keep track of how many read requests Dekaf is getting, broken down by collection and partition. This tracks that, as well as breaking down by read request type:

* `state => read_pending` means the read request came in after a previous request had already fetched the same offset for the topic and partition, and that request is pending.
* `state => collection_not_found` and `state => partition_not_found` are self-evident, though I believe a normal Kafka consumer would have figured out that these topics don't exist during the metadata discovery phase
* `state => new_data_preview_read` indicates a fetch request that we flagged as being for a data preview. These requests have special handling and poison the entire connection to only be usable for other data preview reads
* `state => new_regular_read` indicates a fetch request for a new topic/partition/offset combination.

Ex: 
```
# TYPE dekaf_fetch_requests counter
dekaf_fetch_requests{topic_name="joseph/dekaf-testing",partition_index="0",state="new_regular_read"} 19
dekaf_fetch_requests{topic_name="joseph/dekaf-testing",partition_index="0",state="read_pending"} 248
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1730)
<!-- Reviewable:end -->
