### PR TITLE
go/protocols/ops: ensure we discard to-long ops logs through the newline

### DIFF
--- a/go/protocols/ops/log_write_adapter_test.go
+++ b/go/protocols/ops/log_write_adapter_test.go
@@ -24,6 +24,20 @@ func TestWriteAdapter(t *testing.T) {
 	w.Write([]byte(`more invalid json!` + "\n"))
 	w.Write([]byte(`{"message":"5", "fields":{"f1":1, "fTwo":"two"}}` + "\n"))
 
+	defer func(v int) { maxLogSize = v }(maxLogSize)
+	maxLogSize = 16
+
+	w.Write([]byte(`{"message":"6"}` + "\n"))
+	w.Write([]byte(`this line is way too long it just goes on and on and on`))
+	w.Write([]byte(`{"message":"7"}}}}` + "\n")) // Discarded through EOL.
+	w.Write([]byte(`this line is`))
+	w.Write([]byte(`also way to long`))
+	w.Write([]byte(`though it has`))
+	w.Write([]byte(`multiple`))
+	w.Write([]byte(`smaller writes`))
+	w.Write([]byte(`{"message":"8"}` + "\n" + `{"message":`))
+	w.Write([]byte(`"9"}` + "\n")) // Message 8 is discarded, but 9 is not.
+
 	require.Equal(t, []Log{
 		{Message: "hello world", FieldsJsonMap: map[string]json.RawMessage{"stuff": []byte("42")}},
 		{Message: "1"},
@@ -31,5 +45,7 @@ func TestWriteAdapter(t *testing.T) {
 		{Message: "3"},
 		{Message: "4"},
 		{Message: "5", FieldsJsonMap: map[string]json.RawMessage{"f1": []byte("1"), "fTwo": []byte("\"two\"")}},
+		{Message: "6"},
+		{Message: "9"},
 	}, logs)
 }


### PR DESCRIPTION
Previously we could parse an apparently valid Log if a Write happened to occur on a JSON object boundary. Instead, ensure we explicitly discard all line content until a newline is reached.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1803)
<!-- Reviewable:end -->
