### PR TITLE
Small dekaf fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,8 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.12.0"
-source = "git+https://github.com/tychedelia/kafka-protocol-rs.git?rev=cabe835#cabe835a9cc87fe8ea64649ff599d96a61e1fb66"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1edaf2fc3ecebe689bbc4fd97a6921cacd4cd09df8ebeda348a8e23c9fd48d4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ flate2 = "1.0"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
-fxhash = "0.2"                                               # Used in `json` crate. Replace with xxhash.
+fxhash = "0.2" # Used in `json` crate. Replace with xxhash.
 hex = "0.4.3"
 hexdump = "0.1"
 humantime = "2.1"
@@ -72,9 +72,7 @@ jemalloc-ctl = "0.3"
 json-patch = "0.3"
 jsonwebtoken = { version = "9", default-features = false }
 js-sys = "0.3.60"
-# TODO(jshearer): Swap back after 0.13.0 is released, which includes
-# https://github.com/tychedelia/kafka-protocol-rs/pull/81
-kafka-protocol = { git = "https://github.com/tychedelia/kafka-protocol-rs.git", rev = "cabe835" }
+kafka-protocol = "0.13.0"
 lazy_static = "1.4"
 libc = "0.2"
 librocksdb-sys = { version = "0.16.0", default-features = false, features = [


### PR DESCRIPTION
**Description:**

This pulls a few fixes out of https://github.com/estuary/flow/pull/1738 in order to get them merged before we figure out the right way to do tinybird deletions

* Remove the 64mb readback behavior as it wasn't the solution to lagged consumers, and seemed to be triggering some unexpected behavior in librdkafka when it tries to read at the high-watermark and gets a messageset with _just_ a control doc in it (the ack for the transaction, which is almost always the last document available). This was causing intermittent issues with data preview UIs
* Bump `kafka-protocol` to 0.13.0 and upgrade the Fetch API to support flexible versions. This fixes the warning about `Message at offset xx might be too large to fetch, try increasing receive.message.max.bytes`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1745)
<!-- Reviewable:end -->
