### PR TITLE
agent: limit periodic publications to tasks only

### DIFF
--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -75,6 +75,7 @@ impl CollectionStatus {
         } else {
             None
         };
+        // This function will return None unless this collection is an enabled derivation.
         let periodic_next = periodic::next_periodic_publish(state);
         Ok(NextRun::earliest([inferred_schema_next, periodic_next]))
     }

--- a/crates/agent/src/integration_tests/periodic_publications.rs
+++ b/crates/agent/src/integration_tests/periodic_publications.rs
@@ -1,16 +1,9 @@
 use std::collections::BTreeSet;
 
-// TODO: temporarily disabled
-/*
 use crate::{
-    controllers::{ControllerState, Status},
-    integration_tests::harness::{
-        draft_catalog, mock_inferred_schema, InjectBuildError, TestHarness,
-    },
-    ControlPlane,
+    controllers::Status,
+    integration_tests::harness::{draft_catalog, TestHarness},
 };
-use models::CatalogType;
-use uuid::Uuid;
 
 #[tokio::test]
 #[serial_test::serial]
@@ -129,10 +122,9 @@ async fn specs_are_published_periodically() {
         .await;
 
     // Everything else is expected to get published.
-    let expect_touched_names: BTreeSet<String> = all_spec_names
-        .iter()
-        .filter(|n| !n.contains("disabled"))
-        .cloned()
+    let expect_touched_names: BTreeSet<String> = ["cicadas/capture", "cicadas/materialize"]
+        .into_iter()
+        .map(ToOwned::to_owned)
         .collect();
 
     // Update the `last_updated` time in the database to simulate the passage of time after their creation.
@@ -184,5 +176,3 @@ async fn specs_are_published_periodically() {
         disabled_cap_end.last_build_id
     );
 }
-
-*/


### PR DESCRIPTION
**Description:**

Updates the periodic publication controller so that it applies only to tasks. Previously, we deployed periodic publications and then reverted it because the number of collection publications was overwhelming. The original reason for publishing collections was only to ensure that built specs were all reasonably up to date, but we've decided that no longer seems worth the effort of doing so many publications. So this excludes collections from the periodic publications. The main objective of letting us expire old build databases from the cloud storage bucket is still met by periodically publishing captures, derivations, and materializations. I couldn't think of a reason to exclude catalog tests from periodic publication, so I just left it.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1830)
<!-- Reviewable:end -->
