### PR TITLE
flowctl: add --data-plane-name filter to catalog list

### DIFF
--- a/crates/flowctl/src/catalog/delete.rs
+++ b/crates/flowctl/src/catalog/delete.rs
@@ -37,6 +37,8 @@ pub struct Delete {
     pub name_selector: NameSelector,
     #[clap(flatten)]
     pub type_selector: catalog::SpecTypeSelector,
+    #[clap(flatten)]
+    pub data_plane_selector: catalog::DataPlaneSelector,
     /// Proceed with deletion without prompting for confirmation.
     ///
     /// Normally, delete will stop and ask for confirmation before it proceeds. This flag disables
@@ -60,6 +62,7 @@ pub async fn do_delete(
     Delete {
         name_selector,
         type_selector,
+        data_plane_selector,
         dangerous_auto_approve,
     }: &Delete,
 ) -> anyhow::Result<()> {
@@ -67,6 +70,7 @@ pub async fn do_delete(
         flows: false,
         name_selector: name_selector.clone().into(),
         type_selector: type_selector.clone(),
+        data_plane_selector: data_plane_selector.clone(),
     };
 
     let specs = catalog::fetch_live_specs::<catalog::LiveSpecRow>(
@@ -81,6 +85,7 @@ pub async fn do_delete(
             "last_pub_user_email",
             "last_pub_user_id",
             "last_pub_user_full_name",
+            "data_plane_id",
         ],
     )
     .await

--- a/crates/flowctl/src/catalog/pull_specs.rs
+++ b/crates/flowctl/src/catalog/pull_specs.rs
@@ -1,5 +1,6 @@
 use crate::catalog::{
-    collect_specs, fetch_live_specs, List, LiveSpecRow, NameSelector, SpecTypeSelector,
+    collect_specs, fetch_live_specs, DataPlaneSelector, List, LiveSpecRow, NameSelector,
+    SpecTypeSelector,
 };
 use crate::local_specs;
 use crate::CliContext;
@@ -11,6 +12,8 @@ pub struct PullSpecs {
     name_selector: NameSelector,
     #[clap(flatten)]
     type_selector: SpecTypeSelector,
+    #[clap(flatten)]
+    data_plane_selector: DataPlaneSelector,
     /// Root flow specification to create or update.
     #[clap(long, default_value = "flow.yaml")]
     target: String,
@@ -30,6 +33,7 @@ pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Re
             flows: false,
             name_selector: args.name_selector.clone(),
             type_selector: args.type_selector.clone(),
+            data_plane_selector: args.data_plane_selector.clone(),
         },
         vec![
             "catalog_name",
@@ -41,6 +45,7 @@ pub async fn do_pull_specs(ctx: &mut CliContext, args: &PullSpecs) -> anyhow::Re
             "last_pub_user_id",
             "spec_type",
             "spec",
+            "data_plane_id",
         ],
     )
     .await?;


### PR DESCRIPTION
**Description:**

- Going to use this in est-dry-dock to clean up all tasks and collections of a data-plane, also generally useful

Tested manually using:

```
flowctl catalog pull-specs --data-plane-name ops/dp/private/estuarysupport/az-eastus-c1
flowctl catalog pull-specs --data-plane-name ops/dp/private/estuarysupport/az-eastus-c1 --prefix nonexistentTenant/
flowctl catalog list --data-plane-name ops/dp/private/estuary_support/aws-us-west-2-c1
flowctl catalog delete --data-plane-name ops/dp/private/estuarysupport/az-eastus-c1 --prefix estuary/az-
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2041)
<!-- Reviewable:end -->
