### PR TITLE
Docs: Clean up broken anchor links

### DIFF
--- a/site/docs/concepts/advanced/evolutions.md
+++ b/site/docs/concepts/advanced/evolutions.md
@@ -39,7 +39,7 @@ You can use Flow's **schema evolutions** feature to quickly and simultaneously u
 
 Collection specs may change for a variety of reasons, such as:
 
-- The source system is a database, and someone ran an `ALTER TABLE` statement on a captured table, so you need to update the collection schema (through [AutoDiscover](../captures.md#autodiscover) or manually).
+- The source system is a database, and someone ran an `ALTER TABLE` statement on a captured table, so you need to update the collection schema (through [AutoDiscover](../captures.md#automatically-update-captures) or manually).
 - The source system contains unstructured data, and some data with a different shape was just captured so you need to update the collection schema (through AutoDiscover or manually).
 - Someone manually changed the collection's logical partitions.
 
@@ -53,7 +53,7 @@ When you attempt to publish a breaking change to a collection in the Flow web ap
 
 Click the **Apply** button to trigger an evolution and update all necessary specification to keep your Data Flow functioning. Then, review and publish your draft.
 
-If you enabled [AutoDiscover](../captures.md#autodiscover) on a capture, any breaking changes that it introduces will trigger an automatic schema evolution, so long as you selected the **Breaking change re-versions collections** option (`evolveIncompatibleCollections`).
+If you enabled [AutoDiscover](../captures.md#automatically-update-captures) on a capture, any breaking changes that it introduces will trigger an automatic schema evolution, so long as you selected the **Breaking change re-versions collections** option (`evolveIncompatibleCollections`).
 
 ## What do schema evolutions do?
 

--- a/site/docs/concepts/advanced/shards.md
+++ b/site/docs/concepts/advanced/shards.md
@@ -40,7 +40,7 @@ Flow automatically balances these two extremes to optimize each task,
 but it may be useful in some cases to control transaction duration.
 For example, materializations to large analytical warehouses may benefit from longer transactions,
 which can reduce cost by performing more data reduction before landing data in the warehouse.
-Some endpoint systems, like [BigQuery](../../reference/Connectors/materialization-connectors/BigQuery.md#performance-considerations), limit the number of table operations you can perform.
+Some endpoint systems, like [BigQuery](../../reference/materialization-sync-schedule.md), limit the number of table operations you can perform.
 Longer transaction durations ensure that you don't exceed these limits.
 
 You can set the minimum and maximum transaction duration in a task's [shards configuration](../../reference/Configuring-task-shards.md).

--- a/site/docs/concepts/derivations.md
+++ b/site/docs/concepts/derivations.md
@@ -336,7 +336,7 @@ It will also generate a `deno.json` file in your top-level directory,
 which is designed to work with developer tooling like
 [VSCode's Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
 
-[See the Current Account Balances tutorial for a concrete example of modules](#current-account-balances).
+[See the Current Account Balances tutorial for a concrete example of modules](../getting-started/tutorials/derivations_acmebank.md#current-account-balances).
 
 ### State
 
@@ -607,7 +607,7 @@ the sensor failed to produce a measurement.
 Flow read delays are very efficient and scale better
 than managing very large numbers of fine-grain timers.
 
-[See Grouped Windows of Transfers for an example using a read delay](#grouped-windows-of-transfers)
+[See Grouped Windows of Transfers for an example using a read delay](../getting-started/tutorials/derivations_acmebank.md#grouped-windows-of-transfers)
 
 [Learn more from the Citi Bike "idle bikes" example](https://github.com/estuary/flow/blob/master/examples/citi-bike/idle-bikes.flow.yaml)
 
@@ -674,9 +674,9 @@ This means that, when you implement a derivation,
 you get to choose where **accumulation** will happen:
 
  1. Your lambdas can update and query aggregates stored in [internal task state](#internal-state).
-    [Approving Transfers](#approving-transfers) is an example that maintains account balances in a SQLite table.
+    [Approving Transfers](../getting-started/tutorials/derivations_acmebank.md#approving-transfers) is an example that maintains account balances in a SQLite table.
  2. Or, your lambdas can compute *changes* of an aggregate, which are then reduced by Flow using reduction annotations.
-    [Current Account Balances](#current-account-balances) is an example that combines a lambda with a reduce annotation.
+    [Current Account Balances](../getting-started/tutorials/derivations_acmebank.md#current-account-balances) is an example that combines a lambda with a reduce annotation.
 
 These two approaches can produce equivalent results,
 but they do so in very different ways.

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -142,7 +142,7 @@ They typically include:
   Files used by `npm` to manage dependencies and your Data Flow's associated JavaScript project.
   You may customize `package.json`,
   but its `dependencies` stanza will be overwritten by the
-  [npmDependencies](derivations.md#npm-dependencies)
+  [npmDependencies](./import.md#importing-derivation-resources)
   of your Flow specification source files, if any exist.
 
 When you run commands like `flowctl catalog publish` or `flowctl draft author`, you can use the `--source-dir` flag
@@ -167,7 +167,7 @@ you must define the lambda in an accompanying TypeScript module, and reference t
 in the derivation's definition. To facilitate this,
 you can generate a stub of the module using `flowctl generate`
 and simply write the function bodies.
-[Learn more about this workflow.](./derivations.md#creating-typescript-modules)
+[Learn more about this workflow.](./derivations.md#modules)
 
 If a TypeScript module exists, `flowctl` will never overwrite it,
 even if you update or expand your specifications such that the required interfaces have changed.

--- a/site/docs/concepts/import.md
+++ b/site/docs/concepts/import.md
@@ -110,7 +110,7 @@ and, in certain cases, the NPM dependencies of that TypeScript module.
 
 These imports are specified in the derivation specification, _not_ in the `import` section of the specification file.
 
-For more information, see [Derivation specification](./derivations.md#specification) and [creating TypeScript modules](./derivations.md#creating-typescript-modules).
+For more information, see [Derivation specification](./derivations.md#specification) and [creating TypeScript modules](./derivations.md#modules).
 
 ## Import paths
 

--- a/site/docs/concepts/materialization.md
+++ b/site/docs/concepts/materialization.md
@@ -113,7 +113,7 @@ materializations:
 Flow materializations are **continuous materialized views**.
 They maintain a representation of the collection within the endpoint system
 that is updated in near real-time. It's indexed on the
-[collection key](collections.md#collection-keys).
+[collection key](collections.md#keys).
 As the materialization runs, it ensures that all collection documents
 and their accumulated [reductions](../#reductions) are reflected in this
 managed endpoint resource.

--- a/site/docs/concepts/schemas.md
+++ b/site/docs/concepts/schemas.md
@@ -138,7 +138,7 @@ collections:
 
 To fix the above schema, change `required` to `[id, value]`.
 
-[Learn more of how schemas can be expressed within collections](collections.md#Schemas).
+[Learn more of how schemas can be expressed within collections](./collections.md#schemas).
 
 ### Organization
 
@@ -403,7 +403,7 @@ Note that `$ref: flow://write-schema` expands to the current `writeSchema`. When
 
 When you first publish a collection using the inferred schema, `flow://inferred-schema` expands to a special placeholder schema that rejects *all* documents. This is to ensure that a non-placeholder inferred schema has been published before allowing any documents to be materialized. Once data is captured to the collection, the inferred schema immediately updates to strictly and minimally describe the captured.
 
-Because the effective `readSchema` is only ever updated when the collection is published, the best option is usually to use the inferred schema in conjunction with [autoDiscover](/concepts/captures/#autodiscover).
+Because the effective `readSchema` is only ever updated when the collection is published, the best option is usually to use the inferred schema in conjunction with [autoDiscover](./captures.md#automatically-update-captures).
 
 ## `default` annotations
 

--- a/site/docs/concepts/web-app.md
+++ b/site/docs/concepts/web-app.md
@@ -287,7 +287,7 @@ Documents are organized by their collection key value. Click a key from the list
 **2:** The collection's [schema](./schemas.md) displayed in a read only table. The table columns can be sorted to more easily find what you need.
 
 :::tip
-If you need to modify a collection, edit the [capture](#editing-captures) or [derivation](./derivations.md) that provides its data.
+If you need to modify a collection, edit the [capture](./captures.md) or [derivation](./derivations.md) that provides its data.
 :::
 
 ## Materialization Details Page

--- a/site/docs/getting-started/deployment-options.md
+++ b/site/docs/getting-started/deployment-options.md
@@ -83,7 +83,7 @@ using a cloud provider of your choice.
 
 :::caution Beta
 Setup for self-hosting is not covered in this documentation, and full support is not guaranteed at this time.
-We recommend using the [hosted version of Flow](#get-started-with-the-flow-web-application) for the best experience.
+We recommend using the [hosted version of Flow](../concepts/web-app.md) for the best experience.
 If you'd still like to self-host, refer to the [GitHub repository](https://github.com/estuary/flow) or
 the [Estuary Slack](https://join.slack.com/t/estuary-dev/shared_invite/zt-86nal6yr-VPbv~YfZE9Q~6Zl~gmZdFQ).
 :::

--- a/site/docs/getting-started/quickstart/quickstart.md
+++ b/site/docs/getting-started/quickstart/quickstart.md
@@ -19,7 +19,7 @@ When you register for Flow, your account will use Flow's secure cloud storage bu
 Data in Flow's cloud storage bucket is deleted 20 days after collection.
 
 For production use cases, you
-should [configure your own cloud storage bucket to use with Flow](#configuring-your-cloud-storage-bucket-for-use-with-flow).
+should [configure your own cloud storage bucket to use with Flow](../installation.mdx).
 
 ## Step 1. Set up a Capture<a id="step-2-set-up-a-capture"></a>
 

--- a/site/docs/guides/edit-data-flows.md
+++ b/site/docs/guides/edit-data-flows.md
@@ -55,7 +55,7 @@ You may have to re-authenticate with the source system. Be sure to have current 
 Editing a capture only affects how it will work going forward.
 Data that was captured before editing will reflect the original configuration.
 
-# Edit a materialization
+## Edit a materialization
 
 To edit a materialization:
 

--- a/site/docs/guides/flowctl/create-derivation.md
+++ b/site/docs/guides/flowctl/create-derivation.md
@@ -131,7 +131,7 @@ Using the example above, it'd be called `anvil-status.migration.0.sql`.
 For help writing your derivation, start with these examples:
 
 * [Continuous materialized view tutorial](../../getting-started/tutorials/continuous-materialized-view.md)
-* [Acme Bank examples](../../concepts/derivations.md#tutorial)
+* [Acme Bank examples](../../getting-started/tutorials/derivations_acmebank.md)
 
 The main [derivations page](../../concepts/derivations.md) includes many other examples and in-depth explanations of how derivations work.
 :::
@@ -199,7 +199,7 @@ Using the example above, it'd be called `anvil-status.ts`.
 4. In the TypeScript file, write your transformation.
 
 :::info Tip
-For help writing a TypeScript derivation, start with [this example](../../concepts/derivations.md#current-account-balances).
+For help writing a TypeScript derivation, start with [this example](../transform_data_using_typescript.md).
 
 The main [derivations page](../../concepts/derivations.md) includes many other examples and in-depth explanations of how derivations work.
 :::

--- a/site/docs/guides/get-started-with-flowctl.md
+++ b/site/docs/guides/get-started-with-flowctl.md
@@ -1,6 +1,6 @@
 # Getting Started With flowctl
 
-After your account has been activated through the [web app](#get-started-with-the-flow-web-application), you can begin to work with your data flows from the command line.
+After your account has been activated through the [web app](../concepts/web-app.md), you can begin to work with your data flows from the command line.
 This is not required, but it enables more advanced workflows or might simply be your preference.
 
 Flow has a single binary, **flowctl**.

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -355,11 +355,11 @@ store them separately.
 
 TOASTed values can sometimes present a challenge for systems that rely on the PostgreSQL write-ahead log (WAL), like this connector.
 If a change event occurs on a row that contains a TOASTed value, _but the TOASTed value itself is unchanged_, it is omitted from the WAL.
-As a result, the connector emits a row update with the a value omitted, which might cause
+As a result, the connector emits a row update with the value omitted, which might cause
 unexpected results in downstream catalog tasks if adjustments are not made.
 
-The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/connectors.md#flowctl-discover)
-or use the [Flow UI](/concepts/connectors.md#flow-ui) to create your capture.
+The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/captures.md#discovery)
+or use the [Flow UI](/concepts/web-app.md) to create your capture.
 It uses [merge](/reference/reduction-strategies/merge.md) [reductions](/concepts/schemas.md#reductions)
 to fill in the previous known TOASTed value in cases when that value is omitted from a row update.
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -186,8 +186,8 @@ If a change event occurs on a row that contains a TOASTed value, _but the TOASTe
 As a result, the connector emits a row update with the value omitted, which might cause
 unexpected results in downstream catalog tasks if adjustments are not made.
 
-The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/connectors.md#flowctl-discover)
-or use the [Flow UI](/concepts/connectors.md#flow-ui) to create your capture.
+The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/captures.md#discovery)
+or use the [Flow UI](/concepts/web-app.md) to create your capture.
 It uses [merge](/reference/reduction-strategies/merge.md) [reductions](/concepts/schemas.md#reductions)
 to fill in the previous known TOASTed value in cases when that value is omitted from a row update.
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -158,8 +158,8 @@ If a change event occurs on a row that contains a TOASTed value, _but the TOASTe
 As a result, the connector emits a row update with the value omitted, which might cause
 unexpected results in downstream catalog tasks if adjustments are not made.
 
-The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/connectors.md#flowctl-discover)
-or use the [Flow UI](/concepts/connectors.md#flow-ui) to create your capture.
+The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/captures.md#discovery)
+or use the [Flow UI](/concepts/web-app.md) to create your capture.
 It uses [merge](/reference/reduction-strategies/merge.md) [reductions](/concepts/schemas.md#reductions)
 to fill in the previous known TOASTed value in cases when that value is omitted from a row update.
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -142,8 +142,8 @@ If a change event occurs on a row that contains a TOASTed value, _but the TOASTe
 As a result, the connector emits a row update with the value omitted, which might cause
 unexpected results in downstream catalog tasks if adjustments are not made.
 
-The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](../../../../concepts/connectors.md#flowctl-discover)
-or use the [Flow UI](../../../../concepts/connectors.md#flow-ui) to create your capture.
+The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/captures.md#discovery)
+or use the [Flow UI](/concepts/web-app.md) to create your capture.
 It uses [merge](../../../reduction-strategies/merge.md) [reductions](../../../../concepts/schemas.md#reductions)
 to fill in the previous known TOASTed value in cases when that value is omitted from a row update.
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
@@ -198,8 +198,8 @@ If a change event occurs on a row that contains a TOASTed value, _but the TOASTe
 As a result, the connector emits a row update with the value omitted, which might cause
 unexpected results in downstream catalog tasks if adjustments are not made.
 
-The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](../../../../concepts/connectors.md#flowctl-discover)
-or use the [Flow UI](../../../../concepts/connectors.md#flow-ui) to create your capture.
+The PostgreSQL connector handles TOASTed values for you when you follow the [standard discovery workflow](/concepts/captures.md#discovery)
+or use the [Flow UI](/concepts/web-app.md) to create your capture.
 It uses [merge](../../../reduction-strategies/merge.md) [reductions](../../../../concepts/schemas.md#reductions)
 to fill in the previous known TOASTed value in cases when that value is omitted from a row update.
 

--- a/site/docs/reference/Connectors/capture-connectors/confluence.md
+++ b/site/docs/reference/Connectors/capture-connectors/confluence.md
@@ -9,11 +9,11 @@ This connector is based on an open-source connector from a third party, with mod
 
 ## Supported data resources
 
-When you [configure the connector](#endpoint), you specify your email, api and domain name
+When you [configure the connector](#configuration), you specify your email, API, and domain name.
 
 From your selection, the following data resources are captured:
 
-### resources
+### Resources
 
  - [Audit](https://developer.atlassian.com/cloud/confluence/rest/api-group-audit/#api-wiki-rest-api-audit-get)
  - [Blog Posts](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)

--- a/site/docs/reference/Connectors/capture-connectors/gitlab.md
+++ b/site/docs/reference/Connectors/capture-connectors/gitlab.md
@@ -9,7 +9,7 @@ This connector is based on an open-source connector from a third party, with mod
 
 ## Supported data resources
 
-When you [configure the connector](#endpoint), you may provide a list of GitLab Groups or Projects from which to capture data.
+When you [configure the connector](#configuration), you may provide a list of GitLab Groups or Projects from which to capture data.
 
 From your selection, the following data resources are captured:
 

--- a/site/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -84,7 +84,7 @@ The values and specification sample below provide configuration details specific
 
 #### Endpoint
 
-The following properties reflect the Service Account Key authentication method. If you're working in the Flow web app, you'll use [OAuth2](#using-oauth2-to-authenticate-with-google--in-the-flow-web-app), so some of these properties aren't required.
+The following properties reflect the Service Account Key authentication method. If you're working in the Flow web app, you'll use [OAuth2](#using-oauth2-to-authenticate-with-google-in-the-flow-web-app), so some of these properties aren't required.
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|

--- a/site/docs/reference/Connectors/capture-connectors/netsuite-suitetalk.md
+++ b/site/docs/reference/Connectors/capture-connectors/netsuite-suitetalk.md
@@ -28,7 +28,7 @@ These two different connection modes have some key differences:
 - Oracle NetSuite [account](https://system.netsuite.com/pages/customerlogin.jsp?country=US)
 - Allowed access to all Account permissions options
 - A new integration with token-based authentication
-- A custom role with access to objects you want to capture _or_ a purchased SuiteAnalytics Module. See [setup](#setup).
+- A custom role with access to objects you want to capture _or_ a purchased SuiteAnalytics Module. See [setup](#general-setup).
 - A new user assigned to the custom role
 - Access token generated for the custom role
 

--- a/site/docs/reference/authentication.md
+++ b/site/docs/reference/authentication.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 Read, write, and admin capabilities over Flow catalogs and the [collections](../concepts/collections.md) that comprise them
 are granted to Flow users through **capabilities**.
 
-Capabilities are granted in terms of **prefixes** within the Flow [namespace](../concepts/README.md#namespace).
+Capabilities are granted in terms of **prefixes** within the Flow [namespace](../concepts/catalogs.md#namespace).
 By default, each organization has a unique top-level prefix.
 For example, if you worked for Acme Co, your assigned organization prefix would be `acmeCo/`.
 You may further divide your namespace however you'd like; for example `acmeCo/anvils` and `acmeCo/roadrunners`.

--- a/site/docs/reference/organizing-catalogs.md
+++ b/site/docs/reference/organizing-catalogs.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 :::caution Beta
 This page is outdated. It does not reflect the current state of the Flow web application and the
-[authorization model](./authentication.md#authorizing-users-and-authenticating-with-flow) used to share
+[authorization model](./authentication.md) used to share
 entities in Flow catalogs. Updates are coming soon.
 :::
 
@@ -171,4 +171,4 @@ Every Flow collection has a name, and that name _must_ be unique within a runnin
 
 For example, imagine your catalog for the inside sales team has a collection just named `customers`. If you later try to import a catalog from the outside sales team that also contains a `customers` collection, 💥 there's a collision. A better collection name would be `acme/inside-sales/customers`. This allows a catalog to include customer data from separate teams, and also separate organizations.
 
-[Learn more about the Flow namespace.](../concepts/README.md#namespace)
+[Learn more about the Flow namespace.](../concepts/catalogs.md#namespace)

--- a/site/docs/reference/working-logs-stats.md
+++ b/site/docs/reference/working-logs-stats.md
@@ -18,7 +18,7 @@ You can view a subset of logs and statistics for individual tasks in the Flow we
 
 After you publish a new [capture](../guides/create-dataflow.md#create-a-capture) or [materialization](../guides/create-dataflow.md#create-a-materialization), a pop-up window appears that displays the task's logs.
 Once you close the window, you can't regain access to the full logs in the web app.
-For a complete view of logs, use [flowctl](#accessing-logs-and-statistics-from-the-command-line) or [materialize the logs collection](#accessing-logs-or-stats-by-materialization) to an outside system.
+For a complete view of logs, use [flowctl](#accessing-logs-and-statistics-from-the-command-line).
 
 However, if a task fails, you can view the logs associated with the error(s) that caused the failure.
 In the **Details** view of the published capture or materialization, click the name of its shard to display the logs.


### PR DESCRIPTION
**Description:**

Docs builds exposed a number of lingering issues with anchor links. This update resolves remaining broken links, redirecting or removing links to account for renamed, moved, or deleted sections.

Closes #1935 

**Documentation links affected:**

Various across docs

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1951)
<!-- Reviewable:end -->
