### PR TITLE
Phil/cp http rebased

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,9 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 name = "models"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "caseless",
+ "chrono",
  "humantime-serde",
  "insta",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ version = "0.0.0"
 dependencies = [
  "activate",
  "agent-sql",
+ "aide",
  "allocator",
  "anyhow",
  "async-process",
@@ -149,6 +150,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tower 0.5.0",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -210,6 +212,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aide"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0e3b97a21e41ec5c19bfd9b4fc1f7086be104f8b988681230247ffc91cc8ed"
+dependencies = [
+ "aide-macros",
+ "axum",
+ "axum-extra",
+ "bytes",
+ "cfg-if 1.0.0",
+ "http 1.1.0",
+ "indexmap 2.3.0",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_qs 0.13.0",
+ "thiserror",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "aide-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0487f8598afe49e6bc950a613a678bd962c4a6f431022ded62643c8b990301a"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -772,6 +809,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "serde",
+ "serde_html_form",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -1750,8 +1788,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1769,14 +1817,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3172,6 +3245,7 @@ checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -5606,6 +5680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
+ "indexmap 2.3.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -5754,6 +5829,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.3.0",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5792,6 +5880,19 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
 dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "axum",
+ "futures",
  "percent-encoding",
  "serde",
  "thiserror",
@@ -6877,7 +6978,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ca2384932803823dd024a68d84019666577f4b373d78eb7ccafd5aa2548d615"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,14 @@ license = "BSL"
 
 [workspace.dependencies]
 addr = { version = "0.15.4", default-features = false, features = ["std"] }
+aide = { version = "0.13", features = [
+    "axum",
+    "macros",
+    "scalar",
+    "redoc",
+    "axum-extra",
+    "axum-extra-query",
+] }
 anyhow = "1.0"
 async-compression = { version = "0.3", features = [
     "futures-io",
@@ -227,10 +235,11 @@ pbjson-build = "0.7"
 prost-build = "0.13"
 tonic-build = "0.12"
 
-warp = "0.3.3"                                                # TODO(johnny) remove me in favor of axum
+warp = "0.3.3" # TODO(johnny) remove me in favor of axum
+# Used for the agent http server
 axum = { version = "0.7", features = ["macros"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-axum-extra = { version = "0.9", features = ["typed-header"] }
+axum-extra = { version = "0.9", features = ["typed-header", "query"] }
 
 [profile.release]
 incremental = true

--- a/crates/agent-sql/src/connector_tags.rs
+++ b/crates/agent-sql/src/connector_tags.rs
@@ -3,7 +3,7 @@ use super::{Id, TextJson as Json};
 use chrono::prelude::*;
 use serde::Serialize;
 use serde_json::value::RawValue;
-use sqlx::{postgres::types::PgInterval, types::Uuid, FromRow};
+use sqlx::{types::Uuid, FromRow};
 
 /// Row is the dequeued task shape of a tag connector operation. Note that `connector_tags` jobs
 /// are expected to all be `background` jobs, so we don't bother to include that field in this struct.

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -30,6 +30,7 @@ sources = { path = "../sources" }
 tables = { path = "../tables", features = ["persist"] }
 validation = { path = "../validation" }
 
+aide = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
@@ -60,6 +61,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/agent/src/api/error.rs
+++ b/crates/agent/src/api/error.rs
@@ -1,0 +1,163 @@
+//! Defines the `ApiError` type that can be returned from an API handler, which
+//! specifies an HTTP status code and wraps an `anyhow::Error`. It implements
+//! `IntoResponse`, allowing handlers to return a `Result<Json<T>, ApiError>`.
+//! `From` impls exist for `anyhow::Error`, `Rejection`, and `sqlx::Error` with
+//! reasonable default status codes. The http status code can be customized
+//! using `ApiErrorExt::with_status` if you need to return a specific response
+//! status for a given error.
+//!
+//! These types are written with the aim of making them easy to use in the
+//! server. It's unclear whether we need an error struct defined in the `models`
+//! crate, but in this case it's probably easiest to just use separate structs
+//! for the client and server.
+use axum::http::StatusCode;
+use schemars::JsonSchema;
+
+use super::Rejection;
+
+pub trait ApiErrorExt {
+    /// Sets the given http response status to use when responding with this error.
+    fn with_status(self, status: axum::http::StatusCode) -> ApiError;
+}
+
+impl<E: Into<ApiError> + Sized> ApiErrorExt for E {
+    fn with_status(self, status: axum::http::StatusCode) -> ApiError {
+        let mut err: ApiError = self.into();
+        err.status = status;
+        err
+    }
+}
+
+/// An error response
+#[derive(
+    Debug, thiserror::Error, serde::Serialize, serde::Deserialize, JsonSchema, aide::OperationIo,
+)]
+#[aide(output)]
+#[error("status: {status}, error: {error}")]
+pub struct ApiError {
+    /// The HTTP status code
+    #[serde(with = "status_serde")]
+    #[schemars(schema_with = "status_serde::schema")]
+    status: axum::http::StatusCode,
+
+    /// The error message
+    #[serde(with = "error_serde")]
+    #[schemars(schema_with = "error_serde::schema")]
+    #[source]
+    error: anyhow::Error,
+}
+
+mod status_serde {
+    use serde::{
+        de::{self, Deserialize, Deserializer},
+        ser::{Serialize, Serializer},
+    };
+
+    pub fn schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599,
+        }))
+        .unwrap()
+    }
+    pub fn serialize<S: Serializer>(
+        status: &axum::http::StatusCode,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        status.as_u16().serialize(s)
+    }
+    pub fn deserialize<'a, D: Deserializer<'a>>(
+        deserializer: D,
+    ) -> Result<axum::http::StatusCode, D::Error> {
+        let int_val = <u16 as Deserialize>::deserialize(deserializer)?;
+        axum::http::StatusCode::from_u16(int_val).map_err(|e| de::Error::custom(e))
+    }
+}
+
+mod error_serde {
+    use serde::{
+        de::{Deserialize, Deserializer},
+        ser::Serializer,
+    };
+
+    pub fn schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "string",
+        }))
+        .unwrap()
+    }
+    pub fn serialize<S: Serializer>(error: &anyhow::Error, s: S) -> Result<S::Ok, S::Error> {
+        let err_str = format!("{error:#}"); // alternate renders nested causes
+        s.serialize_str(&err_str)
+    }
+    pub fn deserialize<'a, D: Deserializer<'a>>(
+        deserializer: D,
+    ) -> Result<anyhow::Error, D::Error> {
+        let str_val = <String as Deserialize>::deserialize(deserializer)?;
+        Ok(anyhow::anyhow!(str_val))
+    }
+}
+
+impl ApiError {
+    pub fn not_found() -> ApiError {
+        ApiError::new(
+            StatusCode::NOT_FOUND,
+            anyhow::anyhow!("requested entity does not exist or you are not authorized"),
+        )
+    }
+
+    pub fn new(status: StatusCode, error: anyhow::Error) -> ApiError {
+        ApiError { status, error }
+    }
+
+    fn status_for(err: &anyhow::Error) -> StatusCode {
+        // Ensure that we set the proper status code if the anyhow error itself
+        // wraps a Rejection. This might not be necessary since we generally
+        // convert Rejections into ApiErrors directly, using `From` impl, which
+        // always sets the proper status. But this check is cheap, and it
+        // ensures that we'll set the proper status in case a `?` operator
+        // somewhere converts the Rejection into an `anyhow::Error` before
+        // converting that error into an `ApiError`.
+        if let Some(_rejection) = err.downcast_ref::<Rejection>() {
+            return StatusCode::BAD_REQUEST;
+        }
+        if let Some(api_error) = err.downcast_ref::<ApiError>() {
+            return api_error.status;
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+impl From<sqlx::Error> for ApiError {
+    fn from(error: sqlx::Error) -> ApiError {
+        tracing::error!(?error, "API responding with database error");
+        ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: anyhow::anyhow!("database error, please retry the request"),
+        }
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(error: anyhow::Error) -> Self {
+        let status = Self::status_for(&error);
+        ApiError { status, error }
+    }
+}
+
+impl From<Rejection> for ApiError {
+    fn from(value: Rejection) -> Self {
+        ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: anyhow::Error::from(value).context("Input validation error"),
+        }
+    }
+}
+
+impl axum::response::IntoResponse for ApiError {
+    fn into_response(self) -> axum::response::Response {
+        let status = self.status;
+        (status, axum::Json(self)).into_response()
+    }
+}

--- a/crates/agent/src/api/public/mod.rs
+++ b/crates/agent/src/api/public/mod.rs
@@ -1,0 +1,129 @@
+mod status;
+
+use axum::{http::StatusCode, response::IntoResponse};
+use std::sync::Arc;
+
+use crate::api::{authorize, error::ApiErrorExt, ApiError, App};
+
+/// Creates a router for the public API that can be merged into an existing router.
+/// All endpoints registered here are documented in an OpenAPI spec. For adding new
+/// endpoints, the general rule is to use a handler function signature like:
+///
+/// ```ignore
+/// fn handle_{get|post|etc}_{resource_name}(
+///     state: State<Arc<App>>, // has the database connection pool, etc
+///     claims: Extension<ControlClaims>, // claims from a verified JWT (unauthenticated requests would be rejected automatically)
+///     other_stuff: T, // other extracted data from the request
+/// ) -> Result<Json<Resp>, ApiError>
+/// ```
+///
+/// and register the handler using `.api_route(path, aide::axum::routing::get(handle_get_thing))`.
+///
+/// Other input parameters can be used, as long as they implement
+/// `aide::operation::OperationInput`. The basic ones, like `Path` and `Query`
+/// all do so already. This just ensures that the parameters are documented in
+/// the OpenAPI spec. You can `impl aide::operation::OperationInput for MyInput
+/// {}` if you don't want it to show in the spec.
+///
+/// For accepting query parameters, define a struct with `Deserialize` and
+/// `JsonSchema` impls, and use a parameter of type
+/// `axum_extra::extract::Query<MyQueryParams>` to extract it. This will
+/// automatically return a 400 response if the given query parameters can't be
+/// deserialized into the struct.
+///
+/// The output type `Result<Json<T>, ApiError>` is suitable for any handler that
+/// returns JSON, which is all of them. Just ensure that `T` implements
+/// `serde::Serialize` and `schemars::JsonSchema`. See the `crate::api::error` module
+/// docs for more information on error handling.
+pub fn api_v1_router(app: Arc<App>) -> axum::Router<Arc<App>> {
+    // When errors occur during the process of generating an openapi spec, aide
+    // will call this function with the error so we can log it. They have a note
+    // in their docs warning about false positives where it logs errors even
+    // when it's able to return a valid response. I know it smells, but seems
+    // better than the available alternatives.
+    aide::gen::on_error(|error| {
+        tracing::error!(?error, "aide gen error");
+        if cfg!(test) {
+            panic!("aide gen error: {:?}", error);
+        }
+    });
+
+    // Routes are defined in groups, with the first group all being
+    // authenticated routes that require a valid authentication token, and the
+    // second group being unauthenticated routes that can be accessed by anyone.
+    let router = aide::axum::ApiRouter::new()
+        .api_route(
+            "/api/v1/status",
+            aide::axum::routing::get(status::handle_get_status),
+        )
+        .layer(axum::middleware::from_fn(ensure_accepts_json))
+        // All routes below this are publicly accessible to anyone, without an authentication token
+        .layer(axum::middleware::from_fn_with_state(app.clone(), authorize))
+        // The openapi json is itself documented as an API route
+        .api_route("/api/v1/openapi.json", aide::axum::routing::get(serve_docs))
+        // The docs UI is not documented as an API route
+        .route(
+            "/api/v1/docs",
+            axum::routing::get(
+                aide::scalar::Scalar::new("/api/v1/openapi.json")
+                    .with_title(API_TITLE)
+                    .axum_handler(),
+            ),
+        )
+        .with_state(app.clone());
+
+    // There's kind of a weird twist here, where we take the `OpenApi` that
+    // holds the generated documentation, and add it as an extension to the
+    // router that we just generated the documentation from.
+    let mut api = aide::openapi::OpenApi::default();
+    let router = router.finish_api_with(&mut api, api_docs);
+    router.layer(axum::Extension(Arc::new(api)))
+}
+
+/// Our API currently only supports JSON responses, so we check to make sure
+/// that the accept header permits those.
+async fn ensure_accepts_json(
+    headers: axum::http::HeaderMap,
+    req: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    if let Some(val) = headers.get("accept") {
+        let Ok(accept) = val.to_str() else {
+            return anyhow::anyhow!("invalid accept header was not ascii")
+                .with_status(StatusCode::BAD_REQUEST)
+                .into_response();
+        };
+        if !accept.contains("application/json") && !accept.contains("*/*") {
+            return anyhow::anyhow!("only application/json responses are supported at this time")
+                .with_status(StatusCode::NOT_ACCEPTABLE)
+                .into_response();
+        }
+    }
+    next.run(req).await
+}
+
+/// Handler that serves the openapi spec as JSON
+async fn serve_docs(
+    axum::extract::Extension(api): axum::extract::Extension<Arc<aide::openapi::OpenApi>>,
+) -> impl aide::axum::IntoApiResponse {
+    axum::Json(api).into_response()
+}
+
+const API_TITLE: &str = "Flow Control Plane V1 API";
+
+fn api_docs(api: aide::transform::TransformOpenApi) -> aide::transform::TransformOpenApi {
+    api.title(API_TITLE)
+        .summary("Controlling the control plane")
+        .description("API for the Flow control plane")
+        .security_scheme(
+            "ApiKey",
+            aide::openapi::SecurityScheme::Http {
+                scheme: "bearer".to_string(),
+                bearer_format: Some("JWT".to_string()),
+                description: Some("Estuary authentication token".to_string()),
+                extensions: Default::default(),
+            },
+        )
+        .security_requirement("ApiKey")
+        .default_response_with::<axum::Json<ApiError>, _>(|res| res.example(ApiError::not_found()))
+}

--- a/crates/agent/src/api/public/status.rs
+++ b/crates/agent/src/api/public/status.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use crate::api::error::ApiErrorExt;
+use crate::api::{ApiError, App, ControlClaims};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+// axum_extra's `Query` is needed here because unlike the one from `axum`, it
+// handles multiple query parameters with the same name
+use axum_extra::extract::Query;
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use models::status::{self, StatusResponse};
+use models::Id;
+
+/// Query parameters for the status endpoint
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct StatusQuery {
+    /// The catalog name of the live spec to get the status of
+    pub name: Vec<String>,
+}
+
+#[axum::debug_handler]
+pub async fn handle_get_status(
+    state: State<Arc<App>>,
+    Extension(claims): Extension<ControlClaims>,
+    Query(params): Query<StatusQuery>,
+) -> Result<Json<Vec<StatusResponse>>, ApiError> {
+    if !state
+        .0
+        .is_user_authorized(&claims, &params.name, models::Capability::Read)
+        .await?
+    {
+        return Err(ApiError::not_found());
+    }
+    let pool = state.0.pg_pool.clone();
+    let status = fetch_status(&pool, &params.name).await?;
+    Ok(Json(status))
+}
+
+async fn fetch_status(
+    pool: &sqlx::PgPool,
+    catalog_names: &[String],
+) -> Result<Vec<StatusResponse>, ApiError> {
+    let resp = sqlx::query_as!(StatusResponse, r#"select
+        ls.catalog_name as "catalog_name!: String",
+        ls.id as "live_spec_id: Id",
+        ls.spec_type as "spec_type: models::CatalogType",
+        coalesce(ls.spec->'shards'->>'disable', ls.spec->'derive'->'shards'->>'disable', 'false') = 'true' as "disabled!: bool",
+        ls.last_pub_id as "last_pub_id: Id",
+        ls.last_build_id as "last_build_id: Id",
+        ls.controller_next_run,
+        ls.updated_at as "live_spec_updated_at: DateTime<Utc>",
+        cj.updated_at as "controller_updated_at: DateTime<Utc>",
+        cj.status as "status: status::Status",
+        cj.error as "controller_error: String",
+        cj.failures as "controller_failures: i32"
+    from live_specs ls
+    join controller_jobs cj on ls.id = cj.live_spec_id
+    where ls.catalog_name::text = any($1::text[])
+        "#,
+        catalog_names as &[String],
+    ).fetch_all(pool)
+    .await?;
+
+    if resp.len() < catalog_names.len() {
+        let actual = resp
+            .into_iter()
+            .map(|r| r.catalog_name)
+            .collect::<std::collections::HashSet<String>>();
+        let missing = catalog_names
+            .iter()
+            .filter(|n| !actual.contains(n.as_str()));
+        return Err(
+            anyhow::anyhow!("no live specs found for names: [{}]", missing.format(", "))
+                .with_status(StatusCode::NOT_FOUND),
+        );
+    }
+    Ok(resp)
+}

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -1,598 +1,84 @@
+mod auto_discover;
 use super::{
-    backoff_data_plane_activate,
-    dependencies::Dependencies,
-    publication_status::{ActivationStatus, PendingPublication, PublicationInfo},
-    ControlPlane, ControllerErrorExt, ControllerState, NextRun,
+    backoff_data_plane_activate, dependencies::Dependencies, ControlPlane, ControllerErrorExt,
+    ControllerState, NextRun,
 };
-use crate::{
-    controllers::{periodic, publication_status::PublicationStatus},
-    controlplane::ConnectorSpec,
-    discovers::{Changed, ResourcePath},
-    evolution, publications,
-};
-use crate::{discovers::DiscoverOutput, publications::PublicationResult};
+use crate::controllers::{periodic, publication_status};
 use anyhow::Context;
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use models::status::capture::{AutoDiscoverStatus, CaptureStatus};
 
-/// Status of a capture controller
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
-pub struct CaptureStatus {
-    // TODO: auto discovers are not yet implemented as controllers, but they should be soon.
-    // #[serde(default, skip_serializing_if = "Option::is_none")]
-    // #[schemars(schema_with = "super::datetime_schema")]
-    // pub next_auto_discover: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub publications: PublicationStatus,
-    #[serde(default)]
-    pub activation: ActivationStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auto_discover: Option<AutoDiscoverStatus>,
-}
+pub async fn update<C: ControlPlane>(
+    status: &mut CaptureStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+    model: &models::CaptureDef,
+) -> anyhow::Result<Option<NextRun>> {
+    let mut dependencies = Dependencies::resolve(state, control_plane).await?;
 
-impl CaptureStatus {
-    pub async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-        model: &models::CaptureDef,
-    ) -> anyhow::Result<Option<NextRun>> {
-        let mut dependencies = Dependencies::resolve(state, control_plane).await?;
-
-        let published = dependencies
-            .update(state, control_plane, &mut self.publications, |deleted| {
-                let mut draft_capture = model.clone();
-                let mut disabled_count = 0;
-                for binding in draft_capture.bindings.iter_mut() {
-                    if deleted.contains(binding.target.as_str()) && !binding.disable {
-                        disabled_count += 1;
-                        binding.disable = true;
-                    }
+    let published = dependencies
+        .update(state, control_plane, &mut status.publications, |deleted| {
+            let mut draft_capture = model.clone();
+            let mut disabled_count = 0;
+            for binding in draft_capture.bindings.iter_mut() {
+                if deleted.contains(binding.target.as_str()) && !binding.disable {
+                    disabled_count += 1;
+                    binding.disable = true;
                 }
+            }
 
-                let detail = format!(
-                    "disabled {disabled_count} binding(s) in response to deleted collections: [{}]",
-                    deleted.iter().format(", ")
-                );
-                Ok((detail, draft_capture))
-            })
-            .await?;
-        tracing::debug!(%published, "dependencies status updated successfully");
+            let detail = format!(
+                "disabled {disabled_count} binding(s) in response to deleted collections: [{}]",
+                deleted.iter().format(", ")
+            );
+            Ok((detail, draft_capture))
+        })
+        .await?;
+    tracing::debug!(%published, "dependencies status updated successfully");
+    if published {
+        return Ok(Some(NextRun::immediately()));
+    }
+
+    if model.auto_discover.is_some() {
+        let ad_status = status
+            .auto_discover
+            .get_or_insert_with(AutoDiscoverStatus::default);
+        let published = auto_discover::update(
+            ad_status,
+            state,
+            model,
+            control_plane,
+            &mut status.publications,
+        )
+        .await
+        .context("updating auto-discover")?;
+        tracing::debug!(%published, "auto-discover status updated successfully");
         if published {
             return Ok(Some(NextRun::immediately()));
         }
+    } else {
+        // Clear auto-discover status to avoid confusion, but only if
+        // auto-discover is disabled. We leave the auto-discover status if
+        // shards are disabled, since it's still useful for debugging.
+        status.auto_discover = None;
+    };
 
-        if model.auto_discover.is_some() {
-            let ad_status = self
-                .auto_discover
-                .get_or_insert_with(AutoDiscoverStatus::default);
-            let published = ad_status
-                .update(state, model, control_plane, &mut self.publications)
-                .await
-                .context("updating auto-discover")?;
-            tracing::debug!(%published, "auto-discover status updated successfully");
-            if published {
-                return Ok(Some(NextRun::immediately()));
-            }
-        } else {
-            // Clear auto-discover status to avoid confusion, but only if
-            // auto-discover is disabled. We leave the auto-discover status if
-            // shards are disabled, since it's still useful for debugging.
-            self.auto_discover = None;
-        };
-
-        if periodic::update_periodic_publish(state, &mut self.publications, control_plane).await? {
-            return Ok(Some(NextRun::immediately()));
-        }
-
-        self.activation
-            .update(state, control_plane)
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))?;
-
-        self.publications
-            .update_notify_dependents(state, control_plane)
-            .await
-            .context("failed to notify dependents")?;
-
-        let ad_next = self.auto_discover.as_ref().and_then(|ad| ad.next_run());
-        let periodic_next = periodic::next_periodic_publish(state);
-        Ok(NextRun::earliest([ad_next, periodic_next]))
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
-pub struct DiscoverChange {
-    /// Identifies the resource in the source system that this change pertains to.
-    pub resource_path: ResourcePath,
-    /// The target collection of the capture binding that was changed.
-    pub target: models::Collection,
-    /// Whether the capture binding is disabled.
-    pub disable: bool,
-}
-
-impl DiscoverChange {
-    pub fn new(resource_path: ResourcePath, Changed { target, disable }: Changed) -> Self {
-        Self {
-            resource_path,
-            target,
-            disable,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
-pub struct AutoDiscoverOutcome {
-    /// Time at which the disocver was attempted
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub ts: DateTime<Utc>,
-    /// Bindings that were added to the capture.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub added: Vec<DiscoverChange>,
-    /// Bindings that were modified, either to change the schema or the collection key.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub modified: Vec<DiscoverChange>,
-    /// Bindings that were removed because they no longer appear in the source system.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub removed: Vec<DiscoverChange>,
-    /// Errors that occurred during the discovery or evolution process.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub errors: Vec<crate::draft::Error>,
-    /// Collections that were re-created due to the collection key having changed.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub re_created_collections: Vec<crate::evolution::EvolvedCollection>,
-    /// The result of publishing the discovered changes, if a publication was attempted.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub publish_result: Option<publications::JobStatus>,
-}
-
-impl AutoDiscoverOutcome {
-    fn has_changes(&self) -> bool {
-        self.errors.is_empty()
-            && (!self.added.is_empty() || !self.modified.is_empty() || !self.removed.is_empty())
+    if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
+        return Ok(Some(NextRun::immediately()));
     }
 
-    fn error(ts: DateTime<Utc>, capture_name: &str, error: &anyhow::Error) -> AutoDiscoverOutcome {
-        let errors = vec![crate::draft::Error {
-            catalog_name: capture_name.to_string(),
-            detail: error.to_string(),
-            scope: None,
-        }];
-        AutoDiscoverOutcome {
-            ts,
-            errors,
-            added: Vec::new(),
-            modified: Vec::new(),
-            removed: Vec::new(),
-            re_created_collections: Vec::new(),
-            publish_result: None,
-        }
-    }
+    publication_status::update_activation(&mut status.activation, state, control_plane)
+        .await
+        .with_retry(backoff_data_plane_activate(state.failures))?;
 
-    fn from_output(ts: DateTime<Utc>, output: DiscoverOutput) -> (Self, tables::DraftCatalog) {
-        let DiscoverOutput {
-            capture_name: _,
-            draft,
-            added,
-            modified,
-            removed,
-        } = output;
+    publication_status::update_notify_dependents(&mut status.publications, state, control_plane)
+        .await
+        .context("failed to notify dependents")?;
 
-        let errors = draft
-            .errors
-            .iter()
-            .map(crate::draft::Error::from_tables_error)
-            .collect();
-
-        let outcome = Self {
-            ts,
-            added: added
-                .into_iter()
-                .map(|(rp, change)| DiscoverChange::new(rp, change))
-                .collect(),
-            modified: modified
-                .into_iter()
-                .map(|(rp, change)| DiscoverChange::new(rp, change))
-                .collect(),
-            removed: removed
-                .into_iter()
-                .map(|(rp, change)| DiscoverChange::new(rp, change))
-                .collect(),
-            errors,
-            re_created_collections: Default::default(),
-            publish_result: None,
-        };
-        (outcome, draft)
-    }
-
-    /// Returns true if this represents a successfull auto-discover, meaning
-    /// that the discover itself was successful, and either we were able to
-    /// publish the changes, or there was no publication necessary.
-    fn is_successful(&self) -> bool {
-        self.get_result().is_ok()
-    }
-
-    /// Returns an `Err` if any part of the auto-discover failed. Returns `Ok`
-    /// only if the auto-discover was successful.
-    fn get_result(&self) -> anyhow::Result<()> {
-        if let Some(first_err) = self.errors.get(0) {
-            anyhow::bail!("auto-discover failed: {}", &first_err.detail);
-        }
-        if let Some(pub_result) = self
-            .publish_result
-            .as_ref()
-            .filter(|r| !(r.is_success() || r.is_empty_draft()))
-        {
-            anyhow::bail!("auto-discover publication failed with: {:?}", pub_result)
-        };
-        Ok(())
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
-pub struct AutoDiscoverFailure {
-    /// The number of consecutive failures that have been observed.
-    pub count: u32,
-    /// The timestamp of the first failure in the current sequence.
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub first_ts: DateTime<Utc>,
-    /// The discover outcome corresponding to the most recent failure. This will
-    /// be updated with the results of each retry until an auto-discover
-    /// succeeds.
-    pub last_outcome: AutoDiscoverOutcome,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
-pub struct AutoDiscoverStatus {
-    /// The interval at which auto-discovery is run. This is normally unset, which uses
-    /// the default interval.
-    #[serde(
-        default,
-        with = "humantime_serde",
-        skip_serializing_if = "Option::is_none"
-    )]
-    #[schemars(schema_with = "interval_schema")]
-    pub interval: Option<std::time::Duration>,
-
-    /// Time at which the next auto-discover should be run.
-    #[serde(default)]
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub next_at: Option<DateTime<Utc>>,
-    /// The outcome of the a recent discover, which is about to be published.
-    /// This will typically only be observed if the publication failed for some
-    /// reason.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pending_publish: Option<AutoDiscoverOutcome>,
-    /// The outcome of the last _successful_ auto-discover. If `failure` is set,
-    /// then that will typically be more recent than `last_success`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_success: Option<AutoDiscoverOutcome>,
-    /// If auto-discovery has failed, this will include information about that failure.
-    /// This field is cleared as soon as a successful auto-discover is run.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<AutoDiscoverFailure>,
-}
-
-fn interval_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    serde_json::from_value(serde_json::json!({
-        "type": ["string", "null"],
-        "pattern": "^\\d+(s|m|h)$"
-    }))
-    .unwrap()
-}
-
-impl AutoDiscoverStatus {
-    async fn try_connector_spec<C: ControlPlane>(
-        model: &models::CaptureDef,
-        control_plane: &mut C,
-    ) -> anyhow::Result<ConnectorSpec> {
-        let models::CaptureEndpoint::Connector(cfg) = &model.endpoint else {
-            anyhow::bail!("only connector endpoints are supported for auto-discovery");
-        };
-        let spec = control_plane
-            .get_connector_spec(cfg.image.clone())
-            .await
-            .context("failed to fetch connector spec")?;
-        if spec.resource_path_pointers.is_empty() {
-            anyhow::bail!("connector has no resource path pointers");
-        }
-        Ok(spec)
-    }
-
-    /// Performs an auto-discover if one is due, and returns a boolean
-    /// indicating whether a publication was performed. If this returns true,
-    /// then the controller should immediately return and schedule a subsequent
-    /// run.
-    async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        model: &models::CaptureDef,
-        control_plane: &mut C,
-        pub_status: &mut PublicationStatus,
-    ) -> anyhow::Result<bool> {
-        self.update_next_run(state, model, control_plane).await?;
-        if self
-            .next_at
-            .map(|due| control_plane.current_time() <= due)
-            .unwrap_or(true)
-        {
-            return Ok(false);
-        }
-
-        tracing::debug!("starting auto-discover");
-        // We'll return the original discover error if it fails
-        let result = self
-            .try_auto_discover(state, model, control_plane, pub_status)
-            .await;
-
-        // We'll return whether we've actually published anything. If all we did
-        // was run a discover that found no changes, then we may proceed with
-        // other controller actions.
-        let has_changes = match result {
-            Ok(outcome) => {
-                let has_changes = outcome.is_successful() && outcome.has_changes();
-                let result = outcome.get_result();
-                self.record_outcome(outcome);
-                result?; // return an error if the auto-discover failed
-
-                // Auto-discover was successful, so determine the time of the next attempt
-                self.update_next_run(state, model, control_plane).await?;
-                has_changes
-            }
-            Err(error) => {
-                tracing::debug!(?error, "auto-discover failed with error");
-                let outcome = AutoDiscoverOutcome::error(
-                    control_plane.current_time(),
-                    &state.catalog_name,
-                    &error,
-                );
-                self.record_outcome(outcome);
-                return Err(error);
-            }
-        };
-        Ok(has_changes)
-    }
-
-    async fn update_next_run<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        model: &models::CaptureDef,
-        control_plane: &mut C,
-    ) -> anyhow::Result<()> {
-        if model.shards.disable {
-            self.next_at = None;
-            return Ok(());
-        }
-
-        if self.next_at.is_none()
-            || self.next_at.is_some_and(|n| {
-                self.last_success
-                    .as_ref()
-                    .map(|ls| ls.ts > n)
-                    .unwrap_or(false)
-            })
-        {
-            // `next_at` is `None` or else we've successfully completed a
-            // discover since, so determine the next auto-discover time.
-            // If there's no `connector_tags` row for this capture connector
-            // then we cannot discover, so this is an error.
-            let connector_spec = Self::try_connector_spec(model, control_plane)
-                .await
-                .context("fetching connector spec")?;
-
-            let auto_discover_interval = self
-                .interval
-                .and_then(|i| chrono::Duration::from_std(i).ok())
-                .unwrap_or(connector_spec.auto_discover_interval)
-                .abs();
-
-            let prev = self
-                .last_success
-                .as_ref()
-                .map(|s| s.ts)
-                .unwrap_or(state.created_at);
-
-            let next = prev + auto_discover_interval;
-            tracing::debug!(%next, %auto_discover_interval, "determined new next_at time");
-            self.next_at = Some(next);
-        }
-        Ok(())
-    }
-
-    fn next_run(&self) -> Option<NextRun> {
-        self.next_at
-            .map(|n| NextRun::after(n).with_jitter_percent(0))
-    }
-
-    async fn publication_finished<C: ControlPlane>(
-        &mut self,
-        mut pub_result: PublicationResult,
-        history: &mut PublicationStatus,
-        state: &ControllerState,
-        control_plane: &mut C,
-        model: &models::CaptureDef,
-        pending_outcome: &mut AutoDiscoverOutcome,
-    ) -> anyhow::Result<()> {
-        pending_outcome.publish_result = Some(pub_result.status.clone());
-
-        // Did the publication result in incompatible collections, which we should evolve?
-        let evolve_incompatible = model
-            .auto_discover
-            .as_ref()
-            .unwrap()
-            .evolve_incompatible_collections;
-
-        if let Some(incompatible_collections) = pub_result
-            .status
-            .incompatible_collections()
-            .filter(|_| evolve_incompatible)
-        {
-            let evolve_requests = crate::evolutions_requests(incompatible_collections);
-            // This is because we never try to publish materializations, so we
-            // should never see incompatibilities that don't require re-creating
-            // the collection.
-            assert!(
-                evolve_requests.iter().all(|r| r.new_name.is_some()),
-                "expected all evolutions to re-create collections"
-            );
-            assert!(!evolve_requests.is_empty());
-            let mut draft = std::mem::take(&mut pub_result.draft);
-            draft.errors.clear();
-            let evolution_result = control_plane
-                .evolve_collections(draft, evolve_requests)
-                .await
-                .context("evolving collections")?;
-            if !evolution_result.is_success() {
-                tracing::warn!("evolution failed");
-                pending_outcome.errors.extend(
-                    evolution_result
-                        .draft
-                        .errors
-                        .iter()
-                        .map(crate::draft::Error::from_tables_error),
-                );
-            } else {
-                let evolution::EvolutionOutput { draft, actions } = evolution_result;
-                tracing::info!(
-                    collection_count = actions.len(),
-                    "successfully re-created collections"
-                );
-                let new_detail = format!(
-                    "{}, and re-creating {} collections",
-                    pub_result.detail.as_deref().unwrap_or("no detail"),
-                    actions.len()
-                );
-                pending_outcome.re_created_collections = actions;
-                let new_result = control_plane
-                    .publish(
-                        Some(new_detail),
-                        state.logs_token,
-                        draft,
-                        state.data_plane_name.clone(),
-                    )
-                    .await
-                    .context("publishing evolved collections")?;
-                history.record_result(PublicationInfo::observed(&new_result));
-                pending_outcome.publish_result = Some(new_result.status.clone());
-            }
-        }
-
-        return Ok(());
-    }
-
-    async fn try_auto_discover<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        model: &models::CaptureDef,
-        control_plane: &mut C,
-        pub_status: &mut PublicationStatus,
-    ) -> anyhow::Result<AutoDiscoverOutcome> {
-        let update_only = !model.auto_discover.as_ref().unwrap().add_new_bindings;
-        let capture_name = models::Capture::new(&state.catalog_name);
-
-        let mut draft = tables::DraftCatalog::default();
-        draft.captures.insert(tables::DraftCapture {
-            capture: capture_name.clone(),
-            scope: tables::synthetic_scope(models::CatalogType::Capture, &capture_name),
-            expect_pub_id: Some(state.last_pub_id),
-            model: Some(model.clone()),
-            // start with a touch. The discover merge will set this to false if it actually updates the capture
-            is_touch: true,
-        });
-
-        let mut output = control_plane
-            .discover(
-                models::Capture::new(&state.catalog_name),
-                draft,
-                update_only,
-                state.logs_token,
-                state.data_plane_id,
-            )
-            .await
-            .context("failed to discover")?;
-
-        // Return early if there was a discover error.
-        if !output.is_success() {
-            let (outcome, _) =
-                AutoDiscoverOutcome::from_output(control_plane.current_time(), output);
-            return Ok(outcome);
-        }
-
-        // The discover was successful, but has anything actually changed?
-        // First prune the discovered draft to remove any unchanged specs.
-        let unchanged_count = output.prune_unchanged_specs();
-        let is_unchanged = output.is_unchanged();
-        tracing::info!(
-            %is_unchanged,
-            %unchanged_count,
-            added=output.added.len(),
-            removed=output.removed.len(),
-            modified=output.modified.len(),
-            "auto-discover succeeded"
-        );
-        if is_unchanged {
-            let (outcome, _) =
-                AutoDiscoverOutcome::from_output(control_plane.current_time(), output);
-            return Ok(outcome);
-        }
-
-        // There are changes to publish
-        let (mut outcome, draft) =
-            AutoDiscoverOutcome::from_output(control_plane.current_time(), output);
-
-        assert!(
-            draft.spec_count() > 0,
-            "draft should have at least one spec since has_changes() returned true"
-        );
-
-        let mut pending = PendingPublication::new();
-        let publish_detail = format!(
-            "auto-discover changes ({} added, {} modified, {} removed)",
-            outcome.added.len(),
-            outcome.modified.len(),
-            outcome.removed.len(),
-        );
-        pending.details.push(publish_detail);
-        // Add the draft back into the pending publication, so it will be published.
-        pending.draft = draft;
-        let initial_pub_result = pending
-            .finish(state, pub_status, control_plane)
-            .await
-            .context("executing publication")?;
-
-        self.publication_finished(
-            initial_pub_result,
-            pub_status,
-            state,
-            control_plane,
-            model,
-            &mut outcome,
-        )
-        .await?;
-
-        Ok(outcome)
-    }
-
-    fn record_outcome(&mut self, outcome: AutoDiscoverOutcome) {
-        if outcome.is_successful() {
-            tracing::info!(?outcome, "auto-discover completed successfully");
-            self.failure = None;
-            self.last_success = Some(outcome);
-            return;
-        }
-
-        tracing::info!(?outcome, "auto-discover failed");
-        if let Some(failure) = self.failure.as_mut() {
-            failure.count += 1;
-            failure.last_outcome = outcome;
-        } else {
-            self.failure = Some(AutoDiscoverFailure {
-                count: 1,
-                first_ts: outcome.ts,
-                last_outcome: outcome,
-            });
-        };
-    }
+    let ad_next = status
+        .auto_discover
+        .as_ref()
+        .and_then(|ad| auto_discover::next_run(ad));
+    let periodic_next = periodic::next_periodic_publish(state);
+    Ok(NextRun::earliest([ad_next, periodic_next]))
 }

--- a/crates/agent/src/controllers/capture/auto_discover.rs
+++ b/crates/agent/src/controllers/capture/auto_discover.rs
@@ -1,0 +1,364 @@
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use models::status::{
+    capture::{AutoDiscoverFailure, AutoDiscoverOutcome, AutoDiscoverStatus, DiscoverChange},
+    publications::PublicationStatus,
+};
+
+use crate::{
+    controllers::{
+        publication_status::{self, PendingPublication},
+        ControllerState, NextRun,
+    },
+    controlplane::ConnectorSpec,
+    discovers::DiscoverOutput,
+    evolution,
+    publications::PublicationResult,
+    ControlPlane,
+};
+
+async fn try_connector_spec<C: ControlPlane>(
+    model: &models::CaptureDef,
+    control_plane: &mut C,
+) -> anyhow::Result<ConnectorSpec> {
+    let models::CaptureEndpoint::Connector(cfg) = &model.endpoint else {
+        anyhow::bail!("only connector endpoints are supported for auto-discovery");
+    };
+    let spec = control_plane
+        .get_connector_spec(cfg.image.clone())
+        .await
+        .context("failed to fetch connector spec")?;
+    if spec.resource_path_pointers.is_empty() {
+        anyhow::bail!("connector has no resource path pointers");
+    }
+    Ok(spec)
+}
+
+/// Performs an auto-discover if one is due, and returns a boolean
+/// indicating whether a publication was performed. If this returns true,
+/// then the controller should immediately return and schedule a subsequent
+/// run.
+pub async fn update<C: ControlPlane>(
+    status: &mut AutoDiscoverStatus,
+    state: &ControllerState,
+    model: &models::CaptureDef,
+    control_plane: &mut C,
+    pub_status: &mut PublicationStatus,
+) -> anyhow::Result<bool> {
+    update_next_run(status, state, model, control_plane).await?;
+    if status
+        .next_at
+        .map(|due| control_plane.current_time() <= due)
+        .unwrap_or(true)
+    {
+        return Ok(false);
+    }
+
+    tracing::debug!("starting auto-discover");
+    // We'll return the original discover error if it fails
+    let result = try_auto_discover(state, model, control_plane, pub_status).await;
+
+    // We'll return whether we've actually published anything. If all we did
+    // was run a discover that found no changes, then we may proceed with
+    // other controller actions.
+    let has_changes = match result {
+        Ok(outcome) => {
+            let has_changes = outcome.is_successful() && outcome.has_changes();
+            let result = outcome.get_result();
+            record_outcome(status, outcome);
+            result?; // return an error if the auto-discover failed
+
+            // Auto-discover was successful, so determine the time of the next attempt
+            update_next_run(status, state, model, control_plane).await?;
+            has_changes
+        }
+        Err(error) => {
+            tracing::debug!(?error, "auto-discover failed with error");
+            let outcome = AutoDiscoverOutcome::error(
+                control_plane.current_time(),
+                &state.catalog_name,
+                &error,
+            );
+            record_outcome(status, outcome);
+            return Err(error);
+        }
+    };
+    Ok(has_changes)
+}
+
+async fn update_next_run<C: ControlPlane>(
+    status: &mut AutoDiscoverStatus,
+    state: &ControllerState,
+    model: &models::CaptureDef,
+    control_plane: &mut C,
+) -> anyhow::Result<()> {
+    if model.shards.disable {
+        status.next_at = None;
+        return Ok(());
+    }
+
+    if status.next_at.is_none()
+        || status.next_at.is_some_and(|n| {
+            status
+                .last_success
+                .as_ref()
+                .map(|ls| ls.ts > n)
+                .unwrap_or(false)
+        })
+    {
+        // `next_at` is `None` or else we've successfully completed a
+        // discover since, so determine the next auto-discover time.
+        // If there's no `connector_tags` row for this capture connector
+        // then we cannot discover, so this is an error.
+        let connector_spec = try_connector_spec(model, control_plane)
+            .await
+            .context("fetching connector spec")?;
+
+        let auto_discover_interval = status
+            .interval
+            .and_then(|i| chrono::Duration::from_std(i).ok())
+            .unwrap_or(connector_spec.auto_discover_interval)
+            .abs();
+
+        let prev = status
+            .last_success
+            .as_ref()
+            .map(|s| s.ts)
+            .unwrap_or(state.created_at);
+
+        let next = prev + auto_discover_interval;
+        tracing::debug!(%next, %auto_discover_interval, "determined new next_at time");
+        status.next_at = Some(next);
+    }
+    Ok(())
+}
+
+pub fn next_run(status: &AutoDiscoverStatus) -> Option<NextRun> {
+    status
+        .next_at
+        .map(|n| NextRun::after(n).with_jitter_percent(0))
+}
+
+async fn publication_finished<C: ControlPlane>(
+    mut pub_result: PublicationResult,
+    history: &mut PublicationStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+    model: &models::CaptureDef,
+    pending_outcome: &mut AutoDiscoverOutcome,
+) -> anyhow::Result<()> {
+    pending_outcome.publish_result = Some(pub_result.status.clone());
+
+    // Did the publication result in incompatible collections, which we should evolve?
+    let evolve_incompatible = model
+        .auto_discover
+        .as_ref()
+        .unwrap()
+        .evolve_incompatible_collections;
+
+    if let Some(incompatible_collections) = pub_result
+        .status
+        .incompatible_collections()
+        .filter(|_| evolve_incompatible)
+    {
+        let evolve_requests = crate::evolutions_requests(incompatible_collections);
+        // This is because we never try to publish materializations, so we
+        // should never see incompatibilities that don't require re-creating
+        // the collection.
+        assert!(
+            evolve_requests.iter().all(|r| r.new_name.is_some()),
+            "expected all evolutions to re-create collections"
+        );
+        assert!(!evolve_requests.is_empty());
+        let mut draft = std::mem::take(&mut pub_result.draft);
+        draft.errors.clear();
+        let evolution_result = control_plane
+            .evolve_collections(draft, evolve_requests)
+            .await
+            .context("evolving collections")?;
+        if !evolution_result.is_success() {
+            tracing::warn!("evolution failed");
+            pending_outcome.errors.extend(
+                evolution_result
+                    .draft
+                    .errors
+                    .iter()
+                    .map(tables::Error::to_draft_error),
+            );
+        } else {
+            let evolution::EvolutionOutput { draft, actions } = evolution_result;
+            tracing::info!(
+                collection_count = actions.len(),
+                "successfully re-created collections"
+            );
+            let new_detail = format!(
+                "{}, and re-creating {} collections",
+                pub_result.detail.as_deref().unwrap_or("no detail"),
+                actions.len()
+            );
+            pending_outcome.re_created_collections = actions;
+            let new_result = control_plane
+                .publish(
+                    Some(new_detail),
+                    state.logs_token,
+                    draft,
+                    state.data_plane_name.clone(),
+                )
+                .await
+                .context("publishing evolved collections")?;
+            publication_status::record_result(history, publication_status::pub_info(&new_result));
+            pending_outcome.publish_result = Some(new_result.status.clone());
+        }
+    }
+
+    return Ok(());
+}
+
+pub fn new_outcome(
+    ts: DateTime<Utc>,
+    output: DiscoverOutput,
+) -> (AutoDiscoverOutcome, tables::DraftCatalog) {
+    let DiscoverOutput {
+        capture_name: _,
+        draft,
+        added,
+        modified,
+        removed,
+    } = output;
+
+    let errors = draft
+        .errors
+        .iter()
+        .map(tables::Error::to_draft_error)
+        .collect();
+
+    let outcome = AutoDiscoverOutcome {
+        ts,
+        added: added
+            .into_iter()
+            .map(|(rp, change)| DiscoverChange::new(rp, change))
+            .collect(),
+        modified: modified
+            .into_iter()
+            .map(|(rp, change)| DiscoverChange::new(rp, change))
+            .collect(),
+        removed: removed
+            .into_iter()
+            .map(|(rp, change)| DiscoverChange::new(rp, change))
+            .collect(),
+        errors,
+        re_created_collections: Default::default(),
+        publish_result: None,
+    };
+    (outcome, draft)
+}
+
+async fn try_auto_discover<C: ControlPlane>(
+    state: &ControllerState,
+    model: &models::CaptureDef,
+    control_plane: &mut C,
+    pub_status: &mut PublicationStatus,
+) -> anyhow::Result<AutoDiscoverOutcome> {
+    let update_only = !model.auto_discover.as_ref().unwrap().add_new_bindings;
+    let capture_name = models::Capture::new(&state.catalog_name);
+
+    let mut draft = tables::DraftCatalog::default();
+    draft.captures.insert(tables::DraftCapture {
+        capture: capture_name.clone(),
+        scope: tables::synthetic_scope(models::CatalogType::Capture, &capture_name),
+        expect_pub_id: Some(state.last_pub_id),
+        model: Some(model.clone()),
+        // start with a touch. The discover merge will set this to false if it actually updates the capture
+        is_touch: true,
+    });
+
+    let mut output = control_plane
+        .discover(
+            models::Capture::new(&state.catalog_name),
+            draft,
+            update_only,
+            state.logs_token,
+            state.data_plane_id,
+        )
+        .await
+        .context("failed to discover")?;
+
+    // Return early if there was a discover error.
+    if !output.is_success() {
+        let (outcome, _) = new_outcome(control_plane.current_time(), output);
+        return Ok(outcome);
+    }
+
+    // The discover was successful, but has anything actually changed?
+    // First prune the discovered draft to remove any unchanged specs.
+    let unchanged_count = output.prune_unchanged_specs();
+    let is_unchanged = output.is_unchanged();
+    tracing::info!(
+        %is_unchanged,
+        %unchanged_count,
+        added=output.added.len(),
+        removed=output.removed.len(),
+        modified=output.modified.len(),
+        "auto-discover succeeded"
+    );
+    if is_unchanged {
+        let (outcome, _) = new_outcome(control_plane.current_time(), output);
+        return Ok(outcome);
+    }
+
+    // There are changes to publish
+    let (mut outcome, draft) = new_outcome(control_plane.current_time(), output);
+
+    assert!(
+        draft.spec_count() > 0,
+        "draft should have at least one spec since has_changes() returned true"
+    );
+
+    let mut pending = PendingPublication::new();
+    let publish_detail = format!(
+        "auto-discover changes ({} added, {} modified, {} removed)",
+        outcome.added.len(),
+        outcome.modified.len(),
+        outcome.removed.len(),
+    );
+    pending.details.push(publish_detail);
+    // Add the draft back into the pending publication, so it will be published.
+    pending.draft = draft;
+    let initial_pub_result = pending
+        .finish(state, pub_status, control_plane)
+        .await
+        .context("executing publication")?;
+
+    publication_finished(
+        initial_pub_result,
+        pub_status,
+        state,
+        control_plane,
+        model,
+        &mut outcome,
+    )
+    .await?;
+
+    Ok(outcome)
+}
+
+fn record_outcome(status: &mut AutoDiscoverStatus, outcome: AutoDiscoverOutcome) {
+    if outcome.is_successful() {
+        tracing::info!(?outcome, "auto-discover completed successfully");
+        status.failure = None;
+        status.last_success = Some(outcome);
+        return;
+    }
+
+    tracing::info!(?outcome, "auto-discover failed");
+    if let Some(failure) = status.failure.as_mut() {
+        failure.count += 1;
+        failure.last_outcome = outcome;
+    } else {
+        status.failure = Some(AutoDiscoverFailure {
+            count: 1,
+            first_ts: outcome.ts,
+            last_outcome: outcome,
+        });
+    };
+}

--- a/crates/agent/src/controllers/catalog_test.rs
+++ b/crates/agent/src/controllers/catalog_test.rs
@@ -1,48 +1,37 @@
 use std::collections::BTreeSet;
 
 use super::{dependencies::Dependencies, periodic, ControlPlane, ControllerState, NextRun};
-use crate::controllers::publication_status::PublicationStatus;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use models::status::catalog_test::TestStatus;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
-pub struct TestStatus {
-    pub passing: bool,
-    #[serde(default)]
-    pub publications: PublicationStatus,
-}
-
-impl TestStatus {
-    pub async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-        _model: &models::TestDef,
-    ) -> anyhow::Result<Option<NextRun>> {
-        let mut dependencies = Dependencies::resolve(state, control_plane).await?;
-        self.passing = false;
-        if dependencies
-            .update(
-                state,
-                control_plane,
-                &mut self.publications,
-                error_on_deleted_dependencies,
-            )
-            .await?
-        {
-            // We've successfully published against the latest versions of the dependencies
-            self.passing = true;
-            return Ok(Some(NextRun::immediately()));
-        }
-
-        if periodic::update_periodic_publish(state, &mut self.publications, control_plane).await? {
-            // We've successfully published against the latest versions of the dependencies
-            self.passing = true;
-            return Ok(Some(NextRun::immediately()));
-        }
-
-        Ok(periodic::next_periodic_publish(state))
+pub async fn update<C: ControlPlane>(
+    status: &mut TestStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+    _model: &models::TestDef,
+) -> anyhow::Result<Option<NextRun>> {
+    let mut dependencies = Dependencies::resolve(state, control_plane).await?;
+    status.passing = false;
+    if dependencies
+        .update(
+            state,
+            control_plane,
+            &mut status.publications,
+            error_on_deleted_dependencies,
+        )
+        .await?
+    {
+        // We've successfully published against the latest versions of the dependencies
+        status.passing = true;
+        return Ok(Some(NextRun::immediately()));
     }
+
+    if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
+        // We've successfully published against the latest versions of the dependencies
+        status.passing = true;
+        return Ok(Some(NextRun::immediately()));
+    }
+
+    Ok(periodic::next_periodic_publish(state))
 }
 
 fn error_on_deleted_dependencies(

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -1,84 +1,76 @@
 use std::collections::BTreeSet;
 
 use super::{
-    backoff_data_plane_activate,
-    dependencies::Dependencies,
-    periodic,
-    publication_status::{ActivationStatus, PendingPublication},
-    ControlPlane, ControllerErrorExt, ControllerState, NextRun,
+    backoff_data_plane_activate, dependencies::Dependencies, periodic,
+    publication_status::PendingPublication, ControlPlane, ControllerErrorExt, ControllerState,
+    NextRun,
 };
-use crate::controllers::publication_status::PublicationStatus;
+use crate::controllers::publication_status;
 use anyhow::Context;
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use models::status::{
+    collection::{CollectionStatus, InferredSchemaStatus},
+    publications::PublicationStatus,
+};
 
-/// The status of a collection controller
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
-pub struct CollectionStatus {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub inferred_schema: Option<InferredSchemaStatus>,
-    #[serde(default)]
-    pub publications: PublicationStatus,
-    #[serde(default)]
-    pub activation: ActivationStatus,
-}
-
-impl CollectionStatus {
-    pub async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-        model: &models::CollectionDef,
-    ) -> anyhow::Result<Option<NextRun>> {
-        let uses_inferred_schema = uses_inferred_schema(model);
-        if uses_inferred_schema {
-            let inferred_schema_status = self.inferred_schema.get_or_insert_with(Default::default);
-            if inferred_schema_status
-                .update(state, control_plane, model, &mut self.publications)
-                .await?
-            {
-                return Ok(Some(NextRun::immediately()));
-            }
-        } else {
-            self.inferred_schema = None;
-        };
-
-        let mut dependencies = Dependencies::resolve(state, control_plane).await?;
-        if dependencies
-            .update(state, control_plane, &mut self.publications, |deleted| {
-                handle_deleted_dependencies(model.clone(), deleted)
-            })
-            .await?
+pub async fn update<C: ControlPlane>(
+    status: &mut CollectionStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+    model: &models::CollectionDef,
+) -> anyhow::Result<Option<NextRun>> {
+    let uses_inferred_schema = uses_inferred_schema(model);
+    if uses_inferred_schema {
+        let inferred_schema_status = status.inferred_schema.get_or_insert_with(Default::default);
+        if update_inferred_schema(
+            inferred_schema_status,
+            state,
+            control_plane,
+            model,
+            &mut status.publications,
+        )
+        .await?
         {
             return Ok(Some(NextRun::immediately()));
         }
+    } else {
+        status.inferred_schema = None;
+    };
 
-        if periodic::update_periodic_publish(state, &mut self.publications, control_plane).await? {
-            return Ok(Some(NextRun::immediately()));
-        }
-
-        self.activation
-            .update(state, control_plane)
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))?;
-
-        self.publications
-            .update_notify_dependents(state, control_plane)
-            .await?;
-
-        // Use an infrequent periodic check for inferred schema updates, just in case the database trigger gets
-        // bypassed for some reason.
-        let inferred_schema_next = if uses_inferred_schema {
-            Some(NextRun::after_minutes(240))
-        } else {
-            None
-        };
-        // This function will return None unless this collection is an enabled derivation.
-        let periodic_next = periodic::next_periodic_publish(state);
-        Ok(NextRun::earliest([inferred_schema_next, periodic_next]))
+    let mut dependencies = Dependencies::resolve(state, control_plane).await?;
+    if dependencies
+        .update(state, control_plane, &mut status.publications, |deleted| {
+            handle_deleted_dependencies(model.clone(), deleted)
+        })
+        .await?
+    {
+        return Ok(Some(NextRun::immediately()));
     }
+
+    if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
+        return Ok(Some(NextRun::immediately()));
+    }
+
+    publication_status::update_activation(&mut status.activation, state, control_plane)
+        .await
+        .with_retry(backoff_data_plane_activate(state.failures))?;
+
+    publication_status::update_notify_dependents(&mut status.publications, state, control_plane)
+        .await?;
+
+    // Use an infrequent periodic check for inferred schema updates, just in case the database trigger gets
+    // bypassed for some reason.
+    let inferred_schema_next = if uses_inferred_schema {
+        Some(NextRun::after_minutes(240))
+    } else {
+        None
+    };
+    let periodic_next = if model.derive.is_some() {
+        periodic::next_periodic_publish(state)
+    } else {
+        None
+    };
+    Ok(NextRun::earliest([inferred_schema_next, periodic_next]))
 }
 
 /// Disables transforms that source from deleted collections.
@@ -105,44 +97,69 @@ fn handle_deleted_dependencies(
     Ok((detail, model))
 }
 
-/// Status of the inferred schema
-#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
-pub struct InferredSchemaStatus {
-    /// The time at which the inferred schema was last published. This will only
-    /// be present if the inferred schema was published at least once.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub schema_last_updated: Option<DateTime<Utc>>,
-    /// The md5 sum of the inferred schema that was last published.
-    /// Because the publications handler updates the model instead of the controller, it's
-    /// technically possible for the published inferred schema to be more recent than the one
-    /// corresponding to this hash. If that happens, we would expect a subsequent publication
-    /// on the next controller run, which would update the hash but not actually modify the schema.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub schema_md5: Option<String>,
-}
+pub async fn update_inferred_schema<C: ControlPlane>(
+    status: &mut InferredSchemaStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+    collection_def: &models::CollectionDef,
+    publication_status: &mut PublicationStatus,
+) -> anyhow::Result<bool> {
+    let collection_name = models::Collection::new(&state.catalog_name);
 
-impl InferredSchemaStatus {
-    pub async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-        collection_def: &models::CollectionDef,
-        publication_status: &mut PublicationStatus,
-    ) -> anyhow::Result<bool> {
-        let collection_name = models::Collection::new(&state.catalog_name);
+    let maybe_inferred_schema = control_plane
+        .get_inferred_schema(collection_name.clone())
+        .await
+        .context("fetching inferred schema")?;
 
-        let maybe_inferred_schema = control_plane
-            .get_inferred_schema(collection_name.clone())
-            .await
-            .context("fetching inferred schema")?;
+    // If the read schema includes a bundled write schema, remove it.
+    // TODO: remove this code once all production collections have been updated.
+    let must_remove_write_schema = read_schema_bundles_write_schema(collection_def);
+    if must_remove_write_schema {
+        let mut pending_pub = PendingPublication::new();
+        let draft = pending_pub.start_spec_update(state, "removing bundled write schema");
+        let draft_row = draft.collections.get_or_insert_with(&collection_name, || {
+            tables::DraftCollection {
+                collection: collection_name.clone(),
+                scope: tables::synthetic_scope(models::CatalogType::Collection, &collection_name),
+                expect_pub_id: Some(state.last_pub_id),
+                model: Some(collection_def.clone()),
+                is_touch: false, // We intend to update the model
+            }
+        });
+        let (removed, new_schema) = collection_def
+            .read_schema
+            .as_ref()
+            .unwrap()
+            .remove_bundled_write_schema();
+        if removed {
+            draft_row.model.as_mut().unwrap().read_schema = Some(new_schema);
+            tracing::info!("removing bundled write schema");
+        } else {
+            tracing::warn!("bundled write schema was not removed");
+        }
+        pending_pub
+            .finish(state, publication_status, control_plane)
+            .await?
+            .error_for_status()?;
+        return Ok(true);
+    }
 
-        // If the read schema includes a bundled write schema, remove it.
-        // TODO: remove this code once all production collections have been updated.
-        let must_remove_write_schema = read_schema_bundles_write_schema(collection_def);
-        if must_remove_write_schema {
-            let mut pending_pub = PendingPublication::new();
-            let draft = pending_pub.start_spec_update(state, "removing bundled write schema");
+    if let Some(inferred_schema) = maybe_inferred_schema {
+        let mut pending_pub = PendingPublication::new();
+        let tables::InferredSchema {
+            collection_name,
+            schema: _, // we let the publications handler set the inferred schema
+            md5,
+        } = inferred_schema;
+
+        if status.schema_md5.as_ref() != Some(&md5) {
+            tracing::info!(
+                %collection_name,
+                prev_md5 = ?status.schema_md5,
+                new_md5 = ?md5,
+                "updating inferred schema"
+            );
+            let draft = pending_pub.start_spec_update(state, "updating inferred schema");
             let draft_row = draft.collections.get_or_insert_with(&collection_name, || {
                 tables::DraftCollection {
                     collection: collection_name.clone(),
@@ -155,72 +172,25 @@ impl InferredSchemaStatus {
                     is_touch: false, // We intend to update the model
                 }
             });
-            let (removed, new_schema) = collection_def
-                .read_schema
-                .as_ref()
-                .unwrap()
-                .remove_bundled_write_schema();
-            if removed {
-                draft_row.model.as_mut().unwrap().read_schema = Some(new_schema);
-                tracing::info!("removing bundled write schema");
-            } else {
-                tracing::warn!("bundled write schema was not removed");
-            }
-            pending_pub
+            // The inferred schema is always updated as part of any non-touch publication,
+            // so we don't need to actually update the model here.
+            draft_row.is_touch = false;
+
+            let pub_result = pending_pub
                 .finish(state, publication_status, control_plane)
                 .await?
-                .error_for_status()?;
+                .error_for_status()
+                .do_not_retry()?;
+
+            status.schema_md5 = Some(md5);
+            status.schema_last_updated = Some(pub_result.started_at);
             return Ok(true);
         }
-
-        if let Some(inferred_schema) = maybe_inferred_schema {
-            let mut pending_pub = PendingPublication::new();
-            let tables::InferredSchema {
-                collection_name,
-                schema: _, // we let the publications handler set the inferred schema
-                md5,
-            } = inferred_schema;
-
-            if self.schema_md5.as_ref() != Some(&md5) {
-                tracing::info!(
-                    %collection_name,
-                    prev_md5 = ?self.schema_md5,
-                    new_md5 = ?md5,
-                    "updating inferred schema"
-                );
-                let draft = pending_pub.start_spec_update(state, "updating inferred schema");
-                let draft_row = draft.collections.get_or_insert_with(&collection_name, || {
-                    tables::DraftCollection {
-                        collection: collection_name.clone(),
-                        scope: tables::synthetic_scope(
-                            models::CatalogType::Collection,
-                            &collection_name,
-                        ),
-                        expect_pub_id: Some(state.last_pub_id),
-                        model: Some(collection_def.clone()),
-                        is_touch: false, // We intend to update the model
-                    }
-                });
-                // The inferred schema is always updated as part of any non-touch publication,
-                // so we don't need to actually update the model here.
-                draft_row.is_touch = false;
-
-                let pub_result = pending_pub
-                    .finish(state, publication_status, control_plane)
-                    .await?
-                    .error_for_status()
-                    .do_not_retry()?;
-
-                self.schema_md5 = Some(md5);
-                self.schema_last_updated = Some(pub_result.started_at);
-                return Ok(true);
-            }
-        } else {
-            tracing::debug!(%collection_name, "No inferred schema available yet");
-        }
-
-        Ok(false)
+    } else {
+        tracing::debug!(%collection_name, "No inferred schema available yet");
     }
+
+    Ok(false)
 }
 
 fn read_schema_bundles_write_schema(model: &models::CollectionDef) -> bool {

--- a/crates/agent/src/controllers/dependencies.rs
+++ b/crates/agent/src/controllers/dependencies.rs
@@ -1,14 +1,11 @@
 use std::collections::BTreeSet;
 
 use anyhow::Context;
-use models::{AnySpec, ModelDef};
+use models::{status::publications::PublicationStatus, AnySpec, ModelDef};
 
 use crate::ControlPlane;
 
-use super::{
-    publication_status::{PendingPublication, PublicationStatus},
-    ControllerErrorExt, ControllerState, NextRun,
-};
+use super::{publication_status::PendingPublication, ControllerErrorExt, ControllerState, NextRun};
 
 /// Information about the dependencies of a live spec.
 pub struct Dependencies {

--- a/crates/agent/src/controllers/handler.rs
+++ b/crates/agent/src/controllers/handler.rs
@@ -6,7 +6,7 @@ use crate::{
     DataPlaneConnectors, HandleResult, Handler,
 };
 
-use super::{ControllerState, NextRun, RetryableError, Status};
+use super::{controller_update, ControllerState, NextRun, RetryableError, Status};
 
 use crate::controllers::CONTROLLER_VERSION;
 
@@ -135,5 +135,5 @@ async fn run_controller<C: ControlPlane>(
     next_status: &mut Status,
     control_plane: &mut C,
 ) -> anyhow::Result<Option<NextRun>> {
-    next_status.update(&state, control_plane).await
+    controller_update(next_status, &state, control_plane).await
 }

--- a/crates/agent/src/controllers/periodic.rs
+++ b/crates/agent/src/controllers/periodic.rs
@@ -6,14 +6,11 @@
 //! can already record any useful information, and the `live_specs` table
 //! already records the last update time of each spec.
 use anyhow::Context;
-use models::ModelDef;
+use models::{status::publications::PublicationStatus, ModelDef};
 
 use crate::ControlPlane;
 
-use super::{
-    publication_status::{PendingPublication, PublicationStatus},
-    ControllerState, NextRun,
-};
+use super::{publication_status::PendingPublication, ControllerState, NextRun};
 
 /// 20 days was chosen because we'd like to have a 30 day retention on our
 /// builds, so this gives us 10 days to notice and correct any problems before

--- a/crates/agent/src/controllers/publication_status.rs
+++ b/crates/agent/src/controllers/publication_status.rs
@@ -1,111 +1,38 @@
 use crate::{
-    controllers::ControllerErrorExt,
-    controlplane::ControlPlane,
-    publications::{self, PublicationResult},
+    controllers::ControllerErrorExt, controlplane::ControlPlane, publications::PublicationResult,
 };
 use anyhow::Context;
-use chrono::{DateTime, Utc};
-use models::Id;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
+use models::{
+    draft_error,
+    status::publications::{ActivationStatus, PublicationInfo, PublicationStatus},
+    Id,
+};
 
 use super::{backoff_data_plane_activate, ControllerState};
 
-/// Status of the activation of the task in the data-plane
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
-pub struct ActivationStatus {
-    /// The build id that was last activated in the data plane.
-    /// If this is less than the `last_build_id` of the controlled spec,
-    /// then an activation is still pending.
-    #[serde(default = "Id::zero", skip_serializing_if = "Id::is_zero")]
-    pub last_activated: Id,
-}
+/// Activates the spec in the data plane if necessary.
+pub async fn update_activation<C: ControlPlane>(
+    status: &mut ActivationStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+) -> anyhow::Result<()> {
+    if state.last_build_id > status.last_activated {
+        let name = state.catalog_name.clone();
+        let built_spec = state.built_spec.as_ref().expect("built_spec must be Some");
 
-impl Default for ActivationStatus {
-    fn default() -> Self {
-        Self {
-            last_activated: Id::zero(),
-        }
+        crate::timeout(
+            std::time::Duration::from_secs(60),
+            control_plane.data_plane_activate(name, built_spec, state.data_plane_id),
+            || "Timeout while activating into data-plane",
+        )
+        .await
+        .with_retry(backoff_data_plane_activate(state.failures))
+        .context("failed to activate into data-plane")?;
+
+        tracing::debug!(last_activated = %state.last_build_id, "activated");
+        status.last_activated = state.last_build_id;
     }
-}
-
-impl ActivationStatus {
-    /// Activates the spec in the data plane if necessary.
-    pub async fn update<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-    ) -> anyhow::Result<()> {
-        if state.last_build_id > self.last_activated {
-            let name = state.catalog_name.clone();
-            let built_spec = state.built_spec.as_ref().expect("built_spec must be Some");
-
-            crate::timeout(
-                std::time::Duration::from_secs(60),
-                control_plane.data_plane_activate(name, built_spec, state.data_plane_id),
-                || "Timeout while activating into data-plane",
-            )
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))
-            .context("failed to activate into data-plane")?;
-
-            tracing::debug!(last_activated = %state.last_build_id, "activated");
-            self.last_activated = state.last_build_id;
-        }
-        Ok(())
-    }
-}
-
-/// Summary of a publication that was attempted by a controller.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
-pub struct PublicationInfo {
-    pub id: Id,
-    /// Time at which the publication was initiated
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub created: Option<DateTime<Utc>>,
-    /// Time at which the publication was completed
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(schema_with = "super::datetime_schema")]
-    pub completed: Option<DateTime<Utc>>,
-    /// A brief description of the reason for the publication
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
-    /// The final result of the publication
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub result: Option<publications::JobStatus>,
-    /// Errors will be non-empty for publications that were not successful
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub errors: Vec<crate::draft::Error>,
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub is_touch: bool,
-    #[serde(default = "default_count", skip_serializing_if = "is_one")]
-    #[schemars(schema_with = "count_schema")]
-    pub count: u32,
-}
-
-/// Used for publication info serde
-fn is_false(b: &bool) -> bool {
-    !*b
-}
-
-/// Used for publication info serde
-fn default_count() -> u32 {
-    1
-}
-
-/// Used for publication info serde
-fn is_one(i: &u32) -> bool {
-    *i == 1
-}
-
-fn count_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    serde_json::from_value(serde_json::json!({
-        "type": "integer",
-        "minimum": 1,
-    }))
-    .unwrap()
+    Ok(())
 }
 
 fn is_touch_pub(draft: &tables::DraftCatalog) -> bool {
@@ -115,53 +42,17 @@ fn is_touch_pub(draft: &tables::DraftCatalog) -> bool {
         && draft.materializations.iter().all(|r| r.is_touch)
 }
 
-impl PublicationInfo {
-    pub fn is_success(&self) -> bool {
-        self.result.as_ref().is_some_and(|s| s.is_success())
-    }
-
-    pub fn observed(publication: &PublicationResult) -> Self {
-        let is_touch = is_touch_pub(&publication.draft);
-        PublicationInfo {
-            id: publication.pub_id,
-            created: Some(publication.started_at),
-            completed: Some(publication.completed_at),
-            result: Some(publication.status.clone()),
-            detail: publication.detail.clone(),
-            errors: publication.draft_errors(),
-            count: 1,
-            is_touch,
-        }
-    }
-
-    /// Tries to reduce `other` into `self` if the two should be combined in the
-    /// history. If `other` cannot be reduced into `self`, then it is returned
-    /// unmodified.
-    ///
-    /// Combining events in the history is a way to cram more information into a
-    /// smaller summary, and it helps avoid having repeated publications (like
-    /// touch publications, which can number in the hundreds) quickly push out
-    /// relevant prior events. But it's important that we _only_ combine
-    /// publication entries in the specific cases where we know it won't cause
-    /// confusion. Two publications should be combined in the history only if
-    /// their final `job_status`es are identical (e.g. both `{"type":
-    /// "buildFailed"}`). And then only in one of these cases:
-    /// - they are both touch publications
-    /// - If they are both _unsuccessful_ non-touch publications (i.e. we never
-    ///   combine successful publications that have modified the spec)
-    fn try_reduce(&mut self, other: PublicationInfo) -> Option<PublicationInfo> {
-        if (self.is_touch != other.is_touch)
-            || (self.result != other.result)
-            || (!self.is_touch && self.is_success())
-        {
-            return Some(other);
-        }
-        self.id = other.id;
-        self.count += other.count;
-        self.completed = other.completed;
-        self.errors = other.errors;
-        self.detail = other.detail;
-        None
+pub fn pub_info(publication: &PublicationResult) -> PublicationInfo {
+    let is_touch = is_touch_pub(&publication.draft);
+    PublicationInfo {
+        id: publication.pub_id,
+        created: Some(publication.started_at),
+        completed: Some(publication.completed_at),
+        result: Some(publication.status.clone()),
+        detail: publication.detail.clone(),
+        errors: publication.draft_errors(),
+        count: 1,
+        is_touch,
     }
 }
 
@@ -290,7 +181,7 @@ impl PendingPublication {
             .await;
         match result.as_ref() {
             Ok(r) => {
-                status.record_result(PublicationInfo::observed(r));
+                record_result(status, pub_info(r));
                 if r.status.is_success() {
                     control_plane
                         .notify_dependents(state.catalog_name.clone())
@@ -304,7 +195,7 @@ impl PendingPublication {
                     id: models::Id::zero(),
                     completed: Some(control_plane.current_time()),
                     detail: Some(details.join(", ")),
-                    errors: vec![crate::draft::Error {
+                    errors: vec![draft_error::Error {
                         detail: format!("publish error: {err:#}"),
                         ..Default::default()
                     }],
@@ -313,220 +204,43 @@ impl PendingPublication {
                     count: 1,
                     is_touch,
                 };
-                status.record_result(info);
+                record_result(status, info);
             }
         }
         result
     }
 }
 
-/// Information on the publications performed by the controller.
-/// This does not include any information on user-initiated publications.
-#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
-pub struct PublicationStatus {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dependency_hash: Option<String>,
-    /// The publication id at which the controller has last notified dependent
-    /// specs. A publication of the controlled spec will cause the controller to
-    /// notify the controllers of all dependent specs. When it does so, it sets
-    /// `max_observed_pub_id` to the current `last_pub_id`, so that it can avoid
-    /// notifying dependent controllers unnecessarily.
-    #[serde(default = "Id::zero", skip_serializing_if = "Id::is_zero")]
-    pub max_observed_pub_id: Id,
-    /// A limited history of publications performed by this controller
-    pub history: VecDeque<PublicationInfo>,
+const MAX_HISTORY: usize = 5;
+
+pub async fn update_notify_dependents<C: ControlPlane>(
+    status: &mut PublicationStatus,
+    state: &ControllerState,
+    control_plane: &mut C,
+) -> anyhow::Result<()> {
+    if state.last_pub_id > status.max_observed_pub_id {
+        control_plane
+            .notify_dependents(state.catalog_name.clone())
+            .await?;
+        status.max_observed_pub_id = state.last_pub_id;
+    }
+    Ok(())
 }
 
-impl Clone for PublicationStatus {
-    fn clone(&self) -> Self {
-        PublicationStatus {
-            max_observed_pub_id: self.max_observed_pub_id,
-            history: self.history.clone(),
-            dependency_hash: self.dependency_hash.clone(),
-        }
+pub fn record_result(status: &mut PublicationStatus, publication: PublicationInfo) {
+    tracing::info!(pub_id = ?publication.id, status = ?publication.result, "controller finished publication");
+    for err in publication.errors.iter() {
+        tracing::debug!(?err, "publication error");
     }
-}
-
-impl Default for PublicationStatus {
-    fn default() -> Self {
-        PublicationStatus {
-            dependency_hash: None,
-            max_observed_pub_id: Id::zero(),
-            history: VecDeque::new(),
+    let maybe_new_entry = if let Some(last_entry) = status.history.front_mut() {
+        last_entry.try_reduce(publication)
+    } else {
+        Some(publication)
+    };
+    if let Some(new_entry) = maybe_new_entry {
+        status.history.push_front(new_entry);
+        while status.history.len() > MAX_HISTORY {
+            status.history.pop_back();
         }
-    }
-}
-
-impl PublicationStatus {
-    const MAX_HISTORY: usize = 5;
-
-    pub async fn update_notify_dependents<C: ControlPlane>(
-        &mut self,
-        state: &ControllerState,
-        control_plane: &mut C,
-    ) -> anyhow::Result<()> {
-        if state.last_pub_id > self.max_observed_pub_id {
-            control_plane
-                .notify_dependents(state.catalog_name.clone())
-                .await?;
-            self.max_observed_pub_id = state.last_pub_id;
-        }
-        Ok(())
-    }
-
-    pub fn record_result(&mut self, publication: PublicationInfo) {
-        tracing::info!(pub_id = ?publication.id, status = ?publication.result, "controller finished publication");
-        for err in publication.errors.iter() {
-            tracing::debug!(?err, "publication error");
-        }
-        let maybe_new_entry = if let Some(last_entry) = self.history.front_mut() {
-            last_entry.try_reduce(publication)
-        } else {
-            Some(publication)
-        };
-        if let Some(new_entry) = maybe_new_entry {
-            self.history.push_front(new_entry);
-            while self.history.len() > PublicationStatus::MAX_HISTORY {
-                self.history.pop_back();
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use super::*;
-
-    #[test]
-    fn test_publication_history_folding() {
-        let touch_success = PublicationInfo {
-            id: models::Id::new([1, 1, 1, 1, 1, 1, 1, 1]),
-            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
-            completed: Some("2024-11-22T17:01:01Z".parse().unwrap()),
-            detail: Some("touch success".to_string()),
-            result: Some(publications::JobStatus::Success),
-            errors: Vec::new(),
-            is_touch: true,
-            count: 1,
-        };
-
-        // Sucessful touch publications should be combined
-        let other_touch_success = PublicationInfo {
-            id: models::Id::new([2, 1, 1, 1, 1, 1, 1, 1]),
-            completed: Some("2024-11-22T22:22:22Z".parse().unwrap()),
-            created: Some("2024-11-11T11:00:00Z".parse().unwrap()),
-            detail: Some("other touch success".to_string()),
-            ..touch_success.clone()
-        };
-        let mut reduced = touch_success.clone();
-        assert!(reduced.try_reduce(other_touch_success).is_none());
-        assert_eq!(
-            reduced,
-            PublicationInfo {
-                id: models::Id::new([2, 1, 1, 1, 1, 1, 1, 1]),
-                completed: Some("2024-11-22T22:22:22Z".parse().unwrap()),
-                created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
-                detail: Some("other touch success".to_string()),
-                result: Some(publications::JobStatus::Success),
-                errors: Vec::new(),
-                is_touch: true,
-                count: 2,
-            }
-        );
-
-        let reg_success = PublicationInfo {
-            id: models::Id::new([3, 1, 1, 1, 1, 1, 1, 1]),
-            completed: Some("2024-11-23T23:33:33Z".parse().unwrap()),
-            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
-            detail: Some("non-touch success".to_string()),
-            result: Some(publications::JobStatus::Success),
-            errors: Vec::new(),
-            is_touch: false,
-            count: 1,
-        };
-        // Touch success and regular success should not be combined
-        let mut touch_subject = touch_success.clone();
-        assert!(touch_subject.try_reduce(reg_success.clone()).is_some());
-
-        // Successful non-touch publications should never be combined because we
-        // want to preserve the history of modifications to the model.
-        let mut reg_subject = reg_success.clone();
-        assert!(reg_subject
-            .try_reduce(PublicationInfo {
-                id: models::Id::new([4, 1, 1, 1, 1, 1, 1, 1]),
-                ..reg_success.clone()
-            })
-            .is_some(),);
-
-        let reg_fail = PublicationInfo {
-            id: models::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
-            completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
-            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
-            detail: Some("reg failure".to_string()),
-            result: Some(publications::JobStatus::BuildFailed {
-                incompatible_collections: Vec::new(),
-                evolution_id: None,
-            }),
-            errors: vec![crate::draft::Error {
-                catalog_name: "acmeCo/fail-thing".to_string(),
-                scope: None,
-                detail: "schmeetail".to_string(),
-            }],
-            is_touch: false,
-            count: 1,
-        };
-
-        // A publication with the same unsuccessful status should be combined,
-        // and the detail and error should be that of the most recent
-        // publication.
-        let same_reg_fail = PublicationInfo {
-            id: models::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
-            completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
-            detail: Some("same but different reg failure".to_string()),
-            errors: vec![crate::draft::Error {
-                catalog_name: "acmeCo/fail-thing".to_string(),
-                scope: None,
-                detail: "a different error".to_string(),
-            }],
-            ..reg_fail.clone()
-        };
-        let mut reduced = reg_fail.clone();
-        assert!(reduced.try_reduce(same_reg_fail.clone()).is_none());
-        assert_eq!(
-            reduced,
-            PublicationInfo {
-                id: models::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
-                completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
-                created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
-                detail: Some("same but different reg failure".to_string()),
-                errors: vec![crate::draft::Error {
-                    catalog_name: "acmeCo/fail-thing".to_string(),
-                    scope: None,
-                    detail: "a different error".to_string(),
-                }],
-                result: Some(publications::JobStatus::BuildFailed {
-                    incompatible_collections: Vec::new(),
-                    evolution_id: None
-                }),
-                is_touch: false,
-                count: 2,
-            }
-        );
-
-        // A publication with a different status should not be combined
-        let diff_reg_fail = PublicationInfo {
-            result: Some(publications::JobStatus::BuildFailed {
-                incompatible_collections: vec![publications::IncompatibleCollection {
-                    collection: "acmeCo/anvils".to_string(),
-                    requires_recreation: Vec::new(),
-                    affected_materializations: Vec::new(),
-                }],
-                evolution_id: None,
-            }),
-            ..same_reg_fail.clone()
-        };
-        let mut reg_subject = reg_fail.clone();
-        assert!(reg_subject.try_reduce(diff_reg_fail).is_some());
     }
 }

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -1,8 +1,9 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use crate::proxy_connectors::DiscoverConnectors;
 
 use anyhow::Context;
+use models::discovers::{Changed, Changes};
 use models::split_image_tag;
 use proto_flow::{capture, flow::capture_spec};
 use sqlx::{types::Uuid, PgPool};
@@ -32,23 +33,6 @@ pub struct Discover {
     /// long as they don't conflict with the discover results.
     pub draft: tables::DraftCatalog,
 }
-
-/// Identifies a resource that can be captured from. This is determined by using
-/// the resource path pointers to extract the path from each `resource` spec in
-/// either the capture model or the discovered response.
-pub type ResourcePath = Vec<String>;
-
-/// Represents a capture binding that was added, removed, or modified by a
-/// discover.
-#[derive(Debug, PartialEq, Clone)]
-pub struct Changed {
-    /// The name of the target collection for the binding.
-    pub target: models::Collection,
-    /// Whether the binding is disabled.
-    pub disable: bool,
-}
-/// Represents a set of changes resulting from a discover.
-pub type Changes = BTreeMap<ResourcePath, Changed>;
 
 #[derive(Debug)]
 pub struct DiscoverOutput {

--- a/crates/agent/src/discovers/handler.rs
+++ b/crates/agent/src/discovers/handler.rs
@@ -147,7 +147,7 @@ impl<C: DiscoverConnectors> DiscoverHandler<C> {
                 .draft
                 .errors
                 .iter()
-                .map(draft::Error::from_tables_error)
+                .map(tables::Error::to_draft_error)
                 .collect();
             crate::draft::insert_errors(row.draft_id, draft_errors, txn).await?;
             return Ok((row.id, JobStatus::DiscoverFailed));

--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -1,7 +1,7 @@
 use crate::discovers::Changed;
 
-use super::{Changes, ResourcePath};
 use anyhow::Context;
+use models::{discovers::Changes, ResourcePath};
 use proto_flow::capture::{self, response::discovered};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/agent/src/evolution.rs
+++ b/crates/agent/src/evolution.rs
@@ -1,6 +1,6 @@
 use agent_sql::Capability;
 use itertools::Itertools;
-use schemars::JsonSchema;
+use models::evolutions::EvolvedCollection;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use std::collections::BTreeSet;
@@ -104,18 +104,6 @@ impl EvolveRequest {
         }
         Ok(())
     }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
-pub struct EvolvedCollection {
-    /// Original name of the collection
-    pub old_name: String,
-    /// The new name of the collection, which may be the same as the original name if only materialization bindings were updated
-    pub new_name: String,
-    /// The names of any materializations that were updated as a result of evolving this collection
-    pub updated_materializations: Vec<String>,
-    /// The names of any captures that were updated as a result of evolving this collection
-    pub updated_captures: Vec<String>,
 }
 
 #[tracing::instrument(skip_all, fields(user_id = %evolution.user_id))]

--- a/crates/agent/src/evolution/handler.rs
+++ b/crates/agent/src/evolution/handler.rs
@@ -133,7 +133,7 @@ pub async fn process_row(
             .draft
             .errors
             .iter()
-            .map(crate::draft::Error::from_tables_error)
+            .map(tables::Error::to_draft_error)
             .collect::<Vec<_>>();
         crate::draft::insert_errors(draft_id, errors, txn).await?;
         let error = output.draft.errors.iter().map(|e| &e.error).join(", ");

--- a/crates/agent/src/integration_tests/auto_discovers.rs
+++ b/crates/agent/src/integration_tests/auto_discovers.rs
@@ -1,8 +1,8 @@
 use crate::{
-    controllers::capture::DiscoverChange,
     integration_tests::harness::{draft_catalog, InjectBuildError, TestHarness},
     publications,
 };
+use models::status::capture::DiscoverChange;
 use proto_flow::capture::response::{discovered::Binding, Discovered};
 use serde_json::json;
 

--- a/crates/agent/src/integration_tests/periodic_publications.rs
+++ b/crates/agent/src/integration_tests/periodic_publications.rs
@@ -1,9 +1,14 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    controllers::Status,
-    integration_tests::harness::{draft_catalog, TestHarness},
+    controllers::ControllerState,
+    integration_tests::harness::{
+        draft_catalog, mock_inferred_schema, InjectBuildError, TestHarness,
+    },
+    ControlPlane,
 };
+use models::{status::Status, CatalogType};
+use uuid::Uuid;
 
 #[tokio::test]
 #[serial_test::serial]

--- a/crates/agent/src/publications/handler.rs
+++ b/crates/agent/src/publications/handler.rs
@@ -1,5 +1,6 @@
 use agent_sql::publications::Row;
 use anyhow::Context;
+use models::draft_error;
 use tracing::info;
 
 use crate::{
@@ -57,7 +58,7 @@ impl Handler for Publisher {
                 }
                 Err(error) => {
                     tracing::warn!(?error, pub_id = %id, "build finished with error");
-                    let errors = vec![draft::Error {
+                    let errors = vec![draft_error::Error {
                         catalog_name: String::new(),
                         scope: None,
                         detail: format!("{error:#}"),

--- a/crates/agent/src/publications/incompatible_collections.rs
+++ b/crates/agent/src/publications/incompatible_collections.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+
+use models::publications::{AffectedConsumer, IncompatibleCollection, RejectedField};
+use proto_flow::materialize::response::validated::constraint;
+use tables::BuiltRow;
+
+pub fn get_incompatible_collections(output: &tables::Validations) -> Vec<IncompatibleCollection> {
+    // We'll collect a map of collection names to lists of materializations that have rejected the proposed collection changes.
+    let mut naughty_collections = BTreeMap::new();
+
+    // Look at materialization validation responses for any collections that have been rejected due to unsatisfiable constraints.
+    for mat in output.built_materializations.iter() {
+        let Some(validated) = mat.validated() else {
+            continue;
+        };
+        let Some(model) = mat.model() else {
+            continue;
+        };
+        for (i, binding) in validated.bindings.iter().enumerate() {
+            let naughty_fields: Vec<RejectedField> = binding
+                .constraints
+                .iter()
+                .filter(|(_, constraint)| {
+                    constraint.r#type == constraint::Type::Unsatisfiable as i32
+                })
+                .map(|(field, constraint)| RejectedField {
+                    field: field.clone(),
+                    reason: constraint.reason.clone(),
+                })
+                .collect();
+            if !naughty_fields.is_empty() {
+                // We must skip over disabled bindings in order to translate the index of the
+                // validated binding to the index of the model binding.
+                let collection_name = model
+                    .bindings
+                    .iter()
+                    .filter(|b| !b.disable)
+                    .skip(i)
+                    .next()
+                    .unwrap() //
+                    .source
+                    .collection()
+                    .to_string();
+                let affected_consumers = naughty_collections
+                    .entry(collection_name)
+                    .or_insert_with(|| Vec::new());
+                affected_consumers.push(AffectedConsumer {
+                    name: mat.catalog_name().to_string(),
+                    fields: naughty_fields,
+                    resource_path: binding.resource_path.clone(),
+                });
+            }
+        }
+    }
+
+    naughty_collections
+        .into_iter()
+        .map(
+            |(collection, affected_materializations)| IncompatibleCollection {
+                collection,
+                affected_materializations,
+                requires_recreation: Vec::new(),
+            },
+        )
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use proto_flow::materialize::response::validated;
+    use proto_flow::materialize::response::validated::constraint;
+
+    use super::*;
+
+    #[test]
+    fn test_get_incompatible_collections() {
+        let live_mat: models::MaterializationDef = serde_json::from_value(serde_json::json!({
+            "endpoint": {
+                "connector": {
+                    "image": "test/materialize:foo",
+                    "config": {}
+                }
+            },
+            "bindings": [
+                {
+                    "resource": {"table": "disabledTable"},
+                    "source": "acmeCo/disabledCollection",
+                    "disable": true
+                },
+                {
+                    "resource": {"table": "nice"},
+                    "source": "acmeCo/niceCollection"
+                },
+                {
+                    "resource": {"table": "naughty"},
+                    "source": "acmeCo/naughtyCollection"
+                }
+            ]
+        }))
+        .unwrap();
+
+        fn test_constraints(ty: constraint::Type) -> BTreeMap<String, validated::Constraint> {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "test_field".to_string(),
+                validated::Constraint {
+                    r#type: ty as i32,
+                    reason: "cuz this is a test".to_string(),
+                },
+            );
+            m
+        }
+        let resp = proto_flow::materialize::response::Validated {
+            bindings: vec![
+                validated::Binding {
+                    constraints: test_constraints(constraint::Type::LocationRecommended),
+                    resource_path: vec!["nice".to_string()],
+                    delta_updates: false,
+                },
+                validated::Binding {
+                    constraints: test_constraints(constraint::Type::Unsatisfiable),
+                    resource_path: vec!["naughty".to_string()],
+                    delta_updates: false,
+                },
+            ],
+        };
+
+        let mut validations = tables::Validations::default();
+        validations.built_materializations.insert_row(
+            models::Materialization::new("acmeCo/materialize"),
+            tables::synthetic_scope(models::CatalogType::Materialization, "acmeCo/materialize"),
+            models::Id::zero(),
+            models::Id::zero(),
+            models::Id::zero(),
+            models::Id::zero(),
+            Some(live_mat),
+            Some(resp),
+            None,
+            None,
+            false,
+            None,
+        );
+
+        let result = get_incompatible_collections(&validations);
+        assert_eq!(1, result.len());
+        let ic = result.into_iter().next().unwrap();
+
+        insta::assert_debug_snapshot!(ic, @r###"
+        IncompatibleCollection {
+            collection: "acmeCo/naughtyCollection",
+            requires_recreation: [],
+            affected_materializations: [
+                AffectedConsumer {
+                    name: "acmeCo/materialize",
+                    fields: [
+                        RejectedField {
+                            field: "test_field",
+                            reason: "cuz this is a test",
+                        },
+                    ],
+                    resource_path: [
+                        "naughty",
+                    ],
+                },
+            ],
+        }
+        "###);
+    }
+}

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -113,6 +113,32 @@ impl Client {
         self.user_access_token.is_some()
     }
 
+    /// Performs a GET request to the control-plane agent HTTP API and returns a
+    /// result with either the deserialized response or an error.
+    pub async fn api_get<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        raw_query: &[(String, String)],
+    ) -> anyhow::Result<T> {
+        let url = self.agent_endpoint.join(path)?;
+        let mut builder = self.http_client.get(url).query(raw_query);
+        if let Some(token) = &self.user_access_token {
+            builder = builder.bearer_auth(token);
+        }
+        let request = builder.build()?;
+        tracing::debug!(url = %request.url(), method = "GET", "sending request");
+
+        let response = self.http_client.execute(request).await?;
+        let status = response.status();
+
+        if status.is_success() {
+            Ok(response.json().await?)
+        } else {
+            let body = response.text().await?;
+            anyhow::bail!("GET {path}: {status}: {body}");
+        }
+    }
+
     pub async fn agent_unary<Request, Response>(
         &self,
         path: &str,

--- a/crates/flowctl/src/catalog/mod.rs
+++ b/crates/flowctl/src/catalog/mod.rs
@@ -1,6 +1,7 @@
 mod delete;
 mod publish;
 mod pull_specs;
+mod status;
 mod test;
 
 use crate::{
@@ -75,6 +76,15 @@ pub enum Command {
     /// Once in your draft, use `draft develop` and `draft author` to
     /// develop and author updates to the specification.
     Draft(Draft),
+
+    /// Print status information for a given task or collection (beta).
+    ///
+    /// Note: This command is still in beta and the output is likely to change in the future.
+    ///
+    /// The status shows the current state of the live spec, as known to the
+    /// control plane. This does not yet include _shard_ status from the data
+    /// plane, so not all failures will be visible here.
+    Status(status::Status),
 }
 
 /// Common selection criteria based on the spec name.
@@ -216,6 +226,7 @@ impl Catalog {
             Command::Test(source) => test::do_test(ctx, source).await,
             Command::History(history) => do_history(ctx, history).await,
             Command::Draft(draft) => do_draft(ctx, draft).await,
+            Command::Status(status) => status::do_controller_status(ctx, status).await,
         }
     }
 }

--- a/crates/flowctl/src/catalog/status.rs
+++ b/crates/flowctl/src/catalog/status.rs
@@ -39,11 +39,12 @@ impl crate::output::CliOutput for StatusOutput {
             "Live Spec Updated At",
             "Controller Error",
             "Failures",
+            "Activation Complete",
         ]
     }
 
     fn into_table_row(self, _alt: Self::TableAlt) -> Vec<Self::CellValue> {
-        to_table_row(
+        let mut row = to_table_row(
             &self.0,
             &[
                 "/catalog_name",
@@ -53,6 +54,12 @@ impl crate::output::CliOutput for StatusOutput {
                 "/controller_error",
                 "/failures",
             ],
-        )
+        );
+        // Activation Complete is a computed column so we need to add it manually.
+        let activation_complete = self.0.status.activation_status().map(|activation| {
+            serde_json::Value::Bool(activation.last_activated == self.0.last_build_id)
+        });
+        row.push(JsonCell(activation_complete));
+        row
     }
 }

--- a/crates/flowctl/src/catalog/status.rs
+++ b/crates/flowctl/src/catalog/status.rs
@@ -1,0 +1,58 @@
+use models::status::StatusResponse;
+use serde::Serialize;
+
+use crate::output::{to_table_row, JsonCell};
+
+#[derive(Debug, clap::Args)]
+pub struct Status {
+    /// Names of the live specs to fetch the status of
+    #[clap(required(true))]
+    pub catalog_names: Vec<String>,
+}
+
+pub async fn do_controller_status(
+    ctx: &mut crate::CliContext,
+    Status { catalog_names }: &Status,
+) -> anyhow::Result<()> {
+    let query = catalog_names
+        .iter()
+        .map(|name| ("name".to_string(), name.clone()))
+        .collect::<Vec<_>>();
+    let resp: Vec<StatusResponse> = ctx.client.api_get("/api/v1/status", &query).await?;
+    ctx.write_all::<_, StatusOutput>(resp.into_iter().map(StatusOutput), ())?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct StatusOutput(StatusResponse);
+
+impl crate::output::CliOutput for StatusOutput {
+    type TableAlt = ();
+    type CellValue = JsonCell;
+
+    fn table_headers(_alt: Self::TableAlt) -> Vec<&'static str> {
+        vec![
+            "Name",
+            "Type",
+            "Controller Updated At",
+            "Live Spec Updated At",
+            "Controller Error",
+            "Failures",
+        ]
+    }
+
+    fn into_table_row(self, _alt: Self::TableAlt) -> Vec<Self::CellValue> {
+        to_table_row(
+            &self.0,
+            &[
+                "/catalog_name",
+                "/spec_type",
+                "/controller_updated_at",
+                "/live_spec_updated_at",
+                "/controller_error",
+                "/failures",
+            ],
+        )
+    }
+}

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -11,7 +11,9 @@ license.workspace = true
 [dependencies]
 # NOTE(johnny): DO NOT add proto-flow or proto-gazette to this crate.
 
+anyhow = { workspace = true }
 caseless = { workspace = true }
+chrono = { workspace = true }
 humantime-serde = { workspace = true }
 lazy_static = { workspace = true }
 regex = { workspace = true }

--- a/crates/models/src/discovers.rs
+++ b/crates/models/src/discovers.rs
@@ -1,0 +1,15 @@
+use std::collections::BTreeMap;
+
+use crate::ResourcePath;
+
+/// Represents a capture binding that was added, removed, or modified by a
+/// discover.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Changed {
+    /// The name of the target collection for the binding.
+    pub target: crate::Collection,
+    /// Whether the binding is disabled.
+    pub disable: bool,
+}
+/// Represents a set of changes resulting from a discover.
+pub type Changes = BTreeMap<ResourcePath, Changed>;

--- a/crates/models/src/draft_error.rs
+++ b/crates/models/src/draft_error.rs
@@ -1,0 +1,27 @@
+use crate::publications::LockFailure;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A generic error that can be associated with a particular draft spec for a given operation.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+pub struct Error {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub catalog_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    pub detail: String,
+}
+
+impl From<LockFailure> for Error {
+    fn from(err: LockFailure) -> Self {
+        let detail = format!(
+            "the expectPubId of spec {:?} {:?} did not match that of the live spec {:?}",
+            err.catalog_name, err.expected, err.actual
+        );
+        Error {
+            catalog_name: err.catalog_name,
+            detail,
+            scope: None,
+        }
+    }
+}

--- a/crates/models/src/evolutions.rs
+++ b/crates/models/src/evolutions.rs
@@ -1,0 +1,14 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
+pub struct EvolvedCollection {
+    /// Original name of the collection
+    pub old_name: String,
+    /// The new name of the collection, which may be the same as the original name if only materialization bindings were updated
+    pub new_name: String,
+    /// The names of any materializations that were updated as a result of evolving this collection
+    pub updated_materializations: Vec<String>,
+    /// The names of any captures that were updated as a result of evolving this collection
+    pub updated_captures: Vec<String>,
+}

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -23,6 +23,7 @@ mod schemas;
 mod shards;
 mod source;
 mod source_capture;
+pub(crate) mod sqlx_json;
 pub mod status;
 mod tests;
 

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -9,16 +9,21 @@ mod connector;
 mod derivation;
 mod derive_sqlite;
 mod derive_typescript;
+pub mod discovers;
+pub mod draft_error;
+pub mod evolutions;
 mod id;
 mod journals;
 mod labels;
 mod materializations;
+pub mod publications;
 mod raw_value;
 mod references;
 mod schemas;
 mod shards;
 mod source;
 mod source_capture;
+pub mod status;
 mod tests;
 
 pub use crate::labels::{Label, LabelSelector, LabelSet};
@@ -49,6 +54,11 @@ pub use shards::ShardTemplate;
 pub use source::{FullSource, OnIncompatibleSchemaChange, PartitionSelector, Source};
 pub use source_capture::{SourceCapture, SourceCaptureDef, SourceCaptureSchemaMode};
 pub use tests::{TestDef, TestDocuments, TestStep, TestStepIngest, TestStepVerify};
+
+/// Uniquely identifies a resource in an external system that can be either
+/// captured from or materialized into. For example, a `[schema, table]` in
+/// a database.
+pub type ResourcePath = Vec<String>;
 
 /// ModelDef is the common trait of top-level Flow specifications.
 pub trait ModelDef:
@@ -275,6 +285,14 @@ fn duration_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::
     serde_json::from_value(serde_json::json!({
         "type": ["string", "null"],
         "pattern": "^\\d+(s|m|h)$"
+    }))
+    .unwrap()
+}
+
+fn datetime_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    serde_json::from_value(serde_json::json!({
+        "type": ["string"],
+        "format": "date-time",
     }))
     .unwrap()
 }

--- a/crates/models/src/publications.rs
+++ b/crates/models/src/publications.rs
@@ -1,9 +1,6 @@
-use models::Id;
-use proto_flow::materialize::response::validated::constraint::Type as ConstraintType;
+use crate::Id;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use tables::BuiltRow;
 
 /// JobStatus is the possible outcomes of a handled publication.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
@@ -66,7 +63,7 @@ impl JobStatus {
     }
 
     pub fn has_incompatible_collections(&self) -> bool {
-        matches!(self, JobStatus::BuildFailed { incompatible_collections, .. } if !incompatible_collections.is_empty())
+        self.incompatible_collections().is_some()
     }
 
     pub fn is_empty_draft(&self) -> bool {
@@ -85,8 +82,8 @@ impl JobStatus {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
 pub struct LockFailure {
     pub catalog_name: String,
-    pub expected: models::Id,
-    pub actual: Option<models::Id>,
+    pub expected: Id,
+    pub actual: Option<Id>,
 }
 
 /// Reasons why a draft collection spec would need to be published under a new name.
@@ -134,166 +131,9 @@ pub struct RejectedField {
     pub reason: String,
 }
 
-pub fn get_incompatible_collections(output: &tables::Validations) -> Vec<IncompatibleCollection> {
-    // We'll collect a map of collection names to lists of materializations that have rejected the proposed collection changes.
-    let mut naughty_collections = BTreeMap::new();
-
-    // Look at materialization validation responses for any collections that have been rejected due to unsatisfiable constraints.
-    for mat in output.built_materializations.iter() {
-        let Some(validated) = mat.validated() else {
-            continue;
-        };
-        let Some(model) = mat.model() else {
-            continue;
-        };
-        for (i, binding) in validated.bindings.iter().enumerate() {
-            let naughty_fields: Vec<RejectedField> = binding
-                .constraints
-                .iter()
-                .filter(|(_, constraint)| constraint.r#type == ConstraintType::Unsatisfiable as i32)
-                .map(|(field, constraint)| RejectedField {
-                    field: field.clone(),
-                    reason: constraint.reason.clone(),
-                })
-                .collect();
-            if !naughty_fields.is_empty() {
-                // We must skip over disabled bindings in order to translate the index of the
-                // validated binding to the index of the model binding.
-                let collection_name = model
-                    .bindings
-                    .iter()
-                    .filter(|b| !b.disable)
-                    .skip(i)
-                    .next()
-                    .unwrap() //
-                    .source
-                    .collection()
-                    .to_string();
-                let affected_consumers = naughty_collections
-                    .entry(collection_name)
-                    .or_insert_with(|| Vec::new());
-                affected_consumers.push(AffectedConsumer {
-                    name: mat.catalog_name().to_string(),
-                    fields: naughty_fields,
-                    resource_path: binding.resource_path.clone(),
-                });
-            }
-        }
-    }
-
-    naughty_collections
-        .into_iter()
-        .map(
-            |(collection, affected_materializations)| IncompatibleCollection {
-                collection,
-                affected_materializations,
-                requires_recreation: Vec::new(),
-            },
-        )
-        .collect()
-}
-
 #[cfg(test)]
 mod test {
-    use proto_flow::materialize::response::validated;
-    use proto_flow::materialize::response::validated::constraint;
-
     use super::*;
-
-    #[test]
-    fn test_get_incompatible_collections() {
-        let live_mat: models::MaterializationDef = serde_json::from_value(serde_json::json!({
-            "endpoint": {
-                "connector": {
-                    "image": "test/materialize:foo",
-                    "config": {}
-                }
-            },
-            "bindings": [
-                {
-                    "resource": {"table": "disabledTable"},
-                    "source": "acmeCo/disabledCollection",
-                    "disable": true
-                },
-                {
-                    "resource": {"table": "nice"},
-                    "source": "acmeCo/niceCollection"
-                },
-                {
-                    "resource": {"table": "naughty"},
-                    "source": "acmeCo/naughtyCollection"
-                }
-            ]
-        }))
-        .unwrap();
-
-        fn test_constraints(ty: constraint::Type) -> BTreeMap<String, validated::Constraint> {
-            let mut m = BTreeMap::new();
-            m.insert(
-                "test_field".to_string(),
-                validated::Constraint {
-                    r#type: ty as i32,
-                    reason: "cuz this is a test".to_string(),
-                },
-            );
-            m
-        }
-        let resp = proto_flow::materialize::response::Validated {
-            bindings: vec![
-                validated::Binding {
-                    constraints: test_constraints(constraint::Type::LocationRecommended),
-                    resource_path: vec!["nice".to_string()],
-                    delta_updates: false,
-                },
-                validated::Binding {
-                    constraints: test_constraints(constraint::Type::Unsatisfiable),
-                    resource_path: vec!["naughty".to_string()],
-                    delta_updates: false,
-                },
-            ],
-        };
-
-        let mut validations = tables::Validations::default();
-        validations.built_materializations.insert_row(
-            models::Materialization::new("acmeCo/materialize"),
-            tables::synthetic_scope(models::CatalogType::Materialization, "acmeCo/materialize"),
-            models::Id::zero(),
-            models::Id::zero(),
-            models::Id::zero(),
-            models::Id::zero(),
-            Some(live_mat),
-            Some(resp),
-            None,
-            None,
-            false,
-            None,
-        );
-
-        let result = get_incompatible_collections(&validations);
-        assert_eq!(1, result.len());
-        let ic = result.into_iter().next().unwrap();
-
-        insta::assert_debug_snapshot!(ic, @r###"
-        IncompatibleCollection {
-            collection: "acmeCo/naughtyCollection",
-            requires_recreation: [],
-            affected_materializations: [
-                AffectedConsumer {
-                    name: "acmeCo/materialize",
-                    fields: [
-                        RejectedField {
-                            field: "test_field",
-                            reason: "cuz this is a test",
-                        },
-                    ],
-                    resource_path: [
-                        "naughty",
-                    ],
-                },
-            ],
-        }
-        "###);
-    }
 
     #[test]
     fn test_publication_job_status_serde() {

--- a/crates/models/src/sqlx_json.rs
+++ b/crates/models/src/sqlx_json.rs
@@ -1,0 +1,38 @@
+/// Implements `sqlx::{Type, Decode, Encode}` for a given type, allowing sqlx to
+/// treat it as a plain `json` column (not `jsonb`). The type given to this
+/// macro must implement `serde::Serialize` and `serde::Deserialize`.
+macro_rules! sqlx_json {
+    ($rust_type:ty) => {
+
+        #[cfg(feature = "sqlx-support")]
+        impl sqlx::Type<sqlx::Postgres> for $rust_type {
+            fn type_info() -> sqlx::postgres::PgTypeInfo {
+                sqlx::postgres::PgTypeInfo::with_name("JSON")
+            }
+            // TODO: is `compatible` impl necessary?
+            fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+                *ty == Self::type_info() // Not compatible with JSONB.
+            }
+        }
+
+        #[cfg(feature = "sqlx-support")]
+        impl<'a> sqlx::Decode<'a, sqlx::postgres::Postgres> for $rust_type {
+            fn decode(value: sqlx::postgres::PgValueRef<'a>) -> Result<Self, sqlx::error::BoxDynError> {
+                <sqlx::types::Json<$rust_type> as sqlx::Decode<'a, sqlx::postgres::Postgres>>::decode(value)
+                    .map(|t| t.0)
+            }
+        }
+
+        #[cfg(feature = "sqlx-support")]
+        impl<'q> sqlx::Encode<'q, sqlx::postgres::Postgres> for $rust_type {
+            fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
+                <sqlx::types::Json<&Self> as sqlx::Encode<'q, sqlx::postgres::Postgres>>::encode(
+                    sqlx::types::Json(self),
+                    buf,
+                )
+            }
+        }
+    };
+}
+
+pub(crate) use sqlx_json;

--- a/crates/models/src/status/capture.rs
+++ b/crates/models/src/status/capture.rs
@@ -1,0 +1,170 @@
+use crate::discovers::Changed;
+use crate::draft_error;
+use crate::evolutions::EvolvedCollection;
+use crate::publications;
+use crate::status::publications::{ActivationStatus, PublicationStatus};
+use crate::ResourcePath;
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Status of a capture controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct CaptureStatus {
+    #[serde(default)]
+    pub publications: PublicationStatus,
+    #[serde(default)]
+    pub activation: ActivationStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_discover: Option<AutoDiscoverStatus>,
+}
+
+/// A capture binding that has changed as a result of a discover
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
+pub struct DiscoverChange {
+    /// Identifies the resource in the source system that this change pertains to.
+    pub resource_path: ResourcePath,
+    /// The target collection of the capture binding that was changed.
+    pub target: crate::Collection,
+    /// Whether the capture binding is disabled.
+    pub disable: bool,
+}
+
+impl DiscoverChange {
+    pub fn new(resource_path: ResourcePath, Changed { target, disable }: Changed) -> Self {
+        Self {
+            resource_path,
+            target,
+            disable,
+        }
+    }
+}
+
+/// The results of an auto-discover attempt
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
+pub struct AutoDiscoverOutcome {
+    /// Time at which the disocver was attempted
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub ts: DateTime<Utc>,
+    /// Bindings that were added to the capture.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added: Vec<DiscoverChange>,
+    /// Bindings that were modified, either to change the schema or the collection key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modified: Vec<DiscoverChange>,
+    /// Bindings that were removed because they no longer appear in the source system.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<DiscoverChange>,
+    /// Errors that occurred during the discovery or evolution process.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<draft_error::Error>,
+    /// Collections that were re-created due to the collection key having changed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub re_created_collections: Vec<EvolvedCollection>,
+    /// The result of publishing the discovered changes, if a publication was attempted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publish_result: Option<publications::JobStatus>,
+}
+
+impl AutoDiscoverOutcome {
+    /// Returns true if this represents a successfull auto-discover, meaning
+    /// that the discover itself was successful, and either we were able to
+    /// publish the changes, or there was no publication necessary.
+    pub fn is_successful(&self) -> bool {
+        self.get_result().is_ok()
+    }
+
+    /// Returns an `Err` if any part of the auto-discover failed. Returns `Ok`
+    /// only if the auto-discover was successful.
+    pub fn get_result(&self) -> anyhow::Result<()> {
+        if let Some(first_err) = self.errors.get(0) {
+            anyhow::bail!("auto-discover failed: {}", &first_err.detail);
+        }
+        if let Some(pub_result) = self
+            .publish_result
+            .as_ref()
+            .filter(|r| !(r.is_success() || r.is_empty_draft()))
+        {
+            anyhow::bail!("auto-discover publication failed with: {:?}", pub_result)
+        };
+        Ok(())
+    }
+
+    pub fn has_changes(&self) -> bool {
+        self.errors.is_empty()
+            && (!self.added.is_empty() || !self.modified.is_empty() || !self.removed.is_empty())
+    }
+
+    pub fn error(
+        ts: DateTime<Utc>,
+        capture_name: &str,
+        error: &anyhow::Error,
+    ) -> AutoDiscoverOutcome {
+        let errors = vec![draft_error::Error {
+            catalog_name: capture_name.to_string(),
+            detail: error.to_string(),
+            scope: None,
+        }];
+        AutoDiscoverOutcome {
+            ts,
+            errors,
+            added: Vec::new(),
+            modified: Vec::new(),
+            removed: Vec::new(),
+            re_created_collections: Vec::new(),
+            publish_result: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema, Clone)]
+pub struct AutoDiscoverFailure {
+    /// The number of consecutive failures that have been observed.
+    pub count: u32,
+    /// The timestamp of the first failure in the current sequence.
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub first_ts: DateTime<Utc>,
+    /// The discover outcome corresponding to the most recent failure. This will
+    /// be updated with the results of each retry until an auto-discover
+    /// succeeds.
+    pub last_outcome: AutoDiscoverOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct AutoDiscoverStatus {
+    /// The interval at which auto-discovery is run. This is normally unset, which uses
+    /// the default interval.
+    #[serde(
+        default,
+        with = "humantime_serde",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schemars(schema_with = "interval_schema")]
+    pub interval: Option<std::time::Duration>,
+
+    /// Time at which the next auto-discover should be run.
+    #[serde(default)]
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub next_at: Option<DateTime<Utc>>,
+    /// The outcome of the a recent discover, which is about to be published.
+    /// This will typically only be observed if the publication failed for some
+    /// reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_publish: Option<AutoDiscoverOutcome>,
+    /// The outcome of the last _successful_ auto-discover. If `failure` is set,
+    /// then that will typically be more recent than `last_success`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success: Option<AutoDiscoverOutcome>,
+    /// If auto-discovery has failed, this will include information about that failure.
+    /// This field is cleared as soon as a successful auto-discover is run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<AutoDiscoverFailure>,
+}
+
+fn interval_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    serde_json::from_value(serde_json::json!({
+        "type": ["string", "null"],
+        "pattern": "^\\d+(s|m|h)$"
+    }))
+    .unwrap()
+}

--- a/crates/models/src/status/catalog_test.rs
+++ b/crates/models/src/status/catalog_test.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::publications::PublicationStatus;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct TestStatus {
+    pub passing: bool,
+    #[serde(default)]
+    pub publications: PublicationStatus,
+}

--- a/crates/models/src/status/collection.rs
+++ b/crates/models/src/status/collection.rs
@@ -1,0 +1,33 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::publications::{ActivationStatus, PublicationStatus};
+
+/// The status of a collection controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct CollectionStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inferred_schema: Option<InferredSchemaStatus>,
+    #[serde(default)]
+    pub publications: PublicationStatus,
+    #[serde(default)]
+    pub activation: ActivationStatus,
+}
+
+/// Status of the inferred schema
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
+pub struct InferredSchemaStatus {
+    /// The time at which the inferred schema was last published. This will only
+    /// be present if the inferred schema was published at least once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub schema_last_updated: Option<DateTime<Utc>>,
+    /// The md5 sum of the inferred schema that was last published.
+    /// Because the publications handler updates the model instead of the controller, it's
+    /// technically possible for the published inferred schema to be more recent than the one
+    /// corresponding to this hash. If that happens, we would expect a subsequent publication
+    /// on the next controller run, which would update the hash but not actually modify the schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_md5: Option<String>,
+}

--- a/crates/models/src/status/materialization.rs
+++ b/crates/models/src/status/materialization.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::publications::{ActivationStatus, PublicationStatus};
+
+/// Status of a materialization controller
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct MaterializationStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_capture: Option<SourceCaptureStatus>,
+    #[serde(default)]
+    pub publications: PublicationStatus,
+    #[serde(default)]
+    pub activation: ActivationStatus,
+}
+
+/// Status information about the `sourceCapture`
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+pub struct SourceCaptureStatus {
+    /// Whether the materialization bindings are up-to-date with respect to
+    /// the `sourceCapture` bindings. In normal operation, this should always
+    /// be `true`. Otherwise, there will be a controller `error` and the
+    /// publication status will contain details of why the update failed.
+    #[serde(default)]
+    pub up_to_date: bool,
+    /// If `up_to_date` is `false`, then this will contain the set of
+    /// `sourceCapture` collections that need to be added. This is provided
+    /// simply to aid in debugging in case the publication to add the bindings
+    /// fails.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub add_bindings: BTreeSet<crate::Collection>,
+}

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -4,9 +4,49 @@ pub mod collection;
 pub mod materialization;
 pub mod publications;
 
-use crate::CatalogType;
+use crate::{datetime_schema, is_false, option_datetime_schema, CatalogType, Id};
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+/// Response type for the status endpoint
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct StatusResponse {
+    /// The name of the live spec
+    pub catalog_name: String,
+    /// The id of the live spec
+    pub live_spec_id: Id,
+    /// The type of the live spec
+    pub spec_type: Option<CatalogType>,
+    /// Whether the shards are disabled. Only pertinent to tasks. Omitted if false.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub disabled: bool,
+    /// The id of the last successful publication that modified the spec.
+    pub last_pub_id: Id,
+    /// The id of the last successful publication of the spec, regardless of
+    /// whether the spec was modified. This value can be compared against the
+    /// value of `/status/activations/last_activated` in order to determine
+    /// whether the most recent build has been activated in the data plane.
+    pub last_build_id: Id,
+    /// Time at which the controller is next scheduled to run. Or null if there
+    /// is no run scheduled.
+    #[schemars(schema_with = "option_datetime_schema")]
+    pub controller_next_run: Option<DateTime<Utc>>,
+    /// Time of the last publication that affected the live spec.
+    #[schemars(schema_with = "datetime_schema")]
+    pub live_spec_updated_at: DateTime<Utc>,
+    /// Time of the last controller run for this spec.
+    #[schemars(schema_with = "datetime_schema")]
+    pub controller_updated_at: DateTime<Utc>,
+    /// The controller status json.
+    pub status: Status,
+    /// Error from the most recent controller run, or `null` if the run was
+    /// successful.
+    pub controller_error: Option<String>,
+    /// The number of consecutive failures of the controller. Resets to 0 after
+    /// any successful run.
+    pub controller_failures: i32,
+}
 
 /// Represents the internal state of a controller.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
@@ -16,20 +56,14 @@ pub enum Status {
     Collection(collection::CollectionStatus),
     Materialization(materialization::MaterializationStatus),
     Test(catalog_test::TestStatus),
-    #[schemars(skip)]
     #[serde(other, untagged)]
     Uninitialized,
 }
 
-impl Status {
-    pub fn json_schema() -> schemars::schema::RootSchema {
-        let settings = schemars::gen::SchemaSettings::draft2019_09();
-        //settings.option_add_null_type = false;
-        //settings.inline_subschemas = true;
-        let generator = schemars::gen::SchemaGenerator::new(settings);
-        generator.into_root_schema_for::<Status>()
-    }
+// Status types are serialized as plain json columns.
+crate::sqlx_json::sqlx_json!(Status);
 
+impl Status {
     pub fn catalog_type(&self) -> Option<CatalogType> {
         match self {
             Status::Capture(_) => Some(CatalogType::Capture),
@@ -200,7 +234,10 @@ mod test {
 
     #[test]
     fn test_status_json_schema() {
-        let schema = serde_json::to_value(Status::json_schema()).unwrap();
+        let settings = schemars::gen::SchemaSettings::draft2019_09();
+        let generator = schemars::gen::SchemaGenerator::new(settings);
+        let schema_obj = generator.into_root_schema_for::<Status>();
+        let schema = serde_json::to_value(&schema_obj).unwrap();
         insta::assert_json_snapshot!(schema);
     }
 }

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -78,6 +78,16 @@ impl Status {
         matches!(self, Status::Uninitialized)
     }
 
+    /// Returns the activation status, if this status is for a capture, collection, or materialization.
+    pub fn activation_status(&self) -> Option<&publications::ActivationStatus> {
+        match self {
+            Status::Capture(c) => Some(&c.activation),
+            Status::Collection(c) => Some(&c.activation),
+            Status::Materialization(c) => Some(&c.activation),
+            _ => None,
+        }
+    }
+
     pub fn as_capture_mut(&mut self) -> anyhow::Result<&mut capture::CaptureStatus> {
         if self.is_uninitialized() {
             *self = Status::Capture(Default::default());

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -1,0 +1,206 @@
+pub mod capture;
+pub mod catalog_test;
+pub mod collection;
+pub mod materialization;
+pub mod publications;
+
+use crate::CatalogType;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Represents the internal state of a controller.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(tag = "type")]
+pub enum Status {
+    Capture(capture::CaptureStatus),
+    Collection(collection::CollectionStatus),
+    Materialization(materialization::MaterializationStatus),
+    Test(catalog_test::TestStatus),
+    #[schemars(skip)]
+    #[serde(other, untagged)]
+    Uninitialized,
+}
+
+impl Status {
+    pub fn json_schema() -> schemars::schema::RootSchema {
+        let settings = schemars::gen::SchemaSettings::draft2019_09();
+        //settings.option_add_null_type = false;
+        //settings.inline_subschemas = true;
+        let generator = schemars::gen::SchemaGenerator::new(settings);
+        generator.into_root_schema_for::<Status>()
+    }
+
+    pub fn catalog_type(&self) -> Option<CatalogType> {
+        match self {
+            Status::Capture(_) => Some(CatalogType::Capture),
+            Status::Collection(_) => Some(CatalogType::Collection),
+            Status::Materialization(_) => Some(CatalogType::Materialization),
+            Status::Test(_) => Some(CatalogType::Test),
+            Status::Uninitialized => None,
+        }
+    }
+
+    pub fn is_uninitialized(&self) -> bool {
+        matches!(self, Status::Uninitialized)
+    }
+
+    pub fn as_capture_mut(&mut self) -> anyhow::Result<&mut capture::CaptureStatus> {
+        if self.is_uninitialized() {
+            *self = Status::Capture(Default::default());
+        }
+        match self {
+            Status::Capture(c) => Ok(c),
+            _ => anyhow::bail!("expected capture status"),
+        }
+    }
+
+    pub fn as_collection_mut(&mut self) -> anyhow::Result<&mut collection::CollectionStatus> {
+        if self.is_uninitialized() {
+            *self = Status::Collection(Default::default());
+        }
+        match self {
+            Status::Collection(c) => Ok(c),
+            _ => anyhow::bail!("expected collection status"),
+        }
+    }
+
+    pub fn as_materialization_mut(
+        &mut self,
+    ) -> anyhow::Result<&mut materialization::MaterializationStatus> {
+        if self.is_uninitialized() {
+            *self = Status::Materialization(Default::default());
+        }
+        match self {
+            Status::Materialization(m) => Ok(m),
+            _ => anyhow::bail!("expected materialization status"),
+        }
+    }
+
+    pub fn as_test_mut(&mut self) -> anyhow::Result<&mut catalog_test::TestStatus> {
+        if self.is_uninitialized() {
+            *self = Status::Test(Default::default());
+        }
+        match self {
+            Status::Test(t) => Ok(t),
+            _ => anyhow::bail!("expected test status"),
+        }
+    }
+
+    pub fn unwrap_capture(&self) -> &capture::CaptureStatus {
+        match self {
+            Status::Capture(c) => c,
+            _ => panic!("expected capture status"),
+        }
+    }
+
+    pub fn unwrap_collection(&self) -> &collection::CollectionStatus {
+        match self {
+            Status::Collection(c) => c,
+            _ => panic!("expected collection status"),
+        }
+    }
+
+    pub fn unwrap_materialization(&self) -> &materialization::MaterializationStatus {
+        match self {
+            Status::Materialization(m) => m,
+            _ => panic!("expected materialization status"),
+        }
+    }
+
+    pub fn unwrap_test(&self) -> &catalog_test::TestStatus {
+        match self {
+            Status::Test(t) => t,
+            _ => panic!("expected test status"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{BTreeSet, VecDeque};
+
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::draft_error::Error;
+    use crate::publications::{AffectedConsumer, IncompatibleCollection, JobStatus, RejectedField};
+    use crate::status::materialization::{MaterializationStatus, SourceCaptureStatus};
+    use crate::status::publications::{ActivationStatus, PublicationInfo, PublicationStatus};
+    use crate::Id;
+
+    #[test]
+    fn test_status_round_trip_serde() {
+        let mut add_bindings = BTreeSet::new();
+        add_bindings.insert(crate::Collection::new("snails/shells"));
+
+        let pub_status = PublicationInfo {
+            id: Id::new([4, 3, 2, 1, 1, 2, 3, 4]),
+            created: Some(Utc.with_ymd_and_hms(2024, 5, 30, 9, 10, 11).unwrap()),
+            completed: Some(Utc.with_ymd_and_hms(2024, 5, 30, 9, 10, 11).unwrap()),
+            detail: Some("some detail".to_string()),
+            result: Some(JobStatus::build_failed(vec![IncompatibleCollection {
+                collection: "snails/water".to_string(),
+                requires_recreation: Vec::new(),
+                affected_materializations: vec![AffectedConsumer {
+                    name: "snails/materialize".to_string(),
+                    fields: vec![RejectedField {
+                        field: "a_field".to_string(),
+                        reason: "do not like".to_string(),
+                    }],
+                    resource_path: vec!["water".to_string()],
+                }],
+            }])),
+            errors: vec![Error {
+                catalog_name: "snails/shells".to_string(),
+                scope: Some("flow://materializations/snails/shells".to_string()),
+                detail: "a_field simply cannot be tolerated".to_string(),
+            }],
+            count: 1,
+            is_touch: false,
+        };
+        let mut history = VecDeque::new();
+        history.push_front(pub_status);
+
+        let status = Status::Materialization(MaterializationStatus {
+            activation: ActivationStatus {
+                last_activated: Id::new([1, 2, 3, 4, 4, 3, 2, 1]),
+            },
+            source_capture: Some(SourceCaptureStatus {
+                up_to_date: false,
+                add_bindings,
+            }),
+            publications: PublicationStatus {
+                max_observed_pub_id: Id::new([1, 2, 3, 4, 5, 6, 7, 8]),
+                history,
+                dependency_hash: Some("abc12345".to_string()),
+            },
+        });
+
+        let as_json = serde_json::to_string_pretty(&status).expect("failed to serialize status");
+        let round_tripped: Status =
+            serde_json::from_str(&as_json).expect("failed to deserialize status");
+
+        #[derive(Debug)]
+        #[allow(unused)]
+        struct StatusSnapshot {
+            starting: Status,
+            json: String,
+            parsed: Status,
+        }
+
+        insta::assert_debug_snapshot!(
+            "materialization-status-round-trip",
+            StatusSnapshot {
+                starting: status,
+                json: as_json,
+                parsed: round_tripped,
+            }
+        );
+    }
+
+    #[test]
+    fn test_status_json_schema() {
+        let schema = serde_json::to_value(Status::json_schema()).unwrap();
+        insta::assert_json_snapshot!(schema);
+    }
+}

--- a/crates/models/src/status/publications.rs
+++ b/crates/models/src/status/publications.rs
@@ -1,0 +1,287 @@
+use crate::draft_error;
+use crate::publications;
+use crate::Id;
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+/// Status of the activation of the task in the data-plane
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+pub struct ActivationStatus {
+    /// The build id that was last activated in the data plane.
+    /// If this is less than the `last_build_id` of the controlled spec,
+    /// then an activation is still pending.
+    #[serde(default = "Id::zero", skip_serializing_if = "Id::is_zero")]
+    pub last_activated: Id,
+}
+
+impl Default for ActivationStatus {
+    fn default() -> Self {
+        Self {
+            last_activated: Id::zero(),
+        }
+    }
+}
+
+/// Summary of a publication that was attempted by a controller.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+pub struct PublicationInfo {
+    pub id: Id,
+    /// Time at which the publication was initiated
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub created: Option<DateTime<Utc>>,
+    /// Time at which the publication was completed
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub completed: Option<DateTime<Utc>>,
+    /// A brief description of the reason for the publication
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// The final result of the publication
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<publications::JobStatus>,
+    /// Errors will be non-empty for publications that were not successful
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<draft_error::Error>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_touch: bool,
+    #[serde(default = "default_count", skip_serializing_if = "is_one")]
+    #[schemars(schema_with = "count_schema")]
+    pub count: u32,
+}
+
+/// Used for publication info serde
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Used for publication info serde
+fn default_count() -> u32 {
+    1
+}
+
+/// Used for publication info serde
+fn is_one(i: &u32) -> bool {
+    *i == 1
+}
+
+fn count_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    serde_json::from_value(serde_json::json!({
+        "type": "integer",
+        "minimum": 1,
+    }))
+    .unwrap()
+}
+
+impl PublicationInfo {
+    pub fn is_success(&self) -> bool {
+        self.result.as_ref().is_some_and(|s| s.is_success())
+    }
+
+    /// Tries to reduce `other` into `self` if the two should be combined in the
+    /// history. If `other` cannot be reduced into `self`, then it is returned
+    /// unmodified.
+    ///
+    /// Combining events in the history is a way to cram more information into a
+    /// smaller summary, and it helps avoid having repeated publications (like
+    /// touch publications, which can number in the hundreds) quickly push out
+    /// relevant prior events. But it's important that we _only_ combine
+    /// publication entries in the specific cases where we know it won't cause
+    /// confusion. Two publications should be combined in the history only if
+    /// their final `job_status`es are identical (e.g. both `{"type":
+    /// "buildFailed"}`). And then only in one of these cases:
+    /// - they are both touch publications
+    /// - If they are both _unsuccessful_ non-touch publications (i.e. we never
+    ///   combine successful publications that have modified the spec)
+    pub fn try_reduce(&mut self, other: PublicationInfo) -> Option<PublicationInfo> {
+        if (self.is_touch != other.is_touch)
+            || (self.result != other.result)
+            || (!self.is_touch && self.is_success())
+        {
+            return Some(other);
+        }
+        self.id = other.id;
+        self.count += other.count;
+        self.completed = other.completed;
+        self.errors = other.errors;
+        self.detail = other.detail;
+        None
+    }
+}
+
+/// Information on the publications performed by the controller.
+/// This does not include any information on user-initiated publications.
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+pub struct PublicationStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_hash: Option<String>,
+    /// The publication id at which the controller has last notified dependent
+    /// specs. A publication of the controlled spec will cause the controller to
+    /// notify the controllers of all dependent specs. When it does so, it sets
+    /// `max_observed_pub_id` to the current `last_pub_id`, so that it can avoid
+    /// notifying dependent controllers unnecessarily.
+    #[serde(default = "Id::zero", skip_serializing_if = "Id::is_zero")]
+    pub max_observed_pub_id: Id,
+    /// A limited history of publications performed by this controller
+    pub history: VecDeque<PublicationInfo>,
+}
+
+impl Clone for PublicationStatus {
+    fn clone(&self) -> Self {
+        PublicationStatus {
+            max_observed_pub_id: self.max_observed_pub_id,
+            history: self.history.clone(),
+            dependency_hash: self.dependency_hash.clone(),
+        }
+    }
+}
+
+impl Default for PublicationStatus {
+    fn default() -> Self {
+        PublicationStatus {
+            dependency_hash: None,
+            max_observed_pub_id: Id::zero(),
+            history: VecDeque::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_publication_history_folding() {
+        let touch_success = PublicationInfo {
+            id: crate::Id::new([1, 1, 1, 1, 1, 1, 1, 1]),
+            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
+            completed: Some("2024-11-22T17:01:01Z".parse().unwrap()),
+            detail: Some("touch success".to_string()),
+            result: Some(publications::JobStatus::Success),
+            errors: Vec::new(),
+            is_touch: true,
+            count: 1,
+        };
+
+        // Sucessful touch publications should be combined
+        let other_touch_success = PublicationInfo {
+            id: crate::Id::new([2, 1, 1, 1, 1, 1, 1, 1]),
+            completed: Some("2024-11-22T22:22:22Z".parse().unwrap()),
+            created: Some("2024-11-11T11:00:00Z".parse().unwrap()),
+            detail: Some("other touch success".to_string()),
+            ..touch_success.clone()
+        };
+        let mut reduced = touch_success.clone();
+        assert!(reduced.try_reduce(other_touch_success).is_none());
+        assert_eq!(
+            reduced,
+            PublicationInfo {
+                id: crate::Id::new([2, 1, 1, 1, 1, 1, 1, 1]),
+                completed: Some("2024-11-22T22:22:22Z".parse().unwrap()),
+                created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
+                detail: Some("other touch success".to_string()),
+                result: Some(publications::JobStatus::Success),
+                errors: Vec::new(),
+                is_touch: true,
+                count: 2,
+            }
+        );
+
+        let reg_success = PublicationInfo {
+            id: crate::Id::new([3, 1, 1, 1, 1, 1, 1, 1]),
+            completed: Some("2024-11-23T23:33:33Z".parse().unwrap()),
+            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
+            detail: Some("non-touch success".to_string()),
+            result: Some(publications::JobStatus::Success),
+            errors: Vec::new(),
+            is_touch: false,
+            count: 1,
+        };
+        // Touch success and regular success should not be combined
+        let mut touch_subject = touch_success.clone();
+        assert!(touch_subject.try_reduce(reg_success.clone()).is_some());
+
+        // Successful non-touch publications should never be combined because we
+        // want to preserve the history of modifications to the model.
+        let mut reg_subject = reg_success.clone();
+        assert!(reg_subject
+            .try_reduce(PublicationInfo {
+                id: crate::Id::new([4, 1, 1, 1, 1, 1, 1, 1]),
+                ..reg_success.clone()
+            })
+            .is_some(),);
+
+        let reg_fail = PublicationInfo {
+            id: crate::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
+            completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
+            created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
+            detail: Some("reg failure".to_string()),
+            result: Some(publications::JobStatus::BuildFailed {
+                incompatible_collections: Vec::new(),
+                evolution_id: None,
+            }),
+            errors: vec![draft_error::Error {
+                catalog_name: "acmeCo/fail-thing".to_string(),
+                scope: None,
+                detail: "schmeetail".to_string(),
+            }],
+            is_touch: false,
+            count: 1,
+        };
+
+        // A publication with the same unsuccessful status should be combined,
+        // and the detail and error should be that of the most recent
+        // publication.
+        let same_reg_fail = PublicationInfo {
+            id: crate::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
+            completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
+            detail: Some("same but different reg failure".to_string()),
+            errors: vec![draft_error::Error {
+                catalog_name: "acmeCo/fail-thing".to_string(),
+                scope: None,
+                detail: "a different error".to_string(),
+            }],
+            ..reg_fail.clone()
+        };
+        let mut reduced = reg_fail.clone();
+        assert!(reduced.try_reduce(same_reg_fail.clone()).is_none());
+        assert_eq!(
+            reduced,
+            PublicationInfo {
+                id: crate::Id::new([5, 1, 1, 1, 1, 1, 1, 1]),
+                completed: Some("2024-12-01T01:55:55Z".parse().unwrap()),
+                created: Some("2024-11-11T11:11:11Z".parse().unwrap()),
+                detail: Some("same but different reg failure".to_string()),
+                errors: vec![draft_error::Error {
+                    catalog_name: "acmeCo/fail-thing".to_string(),
+                    scope: None,
+                    detail: "a different error".to_string(),
+                }],
+                result: Some(publications::JobStatus::BuildFailed {
+                    incompatible_collections: Vec::new(),
+                    evolution_id: None
+                }),
+                is_touch: false,
+                count: 2,
+            }
+        );
+
+        // A publication with a different status should not be combined
+        let diff_reg_fail = PublicationInfo {
+            result: Some(publications::JobStatus::BuildFailed {
+                incompatible_collections: vec![publications::IncompatibleCollection {
+                    collection: "acmeCo/anvils".to_string(),
+                    requires_recreation: Vec::new(),
+                    affected_materializations: Vec::new(),
+                }],
+                evolution_id: None,
+            }),
+            ..same_reg_fail.clone()
+        };
+        let mut reg_subject = reg_fail.clone();
+        assert!(reg_subject.try_reduce(diff_reg_fail).is_some());
+    }
+}

--- a/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
+++ b/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/agent/src/controllers/mod.rs
+source: crates/models/src/status/mod.rs
 expression: "StatusSnapshot { starting: status, json: as_json, parsed: round_tripped, }"
 ---
 StatusSnapshot {

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/agent/src/controllers/mod.rs
+source: crates/models/src/status/mod.rs
 expression: schema
 ---
 {
@@ -51,7 +51,9 @@ expression: schema
         "first_ts": {
           "description": "The timestamp of the first failure in the current sequence.",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "last_outcome": {
           "$ref": "#/definitions/AutoDiscoverOutcome",
@@ -66,6 +68,7 @@ expression: schema
       "type": "object"
     },
     "AutoDiscoverOutcome": {
+      "description": "The results of an auto-discover attempt",
       "properties": {
         "added": {
           "description": "Bindings that were added to the capture.",
@@ -116,7 +119,9 @@ expression: schema
         "ts": {
           "description": "Time at which the disocver was attempted",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         }
       },
       "required": [
@@ -160,7 +165,9 @@ expression: schema
           "default": null,
           "description": "Time at which the next auto-discover should be run.",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "pending_publish": {
           "anyOf": [
@@ -185,6 +192,7 @@ expression: schema
       "type": "string"
     },
     "DiscoverChange": {
+      "description": "A capture binding that has changed as a result of a discover",
       "properties": {
         "disable": {
           "description": "Whether the capture binding is disabled.",
@@ -210,6 +218,7 @@ expression: schema
       "type": "object"
     },
     "Error": {
+      "description": "A generic error that can be associated with a particular draft spec for a given operation.",
       "properties": {
         "catalog_name": {
           "type": "string"
@@ -295,7 +304,9 @@ expression: schema
         "schema_last_updated": {
           "description": "The time at which the inferred schema was last published. This will only be present if the inferred schema was published at least once.",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "schema_md5": {
           "description": "The md5 sum of the inferred schema that was last published. Because the publications handler updates the model instead of the controller, it's technically possible for the published inferred schema to be more recent than the one corresponding to this hash. If that happens, we would expect a subsequent publication on the next controller run, which would update the hash but not actually modify the schema.",
@@ -502,7 +513,9 @@ expression: schema
         "completed": {
           "description": "Time at which the publication was completed",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "count": {
           "minimum": 1.0,
@@ -511,7 +524,9 @@ expression: schema
         "created": {
           "description": "Time at which the publication was initiated",
           "format": "date-time",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "detail": {
           "description": "A brief description of the reason for the publication",
@@ -757,6 +772,20 @@ expression: schema
       },
       "required": [
         "passing",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "Uninitialized"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
         "type"
       ],
       "type": "object"

--- a/crates/tables/src/lib.rs
+++ b/crates/tables/src/lib.rs
@@ -363,6 +363,20 @@ tables!(
     }
 );
 
+impl Error {
+    pub fn to_draft_error(&self) -> models::draft_error::Error {
+        let catalog_name = parse_synthetic_scope(&self.scope)
+            .map(|(_, name)| name)
+            .unwrap_or_default();
+        models::draft_error::Error {
+            catalog_name,
+            scope: Some(self.scope.to_string()),
+            // use alternate to print chained contexts
+            detail: format!("{:#}", self.error),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct GrantRef<'a> {
     subject_role: &'a str,


### PR DESCRIPTION
**Description:**

Resolves #1807 
See #1808 for discussion related to the design.
Introduces a public control plane API, along with the first endpoint for fetching status information. This involved moving a bunch of types from the `agent` crate into the `models` crate, which I've isolated in the first commit.

Also introduces the `flowctl catalog status` subcommand for fetching status information using flowctl.

Best to review commits individually for this one.

**Workflow steps:**

- The API docs can be seen at (http://localhost:8675/api/v1/docs)
- `flowctl catalog status my/task my/collection` will print status information to the terminal. Using `-o json|yaml` will include more detailed information.

**Documentation links affected:**

None yet. At some point, we'll probably want to bless the new agent API as being officially supported, at which point we ought to have a docs page on it. But for now, it's still a baby.

**Notes for reviewers:**

We're still working on consuming this API from the UI, so its still possible we may wish to change this. But given how many files I needed to touch in order to move the status into the `models` crate, I'd prefer to get this reviewed and merged before needing to rebase more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1819)
<!-- Reviewable:end -->
