### PR TITLE
data-plane-controller: extend DataPlane model with AWSAssumeRole

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -24,6 +24,8 @@ pub struct DataPlane {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fqdn: Option<String>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aws_assume_role: Option<AWSAssumeRole>,
     pub builds_root: url::Url,
     pub builds_kms_keys: Vec<String>,
     pub control_plane_api: url::Url,
@@ -33,6 +35,12 @@ pub struct DataPlane {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub private_links: Vec<AWSPrivateLink>,
     pub deployments: Vec<Deployment>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AWSAssumeRole {
+    pub role_arn: String,
+    pub external_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
AWS assume-role configuration which is passed through to est-dry-dock for BYOC data-plane setups.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1870)
<!-- Reviewable:end -->
