### PR TITLE
agent: fix skipping auto-discovers for disabled tasks

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -62,6 +62,9 @@ async fn maybe_publish<C: ControlPlane>(
     model: &models::CaptureDef,
 ) -> anyhow::Result<bool> {
     if model.shards.disable {
+        if let Some(ad) = status.auto_discover.as_mut() {
+            ad.next_at.take();
+        }
         return Ok(false);
     }
     let mut dependencies = Dependencies::resolve(state, control_plane).await?;


### PR DESCRIPTION
Fixes an issue that causes the agent to rapidly re-run controllers in certain scenarios when a spec is disabled after previously encountering repeated auto-discover failures. This removes the `next_at` whenever the spec is disabled to ensure that we won't keep running the controller in a tight loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2072)
<!-- Reviewable:end -->
