### PR TITLE
Dekaf: fix datetimes and stats

### DIFF
--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_logs.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_logs.snap
@@ -1,0 +1,36 @@
+---
+source: crates/dekaf/src/log_appender.rs
+expression: captured_logs
+---
+[
+  {
+    "_meta": {
+      "uuid": "[uuid]"
+    },
+    "fields": {
+      "module": "dekaf::log_appender",
+      "stats": "Binding { left: Some(DocsAndBytes { docs_total: 1, bytes_total: 0 }), right: None, out: None }",
+      "task_name": "my_task"
+    },
+    "level": "error",
+    "message": "Invalid stats document emitted! Cannot emit 0 for `bytes_total` or `docs_total`!",
+    "shard": {
+      "keyBegin": "00000000",
+      "kind": "materialization",
+      "name": "my_task",
+      "rClockBegin": "00000000"
+    },
+    "spans": [
+      {
+        "fields": {
+          "module": "dekaf::log_appender::tests",
+          "task_name": "my_task"
+        },
+        "level": "info",
+        "message": "test_session",
+        "ts": "[ts]"
+      }
+    ],
+    "ts": "[ts]"
+  }
+]

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_stats.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats_partial_stats.snap
@@ -1,0 +1,5 @@
+---
+source: crates/dekaf/src/log_appender.rs
+expression: captured_logs
+---
+[]

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -437,11 +437,8 @@ impl Collection {
             registry_id: u32,
         }
 
-        // Note the canonical form of the schema strips away some important metadata
-        // that we require while encoding, such as default values.
-        // It's fully sufficient for readers, though.
         // We map into a serde_json::Value to ensure stability of property order when content-summing.
-        let schema: serde_json::Value = serde_json::from_str(&schema.canonical_form()).unwrap();
+        let schema: serde_json::Value = serde_json::to_value(&schema).unwrap();
         let schema_md5 = format!("{:x}", md5::compute(&schema.to_string()));
 
         let mut rows: Vec<Row> = handle_postgrest_response(


### PR DESCRIPTION
* Stop using `apache_avro::schema::Schema::canonical_form()` for output schemas. This transformation strips out important information from schemas such as `logicalType`, which clients were using to differentiate between e.g numbers and date-timestamps. In `0.17.0` it was [upgraded](https://github.com/apache/avro/pull/2976) to specifically strip `logicalType`.
* Fix emitting incorrect stats docs when we have an ack-only read. We were correctly ignoring the bytes of ack documents, but were still counting them as documents. This was resulting in recording stats like

  ```
  DocsAndBytes {
    docs_total: 1,
    bytes_total: 0,
  }
  ```

  This was subsequently encoded as
  ```
  {
    "docsTotal": 1
  } 
  ```

  Which doesn't match the schema for stats, and brought down the whole L1 rollup shard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1956)
<!-- Reviewable:end -->
