### PR TITLE
data-plane-controller: add optional private_ip6 to AnsibleHost

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -101,6 +101,7 @@ pub struct AnsibleHost {
     pub local_private_key_pem: String,
     pub oci_image: String,
     pub private_ip4: Option<std::net::Ipv4Addr>,
+    pub private_ip6: Option<std::net::Ipv6Addr>,
     pub provider: String,
     pub public_ip4: std::net::Ipv4Addr,
     pub public_ip6: std::net::Ipv6Addr,


### PR DESCRIPTION
**Description:**

- We now have an optional private ip6 that azure uses

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1893)
<!-- Reviewable:end -->
