### PR TITLE
dekaf: Fix high watermark reporting

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -646,10 +646,6 @@ impl Session {
                         unreachable!("Must have already determined data-preview status of session")
                     }
                     SessionDataPreviewState::NotDataPreview => {
-                        partition_data = partition_data
-                            .with_high_watermark(pending.last_write_head) // Map to kafka cursor.
-                            .with_last_stable_offset(pending.last_write_head);
-
                         pending.offset = read.offset;
                         pending.last_write_head = read.last_write_head;
                         pending.handle = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
@@ -660,6 +656,10 @@ impl Session {
                                 std::time::Instant::now() + timeout,
                             ),
                         ));
+
+                        partition_data = partition_data
+                            .with_high_watermark(pending.last_write_head) // Map to kafka cursor.
+                            .with_last_stable_offset(pending.last_write_head);
                     }
                     SessionDataPreviewState::DataPreview(data_preview_states) => {
                         let data_preview_state = data_preview_states


### PR DESCRIPTION
**Description:**

We are returning an incorrectly low high-watermark on the first chunk of a `Read`. This is unexpected behavior and causes the consumer to be incorrectly behind by 1 fetch chunk (the first one). This should fix the problem going forward, though some affected consumer groups may need to be reset (the equivalent of a re-backfill).

For the collection that this was reported in:

```
$ flowctl collections read --uncommitted --collection ... | jq -c 'select(.["_meta"]?.ack != true)' | jq -s 'map(.id) | sort_by(.)[]' | uniq > unique_flowctl_ids.txt

$ kcat -o beginning  -b dekaf.estuary-data.com:9092 \                                                                                                                                                                                                                                                                       
-X security.protocol=SASL_SSL \      
-X sasl.mechanism=PLAIN \
-X sasl.username='{}' \             
-X sasl.password="ey.." \
-t ... \
-s value=avro \
-r \ 'https://{}:ey..@dekaf.estuary-data.com'  -J -C -e | |jq -R "fromjson? | ." | jq -c 'select(.payload.id) | .payload.id' | jq -s -c 'sort_by(.)[]' | uniq > unique_dekaf_ids.txt

$ cat unique_dekaf_ids.txt| | wc -l                                                                                                                                                                                                                                                                                                                      
  680726
$ cat unique_flowctl_ids.txt| uniq | wc -l                                                                                                                                                                                                                                                                                                                    
  686939

... a little while later, testing the fix locally ...

$ kcat -o beginning -b localhost:22262 \                                                                                                                                                                                                                                                                                
-X security.protocol=SASL_PLAINTEXT \
-X sasl.mechanism=PLAIN \
-X sasl.username='{}' \
-X sasl.password="ey.." \
-t ... \
-s value=avro \
-r 'http://{}:ey..@localhost:9081'  -J -C -e | |jq -R "fromjson? | ." | jq -c 'select(.payload.id) | .payload.id' | jq -s -c 'sort_by(.)[]' | uniq > dekaf_fixed_ids.txt

$ cat dekaf_fixed_ids.txt|  wc -l                                                                                                                                                                                                                                                                                                                       
  686954
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1758)
<!-- Reviewable:end -->
