### PR TITLE
dekaf: Fix double `use` statement breaking the build

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -596,7 +596,6 @@ mod tests {
     use tracing::{info, info_span};
     use tracing::{instrument::WithSubscriber, Instrument};
 
-    use bytes::Bytes;
     use tracing_record_hierarchical::SpanExt;
     use tracing_subscriber::prelude::*;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2024)
<!-- Reviewable:end -->
