### PR TITLE
bound maximum serialization depth to < 128, similar to serde_json

### DIFF
--- a/crates/runtime/src/capture/protocol.rs
+++ b/crates/runtime/src/capture/protocol.rs
@@ -363,15 +363,23 @@ pub fn recv_connector_captured(
     task: &Task,
     txn: &mut Transaction,
 ) -> anyhow::Result<()> {
-    let response::Captured { binding, doc_json } = captured;
+    let response::Captured {
+        binding: binding_index,
+        doc_json,
+    } = captured;
 
     let (memtable, alloc, mut doc) = accumulator
         .doc_bytes_to_heap_node(doc_json.as_bytes())
-        .context("couldn't parse captured document as JSON")?;
+        .with_context(|| {
+            format!(
+                "couldn't parse captured document as JSON (target {})",
+                task.bindings[binding_index as usize].collection_name
+            )
+        })?;
 
     let uuid_ptr = &task
         .bindings
-        .get(binding as usize)
+        .get(binding_index as usize)
         .with_context(|| "invalid captured binding {binding}")?
         .document_uuid_ptr;
 
@@ -380,9 +388,9 @@ pub fn recv_connector_captured(
             *node = doc::HeapNode::String(doc::BumpStr::from_str(crate::UUID_PLACEHOLDER, alloc));
         }
     }
-    memtable.add(binding, doc, false)?;
+    memtable.add(binding_index, doc, false)?;
 
-    let stats = txn.stats.entry(binding).or_default();
+    let stats = txn.stats.entry(binding_index).or_default();
     stats.0.docs_total += 1;
     stats.0.bytes_total += doc_json.len() as u64;
 

--- a/crates/runtime/src/materialize/serve.rs
+++ b/crates/runtime/src/materialize/serve.rs
@@ -169,6 +169,7 @@ async fn serve_session<L: LogHandler>(
                         &mut saw_acknowledged,
                         &mut saw_flush,
                         &mut saw_flushed,
+                        &task,
                         &mut txn,
                         &mut wb,
                     )


### PR DESCRIPTION
Restrict the maximum serialization depth of documents to < 128, which guarantees they can be parsed by serde_json and other tools like `jq` which limit maximum recursion.

We want this to be universal, because we never want serde_json to be unable to parse collection documents or loaded `flow_document` columns, and its limit on maximum depth has well-founded motivations: it would be inappropriate to, for example, completely disable limits on recursion, so we follow serde_json's lead in this regard.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1757)
<!-- Reviewable:end -->
