### PR TITLE
agent-sql: storage mapping query should pull all mappings prefixed by tenant

### DIFF
--- a/crates/agent-sql/src/publications.rs
+++ b/crates/agent-sql/src/publications.rs
@@ -596,7 +596,7 @@ pub async fn resolve_storage_mappings(
             m.catalog_prefix,
             m.spec
         from prefixes p
-        join storage_mappings m on m.catalog_prefix = p.prefix;
+        join storage_mappings m on starts_with(m.catalog_prefix, p.prefix);
         "#,
         tenant_names as Vec<&str>,
     )


### PR DESCRIPTION
Rather than just exact matches. Verified (on a local stack) that his allows a tenant to be set up with sub-mappings (only), and that they're correctly used.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1979)
<!-- Reviewable:end -->
