### PR TITLE
derive-typescript: update dependencies

### DIFF
--- a/crates/agent/src/integration_tests/schema_evolution.rs
+++ b/crates/agent/src/integration_tests/schema_evolution.rs
@@ -45,14 +45,6 @@ async fn test_schema_evolution() {
                                 "pre-existing": { "type": "integer" }
                             }
                         },
-                        // Include write schema to start, and expect that this is removed
-                        "flow://write-schema": {
-                            "$id": "flow://write-schema",
-                            "type": "object",
-                            "properties": {
-                                "id": { "type": "string" }
-                            }
-                        }
                     },
                     "allOf": [
                         {"$ref": "flow://write-schema"},

--- a/crates/derive-typescript/Cargo.lock
+++ b/crates/derive-typescript/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -351,6 +351,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "form_urlencoded"
@@ -790,6 +796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,7 +823,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -831,7 +846,7 @@ dependencies = [
 [[package]]
 name = "labels"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "doc",
  "percent-encoding",
@@ -907,7 +922,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "models"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "anyhow",
  "caseless",
@@ -994,7 +1009,7 @@ version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb45190a18e771c500291c549959777a3be38d30113a860930bc1f2119f0cc13"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 1.9.3",
  "integer-sqrt",
  "itertools 0.10.5",
@@ -1048,11 +1063,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.7.1",
 ]
 
@@ -1139,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1149,12 +1164,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1169,12 +1184,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -1182,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -1192,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1207,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1530,7 +1545,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "sources"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1601,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "tables"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1805,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow?branch=master#03e8b476fc436aa2f476e354d9b7a0ab1aa0388c"
+source = "git+https://github.com/estuary/flow?branch=master#99cb8686086889bb5495462738ee0fa0b920dbd7"
 dependencies = [
  "memchr",
  "serde_json",

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -18,7 +18,7 @@ const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
 const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.10-54-g93a4078d44";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.10-62-g99cb868608";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,


### PR DESCRIPTION
Updates the flow dependency for derive-typescript to bring in various protocol extensions.

Also updates the CONNECTOR_INIT_IMAGE reference to do the same.

Finally, clean up a lingering `agent` test fixture.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

