### PR TITLE
Docs: update Stripe connector, fix typos

### DIFF
--- a/site/docs/getting-started/comparisons.md
+++ b/site/docs/getting-started/comparisons.md
@@ -94,7 +94,7 @@ In either case, the usage of connectors is pretty similar.
 In terms of technical capabilities, Flow can do everything that these tools can and more.
 Both Fivetran and Airbyte both currently have graphical interfaces that make them much easier for
 non-technical users to configure. Flow, too, is focused on empowering non-technical users through its web application.
-At the same time, it Flow offers declarative YAML for configuration, which works excellently in a GitOps workflow.
+At the same time, Flow offers declarative YAML for configuration, which works excellently in a GitOps workflow.
 
 [Flow vs Fivetran feature and pricing breakdown.](https://estuary.dev/vs-fivetran/)
 

--- a/site/docs/guides/derivation_tutorial_sql.md
+++ b/site/docs/guides/derivation_tutorial_sql.md
@@ -10,9 +10,9 @@ This tutorial will show you how to implement a stateless transformation using SQ
 
 ## Setting up your development environment<a id="setting-up-your-development-environment"></a>
 
-In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowtcl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
+In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowctl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
 
-Before continuing, sign in to the Estuary Flow dashboard, make sure you enable access to the Wikipedia demo. Using `flowtcl`, quickly verify you are able to view the demo collections used in this guide.
+Before continuing, sign in to the Estuary Flow dashboard, make sure you enable access to the Wikipedia demo. Using `flowctl`, quickly verify you are able to view the demo collections used in this guide.
 
 Execute the below command to display the documents in the `demo/wikipedia/recentchange-sampled` collection:
 

--- a/site/docs/guides/howto_join_two_collections_typescript.md
+++ b/site/docs/guides/howto_join_two_collections_typescript.md
@@ -40,7 +40,7 @@ You can take a look into each via the data preview window on the Collections pag
 
 ![Orders collection](https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//orders_sheet_collection_b99f3c9c84/orders_sheet_collection_b99f3c9c84.png)
 
-In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowtcl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
+In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowctl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
 
 To verify that you’re able to access Flow via `flowctl`, see if you can execute these commands successfully to view documents in your collections.
 
@@ -216,7 +216,7 @@ This command will create a few new files in your current working directory.
 5 directories, 5 files
 ```
 
-The folder `flow_generated` along with the `deno.json` file are two things you won’t have to modify during this tutorial. If you take a look at file that `flowtcl` generated under `flow_generated/typescript/<your_working_directory>/<your_prefix>/customers_with_orders.ts` you can see the types you are able to use in your transformations.
+The folder `flow_generated` along with the `deno.json` file are two things you won’t have to modify during this tutorial. If you take a look at file that `flowctl` generated under `flow_generated/typescript/<your_working_directory>/<your_prefix>/customers_with_orders.ts` you can see the types you are able to use in your transformations.
 
 ```typescript
 // Generated for published documents of derived collection customers_with_orders.

--- a/site/docs/guides/transform_data_using_typescript.md
+++ b/site/docs/guides/transform_data_using_typescript.md
@@ -10,13 +10,14 @@ This tutorial will show you how to implement a stateless transformation using Ty
 
 ## Setting up your development environment<a id="setting-up-your-development-environment"></a>
 
-In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowtcl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
+In order to implement transformations through [derivations](https://docs.estuary.dev/concepts/#derivations), you’ll need to set up your development environment. You’ll need a text editor and [flowctl](https://docs.estuary.dev/concepts/flowctl/), the CLI-tool for Flow installed on your machine. Check out the [docs page](https://docs.estuary.dev/concepts/flowctl/#installation-and-setup) on installation instructions.
 
-Before continuing, sign in to the Estuary Flow dashboard, make sure you enable access to the Wikipedia demo. Using `flowtcl`, quickly verify you are able to view the demo collections used in this guide.
+Before continuing, sign in to the Estuary Flow dashboard, make sure you enable access to the Wikipedia demo. Using `flowctl`, quickly verify you are able to view the demo collections used in this guide.
 
 Execute the below command to display the documents in the `demo/wikipedia/recentchange-sampled` collection:
 
-::note This collection is a 3% sample of the enormous `demo/wikipedia/recentchange` collection which contains millions of documents. Since the purpose of this tutorial is to demonstrate a proof of concept, we avoid publishing a derivation that processes hundreds of gigabytes of data.
+:::note
+This collection is a 3% sample of the enormous `demo/wikipedia/recentchange` collection which contains millions of documents. Since the purpose of this tutorial is to demonstrate a proof of concept, we avoid publishing a derivation that processes hundreds of gigabytes of data.
 :::
 
 ```shell
@@ -201,7 +202,7 @@ If everything went well, you’ll see a bunch of new files that `flowctl` genera
 5 directories, 5 files
 ```
 
-The folder `flow_generated` along with the `deno.json` file are two things you won’t have to modify during this tutorial. If you take a look at file that `flowtcl` generated under `flow_generated/typescript/<your_working_directory>/<your_prefix>/recentchange-filtered-typescript.ts` you can see the types you are able to use in your transformations.
+The folder `flow_generated` along with the `deno.json` file are two things you won’t have to modify during this tutorial. If you take a look at file that `flowctl` generated under `flow_generated/typescript/<your_working_directory>/<your_prefix>/recentchange-filtered-typescript.ts` you can see the types you are able to use in your transformations.
 
 ```typescript
 // Generated for published documents of derived collection Dani/derivation-tutorial/recentchange-filtered-typescript.

--- a/site/docs/reference/Connectors/capture-connectors/stripe.md
+++ b/site/docs/reference/Connectors/capture-connectors/stripe.md
@@ -4,10 +4,6 @@ This connector captures data from Stripe into Flow collections.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-stripe:dev`](https://ghcr.io/estuary/source-stripe:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
-This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
-You can find their documentation [here](https://docs.airbyte.com/integrations/sources/stripe/),
-but keep in mind that the two versions may be significantly different.
-
 ## Supported data resources
 
 The following data resources are supported through the Stripe API:


### PR DESCRIPTION
**Description:**

The new version of the Stripe Capture connector is no longer third-party. This docs update removes information related to the deprecated version.

It also includes some other minor typo fixes, notably correcting `flowctl` spelling across various pages.

**Documentation links affected:**

Provides updates for:

- [Stripe capture connector](https://docs.estuary.dev/reference/Connectors/capture-connectors/stripe/)
- [Getting started comparisons](https://docs.estuary.dev/getting-started/comparisons/)
- [Derivation tutorial SQL](https://docs.estuary.dev/guides/derivation_tutorial_sql/)
- [How to join two collections TypeScript](https://docs.estuary.dev/guides/howto_join_two_collections_typescript)
- [Transform data using TypeScript](https://docs.estuary.dev/guides/transform_data_using_typescript/)

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1811)
<!-- Reviewable:end -->
