### PR TITLE
dekaf: Skip to the correct offset when we get a `Meta` message

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -194,6 +194,8 @@ impl Read {
             let (root, next_offset) = match read {
                 ReadJsonLine::Meta(response) => {
                     self.last_write_head = response.write_head;
+                    // Skip self.offset forward in case we're skipping past a gap
+                    self.offset = response.offset;
                     continue;
                 }
                 ReadJsonLine::Doc { root, next_offset } => (root, next_offset),


### PR DESCRIPTION
**Description:**

We noticed this when the stats for a Dekaf materialization reading from a collection with expired fragments was reporting dramatically higher stats than it should. The problem is that we were accidentally counting the entire missing fragment(s) as data read, instead of correctly resetting our offset tracker to the beginning of the next fragment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2042)
<!-- Reviewable:end -->
