### PR TITLE
feat(firebolt): Update firebolt auth and sql

### DIFF
--- a/crates/schemalate/src/firebolt/firebolt_queries.rs
+++ b/crates/schemalate/src/firebolt/firebolt_queries.rs
@@ -48,12 +48,7 @@ impl<'a> Display for CreateTable<'a> {
         write!(
             f,
             "CREATE {} TABLE {} {} ({}) {} {};",
-            self.table.r#type,
-            if_not_exists,
-            table_name,
-            self.table.schema,
-            indices,
-            self.extra,
+            self.table.r#type, if_not_exists, table_name, self.table.schema, indices, self.extra,
         )
     }
 }
@@ -93,7 +88,7 @@ impl<'a> Display for InsertFromTable<'a> {
 
         write!(
             f,
-            "INSERT INTO {} ({}) SELECT {} FROM {} WHERE source_file_name IN (?) AND ((SELECT count(*) FROM {} WHERE source_file_name IN (?)) < 1);",
+            "INSERT INTO {} ({}) SELECT {} FROM {} WHERE $source_file_name IN (?) AND ((SELECT count(*) FROM {} WHERE $source_file_name IN (?)) < 1);",
             destination_name, column_list, column_list, source_name,
             destination_name
         )
@@ -235,7 +230,7 @@ mod tests {
                 source_name: "source-test"
             }
             .to_string(),
-            "INSERT INTO \"destination-test\" (str,\"Int\") SELECT str,\"Int\" FROM \"source-test\" WHERE source_file_name IN (?) AND ((SELECT count(*) FROM \"destination-test\" WHERE source_file_name IN (?)) < 1);"
+            "INSERT INTO \"destination-test\" (str,\"Int\") SELECT str,\"Int\" FROM \"source-test\" WHERE $source_file_name IN (?) AND ((SELECT count(*) FROM \"destination-test\" WHERE $source_file_name IN (?)) < 1);"
         );
     }
 }

--- a/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
+++ b/crates/schemalate/src/firebolt/firebolt_schema_builder.rs
@@ -112,9 +112,9 @@ pub fn build_firebolt_queries_bundle(
             schema: schema.clone(),
         };
 
