### PR TITLE
runtime: add support for CONNECTOR_CGROUP_PARENT

### DIFF
--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -117,7 +117,6 @@ pub async fn start(
         "--env=LOG_FORMAT=json".to_string(),
         format!("--env=LOG_LEVEL={}", log_level.as_str_name()),
         // Cgroup memory / CPU resource limits.
-        // TODO(johnny): we intend to tighten these down further, over time.
         "--memory=1g".to_string(),
         "--cpus=2".to_string(),
         // For now, we support only Linux amd64 connectors.
@@ -144,6 +143,10 @@ pub async fn start(
             format!("--publish=0.0.0.0:{port}:{CONNECTOR_INIT_PORT}"),
             "--publish-all".to_string(),
         ])
+    }
+
+    if let Some(cgroup_parent) = std::env::var("CONNECTOR_CGROUP_PARENT").ok() {
+        docker_args.append(&mut vec!["--cgroup-parent".to_string(), cgroup_parent]);
     }
 
     docker_args.append(&mut vec![


### PR DESCRIPTION
When set, use the desginated cgroup as the parent of started connector containers.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1829)
<!-- Reviewable:end -->
