### PR TITLE
gazette: Implement `journal::append()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6656,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 tokio-util = { version = "0.7", features = ["io", "compat", "rt"] }
+tokio-stream = { version = "0.1.17" }
 tonic = { version = "0.12", features = ["tls", "tls-roots"] }
 hyper-util = "0.1"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gazette/Cargo.toml
+++ b/crates/gazette/Cargo.toml
@@ -12,7 +12,10 @@ license.workspace = true
 coroutines = { path = "../coroutines" }
 ops = { path = "../ops" }
 proto-gazette = { path = "../proto-gazette" }
-proto-grpc = { path = "../proto-grpc", features = ["broker_client", "consumer_client"] }
+proto-grpc = { path = "../proto-grpc", features = [
+    "broker_client",
+    "consumer_client",
+] }
 
 async-compression = { workspace = true }
 bytes = { workspace = true }

--- a/crates/gazette/src/journal/append.rs
+++ b/crates/gazette/src/journal/append.rs
@@ -1,0 +1,107 @@
+use super::Client;
+use crate::{journal::check_ok, Error};
+use futures::{FutureExt, Stream, StreamExt};
+use proto_gazette::broker::{self, AppendResponse};
+use std::sync::Arc;
+
+impl Client {
+    /// Append the contents of a byte stream to the specified journal.
+    /// Returns a Stream of results which will yield either:
+    /// - An AppendResponse after all data is successfully appended
+    /// - Errors for any failures encountered.
+    /// If polled after an error, regenerates the input stream and
+    /// retries the request from the beginning.
+    pub fn append<'a, S>(
+        &'a self,
+        request: broker::AppendRequest,
+        source: impl Fn() -> S + Send + Sync + 'a,
+    ) -> impl Stream<Item = crate::Result<broker::AppendResponse>> + '_
+    where
+        S: Stream<Item = std::io::Result<bytes::Bytes>> + Send + 'static,
+    {
+        coroutines::coroutine(move |mut co| async move {
+            loop {
+                let input_stream = source();
+
+                match self.try_append(request.clone(), input_stream).await {
+                    Ok(resp) => {
+                        () = co.yield_(Ok(resp)).await;
+                        return;
+                    }
+                    Err(err) => {
+                        () = co.yield_(Err(err)).await;
+                        // Polling after an error indicates the caller would like to retry,
+                        // so continue the loop to re-generate the input stream and try again.
+                    }
+                }
+            }
+        })
+    }
+
+    async fn try_append<S>(
+        &self,
+        request: broker::AppendRequest,
+        source: S,
+    ) -> crate::Result<AppendResponse>
+    where
+        S: Stream<Item = std::io::Result<bytes::Bytes>> + Send + 'static,
+    {
+        let (input_err_tx, input_err_rx) = tokio::sync::oneshot::channel();
+
+        // `JournalClient::append()` wants a stream of `AppendRequest`s, so let's compose one starting with
+        // the initial metadata request containing the journal name and any other request metadata, then
+        // "data" requests that contain chunks of data to write, then the final EOF indicating completion.
+        let request_stream = futures::stream::once(async move { Ok(request) })
+            .chain(source.filter_map(|input| {
+                futures::future::ready(match input {
+                    // It's technically possible to get an empty set of bytes when reading
+                    // from the input stream. Filter these out as otherwise they would look
+                    // like EOFs to the append RPC and cause confusion.
+                    Ok(input_bytes) if input_bytes.len() == 0 => None,
+                    Ok(input_bytes) => Some(Ok(broker::AppendRequest {
+                        content: input_bytes.to_vec(),
+                        ..Default::default()
+                    })),
+                    Err(err) => Some(Err(err)),
+                })
+            }))
+            // Final empty chunk / EOF to signal we're done
+            .chain(futures::stream::once(async {
+                Ok(broker::AppendRequest {
+                    ..Default::default()
+                })
+            }))
+            // Since it's possible to error when reading input data, we handle an error by stopping
+            // the stream and storing the error. Later, we first check if we have hit an input error
+            // and if so we bubble it up, otherwise proceeding with handling the output of the RPC
+            .scan(Some(input_err_tx), |input_err_tx, input_res| {
+                futures::future::ready(match input_res {
+                    Ok(input) => Some(input),
+                    Err(err) => {
+                        input_err_tx
+                            .take()
+                            .expect("we should reach this point at most once")
+                            .send(err)
+                            .expect("we should reach this point at most once");
+                        None
+                    }
+                })
+            });
+
+        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+
+        let resp = client.append(request_stream).await;
+
+        if let Some(Ok(input_err)) = input_err_rx.now_or_never() {
+            return Err(Error::AppendRead(input_err));
+        } else {
+            match resp {
+                Ok(resp) => {
+                    let resp = resp.into_inner();
+                    check_ok(resp.status(), resp)
+                }
+                Err(err) => Err(err.into()),
+            }
+        }
+    }
+}

--- a/crates/gazette/src/journal/mod.rs
+++ b/crates/gazette/src/journal/mod.rs
@@ -1,6 +1,7 @@
 use proto_gazette::broker;
 use tonic::transport::Channel;
 
+mod append;
 mod list;
 mod read;
 

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -35,6 +35,8 @@ pub enum Error {
     },
     #[error("{0}")]
     Protocol(&'static str),
+    #[error("failed to read from input stream")]
+    AppendRead(#[source] std::io::Error),
     #[error(transparent)]
     UUID(#[from] uuid::Error),
     #[error("unexpected server EOF")]
@@ -71,6 +73,7 @@ impl Error {
             Error::Protocol(_) => false,
             Error::UUID(_) => false,
             Error::JWT(_) => false,
+            Error::AppendRead(_) => false,
         }
     }
 }


### PR DESCRIPTION
**Description:**

This implements low-level appends to Gazette. It takes a function that generates a stream of `Bytes`, and attempts to drive an append RPC. If the RPC errors, you can retry by re-polling after recieving an Error.

Pulled out of my Dekaf work in https://github.com/estuary/flow/pull/1840 for better reviewability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1856)
<!-- Reviewable:end -->