-        // Add source_file_name column to main table
+        // Add $source_file_name column to main table
         schema.columns.push(Column {
-            key: "source_file_name".to_string(),
+            key: "$source_file_name".to_string(),
             r#type: FireboltType::Text,
             is_key: false,
             nullable: false,
@@ -241,14 +241,14 @@ mod tests {
             FireboltQueriesBundle {
                 bindings: vec![BindingBundle {
                     create_table:
-                        "CREATE FACT TABLE IF NOT EXISTS test_table (test TEXT,source_file_name TEXT) PRIMARY INDEX test ;"
+                        "CREATE FACT TABLE IF NOT EXISTS test_table (test TEXT,\"$source_file_name\" TEXT) PRIMARY INDEX test ;"
                             .to_string(),
                     create_external_table:
                         "CREATE EXTERNAL TABLE IF NOT EXISTS test_table_external (test TEXT)  CREDENTIALS = ( AWS_KEY_ID = 'aws_key' AWS_SECRET_KEY = 'aws_secret' ) URL = 's3://my-bucket/test' OBJECT_PATTERN = '*.json' TYPE = (JSON);".to_string(),
                     drop_table: "DROP TABLE test_table;".to_string(),
                     drop_external_table: "DROP TABLE test_table_external;".to_string(),
                     insert_from_table:
-                        "INSERT INTO test_table (test,source_file_name) SELECT test,source_file_name FROM test_table_external WHERE source_file_name IN (?) AND ((SELECT count(*) FROM test_table WHERE source_file_name IN (?)) < 1);".to_string()
+                        "INSERT INTO test_table (test,\"$source_file_name\") SELECT test,\"$source_file_name\" FROM test_table_external WHERE $source_file_name IN (?) AND ((SELECT count(*) FROM test_table WHERE $source_file_name IN (?)) < 1);".to_string()
                 }]
             },
         );

--- a/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
@@ -63,6 +63,7 @@ Use the below properties to configure a Firebolt materialization, which will dir
 | **`/s3_bucket`** | S3 bucket | Name of S3 bucket where the intermediate files for external table will be stored. | string | Required |
 | `/s3_prefix` | S3 prefix | A prefix for files stored in the bucket. | string |  |
 | **`/client_id`** | Client ID | ID of your Firebolt service account. | string | Required |
+| **`/account_name`** | Account Name | Name of your [account](https://docs.firebolt.io/Overview/organizations-accounts.html) within your Firebolt organization. | string | Required |
 
 
 #### Bindings
@@ -86,6 +87,7 @@ materializations:
             # For public S3 buckets, only the bucket name is required
             s3_bucket: my-bucket
             client_id: firebolt-user
+            account_name: my-account
           # Path to the latest version of the connector, provided as a Docker image
           image: ghcr.io/estuary/materialize-firebolt:dev
 	# If you have multiple collections you need to materialize, add a binding for each one

--- a/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Firebolt.md
@@ -4,9 +4,9 @@
 
 This Flow connector materializes [delta updates](../../../concepts/materialization.md#delta-updates) of Flow collections into Firebolt `FACT` or `DIMENSION` tables.
 
-To interface between Flow and Firebolt, the connector uses Firebolt's method for [loading data](https://docs.firebolt.io/loading-data/loading-data.html):
+To interface between Flow and Firebolt, the connector uses Firebolt's method for [loading data](https://docs.firebolt.io/Guides/loading-data/loading-data.html):
 First, it stores data as JSON documents in an S3 bucket.
-It then references the S3 bucket to create a [Firebolt _external table_](https://docs.firebolt.io/loading-data/working-with-external-tables.html),
+It then references the S3 bucket to create a [Firebolt _external table_](https://docs.firebolt.io/Guides/loading-data/working-with-external-tables.html),
 which acts as a SQL interface between the JSON documents and the destination table in Firebolt.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/materialize-firebolt:dev`](https://ghcr.io/estuary/materialize-firebolt:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
@@ -15,11 +15,9 @@ It is available for use in the Flow web application. For local development or op
 
 To use this connector, you'll need:
 
-* A Firebolt database with at least one [engine](https://docs.firebolt.io/working-with-engines/)
-  * The engine must be started before creating the materialization.
-  * It's important that the engine stays up throughout the lifetime of the materialization. To ensure this is the case, select Edit Engine on your engine. In the engine settings, set **Auto-stop engine after** to **Always On**.
+* A Firebolt database with at least one [engine](https://docs.firebolt.io/Overview/engine-fundamentals.html#firebolt-engines)
 * An S3 bucket where JSON documents will be stored prior to loading
-  * The bucket must be in a [supported AWS region](https://docs.firebolt.io/general-reference/available-regions.html) matching your Firebolt database.
+  * The bucket must be in a [supported AWS region](https://docs.firebolt.io/Reference/available-regions.html) matching your Firebolt database.
   * The bucket may be public, or may be accessible by an IAM user. To configure your IAM user, see the [steps below](#setup).
 * At least one Flow [collection](../../../concepts/collections.md)
 
@@ -33,7 +31,7 @@ To use this connector, you'll need:
 
 For non-public buckets, you'll need to configure access in AWS IAM.
 
-1. Follow the [Firebolt documentation](https://docs.firebolt.io/loading-data/configuring-aws-role-to-access-amazon-s3.html) to set up an IAM policy and role, and add it to the external table definition.
+1. Follow the [Firebolt documentation](https://docs.firebolt.io/Guides/loading-data/creating-access-keys-aws.html) to set up an IAM policy and role, and add it to the external table definition.
 
 2. Create a new [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console). During setup:
 
@@ -60,11 +58,11 @@ Use the below properties to configure a Firebolt materialization, which will dir
 | `/aws_region` | AWS region | AWS region the bucket is in. | string |  |
 | `/aws_secret_key` | AWS secret access key | AWS secret key for accessing the S3 bucket. | string |  |
 | **`/database`** | Database | Name of the Firebolt database. | string | Required |
-| **`/engine_url`** | Engine URL | Engine URL of the Firebolt database, in the format: `<engine-name>.<organization>.<region>.app.firebolt.io`. | string | Required |
-| **`/password`** | Password | Firebolt password. | string | Required |
+| **`/engine_name`** | Engine Name | Name of the Firebolt engine to run your queries. | string | Required |
+| **`/client_secret`** | Client Secret | Secret of your Firebolt service account. | string | Required |
 | **`/s3_bucket`** | S3 bucket | Name of S3 bucket where the intermediate files for external table will be stored. | string | Required |
 | `/s3_prefix` | S3 prefix | A prefix for files stored in the bucket. | string |  |
-| **`/username`** | Username | Firebolt username. | string | Required |
+| **`/client_id`** | Client ID | ID of your Firebolt service account. | string | Required |
 
 
 #### Bindings
@@ -83,11 +81,11 @@ materializations:
         connector:
           config:
             database: my-db
-            engine_url: my-db-my-engine-name.my-organization.us-east-1.app.firebolt.io
-            password: secret
+            engine_name: my-engine-name
+            client_secret: secret
             # For public S3 buckets, only the bucket name is required
             s3_bucket: my-bucket
-            username: firebolt-user
+            client_id: firebolt-user
           # Path to the latest version of the connector, provided as a Docker image
           image: ghcr.io/estuary/materialize-firebolt:dev
 	# If you have multiple collections you need to materialize, add a binding for each one


### PR DESCRIPTION
**Description:**

New version of Firebolt has changed authentication. Now all programmatic access is done via [service accounts](https://docs.firebolt.io/Guides/managing-your-organization/service-accounts.html). Engine URL is no longer available, instead engine name should be used to connect.
This PR also fixes SQL syntax and tries to to address issues with internal keys added by Flow that don't have a defined type in the schema. 

**Workflow steps:**

No usage changes for Firebolt, only authentication.

Fields removed:
* Username
* Password
* Engine URL

Added fields:
* Client ID
* Client Secret
* Account Name
* Engine Name

**Documentation links affected:**

Reflected changes in authentication in the relevant doc below, original in [Firebolt reference](https://docs.estuary.dev/reference/Connectors/materialization-connectors/Firebolt/). 

**Notes for reviewers:**

There's a discussion about this change in #estuary-firebolt-integration shared channel in Slack.
Related PR https://github.com/estuary/connectors/pull/2116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1753)
<!-- Reviewable:end -->
