### PR TITLE
ops-catalog: update bundled template ... and unrelated agent query perf fix

### DIFF
--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -488,9 +488,15 @@ impl TestHarness {
             .all_spec_names()
             .map(|n| (*n).to_owned())
             .collect();
-        let specs = agent_sql::live_specs::fetch_live_specs(user_id, &owned_names, &self.pool)
-            .await
-            .expect("failed to query live specs");
+        let specs = agent_sql::live_specs::fetch_live_specs(
+            user_id,
+            &owned_names,
+            false, /* don't fetch user capabilities */
+            false, /* don't fetch spec capabilities */
+            &self.pool,
+        )
+        .await
+        .expect("failed to query live specs");
         assert_eq!(
             prev_specs.spec_count(),
             specs.len(),

--- a/ops-catalog/data-plane-template.bundle.json
+++ b/ops-catalog/data-plane-template.bundle.json
@@ -63,7 +63,7 @@
             "name": "logs",
             "source": "ops/tasks/BASE_NAME/logs",
             "shuffle": "any",
-            "lambda": "select json($flow_document)\n  where json_type($fields, '$.eventType') = 'text'\n  and json_type($fields, '$.eventTarget') = 'text'\n  and json_type($fields, '$.error') in ('null', 'text');\n"
+            "lambda": "select json($flow_document)\n  where json_type($fields, '$.eventType') = 'text'\n  and json_type($fields, '$.eventTarget') = 'text'\n  and coalesce(json_type($fields, '$.error'), 'null') in ('null', 'text');\n"
           }
         ],
         "shards": {


### PR DESCRIPTION
I forgot to update the bundled template in the previous PR, which updated the flow.yaml.

Also includes a quick and dirty improvement to an agent sql query.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2012)
<!-- Reviewable:end -->
