### PR TITLE
dekaf: Add connection+buffer size limit, fix network errors being categorized as auth errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "socket2",
  "tables",
  "tempfile",
+ "thiserror",
  "time 0.3.36",
  "tokio",
  "tokio-rustls 0.26.0",

--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -82,6 +82,7 @@ typestate = { workspace = true }
 url = { workspace = true }
 webpki = { workspace = true }
 apache-avro = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 async-process = { path = "../async-process" }

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -69,6 +69,7 @@ impl Read {
         value_schema_id: u32,
         rewrite_offsets_from: Option<i64>,
         auth: &SessionAuthentication,
+        buffer_size: usize,
     ) -> anyhow::Result<Self> {
         let (not_before_sec, _) = collection
             .not_before
@@ -86,7 +87,7 @@ impl Read {
             // Each ReadResponse can be up to 130K. Buffer up to ~4MB so that
             // `dekaf` can do lots of useful transcoding work while waiting for
             // network delay of the next fetch request.
-            30,
+            buffer_size,
         );
 
         Ok(Self {

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -49,6 +49,8 @@ pub struct Session {
     data_preview_state: SessionDataPreviewState,
     broker_urls: Vec<String>,
     msk_region: String,
+    // Number of ReadResponses to buffer in PendingReads
+    read_buffer_size: usize,
 
     // ------ This can be cleaned up once everyone is migrated off of the legacy connection mode ------
     legacy_mode_broker_urls: Vec<String>,
@@ -63,6 +65,7 @@ impl Session {
         secret: String,
         broker_urls: Vec<String>,
         msk_region: String,
+        read_buffer_size: usize,
         legacy_mode_broker_urls: Vec<String>,
         legacy_mode_broker_username: String,
         legacy_mode_broker_password: String,
@@ -72,6 +75,7 @@ impl Session {
             client: None,
             broker_urls,
             msk_region,
+            read_buffer_size,
             legacy_mode_broker_urls,
             legacy_mode_broker_username,
             legacy_mode_broker_password,
@@ -604,6 +608,7 @@ impl Session {
                                     value_schema_id,
                                     Some(partition_request.fetch_offset - 1),
                                     &auth,
+                                    self.read_buffer_size,
                                 )?
                                 .next_batch(
                                     // Have to read at least 2 docs, as the very last doc
@@ -632,6 +637,7 @@ impl Session {
                                     value_schema_id,
                                     None,
                                     &auth,
+                                    self.read_buffer_size,
                                 )?
                                 .next_batch(
                                     crate::read::ReadTarget::Bytes(


### PR DESCRIPTION
#### Tunables

We were seeing issues caused by large numbers of incoming connection requests causing OOMs, so I'm hoping that adding and subsequently tuning these knobs will let us prevent that in the future. It's possible that we'll want to introduce the ability to adjust the chunk cap on a per-materialization basis, but for the moment tuning it globally is good enough.

* `MAX_CONNECTIONS` limits the total number of connections per Dekaf pod. The limit is enforced by immediately disconnecting new connections if we're over the limit.
* `READ_BUFFER_CHUNK_LIMIT` allows for configuring the buffer size we ask [`read_json_lines()`](https://github.com/estuary/flow/blob/master/crates/gazette/src/journal/read_json_lines.rs#L27) to maintain. Previously this was hardcoded to 30, which means we can have up to 4mb buffered per session. If we have 300 sessions, that's ~1.2gb in just `ReadJsonLine` buffers. 

#### Error codes

We're getting lots of complaints about unexpected authentication errors. This is because we're currently categorizing _all_ errors encountered during `sasl_authenticate` as `SaslAuthenticationFailed`, whereas most of the real causes are transient network related errors. We could be even better about breaking down the error variants, but this should be enough to stop the bleeding.

Fixes https://github.com/estuary/flow/issues/2064

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2070)
<!-- Reviewable:end -->
