### PR TITLE
gazette: refactor retry, introduce backoffs, and fixing routing

### DIFF
--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -3,7 +3,6 @@ use anyhow::Context;
 use futures::StreamExt;
 use gazette::journal::ReadJsonLine;
 use proto_gazette::broker;
-use rand::Rng;
 use std::io::Write;
 use time::OffsetDateTime;
 
@@ -116,6 +115,7 @@ pub async fn read_collection_journal(
             offset: 0,
             block: bounds.follow,
             begin_mod_time,
+            // TODO(johnny): Set `do_not_proxy: true` once cronut is migrated.
             ..Default::default()
         },
         1,
@@ -127,7 +127,13 @@ pub async fn read_collection_journal(
 
     while let Some(line) = lines.next().await {
         match line {
-            Ok(ReadJsonLine::Meta(_)) => (),
+            Ok(ReadJsonLine::Meta(broker::ReadResponse {
+                fragment,
+                write_head,
+                ..
+            })) => {
+                tracing::debug!(?fragment, %write_head, "journal metadata");
+            }
             Ok(ReadJsonLine::Doc {
                 root,
                 next_offset: _,
@@ -136,26 +142,25 @@ pub async fn read_collection_journal(
                 v.push(b'\n');
                 () = stdout.write_all(&v)?;
             }
-            Err(gazette::Error::BrokerStatus(broker::Status::Suspended)) if bounds.follow => {
-                // The journal is fully suspended, so we use a pretty long delay
-                // here because it's unlikely to be resumed quickly and also
-                // unlikely that anyone will care about the little bit of extra
-                // latency in this case.
-                let delay_secs = rand::thread_rng().gen_range(30..=60);
-                tracing::info!(delay_secs, "journal suspended, will retry");
-                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
-            }
-            Err(gazette::Error::BrokerStatus(
-                status @ broker::Status::OffsetNotYetAvailable | status @ broker::Status::Suspended,
-            )) => {
-                tracing::debug!(?status, "stopping read at end of journal content");
-                break; // Graceful EOF of non-blocking read.
-            }
-            Err(err) if err.is_transient() => {
-                tracing::warn!(?err, "error reading collection (will retry)");
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            }
-            Err(err) => anyhow::bail!(err),
+            Err(gazette::RetryError {
+                inner: err,
+                attempt,
+            }) => match err {
+                err if err.is_transient() => {
+                    tracing::warn!(?err, %attempt, "error reading collection (will retry)");
+                }
+                gazette::Error::BrokerStatus(broker::Status::Suspended) if bounds.follow => {
+                    tracing::debug!(?err, %attempt, "journal is suspended (will retry)");
+                }
+                gazette::Error::BrokerStatus(
+                    status @ broker::Status::OffsetNotYetAvailable
+                    | status @ broker::Status::Suspended,
+                ) => {
+                    tracing::debug!(?status, "stopping read at end of journal content");
+                    break; // Graceful EOF of non-blocking read.
+                }
+                err => anyhow::bail!(err),
+            },
         }
     }
 

--- a/crates/gazette/src/journal/mod.rs
+++ b/crates/gazette/src/journal/mod.rs
@@ -1,3 +1,4 @@
+use crate::router;
 use proto_gazette::broker;
 use tonic::transport::Channel;
 
@@ -51,7 +52,11 @@ impl Client {
 
     /// Invoke the Gazette journal Apply API.
     pub async fn apply(&self, req: broker::ApplyRequest) -> crate::Result<broker::ApplyResponse> {
-        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
 
         let resp = client
             .apply(req)
@@ -67,7 +72,11 @@ impl Client {
         &self,
         req: broker::FragmentsRequest,
     ) -> crate::Result<broker::FragmentsResponse> {
-        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
 
         let resp = client
             .list_fragments(req)

--- a/crates/gazette/src/shard/mod.rs
+++ b/crates/gazette/src/shard/mod.rs
@@ -1,3 +1,4 @@
+use crate::router;
 use proto_gazette::{broker, consumer};
 use tonic::transport::Channel;
 
@@ -44,7 +45,11 @@ impl Client {
         &self,
         req: consumer::ListRequest,
     ) -> Result<consumer::ListResponse, crate::Error> {
-        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
 
         let resp = client
             .list(req)
@@ -60,7 +65,11 @@ impl Client {
         &self,
         req: consumer::ApplyRequest,
     ) -> Result<consumer::ApplyResponse, crate::Error> {
-        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
 
         let resp = client
             .apply(req)
@@ -76,7 +85,11 @@ impl Client {
         &self,
         req: consumer::UnassignRequest,
     ) -> Result<consumer::UnassignResponse, crate::Error> {
-        let mut client = self.into_sub(self.router.route(None, false, &self.default)?);
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
 
         let resp = client
             .unassign(req)

--- a/crates/proto-gazette/build.rs
+++ b/crates/proto-gazette/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     prost_build::Config::new()
         .out_dir(&b.src_dir)
-        .bytes(&["ReadResponse.content"])
+        .bytes(&["AppendRequest.content", "ReadResponse.content"])
         .file_descriptor_set_path(&b.descriptor_path)
         .compile_well_known_types()
         .extern_path(".google.protobuf", "::pbjson_types")

--- a/crates/proto-gazette/src/protocol.rs
+++ b/crates/proto-gazette/src/protocol.rs
@@ -524,8 +524,8 @@ pub struct AppendRequest {
     /// the client must send an empty chunk (eg, zero-valued AppendRequest) to
     /// indicate the Append should be committed. Absence of this empty chunk
     /// prior to EOF is interpreted by the broker as a rollback of the Append.
-    #[prost(bytes = "vec", tag = "4")]
-    pub content: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "4")]
+    pub content: ::prost::bytes::Bytes,
 }
 /// Nested message and enum types in `AppendRequest`.
 pub mod append_request {


### PR DESCRIPTION
Previously, gazette routing was previously broken in some subtle ways:

* The process ID of a prior response was sent in the next request, causing "ProcessID doesn't match our own" errors in production.

* Improperly assuming that endpoints present in response headers are reach-able from the client. We need to condition that assumption on the `do_not_proxy` flag.

* `append` routine was not leveraging a prior response header to route its next attempt.

Sleep-based backoffs are also introduced to retry-able client routines, rather than making them a responsibility of the caller. This standardizes handling and prevents accidental thundering-herds of retries if a caller forgets to put in a backoff. Now callers don't need to worry about it, and must only decide whether to re-poll, drop to cancel, log, or take some other action.

We additionally want to surface a notion of how many operation _attempts_ there have been since the last success. This is important both for logging (logged attempts in Go implementations are useful), and also for client determinations of when to give up.

Update simd_doc::Parser::chunk to be able to recover should a caller provide discontinuous partial documents. This was a missing re-entrancy case when retrying a ReadJsonLines stream.

Reserve a simd_doc::Parser::transcode_many() buffer based on the input size, to prevent frequent re-allocations in the common usage of ReadJsonLines.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1897)
<!-- Reviewable:end -->
