### PR TITLE
runtime/container: --log-driver=none for connector containers

### DIFF
--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -102,6 +102,8 @@ pub async fn start(
         // The entrypoint into a connector is always flow-connector-init,
         // which will delegate to the actual entrypoint of the connector.
         "--entrypoint=/flow-connector-init".to_string(),
+        // Disable logging of connector containers.
+        "--log-driver=none".to_string(),
         // Mount the flow-connector-init binary and `docker inspect` output.
         format!(
             "--mount=type=bind,source={},target=/flow-connector-init",


### PR DESCRIPTION
**Description:**

- Add `--log-driver=none` for container connectors, since we don't want to retain their logs, given that their logs are available as gazette journals

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1735)
<!-- Reviewable:end -->
