### PR TITLE
dekaf: Refactor `KafkaApiClient` to remove connection pooling

### DIFF
--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -44,11 +44,6 @@ async fn async_connect(broker_url: &str) -> anyhow::Result<BoxedKafkaConnection>
 
     let root_certs = ROOT_CERT_STORE
         .get_or_try_init(|| async {
-            // This returns an Err indicating that the default provider is already set
-            // but without this call rustls crashes with the following error:
-            // `no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`
-            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
             let mut certs = rustls::RootCertStore::empty();
             certs.add_parsable_certificates(
                 rustls_native_certs::load_native_certs().expect("failed to load native certs"),

--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -34,8 +34,6 @@ pub struct App {
     pub advertise_host: String,
     /// Port which is advertised for Kafka access.
     pub advertise_kafka_port: u16,
-    /// Client used when proxying group management APIs.
-    pub kafka_client: KafkaApiClient,
     /// Secret used to secure Prometheus endpoint
     pub secret: String,
     /// Share a single base client in order to re-use connection pools

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -112,6 +112,11 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     tracing::info!("Starting dekaf");
 
+    // This returns an Err indicating that the default provider is already set
+    // but without this call rustls crashes with the following error:
+    // `no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let (api_endpoint, api_key) = if cli.local {
         (LOCAL_PG_URL.to_owned(), LOCAL_PG_PUBLIC_TOKEN.to_string())
     } else {

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -112,10 +112,9 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     tracing::info!("Starting dekaf");
 
-    // This returns an Err indicating that the default provider is already set
-    // but without this call rustls crashes with the following error:
-    // `no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .unwrap();
 
     let (api_endpoint, api_key) = if cli.local {
         (LOCAL_PG_URL.to_owned(), LOCAL_PG_PUBLIC_TOKEN.to_string())


### PR DESCRIPTION
**Description:**

We believe that some of the instability issues we've been seeing are related to a disconnect between Dekaf sessions and upstream Kafka sessions. Specifically, when a group member goes offline and disconnects from Dekaf, if that group member is using static memberships and tries to rejoin the group, Kafka will error as from its perspective, the previous member connection is still open, since Dekaf uses connection pooling.

This change causes Dekaf to always open a new Kafka connection per session, and close that connection at the end of each session.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1801)
<!-- Reviewable:end -->
