### PR TITLE
two minor runtime fixes 

### DIFF
--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -120,7 +120,7 @@ func startWatches(ctx context.Context, jc pb.JournalClient, shuffles []shuffle) 
 	}
 	// Block until all watches are ready, surfacing any errors during initialization.
 	// We log but don't fail on errors after fetching initial snapshots.
-	for ready := false; !ready; {
+	for ready := len(shuffles) == 0; !ready; {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()


### PR DESCRIPTION
**Description:**

* Best-effort filtering of empty derive-SQLite blocks
* Don't wait for reader watch updates when there are no bindings

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1771)
<!-- Reviewable:end -->
