### PR TITLE
dekaf: Fix read offset jumps

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -530,7 +530,7 @@ impl Session {
 
                         auth.refresh_gazette_clients();
                     }
-                    Some(_) => {
+                    Some((pending, _)) if pending.offset == fetch_offset => {
                         metrics::counter!(
                             "dekaf_fetch_requests",
                             "topic_name" => key.0.to_string(),


### PR DESCRIPTION
This was broken a while ago while introducing support for data-preview UIs. I'm pretty sure that this is the cause of the infrequent missing rows that we're seeing:

Read through offset X, successfully commit, then read X+1 and fail to commit, rejoin group and get back X as the last committed offset, try to read at offset X but there’s a pending read that doesn’t get correctly reset back to X, so you miss X+1 and continue on to X+2.

I'm working on splitting up this `read` function as it has a lot of nesting/complexity, but I just wanted to get this minimal fix out and building to confirm whether it fixes the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1982)
<!-- Reviewable:end -->
