### PR TITLE
Phil/controller cleanups

### DIFF
--- a/crates/agent/src/api/public/status.rs
+++ b/crates/agent/src/api/public/status.rs
@@ -52,7 +52,7 @@ async fn fetch_status(
         ls.controller_next_run,
         ls.updated_at as "live_spec_updated_at: DateTime<Utc>",
         cj.updated_at as "controller_updated_at: DateTime<Utc>",
-        cj.status as "status: status::Status",
+        cj.status as "controller_status: status::ControllerStatus",
         cj.error as "controller_error: String",
         cj.failures as "controller_failures: i32"
     from live_specs ls

--- a/crates/agent/src/controllers/handler.rs
+++ b/crates/agent/src/controllers/handler.rs
@@ -6,7 +6,7 @@ use crate::{
     DataPlaneConnectors, HandleResult, Handler,
 };
 
-use super::{controller_update, ControllerState, NextRun, RetryableError, Status};
+use super::{controller_update, ControllerState, ControllerStatus, NextRun, RetryableError};
 
 use crate::controllers::CONTROLLER_VERSION;
 
@@ -132,7 +132,7 @@ impl Handler for ControllerHandler {
 ))]
 async fn run_controller<C: ControlPlane>(
     state: &ControllerState,
-    next_status: &mut Status,
+    next_status: &mut ControllerStatus,
     control_plane: &mut C,
 ) -> anyhow::Result<Option<NextRun>> {
     controller_update(next_status, &state, control_plane).await

--- a/crates/agent/src/integration_tests/periodic_publications.rs
+++ b/crates/agent/src/integration_tests/periodic_publications.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     ControlPlane,
 };
-use models::{status::Status, CatalogType};
+use models::{status::ControllerStatus, CatalogType};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -150,11 +150,11 @@ async fn specs_are_published_periodically() {
 
         let after_state = harness.get_controller_state(&name).await;
         let pub_status = match after_state.current_status {
-            Status::Capture(cap) => cap.publications,
-            Status::Materialization(m) => m.publications,
-            Status::Collection(c) => c.publications,
-            Status::Test(t) => t.publications,
-            Status::Uninitialized => panic!("unexpected status"),
+            ControllerStatus::Capture(cap) => cap.publications,
+            ControllerStatus::Materialization(m) => m.publications,
+            ControllerStatus::Collection(c) => c.publications,
+            ControllerStatus::Test(t) => t.publications,
+            ControllerStatus::Uninitialized => panic!("unexpected status"),
         };
         assert_eq!(
             Some("periodic publication"),

--- a/crates/flowctl/src/catalog/status.rs
+++ b/crates/flowctl/src/catalog/status.rs
@@ -56,9 +56,13 @@ impl crate::output::CliOutput for StatusOutput {
             ],
         );
         // Activation Complete is a computed column so we need to add it manually.
-        let activation_complete = self.0.status.activation_status().map(|activation| {
-            serde_json::Value::Bool(activation.last_activated == self.0.last_build_id)
-        });
+        let activation_complete = self
+            .0
+            .controller_status
+            .activation_status()
+            .map(|activation| {
+                serde_json::Value::Bool(activation.last_activated == self.0.last_build_id)
+            });
         row.push(JsonCell(activation_complete));
         row
     }

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -811,5 +811,5 @@ expression: schema
       "type": "object"
     }
   ],
-  "title": "Status"
+  "title": "ControllerStatus"
 }


### PR DESCRIPTION
**Description:**

Rolls up a couple of small changes to agent:

- Ensure failing auto-discovers don't prevent activation of published changes. This has been a pretty major annoyance on a few occasions already.
- Rename `status -> controller_status` in the `/status` response. The `/status` endpoint hasn't been fully released yet, so taking the opportunity to fix this while it's still easy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1852)
<!-- Reviewable:end -->
