### PR TITLE
Docs: Connector references for MongoDB variants, Brevo, Criteo

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
@@ -1,0 +1,116 @@
+# Amazon DocumentDB
+
+This connector captures data from your Amazon DocumentDB collections into Flow collections.
+
+[`ghcr.io/estuary/source-amazon-documentdb:dev`](https://ghcr.io/estuary/source-amazon-documentdb:dev) provides the
+latest connector image. You can also follow the link in your browser to see past image versions.
+
+## Data model
+
+Amazon DocumentDB is a NoSQL database. It is compatible with [MongoDB's data
+model](https://www.mongodb.com/docs/manual/core/data-modeling-introduction/), which consists of
+**documents** (lightweight records that contain mappings of fields and values) organized in
+**collections**. MongoDB documents have a mandatory `_id` field that is used as the key of the
+collection.
+
+## Prerequisites
+
+You'll need:
+
+- Credentials for connecting to your Amazon DocumentDB instance and database.
+
+- Read access to your DocumentDB database(s). See [Database access using Role-Based Access
+  Control](https://docs.aws.amazon.com/documentdb/latest/developerguide/role_based_access_control.html) for more information.
+
+## Capture Modes
+
+A "batch" mode of capturing documents can be used. The capture mode is configured on a per-collection level in the
+**Bindings** configuration and can be one of the following:
+- **Batch Snapshot**: Performs a "full refresh" by scanning the entire DocumentDB
+  collection on a set schedule. A cursor field must be configured, which should
+  usually be the `_id` field.
+- **Batch Incremental**: Performs a scan on a set schedule where only documents
+  having a higher cursor field value than previously observed are captured. This
+  mode should be used for append-only collections, or where a field value is
+  known to be strictly increasing for all document insertions and updates.
+
+:::tip Using Cursor Fields
+For best performance the selected cursor field should have an
+[index](https://www.mongodb.com/docs/manual/indexes/). This ensures backfill
+queries are able to be run efficiently, since they require sorting the
+collection based on the cursor field.
+:::
+
+:::tip Time Series Collections
+Time series collections do _not_ have a default index on the `_id`, but do have
+an index on the `timeField` for the collection. This makes the `timeField` a
+good choice for an incremental cursor if new documents are only ever added to
+the collection with strictly increasing values for the `timeField`. The capture
+connector will automatically discover time series collections in **Batch
+Incremental** mode with the cursor set to the collection's `timeField`.
+:::
+
+**Batch Snapshot** will capture updates by virtue of it re-capturing the
+entire source collection periodically. **Batch Incremental** _may_ capture
+updates to documents if updated documents have strictly increasing values for
+the cursor field.
+
+
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the Flow specification
+file. See [connectors](../../../../concepts/connectors.md#using-connectors) to learn more about using
+connectors. The values and specification sample below provide configuration details specific to the
+Amazon DocumentDB source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property                | Title                                                              | Description                                                                                                                                                                                                                                                                                                     | Type    | Required/Default |
+|-------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|------------------|
+| **`/address`**          | Address                                                            | Host and port of the database. Optionally can specify scheme for the URL such as mongodb+srv://host.                                                                                                                                                                                                            | string  | Required         |
+| **`/user`**             | User                                                               | Database user to connect as.                                                                                                                                                                                                                                                                                    | string  | Required         |
+| **`/password`**         | Password                                                           | Password for the specified database user.                                                                                                                                                                                                                                                                       | string  | Required         |
+| `/database`             | Database                                                           | Optional comma-separated list of the databases to discover. If not provided will discover all available databases in the instance.                                                                                                                                                                              | string  |                  |
+| `/batchAndChangeStream` | Capture Batch Collections in Addition to Change Stream Collections | Discover collections that can only be batch captured if the deployment supports change streams. Check this box to capture views and time series collections as well as change streams. All collections will be captured in batch mode if the server does not support change streams regardless of this setting. | boolean |                  |
+| `/pollSchedule`         | Default Batch Collection Polling Schedule                          | When and how often to poll batch collections. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset                                                                 | string  |                  |
+
+#### Bindings
+
+| Property          | Title            | Description                                                                                                                                                                                                                                                                                | Type   | Required/Default |
+|-------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|------------------|
+| **`/database`**   | Database         | Database name                                                                                                                                                                                                                                                                              | string | Required         |
+| **`/collection`** | Stream           | Collection name                                                                                                                                                                                                                                                                            | string | Required         |
+| `/captureMode`    | Capture Mode     | Either **Batch Snapshot**, or **Batch Incremental**                                                                                                                                                                                                         | string |                  |
+| `/cursorField`    | Cursor Field     | The name of the field to use as a cursor for batch-mode bindings. For best performance this field should be indexed. When used with 'Batch Incremental' mode documents added to the collection are expected to always have the cursor field and for it to be strictly increasing.          | string |                  |
+| `/pollSchedule`   | Polling Schedule | When and how often to poll batch collections (overrides the connector default setting). Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset. | string |                  |
+
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-amazon-documentdb:dev
+        config:
+          address: "mongo:27017"
+          password: "flow"
+          user: "flow"
+    bindings:
+      - resource:
+          collection: users
+          database: test
+        target: ${PREFIX}/users
+```
+
+## SSH Tunneling
+
+As an alternative to connecting to your DocumentDB instance directly, you can allow secure connections via [SSH tunneling](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect-from-outside-a-vpc.html). To do so:
+
+1. Refer to the [guide](../../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+
+2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](../../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.

--- a/site/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
@@ -1,0 +1,120 @@
+# Azure CosmosDB
+
+This connector captures data from your Azure Cosmos DB collections into Flow collections.
+
+[`ghcr.io/estuary/source-cosmosdb-mongodb:dev`](https://ghcr.io/estuary/source-cosmosdb-mongodb:dev) provides the
+latest connector image. You can also follow the link in your browser to see past image versions.
+
+## Data model
+
+Azure Cosmos DB is a NoSQL database. It is compatible with [MongoDB's data
+model](https://www.mongodb.com/docs/manual/core/data-modeling-introduction/), which consists of
+**documents** (lightweight records that contain mappings of fields and values) organized in
+**collections**. MongoDB documents have a mandatory `_id` field that is used as the key of the
+collection.
+
+## Prerequisites
+
+You'll need:
+
+- Credentials for connecting to your Cosmos DB instance and database.
+
+- Read access to your Cosmos DB database(s). See [Use control plane role-based access control with Azure Cosmos DB for NoSQL](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/security/how-to-grant-control-plane-role-based-access) for more information.
+
+- If your Cosmos DB instance has an [IP firewall](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall) configured, you need to
+  [allowlist the Estuary IP addresses](/reference/allow-ip-addresses).
+
+## Capture Modes
+
+Azure Cosmos DB [change feeds](https://learn.microsoft.com/en-us/azure/cosmos-db/change-feed) are
+the preferred way to capture on-going changes to collections. Change streams
+allow capturing real-time events representing new documents in your collections,
+updates to existing documents, and deletions of documents. If change streams are
+enabled on the Cosmos DB instance/deployment you are connecting to, they will be
+used preferentially for capturing changes.
+
+An alternate "batch" mode of capturing documents can be used for deployments
+that do not support change streams, and for Cosmos DB collection types that do not
+support change streams. The capture mode is configured on a per-collection level in the
+**Bindings** configuration and can be one of the following:
+- **Change Stream Incremental**: This is the preferred mode and uses change streams to capture change events.
+- **Batch Snapshot**: Performs a "full refresh" by scanning the entire Cosmos DB
+  collection on a set schedule. A cursor field must be configured, which should
+  usually be the `_id` field.
+- **Batch Incremental**: Performs a scan on a set schedule where only documents
+  having a higher cursor field value than previously observed are captured. This
+  mode should be used for append-only collections, or where a field value is
+  known to be strictly increasing for all document insertions and updates.
+
+:::tip Using Cursor Fields
+For best performance the selected cursor field should have an
+[index](https://www.mongodb.com/docs/manual/indexes/). This ensures backfill
+queries are able to be run efficiently, since they require sorting the
+collection based on the cursor field.
+:::
+
+:::tip Time Series Collections
+Time series collections do _not_ have a default index on the `_id`, but do have
+an index on the `timeField` for the collection. This makes the `timeField` a
+good choice for an incremental cursor if new documents are only ever added to
+the collection with strictly increasing values for the `timeField`. The capture
+connector will automatically discover time series collections in **Batch
+Incremental** mode with the cursor set to the collection's `timeField`.
+:::
+
+Only the **Change Stream Incremental** mode is capable of capturing deletion
+events. **Batch Snapshot** will capture updates by virtue of it re-capturing the
+entire source collection periodically. **Batch Incremental** _may_ capture
+updates to documents if updated documents have strictly increasing values for
+the cursor field.
+
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the Flow specification
+file. See [connectors](../../../../concepts/connectors.md#using-connectors) to learn more about using
+connectors. The values and specification sample below provide configuration details specific to the
+Azure Cosmos DB source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property                | Title                                                              | Description                                                                                                                                                                                                                                                                                                     | Type    | Required/Default |
+|-------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|------------------|
+| **`/address`**          | Address                                                            | Host and port of the database. Optionally can specify scheme for the URL such as mongodb+srv://host.                                                                                                                                                                                                            | string  | Required         |
+| **`/user`**             | User                                                               | Database user to connect as.                                                                                                                                                                                                                                                                                    | string  | Required         |
+| **`/password`**         | Password                                                           | Password for the specified database user.                                                                                                                                                                                                                                                                       | string  | Required         |
+| `/database`             | Database                                                           | Optional comma-separated list of the databases to discover. If not provided will discover all available databases in the instance.                                                                                                                                                                              | string  |                  |
+| `/batchAndChangeStream` | Capture Batch Collections in Addition to Change Stream Collections | Discover collections that can only be batch captured if the deployment supports change streams. Check this box to capture views and time series collections as well as change streams. All collections will be captured in batch mode if the server does not support change streams regardless of this setting. | boolean |                  |
+| `/pollSchedule`         | Default Batch Collection Polling Schedule                          | When and how often to poll batch collections. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset                                                                 | string  |                  |
+
+#### Bindings
+
+| Property          | Title            | Description                                                                                                                                                                                                                                                                                | Type   | Required/Default |
+|-------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|------------------|
+| **`/database`**   | Database         | Database name                                                                                                                                                                                                                                                                              | string | Required         |
+| **`/collection`** | Stream           | Collection name                                                                                                                                                                                                                                                                            | string | Required         |
+| `/captureMode`    | Capture Mode     | Either **Change Stream Incremental**, **Batch Snapshot**, or **Batch Incremental**                                                                                                                                                                                                         | string |                  |
+| `/cursorField`    | Cursor Field     | The name of the field to use as a cursor for batch-mode bindings. For best performance this field should be indexed. When used with 'Batch Incremental' mode documents added to the collection are expected to always have the cursor field and for it to be strictly increasing.          | string |                  |
+| `/pollSchedule`   | Polling Schedule | When and how often to poll batch collections (overrides the connector default setting). Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset. | string |                  |
+
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-cosmosdb-mongodb:dev
+        config:
+          address: "mongo:27017"
+          password: "flow"
+          user: "flow"
+    bindings:
+      - resource:
+          collection: users
+          database: test
+        target: ${PREFIX}/users
+```

--- a/site/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
@@ -5,6 +5,13 @@ This connector captures data from your MongoDB collections into Flow collections
 [`ghcr.io/estuary/source-mongodb:dev`](https://ghcr.io/estuary/source-mongodb:dev) provides the
 latest connector image. You can also follow the link in your browser to see past image versions.
 
+## Supported platforms
+
+The MongoDB connector has a couple variants to support additional document-based database options. Continue reading this page for standard MongoDB setup or see one of the following:
+
+* [Amazon DocumentDB](./amazon-documentdb.md)
+* [Azure Cosmos DB](./azure-cosmosdb.md)
+
 ## Data model
 
 MongoDB is a NoSQL database. Its [data
@@ -17,7 +24,7 @@ collection.
 
 You'll need:
 
-- Credentials for connecting to your MongoDB instance and database
+- Credentials for connecting to your MongoDB instance and database.
 
 - Read access to your MongoDB database(s), see [Role-Based Access
   Control](https://www.mongodb.com/docs/manual/core/authorization/) for more information.
@@ -78,11 +85,10 @@ updates to documents if updated documents have strictly increasing values for
 the cursor field.
 
 
-
 ## Configuration
 
 You configure connectors either in the Flow web app, or by directly editing the Flow specification
-file. See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using
+file. See [connectors](../../../../concepts/connectors.md#using-connectors) to learn more about using
 connectors. The values and specification sample below provide configuration details specific to the
 MongoDB source connector.
 
@@ -133,9 +139,9 @@ captures:
 
 As an alternative to connecting to your MongoDB instance directly, you can allow secure connections via SSH tunneling. To do so:
 
-1. Refer to the [guide](../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+1. Refer to the [guide](../../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
 
-2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
+2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](../../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
 
 ## Backfill and real-time updates
 

--- a/site/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
+++ b/site/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
@@ -139,7 +139,7 @@ captures:
 
 As an alternative to connecting to your MongoDB instance directly, you can allow secure connections via SSH tunneling. To do so:
 
-1. Refer to the [guide](../../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+1. Refer to the [guide](../../../../guides/connect-network.md) to configure an SSH server on the cloud platform of your choice.
 
 2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](../../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
 

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -141,7 +141,7 @@ All Estuary connectors capture data in real time, as it appears in the source sy
   - [Configuration](./SQLServer/)
   - Package - ghcr.io/estuary/source-sqlserver:dev
 - MongoDB
-  - [Configuration](./mongodb/)
+  - [Configuration](./MongoDB/mongodb.md)
   - Package - ghcr.io/estuary/source-mongodb:dev
 - MySQL
   - [Configuration](./MySQL/)

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -23,6 +23,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Alpaca
   - [Configuration](./alpaca.md)
   - Package - ghcr.io/estuary/source-alpaca:dev
+- Amazon DocumentDB
+  - [Configuration](./MongoDB/amazon-documentdb.md)
+  - Package - ghcr.io/estuary/source-amazon-documentdb:dev
 - Amazon Dynamodb
   - [Configuration](./amazon-dynamodb.md)
   - Package - ghcr.io/estuary/source-dynamodb:dev
@@ -47,6 +50,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Azure Blob Storage
   - [Configuration](./azure-blob-storage.md)
   - Package — ghcr.io/estuary/azure-blob-storage:dev
+- Azure Cosmos DB
+  - [Configuration](./MongoDB/azure-cosmosdb.md)
+  - Package - ghcr.io/estuary/source-cosmosdb-mongodb:dev
 - Azure SQL Server
   - [Configuration](./SQLServer/)
   - Package - ghcr.io/estuary/source-azure-sqlserver:dev
@@ -56,6 +62,12 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Braintree
   - [Configuration](./braintree.md)
   - Package - ghcr.io/estuary/source-braintree-native:dev
+- Brevo
+  - [Configuration](./brevo.md)
+  - Package - ghcr.io/estuary/source-brevo:dev
+- Criteo
+  - [Configuration](./criteo.md)
+  - Package - ghcr.io/estuary/source-criteo:dev
 - Dropbox
   - [Configuration](./dropbox.md)
   - Package - ghcr.io/estuary/source-dropbox:dev

--- a/site/docs/reference/Connectors/capture-connectors/brevo.md
+++ b/site/docs/reference/Connectors/capture-connectors/brevo.md
@@ -1,0 +1,63 @@
+
+# Brevo
+
+This connector captures data from [Brevo's REST API](https://developers.brevo.com/reference).
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-brevo:dev`](https://ghcr.io/estuary/source-brevo:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+## Supported data resources
+
+The following data resources are supported through the Brevo APIs:
+
+* [Contacts](https://developers.brevo.com/reference/getcontacts-1)
+* [Contacts Attributes](https://developers.brevo.com/reference/getattributes-1)
+* [Contacts Lists](https://developers.brevo.com/reference/getlists-1)
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+If your use case requires additional Brevo APIs, such as Campaigns, Events, or Accounts, [contact us](mailto:info@estuary.dev) to discuss the possibility of expanding this connector.
+
+## Prerequisites
+
+You will need a Brevo API key. See [Brevo's documentation](https://developers.brevo.com/docs/getting-started#using-your-api-key-to-authenticate) for instructions on creating one.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Brevo source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| `/api-key` | API Key | The Brevo API key used for authentication. | string | Required |
+| `/start_date` | Start Date | Earliest date to read data from. Uses date-time format, ex. `YYYY-MM-DDT00:00:00.000Z`. | string |  |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Brevo resource from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+```yaml
+
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-brevo:dev
+        config:
+          api-key: {secret}
+          start_date: 2025-01-01T00:00:00.000Z
+    bindings:
+      - resource:
+          stream: contacts
+          syncMode: full_refresh
+        target: ${PREFIX}/contacts
+      {...}
+```

--- a/site/docs/reference/Connectors/capture-connectors/criteo.md
+++ b/site/docs/reference/Connectors/capture-connectors/criteo.md
@@ -1,0 +1,84 @@
+
+# Criteo
+
+This connector captures data from [Criteo's API](https://developers.criteo.com/marketing-solutions/reference).
+
+It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-criteo:dev`](https://ghcr.io/estuary/source-criteo:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+## Supported data resources
+
+The following data resources are supported through the Criteo APIs:
+
+* [Ad Sets](https://developers.criteo.com/marketing-solutions/docs/ad-set)
+* [Advertisers](https://developers.criteo.com/marketing-solutions/docs/get-advertiser-portfolio)
+* [Audiences](https://developers.criteo.com/marketing-solutions/docs/audiences)
+* [Audiences (Legacy)](https://developers.criteo.com/marketing-solutions/v2020.07/docs/get-existing-audiences)
+* [Campaigns (Legacy)](https://developers.criteo.com/marketing-solutions/v2020.07/docs/get-existing-campaigns)
+* [Campaigns (Preview)](https://developers.criteo.com/marketing-solutions/docs/campaigns)
+* [Categories (Legacy)](https://developers.criteo.com/marketing-solutions/v2020.07/docs/campaigns-get-campaign-categories)
+
+You may also configure multiple [Report](https://developers.criteo.com/marketing-solutions/docs/campaign-statistics) resources based on desired dimensions and metrics.
+
+By default, each resource is mapped to a Flow collection through a separate binding.
+
+## Prerequisites
+
+To set up a Criteo source connector in Flow, you will need:
+
+* A Criteo Client ID
+* A Criteo Client Secret
+* One or more Advertiser IDs
+
+See Criteo's documentation for information on [authentication](https://developers.criteo.com/marketing-solutions/docs/authentication) and where to find your IDs.
+
+## Configuration
+
+You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Criteo source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| `/client_id` | Client ID | The Criteo client ID used for authentication. | string | Required |
+| `/client_secret` | Client Secret | The Criteo client secret used for authentication. | string | Required |
+| `/advertiser_ids` | Advertiser IDs | One or more Criteo advertiser IDs. | string[] | Required |
+| `/start_date` | Start Date | Earliest date to read data from. Uses UTC date-time format, ex. `YYYY-MM-DDT00:00:00.000Z`. | string | Required |
+| `/reports` | Reports | Optional configuration for additional report streams. | object[] |  |
+| `/reports/-/name` | Report Name | The report's name. | string |  |
+| `/reports/-/dimensions` | Report Dimensions | An array of dimensions. See [Criteo's documentation](https://developers.criteo.com/marketing-solutions/docs/campaign-statistics#dimensions) for possible options. | string |  |
+| `/reports/-/metrics` | Report Metrics | An array of metrics. See [Criteo's documentation](https://developers.criteo.com/marketing-solutions/docs/campaign-statistics#full-list-of-metrics) for possible options. | string |  |
+| `/reports/-/currency` | Report Currency | The report's currency. | string | `USD` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/stream`** | Stream | Criteo resource from which collections are captured. | string | Required |
+| **`/syncMode`** | Sync Mode | Connection method. | string | Required |
+
+### Sample
+
+```yaml
+
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-criteo:dev
+        config:
+          client_id: {secret}
+          client_secret: {secret}
+          advertiser_ids:
+            - "12345"
+            - "67890"
+          start_date: 2025-01-01T00:00:00.000Z
+    bindings:
+      - resource:
+          stream: advertisers
+          syncMode: full_refresh
+        target: ${PREFIX}/advertisers
+      {...}
+```


### PR DESCRIPTION
**Description:**

This update adds connector reference docs for Amazon DocumentDB, Azure Cosmos DB, Brevo, and Criteo. DocumentDB and Cosmos DB are variants of MongoDB, with some modifications (ex. DocumentDB does not support CDC).

**Documentation links affected:**

Will add pages for:
* [Amazon DocumentDB](https://docs.estuary.dev/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb/)
* [Azure Cosmos DB](https://docs.estuary.dev/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb/)
* [Brevo](https://docs.estuary.dev/reference/Connectors/capture-connectors/brevo/)
* [Criteo](https://docs.estuary.dev/reference/Connectors/capture-connectors/criteo/)

And adds minor modifications to the main connector reference page and existing MongoDB reference.

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1916)
<!-- Reviewable:end -->
