### PR TITLE
agent: Switch `/authorize/dekaf` to fetch+return the task's built spec

### DIFF
--- a/crates/agent/src/api/authorize_dekaf.rs
+++ b/crates/agent/src/api/authorize_dekaf.rs
@@ -81,7 +81,7 @@ async fn do_authorize_dekaf(app: &App, Request { token }: &Request) -> anyhow::R
             let materialization_spec = sqlx::query!(
                 r#"
                     select
-                        spec as "spec: sqlx::types::Json<models::MaterializationDef>",
+                        built_spec as "spec: sqlx::types::Json<models::RawValue>",
                         spec_type as "spec_type: models::CatalogType"
                     from live_specs
                     where live_specs.catalog_name = $1

--- a/crates/models/src/authorizations.rs
+++ b/crates/models/src/authorizations.rs
@@ -160,9 +160,10 @@ pub struct DekafAuthResponse {
     // Name of the journal that contains the stats for the specified task
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub ops_stats_journal: String,
-    // Spec of the task
+    // The built spec of the materialization. This is actually proto_flow::flow::MaterializationSpec
+    // but we can't depend on `proto_flow` here, so `RawValue` it is
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub task_spec: Option<crate::materializations::MaterializationDef>,
+    pub task_spec: Option<crate::RawValue>,
     /// # Number of milliseconds to wait before retrying the request.
     /// Non-zero if and only if token is not set.
     pub retry_millis: u64,


### PR DESCRIPTION
**Description:**

We need the built spec as it contains the final output of field selection, which Dekaf needs in order to generate the correct schema and output documents. Only https://github.com/estuary/flow/pull/1840 uses this endpoint, and it's not live yet so there shouldn't be any risk in changing this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1865)
<!-- Reviewable:end -->
