### PR TITLE
data-plane-controller: add azure_application_client_id to table

### DIFF
--- a/crates/data-plane-controller/src/controller.rs
+++ b/crates/data-plane-controller/src/controller.rs
@@ -845,6 +845,7 @@ impl automations::Outcome for Outcome {
             ssh_key: _,
             bastion_tunnel_private_key,
             azure_application_name,
+            azure_application_client_id,
         }) = self.publish_exports
         {
             _ = sqlx::query!(
@@ -857,7 +858,8 @@ impl automations::Outcome for Outcome {
                     hmac_keys = $7,
                     bastion_tunnel_private_key = $8,
                     azure_application_name = $9,
-                    azure_link_endpoints = $10
+                    azure_link_endpoints = $10,
+                    azure_application_client_id = $11
                 WHERE id = $1 AND controller_task_id = $2
                 "#,
                 self.data_plane_id as models::Id,
@@ -870,6 +872,7 @@ impl automations::Outcome for Outcome {
                 bastion_tunnel_private_key,
                 azure_application_name,
                 &azure_link_endpoints,
+                azure_application_client_id,
             )
             .execute(&mut *txn)
             .await

--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -239,6 +239,7 @@ pub struct ControlExports {
     pub ssh_key: String,
     pub bastion_tunnel_private_key: Option<String>,
     pub azure_application_name: String,
+    pub azure_application_client_id: String,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/supabase/migrations/20250319105337_data_plane_azure_client_id.sql
+++ b/supabase/migrations/20250319105337_data_plane_azure_client_id.sql
@@ -1,0 +1,9 @@
+-- Add azure application client ID column to data_planes
+
+begin;
+
+ALTER TABLE public.data_planes ADD azure_application_client_id TEXT;
+
+GRANT SELECT(azure_application_client_id) ON public.data_planes TO authenticated;
+
+commit;


### PR DESCRIPTION
**Description:**

- This is necessary to construct the URL for authorizing the Azure Application access to customer storage in `est_dry_dock details` and potentially in the future in the UI

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2017)
<!-- Reviewable:end -->
