### PR TITLE
stripe: Fix invoice generator's argument parsing to work with clap v4

### DIFF
--- a/crates/billing-integrations/src/stripe.rs
+++ b/crates/billing-integrations/src/stripe.rs
@@ -32,7 +32,7 @@ pub struct PublishInvoice {
     #[clap(long)]
     stripe_api_key: String,
     /// Comma-separated list of tenants to publish invoices for
-    #[clap(long, value_delimiter = ',', required_unless_present("all-tenants"))]
+    #[clap(long, value_delimiter = ',', required_unless_present("all_tenants"))]
     tenants: Vec<String>,
     /// Generate invoices for all tenants that have bills in the provided month.
     #[clap(long, conflicts_with("tenants"))]


### PR DESCRIPTION
**Description:**

Fixes this runtime error introduced by the upgrade to clap v4, and not caught until I ran the invoice generator last Friday:
```
Command stripe: Argument or group 'all-tenants' specified in 'required_unless*' for 'tenants' does not exist
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1754)
<!-- Reviewable:end -->
