### PR TITLE
Docs: Add Dekaf variants

### DIFF
--- a/site/docs/reference/Connectors/dekaf/README.md
+++ b/site/docs/reference/Connectors/dekaf/README.md
@@ -29,4 +29,10 @@ Estuary provides multiple options for integrating with a Kafka ecosystem. Which 
 
 Dekaf is compatible with many Kafka consumers. For instructions on integrating with specific systems, choose from the following materialization connectors.
 
+- [Bytewax](../materialization-connectors/Dekaf/bytewax.md)
+- [ClickHouse](../materialization-connectors/Dekaf/clickhouse.md)
+- [Imply Polaris](../materialization-connectors/Dekaf/imply-polaris.md)
+- [Materialize](../materialization-connectors/Dekaf/materialize.md)
+- [SingleStore](../materialization-connectors/Dekaf/singlestore.md)
+- [Startree](../materialization-connectors/Dekaf/startree.md)
 - [Tinybird](../materialization-connectors/Dekaf/tinybird.md)

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
@@ -1,0 +1,117 @@
+
+# Bytewax
+
+This connector materializes Flow collections as Kafka-compatible messages that a Bytewax Kafka consumer can read. [Bytewax](https://bytewax.io/) is a Python framework for building scalable dataflow applications, designed for
+high-throughput, low-latency data processing tasks.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* At least one Flow collection
+* A Python development setup
+
+## Variants
+
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
+
+## Setup
+
+Provide an auth token when setting up the Dekaf connector. This can be a password of your choosing and will be used to authenticate consumers to your Kafka topics.
+
+Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
+
+## Connecting Estuary Flow to Bytewax
+
+1. Install Bytewax and the Kafka Python client:
+
+   ```
+   pip install bytewax kafka-python
+   ```
+
+2. Create a Python script for your Bytewax dataflow. You can use the following template, inserting your own Kafka topic name(s), your materialization task name, and the auth token you created:
+
+   ```python
+   import json
+   from datetime import timedelta
+   from bytewax.dataflow import Dataflow
+   from bytewax.inputs import KafkaInputConfig
+   from bytewax.outputs import StdOutputConfig
+   from bytewax.window import TumblingWindowConfig, SystemClockConfig
+
+   # Estuary Flow Dekaf configuration
+   KAFKA_BOOTSTRAP_SERVERS = "dekaf.estuary-data.com:9092"
+   KAFKA_TOPIC = "/your-collection-name"
+
+   # Parse incoming messages
+   def parse_message(msg):
+       data = json.loads(msg)
+       # Process your data here
+       return data
+
+   # Define your dataflow
+    src = KafkaSource(brokers=KAFKA_BOOTSTRAP_SERVERS, topics=[KAFKA_TOPIC], add_config={
+        "security.protocol": "SASL_SSL",
+        "sasl.mechanism": "PLAIN",
+        "sasl.username": "YOUR_MATERIALIZATION_NAME",
+        "sasl.password": os.getenv("DEKAF_AUTH_TOKEN"),
+    })
+
+    flow = Dataflow()
+    flow.input("input", src)
+    flow.input("input", KafkaInputConfig(KAFKA_BOOTSTRAP_SERVERS, KAFKA_TOPIC))
+    flow.map(parse_message)
+    # Add more processing steps as needed
+    flow.output("output", StdOutputConfig())
+
+    if __name__ == "__main__":
+        from bytewax.execution import run_main
+        run_main(flow)
+   ```
+
+3. Run your Bytewax dataflow:
+
+   ```
+   python your_dataflow_script.py
+   ```
+
+4. Your Bytewax dataflow is now processing data from Estuary Flow in real-time.
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a Dekaf materialization, which will direct one or more of your Flow collections to your desired topics.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
+| `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/topic_name` | Topic Name | Kafka topic name that Dekaf will publish under. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      dekaf:
+        config:
+          token: <auth-token>
+          strict_topic_names: false
+          deletions: kafka
+        variant: bytewax
+    bindings:
+      - resource:
+          topic_name: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
@@ -1,30 +1,18 @@
 
-# Dekaf
+# ClickHouse
 
-This connector materializes Flow collections as Kafka-compatible messages that Kafka consumers can read.
-
-If you want to send messages to your own Kafka broker, see the [Kafka](../apache-kafka.md) materialization connector instead.
+This connector materializes Flow collections as Kafka-compatible messages that a ClickHouse Kafka consumer can read. [ClickHouse](https://clickhouse.com/) is a real-time analytical database and warehouse.
 
 ## Prerequisites
 
 To use this connector, you'll need:
 
 * At least one Flow collection
-* At least one Kafka consumer
+* **[ClickHouse Cloud](https://clickhouse.com/) account** with permissions to configure ClickPipes for data ingestion
 
 ## Variants
 
-Dekaf can be used with a number of systems that act as Kafka consumers. Specific instructions are provided for the following systems:
-
-* [Bytewax](bytewax.md)
-* [ClickHouse](clickhouse.md)
-* [Imply Polaris](imply-polaris.md)
-* [Materialize](materialize.md)
-* [SingleStore](singlestore.md)
-* [Startree](startree.md)
-* [Tinybird](tinybird.md)
-
-For other use cases, continue with the setup details below for general instruction.
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
 
 ## Setup
 
@@ -32,18 +20,28 @@ Provide an auth token when setting up the Dekaf connector. This can be a passwor
 
 Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
 
-You may then connect to a Kafka consumer of your choice using the following details:
+## Connecting Estuary Flow to ClickPipes in ClickHouse Cloud
 
-* **Broker Address**: `dekaf.estuary-data.com:9092`
-* **Schema Registry Address**: `https://dekaf.estuary-data.com`
-* **Security Protocol**: `SASL_SSL`
-* **SASL Mechanism**: `PLAIN`
-* **SASL Username**: The full task name of your materialization
-* **SASL Password**: The auth token you specified
-* **Schema Registry Username**: The full task name of your materialization
-* **Schema Registry Password**: The auth token you specified
+1. **Set Up ClickPipes**:
+    - In ClickHouse Cloud, go to **Integrations** and select **Apache Kafka** as the data source.
 
-To subscribe to a particular topic, use a binding's topic name. By default, this will be the collection name.
+2. **Enter Connection Details**:
+    - Use the following connection parameters to configure access to Estuary Flow.
+        * **Broker Address**: `dekaf.estuary-data.com:9092`
+        * **Schema Registry Address**: `https://dekaf.estuary-data.com`
+        * **Security Protocol**: `SASL_SSL`
+        * **SASL Mechanism**: `PLAIN`
+        * **SASL Username**: The full task name of your materialization
+        * **SASL Password**: The auth token you specified in your materialization
+        * **Schema Registry Username**: Same as the SASL username
+        * **Schema Registry Password**: Same as the SASL password
+
+3. **Map Data Fields**:
+    - Ensure that ClickHouse can parse the incoming data properly. Use ClickHouse’s mapping interface to align fields
+      between Estuary Flow collections and ClickHouse tables.
+
+4. **Provision the ClickPipe**:
+    - Kick off the integration and allow ClickPipes to set up the pipeline. This should complete within a few seconds.
 
 ## Configuration
 
@@ -77,7 +75,7 @@ materializations:
           token: <auth-token>
           strict_topic_names: false
           deletions: kafka
-        variant: generic
+        variant: clickhouse
     bindings:
       - resource:
           topic_name: ${COLLECTION_NAME}

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
@@ -1,0 +1,92 @@
+
+# Imply Polaris
+
+This connector materializes Flow collections as Kafka-compatible messages that an Imply Polaris Kafka consumer can read. [Imply Polaris](https://imply.io/polaris) is a fully managed, cloud-native Database-as-a-Service (DBaaS) built on Apache
+Druid, designed for real-time analytics on streaming and batch data.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* At least one Flow collection
+* An Imply Polaris account
+
+## Variants
+
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
+
+## Setup
+
+Provide an auth token when setting up the Dekaf connector. This can be a password of your choosing and will be used to authenticate consumers to your Kafka topics.
+
+Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
+
+## Connecting Estuary Flow to Imply Polaris
+
+1. Log in to your Imply Polaris account and navigate to your project.
+
+2. In the left sidebar, click on "Tables" and then "Create Table".
+
+3. Choose "Kafka" as the input source for your new table.
+
+4. In the Kafka configuration section, enter the following details:
+
+    - **Bootstrap Servers**: `dekaf.estuary-data.com:9092`
+    - **Topic**: The name of an Estuary Flow collection you added to your materialization (e.g., `/my-collection`)
+    - **Security Protocol**: `SASL_SSL`
+    - **SASL Mechanism**: `PLAIN`
+    - **SASL Username**: Your materialization's task name
+    - **SASL Password**: Your materialization's auth token
+
+5. For the "Input Format", select "avro".
+
+6. Configure the Schema Registry settings:
+    - **Schema Registry URL**: `https://dekaf.estuary-data.com`
+    - **Schema Registry Username**: Same as the SASL username
+    - **Schema Registry Password**: Same as the SASL password
+
+7. In the "Schema" section, Imply Polaris should automatically detect the schema from your Avro data. Review and adjust
+   the column definitions as needed.
+
+8. Review and finalize your table configuration, then click "Create Table".
+
+9. Your Imply Polaris table should now start ingesting data from Estuary Flow.
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a Dekaf materialization, which will direct one or more of your Flow collections to your desired topics.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
+| `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/topic_name` | Topic Name | Kafka topic name that Dekaf will publish under. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      dekaf:
+        config:
+          token: <auth-token>
+          strict_topic_names: false
+          deletions: kafka
+        variant: imply-polaris
+    bindings:
+      - resource:
+          topic_name: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
@@ -1,0 +1,112 @@
+
+# Materialize
+
+This connector materializes Flow collections as Kafka-compatible messages that a Materialize Kafka consumer can read. [Materialize](https://materialize.com/) is an operational data warehouse for real-time analytics that uses standard SQL
+for defining transformations and queries.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* At least one Flow collection
+* A Materialize account
+
+## Variants
+
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
+
+## Setup
+
+Provide an auth token when setting up the Dekaf connector. This can be a password of your choosing and will be used to authenticate consumers to your Kafka topics.
+
+Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
+
+## Connecting Estuary Flow to Materialize
+
+1. In your Materialize dashboard, use the SQL shell to create a new secret and connection using the Kafka source
+   connector. Use the following SQL commands to configure the connection to Estuary Flow:
+
+   ```sql
+   CREATE
+   SECRET estuary_token AS
+     'your_materialization_auth_token_here';
+
+   CREATE
+   CONNECTION estuary_connection TO KAFKA (
+       BROKER 'dekaf.estuary-data.com',
+       SECURITY PROTOCOL = 'SASL_SSL',
+       SASL MECHANISMS = 'PLAIN',
+       SASL USERNAME = 'your_materialization_task_name_here',
+       SASL PASSWORD = SECRET estuary_token
+   );
+
+   CREATE
+   CONNECTION csr_estuary_connection TO CONFLUENT SCHEMA REGISTRY (
+       URL 'https://dekaf.estuary-data.com',
+       USERNAME = 'your_materialization_task_name_here',
+       PASSWORD = SECRET estuary_token
+   );
+   ```
+
+2. **Create a source in Materialize** to read from the Kafka topic. Use the following SQL command,
+   replacing `<name-of-your-flow-collection>` with the name of a collection you added to your Estuary Flow materialization:
+
+   ```sql
+   CREATE SOURCE materialize_source
+   FROM KAFKA CONNECTION estuary_connection (TOPIC '<name-of-your-flow-collection>')
+   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_estuary_connection
+   ENVELOPE UPSERT;
+   ```
+
+### Creating Real-Time Views
+
+To begin analyzing the data, create a real-time view using SQL in Materialize. Here is an example query to create a
+materialized view that tracks data changes:
+
+```sql
+CREATE MATERIALIZED VIEW my_view AS
+SELECT *
+FROM materialize_source;
+```
+
+For more detailed information on creating materialized views and other advanced configurations, refer to
+the [Materialize documentation](https://materialize.com/docs/).
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a Dekaf materialization, which will direct one or more of your Flow collections to your desired topics.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
+| `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/topic_name` | Topic Name | Kafka topic name that Dekaf will publish under. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      dekaf:
+        config:
+          token: <auth-token>
+          strict_topic_names: false
+          deletions: kafka
+        variant: materialize
+    bindings:
+      - resource:
+          topic_name: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
@@ -1,0 +1,92 @@
+
+# SingleStore
+
+This connector materializes Flow collections as Kafka-compatible messages that a SingleStore Kafka consumer can read. [SingleStore](https://www.singlestore.com/) is a distributed SQL database designed for data-intensive applications,
+offering high performance for both transactional and analytical workloads.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* At least one Flow collection
+* A SingleStore account
+
+## Variants
+
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
+
+## Setup
+
+Provide an auth token when setting up the Dekaf connector. This can be a password of your choosing and will be used to authenticate consumers to your Kafka topics.
+
+Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
+
+## Connecting Estuary Flow to SingleStore
+
+1. In the SingleStore Cloud Portal, navigate to the SQL Editor section of the Data Studio.
+
+2. Execute the following script to create a table and an ingestion pipeline to hydrate it.
+
+   This example will ingest data from the demo wikipedia collection (`/demo/wikipedia/recentchange-sampled`) in Estuary Flow. This becomes the `recentchange-sampled` topic once added to the SingleStore materialization.
+
+    ```sql
+    CREATE TABLE test_table (id NUMERIC, server_name VARCHAR(255), title VARCHAR(255));
+
+    CREATE PIPELINE test AS
+            LOAD DATA KAFKA "dekaf.estuary-data.com:9092/recentchange-sampled"
+            CONFIG '{
+                "security.protocol":"SASL_SSL",
+                "sasl.mechanism":"PLAIN",
+                "sasl.username":"{YOUR_TASK_NAME}",
+                "broker.address.family": "v4",
+                "schema.registry.username": "{YOUR_TASK_NAME}",
+                "fetch.wait.max.ms": "2000"
+            }'
+            CREDENTIALS '{
+                "sasl.password": "YOUR_AUTH_TOKEN",
+                "schema.registry.password": "YOUR_AUTH_TOKEN"
+            }'
+            INTO table test_table
+            FORMAT AVRO SCHEMA REGISTRY 'https://dekaf.estuary-data.com'
+            ( id <- id, server_name <- server_name, title <- title );
+    ```
+3. Your pipeline should now start ingesting data from Estuary Flow into SingleStore.
+
+## Configuration
+
+To use this connector, begin with data in one or more Flow collections.
+Use the below properties to configure a Dekaf materialization, which will direct one or more of your Flow collections to your desired topics.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
+| `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/topic_name` | Topic Name | Kafka topic name that Dekaf will publish under. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      dekaf:
+        config:
+          token: <auth-token>
+          strict_topic_names: false
+          deletions: kafka
+        variant: singlestore
+    bindings:
+      - resource:
+          topic_name: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
@@ -1,30 +1,19 @@
 
-# Dekaf
+# Startree
 
-This connector materializes Flow collections as Kafka-compatible messages that Kafka consumers can read.
-
-If you want to send messages to your own Kafka broker, see the [Kafka](../apache-kafka.md) materialization connector instead.
+This connector materializes Flow collections as Kafka-compatible messages that a Startree Kafka consumer can read. [StarTree](https://startree.ai/) is a real-time analytics platform built on Apache Pinot, designed for performing fast,
+low-latency analytics on large-scale data.
 
 ## Prerequisites
 
 To use this connector, you'll need:
 
 * At least one Flow collection
-* At least one Kafka consumer
+* A Startree account
 
 ## Variants
 
-Dekaf can be used with a number of systems that act as Kafka consumers. Specific instructions are provided for the following systems:
-
-* [Bytewax](bytewax.md)
-* [ClickHouse](clickhouse.md)
-* [Imply Polaris](imply-polaris.md)
-* [Materialize](materialize.md)
-* [SingleStore](singlestore.md)
-* [Startree](startree.md)
-* [Tinybird](tinybird.md)
-
-For other use cases, continue with the setup details below for general instruction.
+This connector is a variant of the default Dekaf connector. For other integration options, see the main [Dekaf](dekaf.md) page.
 
 ## Setup
 
@@ -32,18 +21,27 @@ Provide an auth token when setting up the Dekaf connector. This can be a passwor
 
 Once the connector is created, note the task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`. You will use this as the username.
 
-You may then connect to a Kafka consumer of your choice using the following details:
+## Connecting Estuary Flow to StarTree
 
-* **Broker Address**: `dekaf.estuary-data.com:9092`
-* **Schema Registry Address**: `https://dekaf.estuary-data.com`
-* **Security Protocol**: `SASL_SSL`
-* **SASL Mechanism**: `PLAIN`
-* **SASL Username**: The full task name of your materialization
-* **SASL Password**: The auth token you specified
-* **Schema Registry Username**: The full task name of your materialization
-* **Schema Registry Password**: The auth token you specified
+1. In the StarTree UI, navigate to the **Data Sources** section and choose **Add New Data Source**.
 
-To subscribe to a particular topic, use a binding's topic name. By default, this will be the collection name.
+2. Select **Kafka** as your data source type.
+
+3. Enter the following connection details:
+
+    - **Bootstrap Servers**: `dekaf.estuary-data.com`
+    - **Security Protocol**: `SASL_SSL`
+    - **SASL Mechanism**: `PLAIN`
+    - **SASL Username**: Your materialization task name, such as `YOUR-ORG/YOUR-PREFIX/YOUR-MATERIALIZATION`
+    - **SASL Password**: Your materialization's auth token
+
+4. **Configure Schema Registry**: To decode Avro messages, enable schema registry settings:
+
+    - **Schema Registry URL**: `https://dekaf.estuary-data.com`
+    - **Schema Registry Username**: Same as the SASL username
+    - **Schema Registry Password**: Same as the SASL password
+
+5. Click **Create Connection** to proceed.
 
 ## Configuration
 
@@ -77,7 +75,7 @@ materializations:
           token: <auth-token>
           strict_topic_names: false
           deletions: kafka
-        variant: generic
+        variant: startree
     bindings:
       - resource:
           topic_name: ${COLLECTION_NAME}

--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -44,6 +44,10 @@ In the future, other open-source materialization connectors from third parties c
 * Azure SQL Server
   * [Configuration](./SQLServer/)
   * Package - ghcr.io/estuary/materialize-sqlserver:dev
+* Bytewax
+  * [Configuration](./Dekaf/bytewax.md)
+* ClickHouse
+  * [Configuration](./Dekaf/clickhouse.md)
 * CSV Files in GCS
   * [Configuration](./google-gcs-csv.md)
   * Package — ghcr.io/estuary/materialize-gcs-csv:dev
@@ -82,6 +86,10 @@ In the future, other open-source materialization connectors from third parties c
 * HTTP Webhook
   * [Configuration](./http-webhook.md)
   * Package - ghcr.io/estuary/materialize-webhook:dev
+* Imply Polaris
+  * [Configuration](./Dekaf/imply-polaris.md)
+* Materialize
+  * [Configuration](./Dekaf/materialize.md)
 * MongoDB
   * [Configuration](./mongodb.md)
   * Package - ghcr.io/estuary/materialize-mongodb:dev
@@ -103,6 +111,8 @@ In the future, other open-source materialization connectors from third parties c
 * Rockset
   * [Configuration](./Rockset.md)
   * Package — ghcr.io/estuary/materialize-rockset:dev
+* SingleStore
+  * [Configuration](./Dekaf/singlestore.md)
 * Slack
   * [Configuration](./slack.md)
   * Package - ghcr.io/estuary/materialize-slack:dev
@@ -118,6 +128,8 @@ In the future, other open-source materialization connectors from third parties c
 * Starburst
   * [Configuration](./starburst.md)
   * Package - ghcr.io/estuary/materialize-starburst:dev
+* Startree
+  * [Configuration](./Dekaf/startree.md)
 * TimescaleDB
   * [Configuration](./timescaledb.md)
   * Package - ghcr.io/estuary/materialize-timescaledb:dev


### PR DESCRIPTION
**Description:**

Adds docs for new Dekaf connector variants, updating the information from their original tutorials where necessary.

**Documentation links affected:**

Mainly adds new pages under the [Dekaf materialization section](https://docs.estuary.dev/reference/Connectors/materialization-connectors/Dekaf/) and updates connector lists.

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1983)
<!-- Reviewable:end -->
