### PR TITLE
avro: Fix generation of schemas for optional fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,8 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.12.0"
-source = "git+https://github.com/tychedelia/kafka-protocol-rs.git?rev=cabe835#cabe835a9cc87fe8ea64649ff599d96a61e1fb66"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1edaf2fc3ecebe689bbc4fd97a6921cacd4cd09df8ebeda348a8e23c9fd48d4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ flate2 = "1.0"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
-fxhash = "0.2"                                               # Used in `json` crate. Replace with xxhash.
+fxhash = "0.2" # Used in `json` crate. Replace with xxhash.
 hex = "0.4.3"
 hexdump = "0.1"
 humantime = "2.1"
@@ -72,9 +72,7 @@ jemalloc-ctl = "0.3"
 json-patch = "0.3"
 jsonwebtoken = { version = "9", default-features = false }
 js-sys = "0.3.60"
-# TODO(jshearer): Swap back after 0.13.0 is released, which includes
-# https://github.com/tychedelia/kafka-protocol-rs/pull/81
-kafka-protocol = { git = "https://github.com/tychedelia/kafka-protocol-rs.git", rev = "cabe835" }
+kafka-protocol = "0.13.0"
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "0.16.0", default-features = false, features = [

--- a/crates/avro/src/snapshots/avro__schema__test__unions.snap.new
+++ b/crates/avro/src/snapshots/avro__schema__test__unions.snap.new
@@ -1,0 +1,89 @@
+---
+source: crates/avro/src/schema.rs
+assertion_line: 370
+expression: "schema_test(&fixture, &key)"
+---
+{
+  "key": {
+    "fields": [
+      {
+        "name": "_flow_key",
+        "type": {
+          "fields": [
+            {
+              "name": "p1",
+              "type": "string"
+            }
+          ],
+          "name": "Parts",
+          "namespace": "root.Key",
+          "type": "record"
+        }
+      }
+    ],
+    "name": "Key",
+    "namespace": "root",
+    "type": "record"
+  },
+  "value": {
+    "fields": [
+      {
+        "name": "both_required",
+        "type": "string"
+      },
+      {
+        "name": "both_required_and_nullable",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "default": null,
+        "name": "neither_required",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "default": null,
+        "name": "side_a",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "default": null,
+        "name": "side_b",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "name": "_flow_extra",
+        "type": {
+          "type": "map",
+          "values": [
+            "null",
+            {
+              "fields": [
+                {
+                  "name": "json",
+                  "type": "string"
+                }
+              ],
+              "name": "RawJSON",
+              "namespace": "root._flow_extra",
+              "type": "record"
+            }
+          ]
+        }
+      }
+    ],
+    "name": "root",
+    "type": "record"
+  }
+}

--- a/crates/dekaf/src/connector.rs
+++ b/crates/dekaf/src/connector.rs
@@ -4,6 +4,19 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum DeletionMode {
+    Default,
+    Header,
+}
+
+impl Default for DeletionMode {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 /// Configures the behavior of a whole dekaf task
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DekafConfig {
@@ -15,6 +28,11 @@ pub struct DekafConfig {
     // #[schemars(extend("secret" = true))]
     #[schemars(schema_with = "token_secret")]
     pub token: String,
+    /// How to handle deletion events. "Default" emits them as regular Kafka
+    /// tombstones with null values, and "Header" emits then as a kafka document
+    /// with empty string and `_is_deleted` header set to `1`. Setting this value
+    /// will also cause all other non-deletions to have an `_is_deleted` header of `0`.
+    pub deletions: DeletionMode,
 }
 
 /// Configures a particular binding in a Dekaf-type materialization

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -55,7 +55,6 @@ pub enum ReadTarget {
     Docs(usize),
 }
 
-const OFFSET_READBACK: i64 = 2 << 25 + 1; // 64mb, single document max size
 const DELETION_HEADER: &str = "_is_deleted";
 const DELETION_VAL_DELETED: &[u8] = &[1u8];
 const DELETION_VAL_NOT_DELETED: &[u8] = &[0u8];
@@ -75,12 +74,7 @@ impl Read {
 
         let stream = client.clone().read_json_lines(
             broker::ReadRequest {
-                // Start reading at least 1 document in the past
-                offset: if rewrite_offsets_from.is_some() {
-                    offset
-                } else {
-                    std::cmp::max(0, offset - OFFSET_READBACK)
-                },
+                offset,
                 block: true,
                 journal: partition.spec.name.clone(),
                 begin_mod_time: not_before_sec as i64,
@@ -352,7 +346,8 @@ impl Read {
             last_write_head = self.last_write_head,
             ratio = buf.len() as f64 / (records_bytes + 1) as f64,
             records_bytes,
-            "returning records"
+            did_timeout,
+            "batch complete"
         );
 
         metrics::counter!("dekaf_documents_read", "journal_name" => self.journal_name.to_owned())

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -76,7 +76,11 @@ impl Read {
         let stream = client.clone().read_json_lines(
             broker::ReadRequest {
                 // Start reading at least 1 document in the past
-                offset: std::cmp::max(0, offset - OFFSET_READBACK),
+                offset: if rewrite_offsets_from.is_some() {
+                    offset
+                } else {
+                    std::cmp::max(0, offset - OFFSET_READBACK)
+                },
                 block: true,
                 journal: partition.spec.name.clone(),
                 begin_mod_time: not_before_sec as i64,

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -10,10 +10,11 @@ use anyhow::{bail, Context};
 use bytes::{BufMut, Bytes, BytesMut};
 use kafka_protocol::{
     error::{ParseResponseErrorCode, ResponseError},
-    indexmap::IndexMap,
     messages::{
         self,
-        metadata_response::{MetadataResponsePartition, MetadataResponseTopic},
+        metadata_response::{
+            MetadataResponseBroker, MetadataResponsePartition, MetadataResponseTopic,
+        },
         ConsumerProtocolAssignment, ConsumerProtocolSubscription, ListGroupsResponse,
         RequestHeader, TopicName,
     },
@@ -128,13 +129,10 @@ impl Session {
         }?;
 
         // We only ever advertise a single logical broker.
-        let mut brokers = kafka_protocol::indexmap::IndexMap::new();
-        brokers.insert(
-            messages::BrokerId(1),
-            messages::metadata_response::MetadataResponseBroker::default()
-                .with_host(StrBytes::from_string(self.app.advertise_host.clone()))
-                .with_port(self.app.advertise_kafka_port as i32),
-        );
+        let brokers = vec![MetadataResponseBroker::default()
+            .with_node_id(messages::BrokerId(1))
+            .with_host(StrBytes::from_string(self.app.advertise_host.clone()))
+            .with_port(self.app.advertise_kafka_port as i32)];
 
         Ok(messages::MetadataResponse::default()
             .with_brokers(brokers)
@@ -144,9 +142,7 @@ impl Session {
     }
 
     // Lists all read-able collections as Kafka topics. Omits partition metadata.
-    async fn metadata_all_topics(
-        &mut self,
-    ) -> anyhow::Result<IndexMap<TopicName, MetadataResponseTopic>> {
+    async fn metadata_all_topics(&mut self) -> anyhow::Result<Vec<MetadataResponseTopic>> {
         let collections = fetch_all_collection_names(
             &self
                 .auth
@@ -163,14 +159,12 @@ impl Session {
         let topics = collections
             .into_iter()
             .map(|name| {
-                (
-                    self.encode_topic_name(name),
-                    MetadataResponseTopic::default()
-                        .with_is_internal(false)
-                        .with_partitions(vec![MetadataResponsePartition::default()
-                            .with_partition_index(0)
-                            .with_leader_id(0.into())]),
-                )
+                MetadataResponseTopic::default()
+                    .with_name(Some(self.encode_topic_name(name)))
+                    .with_is_internal(false)
+                    .with_partitions(vec![MetadataResponsePartition::default()
+                        .with_partition_index(0)
+                        .with_leader_id(0.into())])
             })
             .collect();
 
@@ -181,7 +175,7 @@ impl Session {
     async fn metadata_select_topics(
         &mut self,
         requests: Vec<messages::metadata_request::MetadataRequestTopic>,
-    ) -> anyhow::Result<IndexMap<TopicName, MetadataResponseTopic>> {
+    ) -> anyhow::Result<Vec<MetadataResponseTopic>> {
         let client = self
             .auth
             .as_mut()
@@ -206,13 +200,13 @@ impl Session {
             .await
             .map_err(|e| anyhow::anyhow!("Timed out loading metadata {e}"))?;
 
-        let mut topics = IndexMap::new();
+        let mut topics = vec![];
 
         for (name, maybe_collection) in collections? {
             let Some(collection) = maybe_collection else {
-                topics.insert(
-                    self.encode_topic_name(name.to_string()),
+                topics.push(
                     MetadataResponseTopic::default()
+                        .with_name(Some(self.encode_topic_name(name.to_string())))
                         .with_error_code(ResponseError::UnknownTopicOrPartition.code()),
                 );
                 continue;
@@ -231,9 +225,9 @@ impl Session {
                 })
                 .collect();
 
-            topics.insert(
-                name,
+            topics.push(
                 MetadataResponseTopic::default()
+                    .with_name(Some(name))
                     .with_is_internal(false)
                     .with_partitions(partitions),
             );
@@ -738,21 +732,18 @@ impl Session {
         let responses = req
             .topic_data
             .into_iter()
-            .map(|(k, v)| {
-                (
-                    k,
-                    TopicProduceResponse::default().with_partition_responses(
-                        v.partition_data
-                            .into_iter()
-                            .map(|part| {
-                                PartitionProduceResponse::default()
-                                    .with_index(part.index)
-                                    .with_error_code(
-                                        kafka_protocol::error::ResponseError::InvalidRequest.code(),
-                                    )
-                            })
-                            .collect(),
-                    ),
+            .map(|v| {
+                TopicProduceResponse::default().with_partition_responses(
+                    v.partition_data
+                        .into_iter()
+                        .map(|part| {
+                            PartitionProduceResponse::default()
+                                .with_index(part.index)
+                                .with_error_code(
+                                    kafka_protocol::error::ResponseError::InvalidRequest.code(),
+                                )
+                        })
+                        .collect(),
                 )
             })
             .collect();
@@ -773,7 +764,7 @@ impl Session {
             .await?;
 
         let mut mutable_req = req.clone();
-        for (_, protocol) in mutable_req.protocols.iter_mut() {
+        for protocol in mutable_req.protocols.iter_mut() {
             let mut consumer_protocol_subscription_raw = protocol.metadata.clone();
 
             let consumer_protocol_subscription_version = consumer_protocol_subscription_raw
@@ -950,7 +941,10 @@ impl Session {
             consumer_protocol_assignment_msg.assigned_partitions = consumer_protocol_assignment_msg
                 .assigned_partitions
                 .into_iter()
-                .map(|(name, item)| (self.encrypt_topic_name(name.to_owned().into()).into(), item))
+                .map(|part| {
+                    let transformed_topic = self.encrypt_topic_name(part.topic.to_owned());
+                    part.with_topic(transformed_topic)
+                })
                 .collect();
 
             let mut new_protocol_assignment = BytesMut::new();
@@ -986,7 +980,10 @@ impl Session {
         consumer_protocol_assignment_msg.assigned_partitions = consumer_protocol_assignment_msg
             .assigned_partitions
             .into_iter()
-            .map(|(name, item)| (self.decrypt_topic_name(name.to_owned().into()).into(), item))
+            .map(|part| {
+                let transformed_topic = self.decrypt_topic_name(part.topic.to_owned());
+                part.with_topic(transformed_topic)
+            })
             .collect();
 
         let mut new_protocol_assignment = BytesMut::new();
@@ -1144,132 +1141,70 @@ impl Session {
     ) -> anyhow::Result<messages::ApiVersionsResponse> {
         use kafka_protocol::messages::{api_versions_response::ApiVersion, *};
 
-        fn version<T: kafka_protocol::protocol::Message>() -> ApiVersion {
-            let mut v = ApiVersion::default();
-            v.max_version = T::VERSIONS.max;
-            v.min_version = T::VERSIONS.min;
-            v
-        }
-        let mut res = ApiVersionsResponse::default();
-
-        res.api_keys.insert(
-            ApiKey::ApiVersionsKey as i16,
-            version::<ApiVersionsRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::SaslHandshakeKey as i16,
-            version::<SaslHandshakeRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::SaslAuthenticateKey as i16,
-            version::<SaslAuthenticateRequest>(),
-        );
-        res.api_keys
-            .insert(ApiKey::MetadataKey as i16, version::<MetadataRequest>());
-        res.api_keys.insert(
-            ApiKey::FindCoordinatorKey as i16,
+        fn version<T: kafka_protocol::protocol::Message>(api_key: ApiKey) -> ApiVersion {
             ApiVersion::default()
+                .with_api_key(api_key as i16)
+                .with_max_version(T::VERSIONS.max)
+                .with_min_version(T::VERSIONS.min)
+        }
+        let res = ApiVersionsResponse::default().with_api_keys(vec![
+            version::<ApiVersionsRequest>(ApiKey::ApiVersionsKey),
+            version::<SaslHandshakeRequest>(ApiKey::SaslHandshakeKey),
+            version::<SaslAuthenticateRequest>(ApiKey::SaslAuthenticateKey),
+            version::<MetadataRequest>(ApiKey::MetadataKey),
+            ApiVersion::default()
+                .with_api_key(ApiKey::FindCoordinatorKey as i16)
                 .with_min_version(0)
                 .with_max_version(2),
-        );
-        res.api_keys.insert(
-            ApiKey::ListOffsetsKey as i16,
-            version::<ListOffsetsRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::FetchKey as i16,
+            version::<ListOffsetsRequest>(ApiKey::ListOffsetsKey),
             ApiVersion::default()
+                .with_api_key(ApiKey::FetchKey as i16)
                 // This is another non-obvious requirement in librdkafka. If we advertise <4 as a minimum here, some clients'
                 // fetch requests will sit in a tight loop erroring over and over. This feels like a bug... but it's probably
                 // just the consequence of convergent development, where some implicit requirement got encoded both in the client
                 // and server without being explicitly documented anywhere.
                 .with_min_version(4)
-                // I don't understand why, but some kafka clients don't seem to be able to send flexver fetch requests correctly
-                // For example, `kcat` sends an empty topic name when >= v12. I'm 99% sure there's more to this however.
-                .with_max_version(11),
-        );
-
-        // Needed by `kaf`.
-        res.api_keys.insert(
-            ApiKey::DescribeConfigsKey as i16,
-            version::<DescribeConfigsRequest>(),
-        );
-
-        res.api_keys.insert(
-            ApiKey::ProduceKey as i16,
+                // Version >= 13 did away with topic names in favor of unique topic UUIDs, so we need to stick below that.
+                .with_max_version(12),
+            // Needed by `kaf`.
+            version::<DescribeConfigsRequest>(ApiKey::DescribeConfigsKey),
             ApiVersion::default()
+                .with_api_key(ApiKey::ProduceKey as i16)
                 .with_min_version(3)
                 .with_max_version(9),
-        );
-
-        res.api_keys.insert(
-            ApiKey::JoinGroupKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<JoinGroupRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::LeaveGroupKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<LeaveGroupRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::ListGroupsKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<ListGroupsRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::SyncGroupKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<SyncGroupRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::DeleteGroupsKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<DeleteGroupsRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::HeartbeatKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<HeartbeatRequest>()?,
-        );
-
-        res.api_keys.insert(
-            ApiKey::OffsetCommitKey as i16,
             self.app
                 .kafka_client
                 .supported_versions::<OffsetCommitRequest>()?,
-        );
-        res.api_keys.insert(
-            ApiKey::OffsetFetchKey as i16,
             ApiVersion::default()
+                .with_api_key(ApiKey::OffsetFetchKey as i16)
                 .with_min_version(0)
                 .with_max_version(7),
-        );
+        ]);
 
         // UNIMPLEMENTED:
         /*
-        res.api_keys.insert(
-            ApiKey::LeaderAndIsrKey as i16,
-            version::<LeaderAndIsrRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::StopReplicaKey as i16,
-            version::<StopReplicaRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::CreateTopicsKey as i16,
-            version::<CreateTopicsRequest>(),
-        );
-        res.api_keys.insert(
-            ApiKey::DeleteTopicsKey as i16,
-            version::<DeleteTopicsRequest>(),
-        );
+            ApiKey::LeaderAndIsrKey,
+            ApiKey::StopReplicaKey,
+            ApiKey::CreateTopicsKey,
+            ApiKey::DeleteTopicsKey,
         */
 
         Ok(res)


### PR DESCRIPTION
Avro requires that optional fields be encoded in a specific way:
* Their type be a union of "null", and their actual schema, where "null" is the first element in the list
* They have a default of `null`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1742)
<!-- Reviewable:end -->
