### PR TITLE
dekaf: Fix dropped topic name translation

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1127,6 +1127,7 @@ impl Session {
             for topic in topics {
                 let encrypted = self.encrypt_topic_name(topic.name.clone());
                 tracing::info!(topic_name = ?topic.name, encrypted_name = ?encrypted, "Fetching offset");
+                topic.name = encrypted;
             }
         }
 


### PR DESCRIPTION
This fixes a bug introduced in #1799 that dropped the topic name translation in `offset_fetch`

Confirmed that a consumer can join a group and fetch offsets correctly now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1806)
<!-- Reviewable:end -->
