### PR TITLE
dekaf: Fix log forwarding dropping some messages

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -243,7 +243,8 @@ impl App {
             // We only set this after successfully validating that this task exists and is a Dekaf
             // materialization. Otherwise we will either log auth errors attempting to append to
             // a journal that doesn't exist, or possibly log confusing errors to a different task's logs entirely.
-            logging::get_log_forwarder().set_task_name(username.clone(), labels.build.clone());
+            logging::get_log_forwarder()
+                .map(|f| f.set_task_name(username.clone(), labels.build.clone()));
 
             // 3. Validate that the provided password matches the task's bearer token
             if password != config.token {
@@ -261,8 +262,8 @@ impl App {
             )?))
         } else if username.contains("{") {
             // Since we don't have a task, we also don't have a logs journal to write to,
-            // so we should isable log forwarding for this session.
-            logging::get_log_forwarder().shutdown();
+            // so we should disable log forwarding for this session.
+            logging::get_log_forwarder().map(|f| f.shutdown());
 
             let raw_token = String::from_utf8(base64::decode(password)?.to_vec())?;
             let refresh: RefreshToken = serde_json::from_str(raw_token.as_str())?;

--- a/crates/dekaf/src/logging.rs
+++ b/crates/dekaf/src/logging.rs
@@ -131,12 +131,12 @@ where
     )
 }
 
-pub fn get_log_forwarder() -> TaskForwarder<GazetteWriter> {
-    TASK_FORWARDER.get()
+pub fn get_log_forwarder() -> Option<TaskForwarder<GazetteWriter>> {
+    TASK_FORWARDER.try_with(|v| v.clone()).ok()
 }
 
 pub fn set_log_level(level: ops::LogLevel) {
-    LOG_LEVEL.with(|current_level| {
+    let _ = LOG_LEVEL.try_with(|current_level| {
         current_level.set(build_log_filter(level));
-    })
+    });
 }

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -354,22 +354,24 @@ impl Read {
         // Right: Input documents from journal. Left: Input docs from destination. Out: Right Keys ⋃ Left Keys
         // Dekaf reads docs from journals, so it emits "right". It doesn't do reduction with a destination system,
         // so it does not emit "left". And right now, it does not reduce at all, so "out" is the same as "right".
-        logging::get_log_forwarder().send_stats(
-            self.collection_name.to_owned(),
-            ops::stats::Binding {
-                right: Some(ops::stats::DocsAndBytes {
-                    docs_total: stats_records,
-                    bytes_total: stats_bytes,
-                }),
-                out: Some(ops::stats::DocsAndBytes {
-                    docs_total: stats_records,
-                    bytes_total: stats_bytes,
-                }),
-                left: None,
-                last_source_published_at: last_source_published_at
-                    .and_then(|c| c.to_pb_json_timestamp()),
-            },
-        );
+        logging::get_log_forwarder().map(|f| {
+            f.send_stats(
+                self.collection_name.to_owned(),
+                ops::stats::Binding {
+                    right: Some(ops::stats::DocsAndBytes {
+                        docs_total: stats_records,
+                        bytes_total: stats_bytes,
+                    }),
+                    out: Some(ops::stats::DocsAndBytes {
+                        docs_total: stats_records,
+                        bytes_total: stats_bytes,
+                    }),
+                    left: None,
+                    last_source_published_at: last_source_published_at
+                        .and_then(|c| c.to_pb_json_timestamp()),
+                },
+            );
+        });
 
         let frozen = buf.freeze();
 


### PR DESCRIPTION
**Description:**

I realized we were dropping some log messages on the floor, especially messages that were logged soon before a task exited. I ended up realizing that because the append futures were being directly provided to `tokio::select!`, they will get cancelled if another future in the select resolves first. Per convo w/ @jgraettinger, I refactored the append loop to:

* First check if a new log or stats append can be started. If it can, start it and store it in a `MaybeFuture::Future`
* Poll either/both `MaybeFuture`s if they're not `Done` or `Gone`
* Poll for new messages
* Poll for a tick to send any gathered/rolled up stats since the last tick

Also per convo w/ @psFried, remove log forwarding from the registry. We never ended up setting a task name so no logs got sent, and it's best if we don't allow external data like from HTTP requests to get into the ops logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2055)
<!-- Reviewable:end -->
