### PR TITLE
runtime: Correct handling for calling `dekaf::connector::unary_materialize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "bumpalo",
  "bytes",
  "clap 4.5.21",
+ "coroutines",
  "crypto-common",
  "deadpool",
  "doc",

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -25,6 +25,7 @@ proto-gazette = { path = "../proto-gazette" }
 simd-doc = { path = "../simd-doc" }
 tuple = { path = "../tuple" }
 unseal = { path = "../unseal" }
+coroutines = { path = "../coroutines" }
 
 aes-siv = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/runtime/src/materialize/connector.rs
+++ b/crates/runtime/src/materialize/connector.rs
@@ -89,7 +89,9 @@ pub async fn start<L: LogHandler>(
             .boxed()
         }
         models::MaterializationEndpoint::Dekaf(_) => {
-            bail!("Dekaf endpoint types are purely descriptive and cannot be started.")
+            connector_tx.try_send(initial).unwrap();
+
+            dekaf::connector::connector(connector_rx).boxed()
         }
     };
 


### PR DESCRIPTION
**Description:**

Originally the Dekaf special-case lived in `Runtime::unary_materialize`, but https://github.com/estuary/flow/pull/2001 changed the way unary RPCs are invoked in a way that bypassed that logic. Moving it into `Runtime::serve_materialize` fixes things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2018)
<!-- Reviewable:end -->
