### PR TITLE
doc: Fix intersection of shape defaults

### DIFF
--- a/crates/dekaf/tests/dekaf_schema_test.rs
+++ b/crates/dekaf/tests/dekaf_schema_test.rs
@@ -238,6 +238,64 @@ async fn roundtrip(
 }
 
 #[tokio::test]
+async fn test_allof_with_null_default() -> anyhow::Result<()> {
+    for output in roundtrip(
+        connector::DekafConfig {
+            deletions: connector::DeletionMode::Kafka,
+            token: "1234".to_string(),
+            strict_topic_names: false,
+        },
+        json!({
+          "schema": {
+            "allOf": [
+              {
+                "properties": {
+                  "id": {
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "conflicts": {
+                    "type": ["integer", "null"],
+                    "default": null,
+                    "title": "Updatedbyuserid"
+                  }
+                },
+                "required": ["id"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "id": {
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "conflicts": {
+                    "type": "integer"
+                  }
+                },
+                "required": ["id"],
+                "type": "object"
+              }
+            ]
+          },
+          "key": ["/id"]
+        }),
+        json!({
+            "recommended": true
+        }),
+        vec![json!({
+          "id": 671963468
+        })],
+    )
+    .await?
+    {
+        insta::assert_debug_snapshot!(output?);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_field_selection_specific_fields() -> anyhow::Result<()> {
     for output in roundtrip(
         dekaf::connector::DekafConfig {


### PR DESCRIPTION
**Description:**

We weren't correctly narrowing the default of intersected shapes. For example, if we intersected one shape like
```json
{
    "type": ["string", "null"],
    "default": "null"
}
```

with another shape like
```json
{
    "type": "string"
}
```

We'd end up with a shape of
```json
{
    "type": "string",
    "default": null
}
```

Which isn't correct, as when we try to actually emit a document for this shape that's missing the field in question and provide its default value of null, that will subsequently fail to validate against the schema.

Also adds a test to confirm Dekaf's proper handling of schemas like this, which is why this branch is ontop of that one.

Fixes #1944

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1950)
<!-- Reviewable:end -->
