### PR TITLE
dekaf: rebuild on protocol changes

### DIFF
--- a/.github/workflows/dekaf.yaml
+++ b/.github/workflows/dekaf.yaml
@@ -5,6 +5,7 @@ on:
     branches: [master]
     paths:
       - "crates/dekaf/**"
+      - "crates/proto-**"
       - "Cargo.lock"
   pull_request:
     branches: [master]


### PR DESCRIPTION
**Description:**

Dekaf depends on multiple protocol crates including `proto-flow` and `proto-gazette`, so it should be rebuilt when one of those changes. As a simplification, this modification will run the dekaf CI whenever any `proto-***` crate changes.

Future work may consider building dekaf like we do other rust binaries and packaging it similarly to reactor or agent.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1826)
<!-- Reviewable:end -->
