### PR TITLE
runtime: add materialize-azure-fabric-warehouse to ser_policy

### DIFF
--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -32,6 +32,7 @@ impl Task {
         // that don't handle large strings very well. This should be negotiated via connector protocol.
         // See go/runtime/materialize.go:135
         let ser_policy = if [
+            "ghcr.io/estuary/materialize-azure-fabric-warehouse",
             "ghcr.io/estuary/materialize-bigquery",
             "ghcr.io/estuary/materialize-kafka",
             "ghcr.io/estuary/materialize-snowflake",


### PR DESCRIPTION
**Description:**

Azure Fabric Warehouse has a 1MB size limit on VARCHAR(MAX) columns, so we need to try to stay below that size for any individual string field, and probably more importantly the entire document, since the document is stored in such a column.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2048)
<!-- Reviewable:end -->
