### PR TITLE
bump gazette pin to 298d8931dc89716d4481eaeccf00b20ddb6e8b69

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
-	go.gazette.dev/core v0.99.1-0.20241017144640-719adefdbad9
+	go.gazette.dev/core v0.99.1-0.20241119185018-298d8931dc89
 	golang.org/x/net v0.26.0
 	google.golang.org/api v0.126.0
 	google.golang.org/grpc v1.65.0

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.99.1-0.20241017144640-719adefdbad9 h1:XLmw3XLHtmuRNRAWy0qs6RwQKV27WAWJzFR3HF0Rvrs=
-go.gazette.dev/core v0.99.1-0.20241017144640-719adefdbad9/go.mod h1:QR31EBrUMzThz/oDYxJHYwmlFSOjgvuNE14lHl/ViX4=
+go.gazette.dev/core v0.99.1-0.20241119185018-298d8931dc89 h1:tfOe9OgS4BPoXJtSsySheyx+78JGmFfkT2rHuea2N+g=
+go.gazette.dev/core v0.99.1-0.20241119185018-298d8931dc89/go.mod h1:QR31EBrUMzThz/oDYxJHYwmlFSOjgvuNE14lHl/ViX4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
This brings in a new Etcd watch restart retry for gRPC status code `Unknown`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1784)
<!-- Reviewable:end -->
