### PR TITLE
dekaf: include task name in fetch request metrics

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -436,6 +436,14 @@ impl Session {
     ) -> anyhow::Result<messages::FetchResponse> {
         use messages::fetch_response::{FetchableTopicResponse, PartitionData};
 
+        let task_name = match &self.auth {
+            Some(SessionAuthentication::Task(auth)) => auth.task_name.clone(),
+            Some(SessionAuthentication::User(auth)) => {
+                format!("user-auth: {:?}", auth.claims.email)
+            }
+            None => bail!("Not authenticated"),
+        };
+
         let messages::FetchRequest {
             topics: topic_requests,
             max_bytes: _, // Ignored.
@@ -519,6 +527,7 @@ impl Session {
                             "dekaf_fetch_requests",
                             "topic_name" => key.0.to_string(),
                             "partition_index" => key.1.to_string(),
+                            "task_name" => task_name.to_string(),
                             "state" => "read_expired"
                         )
                         .increment(1);
@@ -537,6 +546,7 @@ impl Session {
                             "dekaf_fetch_requests",
                             "topic_name" => key.0.to_string(),
                             "partition_index" => key.1.to_string(),
+                            "task_name" => task_name.to_string(),
                             "state" => "read_pending"
                         )
                         .increment(1);
@@ -554,6 +564,7 @@ impl Session {
                         "dekaf_fetch_requests",
                         "topic_name" => key.0.to_string(),
                         "partition_index" => key.1.to_string(),
+                        "task_name" => task_name.to_string(),
                         "state" => "collection_not_found"
                     )
                     .increment(1);
@@ -568,6 +579,7 @@ impl Session {
                         "dekaf_fetch_requests",
                         "topic_name" => key.0.to_string(),
                         "partition_index" => key.1.to_string(),
+                        "task_name" => task_name.to_string(),
                         "state" => "partition_not_found"
                     )
                     .increment(1);
@@ -591,6 +603,7 @@ impl Session {
                                 "dekaf_fetch_requests",
                                 "topic_name" => key.0.to_string(),
                                 "partition_index" => key.1.to_string(),
+                                "task_name" => task_name.to_string(),
                                 "state" => "new_data_preview_read"
                             )
                             .increment(1);
@@ -619,6 +632,7 @@ impl Session {
                                 "dekaf_fetch_requests",
                                 "topic_name" => key.0.to_string(),
                                 "partition_index" => key.1.to_string(),
+                                "task_name" => task_name.to_string(),
                                 "state" => "new_regular_read"
                             )
                             .increment(1);


### PR DESCRIPTION
Now that topic names are no longer collection names, we need a way to break down stats by task in order to correctly roll up by tenant, among other things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2071)
<!-- Reviewable:end -->
