### PR TITLE
dekaf: Upstream kafka fallback and per-connection-type routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,36 +353,12 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apache-avro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
-dependencies = [
- "crc32fast",
- "digest",
- "lazy_static",
- "libflate",
- "log",
- "num-bigint",
- "quad-rand",
- "rand 0.8.5",
- "regex-lite",
- "serde",
- "serde_json",
- "snap",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror",
- "typed-builder 0.16.2",
- "uuid 1.10.0",
-]
-
-[[package]]
-name = "apache-avro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aef82843a0ec9f8b19567445ad2421ceeb1d711514384bdd3d49fe37102ee13"
 dependencies = [
  "bigdecimal 0.4.7",
+ "crc32fast",
  "digest",
  "libflate",
  "log",
@@ -393,10 +369,11 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "snap",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "thiserror",
- "typed-builder 0.19.1",
+ "typed-builder",
  "uuid 1.10.0",
 ]
 
@@ -721,7 +698,7 @@ dependencies = [
 name = "avro"
 version = "0.0.0"
 dependencies = [
- "apache-avro 0.16.0",
+ "apache-avro",
  "doc",
  "hexdump",
  "insta",
@@ -1992,7 +1969,7 @@ dependencies = [
  "aes-siv",
  "allocator",
  "anyhow",
- "apache-avro 0.16.0",
+ "apache-avro",
  "async-process",
  "async-trait",
  "avro",
@@ -4518,7 +4495,7 @@ dependencies = [
 name = "parser"
 version = "0.0.0"
 dependencies = [
- "apache-avro 0.16.0",
+ "apache-avro",
  "assert_cmd",
  "base64 0.13.1",
  "bytecount",
@@ -5938,7 +5915,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc3cf40651cf503827a34bcd7efbbd4750a7e3adc6768bb8089977e4d07303b"
 dependencies = [
- "apache-avro 0.17.0",
+ "apache-avro",
  "byteorder",
  "dashmap 6.1.0",
  "futures",
@@ -6622,12 +6599,6 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -6643,19 +6614,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.74",
 ]
 
 [[package]]
@@ -7337,31 +7295,11 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
-dependencies = [
- "typed-builder-macro 0.16.2",
-]
-
-[[package]]
-name = "typed-builder"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
 dependencies = [
- "typed-builder-macro 0.19.1",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
+ "typed-builder-macro",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
 dependencies = [
+ "psl",
  "psl-types",
 ]
 
@@ -136,7 +137,7 @@ dependencies = [
  "proto-grpc",
  "rand 0.8.5",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "runtime",
  "rustls 0.23.10",
  "schemars",
@@ -371,7 +372,31 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror",
- "typed-builder",
+ "typed-builder 0.16.2",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "apache-avro"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aef82843a0ec9f8b19567445ad2421ceeb1d711514384bdd3d49fe37102ee13"
+dependencies = [
+ "bigdecimal 0.4.7",
+ "digest",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand 0.8.5",
+ "regex-lite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror",
+ "typed-builder 0.19.1",
  "uuid 1.10.0",
 ]
 
@@ -610,7 +635,7 @@ dependencies = [
  "hmac",
  "http-types",
  "hyper 0.14.30",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -696,7 +721,7 @@ dependencies = [
 name = "avro"
 version = "0.0.0"
 dependencies = [
- "apache-avro",
+ "apache-avro 0.16.0",
  "doc",
  "hexdump",
  "insta",
@@ -898,6 +923,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "billing-integrations"
 version = "0.0.0"
 dependencies = [
@@ -1066,7 +1105,7 @@ dependencies = [
  "models",
  "ops",
  "proto-flow",
- "reqwest",
+ "reqwest 0.11.27",
  "runtime",
  "rusqlite",
  "sources",
@@ -1873,6 +1912,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,7 +1992,8 @@ dependencies = [
  "aes-siv",
  "allocator",
  "anyhow",
- "apache-avro",
+ "apache-avro 0.16.0",
+ "async-process",
  "async-trait",
  "avro",
  "axum",
@@ -1954,17 +2008,20 @@ dependencies = [
  "doc",
  "extractors",
  "flow-client",
+ "flowctl",
  "futures",
  "gazette",
  "hex",
  "hexdump",
  "humantime",
+ "insta",
  "itertools 0.10.5",
  "json",
  "jsonwebtoken",
  "kafka-protocol",
  "labels",
  "lazy_static",
+ "locate-bin",
  "lz4_flex",
  "md5",
  "metrics",
@@ -1977,16 +2034,20 @@ dependencies = [
  "proto-flow",
  "proto-gazette",
  "rand 0.8.5",
+ "rdkafka",
  "regex",
+ "reqwest 0.11.27",
  "rsasl",
  "rustls 0.23.10",
  "rustls-native-certs 0.7.2",
  "rustls-pemfile 2.1.3",
+ "schema_registry_converter",
  "schemars",
  "serde",
  "serde_json",
  "simd-doc",
  "socket2",
+ "tempfile",
  "time 0.3.36",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -1996,6 +2057,7 @@ dependencies = [
  "tracing",
  "tracing-record-hierarchical",
  "tracing-subscriber",
+ "tracing-test",
  "tuple",
  "typestate",
  "unseal",
@@ -2154,10 +2216,10 @@ version = "0.0.0"
 dependencies = [
  "allocator",
  "base64 0.13.1",
- "bigdecimal",
+ "bigdecimal 0.3.1",
  "bumpalo",
  "bytes",
- "fancy-regex",
+ "fancy-regex 0.10.0",
  "futures",
  "fxhash",
  "hexdump",
@@ -2198,6 +2260,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -2259,6 +2327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +2389,16 @@ name = "fancy-regex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -2385,7 +2472,7 @@ dependencies = [
  "postgrest",
  "proto-flow",
  "proto-gazette",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "time 0.3.36",
@@ -2468,7 +2555,7 @@ dependencies = [
  "proto-gazette",
  "proto-grpc",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "runtime",
  "rusqlite",
  "rustls 0.23.10",
@@ -2689,7 +2776,7 @@ dependencies = [
  "proto-gazette",
  "proto-grpc",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde_json",
  "simd-doc",
  "thiserror",
@@ -3161,6 +3248,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,10 +3554,10 @@ name = "json"
 version = "0.0.0"
 dependencies = [
  "addr",
- "bigdecimal",
+ "bigdecimal 0.3.1",
  "bitvec 0.19.6",
  "criterion",
- "fancy-regex",
+ "fancy-regex 0.10.0",
  "fxhash",
  "glob",
  "iri-string",
@@ -3480,6 +3583,25 @@ dependencies = [
  "serde_json",
  "thiserror",
  "treediff",
+]
+
+[[package]]
+name = "json-pointer"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe841b94e719a482213cee19dd04927cf412f26d8dc84c5a446c081e49c2997"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "jsonway"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effcb749443c905fbaef49d214f8b1049c240e0adb7af9baa0e201e625e4f9de"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3640,7 +3762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3697,6 +3819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4090,6 +4213,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4156,6 +4280,27 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -4373,7 +4518,7 @@ dependencies = [
 name = "parser"
 version = "0.0.0"
 dependencies = [
- "apache-avro",
+ "apache-avro 0.16.0",
  "assert_cmd",
  "base64 0.13.1",
  "bytecount",
@@ -4570,6 +4715,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,7 +4839,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a966c650b47a064e7082170b4be74fca08c088d893244fc4b70123e3c1f3ee7"
 dependencies = [
- "reqwest",
+ "reqwest 0.11.27",
 ]
 
 [[package]]
@@ -4719,6 +4902,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.74",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4792,7 +4984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -4930,6 +5122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "psl"
+version = "2.1.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923004c561dc4ed49d1e19cbf2af39780666b32d99941dafe8561f311daffd3d"
+dependencies = [
+ "psl-types",
 ]
 
 [[package]]
@@ -5171,6 +5372,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdkafka"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.8.0+2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5326,6 +5557,45 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5663,6 +5933,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "schema_registry_converter"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc3cf40651cf503827a34bcd7efbbd4750a7e3adc6768bb8089977e4d07303b"
+dependencies = [
+ "apache-avro 0.17.0",
+ "byteorder",
+ "dashmap 6.1.0",
+ "futures",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "valico",
+]
+
+[[package]]
 name = "schemalate"
 version = "0.0.0"
 dependencies = [
@@ -5821,6 +6109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,7 +6249,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
 dependencies = [
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "lazy_static",
  "log",
@@ -6070,6 +6367,12 @@ name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "size"
@@ -6324,6 +6627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6343,6 +6652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6394,6 +6716,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -6724,6 +7049,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.3.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6921,6 +7263,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "treediff"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6978,7 +7341,16 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.16.2",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
+dependencies = [
+ "typed-builder-macro 0.19.1",
 ]
 
 [[package]]
@@ -6986,6 +7358,17 @@ name = "typed-builder-macro"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7109,6 +7492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "uritemplate-next"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcde98d1fc3f528255b1ecb22fb688ee0d23deb672a8c57127df10b98b4bd18c"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7149,6 +7541,30 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
+]
+
+[[package]]
+name = "valico"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a0a4df97f827fcbcbe69c65364acddddf3a4bb50e6507f63361177a7ea7a4"
+dependencies = [
+ "addr",
+ "base64 0.21.7",
+ "chrono",
+ "downcast-rs",
+ "erased-serde",
+ "fancy-regex 0.11.0",
+ "json-pointer",
+ "jsonway",
+ "percent-encoding",
+ "phf",
+ "phf_codegen",
+ "serde",
+ "serde_json",
+ "uritemplate-next",
+ "url",
+ "uuid 1.10.0",
 ]
 
 [[package]]
@@ -7540,6 +7956,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7743,6 +8189,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,8 @@ dependencies = [
  "aes-siv",
  "allocator",
  "anyhow",
+ "apache-avro",
+ "async-trait",
  "avro",
  "axum",
  "axum-extra",
@@ -1977,7 +1979,6 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rsasl",
- "runtime",
  "rustls 0.23.10",
  "rustls-native-certs 0.7.2",
  "rustls-pemfile 2.1.3",
@@ -1986,15 +1987,16 @@ dependencies = [
  "serde_json",
  "simd-doc",
  "socket2",
- "sqlx",
  "time 0.3.36",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tokio-stream",
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-record-hierarchical",
  "tracing-subscriber",
- "tracing-test",
+ "tuple",
  "typestate",
  "unseal",
  "url",
@@ -5743,6 +5745,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6860,6 +6874,18 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-record-hierarchical"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4870b936b70cfeef3d45599052b53b0c9be6dce769cdb1f2fae5cbf47c3ef9d0"
+dependencies = [
+ "lazy_static",
+ "sealed",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "fmt",
 ] }
+tracing-record-hierarchical = "0.1.1"
 rustls-native-certs = "0.7.2"
 zeroize = "1.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,14 @@ insta = { version = "1.20", features = ["redactions", "json", "yaml"] }
 pretty_assertions = "1.4.0"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = { version = "0.4" }
+rdkafka = "0.37"
+schema_registry_converter = { version = "4.2.0", features = [
+    "easy",
+    "avro",
+    "json",
+] }
 serial_test = "0.9"
+tracing-test = "0.2.5"
 wasm-bindgen-test = "0.3.13"
 
 # Used exclusively as build-dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ async-compression = { version = "0.3", features = [
 async-stripe = { version = "0.37", features = ["runtime-tokio-hyper"] }
 async-trait = "0.1"
 atty = "0.2"
-apache-avro = { version = "0.16.0", features = ["snappy"] }
+apache-avro = { version = "0.17.0", features = ["snappy"] }
 
 base64 = "0.13"
 bigdecimal = "0.3.0"

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,10 @@ ${RUSTBIN}/agent:
 ${RUSTBIN}/flowctl:
 	cargo build --release --locked -p flowctl
 
+.PHONY: ${RUSTBIN}/dekaf
+${RUSTBIN}/dekaf:
+	cargo build --release --locked -p dekaf
+
 # Statically linked binaries using MUSL:
 
 .PHONY: ${RUST_MUSL_BIN}/flow-connector-init
@@ -199,6 +203,7 @@ GNU_TARGETS = \
 	${PKGDIR}/bin/deno \
 	${PKGDIR}/bin/etcd \
 	${PKGDIR}/bin/flowctl \
+	${PKGDIR}/bin/dekaf \
 	${PKGDIR}/bin/flowctl-go \
 	${PKGDIR}/bin/gazette \
 	${PKGDIR}/bin/sops
@@ -250,6 +255,9 @@ ${PKGDIR}/bin/flow-schemalate: ${RUST_MUSL_BIN}/flow-schemalate | ${PKGDIR}
 
 ${PKGDIR}/bin/flowctl: ${RUSTBIN}/flowctl | ${PKGDIR}
 	cp ${RUSTBIN}/flowctl $@
+
+${PKGDIR}/bin/dekaf: ${RUSTBIN}/dekaf | ${PKGDIR}
+	cp ${RUSTBIN}/dekaf $@
 
 # Control-plane binaries
 

--- a/crates/avro/src/schema.rs
+++ b/crates/avro/src/schema.rs
@@ -135,7 +135,7 @@ fn object_to_avro(loc: json::Location, obj: doc::shape::ObjShape) -> avro::Schem
     // additional properties, then interpret it as an Avro map.
     if extra.type_ != types::INVALID && obj.properties.is_empty() {
         let schema = shape_to_avro(loc, extra, true);
-        return avro::Schema::Map(Box::new(schema));
+        return avro::Schema::map(schema);
     }
 
     // Otherwise, build a Record which may have a placeholder
@@ -166,7 +166,7 @@ fn object_to_avro(loc: json::Location, obj: doc::shape::ObjShape) -> avro::Schem
 
     if extra.type_ != types::INVALID {
         let schema = shape_to_avro(loc.push_prop(FLOW_EXTRA_NAME), extra, true);
-        let schema = avro::Schema::Map(Box::new(schema));
+        let schema = avro::Schema::map(schema);
 
         fields.push(avro::RecordField {
             aliases: None,
@@ -205,7 +205,7 @@ fn array_to_avro(loc: json::Location, shape: doc::shape::ArrayShape) -> avro::Sc
     }
 
     let items = shape_to_avro(loc.push_prop("_items"), items, true);
-    avro::Schema::Array(Box::new(items))
+    avro::Schema::array(items)
 }
 
 // Map a location into a special Schema holding a string-encoded JSON value.

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -14,7 +14,6 @@ allocator = { path = "../allocator" }
 avro = { path = "../avro" }
 doc = { path = "../doc" }
 extractors = { path = "../extractors" }
-tuple = { path = "../tuple" }
 flow-client = { path = "../flow-client" }
 gazette = { path = "../gazette" }
 json = { path = "../json" }
@@ -24,6 +23,7 @@ ops = { path = "../ops" }
 proto-flow = { path = "../proto-flow" }
 proto-gazette = { path = "../proto-gazette" }
 simd-doc = { path = "../simd-doc" }
+tuple = { path = "../tuple" }
 unseal = { path = "../unseal" }
 
 aes-siv = { workspace = true }

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -23,12 +23,12 @@ models = { path = "../models" }
 ops = { path = "../ops" }
 proto-flow = { path = "../proto-flow" }
 proto-gazette = { path = "../proto-gazette" }
-runtime = { path = "../runtime" }
 simd-doc = { path = "../simd-doc" }
 unseal = { path = "../unseal" }
 
 aes-siv = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
 axum-server = { workspace = true }
@@ -67,6 +67,8 @@ time = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+tracing-record-hierarchical = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -74,3 +76,16 @@ typestate = { workspace = true }
 url = { workspace = true }
 webpki = { workspace = true }
 apache-avro = { workspace = true }
+
+[dev-dependencies]
+async-process = { path = "../async-process" }
+flowctl = { path = "../flowctl" }
+locate-bin = { path = "../locate-bin" }
+
+apache-avro = { workspace = true }
+insta = { workspace = true }
+rdkafka = { workspace = true }
+reqwest = { workspace = true }
+schema_registry_converter = { workspace = true }
+tempfile = { workspace = true }
+tracing-test = { workspace = true }

--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -371,8 +371,7 @@ impl KafkaApiClient {
             )
             .await?;
 
-        let (coord_host, coord_port) = if resp.coordinators.len() > 0 {
-            let coord = resp.coordinators.get(0).expect("already checked length");
+        let (coord_host, coord_port) = if let Some(coord) = resp.coordinators.first() {
             (coord.host.as_str(), coord.port)
         } else {
             (resp.host.as_str(), resp.port)

--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -6,6 +6,9 @@ use kafka_protocol::{
 };
 use tracing::instrument;
 
+pub mod log_appender;
+pub mod logging;
+
 mod topology;
 use topology::{Collection, Partition};
 
@@ -26,10 +29,12 @@ pub use api_client::KafkaApiClient;
 
 use aes_siv::{aead::Aead, Aes256SivAead, KeyInit, KeySizeUser};
 use flow_client::client::{refresh_authorizations, RefreshToken};
+use log_appender::{SESSION_CLIENT_ID_FIELD_MARKER, SESSION_TASK_NAME_FIELD_MARKER};
 use percent_encoding::{percent_decode_str, utf8_percent_encode};
 use proto_flow::flow;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, time::SystemTime};
+use tracing_record_hierarchical::SpanExt;
 
 pub struct App {
     /// Hostname which is advertised for Kafka access.
@@ -212,6 +217,9 @@ impl App {
         if models::Materialization::regex().is_match(username.as_ref())
             && !username.starts_with("{")
         {
+            // This marks this Session as being associated with the task name contained in `username`.
+            logging::get_log_forwarder().set_task_name(username.clone());
+
             // Ask the agent for information about this task, as well as a short-lived
             // control-plane access token authorized to interact with the avro schemas table
             let (client, claims, _, ops_stats_journal, task_spec) =
@@ -252,6 +260,10 @@ impl App {
                 time::OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(claims.exp as i64),
             )?))
         } else if username.contains("{") {
+            // Since we don't have a task, we also don't have a logs journal to write to,
+            // so we should isable log forwarding for this session.
+            logging::get_log_forwarder().shutdown();
+
             let raw_token = String::from_utf8(base64::decode(password)?.to_vec())?;
             let refresh: RefreshToken = serde_json::from_str(raw_token.as_str())?;
 
@@ -344,8 +356,11 @@ async fn handle_api(
         ApiKey::ApiVersionsKey => {
             // https://github.com/confluentinc/librdkafka/blob/e03d3bb91ed92a38f38d9806b8d8deffe78a1de5/src/rdkafka_request.c#L2823
             let (header, request) = dec_request(frame, version)?;
-            tracing::debug!(client_id=?header.client_id, "Got client ID!");
-            session.client_id = header.client_id.clone().map(|id| id.to_string());
+            if let Some(client_id) = &header.client_id {
+                tracing::Span::current()
+                    .record_hierarchical(SESSION_CLIENT_ID_FIELD_MARKER, client_id.to_string());
+                tracing::info!("Got client ID!");
+            }
             Ok(enc_resp(out, &header, session.api_versions(request).await?))
         }
         ApiKey::SaslHandshakeKey => {

--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -1,0 +1,494 @@
+use crate::{dekaf_shard_template_id, topology::fetch_dekaf_task_auth, App};
+use async_trait::async_trait;
+use bytes::Bytes;
+use flow_client::fetch_task_authorization;
+use futures::{StreamExt, TryStreamExt};
+use gazette::{
+    journal,
+    uuid::{self, Producer},
+    RetryError,
+};
+use proto_gazette::message_flags;
+use rand::Rng;
+use std::{collections::VecDeque, marker::PhantomData, sync::Arc, time::Duration};
+use tokio_stream::wrappers::ReceiverStream;
+
+#[derive(Debug)]
+enum LoggingMessage {
+    SetTaskName(String),
+    Log(ops::Log),
+    Shutdown,
+}
+
+// This abstraction exists mostly in order to make testing easier.
+#[async_trait]
+pub trait LogWriter: Send + Sync {
+    async fn append_log_data(&self, log_data: Bytes) -> anyhow::Result<()>;
+
+    async fn set_task_name(&mut self, name: String) -> anyhow::Result<()>;
+}
+
+#[derive(Clone)]
+pub struct GazetteLogWriter {
+    app: Arc<App>,
+    client: Option<journal::Client>,
+    journal_name: Option<String>,
+}
+
+#[async_trait]
+impl LogWriter for GazetteLogWriter {
+    async fn set_task_name(&mut self, task_name: String) -> anyhow::Result<()> {
+        let (client, journal) = self.get_journal_client(task_name).await?;
+        self.client.replace(client);
+        self.journal_name.replace(journal);
+        Ok(())
+    }
+
+    async fn append_log_data(&self, log_data: Bytes) -> anyhow::Result<()> {
+        let resp = self
+            .client
+            .as_ref()
+            .ok_or(anyhow::anyhow!("missing journal client"))?
+            .append(
+                gazette::broker::AppendRequest {
+                    journal: self
+                        .journal_name
+                        .as_ref()
+                        .ok_or(anyhow::anyhow!("missing journal name"))?
+                        .to_owned(),
+                    ..Default::default()
+                },
+                || {
+                    futures::stream::once({
+                        let value = log_data.clone();
+                        async move { Ok(value) }
+                    })
+                },
+            );
+
+        tokio::pin!(resp);
+
+        loop {
+            match resp.try_next().await {
+                Err(RetryError { attempt, inner }) if inner.is_transient() && attempt < 3 => {
+                    let wait_ms = rand::thread_rng().gen_range(400..5_000);
+
+                    tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+                    continue;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "Got recoverable error multiple times while trying to write logs"
+                    );
+                    return Err(err.inner.into());
+                }
+                Ok(_) => return Ok(()),
+            }
+        }
+    }
+}
+
+impl GazetteLogWriter {
+    pub fn new(app: Arc<App>) -> Self {
+        Self {
+            app: app,
+            client: None,
+            journal_name: None,
+        }
+    }
+
+    async fn get_journal_client(
+        &self,
+        task_name: String,
+    ) -> anyhow::Result<(journal::Client, String)> {
+        let (client, _claims, ops_logs, _ops_stats, _task_spec) = fetch_dekaf_task_auth(
+            self.app.client_base.clone(),
+            &task_name,
+            &self.app.data_plane_fqdn,
+            &self.app.data_plane_signer,
+        )
+        .await?;
+
+        let client = fetch_task_authorization(
+            &client,
+            &dekaf_shard_template_id(task_name.as_str()),
+            &self.app.data_plane_fqdn,
+            &self.app.data_plane_signer,
+            proto_flow::capability::AUTHORIZE | proto_gazette::capability::APPEND,
+            gazette::broker::LabelSelector {
+                include: Some(labels::build_set([("name", ops_logs.as_str())])),
+                exclude: None,
+            },
+        )
+        .await?;
+
+        Ok((client, ops_logs))
+    }
+}
+
+#[derive(Clone)]
+pub struct LogForwarder<W: LogWriter> {
+    logs_tx: tokio::sync::mpsc::Sender<LoggingMessage>,
+    _handle: Arc<tokio::task::JoinHandle<()>>,
+    _ph: PhantomData<W>,
+}
+
+// These well-known tracing field names are used to annotate all log messages within a particular session.
+// This is done by using `tracing_record_hierarchical` to update the field value wherever it's defined in the span hierarchy:
+//
+// tracing::Span::current().record_hierarchical(SESSION_CLIENT_ID_FIELD_MARKER, ...client_id...);
+pub const SESSION_TASK_NAME_FIELD_MARKER: &str = "task_name";
+pub const SESSION_CLIENT_ID_FIELD_MARKER: &str = "session_client_id";
+const WELL_KNOWN_LOG_FIELDS: &'static [&'static str] = &[
+    SESSION_TASK_NAME_FIELD_MARKER,
+    SESSION_CLIENT_ID_FIELD_MARKER,
+];
+
+impl<W: LogWriter + 'static> LogForwarder<W> {
+    pub fn new(producer: Producer, writer: W) -> Self {
+        let (logs_tx, logs_rx) = tokio::sync::mpsc::channel::<LoggingMessage>(50);
+
+        let handle = tokio::spawn(async move {
+            if let Err(e) = Self::forward_logs(logs_rx, writer, producer).await {
+                tracing::error!(error = ?e, "Log forwarding errored");
+            }
+        });
+
+        Self {
+            logs_tx,
+            _handle: Arc::new(handle),
+            _ph: Default::default(),
+        }
+    }
+
+    async fn forward_logs(
+        mut logs_rx: tokio::sync::mpsc::Receiver<LoggingMessage>,
+        mut writer: W,
+        uuid_producer: Producer,
+    ) -> anyhow::Result<()> {
+        let mut pending_logs = VecDeque::new();
+
+        loop {
+            match logs_rx.recv().await {
+                Some(LoggingMessage::SetTaskName(name)) => {
+                    writer.set_task_name(name.to_owned()).await?;
+                    break;
+                }
+                Some(LoggingMessage::Log(log)) => {
+                    pending_logs.push_front(log);
+                    // Keep at most the latest 100 log messages when in this pending state
+                    pending_logs.truncate(100);
+                }
+                Some(LoggingMessage::Shutdown) | None => return Ok(()),
+            }
+        }
+
+        let mut event_stream = futures::stream::iter(
+            pending_logs
+                .into_iter()
+                // VecDeque::truncate keeps the first N items, so we use `push_front` + `truncate` to
+                // store the most recent items in the front of the queue. We need to reverse
+                // that when sending, as logs should be sent in oldest-first order.
+                .rev()
+                .map(|log| LoggingMessage::Log(log)),
+        )
+        .chain(ReceiverStream::new(logs_rx));
+
+        while let Some(msg) = event_stream.next().await {
+            match msg {
+                LoggingMessage::SetTaskName(_) => {}
+                LoggingMessage::Log(mut log) => {
+                    // Attach any present well known fields to the top-level Log's fields
+                    for well_known in WELL_KNOWN_LOG_FIELDS {
+                        if let Some(value) = log
+                            .spans
+                            .iter()
+                            .find_map(|l| l.fields_json_map.get(&well_known.to_string()))
+                        {
+                            log.fields_json_map
+                                .insert(well_known.to_string(), value.to_string());
+                        }
+                    }
+
+                    writer
+                        .append_log_data(Self::serialize_log(uuid_producer, log).into())
+                        .await?;
+                }
+                LoggingMessage::Shutdown => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    fn serialize_log(producer: Producer, mut log: ops::Log) -> Vec<u8> {
+        let uuid = gazette::uuid::build(
+            producer,
+            gazette::uuid::Clock::from_time(std::time::SystemTime::now()),
+            uuid::Flags((message_flags::OUTSIDE_TXN).try_into().unwrap()),
+        );
+        log.meta = Some(ops::Meta {
+            uuid: uuid.to_string(),
+        });
+
+        let mut buf = serde_json::to_vec(&log).expect("Value always serializes");
+        buf.push(b'\n');
+
+        buf
+    }
+
+    pub fn set_task_name(&self, name: String) {
+        use tracing_record_hierarchical::SpanExt;
+
+        if !self.logs_tx.is_closed() {
+            self.logs_tx
+                .try_send(LoggingMessage::SetTaskName(name.to_owned()))
+                .unwrap();
+        }
+        // Also set the task name on the parent span so it's included in the logs. This also adds it
+        // to the logs that Dekaf writes to stdout, which makes debugging issues much easier.
+        tracing::Span::current().record_hierarchical(SESSION_TASK_NAME_FIELD_MARKER, name);
+    }
+
+    pub fn send_log_message(&self, log: ops::Log) {
+        if !self.logs_tx.is_closed() {
+            self.logs_tx.try_send(LoggingMessage::Log(log)).unwrap();
+        }
+    }
+
+    pub fn shutdown(&self) {
+        if !self.logs_tx.is_closed() {
+            self.logs_tx.try_send(LoggingMessage::Shutdown).unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::Future;
+    use insta::assert_json_snapshot;
+    use itertools::Itertools;
+    use rand::Rng;
+    use std::time::Duration;
+    use tracing::{info, info_span};
+    use tracing::{instrument::WithSubscriber, Instrument};
+
+    use tracing_record_hierarchical::SpanExt;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Default, Clone)]
+    struct MockLogWriter {
+        pub logs: Arc<tokio::sync::Mutex<VecDeque<Bytes>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LogWriter for MockLogWriter {
+        async fn set_task_name(&mut self, _: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn append_log_data(&self, log_data: Bytes) -> anyhow::Result<()> {
+            self.logs.lock().await.push_back(log_data);
+            Ok(())
+        }
+    }
+
+    tokio::task_local! {
+        static MOCK_LOG_FORWARDER: LogForwarder<MockLogWriter>;
+    }
+
+    fn gen_producer() -> Producer {
+        // There's probably a neat bit-banging way to do this with i64 and masks, but I'm just not that fancy.
+        let mut producer_id = rand::thread_rng().gen::<[u8; 6]>();
+        producer_id[0] |= 0x01;
+        gazette::uuid::Producer::from_bytes(producer_id)
+    }
+
+    async fn setup<F, Fut>(f: F)
+    where
+        F: FnOnce(Arc<tokio::sync::Mutex<VecDeque<Bytes>>>) -> Fut,
+        Fut: Future,
+    {
+        let mock_writer = MockLogWriter::default();
+        let logs = mock_writer.logs.clone();
+
+        let producer = gen_producer();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_record_hierarchical::HierarchicalRecord::default())
+            .with(ops::tracing::Layer::new(
+                |log| MOCK_LOG_FORWARDER.get().send_log_message(log.clone()),
+                std::time::SystemTime::now,
+            ))
+            .with(tracing_subscriber::fmt::Layer::default());
+
+        MOCK_LOG_FORWARDER
+            .scope(
+                LogForwarder::new(producer, mock_writer),
+                async move {
+                    f(logs)
+                        .instrument(tracing::info_span!(
+                            "test_session",
+                            { SESSION_TASK_NAME_FIELD_MARKER } = tracing::field::Empty,
+                        ))
+                        .await
+                }
+                .with_subscriber(subscriber),
+            )
+            .await;
+    }
+
+    async fn assert_output(name: &str, logs: Arc<tokio::sync::Mutex<VecDeque<Bytes>>>) {
+        let captured_log_bytes = logs
+            .lock()
+            .await
+            .clone()
+            .into_iter()
+            .map(|b| Vec::from(b))
+            .flatten()
+            .collect::<Vec<u8>>();
+
+        let full_str = String::from_utf8(captured_log_bytes.into()).unwrap();
+
+        let captured_logs = full_str
+            .split("\n")
+            .filter(|l| l.len() > 0)
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect_vec();
+
+        assert_json_snapshot!(name, captured_logs, {
+            ".*._meta.uuid" => "[uuid]",
+            ".*.spans.*.ts" => "[ts]",
+            ".*.ts" => "[ts]"
+        });
+    }
+
+    #[tokio::test]
+    async fn test_logging_with_no_task_name() {
+        setup(|logs| async move {
+            {
+                info!("Test log data, you shouldn't be able to see me");
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let captured_logs = logs.lock().await;
+            assert!(captured_logs.is_empty());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_logging_with_task_name() {
+        setup(|logs| async move {
+            {
+                info!("Test log data before setting name, you should see me");
+
+                MOCK_LOG_FORWARDER
+                    .get()
+                    .set_task_name("my_task".to_string());
+
+                info!("Test log data with a task name!");
+            };
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            assert_output("session_logger_and_task_name", logs).await;
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_logging_with_client_id_hierarchical() {
+        setup(|logs| async move {
+            {
+                info!("Test log data before setting name, you should see me");
+                let session_span = info_span!(
+                    "session_span",
+                    { SESSION_CLIENT_ID_FIELD_MARKER } = tracing::field::Empty
+                );
+                let session_guard = session_span.enter();
+
+                info!("Test log data without a task name yet!");
+
+                MOCK_LOG_FORWARDER
+                    .get()
+                    .set_task_name("my_task".to_string());
+
+                let child_span = info_span!("child_span");
+                let child_guard = child_span.enter();
+
+                tracing::Span::current()
+                    .record_hierarchical(SESSION_CLIENT_ID_FIELD_MARKER, "my-client-id");
+
+                info!("I should have a client ID");
+                drop(child_guard);
+                info!("I should also have a client ID");
+                drop(session_guard)
+            };
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            assert_output("session_logger_and_task_name_hierarchical", logs).await;
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_subscriber_layer_taskless() {
+        setup(|logs| async move {
+            {
+                info!("Logged without name, you shouldn't see me because of the shutdown");
+
+                MOCK_LOG_FORWARDER.get().shutdown();
+
+                info!("After shutdown, still shouldn't see me");
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let captured_logs = logs.lock().await;
+            assert!(
+                captured_logs.is_empty(),
+                "Expected no logs for taskless session"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_subscriber_layer_nested_spans() {
+        setup(|logs| async move {
+            {
+                info!("From before task name, should be visible");
+
+                let nested_span = info_span!("nested");
+                let nested_guard = nested_span.enter();
+
+                info!("From inside nested span but before task_name, should be visible");
+
+                MOCK_LOG_FORWARDER
+                    .get()
+                    .set_task_name("my_task".to_string());
+
+                info!("Log from nested span after task name marker");
+
+                drop(nested_guard);
+
+                info!("Back in session span after task name");
+
+                let new_span = info_span!("new_nested");
+                let _new_guard = new_span.enter();
+
+                info!("In child of session span after task name");
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            assert_output("nested_spans", logs).await;
+        })
+        .await;
+    }
+}

--- a/crates/dekaf/src/logging.rs
+++ b/crates/dekaf/src/logging.rs
@@ -1,0 +1,105 @@
+use crate::log_appender::{self, GazetteLogWriter, LogForwarder};
+use futures::Future;
+use lazy_static::lazy_static;
+use rand::Rng;
+use tracing::{level_filters::LevelFilter, Instrument};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
+
+// These are accessible anywhere inside the call stack of a future wrapped with [`forward_logs()`].
+// The relationship between LogForwarder and log journal is one-to-one. That means that all logs
+// from the point at which you call `forward_logs()` downwards will get forwarder to the same journal.
+tokio::task_local! {
+    static LOG_FORWARDER: LogForwarder<GazetteLogWriter>;
+    static LOG_LEVEL: std::cell::Cell<ops::LogLevel>;
+}
+
+pub fn install() {
+    // Build a tracing_subscriber::Filter which uses our dynamic log level.
+    let log_filter = tracing_subscriber::filter::DynFilterFn::new(move |metadata, _cx| {
+        let cur_level = match metadata.level().as_str() {
+            "TRACE" => ops::LogLevel::Trace as i32,
+            "DEBUG" => ops::LogLevel::Debug as i32,
+            "INFO" => ops::LogLevel::Info as i32,
+            "WARN" => ops::LogLevel::Warn as i32,
+            "ERROR" => ops::LogLevel::Error as i32,
+            _ => ops::LogLevel::UndefinedLevel as i32,
+        };
+
+        cur_level
+            <= LOG_LEVEL
+                .try_with(|log_level| log_level.get())
+                .unwrap_or(ops::LogLevel::Info)
+                .into()
+    });
+
+    // We want to be able to control Dekaf's own logging output via the RUST_LOG environment variable like usual.
+    let fmt_layer = tracing_subscriber::fmt::Layer::default()
+        .with_writer(std::io::stderr)
+        .with_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into()) // Otherwise it's ERROR.
+                .from_env_lossy(),
+        );
+
+    let registry = tracing_subscriber::registry()
+        .with(tracing_record_hierarchical::HierarchicalRecord::default())
+        .with(
+            ops::tracing::Layer::new(
+                |log| {
+                    let _ = LOG_FORWARDER.try_with(|f| f.send_log_message(log.clone()));
+                },
+                std::time::SystemTime::now,
+            )
+            .with_filter(log_filter),
+        )
+        .with(fmt_layer);
+
+    registry.init();
+}
+
+lazy_static! {
+    // Producer IDs should change infrequently, so we should create one as early as possible and use it for the lifetime of the process
+    static ref PRODUCER: gazette::uuid::Producer = {
+        // There's probably a neat bit-banging way to do this with i64 and masks, but I'm just not that fancy.
+        let mut producer_id = rand::thread_rng().gen::<[u8; 6]>();
+        producer_id[0] |= 0x01;
+        gazette::uuid::Producer::from_bytes(producer_id)
+    };
+}
+
+/// Capture all log messages emitted by the passed future and all of its descendants, and writes them out
+/// based on the behavior of the provided writer. Initially, log messages will get buffered in a circular
+/// queue until such time as the forwarder is informed of the name of the journal to emit them into. Then,
+/// all buffered logs as well as all new incoming logs will be written out to that journal.
+///
+/// The log forwarder can be configured (i.e to inform it of the log journal, once it's known) via [`get_log_forwarder()`].
+///  - Note: This will panic if called from outside the context of a future wrapped by [`forward_logs()`]!
+/// The level filter can be dynamically configured for new messages via [`set_log_level()`].
+pub fn forward_logs<F, O>(writer: GazetteLogWriter, fut: F) -> impl Future<Output = O>
+where
+    F: Future<Output = O>,
+{
+    let forwarder = LogForwarder::new(PRODUCER.to_owned(), writer);
+
+    LOG_LEVEL.scope(
+        ops::LogLevel::Info.into(),
+        LOG_FORWARDER.scope(
+            forwarder,
+            fut.instrument(tracing::info_span!(
+                // Attach these empty fields so that later on we can use tracing_record_hierarchical
+                // to set them, effectively adding a field to every event emitted inside a Session.
+                "dekaf_session",
+                { log_appender::SESSION_CLIENT_ID_FIELD_MARKER } = tracing::field::Empty,
+                { log_appender::SESSION_TASK_NAME_FIELD_MARKER } = tracing::field::Empty,
+            )),
+        ),
+    )
+}
+
+pub fn get_log_forwarder() -> LogForwarder<GazetteLogWriter> {
+    LOG_FORWARDER.get()
+}
+
+pub fn set_log_level(level: ops::LogLevel) {
+    LOG_LEVEL.with(|cell| cell.set(level))
+}

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__nested_spans.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__nested_spans.snap
@@ -1,0 +1,141 @@
+---
+source: crates/dekaf/src/log_appender.rs
+expression: captured_logs
+---
+[
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests"
+    },
+    "level": "info",
+    "message": "From before task name, should be visible",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests"
+    },
+    "level": "info",
+    "message": "From inside nested span but before task_name, should be visible",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "nested",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "Log from nested span after task name marker",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "nested",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "Back in session span after task name",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "In child of session span after task name",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "new_nested",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  }
+]

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__session_logger_and_task_name.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__session_logger_and_task_name.snap
@@ -1,0 +1,50 @@
+---
+source: crates/dekaf/src/log_appender.rs
+expression: captured_logs
+---
+[
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests"
+    },
+    "level": "info",
+    "message": "Test log data before setting name, you should see me",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "Test log data with a task name!",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  }
+]

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__session_logger_and_task_name_hierarchical.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__session_logger_and_task_name_hierarchical.snap
@@ -1,0 +1,130 @@
+---
+source: crates/dekaf/src/log_appender.rs
+expression: captured_logs
+---
+[
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests"
+    },
+    "level": "info",
+    "message": "Test log data before setting name, you should see me",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests"
+    },
+    "level": "info",
+    "message": "Test log data without a task name yet!",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "session_span",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "session_client_id": "my-client-id",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "I should have a client ID",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "session_client_id": "my-client-id"
+        },
+        "level": "info",
+        "message": "session_span",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests"
+        },
+        "level": "info",
+        "message": "child_span",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  },
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender::tests",
+      "session_client_id": "my-client-id",
+      "task_name": "my_task"
+    },
+    "level": "info",
+    "message": "I should also have a client ID",
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      },
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "session_client_id": "my-client-id"
+        },
+        "level": "info",
+        "message": "session_span",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  }
+]

--- a/crates/dekaf/tests/dekaf_integration_test.rs
+++ b/crates/dekaf/tests/dekaf_integration_test.rs
@@ -1,0 +1,729 @@
+use anyhow::Context;
+use dekaf::connector::DekafConfig;
+use futures::StreamExt;
+use locate_bin;
+use rand::Rng;
+use rdkafka::{consumer::Consumer, Message};
+use schema_registry_converter::async_impl::avro;
+use schema_registry_converter::async_impl::schema_registry;
+use serde_json::json;
+use std::{collections::HashMap, env, io::Write, time::Duration};
+
+async fn create_consumer<'a>(
+    username: &'a str,
+    token: &'a str,
+    topic: &'a str,
+) -> (rdkafka::consumer::StreamConsumer, avro::AvroDecoder<'a>) {
+    #[allow(non_snake_case)]
+    let DEKAF_BROKER = env::var("DEKAF_BROKER").expect("Missing DEKAF_BROKER environment variable");
+    #[allow(non_snake_case)]
+    let SCHEMA_REGISTRY =
+        env::var("DEKAF_REGISTRY").expect("Missing DEKAF_REGISTRY environment variable");
+
+    let consumer: rdkafka::consumer::StreamConsumer = rdkafka::ClientConfig::new()
+        .set("bootstrap.servers", DEKAF_BROKER)
+        .set("security.protocol", "SASL_PLAINTEXT")
+        .set("sasl.mechanism", "PLAIN")
+        .set("sasl.username", username)
+        .set("sasl.password", token)
+        .set("group.id", "this_needs_to_be_set_but_we_dont_use_it")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "smallest")
+        .set("enable.auto.offset.store", "false")
+        .create()
+        .expect("Consumer creation failed");
+
+    consumer
+        .subscribe(vec![topic].as_slice())
+        .expect("Consumer subscription failed");
+
+    let decoder = avro::AvroDecoder::new(
+        schema_registry::SrSettings::new_builder(String::from(SCHEMA_REGISTRY))
+            .set_basic_authorization(username, Some(token))
+            .build()
+            .expect("failed to build avro decoder"),
+    );
+
+    (consumer, decoder)
+}
+
+#[derive(Debug)]
+enum SpecAction {
+    Create,
+    Delete,
+}
+
+async fn test_specs(
+    name: &str,
+    action: SpecAction,
+    mut capture: models::CaptureDef,
+    collections: HashMap<&str, models::CollectionDef>,
+    mut materialization: models::MaterializationDef,
+) -> anyhow::Result<(String, String)> {
+    let mut temp_flow = tempfile::NamedTempFile::new()?;
+
+    let suffix: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(4)
+        .map(char::from)
+        .collect();
+
+    let capture_name = format!("{}/{suffix}/source-http-ingest", name);
+    let materialization_name = format!("{}/{suffix}/test-dekaf", name);
+
+    tracing::info!(temp=?temp_flow, "Attempting to {:?}", action);
+
+    // rewrite capture bindings
+    capture.bindings.iter_mut().for_each(|binding| {
+        binding.target = models::Collection::new(format!("{name}/{}", binding.target.to_string()))
+    });
+
+    // rewrite materialization sources
+    materialization.bindings.iter_mut().for_each(|binding| {
+        binding
+            .source
+            .set_collection(models::Collection::new(format!(
+                "{name}/{}",
+                binding.source.collection()
+            )))
+    });
+
+    let collections_mapped = collections
+        .into_iter()
+        .fold(HashMap::new(), |mut state, (k, v)| {
+            state.insert(format!("{name}/{k}"), v);
+            state
+        });
+
+    let file_contents = json!({
+        "captures": {
+            &capture_name: capture
+        },
+        "collections": collections_mapped,
+        "materializations": {
+            &materialization_name: materialization
+        }
+    });
+
+    temp_flow.write(serde_json::to_vec(&file_contents)?.as_slice())?;
+
+    let flowctl = locate_bin::locate("flowctl").context("failed to locate flowctl")?;
+
+    let async_process::Output {
+        stderr,
+        stdout: _stdout,
+        status,
+    } = async_process::output(
+        async_process::Command::new(flowctl).args(
+            match action {
+                SpecAction::Create => vec![
+                    "catalog",
+                    "publish",
+                    "--auto-approve",
+                    "--default-data-plane",
+                    "ops/dp/public/local-cluster",
+                    "--source",
+                    temp_flow.path().to_str().unwrap(),
+                ],
+                SpecAction::Delete => vec![
+                    "catalog",
+                    "delete",
+                    "--prefix",
+                    name,
+                    "--captures=true",
+                    "--collections=true",
+                    "--materializations=true",
+                    "--dangerous-auto-approve",
+                ],
+            }
+            .as_slice(),
+        ),
+    )
+    .await
+    .context("failed to invoke flowctl")?;
+
+    if !status.success() {
+        let output = String::from_utf8_lossy(&stderr);
+        if !output.contains("no specs found matching given selector") {
+            anyhow::bail!("flowctl failed: {}", output);
+        }
+    }
+
+    tracing::info!(
+        ?capture_name,
+        ?materialization_name,
+        "Successful {:?}",
+        action
+    );
+
+    Ok((capture_name, materialization_name))
+}
+
+async fn sops_encrypt(input: models::RawValue) -> anyhow::Result<models::RawValue> {
+    #[allow(non_snake_case)]
+    let KEYRING = env::var("SOPS_KEYRING").unwrap_or(
+        "projects/estuary-control/locations/us-central1/keyRings/sops/cryptoKeys/cd-github-control"
+            .to_string(),
+    );
+
+    let sops = locate_bin::locate("sops").context("failed to locate sops")?;
+
+    let async_process::Output {
+        stderr,
+        stdout,
+        status,
+    } = async_process::input_output(
+        async_process::Command::new(sops).args([
+            "--encrypt",
+            "--input-type",
+            "json",
+            "--output-type",
+            "json",
+            "--gcp-kms",
+            &KEYRING,
+            "--encrypted-suffix",
+            "_sops",
+            "/dev/stdin",
+        ]),
+        input.get().as_bytes(),
+    )
+    .await
+    .context("failed to run sops")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "decrypting sops document failed: {}",
+            String::from_utf8_lossy(&stderr),
+        );
+    }
+
+    Ok(models::RawValue::from_string(
+        std::str::from_utf8(stdout.as_slice())
+            .context("failed to parse sops output")?
+            .to_string(),
+    )?)
+}
+
+async fn get_shard_info(
+    task_name: &str,
+) -> anyhow::Result<proto_gazette::consumer::list_response::Shard> {
+    let flowctl = locate_bin::locate("flowctl").context("failed to locate flowctl")?;
+
+    let async_process::Output {
+        stderr,
+        stdout,
+        status,
+    } = async_process::output(async_process::Command::new(flowctl).args([
+        "raw",
+        "list-shards",
+        "--task",
+        task_name,
+        "-ojson",
+    ]))
+    .await
+    .context("failed to list shards")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "listing shards failed: {}",
+            String::from_utf8_lossy(&stderr),
+        );
+    }
+
+    Ok(serde_json::from_slice(&stdout)?)
+}
+
+async fn wait_for_primary(task_name: &str) -> anyhow::Result<()> {
+    loop {
+        match get_shard_info(task_name).await {
+            Err(e) => {
+                tracing::warn!(?e, "Error getting shard info");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            Ok(info)
+                if info.status.iter().any(|status| {
+                    status.code() == gazette::consumer::replica_status::Code::Primary
+                }) =>
+            {
+                return Ok(())
+            }
+            Ok(info)
+                if info.status.iter().any(|status| {
+                    status.code() == gazette::consumer::replica_status::Code::Failed
+                }) =>
+            {
+                tracing::warn!(statuses = ?info.status, "Shard failed");
+                anyhow::bail!("Shard failed");
+            }
+            Ok(info) => {
+                tracing::info!(statuses = ?info.status,"Waiting for primary");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        }
+    }
+}
+
+async fn send_docs(task_name: &str, path: &str, docs: Vec<models::RawValue>) -> anyhow::Result<()> {
+    let shard = get_shard_info(task_name).await?;
+
+    let shard_endpoint = shard
+        .route
+        .context("missing shard route")?
+        .endpoints
+        .first()
+        .context("missing shard endpoint")?
+        .replace("https://", "");
+    let shard_labels = shard
+        .spec
+        .context("missing shard spec")?
+        .labels
+        .context("missing shard labels")?
+        .labels;
+
+    let hostname = &shard_labels
+        .iter()
+        .find(|lab| lab.name == labels::HOSTNAME)
+        .context("missing HOSTNAME label")?
+        .value;
+    let port = &shard_labels
+        .iter()
+        .find(|lab| lab.name == labels::EXPOSE_PORT)
+        .context("missing HOSTNAME label")?
+        .value;
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let url = format!("https://{hostname}-{port}.{shard_endpoint}/{path}");
+
+    tracing::info!(url, "Sending docs");
+
+    for doc in docs {
+        let response = client
+            .post(url.clone())
+            .header("Content-Type", "application/json")
+            .body(doc.get().to_string())
+            .send()
+            .await
+            .context("failed to send document")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("failed to send document: status={}, body={}", status, body);
+        }
+    }
+
+    Ok(())
+}
+
+// Note: For the moment, this is going to use an externally-running `agent`, either from Tilt
+// or the one running in prod. That means that any changes to `dekaf::connector` will not get
+// tested, as that functionality gets baked into the agent/runtime directly. An improvement
+// to these tests would be to additionally run/test against a local build of the latest `agent`.
+async fn roundtrip(
+    name: String,
+    endpoint_config: DekafConfig,
+    schema: serde_json::Value,
+    field_selection: serde_json::Value,
+    docs: Vec<serde_json::Value>,
+) -> anyhow::Result<()> {
+    // Create test collection with specific schema
+    // Create test Dekaf materialization
+    let materialization_config = sops_encrypt(models::RawValue::from_value(&serde_json::to_value(
+        endpoint_config.clone(),
+    )?))
+    .await?;
+
+    let capture: models::CaptureDef = serde_json::from_value(json!({
+        "endpoint": {
+            "connector": {
+                "image": "ghcr.io/estuary/source-http-ingest:dev",
+                "config": sops_encrypt(models::RawValue::from_value(&json!({
+                    "paths": ["/data"]
+                }))).await?
+            }
+        },
+        "bindings": [{
+            "resource": {
+                "path": "/data",
+                "stream": "/data"
+            },
+            "target": "single_collection"
+        }]
+    }))?;
+
+    let collections = HashMap::from_iter(
+        vec![("single_collection", serde_json::from_value(schema)?)].into_iter(),
+    );
+
+    let materialization: models::MaterializationDef = serde_json::from_value(json!({
+        "endpoint": {
+            "dekaf": {
+                "variant": "foo",
+                "config": materialization_config
+            }
+        },
+        "bindings": [
+            {
+                "resource": {
+                    "topic_name": "test_topic"
+                },
+                "source": "single_collection",
+                "fields": field_selection
+            }
+        ]
+    }))?;
+
+    let task_name_prefix = format!("test/dekaf_testing/{name}");
+
+    test_specs(
+        &task_name_prefix,
+        SpecAction::Delete,
+        capture.clone(),
+        collections.clone(),
+        materialization.clone(),
+    )
+    .await?;
+
+    let (capture_name, materialization_name) = test_specs(
+        &task_name_prefix,
+        SpecAction::Create,
+        capture.clone(),
+        collections.clone(),
+        materialization.clone(),
+    )
+    .await?;
+
+    wait_for_primary(&capture_name).await?;
+
+    tracing::info!("Capture is primary");
+
+    send_docs(
+        &capture_name,
+        "data",
+        docs.iter()
+            .map(models::RawValue::from_value)
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+
+    tracing::info!("Sent test docs");
+
+    // Consume test documents
+    let (consumer, decoder) =
+        create_consumer(&materialization_name, &endpoint_config.token, "test_topic").await;
+
+    let mut doc_stream = consumer.stream();
+
+    let mut counter = 0;
+    while let Some(consumed) = doc_stream.next().await {
+        let consumed = consumed?;
+
+        // Connfirm that field selection was applied
+
+        let decoded_key = match decoder.decode(consumed.key()).await {
+            Err(e) => {
+                tracing::error!(err=?e, "Error decoding key");
+                return Err(anyhow::Error::from(e));
+            }
+            Ok(d) => apache_avro::from_value::<serde_json::Value>(&d.value),
+        }?;
+
+        insta::assert_json_snapshot!(format!("{name}-key-{counter}"), &decoded_key);
+
+        let decoded_payload = match decoder.decode(consumed.payload()).await {
+            Err(e) => {
+                tracing::error!(err=?e, "Error decoding value");
+                return Err(anyhow::Error::from(e));
+            }
+            Ok(d) => apache_avro::from_value::<serde_json::Value>(&d.value),
+        }?;
+
+        insta::assert_json_snapshot!(format!("{name}-value-{counter}"), &decoded_payload, {
+            ".flow_published_at.json" => "[timestamp]",
+            ".flow_document._flow_extra._meta.json" => "[contains_timestamp]"
+        });
+
+        counter += 1;
+        if counter >= docs.len() {
+            break;
+        }
+    }
+
+    // Delete test specs
+
+    test_specs(
+        &task_name_prefix,
+        SpecAction::Delete,
+        capture.clone(),
+        collections.clone(),
+        materialization.clone(),
+    )
+    .await?;
+    Ok(())
+}
+
+#[ignore]
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_field_selection_specific() -> anyhow::Result<()> {
+    roundtrip(
+        "field_selection_specific".to_string(),
+        dekaf::connector::DekafConfig {
+            deletions: dekaf::connector::DeletionMode::Kafka,
+            strict_topic_names: false,
+            token: "1234".to_string(),
+        },
+        json!({
+            "schema": {
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "field_a": {
+                        "type": "string",
+                    },
+                    "field_b": {
+                        "type": "string",
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                    "field_a",
+                    "field_b"
+                ],
+            },
+            "key": [
+                "/key"
+            ]
+        }),
+        json!({
+            "include": {
+                "field_a": {}
+            },
+            "recommended": false
+        }),
+        vec![json!({
+            "key": "first",
+            "field_a": "foo",
+            "field_b": "bar"
+        })],
+    )
+    .await
+}
+
+#[ignore]
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_field_selection_recommended() -> anyhow::Result<()> {
+    roundtrip(
+        "field_selection_recommended".to_string(),
+        dekaf::connector::DekafConfig {
+            deletions: dekaf::connector::DeletionMode::Kafka,
+            strict_topic_names: false,
+            token: "1234".to_string(),
+        },
+        json!({
+            "schema": {
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "field_a": {
+                        "type": "string",
+                    },
+                    "field_b": {
+                        "type": "string",
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                    "field_a",
+                    "field_b"
+                ],
+            },
+            "key": [
+                "/key"
+            ]
+        }),
+        json!({
+            "recommended": true
+        }),
+        vec![json!({
+            "key": "first",
+            "field_a": "foo",
+            "field_b": "bar"
+        })],
+    )
+    .await
+}
+
+#[ignore]
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_field_selection_flow_document() -> anyhow::Result<()> {
+    roundtrip(
+        "field_selection_flow_document".to_string(),
+        dekaf::connector::DekafConfig {
+            deletions: dekaf::connector::DeletionMode::Kafka,
+            strict_topic_names: false,
+            token: "1234".to_string(),
+        },
+        json!({
+            "schema": {
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "field_a": {
+                        "type": "string",
+                    },
+                    "field_b": {
+                        "type": "string",
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                    "field_a",
+                    "field_b"
+                ],
+            },
+            "key": [
+                "/key"
+            ]
+        }),
+        json!({
+            "include": {
+                "key": {},
+                "flow_document": {}
+            },
+            "exclude": [
+                "field_a",
+                "field_b"
+            ],
+            "recommended": true
+        }),
+        vec![json!({
+            "key": "first",
+            "field_a": "foo",
+            "field_b": "bar"
+        })],
+    )
+    .await
+}
+
+#[ignore]
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_meta_is_deleted() -> anyhow::Result<()> {
+    roundtrip(
+        "meta_is_deleted".to_string(),
+        dekaf::connector::DekafConfig {
+            deletions: dekaf::connector::DeletionMode::CDC,
+            strict_topic_names: false,
+            token: "1234".to_string(),
+        },
+        json!({
+            "schema": {
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "field_a": {
+                        "type": "string",
+                    },
+                    "field_b": {
+                        "type": "string",
+                    },
+                    "_meta": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                ],
+            },
+            "key": [
+                "/key"
+            ]
+        }),
+        json!({
+            "include": {
+                "key": {},
+            },
+            "recommended": false
+        }),
+        vec![
+            json!({
+                "key": "first",
+                "field_a": "foo",
+                "field_b": "bar",
+                "_meta": {
+                    "op": "c"
+                }
+            }),
+            json!({
+                "key": "first",
+                "field_a": "foo",
+                "field_b": "bar",
+                "_meta": {
+                    "op": "d"
+                }
+            }),
+        ],
+    )
+    .await
+}
+
+#[ignore]
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_fields_not_required() -> anyhow::Result<()> {
+    roundtrip(
+        "fields_not_required".to_string(),
+        dekaf::connector::DekafConfig {
+            deletions: dekaf::connector::DeletionMode::Kafka,
+            strict_topic_names: false,
+            token: "1234".to_string(),
+        },
+        json!({
+            "schema": {
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "field_a": {
+                        "type": "string",
+                    },
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                ],
+            },
+            "key": [
+                "/key"
+            ]
+        }),
+        json!({
+            "recommended": true
+        }),
+        vec![json!({
+            "key": "first",
+            // Omitting "field_a"
+        })],
+    )
+    .await
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_flow_document-key-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_flow_document-key-0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+assertion_line: 435
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_flow_document-value-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_flow_document-value-0.snap
@@ -1,0 +1,20 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "flow_document": {
+    "_flow_extra": {
+      "_meta": {
+        "json": "[contains_timestamp]"
+      }
+    },
+    "field_a": "foo",
+    "field_b": "bar",
+    "key": "first"
+  },
+  "flow_published_at": {
+    "json": "[timestamp]"
+  },
+  "key": "first"
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_recommended-key-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_recommended-key-0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+assertion_line: 435
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_recommended-value-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_recommended-value-0.snap
@@ -1,0 +1,12 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "field_a": "foo",
+  "field_b": "bar",
+  "flow_published_at": {
+    "json": "[timestamp]"
+  },
+  "key": "first"
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_specific-key-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_specific-key-0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+assertion_line: 435
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_specific-value-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__field_selection_specific-value-0.snap
@@ -1,0 +1,7 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "field_a": "foo"
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__fields_not_required-key-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__fields_not_required-key-0.snap
@@ -1,0 +1,9 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__fields_not_required-value-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__fields_not_required-value-0.snap
@@ -1,0 +1,11 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "field_a": null,
+  "flow_published_at": {
+    "json": "[timestamp]"
+  },
+  "key": "first"
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-key-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-key-0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+assertion_line: 435
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-key-1.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-key-1.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+assertion_line: 435
+expression: "&decoded_key"
+---
+{
+  "_flow_key": {
+    "p1": "first"
+  }
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-value-0.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-value-0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "_meta": {
+    "is_deleted": 0
+  },
+  "key": "first"
+}

--- a/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-value-1.snap
+++ b/crates/dekaf/tests/snapshots/dekaf_integration_test__meta_is_deleted-value-1.snap
@@ -1,0 +1,10 @@
+---
+source: crates/dekaf/tests/dekaf_integration_test.rs
+expression: "&decoded_payload"
+---
+{
+  "_meta": {
+    "is_deleted": 1
+  },
+  "key": "first"
+}

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -46,6 +46,7 @@ pub enum Error {
 }
 
 /// RetryError is an Error encountered during a retry-able operation.
+#[derive(Debug)]
 pub struct RetryError {
     /// Number of operation attempts since the last success.
     pub attempt: usize,

--- a/crates/models/src/connector.rs
+++ b/crates/models/src/connector.rs
@@ -25,7 +25,7 @@ pub const DEKAF_IMAGE_NAME_PREFIX: &str = "ghcr.io/estuary/dekaf-";
 /// Dekaf doesn't use images, but important information such as endpoint/resource config schema are associated
 /// with a particular `connector_tags` row. Rather than refactoring this deeply interconnected piece of the system,
 /// we've decided to just give Dekaf a `connector_tags` row. This is its tag.
-pub const DEKAF_IMAGE_TAG: &str = "v1";
+pub const DEKAF_IMAGE_TAG: &str = ":v1";
 
 /// Dekaf service configuration
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
@@ -41,10 +41,7 @@ pub struct DekafConfig {
 
 impl DekafConfig {
     pub fn image_name(&self) -> String {
-        format!(
-            "{DEKAF_IMAGE_NAME_PREFIX}{}:{DEKAF_IMAGE_TAG}",
-            self.variant
-        )
+        format!("{DEKAF_IMAGE_NAME_PREFIX}{}{DEKAF_IMAGE_TAG}", self.variant)
     }
 }
 

--- a/crates/models/src/connector.rs
+++ b/crates/models/src/connector.rs
@@ -30,7 +30,8 @@ pub const DEKAF_IMAGE_TAG: &str = "v1";
 /// Dekaf service configuration
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub struct DekafConfig {
-    /// # Dekaf variant type. Since we support integrating with a bunch of different providers via Dekaf,
+    /// # Dekaf variant type.
+    /// Since we support integrating with a bunch of different providers via Dekaf,
     /// this allows us to store which of those connector variants this particular Dekaf connector was
     /// created as, in order to e.g link to the correct docs URL, show the correct name and logo, etc.
     pub variant: String,

--- a/crates/ops/src/tracing.rs
+++ b/crates/ops/src/tracing.rs
@@ -26,7 +26,7 @@ where
         Self(handler, timesource)
     }
 
-    fn log_from_metadata(&self, metadata: &tracing::Metadata) -> Log {
+    pub fn log_from_metadata(&self, metadata: &tracing::Metadata) -> Log {
         let mut log = Log {
             meta: None,
             timestamp: Some(proto_flow::as_timestamp(self.1())),
@@ -97,7 +97,7 @@ where
     }
 }
 
-struct FieldVisitor<'a>(&'a mut Log);
+pub struct FieldVisitor<'a>(pub &'a mut Log);
 
 impl<'a> FieldVisitor<'a> {
     fn record_raw<S>(&mut self, field: &tracing::field::Field, value: S)
@@ -184,7 +184,7 @@ impl<'a> tracing::field::Visit for FieldVisitor<'a> {
     }
 }
 
-fn level_from_tracing(lvl: &tracing::Level) -> LogLevel {
+pub fn level_from_tracing(lvl: &tracing::Level) -> LogLevel {
     match lvl.as_str() {
         "TRACE" => LogLevel::Trace,
         "DEBUG" => LogLevel::Debug,

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -472,7 +472,8 @@ expression: "&schema"
           "title": "Dekaf endpoint config."
         },
         "variant": {
-          "title": "Dekaf variant type",
+          "title": "Dekaf variant type.",
+          "description": "Since we support integrating with a bunch of different providers via Dekaf, this allows us to store which of those connector variants this particular Dekaf connector was created as, in order to e.g link to the correct docs URL, show the correct name and logo, etc.",
           "type": "string"
         }
       }

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -468,7 +468,8 @@
           "title": "Dekaf endpoint config."
         },
         "variant": {
-          "title": "Dekaf variant type",
+          "title": "Dekaf variant type.",
+          "description": "Since we support integrating with a bunch of different providers via Dekaf, this allows us to store which of those connector variants this particular Dekaf connector was created as, in order to e.g link to the correct docs URL, show the correct name and logo, etc.",
           "type": "string"
         }
       }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -76,6 +76,17 @@ begin
   insert into public.connector_tags (connector_id, image_tag) values (connector_id, ':dev');
 
   insert into public.connectors (image_name, title, short_description, logo_url, external_url, recommended) values (
+    'ghcr.io/estuary/source-http-ingest',
+    json_build_object('en-US','HTTP Webhook'),
+    json_build_object('en-US','Captures HTTP requests sent by webhooks or other clients'),
+    json_build_object('en-US','https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//61de33_Group_22481_150x150_bdfc5a186d/61de33_Group_22481_150x150_bdfc5a186d.png'),
+    'https://estuary.dev',
+    true
+  )
+  returning id strict into connector_id;
+  insert into public.connector_tags (connector_id, image_tag) values (connector_id, ':dev');
+
+  insert into public.connectors (image_name, title, short_description, logo_url, external_url, recommended) values (
     'ghcr.io/estuary/source-postgres',
     json_build_object('en-US','PostgreSQL'),
     json_build_object('en-US','Capture PostgreSQL tables into collections'),


### PR DESCRIPTION
**Description:**

As part of #1876, we want to implement broker fallback so Dekaf can connect to any of the brokers in the cluster if one doesn't respond. This adds the ability to pass a list of broker addresses, which Dekaf will try one after another until one picks up.

An improvement here would be to periodically fetch the metadata from at least one of the responding brokers and update this list of addresses so that future sessions can know about/use any newly created members of the cluster. I don't anticipate changing the topology of our cluster that frequently, and if we do then updating Dekaf's deployment configs isn't that big of a deal. I may eat my hat on this, we'll see.

In addition, we want to move people over to the new MSK cluster, so this implements routing new-style connections to a separate cluster with separate credentials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1911)
<!-- Reviewable:end -->
