### PR TITLE
ci: Bump version of `actions/cache`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           prefix-key: "2404"
 
       - name: Cache/Restore Go dependencies.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
**Description:**

`v2` is deprecated and will go away next month. See https://github.com/actions/cache/discussions/1510, the migration guide claims that we can just upgrade to `@v4`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1945)
<!-- Reviewable:end -->
