### PR TITLE
Phil/controller backoffs

### DIFF
--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -109,7 +109,7 @@ async fn maybe_publish<C: ControlPlane>(
         status.source_capture.take();
     }
 
-    let periodic = periodic::start_periodic_publish_update(state, control_plane);
+    let periodic = periodic::start_periodic_publish_update(state, control_plane)?;
     if periodic.has_pending() {
         do_publication(&mut status.publications, state, periodic, control_plane).await?;
         return Ok(true);

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -60,7 +60,7 @@ async fn maybe_publish<C: ControlPlane>(
     // because we need to handle the schema evolution whenever we publish. The collection schemas could have changed
     // since the last publish, and we might need to apply `onIncompatibleSchemaChange` actions.
     let dependency_pub = dependencies
-        .start_update(state, |deleted| {
+        .start_update(state, control_plane.current_time(), |deleted| {
             Ok(handle_deleted_dependencies(deleted, model.clone()))
         })
         .await?;

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -170,6 +170,16 @@ impl ControllerState {
     }
 }
 
+/// Returns an `Err` result with a backoff message, and a next retry set to the given `next_attempt`.
+fn backoff_err<T>(next_attempt: NextRun, action: &str, fail_count: u32) -> anyhow::Result<T> {
+    let plural = if fail_count > 1 { "s" } else { "" };
+    anyhow::Result::<T>::Err(anyhow::anyhow!(
+        "backing off {action} after {fail_count} failure{plural}"
+    ))
+    .with_retry(next_attempt)
+    .map_err(Into::into)
+}
+
 /// A wrapper around an `anyhow::Error` that also contains retry information.
 /// Allows marking an error as non-retryable by setting `retry` to `None`.
 #[derive(Debug)]

--- a/crates/agent/src/controllers/periodic.rs
+++ b/crates/agent/src/controllers/periodic.rs
@@ -6,6 +6,7 @@
 //! can already record any useful information, and the `live_specs` table
 //! already records the last update time of each spec.
 use anyhow::Context;
+use chrono::{DateTime, Utc};
 use models::{status::publications::PublicationStatus, ModelDef};
 
 use crate::ControlPlane;
@@ -20,23 +21,58 @@ const PERIODIC_PUBLISH_INTERVAL: chrono::Duration = chrono::Duration::days(20);
 /// Returns a `NextRun` for the next scheduled periodic publication, unless the
 /// spec is disabled.
 pub fn next_periodic_publish(state: &ControllerState) -> Option<NextRun> {
+    // Tiny jitter because we're dealing with pretty long durations.
+    next_pub_time(state).map(|(when, _)| NextRun::after(when).with_jitter_percent(2))
+}
+
+/// Computes the wall clock time of the next desired periodic publication,
+/// and returns it along with a count of recent publication failures.
+/// Returns None if the spec is disabled.
+fn next_pub_time(state: &ControllerState) -> Option<(DateTime<Utc>, u32)> {
     if !is_enabled_task(state) {
         return None;
     }
+
     let next = state.live_spec_updated_at + PERIODIC_PUBLISH_INTERVAL;
-    // Tiny jitter because we're dealing with pretty long durations.
-    Some(NextRun::after(next).with_jitter_percent(2))
+    if let Some((last_attempt, fail_count)) =
+        state
+            .current_status
+            .publication_status()
+            .and_then(|pub_status| {
+                // We look at the most recent entry in the publication history
+                // to determine the last attempt and number of failures.
+                // Technically, this entry might not be from a periodic
+                // publication attemt (it could be due to dependency changes,
+                // etc), and that's OK. Our goal is to limit the overall rate of
+                // publication attempts.
+                pub_status
+                    .history
+                    .front()
+                    .filter(|e| !e.is_success())
+                    .and_then(|e| {
+                        e.completed
+                            // Ignore prior attempts that were before the periodic pulication came due.
+                            .filter(|last| *last > next)
+                            .map(|last_attempt| (last_attempt, e.count))
+                    })
+            })
+    {
+        Some((last_attempt + chrono::TimeDelta::hours(1), fail_count))
+    } else {
+        Some((next, 0))
+    }
 }
 
 /// Publishes the spec if necessary, and returns a boolean indicating whether it
 /// was published. If this returns `true`, then the controller must immediately
-/// return and schedule a subsequent run.
+/// return and schedule a subsequent run. Returns an error if a periodic publication
+/// is needed, but can't yet be attempted due to the backoff.
 pub async fn update_periodic_publish<C: ControlPlane>(
     state: &ControllerState,
     pub_status: &mut PublicationStatus,
     control_plane: &C,
 ) -> anyhow::Result<bool> {
-    let mut pending = start_periodic_publish_update(state, control_plane);
+    let mut pending = start_periodic_publish_update(state, control_plane)?;
     if !pending.has_pending() {
         return Ok(false);
     }
@@ -51,18 +87,26 @@ pub async fn update_periodic_publish<C: ControlPlane>(
 
 /// Starts the update and returns a `PendingPublication`. If no publication is
 /// necessary at this time, then the pending draft will be empty. Otherwise, it
-/// will contain a touch publication of the spec.
+/// will contain a touch publication of the spec. Will return an error if a periodic
+/// publication is needed, but shouldn't be attempted yet due to the backoff.
 pub fn start_periodic_publish_update<C: ControlPlane>(
     state: &ControllerState,
     control_plane: &C,
-) -> PendingPublication {
+) -> anyhow::Result<PendingPublication> {
     let mut pending = PendingPublication::new();
-    if is_enabled_task(state)
-        && control_plane.current_time() - state.live_spec_updated_at > PERIODIC_PUBLISH_INTERVAL
-    {
-        pending.start_touch(state, "periodic publication");
+    if let Some((next_attempt, failures)) = next_pub_time(state) {
+        if next_attempt < control_plane.current_time() {
+            pending.start_touch(state, "periodic publication");
+        } else if failures > 0 {
+            // `next_attempt` is in the future, error with a retry that's set to the next attempt.
+            return super::backoff_err(
+                NextRun::after(next_attempt).with_jitter_percent(5),
+                "periodic publication",
+                failures,
+            );
+        }
     }
-    pending
+    Ok(pending)
 }
 
 /// Returns true if the live spec is a task that is enabled. False for all

--- a/crates/agent/src/controllers/periodic.rs
+++ b/crates/agent/src/controllers/periodic.rs
@@ -44,17 +44,9 @@ fn next_pub_time(state: &ControllerState) -> Option<(DateTime<Utc>, u32)> {
                 // Technically, this entry might not be from a periodic
                 // publication attemt (it could be due to dependency changes,
                 // etc), and that's OK. Our goal is to limit the overall rate of
-                // publication attempts.
-                pub_status
-                    .history
-                    .front()
-                    .filter(|e| !e.is_success())
-                    .and_then(|e| {
-                        e.completed
-                            // Ignore prior attempts that were before the periodic pulication came due.
-                            .filter(|last| *last > next)
-                            .map(|last_attempt| (last_attempt, e.count))
-                    })
+                // publication attempts. Also ignore prior attempts that were
+                // before the periodic pulication came due.
+                super::last_pub_failed(pub_status, "").filter(|(last, _)| *last > next)
             })
     {
         Some((last_attempt + chrono::TimeDelta::hours(1), fail_count))

--- a/crates/agent/src/integration_tests/schema_evolution.rs
+++ b/crates/agent/src/integration_tests/schema_evolution.rs
@@ -348,6 +348,11 @@ async fn test_schema_evolution() {
 
     // Now re-try materializeMixed, and this time there is no unsatisfiable constraint. IRL, this
     // might happen if someone was manually updating the destination table.
+    // We need to first skip past the backoff from the failed publication.
+    let new_last_attempt = harness.control_plane().current_time() - chrono::Duration::minutes(2);
+    harness
+        .push_back_last_pub_history_ts("goats/materializeMixed", new_last_attempt)
+        .await;
     harness
         .run_pending_controller("goats/materializeMixed")
         .await;

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -98,6 +98,16 @@ impl ControllerStatus {
         }
     }
 
+    pub fn publication_status(&self) -> Option<&publications::PublicationStatus> {
+        match self {
+            ControllerStatus::Capture(c) => Some(&c.publications),
+            ControllerStatus::Collection(c) => Some(&c.publications),
+            ControllerStatus::Materialization(c) => Some(&c.publications),
+            ControllerStatus::Test(s) => Some(&s.publications),
+            ControllerStatus::Uninitialized => None,
+        }
+    }
+
     pub fn as_capture_mut(&mut self) -> anyhow::Result<&mut capture::CaptureStatus> {
         if self.is_uninitialized() {
             *self = ControllerStatus::Capture(Default::default());

--- a/crates/runtime/src/materialize/protocol.rs
+++ b/crates/runtime/src/materialize/protocol.rs
@@ -464,7 +464,7 @@ pub fn send_client_flushed(buf: &mut bytes::BytesMut, task: &Task, txn: &Transac
         ops::merge_docs_and_bytes(&binding_stats.1, &mut entry.right);
         ops::merge_docs_and_bytes(&binding_stats.2, &mut entry.out);
 
-        if entry.left.is_some() {
+        if entry.right.is_some() {
             entry.last_source_published_at = binding_stats.3.to_pb_json_timestamp();
         }
     }


### PR DESCRIPTION
**Description:**

Resolves #2032
Adds backoffs to controller-initiated publications and discovers, so that they don't retry them too frequently when the controller is invoked frequently for various different reasons. This ought to dramatically reduce the rate of failed publications and discovers, which are being run due to frequent shard failures, which trigger controller runs.

In all of these, the goal is to still show the controller as being in error status when it's waiting on a backoff, so that failures are still obvious when looking at the overall status.

Also fixes a bug in the runtime, which caused us to fail to set `lastSourcePublishedAt` in materialization stats documents if no documents were read from the source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2038)
<!-- Reviewable:end -->
