### PR TITLE
docs: SEO update for the connector docs

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6908,9 +6908,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6931,7 +6931,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -6946,6 +6946,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/content-disposition": {
@@ -6973,9 +6977,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/express/node_modules/range-parser": {
       "version": "1.2.1",
@@ -7026,14 +7030,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -13825,11 +13821,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
-    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -15091,24 +15082,23 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -16858,9 +16848,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17147,9 +17137,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4611,9 +4611,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001633",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-      "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==",
+      "version": "1.0.30001699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4627,8 +4627,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/ccount": {
       "version": "2.0.1",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/plugin-google-tag-manager": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
         "@mdx-js/react": "^3.0.1",
+        "cheerio": "^1.0.0",
         "clsx": "^2.1.1",
         "docusaurus-lunr-search": "^3.4.0",
         "mermaid": "^10.9.3",
@@ -4703,21 +4704,24 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -6584,6 +6588,18 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8622,9 +8638,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -8632,12 +8648,11 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -12898,12 +12913,11 @@
       "license": "ISC"
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "license": "MIT",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -12916,6 +12930,17 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -16057,6 +16082,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -16966,6 +16999,25 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "postBuild": "node postBuildCustomizations.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -20,6 +21,7 @@
     "@docusaurus/plugin-google-tag-manager": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@mdx-js/react": "^3.0.1",
+    "cheerio": "^1.0.0",
     "clsx": "^2.1.1",
     "docusaurus-lunr-search": "^3.4.0",
     "mermaid": "^10.9.3",
@@ -27,8 +29,8 @@
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "reodotdev": "^1.0.0",
     "react-player": "^2.16.0",
+    "reodotdev": "^1.0.0",
     "stable": "^0.1.8"
   },
   "devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build; npm run postBuild",
-    "postBuild": "node postBuildCustomizations.js",
+    "build": "docusaurus build",
+    "postbuild": "node postBuildCustomizations.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build; npm run postBuild",
     "postBuild": "node postBuildCustomizations.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -1,0 +1,42 @@
