### PR TITLE
models: refactor Schema APIs and introduce relaxation

### DIFF
--- a/crates/agent/src/integration_tests/schema_evolution.rs
+++ b/crates/agent/src/integration_tests/schema_evolution.rs
@@ -1,11 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::harness::{draft_catalog, mock_inferred_schema, FailBuild, TestHarness};
-use crate::{
-    controllers::ControllerState,
-    publications::{JobStatus, UncommittedBuild},
-    ControlPlane,
-};
+use crate::{controllers::ControllerState, publications::UncommittedBuild, ControlPlane};
 use models::CatalogType;
 use proto_flow::materialize::response::validated::constraint::Type as ConstraintType;
 use tables::BuiltRow;
@@ -176,26 +172,6 @@ async fn test_schema_evolution() {
     assert!(totes_spec
         .read_schema_json
         .contains("inferredSchemaIsNotAvailable"));
-    // Assert that the bundled write schema has been removed. We expect one reference to
-    // the write schema url, down from 3 originally.
-    // TODO: we can remove these assertions (and the bundled write schema in the setup) once
-    // all the collections have been updated.
-    let totes_model = totes_state
-        .live_spec
-        .as_ref()
-        .unwrap()
-        .as_collection()
-        .unwrap();
-    assert_eq!(
-        1,
-        totes_model
-            .read_schema
-            .as_ref()
-            .unwrap()
-            .get()
-            .matches(models::Schema::REF_WRITE_SCHEMA_URL)
-            .count()
-    );
     // Assert that the schema in the built spec _does_ contain the bundled write schema
     assert_eq!(
         3,

--- a/crates/models/src/fixture.schema.json
+++ b/crates/models/src/fixture.schema.json
@@ -1,0 +1,185 @@
+{
+  "$defs": {
+    "PublicFoobar": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "$anchor": "PublicFoobar",
+      "properties": {
+        "an_int": {
+          "description": "(source type: int4)",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "a_string": {
+          "description": "(source type: varchar)",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 16
+        },
+        "an_array_of_timestamps": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "minItems": 128,
+          "maxItems": 128
+        },
+        "id": {
+          "type": "integer",
+          "description": "(source type: non-nullable int4)"
+        },
+        "complex_subproperty": {
+          "if": {
+            "type": "integer"
+          },
+          "then": {
+            "type": "integer"
+          },
+          "else": {
+            "type": "string"
+          },
+          "anyOf": [
+            {
+              "type": "bool"
+            },
+            {
+              "required": [
+                "foo"
+              ]
+            }
+          ],
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "required": [
+                "bar"
+              ]
+            }
+          ],
+          "allOf": [
+            {
+              "type": "integer",
+              "title": "this is relaxed"
+            },
+            {
+              "required": [
+                "quib"
+              ],
+              "title": "so is this"
+            }
+          ],
+          "description": "We should not relax these complex and non-standard sub-schemas, except allOf"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      },
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "properties": {
+        "_meta": {
+          "type": "object",
+          "required": [
+            "op",
+            "source"
+          ],
+          "properties": {
+            "before": {
+              "$ref": "#PublicFoobar",
+              "description": "Record state immediately before this change was applied.",
+              "reduce": {
+                "strategy": "firstWriteWins"
+              }
+            },
+            "op": {
+              "enum": [
+                "c",
+                "d",
+                "u"
+              ],
+              "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+            },
+            "source": {
+              "properties": {
+                "ts_ms": {
+                  "type": "integer",
+                  "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "Database schema (namespace) of the event."
+                },
+                "snapshot": {
+                  "type": "boolean",
+                  "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                },
+                "table": {
+                  "type": "string",
+                  "description": "Database table of the event."
+                },
+                "loc": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array",
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                },
+                "txid": {
+                  "type": "integer",
+                  "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                }
+              },
+              "type": "object",
+              "required": [
+                "schema",
+                "table",
+                "loc"
+              ]
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        }
+      }
+    },
+    {
+      "$ref": "#PublicFoobar"
+    }
+  ]
+}

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -19,7 +19,7 @@ mod materializations;
 pub mod publications;
 mod raw_value;
 mod references;
-mod schemas;
+pub mod schemas;
 mod shards;
 mod source;
 mod source_capture;

--- a/crates/models/src/snapshots/models__schemas__test__references_and_add_defs.snap
+++ b/crates/models/src/snapshots/models__schemas__test__references_and_add_defs.snap
@@ -1,0 +1,66 @@
+---
+source: crates/models/src/schemas.rs
+expression: outcome.to_value()
+---
+{
+  "$defs": {
+    "extra": {
+      "properties": {
+        "f": {
+          "type": "string"
+        }
+      }
+    },
+    "flow://inferred-schema": {
+      "$id": "flow://inferred-schema",
+      "properties": {
+        "a": {
+          "type": "integer"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "flow://write-schema": {
+      "$id": "flow://write-schema",
+      "properties": {
+        "a": {
+          "type": "integer"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "not_overwritten": {
+      "properties": {
+        "f": {
+          "type": "string"
+        }
+      }
+    },
+    "replaced": {
+      "$id": "replaced",
+      "properties": {
+        "a": {
+          "type": "integer"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "flow://inferred-schema"
+    },
+    {
+      "$ref": "flow://write-schema"
+    }
+  ]
+}

--- a/crates/models/src/snapshots/models__schemas__test__relaxation.snap
+++ b/crates/models/src/snapshots/models__schemas__test__relaxation.snap
@@ -1,0 +1,146 @@
+---
+source: crates/models/src/schemas.rs
+expression: fixture.to_relaxed_schema().to_value()
+---
+{
+  "$defs": {
+    "PublicFoobar": {
+      "$anchor": "PublicFoobar",
+      "properties": {
+        "a_string": {
+          "description": "(source type: varchar)",
+          "minLength": 16
+        },
+        "an_array_of_timestamps": {
+          "items": {},
+          "maxItems": 128,
+          "minItems": 128
+        },
+        "an_int": {
+          "description": "(source type: int4)"
+        },
+        "complex_subproperty": {
+          "allOf": [
+            {
+              "title": "this is relaxed"
+            },
+            {
+              "title": "so is this"
+            }
+          ],
+          "anyOf": [
+            {
+              "type": "bool"
+            },
+            {
+              "required": [
+                "foo"
+              ]
+            }
+          ],
+          "description": "We should not relax these complex and non-standard sub-schemas, except allOf",
+          "else": {
+            "type": "string"
+          },
+          "if": {
+            "type": "integer"
+          },
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "required": [
+                "bar"
+              ]
+            }
+          ],
+          "then": {
+            "type": "integer"
+          }
+        },
+        "id": {
+          "description": "(source type: non-nullable int4)"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "else": {
+        "reduce": {
+          "strategy": "merge"
+        }
+      },
+      "if": {
+        "properties": {
+          "_meta": {
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "properties": {
+        "_meta": {
+          "properties": {
+            "before": {
+              "$ref": "#PublicFoobar",
+              "description": "Record state immediately before this change was applied.",
+              "reduce": {
+                "strategy": "firstWriteWins"
+              }
+            },
+            "op": {
+              "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete.",
+              "enum": [
+                "c",
+                "d",
+                "u"
+              ]
+            },
+            "source": {
+              "properties": {
+                "loc": {
+                  "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html",
+                  "items": {},
+                  "maxItems": 3,
+                  "minItems": 3
+                },
+                "schema": {
+                  "description": "Database schema (namespace) of the event."
+                },
+                "snapshot": {
+                  "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                },
+                "table": {
+                  "description": "Database table of the event."
+                },
+                "ts_ms": {
+                  "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                },
+                "txid": {
+                  "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                }
+              }
+            }
+          },
+          "reduce": {
+            "strategy": "merge"
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "delete": true,
+          "strategy": "merge"
+        }
+      }
+    },
+    {
+      "$ref": "#PublicFoobar"
+    }
+  ]
+}


### PR DESCRIPTION
Define a new flow://relaxed-write-schema reference for use within read schemas, and a Schema::to_relaxed_schema() routine for relaxing a Schema.

Make Schema::add_defs() public and the primary interface for adding definitions. Begin to deprecate Schema::extend_read_bundle() and Schema::build_read_schema_bundle(). These will be replaced with direct usage of Schema::add_defs().

Update flow-web to use Schema::add_defs() and to support flow://relaxed-write-schema.

Update the agent to drop support for removing a historically inlined flow://write-schema instances, as we've already removed these.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1937)
<!-- Reviewable:end -->
