### PR TITLE
Phil/agent jwt secret

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -164,6 +164,7 @@ local_resource(
         "DATABASE_URL": DATABASE_URL,
         "RUST_LOG": "info",
         "SSL_CERT_FILE": CA_CERT_PATH,
+        "CONTROL_PLANE_JWT_SECRET": "super-secret-jwt-token-with-at-least-32-characters-long",
     },
     resource_deps=['reactor', 'gazette']
 )

--- a/crates/agent/src/controllers/periodic.rs
+++ b/crates/agent/src/controllers/periodic.rs
@@ -68,12 +68,14 @@ pub fn start_periodic_publish_update<C: ControlPlane>(
     pending
 }
 
+// TODO: periodic publications are temporarily disabled
 fn is_spec_disabled(state: &ControllerState) -> bool {
-    state
-        .live_spec
-        .as_ref()
-        // Collections are never considered disabled, since they can still be
-        // captured or materialized even if derivation shards are disabled.
-        .map(|ls| ls.catalog_type() != models::CatalogType::Collection && !ls.is_enabled())
-        .unwrap_or(true)
+    true
+    // state
+    //     .live_spec
+    //     .as_ref()
+    //     // Collections are never considered disabled, since they can still be
+    //     // captured or materialized even if derivation shards are disabled.
+    //     .map(|ls| ls.catalog_type() != models::CatalogType::Collection && !ls.is_enabled())
+    //     .unwrap_or(true)
 }

--- a/crates/agent/src/integration_tests/periodic_publications.rs
+++ b/crates/agent/src/integration_tests/periodic_publications.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+// TODO: temporarily disabled
+/*
 use crate::{
     controllers::{ControllerState, Status},
     integration_tests::harness::{
@@ -182,3 +184,5 @@ async fn specs_are_published_periodically() {
         disabled_cap_end.last_build_id
     );
 }
+
+*/

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -157,9 +157,8 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
     let system_user_id = agent_sql::get_user_id_for_email(&args.accounts_email, &pg_pool)
         .await
         .context("querying for agent user id")?;
-    let jwt_secret: String = sqlx::query_scalar(r#"show app.settings.jwt_secret;"#)
-        .fetch_one(&pg_pool)
-        .await?;
+    let jwt_secret: String =
+        std::env::var("CONTROL_PLANE_JWT_SECRET").context("missing CONTROL_PLANE_JWT_SECRET")?;
 
     if args.builds_root.scheme() == "file" {
         std::fs::create_dir_all(args.builds_root.path())

--- a/supabase/migrations/20241212195226_jwt_secret.sql
+++ b/supabase/migrations/20241212195226_jwt_secret.sql
@@ -1,0 +1,15 @@
+
+begin;
+
+select vault.create_secret('super-secret-jwt-token-with-at-least-32-characters-long', 'app.jwt_secret', 'The jwt secret');
+
+CREATE OR REPLACE FUNCTION internal.access_token_jwt_secret() RETURNS text
+    LANGUAGE sql STABLE
+    AS $$
+
+    select decrypted_secret
+       from vault.decrypted_secrets
+       where name = 'app.jwt_secret';
+$$;
+
+commit;


### PR DESCRIPTION
**Description:**

Updates the agent to read `CONTROL_PLANE_JWT_SECRET` from the env instead of querying it from the database. Supabase recently did a [rug pull](https://github.com/orgs/supabase/discussions/30606) on `app.settings.jwt_secret`, and agents were relying on the presence of that as part of their startup routine. This updates agent to read the jwt secret from an env variable instead of querying it from the database.

Also updates the `internal.access_token_jwt_secret` sql function to read the jwt secret from vault instead of relying on `app.settings.jwt_secret`.

I also hacked in a disablement of the periodic publications, since the fix to make those apply to tasks only hasn't merged yet.

The migration has already been run, and the agents have already been deployed.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1825)
<!-- Reviewable:end -->
