### PR TITLE
dekaf: Generate predictable shard IDs for dekaf materialization endpoints

### DIFF
--- a/.github/workflows/dekaf.yaml
+++ b/.github/workflows/dekaf.yaml
@@ -6,6 +6,16 @@ on:
     paths:
       - "crates/dekaf/**"
       - "crates/proto-**"
+      - "crates/allocator"
+      - "crates/avro"
+      - "crates/doc"
+      - "crates/flow-client"
+      - "crates/gazette"
+      - "crates/json"
+      - "crates/labels"
+      - "crates/models"
+      - "crates/ops"
+      - "crates/simd-doc"
       - "Cargo.lock"
   pull_request:
     branches: [master]

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -327,6 +327,20 @@ async fn walk_materialization(
     {
         shard_template.id.clone()
     } else {
+        let pub_id = match endpoint {
+            // Dekaf materializations don't create any shards, so the problem of
+            // deleting and re-creating tasks with the same name, which this
+            // shard id template logic was introduced to resolve, isn't applicable.
+            // Instead, since the Dekaf service uses the task name to authenticate
+            // whereas the authorization API expects the shard template id, it's
+            // useful to be able to generate the correct shard template id for a
+            // Dekaf materialization given only its task name, so we set the pub id
+            // to a well-known value of all zeros.
+            models::MaterializationEndpoint::Dekaf(_) => models::Id::zero(),
+            models::MaterializationEndpoint::Connector(_)
+            | models::MaterializationEndpoint::Local(_) => pub_id,
+        };
+
         assemble::shard_id_prefix(pub_id, materialization, labels::TASK_TYPE_MATERIALIZATION)
     };
 


### PR DESCRIPTION
For UX reasons, we only want to use the task name (`myTenant/materializations/dekaf`) when authenticating to Dekaf, as opposed to the full shard template ID (`/myTenant/materializations/dekaf/0fa42cafc58003fa`). 

OTOH, the agent API's `/authorize/task` endpoint expects to be passed the full shard template ID, so since Dekaf materializations never actually create any shards, we decided to use a fixed value for the pub ID component, allowing Dekaf to craft the correct shard template ID given only the task name.

Cherry-picked out of https://github.com/estuary/flow/pull/1840, as it's required to test Dekaf materialization functionality e2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1848)
<!-- Reviewable:end -->
