### PR TITLE
reactor: change state key for max load keys

### DIFF
--- a/crates/runtime/src/materialize/protocol.rs
+++ b/crates/runtime/src/materialize/protocol.rs
@@ -586,5 +586,10 @@ pub async fn recv_connector_started_commit(
 }
 
 fn max_key_key(binding: &Binding) -> String {
-    format!("MK:{}", &binding.state_key)
+    // Key name changed in order to effectively disable the load optimization
+    // for all existing materializations, while preserving it for any new ones.
+    // The optimization was temporarily disabled as part of the 0325 incident
+    // recovery, and this effectively makes that permanent, while allowing it to
+    // be used on new tasks.
+    format!("MK-v2:{}", &binding.state_key)
 }


### PR DESCRIPTION
Updates the key that's used within materialization state to track the max key that's been observed. We had temporarily disabled the load key optimizations as part of the 0325 indcident recovery, and this effectively makes that disablement permanent for existing tasks, while allowing it to be used for any newly created tasks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2051)
<!-- Reviewable:end -->
