### PR TITLE
Phil/fetch live chunks

### DIFF
--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -11,13 +11,6 @@ use std::fmt;
 use std::sync::LazyLock;
 use tables::DraftCollection;
 
-static MAX_DISCOVER_BINDINGS: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("MAX_DISCOVER_BINDINGS")
-        .ok()
-        .map(|s| s.parse().expect("MAX_DISCOVER_BINDINGS must be a number"))
-        .unwrap_or(3000)
-});
-
 pub fn parse_response(response: capture::Response) -> anyhow::Result<Vec<discovered::Binding>> {
     let capture::Response {
         discovered: Some(capture::response::Discovered { mut bindings }),
@@ -26,14 +19,6 @@ pub fn parse_response(response: capture::Response) -> anyhow::Result<Vec<discove
     else {
         anyhow::bail!("response is not a discovered");
     };
-
-    anyhow::ensure!(
-        bindings.len() <= *MAX_DISCOVER_BINDINGS,
-        "The connector discovered {} bindings, which is over our limit of {}. Please consider \
-        changing the endpoint configuration to restrict the number of resources to discover from",
-        bindings.len(),
-        *MAX_DISCOVER_BINDINGS
-    );
 
     // Sort bindings so they're consistently ordered on their recommended name.
     // This reduces potential churn if an established capture is refreshed.

--- a/crates/agent/src/live_specs.rs
+++ b/crates/agent/src/live_specs.rs
@@ -12,42 +12,49 @@ pub async fn get_live_specs(
     filter_capability: Option<Capability>,
     db: &sqlx::PgPool,
 ) -> anyhow::Result<tables::LiveCatalog> {
-    let rows = agent_sql::live_specs::fetch_live_specs(user_id, &names, db).await?;
     let mut live = tables::LiveCatalog::default();
-    for row in rows {
-        // Spec type might be null because we used to set it to null when deleting specs.
-        // For recently deleted specs, it will still be present.
-        let Some(catalog_type) = row.spec_type.map(Into::into) else {
-            continue;
-        };
-        let Some(model_json) = row.spec.as_deref() else {
-            continue;
-        };
-        if let Some(min_capability) = filter_capability {
-            if !row
-                .user_capability
-                .is_some_and(|actual_capability| actual_capability >= min_capability)
-            {
-                continue;
-            }
-        }
-        let built_spec_json = row.built_spec.as_ref().ok_or_else(|| {
-            tracing::warn!(catalog_name = %row.catalog_name, id = %row.id, "got row with spec but not built_spec");
-            anyhow::anyhow!("missing built_spec for {:?}, but spec is non-null", row.catalog_name)
-        })?.deref();
 
-        live.add_spec(
-            catalog_type,
-            &row.catalog_name,
-            row.id.into(),
-            row.data_plane_id.into(),
-            row.last_pub_id.into(),
-            row.last_build_id.into(),
-            model_json,
-            built_spec_json,
-            row.dependency_hash,
-        )
-        .with_context(|| format!("deserializing specs for {:?}", row.catalog_name))?;
+    // The query that's used by `fetch_live_specs` is pretty slow because of how
+    // it queries authZ capabilities for each name, even if it doesn't exist.
+    // Limit each individual query to 512 names to avoid statement timeouts when
+    // fetching a large number of specs.
+    for names_chunk in names.chunks(512) {
+        let rows = agent_sql::live_specs::fetch_live_specs(user_id, names_chunk, db).await?;
+        for row in rows {
+            // Spec type might be null because we used to set it to null when deleting specs.
+            // For recently deleted specs, it will still be present.
+            let Some(catalog_type) = row.spec_type.map(Into::into) else {
+                continue;
+            };
+            let Some(model_json) = row.spec.as_deref() else {
+                continue;
+            };
+            if let Some(min_capability) = filter_capability {
+                if !row
+                    .user_capability
+                    .is_some_and(|actual_capability| actual_capability >= min_capability)
+                {
+                    continue;
+                }
+            }
+            let built_spec_json = row.built_spec.as_ref().ok_or_else(|| {
+                tracing::warn!(catalog_name = %row.catalog_name, id = %row.id, "got row with spec but not built_spec");
+                anyhow::anyhow!("missing built_spec for {:?}, but spec is non-null", row.catalog_name)
+            })?.deref();
+
+            live.add_spec(
+                catalog_type,
+                &row.catalog_name,
+                row.id.into(),
+                row.data_plane_id.into(),
+                row.last_pub_id.into(),
+                row.last_build_id.into(),
+                model_json,
+                built_spec_json,
+                row.dependency_hash,
+            )
+            .with_context(|| format!("deserializing specs for {:?}", row.catalog_name))?;
+        }
     }
 
     Ok(live)


### PR DESCRIPTION
Tiny PR to update agent to fetch live specs in chunks, to avoid statement timeouts. We were seeing these queries fail when discover responses included a large number of bindings. Also removes the limit on the number of discovered bindings, since that's no longer necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1895)
<!-- Reviewable:end -->
