### PR TITLE
validation: relax error checks of pre-existing exclusions

### DIFF
--- a/crates/models/src/raw_value.rs
+++ b/crates/models/src/raw_value.rs
@@ -2,6 +2,7 @@
 /// values can safely be used in newline-delimited contexts.
 #[derive(serde::Serialize, Clone)]
 pub struct RawValue(Box<serde_json::value::RawValue>);
+
 // RawValues are only equal if they are byte-for-byte identical,
 // except for leading and trailing whitespace.
 impl std::cmp::PartialEq<RawValue> for RawValue {

--- a/crates/tables/src/draft.rs
+++ b/crates/tables/src/draft.rs
@@ -406,7 +406,7 @@ pub trait DraftRow: crate::Row {
     fn expect_pub_id(&self) -> Option<models::Id>;
     /// Model of this specification.
     fn model(&self) -> Option<&Self::ModelDef>;
-    /// Whether this represents a touch operation. If true, then `model` must be `None`.
+    /// Whether this represents a touch operation.
     fn is_touch(&self) -> bool;
 
     fn spec_type(&self) -> models::CatalogType;

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -83,6 +83,7 @@ async fn walk_capture(
         data_plane_id,
         expect_pub_id,
         expect_build_id,
+        _live_model,
         live_spec,
         is_touch,
     ) = match walk_transition(pub_id, build_id, default_plane_id, eob, errors) {

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -52,6 +52,7 @@ fn walk_collection(
         data_plane_id,
         expect_pub_id,
         expect_build_id,
+        _live_model,
         live_spec,
         is_touch,
     ) = match walk_transition(pub_id, build_id, default_plane_id, eob, errors) {

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -229,8 +229,9 @@ fn walk_transition<'a, D, L, B>(
         models::Id,               // Assigned data-plane.
         models::Id,               // Live publication ID.
         models::Id,               // Live last build ID.
-        Option<&'a L::BuiltSpec>, // Live spec.
-        bool,                     // Is this a touch operation
+        Option<&'a L::ModelDef>,  // Live model.
+        Option<&'a L::BuiltSpec>, // Live built spec.
+        bool,                     // Is this a touch operation?
     ),
     // Result::Err is a completed BuiltRow for this specification.
     B,
@@ -267,13 +268,11 @@ where
             ))
         }
         EOB::Right(draft) => {
-            let last_pub_id = models::Id::zero(); // Not published.
-
-            if let Some(expect) = draft.expect_pub_id() {
-                if expect != last_pub_id {
+            if let Some(expect_id) = draft.expect_pub_id() {
+                if expect_id != models::Id::zero() {
                     Error::ExpectPubIdNotMatched {
-                        expect_id: expect,
-                        actual_id: last_pub_id,
+                        expect_id,
+                        actual_id: models::Id::zero(),
                     }
                     .push(Scope::new(draft.scope()), errors);
                 }
@@ -296,11 +295,12 @@ where
                     draft.catalog_name(),
                     draft.scope(),
                     model,
-                    models::Id::zero(), // No control-plane ID.
+                    models::Id::zero(), // Has no control-plane ID.
                     default_plane_id,   // Assign default data-plane.
-                    last_pub_id,        // Not published (zero).
-                    last_pub_id,        // Not published (zero).
-                    None,               // No live spec.
+                    models::Id::zero(), // Never published.
+                    models::Id::zero(), // Never built.
+                    None,               // Has no live model.
+                    None,               // Has no live built spec.
                     false,              // !is_touch
                 )),
                 None => {
@@ -326,9 +326,9 @@ where
         }
         EOB::Both(live, draft) => {
             match draft.expect_pub_id() {
-                Some(expect) if expect != live.last_pub_id() => {
+                Some(expect_id) if expect_id != live.last_pub_id() => {
                     Error::ExpectPubIdNotMatched {
-                        expect_id: expect,
+                        expect_id,
                         actual_id: live.last_pub_id(),
                     }
                     .push(Scope::new(draft.scope()), errors);
@@ -387,6 +387,7 @@ where
                     live.data_plane_id(),
                     live.last_pub_id(),
                     live.last_build_id(),
+                    Some(live.model()),
                     Some(live.spec()),
                     draft.is_touch(),
                 )),
@@ -501,7 +502,7 @@ mod test {
         )
         .unwrap();
         assert!(errors.is_empty());
-        assert!(result.8); // is_touch
+        assert!(result.9); // is_touch
         assert_eq!(last_pub_id, result.5);
         assert_eq!(last_build_id, result.6);
 

--- a/crates/validation/src/test_step.rs
+++ b/crates/validation/src/test_step.rs
@@ -48,6 +48,7 @@ fn walk_test(
         _data_plane_id,
         expect_pub_id,
         expect_build_id,
+        _live_model,
         live_spec,
         is_touch,
     ) = match walk_transition(pub_id, build_id, Some(models::Id::zero()), eob, errors) {

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -248,7 +248,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
     // Load into LiveCatalog::live_materializations.
     for (materialization, mock) in &mock_calls.live_materializations {
         let model = models::MaterializationDef {
-            bindings: Vec::new(),
+            bindings: mock.bindings.clone(),
             endpoint: models::MaterializationEndpoint::Connector(live_connector_fixture.clone()),
             expect_pub_id: None,
             shards: models::ShardTemplate::default(),
@@ -411,6 +411,8 @@ struct MockLiveMaterialization {
     last_pub_id: models::Id,
     #[serde(default)]
     last_build_id: Option<models::Id>,
+    #[serde(default)]
+    bindings: Vec<models::MaterializationBinding>,
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
Introduce a carve-out which prevents raising an error for a materialization field selection exclude which does not exist as a projection, IF that exclusion is also present in the live model.

This allows an exclusion to carry forward and not error if (for example) the source schema is changed by automations or another user to remove the excluded location, while still catching and flagging newly-introduced exclusions which don't actually exist.

Fixes #1743

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1744)
<!-- Reviewable:end -->
