### PR TITLE
Revert "validation: allow numbers to be keyed locations"

### DIFF
--- a/crates/json/src/schema/types.rs
+++ b/crates/json/src/schema/types.rs
@@ -274,9 +274,9 @@ impl Set {
     ///
     /// assert!(STRING.is_keyable_type());
     /// assert!(INTEGER.is_keyable_type());
-    /// assert!(FRACTIONAL.is_keyable_type());
+    /// assert!(!FRACTIONAL.is_keyable_type());
     /// assert!(BOOLEAN.is_keyable_type());
-    /// assert!(INT_OR_FRAC.is_keyable_type());
+    /// assert!(!INT_OR_FRAC.is_keyable_type());
     /// assert!((STRING | NULL).is_keyable_type());
     ///
     /// assert!(!(NULL.is_keyable_type()));
@@ -289,7 +289,7 @@ impl Set {
     /// ```
     pub fn is_keyable_type(&self) -> bool {
         match *self - NULL {
-            BOOLEAN | INTEGER | INT_OR_FRAC | FRACTIONAL | STRING => true,
+            BOOLEAN | INTEGER | STRING => true,
             _ => false,
         }
     }

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -81,7 +81,7 @@ pub enum Error {
     PtrRegexUnmatched { ptr: String, unmatched: String },
     #[error("location {ptr} is prohibited from ever existing by the schema {schema}")]
     PtrCannotExist { ptr: String, schema: Url },
-    #[error("location {ptr} accepts {type_:?} in schema {schema}, but locations used as keys may only be null-able numbers, strings, or booleans")]
+    #[error("location {ptr} accepts {type_:?} in schema {schema}, but locations used as keys may only be null-able integers, strings, or booleans")]
     KeyWrongType {
         ptr: String,
         type_: types::Set,

--- a/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__keyed_location_wrong_type.snap
@@ -5,34 +5,34 @@ expression: errors
 [
     Error {
         scope: test://example/int-halve#/collections/testing~1int-halve/key/0,
-        error: location /int accepts "number", "object" in schema test://example/canonical/int-string-len.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/canonical/int-string-len.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-reverse#/collections/testing~1int-reverse/key/0,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string/key/0,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/key/0,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/key/0,
-        error: location /int accepts "number", "object" in schema test://example/int-string#/collections/testing~1int-string-ref-write-schema/readSchema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/int-string#/collections/testing~1int-string-ref-write-schema/readSchema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/key/0,
-        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/int-string.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/key/0,
-        error: location /int accepts "number", "object" in schema test://example/canonical/int-string-len.schema, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://example/canonical/int-string-len.schema, but locations used as keys may only be null-able integers, strings, or booleans,
     },
     Error {
         scope: test://example/int-string#/collections/testing~1int-string.v2/key/0,
-        error: location /int accepts "number", "object" in schema test://inlined/canonical/id, but locations used as keys may only be null-able numbers, strings, or booleans,
+        error: location /int accepts "number", "object" in schema test://inlined/canonical/id, but locations used as keys may only be null-able integers, strings, or booleans,
     },
 ]


### PR DESCRIPTION
This reverts commit d7f30082aa31b720b63af1a09026c4982fd19d41.

We resolved this concern by instead establishing a policy with source-postgres and other connectors, they they use `type: string, format: number` for keyed locations which are numeric.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1940)
<!-- Reviewable:end -->
