### PR TITLE
close out a number of TODOs which have been resolved

### DIFF
--- a/.github/workflows/deploy-agent-api.yaml
+++ b/.github/workflows/deploy-agent-api.yaml
@@ -2,9 +2,6 @@ name: Deploy agent-api
 
 on:
   workflow_dispatch: {}
-  # TODO(johnny): Remove after merging.
-  push:
-    branches: [johnny/dpc-cd]
 
 env:
   CARGO_INCREMENTAL: 0 # Faster from-scratch builds.

--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -2,9 +2,6 @@ name: Deploy data-plane-controller
 
 on:
   workflow_dispatch: {}
-  # TODO(johnny): Remove after merging.
-  push:
-    branches: [johnny/dpc-cd]
 
 env:
   CARGO_INCREMENTAL: 0 # Faster from-scratch builds.

--- a/crates/connector-init/src/capture.rs
+++ b/crates/connector-init/src/capture.rs
@@ -24,7 +24,7 @@ impl proto_grpc::capture::connector_server::Connector for Proxy {
                 rpc::new_command(&self.entrypoint),
                 self.codec,
                 request.into_inner().map_ok(|mut request| {
-                    request.internal.clear(); // TODO(johnny): Temporarily remove $internal.
+                    request.internal.clear();
                     request
                 }),
                 ops::stderr_log_handler,

--- a/crates/connector-init/src/derive.rs
+++ b/crates/connector-init/src/derive.rs
@@ -24,7 +24,7 @@ impl proto_grpc::derive::connector_server::Connector for Proxy {
                 rpc::new_command(&self.entrypoint),
                 self.codec,
                 request.into_inner().map_ok(|mut request| {
-                    request.internal.clear(); // TODO(johnny): Temporarily remove $internal.
+                    request.internal.clear();
                     request
                 }),
                 ops::stderr_log_handler,

--- a/crates/connector-init/src/materialize.rs
+++ b/crates/connector-init/src/materialize.rs
@@ -24,7 +24,7 @@ impl proto_grpc::materialize::connector_server::Connector for Proxy {
                 rpc::new_command(&self.entrypoint),
                 self.codec,
                 request.into_inner().map_ok(|mut request| {
-                    request.internal.clear(); // TODO(johnny): Temporarily remove $internal.
+                    request.internal.clear();
                     request
                 }),
                 ops::stderr_log_handler,

--- a/crates/data-plane-controller/src/controller.rs
+++ b/crates/data-plane-controller/src/controller.rs
@@ -20,7 +20,6 @@ pub enum Message {
     Preview,
     Refresh,
     Converge,
-    // TODO(johnny): `Destroy` variant for managed tear-down.
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/go/network/frontend.go
+++ b/go/network/frontend.go
@@ -382,7 +382,7 @@ func (p *Frontend) serveConnHTTP(user *frontendConn) {
 		} else if req.URL.Path == "/auth-redirect" {
 			completeAuthRedirect(w, req)
 			httpHandledCounter.WithLabelValues(task, port, "CompleteAuth").Inc()
-		} else if err := verifyAuthorization(req, p.verifier, user.resolved.taskName); err == nil {
+		} else if err := verifyAuthorization(req, p.verifier, user.resolved.shardIDPrefix); err == nil {
 			reverse.ServeHTTP(w, req)
 		} else if req.Method == "GET" && strings.Contains(req.Header.Get("accept"), "html") {
 			// Presence of "html" in Accept means this is probably a browser.


### PR DESCRIPTION
* deploy-agent-api, deploy-data-plane-controller, and derive-typescript are merged.

* `name:prefix` support has been live for some time now.

* Continue to clear the `internal` field in flow-connector-init. There's no use case for sending it into connectors.

* No current plan to implement a Destroy data-plane-controller message.

* Current UI is generating tokens via /authorize/user/task

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1814)
<!-- Reviewable:end -->