+const cheerio = require('cheerio');
+const fs = require('fs');
+
+const outputDir = './build';
+const connectorsDir = `${outputDir}/reference/Connectors`
+const divider = ' | ';
+
+const updateAllConnectorPages = (params, titleAddition) => {
+    console.log('Customizing BEGIN')
+
+    fs.readdirSync(params, {
+        recursive: true,
+    }).forEach(file => {
+
+        if (file.includes('.html')) {
+            const $cheer = cheerio.load(fs.readFileSync(`${connectorsDir}/${file}`));
+            const $title = $cheer("title")
+            const titleText = $title.text();
+
+            if (!titleText.includes(titleAddition)) {
+                const fileFullPath = `${connectorsDir}/${file}`;
+                console.log('-updating', {
+                    path: fileFullPath
+                })
+
+                const newTitle = titleText.replace(divider, titleAddition);
+
+                $title.text(newTitle);
+
+                console.log(`-title`, {
+                    newTitle
+                })
+
+                fs.writeFileSync(fileFullPath, $cheer.html());
+            }
+        }
+    });
+    console.log('Customizing DONE')
+
+}
+
+updateAllConnectorPages(connectorsDir, `Connector${divider}`);

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -32,9 +32,11 @@ const updateAllConnectorPages = (params, titleAddition) => {
                 // Skip if plural version is there (ex: Capture Connectors)
                 !titleText.toLowerCase().includes(`${connector}s |`.toLowerCase())
             ) {
-                console.debug(`    -updating ${fileFullPath}`)
+                const newTitle = titleText.replace(divider, titleAddition);
+                console.debug(`    - updating ${fileFullPath}`)
+                console.debug(`       "${newTitle}"`)
 
-                $title.text(titleText.replace(divider, titleAddition));
+                $title.text(newTitle);
                 fs.writeFileSync(fileFullPath, $cheer.html());
                 updateCount += 1;
             }

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -13,11 +13,11 @@ const updateAllConnectorPages = (params, titleAddition) => {
     }).forEach(file => {
 
         if (file.includes('.html')) {
-            const $cheer = cheerio.load(fs.readFileSync(`${connectorsDir}/${file}`));
+            const fileFullPath = `${connectorsDir}/${file}`;
+            const $cheer = cheerio.load(fs.readFileSync(fileFullPath));
             const $title = $cheer("title")
 
             if (!$title.text().includes(titleAddition)) {
-                const fileFullPath = `${connectorsDir}/${file}`;
                 console.log('-updating', {
                     path: fileFullPath
                 })

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -18,9 +18,7 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const $title = $cheer("title")
 
             if (!$title.text().includes(titleAddition)) {
-                console.log('-updating', {
-                    path: fileFullPath
-                })
+                console.log(`-updating ${fileFullPath}`)
 
                 $title.text(titleText.replace(divider, titleAddition));
                 fs.writeFileSync(fileFullPath, $cheer.html());

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -16,8 +16,9 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const fileFullPath = `${connectorsDir}/${file}`;
             const $cheer = cheerio.load(fs.readFileSync(fileFullPath));
             const $title = $cheer("title")
+            const titleText = $title.text();
 
-            if (!$title.text().includes(titleAddition)) {
+            if (!titleText.includes(titleAddition)) {
                 console.log(`-updating ${fileFullPath}`)
 
                 $title.text(titleText.replace(divider, titleAddition));

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -33,8 +33,8 @@ const updateAllConnectorPages = (params, titleAddition) => {
                 !titleText.toLowerCase().includes(`${connector}s |`.toLowerCase())
             ) {
                 const newTitle = titleText.replace(divider, titleAddition);
-                console.debug(`    - updating ${fileFullPath}`)
-                console.debug(`       "${newTitle}"`)
+                console.debug(`  - updating ${fileFullPath}`)
+                console.debug(`   "${newTitle}"`)
 
                 $title.text(newTitle);
                 fs.writeFileSync(fileFullPath, $cheer.html());

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -33,8 +33,8 @@ const updateAllConnectorPages = (params, titleAddition) => {
                 !titleText.toLowerCase().includes(`${connector}s |`.toLowerCase())
             ) {
                 const newTitle = titleText.replace(divider, titleAddition);
-                console.debug(`  - updating ${fileFullPath}`)
-                console.debug(`   "${newTitle}"`)
+                console.debug(`  - updating    : ${fileFullPath}`)
+                console.debug(`    - new title : ${newTitle}`)
 
                 $title.text(newTitle);
                 fs.writeFileSync(fileFullPath, $cheer.html());

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -22,15 +22,15 @@ const updateAllConnectorPages = (params, titleAddition) => {
 
             if (
                 // Skip if we are on a specific "root" page
-                !titleText.startsWith(connector) &&
-                !titleText.startsWith('Dekaf integrations') && 
-                !titleText.startsWith('Materialization Protocol') && 
+                !titleText.toLowerCase().startsWith(connector.toLowerCase()) &&
+                !titleText.toLowerCase().startsWith('dekaf integrations'.toLowerCase()) && 
+                !titleText.toLowerCase().startsWith('materialization protocol'.toLowerCase()) && 
 
                 // Skip if it is already there
-                !titleText.includes(titleAddition) && 
+                !titleText.toLowerCase().includes(titleAddition) && 
 
                 // Skip if plural version is there (ex: Capture Connectors)
-                !titleText.includes(`${connector}s |`)
+                !titleText.toLowerCase().includes(`${connector}s |`.toLowerCase())
             ) {
                 console.debug(`    -updating ${fileFullPath}`)
 

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -20,10 +20,17 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const $title = $cheer("title")
             const titleText = $title.text();
 
-            if (!titleText.startsWith('Connector') &&
+            if (
+                // Skip if we are on a specific "root" page
+                !titleText.startsWith(connector) &&
                 !titleText.startsWith('Dekaf integrations') && 
+                !titleText.startsWith('Materialization Protocol') && 
+
+                // Skip if it is already there
                 !titleText.includes(titleAddition) && 
-                !titleText.includes('connectors |')
+
+                // Skip if plural version is there (ex: Capture Connectors)
+                !titleText.includes(`${connector}s |`)
             ) {
                 console.debug(`    -updating ${fileFullPath}`)
 

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 
 const outputDir = './build';
 const connectorsDir = `${outputDir}/reference/Connectors`
+const connector = 'Connector';
 const divider = ' | ';
 
 const updateAllConnectorPages = (params, titleAddition) => {
@@ -19,7 +20,7 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const $title = $cheer("title")
             const titleText = $title.text();
 
-            if (!titleText.includes(titleAddition)) {
+            if (!titleText.includes(titleAddition) && !titleText.startsWith(connector)) {
                 console.debug(`    -updating ${fileFullPath}`)
 
                 $title.text(titleText.replace(divider, titleAddition));
@@ -33,4 +34,4 @@ const updateAllConnectorPages = (params, titleAddition) => {
 
 }
 
-updateAllConnectorPages(connectorsDir, ` Connector${divider}`);
+updateAllConnectorPages(connectorsDir, ` ${connector}${divider}`);

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -8,6 +8,7 @@ const divider = ' | ';
 const updateAllConnectorPages = (params, titleAddition) => {
     console.log('Customizing BEGIN')
 
+    let updateCount = 0;
     fs.readdirSync(params, {
         recursive: true,
     }).forEach(file => {
@@ -19,13 +20,15 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const titleText = $title.text();
 
             if (!titleText.includes(titleAddition)) {
-                console.log(`-updating ${fileFullPath}`)
+                console.debug(`    -updating ${fileFullPath}`)
 
                 $title.text(titleText.replace(divider, titleAddition));
                 fs.writeFileSync(fileFullPath, $cheer.html());
+                updateCount += 1;
             }
         }
     });
+    console.log(` - updated ${updateCount}`)
     console.log('Customizing DONE')
 
 }

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -15,22 +15,14 @@ const updateAllConnectorPages = (params, titleAddition) => {
         if (file.includes('.html')) {
             const $cheer = cheerio.load(fs.readFileSync(`${connectorsDir}/${file}`));
             const $title = $cheer("title")
-            const titleText = $title.text();
 
-            if (!titleText.includes(titleAddition)) {
+            if (!$title.text().includes(titleAddition)) {
                 const fileFullPath = `${connectorsDir}/${file}`;
                 console.log('-updating', {
                     path: fileFullPath
                 })
 
-                const newTitle = titleText.replace(divider, titleAddition);
-
-                $title.text(newTitle);
-
-                console.log(`-title`, {
-                    newTitle
-                })
-
+                $title.text(titleText.replace(divider, titleAddition));
                 fs.writeFileSync(fileFullPath, $cheer.html());
             }
         }
@@ -39,4 +31,4 @@ const updateAllConnectorPages = (params, titleAddition) => {
 
 }
 
-updateAllConnectorPages(connectorsDir, `Connector${divider}`);
+updateAllConnectorPages(connectorsDir, ` Connector${divider}`);

--- a/site/postBuildCustomizations.js
+++ b/site/postBuildCustomizations.js
@@ -20,7 +20,11 @@ const updateAllConnectorPages = (params, titleAddition) => {
             const $title = $cheer("title")
             const titleText = $title.text();
 
-            if (!titleText.includes(titleAddition) && !titleText.startsWith(connector)) {
+            if (!titleText.startsWith('Connector') &&
+                !titleText.startsWith('Dekaf integrations') && 
+                !titleText.includes(titleAddition) && 
+                !titleText.includes('connectors |')
+            ) {
                 console.debug(`    -updating ${fileFullPath}`)
 
                 $title.text(titleText.replace(divider, titleAddition));


### PR DESCRIPTION
**Description:**

### https://github.com/estuary/flow/issues/1934

- Added a new script that steps through connector pages and updates the title to include `Connector` to try to help with search

### Misc

- Updated the browser list
- ran `npm audit fix` to handle 3 of the 4 audit issues

**Workflow steps:**

This impacts developer / build process. We will not have a new "post build" step that runs after the current build and steps through the output of Docusaurus and updates the titles.

out put example:
```shell
...
  - updating    : ./build/reference/Connectors/materialization-connectors/PostgreSQL/google-cloud-sql-postgres/index.html
    - new title : Google Cloud SQL for PostgreSQL Connector | Estuary Flow Documentation
  - updating    : ./build/reference/Connectors/materialization-connectors/SQLServer/amazon-rds-sqlserver/index.html
    - new title : Amazon RDS for SQL Server Connector | Estuary Flow Documentation
  - updating    : ./build/reference/Connectors/materialization-connectors/SQLServer/google-cloud-sql-sqlserver/index.html
    - new title : Google Cloud SQL for SQLServer Connector | Estuary Flow Documentation
 - updated 156
Customizing DONE

```


**Documentation links affected:**

Paths under `/reference/Connectors/`

**Notes for reviewers:**

Would be nice to make sure you can run a `npm run build` in the docs site

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1933)
<!-- Reviewable:end -->
