### PR TITLE
runtime: add materialize-kafka to ser_policy

### DIFF
--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -32,6 +32,7 @@ impl Task {
         // See go/runtime/materialize.go:135
         let ser_policy = if [
             "ghcr.io/estuary/materialize-bigquery",
+            "ghcr.io/estuary/materialize-kafka",
             "ghcr.io/estuary/materialize-snowflake",
             "ghcr.io/estuary/materialize-redshift",
             "ghcr.io/estuary/materialize-sqlite",


### PR DESCRIPTION
**Description:**

Kafka has a default maximum message size of 1MiB.

This adds `materialize-kafka` to the list of connectors that use `ser_policy`, which should generally ensure that documents with individual extremely large string, array, or object fields don't exceed the message size limit for Kafka.

This simple heuristic may not always be 100% what users desire, but in general it seems better to have the connector at least sort-of-work rather than crash in a way that would require a more complicated fix (possibly a derivation) to best
support data exploration / PoC use cases.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1881)
<!-- Reviewable:end -->
