### PR TITLE
docs/SQLServer: Remove mention of watermarks

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -24,12 +24,10 @@ To capture change events from SQL Server tables using this connector, you need:
   on the database and the individual tables to be captured.
   (This creates _change tables_ in the database, from which the connector reads.)
 
-- A **watermarks table**. The watermarks table is a small “scratch space” to which the connector occasionally writes a small amount of data to ensure accuracy when backfilling preexisting table contents.
-
 - A user role with:
   - `SELECT` permissions on the CDC schema and the schemas that contain tables to be captured.
   - Access to the change tables created as part of the SQL Server CDC process.
-  - `SELECT`, `INSERT`, and `UPDATE` permissions on the watermarks table
+  - The `VIEW DATABASE STATE` or (in newer versions of SQL Server) `VIEW DATABASE PERFORMANCE STATE` permission.
 
 ### Setup
 
@@ -57,12 +55,11 @@ CREATE USER flow_capture FOR LOGIN flow_capture;
 -- Add similar queries for any other schemas that contain tables you want to capture.
 GRANT SELECT ON SCHEMA :: dbo TO flow_capture;
 GRANT SELECT ON SCHEMA :: cdc TO flow_capture;
--- Create the watermarks table and grant permissions.
-CREATE TABLE dbo.flow_watermarks(slot INTEGER PRIMARY KEY, watermark TEXT);
-GRANT SELECT, INSERT, UPDATE ON dbo.flow_watermarks TO flow_capture;
--- Enable CDC on tables. The below query enables CDC the watermarks table ONLY.
--- You should add similar query for all other tables you intend to capture.
-EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'flow_watermarks', @role_name = 'flow_capture';
+-- Grant the 'VIEW DATABASE STATE' permission.
+GRANT VIEW DATABASE STATE TO flow_capture;
+-- Enable CDC on tables. The below query enables CDC on table 'dbo.foobar',
+-- you should add similar query for all other tables you intend to capture.
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foobar', @role_name = 'flow_capture';
 ```
 
 3. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `1433`.
@@ -86,7 +83,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/backfill_chunk_size` | Backfill Chunk Size | The number of rows which should be fetched from the database in a single backfill query.                                                    | integer | `4096`                     |
 | `/advanced/skip_backfills`      | Skip Backfills      | A comma-separated list of fully-qualified table names which should not be backfilled.                                                       | string  |                            |
-| `/advanced/watermarksTable`     | Watermarks Table    | The name of the table used for watermark writes during backfills. Must be fully-qualified in &#x27;&lt;schema&gt;.&lt;table&gt;&#x27; form. | string  | `"dbo.flow_watermarks"`    |
 
 #### Bindings
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -31,12 +31,10 @@ To capture change events from SQL Server tables using this connector, you need:
   on the database and the individual tables to be captured.
   (This creates _change tables_ in the database, from which the connector reads.)
 
-- A **watermarks table**. The watermarks table is a small “scratch space” to which the connector occasionally writes a small amount of data to ensure accuracy when backfilling preexisting table contents.
-
 - A user role with:
+  - The `VIEW DATABASE STATE` or (in newer versions of SQL Server) `VIEW DATABASE PERFORMANCE STATE` permission.
   - `SELECT` permissions on the CDC schema and the schemas that contain tables to be captured.
   - Access to the change tables created as part of the SQL Server CDC process.
-  - `SELECT`, `INSERT`, and `UPDATE` permissions on the watermarks table.
 
 ## Setup
 
@@ -63,12 +61,11 @@ CREATE USER flow_capture FOR LOGIN flow_capture;
 -- Add similar queries for any other schemas that contain tables you want to capture.
 GRANT SELECT ON SCHEMA :: dbo TO flow_capture;
 GRANT SELECT ON SCHEMA :: cdc TO flow_capture;
--- Create the watermarks table and grant permissions.
-CREATE TABLE dbo.flow_watermarks(slot INTEGER PRIMARY KEY, watermark TEXT);
-GRANT SELECT, INSERT, UPDATE ON dbo.flow_watermarks TO flow_capture;
--- Enable CDC on tables. The below query enables CDC the watermarks table ONLY.
--- You should add similar query for all other tables you intend to capture.
-EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'flow_watermarks', @role_name = 'flow_capture';
+-- Grant the 'VIEW DATABASE STATE' permission.
+GRANT VIEW DATABASE STATE TO flow_capture;
+-- Enable CDC on tables. The below query enables CDC on table 'dbo.foobar',
+-- you should add similar query for all other tables you intend to capture.
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foobar', @role_name = 'flow_capture';
 ```
 
 2. Allow secure connection to Estuary Flow from your hosting environment. Either:
@@ -108,12 +105,11 @@ CREATE USER flow_capture FOR LOGIN flow_capture;
 -- Add similar queries for any other schemas that contain tables you want to capture.
 GRANT SELECT ON SCHEMA :: dbo TO flow_capture;
 GRANT SELECT ON SCHEMA :: cdc TO flow_capture;
--- Create the watermarks table and grant permissions.
-CREATE TABLE dbo.flow_watermarks(slot INTEGER PRIMARY KEY, watermark TEXT);
-GRANT SELECT, INSERT, UPDATE ON dbo.flow_watermarks TO flow_capture;
--- Enable CDC on tables. The below query enables CDC the watermarks table ONLY.
--- You should add similar query for all other tables you intend to capture.
-EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'flow_watermarks', @role_name = 'flow_capture';
+-- Grant the 'VIEW DATABASE STATE' permission.
+GRANT VIEW DATABASE STATE TO flow_capture;
+-- Enable CDC on tables. The below query enables CDC on table 'dbo.foobar',
+-- you should add similar query for all other tables you intend to capture.
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foobar', @role_name = 'flow_capture';
 ```
 
 3. Note the following important items for configuration:
@@ -138,7 +134,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/backfill_chunk_size` | Backfill Chunk Size | The number of rows which should be fetched from the database in a single backfill query.                                                    | integer | `4096`                     |
 | `/advanced/skip_backfills`      | Skip Backfills      | A comma-separated list of fully-qualified table names which should not be backfilled.                                                       | string  |                            |
-| `/advanced/watermarksTable`     | Watermarks Table    | The name of the table used for watermark writes during backfills. Must be fully-qualified in &#x27;&lt;schema&gt;.&lt;table&gt;&#x27; form. | string  | `"dbo.flow_watermarks"`    |
 
 #### Bindings
 


### PR DESCRIPTION
**Description:**

Now that github.com/estuary/connectors/pull/2385 is merged the default capture behavior for new users will be read-only, which requires the `VIEW DATABASE STATE` permission but doesn't use a watermarks table. This updates the docs to reflect that.

Part of https://github.com/estuary/connectors/issues/2339

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1953)
<!-- Reviewable:end -->
