### PR TITLE
agent: controllers activate despite publication failures

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -15,8 +15,46 @@ pub async fn update<C: ControlPlane>(
     control_plane: &C,
     model: &models::CaptureDef,
 ) -> anyhow::Result<Option<NextRun>> {
-    let mut dependencies = Dependencies::resolve(state, control_plane).await?;
+    let published = maybe_publish(status, state, control_plane, model).await;
 
+    // Return immediately if we've successfully published. If a publication was
+    // attempted, but failed, then we'll still attempt to update activation, so
+    // that we can activate new builds and restart failed shards.
+    if Some(&true) == published.as_ref().ok() {
+        return Ok(Some(NextRun::immediately()));
+    }
+
+    let activate_next_run =
+        activation::update_activation(&mut status.activation, state, events, control_plane)
+            .await
+            .with_retry(backoff_data_plane_activate(state.failures))?;
+
+    // Return the publication error now, if there is one.
+    let _ = published?;
+
+    publication_status::update_notify_dependents(&mut status.publications, state, control_plane)
+        .await
+        .context("failed to notify dependents")?;
+
+    let ad_next = status
+        .auto_discover
+        .as_ref()
+        .and_then(auto_discover::next_run);
+    let periodic_next = periodic::next_periodic_publish(state);
+    Ok(NextRun::earliest([
+        ad_next,
+        periodic_next,
+        activate_next_run,
+    ]))
+}
+
+async fn maybe_publish<C: ControlPlane>(
+    status: &mut CaptureStatus,
+    state: &ControllerState,
+    control_plane: &C,
+    model: &models::CaptureDef,
+) -> anyhow::Result<bool> {
+    let mut dependencies = Dependencies::resolve(state, control_plane).await?;
     let published = dependencies
         .update(state, control_plane, &mut status.publications, |deleted| {
             let mut draft_capture = model.clone();
@@ -35,25 +73,15 @@ pub async fn update<C: ControlPlane>(
             Ok((detail, draft_capture))
         })
         .await?;
-    tracing::debug!(%published, "dependencies status updated successfully");
     if published {
-        return Ok(Some(NextRun::immediately()));
+        return Ok(true);
     }
-
-    let activate_next_run =
-        activation::update_activation(&mut status.activation, state, events, control_plane)
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))?;
-
-    publication_status::update_notify_dependents(&mut status.publications, state, control_plane)
-        .await
-        .context("failed to notify dependents")?;
 
     if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
-        return Ok(Some(NextRun::immediately()));
+        return Ok(true);
     }
 
-    let ad_next = if model.auto_discover.is_some() {
+    if model.auto_discover.is_some() {
         let ad_status = status
             .auto_discover
             .get_or_insert_with(AutoDiscoverStatus::default);
@@ -68,21 +96,13 @@ pub async fn update<C: ControlPlane>(
         .context("updating auto-discover")?;
         tracing::debug!(%published, "auto-discover status updated successfully");
         if published {
-            return Ok(Some(NextRun::immediately()));
+            return Ok(true);
         }
-        auto_discover::next_run(ad_status)
     } else {
         // Clear auto-discover status to avoid confusion, but only if
         // auto-discover is disabled. We leave the auto-discover status if
         // shards are disabled, since it's still useful for debugging.
         status.auto_discover = None;
-        None
     };
-
-    let periodic_next = periodic::next_periodic_publish(state);
-    Ok(NextRun::earliest([
-        ad_next,
-        periodic_next,
-        activate_next_run,
-    ]))
+    Ok(false)
 }


### PR DESCRIPTION
This addresses a fairly common failure scenario, where controllers have a need to both publish a new version of the spec, and also activate the current version of the spec.  Controllers generally perform any publications before attempting any activations, in order to minimize the number of activations that need to be preformed.

Previously, this meant that a failure to publish would cause the controller to error before it could attempt the activation, meaning that persistent publication failures could completely prevent the activation of task shards.

This updates controllers to attempt activations after a publication failure, so that a failed publication can no longer prevent the activation of the existing build.  This is especially important now that controllers are responsible for restarting failed shards. There are tasks that can run and make progress, even though attempts to publish them will consistently fail.  As of this commit, agents will now restart those shards as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2022)
<!-- Reviewable:end -->
