### PR TITLE
dekaf: Set `_meta/is_deleted` when `deletions: CDC` is set, even if collection schema has `additionalProperties: true`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "hexdump",
  "humantime",
  "itertools 0.10.5",
+ "json",
  "kafka-protocol",
  "labels",
  "lazy_static",

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -10,24 +10,25 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-aes-siv = { workspace = true }
 allocator = { path = "../allocator" }
 avro = { path = "../avro" }
 doc = { path = "../doc" }
 flow-client = { path = "../flow-client" }
 gazette = { path = "../gazette" }
+json = { path = "../json" }
 labels = { path = "../labels" }
 models = { path = "../models" }
 ops = { path = "../ops" }
 proto-flow = { path = "../proto-flow" }
 proto-gazette = { path = "../proto-gazette" }
 simd-doc = { path = "../simd-doc" }
+
+aes-siv = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
 axum-server = { workspace = true }
 base64 = { workspace = true }
-humantime = { workspace = true }
 bumpalo = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
@@ -36,6 +37,7 @@ deadpool = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hexdump = { workspace = true }
+humantime = { workspace = true }
 itertools = { workspace = true }
 kafka-protocol = { workspace = true }
 lazy_static = { workspace = true }


### PR DESCRIPTION
**Description:**

Had to switch from `Shape::widen()` to manually adding the location as if the collection schema has `additionalProperties: true` (or unset), `Shape::widen()` will be a no-op.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1832)
<!-- Reviewable:end -->
