### PR TITLE
billing: Switch payment intents to use Stripe's "automatic payment methods" feature

### DIFF
--- a/supabase/functions/billing/setup_intent.ts
+++ b/supabase/functions/billing/setup_intent.ts
@@ -60,8 +60,9 @@ export async function setupIntent(
         customer: customer.id,
         description: "Store your payment details",
         usage: "off_session",
-        // payment_method_types: ["card", "us_bank_account"],
-        payment_method_types: ["card"],
+        automatic_payment_methods: {
+            enabled: true
+        }
     });
 
     return [JSON.stringify({ intent_secret: intent.client_secret }), {


### PR DESCRIPTION
This lets you select and configure which payment methods are enabled from the Stripe web UI. The original goal was to enable ACH payments, but it seemed better to just switch us over to something that lets these be configured w/o any code changes required.

Payment input UI after this change (since card and ACH are turned on in Stripe):

![Screenshot 2024-10-29 at 13 42 34](https://github.com/user-attachments/assets/7802e290-1bc3-41c5-8fc2-c83470500488)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1746)
<!-- Reviewable:end -->
