### PR TITLE
agent: update all APIs to use ApiErrorExt

### DIFF
--- a/crates/agent/src/api/authorize_user_task.rs
+++ b/crates/agent/src/api/authorize_user_task.rs
@@ -1,26 +1,29 @@
 use super::{App, Snapshot};
+use crate::api::error::ApiErrorExt;
 use anyhow::Context;
+use axum::http::StatusCode;
 use std::sync::Arc;
 
 type Request = models::authorizations::UserTaskAuthorizationRequest;
 type Response = models::authorizations::UserTaskAuthorization;
 
+#[axum::debug_handler]
 #[tracing::instrument(
-    skip(snapshot),
+    skip(app),
     err(level = tracing::Level::WARN),
 )]
-async fn do_authorize_user_task(
-    App { snapshot, .. }: &App,
-    super::ControlClaims {
+pub async fn authorize_user_task(
+    axum::extract::State(app): axum::extract::State<Arc<App>>,
+    axum::Extension(super::ControlClaims {
         sub: user_id,
         email,
         ..
-    }: super::ControlClaims,
-    Request {
+    }): axum::Extension<super::ControlClaims>,
+    super::Request(Request {
         task: task_name,
         started_unix,
-    }: Request,
-) -> anyhow::Result<Response> {
+    }): super::Request<Request>,
+) -> Result<axum::Json<Response>, crate::api::ApiError> {
     let (has_started, started_unix) = if started_unix == 0 {
         (false, jsonwebtoken::get_current_timestamp())
     } else {
@@ -28,15 +31,15 @@ async fn do_authorize_user_task(
     };
 
     loop {
-        match Snapshot::evaluate(snapshot, started_unix, |snapshot: &Snapshot| {
+        match Snapshot::evaluate(&app.snapshot, started_unix, |snapshot: &Snapshot| {
             evaluate_authorization(snapshot, user_id, email.as_ref(), &task_name)
         }) {
-            Ok(response) => return Ok(response),
+            Ok(response) => return Ok(axum::Json(response)),
             Err(Ok(retry_millis)) if has_started => {
-                return Ok(Response {
+                return Ok(axum::Json(Response {
                     retry_millis,
                     ..Default::default()
-                })
+                }))
             }
             Err(Ok(retry_millis)) => {
                 () = tokio::time::sleep(std::time::Duration::from_millis(retry_millis)).await;
@@ -51,7 +54,7 @@ fn evaluate_authorization(
     user_id: uuid::Uuid,
     user_email: Option<&String>,
     task_name: &models::Name,
-) -> anyhow::Result<Response> {
+) -> Result<Response, crate::api::ApiError> {
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,
         &snapshot.user_grants,
@@ -59,34 +62,43 @@ fn evaluate_authorization(
         task_name,
         models::Capability::Read,
     ) {
-        anyhow::bail!(
+        return Err(anyhow::anyhow!(
             "{} is not authorized to {task_name}",
             user_email.map(String::as_str).unwrap_or("user")
-        );
+        )
+        .with_status(StatusCode::FORBIDDEN));
     }
 
     let Some(task) = snapshot.task_by_catalog_name(task_name) else {
-        anyhow::bail!("task {task_name} is not known")
-    };
-    let Some(data_plane) = snapshot.data_planes.get_by_key(&task.data_plane_id) else {
-        anyhow::bail!("couldn't resolve task {task_name} data-plane")
-    };
-    let Some(encoding_key) = data_plane.hmac_keys.first() else {
-        anyhow::bail!(
-            "task data-plane {} has no configured HMAC keys",
-            data_plane.data_plane_name
+        return Err(
+            anyhow::anyhow!("task {task_name} is not known").with_status(StatusCode::NOT_FOUND)
         );
     };
-    let encoding_key = jsonwebtoken::EncodingKey::from_base64_secret(&encoding_key)?;
+    let Some(data_plane) = snapshot.data_planes.get_by_key(&task.data_plane_id) else {
+        return Err(
+            anyhow::anyhow!("task data-plane {} not found", task.data_plane_id)
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR),
+        );
+    };
+    let Some(encoding_key) = data_plane.hmac_keys.first() else {
+        return Err(anyhow::anyhow!(
+            "task data-plane {} has no configured HMAC keys",
+            data_plane.data_plane_name
+        )
+        .with_status(StatusCode::INTERNAL_SERVER_ERROR));
+    };
+    let encoding_key = jsonwebtoken::EncodingKey::from_base64_secret(&encoding_key)
+        .context("invalid data-plane hmac key")?;
 
     let (Some(ops_logs), Some(ops_stats)) = (
         snapshot.collection_by_catalog_name(&data_plane.ops_logs_name),
         snapshot.collection_by_catalog_name(&data_plane.ops_stats_name),
     ) else {
-        anyhow::bail!(
+        return Err(anyhow::anyhow!(
             "couldn't resolve data-plane {} ops collections",
             task.data_plane_id
         )
+        .with_status(StatusCode::INTERNAL_SERVER_ERROR));
     };
 
     let ops_suffix = super::ops_suffix(task);
@@ -150,13 +162,4 @@ fn evaluate_authorization(
         retry_millis: 0,
         shard_id_prefix: task.shard_template_id.clone(),
     })
-}
-
-#[axum::debug_handler]
-pub async fn authorize_user_task(
-    axum::extract::State(app): axum::extract::State<Arc<App>>,
-    axum::Extension(claims): axum::Extension<super::ControlClaims>,
-    super::Request(request): super::Request<Request>,
-) -> axum::response::Response {
-    super::wrap(async move { do_authorize_user_task(&app, claims, request).await }).await
 }

--- a/crates/agent/src/api/error.rs
+++ b/crates/agent/src/api/error.rs
@@ -38,13 +38,13 @@ pub struct ApiError {
     /// The HTTP status code
     #[serde(with = "status_serde")]
     #[schemars(schema_with = "status_serde::schema")]
-    status: axum::http::StatusCode,
+    pub status: axum::http::StatusCode,
 
     /// The error message
     #[serde(with = "error_serde")]
     #[schemars(schema_with = "error_serde::schema")]
     #[source]
-    error: anyhow::Error,
+    pub error: anyhow::Error,
 }
 
 mod status_serde {

--- a/crates/agent/src/api/mod.rs
+++ b/crates/agent/src/api/mod.rs
@@ -62,7 +62,7 @@ impl App {
         claims: &ControlClaims,
         catalog_names: &[impl AsRef<str>],
         capability: Capability,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool, crate::api::ApiError> {
         let started_unix = jsonwebtoken::get_current_timestamp();
         loop {
             match Snapshot::evaluate(&self.snapshot, started_unix, |snapshot: &Snapshot| {
@@ -214,22 +214,6 @@ impl axum::response::IntoResponse for Rejection {
                 (StatusCode::BAD_REQUEST, message).into_response()
             }
             Rejection::JsonError(inner) => inner.into_response(),
-        }
-    }
-}
-
-// TODO(johnny): Helper for more ergonomic errors.
-// I'm near-certain there's a cleaner way to do this, but haven't found it yet.
-async fn wrap<F, T>(fut: F) -> axum::response::Response
-where
-    T: serde::Serialize,
-    F: std::future::Future<Output = anyhow::Result<T>>,
-{
-    match fut.await {
-        Ok(inner) => (StatusCode::OK, axum::Json::from(inner)).into_response(),
-        Err(err) => {
-            let err = format!("{err:#}");
-            (StatusCode::BAD_REQUEST, err).into_response()
         }
     }
 }

--- a/crates/tables/src/behaviors.rs
+++ b/crates/tables/src/behaviors.rs
@@ -71,12 +71,13 @@ impl super::RoleGrant {
     /// Given a role or name, determine if it's authorized to the object name for the given capability.
     pub fn is_authorized<'a>(
         role_grants: &'a [super::RoleGrant],
-        role_or_name: &'a str,
-        object_name: &'a str,
+        subject_role_or_name: &'a str,
+        object_role_or_name: &'a str,
         capability: models::Capability,
     ) -> bool {
-        Self::transitive_roles(role_grants, role_or_name).any(|role_grant| {
-            object_name.starts_with(role_grant.object_role) && role_grant.capability >= capability
+        Self::transitive_roles(role_grants, subject_role_or_name).any(|role_grant| {
+            object_role_or_name.starts_with(role_grant.object_role)
+                && role_grant.capability >= capability
         })
     }
 
@@ -111,12 +112,13 @@ impl super::UserGrant {
     pub fn is_authorized<'a>(
         role_grants: &'a [super::RoleGrant],
         user_grants: &'a [super::UserGrant],
-        user_id: uuid::Uuid,
-        object_name: &'a str,
+        subject_user_id: uuid::Uuid,
+        object_role_or_name: &'a str,
         capability: models::Capability,
     ) -> bool {
-        Self::transitive_roles(role_grants, user_grants, user_id).any(|role_grant| {
-            object_name.starts_with(role_grant.object_role) && role_grant.capability >= capability
+        Self::transitive_roles(role_grants, user_grants, subject_user_id).any(|role_grant| {
+            object_role_or_name.starts_with(role_grant.object_role)
+                && role_grant.capability >= capability
         })
     }
 
@@ -315,14 +317,14 @@ mod test {
         ));
         assert!(RoleGrant::is_authorized(
             &role_grants,
-            "daveCo/hidden/thing",
-            "carolCo/even/more/hidden/thing",
+            "daveCo/hidden/",
+            "carolCo/even/more/hidden/",
             Read
         ));
         assert!(!RoleGrant::is_authorized(
             &role_grants,
             "daveCo/hidden/thing",
-            "carolCo/even/more/hidden/thing",
+            "carolCo/even/more/hidden/",
             Write
         ));
 


### PR DESCRIPTION
Return considered status codes for most every error response.

Notably, return 404 if a valid task is attempting to authorize a collection which doesn't exist, as this lets the task recover if it's attempting to write ACK intents to a since-deleted collection.

Also refactor authorize_task() and authorize_dekaf() to validate the request token against its declared data-plane before doing anything else. This ensures the requestor is in possession of a correct data-plane HMAC key before we could possibly leak any information about whether the subject task exists or not.

Tested all APIs **except for authorize_dekaf** on a local stack.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2006)
<!-- Reviewable:end -->
