### PR TITLE
Phil/agent fails

### DIFF
--- a/crates/agent/src/discovers/handler.rs
+++ b/crates/agent/src/discovers/handler.rs
@@ -129,7 +129,7 @@ impl<C: DiscoverConnectors> DiscoverHandler<C> {
         };
 
         let image_composed = format!("{}{}", row.image_name, row.image_tag);
-        let disco = prepare_discover(
+        let prepared = prepare_discover(
             row.user_id,
             row.draft_id,
             models::Capture::new(&row.capture_name),
@@ -140,11 +140,14 @@ impl<C: DiscoverConnectors> DiscoverHandler<C> {
             data_plane,
             pool,
         )
-        .await?;
+        .await;
 
-        let result = self
-            .discover(pool, disco)
-            .await
+        let result = match prepared {
+            Ok(disco) => self.discover(pool, disco).await,
+            Err(e) => Err(e),
+        };
+
+        let result = result
             .map_err(|err| {
                 vec![models::draft_error::Error {
                     scope: None,


### PR DESCRIPTION
**Description:**

Prevents most of the remaining discover failure scenarios from bubbling up to a more widespread failure of the agent. Discussed in [this Slack thread](https://estuaryworkspace.slack.com/archives/C03QBN83GQ4/p1737689571320549). Returning an error from a `Handler` will cause the agent to crash, and it will also result in the job that was being handled remaining `queued` (so another agent will immediately try to handle it). Thus an error in one job could severely degrade our handling of other jobs. This fixes that by failing the discover instead of returning an error from the Handler.

I also reviewed the error handling in the handlers for publications, connector tags, and directives, didn't see any other failure scenarios that looked like they'd need similar treatment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1899)
<!-- Reviewable:end -->
