### PR TITLE
Update `alert trial_ending` to handle `external` payment method

### DIFF
--- a/supabase/migrations/20250311000000_update_alert_view.sql
+++ b/supabase/migrations/20250311000000_update_alert_view.sql
@@ -4,7 +4,7 @@
 CREATE OR REPLACE VIEW internal.alert_free_trial_ending AS
  SELECT 'free_trial_ending'::public.alert_type AS alert_type,
     (((tenants.tenant)::text || 'alerts/free_trial_ending'::text))::public.catalog_name AS catalog_name,
-    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL) OR (tenants.payment_provider != 'external'))) AS arguments,
+    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL) OR (tenants.payment_provider == 'external'))) AS arguments,
     ((tenants.trial_start IS NOT NULL) AND ((now() - (tenants.trial_start)::timestamp with time zone) >= ('1 mon'::interval - '5 days'::interval)) AND ((now() - (tenants.trial_start)::timestamp with time zone) < ('1 mon'::interval - '4 days'::interval)) AND (tenants.trial_start <= now())) AS firing
    FROM (((public.tenants
      LEFT JOIN public.alert_subscriptions ON ((((alert_subscriptions.catalog_prefix)::text ^@ (tenants.tenant)::text) AND (alert_subscriptions.email IS NOT NULL))))

--- a/supabase/migrations/20250311000000_update_alert_view.sql
+++ b/supabase/migrations/20250311000000_update_alert_view.sql
@@ -1,8 +1,11 @@
+-- If a tenant has `external` payment method then we do not
+-- want to trigger any messaging about missing payment.
+
 CREATE OR REPLACE VIEW internal.alert_free_trial_ending AS
  SELECT 'free_trial_ending'::public.alert_type AS alert_type,
     (((tenants.tenant)::text || 'alerts/free_trial_ending'::text))::public.catalog_name AS catalog_name,
-    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL), (tenants.payment_provider = 'external'))) AS arguments,
-    ((tenants.trial_start IS NOT NULL) AND ((now() - (tenants.trial_start)::timestamp with time zone) >= ('1 mon'::interval - '5 days'::interval)) AND ((now() - (tenants.trial_start)::timestamp with time zone) < ('1 mon'::interval - '4 days'::interval)) AND (tenants.trial_start <= now())) AS firing,
+    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL) OR (tenants.payment_provider != 'external'))) AS arguments,
+    ((tenants.trial_start IS NOT NULL) AND ((now() - (tenants.trial_start)::timestamp with time zone) >= ('1 mon'::interval - '5 days'::interval)) AND ((now() - (tenants.trial_start)::timestamp with time zone) < ('1 mon'::interval - '4 days'::interval)) AND (tenants.trial_start <= now())) AS firing
    FROM (((public.tenants
      LEFT JOIN public.alert_subscriptions ON ((((alert_subscriptions.catalog_prefix)::text ^@ (tenants.tenant)::text) AND (alert_subscriptions.email IS NOT NULL))))
      LEFT JOIN stripe.customers ON ((customers.name = (tenants.tenant)::text)))

--- a/supabase/migrations/20250311000000_update_alert_view.sql
+++ b/supabase/migrations/20250311000000_update_alert_view.sql
@@ -4,7 +4,7 @@
 CREATE OR REPLACE VIEW internal.alert_free_trial_ending AS
  SELECT 'free_trial_ending'::public.alert_type AS alert_type,
     (((tenants.tenant)::text || 'alerts/free_trial_ending'::text))::public.catalog_name AS catalog_name,
-    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL) OR (tenants.payment_provider == 'external'))) AS arguments,
+    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL) OR (tenants.payment_provider = 'external'))) AS arguments,
     ((tenants.trial_start IS NOT NULL) AND ((now() - (tenants.trial_start)::timestamp with time zone) >= ('1 mon'::interval - '5 days'::interval)) AND ((now() - (tenants.trial_start)::timestamp with time zone) < ('1 mon'::interval - '4 days'::interval)) AND (tenants.trial_start <= now())) AS firing
    FROM (((public.tenants
      LEFT JOIN public.alert_subscriptions ON ((((alert_subscriptions.catalog_prefix)::text ^@ (tenants.tenant)::text) AND (alert_subscriptions.email IS NOT NULL))))

--- a/supabase/migrations/20250311000000_update_alert_view.sql
+++ b/supabase/migrations/20250311000000_update_alert_view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW internal.alert_free_trial_ending AS
+ SELECT 'free_trial_ending'::public.alert_type AS alert_type,
+    (((tenants.tenant)::text || 'alerts/free_trial_ending'::text))::public.catalog_name AS catalog_name,
+    json_build_object('tenant', tenants.tenant, 'recipients', array_agg(DISTINCT jsonb_build_object('email', alert_subscriptions.email, 'full_name', (users.raw_user_meta_data ->> 'full_name'::text))), 'trial_start', tenants.trial_start, 'trial_end', ((tenants.trial_start + '1 mon'::interval))::date, 'has_credit_card', bool_or((customers."invoice_settings/default_payment_method" IS NOT NULL), (tenants.payment_provider = 'external'))) AS arguments,
+    ((tenants.trial_start IS NOT NULL) AND ((now() - (tenants.trial_start)::timestamp with time zone) >= ('1 mon'::interval - '5 days'::interval)) AND ((now() - (tenants.trial_start)::timestamp with time zone) < ('1 mon'::interval - '4 days'::interval)) AND (tenants.trial_start <= now())) AS firing,
+   FROM (((public.tenants
+     LEFT JOIN public.alert_subscriptions ON ((((alert_subscriptions.catalog_prefix)::text ^@ (tenants.tenant)::text) AND (alert_subscriptions.email IS NOT NULL))))
+     LEFT JOIN stripe.customers ON ((customers.name = (tenants.tenant)::text)))
+     LEFT JOIN auth.users ON ((((users.email)::text = alert_subscriptions.email) AND (users.is_sso_user IS FALSE))))
+  GROUP BY tenants.tenant, tenants.trial_start;
+
+
+ALTER VIEW internal.alert_free_trial_ending OWNER TO postgres;


### PR DESCRIPTION
**Description:**

https://github.com/estuary/flow/issues/1996
Updating the view to set `has_credit_card` to include `external` payment methods.

**Workflow steps:**

n/a

**Documentation links affected:**

n/a

**Notes for reviewers:**

ran `supabase db reset` to test
```
travis@pop-os:~/code/flow/supabase$ supabase db reset
Using workdir /home/travis/code/flow
Resetting local database...
Recreating database...
Setting up initial schema...
Seeding globals from roles.sql...
Skipping migration README.md... (file name must match pattern "<timestamp>_name.sql")
Applying migration 00_polyfill.sql...
Applying migration 20241012000000_compacted.sql...
Applying migration 20241012072256_job_queue.sql...
Applying migration 20241013000000_enable_pg_cron.sql...
Applying migration 20241022035435_view_logs_and_pulumi_stack.sql...
Applying migration 20241125194715_dekaf_role.sql...
Applying migration 20241209000000_make_aws_link_endpoints_readable.sql...
Applying migration 20241212195226_jwt_secret.sql...
Applying migration 20241219171749_controller_automations-1.sql...
Applying migration 20250106141749_controller-automations-2.sql...
Applying migration 20250106141751_controller-automations-3.sql...
Applying migration 20250121000000_update_alert_view.sql...
Applying migration 20250127152418_handler-automations.sql...
Applying migration 20250311000000_update_alert_view.sql...
Seeding data from supabase/seed.sql...
Restarting containers...
Finished supabase db reset on branch travjenkins/bug/update-alert-trial-ending-to-know-about-external-payment.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/1997)
<!-- Reviewable:end -->
