### PR TITLE
Docs: IP addresses based on data plane

### DIFF
--- a/site/docs/concepts/web-app.md
+++ b/site/docs/concepts/web-app.md
@@ -365,6 +365,12 @@ If you're a trial user, your data is stored temporarily in Estuary's cloud stora
 
 [Learn more about storage mappings.](./storage-mappings.md)
 
+#### Data Planes
+
+The **Data Planes** section provides a table of all available data plane options, broken out by **Private** and **Public** data planes.
+
+You can find information here related to connecting and allowing access to your data plane of choice. See [Allowlisting IP Addresses](../reference/allow-ip-addresses.md) for more.
+
 ### Billing
 
 The **Billing** tab allows you to view and manage information related to past usage, the current billing cycle, and payment methods.

--- a/site/docs/reference/allow-ip-addresses.md
+++ b/site/docs/reference/allow-ip-addresses.md
@@ -1,14 +1,36 @@
 # Allowlisting IP Addresses for Estuary Flow
 
 When configuring systems that interact with Estuary Flow, it's crucial to ensure that the necessary IP addresses are
-allowlisted. This allows communication between Estuary Flow and your data systems. Below are the IP addresses that must
-be allowlisted:
+allowlisted. This allows communication between Estuary Flow and your data systems.
+The IP addresses you need to allowlist depend on the data plane you use.
+
+## Data Plane IP Addresses
+
+You can find the IP addresses relevant to your use case in the **Admin** section of your dashboard. To do so:
+
+1. On the **[Settings](https://dashboard.estuary.dev/admin/settings)** page, find the **Data Planes** section.
+
+2. Choose between the **Private** and **Public** tabs [based on your use case](../getting-started/deployment-options.md).
+
+   Make sure to select the desired data plane when configuring a connector as well.
+
+   If you wish to use a public data plane, Estuary currently offers AWS `eu-west-1` and GCP `us-central1` options.
+
+3. Find the **CIDR Blocks** column in the Data Planes table. This column includes a comma-separated list of IP addresses for that data plane.
+
+   Ensure that these IP addresses are allowlisted on both the source and destination systems that interact with Estuary Flow.
 
 ## IP Addresses to Allowlist
 
-Ensure that the following IP addresses are allowlisted on both the source and destination systems that interact with
-Estuary Flow:
+While your dashboard is the best location to find accurate, up-to-date IP addresses to allowlist, you may also find the current public data plane IP addresses below.
+
+**GCP** (`us-central1 c1`):
 
 - **34.121.207.128**
 - **35.226.75.135**
 - **34.68.62.148**
+
+**AWS** (`eu-west-1 c1`):
+
+- **18.200.127.124/32**
+- **34.247.94.19/32**


### PR DESCRIPTION
**Description:**

Update the docs around allowlisting IP addresses to capture that IP addresses are based on data plane and can now be found in the dashboard.

**Documentation links affected:**

[Allowlisting IP Addresses](https://docs.estuary.dev/reference/allow-ip-addresses/)

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2011)
<!-- Reviewable:end -->
