### PR TITLE
agent: Populate `live_specs.connector_image_name` and `live_specs.connector_image_tag` when publishing a Dekaf materialization

### DIFF
--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -22,6 +22,7 @@ pub enum JobStatus {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum ValidationError {
     ResourcePathPointersChanged { rejected: Vec<String> },
+    InvalidDekafTag,
 }
 
 impl JobStatus {
@@ -100,8 +101,23 @@ impl TagHandler {
         );
         let image_composed = format!("{}{}", row.image_name, row.image_tag);
 
+        // A Dekaf connector's tag is meaningless since it'll never get pulled, _except_ that
+        // it must later on match the value in `live_specs.connector_image_tag`. Since we hard-code
+        // that to the value of DEKAF_IMAGE_TAG, we must also ensure that no dekaf `connector_tags` rows
+        // get inserted with a different image_tag value.
+        if row.image_name.starts_with(models::DEKAF_IMAGE_NAME_PREFIX) {
+            if row.image_tag != models::DEKAF_IMAGE_TAG {
+                return Ok((
+                    row.tag_id,
+                    JobStatus::ValidationFailed {
+                        error: ValidationError::InvalidDekafTag,
+                    },
+                ));
+            }
+        }
+
         if row.image_tag != LOCAL_IMAGE_TAG
-            && !row.image_name.starts_with(runtime::DEKAF_IMAGE_NAME_PREFIX)
+            && !row.image_name.starts_with(models::DEKAF_IMAGE_NAME_PREFIX)
         {
             // Pull the image.
             let pull = jobs::run(
@@ -222,7 +238,7 @@ async fn spec_materialization(
 ) -> anyhow::Result<ConnectorSpec> {
     use proto_flow::materialize;
 
-    let connector_type = if image.starts_with(runtime::DEKAF_IMAGE_NAME_PREFIX) {
+    let connector_type = if image.starts_with(models::DEKAF_IMAGE_NAME_PREFIX) {
         flow::materialization_spec::ConnectorType::Dekaf as i32
     } else {
         flow::materialization_spec::ConnectorType::Image as i32

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -313,7 +313,7 @@ pub async fn check_source_capture_annotations(
         let Some(image) = model.connector_image() else {
             continue;
         };
-        let (image_name, image_tag) = split_image_tag(image);
+        let (image_name, image_tag) = split_image_tag(&image);
 
         let Some(source_capture) = &model.source_capture else {
             continue;
@@ -418,7 +418,7 @@ async fn check_connector_image(
     let Some(image) = model.connector_image() else {
         return Ok(None);
     };
-    let (image_name, _) = split_image_tag(image);
+    let (image_name, _) = split_image_tag(&image);
     if !cached.contains_key(&image_name) {
         let exists = agent_sql::connector_tags::does_connector_exist(&image_name, pool).await?;
         cached.insert(image_name.clone(), exists);
@@ -437,7 +437,7 @@ fn image_and_tag<M: ModelDef>(model: Option<&M>) -> (Option<String>, Option<Stri
     let Some(full_image) = model.and_then(ModelDef::connector_image) else {
         return (None, None);
     };
-    let (image_name, image_tag) = split_image_tag(full_image);
+    let (image_name, image_tag) = split_image_tag(&full_image);
     (Some(image_name), Some(image_tag))
 }
 

--- a/crates/models/src/captures.rs
+++ b/crates/models/src/captures.rs
@@ -158,9 +158,9 @@ impl super::ModelDef for CaptureDef {
         !self.shards.disable
     }
 
-    fn connector_image(&self) -> Option<&str> {
+    fn connector_image(&self) -> Option<String> {
         match &self.endpoint {
-            CaptureEndpoint::Connector(cfg) => Some(&cfg.image),
+            CaptureEndpoint::Connector(cfg) => Some(cfg.image.to_owned()),
             _ => None,
         }
     }

--- a/crates/models/src/collections.rs
+++ b/crates/models/src/collections.rs
@@ -157,9 +157,9 @@ impl super::ModelDef for CollectionDef {
             .map(|d| !d.shards.disable)
             .unwrap_or(true)
     }
-    fn connector_image(&self) -> Option<&str> {
+    fn connector_image(&self) -> Option<String> {
         self.derive.as_ref().and_then(|d| match &d.using {
-            DeriveUsing::Connector(cfg) => Some(cfg.image.as_str()),
+            DeriveUsing::Connector(cfg) => Some(cfg.image.to_owned()),
             _ => None,
         })
     }

--- a/crates/models/src/connector.rs
+++ b/crates/models/src/connector.rs
@@ -17,6 +17,16 @@ pub fn split_image_tag(image_full: &str) -> (String, String) {
     }
 }
 
+/// Connectors with an image name starting with this value are Dekaf-type materializations. No image with this
+/// name exists, instead we use it to identify which connectors get marked as `connector_type: ConnectorType::Dekaf`,
+/// causing the runtime to invoke Dekaf's in-tree connector logic in `[dekaf::connector]`
+pub const DEKAF_IMAGE_NAME_PREFIX: &str = "ghcr.io/estuary/dekaf-";
+
+/// Dekaf doesn't use images, but important information such as endpoint/resource config schema are associated
+/// with a particular `connector_tags` row. Rather than refactoring this deeply interconnected piece of the system,
+/// we've decided to just give Dekaf a `connector_tags` row. This is its tag.
+pub const DEKAF_IMAGE_TAG: &str = "v1";
+
 /// Dekaf service configuration
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub struct DekafConfig {
@@ -24,6 +34,15 @@ pub struct DekafConfig {
     pub variant: String,
     /// # Dekaf endpoint config.
     pub config: RawValue,
+}
+
+impl DekafConfig {
+    pub fn image_name(&self) -> String {
+        format!(
+            "{DEKAF_IMAGE_NAME_PREFIX}{}:{DEKAF_IMAGE_TAG}",
+            self.variant
+        )
+    }
 }
 
 /// Connector image and configuration specification.

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -31,7 +31,10 @@ pub use crate::labels::{Label, LabelSelector, LabelSet};
 pub use captures::{AutoDiscover, CaptureBinding, CaptureDef, CaptureEndpoint};
 pub use catalogs::{Capability, Catalog, CatalogType};
 pub use collections::{CollectionDef, Projection};
-pub use connector::{split_image_tag, ConnectorConfig, DekafConfig, LocalConfig};
+pub use connector::{
+    split_image_tag, ConnectorConfig, DekafConfig, LocalConfig, DEKAF_IMAGE_NAME_PREFIX,
+    DEKAF_IMAGE_TAG,
+};
 pub use derivation::{Derivation, DeriveUsing, Shuffle, ShuffleType, TransformDef};
 pub use derive_sqlite::DeriveUsingSqlite;
 pub use derive_typescript::DeriveUsingTypescript;
@@ -88,7 +91,7 @@ pub trait ModelDef:
     fn is_enabled(&self) -> bool;
 
     /// The full connector image name used by this specificiation, including the tag.
-    fn connector_image(&self) -> Option<&str>;
+    fn connector_image(&self) -> Option<String>;
 
     /// If this spec is a materialization, returns the value of `source_capture`.
     /// This function is admittedly a little smelly, but it's included in the trait
@@ -246,7 +249,7 @@ impl ModelDef for AnySpec {
         }
     }
 
-    fn connector_image(&self) -> Option<&str> {
+    fn connector_image(&self) -> Option<String> {
         match self {
             AnySpec::Capture(c) => c.connector_image(),
             AnySpec::Collection(c) => c.connector_image(),

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -212,9 +212,10 @@ impl super::ModelDef for MaterializationDef {
         }
     }
 
-    fn connector_image(&self) -> Option<&str> {
+    fn connector_image(&self) -> Option<String> {
         match &self.endpoint {
-            MaterializationEndpoint::Connector(cfg) => Some(&cfg.image),
+            MaterializationEndpoint::Connector(cfg) => Some(cfg.image.to_owned()),
+            MaterializationEndpoint::Dekaf(cfg) => Some(cfg.image_name()),
             _ => None,
         }
     }

--- a/crates/models/src/tests.rs
+++ b/crates/models/src/tests.rs
@@ -172,7 +172,7 @@ impl super::ModelDef for TestDef {
         true // there's no way to disable a test
     }
 
-    fn connector_image(&self) -> Option<&str> {
+    fn connector_image(&self) -> Option<String> {
         None
     }
 }

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -21,17 +21,12 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.7-119-g552f6c0ee2";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
-/// Connectors with an image name starting with this value are Dekaf-type materializations and we should
-/// not pull the image, as it won't exist. Instead, we mark them as having `connector_type: ConnectorType::Dekaf`
-/// so that `Runtime` will invoke Dekaf's in-tree connector implementation
-pub const DEKAF_IMAGE_NAME_PREFIX: &str = "ghcr.io/estuary/dekaf-";
-
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,
 /// then it's value is used. Otherwise, this will apply a simple heuristic based on the image name,
 /// for backward compatibility purposes. An error will be returned if it fails to inspect the image
 /// or parse the label. The image must already have been pulled before calling this function.
 pub async fn flow_runtime_protocol(image: &str) -> anyhow::Result<RuntimeProtocol> {
-    if image.starts_with(DEKAF_IMAGE_NAME_PREFIX) {
+    if image.starts_with(models::DEKAF_IMAGE_NAME_PREFIX) {
         return Ok(RuntimeProtocol::Materialize);
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -16,7 +16,7 @@ mod tokio_context;
 mod unary;
 pub mod uuid;
 
-pub use container::{flow_runtime_protocol, DEKAF_IMAGE_NAME_PREFIX};
+pub use container::flow_runtime_protocol;
 pub use task_service::TaskService;
 pub use tokio_context::TokioContext;
 


### PR DESCRIPTION
**Description:**

Populates `live_specs.connector_image_name` and `live_specs.connector_image_tag` when publishing a Dekaf materialization

The UI depends on `live_specs_ext` containing these values in order to display connector information, display task edit workflows/schema-driven forms, etc. Since we've already agreed on Dekaf "connectors" getting an image of `ghcr.io/estuary/dekaf-{variant}`, the only other convention is the tag, and I went with `:v1`.

The caveat is that since this value will get populated in `live_specs`, which `live_specs_ext` will then use to look up other information from `connector_tags`, we must ensure that those values match. Normally this isn't a problem because the full image+tag is stored in the task config, but since Dekaf doesn't use containers and so has no need to store an image tag, we instead have to explicitly validate that only the value `v1` is specified for the tag to avoid getting into a confusing/broken state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1858)
<!-- Reviewable:end -->
