### PR TITLE
dekaf: Improve log filtering

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -494,17 +494,17 @@ impl<W: TaskWriter + 'static> TaskForwarder<W> {
     pub fn send_stats(&self, collection_name: String, stats: ops::stats::Binding) {
         if stats
             .left
-            .is_some_and(|s| s.bytes_total == 0 || s.docs_total == 0)
+            .is_some_and(|s| (s.bytes_total == 0) != (s.docs_total == 0))
             || stats
                 .right
-                .is_some_and(|s| s.bytes_total == 0 || s.docs_total == 0)
+                .is_some_and(|s| (s.bytes_total == 0) != (s.docs_total == 0))
             || stats
                 .out
-                .is_some_and(|s| s.bytes_total == 0 || s.docs_total == 0)
+                .is_some_and(|s| (s.bytes_total == 0) != (s.docs_total == 0))
         {
             tracing::error!(
                 ?stats,
-                "Invalid stats document emitted! Cannot emit 0 for `bytes_total` or `docs_total`!"
+                "Invalid stats document emitted! Cannot emit 0 for just one of `bytes_total` or `docs_total`!"
             );
         } else {
             self.send_message(TaskWriterMessage::Stats((collection_name, stats)))

--- a/crates/dekaf/src/logging.rs
+++ b/crates/dekaf/src/logging.rs
@@ -2,7 +2,9 @@ use crate::log_appender::{self, GazetteWriter, TaskForwarder};
 use futures::Future;
 use lazy_static::lazy_static;
 use rand::Rng;
-use tracing::{level_filters::LevelFilter, Instrument};
+use tracing::Instrument;
+use tracing::{level_filters::LevelFilter, Level};
+use tracing_subscriber::filter::Targets;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 // These are accessible anywhere inside the call stack of a future wrapped with [`forward_logs()`].
@@ -10,12 +12,12 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 // from the point at which you call `forward_logs()` downwards will get forwarded to the same journal.
 tokio::task_local! {
     static TASK_FORWARDER: TaskForwarder<GazetteWriter>;
-    static LOG_LEVEL: std::cell::Cell<ops::LogLevel>;
+    static LOG_LEVEL: std::cell::Cell<&'static tracing_subscriber::filter::Targets>;
 }
 
 pub fn install() {
     // Build a tracing_subscriber::Filter which uses our dynamic log level.
-    let log_filter = tracing_subscriber::filter::DynFilterFn::new(move |metadata, _cx| {
+    let log_filter = tracing_subscriber::filter::DynFilterFn::new(move |metadata, ctx| {
         if metadata
             .fields()
             .iter()
@@ -24,20 +26,9 @@ pub fn install() {
             return false;
         }
 
-        let cur_level = match metadata.level().as_str() {
-            "TRACE" => ops::LogLevel::Trace as i32,
-            "DEBUG" => ops::LogLevel::Debug as i32,
-            "INFO" => ops::LogLevel::Info as i32,
-            "WARN" => ops::LogLevel::Warn as i32,
-            "ERROR" => ops::LogLevel::Error as i32,
-            _ => ops::LogLevel::UndefinedLevel as i32,
-        };
-
-        cur_level
-            <= LOG_LEVEL
-                .try_with(|log_level| log_level.get())
-                .unwrap_or(ops::LogLevel::Info)
-                .into()
+        LOG_LEVEL
+            .try_with(|filter| filter.get().enabled(&metadata, ctx.to_owned()))
+            .unwrap_or_else(|_| metadata.level() <= &tracing::metadata::Level::INFO)
     });
 
     // We want to be able to control Dekaf's own logging output via the RUST_LOG environment variable like usual.
@@ -51,6 +42,7 @@ pub fn install() {
 
     let registry = tracing_subscriber::registry()
         .with(tracing_record_hierarchical::HierarchicalRecord::default())
+        .with(fmt_layer)
         .with(
             ops::tracing::Layer::new(
                 |log| {
@@ -59,8 +51,7 @@ pub fn install() {
                 std::time::SystemTime::now,
             )
             .with_filter(log_filter),
-        )
-        .with(fmt_layer);
+        );
 
     registry.init();
 }
@@ -73,6 +64,22 @@ lazy_static! {
         producer_id[0] |= 0x01;
         gazette::uuid::Producer::from_bytes(producer_id)
     };
+    static ref ERROR_FILTER: Targets = "error".parse().unwrap();
+    static ref WARN_FILTER: Targets = "warn".parse().unwrap();
+    static ref INFO_FILTER: Targets = "warn,dekaf=info".parse().unwrap();
+    static ref DEBUG_FILTER: Targets = "debug,simple_crypt=warn,aws_configure=warn,h2=warn".parse().unwrap();
+    static ref TRACE_FILTER: Targets = "trace,simple_crypt=warn,aws_configure=warn,h2=warn".parse().unwrap();
+
+}
+
+fn build_log_filter(level: ops::LogLevel) -> &'static tracing_subscriber::filter::Targets {
+    match level {
+        ops::LogLevel::Error => &ERROR_FILTER,
+        ops::LogLevel::Warn => &WARN_FILTER,
+        ops::LogLevel::Info | ops::LogLevel::UndefinedLevel => &INFO_FILTER,
+        ops::LogLevel::Debug => &DEBUG_FILTER,
+        ops::LogLevel::Trace => &TRACE_FILTER,
+    }
 }
 
 /// Capture all log messages emitted by the passed future and all of its descendants, and writes them out
@@ -90,7 +97,7 @@ where
     let forwarder = TaskForwarder::new(PRODUCER.to_owned(), writer);
 
     LOG_LEVEL.scope(
-        ops::LogLevel::Info.into(),
+        std::cell::Cell::new(build_log_filter(ops::LogLevel::Info)),
         TASK_FORWARDER.scope(
             forwarder,
             fut.instrument(tracing::info_span!(
@@ -111,7 +118,7 @@ pub fn propagate_task_forwarder<F, O>(fut: F) -> impl Future<Output = O>
 where
     F: Future<Output = O>,
 {
-    let current_level = LOG_LEVEL.get();
+    let current_level = LOG_LEVEL.with(|l| l.clone());
     let current_forwarder = TASK_FORWARDER.get();
 
     LOG_LEVEL.scope(
@@ -125,5 +132,7 @@ pub fn get_log_forwarder() -> TaskForwarder<GazetteWriter> {
 }
 
 pub fn set_log_level(level: ops::LogLevel) {
-    LOG_LEVEL.with(|cell| cell.set(level))
+    LOG_LEVEL.with(|current_level| {
+        current_level.set(build_log_filter(level));
+    })
 }

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_logs.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_logs.snap
@@ -13,7 +13,7 @@ expression: captured_logs
       "task_name": "my_task"
     },
     "level": "error",
-    "message": "Invalid stats document emitted! Cannot emit 0 for `bytes_total` or `docs_total`!",
+    "message": "Invalid stats document emitted! Cannot emit 0 for just one of `bytes_total` or `docs_total`!",
     "shard": {
       "keyBegin": "00000000",
       "kind": "materialization",


### PR DESCRIPTION
Since we're now piping `tracing` logs into the task logs which is user facing, we'd like to make the logs we send as meaningful as possible. In order to do that, we need to be able to more narrowly specify which logs should get sent. In order to do that, I've swapped the simple log level filter for a slightly more advanced `tracing_subscriber::filter::Targets` which allows us to specify log filters such as `debug,simple_crypt=warn,aws_config=warn,h2=warn`.

An alternative to Arc<RwLock<T>> would be something like the the [`arc-swap`](https://docs.rs/arc-swap/latest/arc_swap/) crate which provides a lock-free way to accomplish this shared mutable state, but since the usage pattern of `LOG_LEVEL` is pretty much entirely reads, I don't anticipate any actual lock contention to happen here and wanted to avoid yet another new dependency.

**This appears to have some locking issue, holding off for the moment.**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1947)
<!-- Reviewable:end -->
