### PR TITLE
Dekaf: Support reads at a specific offset

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1321,7 +1321,7 @@ impl Session {
             // If fetch_offset is > latest_offset, this is a caught-up consumer
             // polling for new documents, not a data preview request.
             if fetch_offset <= latest_offset && latest_offset - fetch_offset < 13 {
-                tracing::debug!(
+                tracing::info!(
                     latest_offset,
                     diff = latest_offset - fetch_offset,
                     "Marking session as data-preview"

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -430,7 +430,7 @@ impl Session {
                             // so long as the request is still a data preview request. If not, bail out
                             Entry::Occupied(entry) => {
                                 let data_preview_state = entry.get();
-                                if fetch_offset > data_preview_state.offset
+                                if fetch_offset >= data_preview_state.offset
                                     || data_preview_state.offset - fetch_offset > 12
                                 {
                                     bail!("Session was used for fetching preview data, cannot be used for fetching non-preview data.")
@@ -1318,9 +1318,9 @@ impl Session {
             .fetch_partition_offset(partition as usize, -1)
             .await?
         {
-            // If fetch_offset is > latest_offset, this is a caught-up consumer
+            // If fetch_offset is >= latest_offset, this is a caught-up consumer
             // polling for new documents, not a data preview request.
-            if fetch_offset <= latest_offset && latest_offset - fetch_offset < 13 {
+            if fetch_offset < latest_offset && latest_offset - fetch_offset < 13 {
                 tracing::info!(
                     latest_offset,
                     diff = latest_offset - fetch_offset,


### PR DESCRIPTION
This changes the way Dekaf reads from journals in order to support reads issued at a particular document offset. Previously, since the reported document offset is the _last_ inclusive byte of that doc, a new `Fetch` request issued starting at the requested offset would not include that document. We didn't think this would cause issues as caught-up consumers ought to poll from the _next_ offset, but we were seeing consumers instead try to fetch the last inclusive offset instead.

So this shifts new read requests to read from at most 16mb before the requested offset (the max document size is 16mb). While this _will_ result in higher read latencies as a whole bunch of documents are read through and thrown away, it will allow consumers to fetch any document by the offset it was reported as being at.

**Also included:**

In order to debug what's happening with infrequent consumer lags, we want to keep track of how many read requests Dekaf is getting, broken down by collection and partition. This tracks that, as well as breaking down by read request type:

* `state => read_pending` means the read request came in after a previous request had already fetched the same offset for the topic and partition, and that request is pending.
* `state => collection_not_found` and `state => partition_not_found` are self-evident, though I believe a normal Kafka consumer would have figured out that these topics don't exist during the metadata discovery phase
* `state => new_data_preview_read` indicates a fetch request that we flagged as being for a data preview. These requests have special handling and poison the entire connection to only be usable for other data preview reads
* `state => new_regular_read` indicates a fetch request for a new topic/partition/offset combination.

Ex: 
```
# TYPE dekaf_fetch_requests counter
dekaf_fetch_requests{topic_name="joseph/dekaf-testing",partition_index="0",state="new_regular_read"} 19
dekaf_fetch_requests{topic_name="joseph/dekaf-testing",partition_index="0",state="read_pending"} 248
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1733)
<!-- Reviewable:end -->
