### PR TITLE
flowctl: add raw list-shards subcommand

### DIFF
--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -14,6 +14,7 @@ use tables::CatalogResolver;
 mod discover;
 mod materialize_fixture;
 mod oauth;
+mod shards;
 mod spec;
 
 #[derive(Debug, clap::Args)]
@@ -65,6 +66,8 @@ pub enum Command {
     Stats(Stats),
     /// Stream logs associated with the given bearer token.
     BearerLogs(BearerLogs),
+    /// Print information about the shards for a given task
+    ListShards(TaskSelector),
 }
 
 #[derive(Debug, clap::Args)]
@@ -225,6 +228,7 @@ impl Advanced {
             }
             Command::Stats(stats) => stats.run(ctx).await,
             Command::BearerLogs(bearer_logs) => bearer_logs.run(ctx).await,
+            Command::ListShards(selector) => shards::do_list_shards(ctx, selector).await,
         }
     }
 }

--- a/crates/flowctl/src/raw/shards.rs
+++ b/crates/flowctl/src/raw/shards.rs
@@ -1,0 +1,110 @@
+use crate::{ops::TaskSelector, CliContext};
+
+pub async fn do_list_shards(ctx: &mut CliContext, selector: &TaskSelector) -> anyhow::Result<()> {
+    let task_name = &selector.task;
+    let (shard_id_prefix, _, _, shard_client, _journal_client) =
+        flow_client::fetch_user_task_authorization(&ctx.client, task_name).await?;
+
+    let req = proto_gazette::consumer::ListRequest {
+        selector: Some(proto_gazette::LabelSelector {
+            include: Some(proto_gazette::LabelSet {
+                labels: vec![proto_gazette::Label {
+                    name: "id".to_string(),
+                    value: shard_id_prefix.clone(),
+                    prefix: true,
+                }],
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let resp = shard_client.list(req).await?;
+    if resp.status != (proto_gazette::consumer::Status::Ok as i32) {
+        tracing::warn!(response = ?resp, "failed to list shards");
+        return Err(anyhow::anyhow!(
+            "shard lising response returned error code: {} ({})",
+            resp.status,
+            resp.status().as_str_name()
+        ));
+    }
+    let wrapped = resp.shards.into_iter().map(ShardWrapper);
+    ctx.write_all(wrapped, ())?;
+
+    Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(transparent)]
+struct ShardWrapper(proto_gazette::consumer::list_response::Shard);
+
+impl crate::output::CliOutput for ShardWrapper {
+    type TableAlt = ();
+    type CellValue = String;
+
+    fn table_headers(_alt: Self::TableAlt) -> Vec<&'static str> {
+        vec!["ID", "Status", "Primary", "Error"]
+    }
+
+    fn into_table_row(self, _alt: Self::TableAlt) -> Vec<Self::CellValue> {
+        let id = self
+            .0
+            .spec
+            .as_ref()
+            .map(|s| s.id.clone())
+            .unwrap_or_default();
+        vec![
+            id,
+            extract_status(&self.0),
+            extract_primary(&self.0),
+            extract_error(&self.0),
+        ]
+    }
+}
+
+fn extract_primary(shard: &proto_gazette::consumer::list_response::Shard) -> String {
+    let Some(route) = shard.route.as_ref() else {
+        return "No routes".to_string();
+    };
+    if route.primary == -1 {
+        return "No primary".to_string();
+    }
+    route
+        .members
+        .get(route.primary as usize)
+        .map(|m| m.suffix.clone())
+        .unwrap_or_default()
+}
+
+fn extract_status(shard: &proto_gazette::consumer::list_response::Shard) -> String {
+    let Some(route) = shard.route.as_ref() else {
+        return "No routes".to_string();
+    };
+    if route.primary == -1 {
+        return "No primary".to_string();
+    }
+    let Some(primary_status) = shard.status.get(route.primary as usize) else {
+        return "Missing status for primary route".to_string();
+    };
+    proto_gazette::consumer::replica_status::Code::try_from(primary_status.code)
+        .map(|c| c.as_str_name().to_owned())
+        .unwrap_or_else(|_| format!("Unknown status code: {}", primary_status.code))
+}
+
+fn extract_error(shard: &proto_gazette::consumer::list_response::Shard) -> String {
+    use std::fmt::Write;
+    let Some(route) = shard.route.as_ref() else {
+        return "No routes".to_string();
+    };
+    if route.primary == -1 {
+        return "No primary".to_string();
+    }
+    let Some(primary_status) = shard.status.get(route.primary as usize) else {
+        return "Missing status for primary route".to_string();
+    };
+
+    let mut err = primary_status.errors.get(0).cloned().unwrap_or_default();
+    if primary_status.errors.len() > 1 {
+        write!(&mut err, " (+{} more)", primary_status.errors.len() - 1).unwrap();
+    }
+    err
+}

--- a/crates/proto-gazette/src/lib.rs
+++ b/crates/proto-gazette/src/lib.rs
@@ -21,6 +21,8 @@ mod serde_recoverylog {
     include!("recoverylog.serde.rs");
 }
 
+pub use protocol::{Label, LabelSelector, LabelSet};
+
 /// Message UUID flags defined by Gazette, and used by Flow.
 /// C.f. Gazette's `message` package, where these are originally defined.
 pub mod message_flags {


### PR DESCRIPTION
Resolves #1710
Adds `flowctl raw list-shards`, which fetches shard information for a given task. It's not yet clear whether this will have relevance to most users, since we plan to integrate shard status into the higher-level "status". But it's pretty inconvenient to use `flowctl-go` with legacy data planes, so this is just meant to give us a debugging tool that we can use in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1831)
<!-- Reviewable:end -->
