### PR TITLE
agent: more robust controller error handling

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -15,60 +15,40 @@ pub async fn update<C: ControlPlane>(
     control_plane: &C,
     model: &models::CaptureDef,
 ) -> anyhow::Result<Option<NextRun>> {
-    let published = maybe_publish(status, state, control_plane, model).await;
-
-    // Return immediately if we've successfully published. If a publication was
-    // attempted, but failed, then we'll still attempt to update activation, so
-    // that we can activate new builds and restart failed shards.
-    if Some(&true) == published.as_ref().ok() {
-        return Ok(Some(NextRun::immediately()));
-    }
-
-    let activate_result =
-        activation::update_activation(&mut status.activation, state, events, control_plane)
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))
-            .map_err(Into::into);
-
-    // Only notify dependents if our publication and activation were successful.
-    let notify_result = if published.is_ok() && activate_result.is_ok() {
-        publication_status::update_notify_dependents(&mut status.publications, state, control_plane)
-            .await
-            .context("failed to notify dependents")
-            .map(|_| None)
+    let auto_discover_result = if model.auto_discover.is_some() && !model.shards.disable {
+        let ad_status = status
+            .auto_discover
+            .get_or_insert_with(AutoDiscoverStatus::default);
+        let result = auto_discover::update(
+            ad_status,
+            state,
+            model,
+            control_plane,
+            &mut status.publications,
+        )
+        .await
+        .context("updating auto-discover");
+        tracing::debug!(?result, "auto-discover status updated");
+        if result.as_ref().ok() == Some(&true) {
+            return Ok(Some(NextRun::immediately()));
+        }
+        result.map(|_| auto_discover::next_run(ad_status))
     } else {
-        Ok(None)
-    };
-
-    let ad_next = status
-        .auto_discover
-        .as_ref()
-        .and_then(auto_discover::next_run);
-    let periodic_next = periodic::next_periodic_publish(state);
-
-    coalesce_results([
-        published.map(|_| None),
-        Ok(ad_next),
-        Ok(periodic_next),
-        activate_result,
-        notify_result,
-    ])
-}
-
-async fn maybe_publish<C: ControlPlane>(
-    status: &mut CaptureStatus,
-    state: &ControllerState,
-    control_plane: &C,
-    model: &models::CaptureDef,
-) -> anyhow::Result<bool> {
-    if model.shards.disable {
+        // Clear auto-discover status to avoid confusion, but only if
+        // auto-discover is disabled. We leave the auto-discover status if
+        // shards are disabled, since it's still useful for debugging.
+        if !model.shards.disable {
+            status.auto_discover = None;
+        }
+        // Otherwise, just clear the `next_at` time.
         if let Some(ad) = status.auto_discover.as_mut() {
             ad.next_at.take();
         }
-        return Ok(false);
-    }
+        Ok(None)
+    };
+
     let mut dependencies = Dependencies::resolve(state, control_plane).await?;
-    let published = dependencies
+    let dependencies_published = dependencies
         .update(state, control_plane, &mut status.publications, |deleted| {
             let mut draft_capture = model.clone();
             let mut disabled_count = 0;
@@ -85,37 +65,41 @@ async fn maybe_publish<C: ControlPlane>(
             );
             Ok((detail, draft_capture))
         })
-        .await?;
-    if published {
-        return Ok(true);
+        .await;
+    if dependencies_published.as_ref().ok() == Some(&true) {
+        return Ok(Some(NextRun::immediately()));
     }
-
-    if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
-        return Ok(true);
+    let dependencies_result = dependencies_published.map(|_| None);
+    let periodic_published =
+        periodic::update_periodic_publish(state, &mut status.publications, control_plane).await;
+    if periodic_published.as_ref().ok() == Some(&true) {
+        return Ok(Some(NextRun::immediately()));
     }
+    let periodic_result = periodic_published.map(|_| periodic::next_periodic_publish(state));
 
-    if model.auto_discover.is_some() {
-        let ad_status = status
-            .auto_discover
-            .get_or_insert_with(AutoDiscoverStatus::default);
-        let published = auto_discover::update(
-            ad_status,
-            state,
-            model,
-            control_plane,
-            &mut status.publications,
-        )
-        .await
-        .context("updating auto-discover")?;
-        tracing::debug!(%published, "auto-discover status updated successfully");
-        if published {
-            return Ok(true);
-        }
-    } else {
-        // Clear auto-discover status to avoid confusion, but only if
-        // auto-discover is disabled. We leave the auto-discover status if
-        // shards are disabled, since it's still useful for debugging.
-        status.auto_discover = None;
-    };
-    Ok(false)
+    let activate_result =
+        activation::update_activation(&mut status.activation, state, events, control_plane)
+            .await
+            .with_retry(backoff_data_plane_activate(state.failures))
+            .map_err(Into::into);
+
+    let notify_result = publication_status::update_notify_dependents(
+        &mut status.publications,
+        state,
+        control_plane,
+    )
+    .await
+    .context("failed to notify dependents")
+    .map(|_| None);
+
+    coalesce_results(
+        state.failures,
+        [
+            auto_discover_result,
+            dependencies_result,
+            periodic_result,
+            activate_result,
+            notify_result,
+        ],
+    )
 }

--- a/crates/agent/src/controllers/executor.rs
+++ b/crates/agent/src/controllers/executor.rs
@@ -9,7 +9,7 @@
 use std::collections::VecDeque;
 
 use crate::{
-    controllers::{fetch_controller_state, RetryableError},
+    controllers::{fallback_backoff_next_run, fetch_controller_state, RetryableError},
     ControlPlane,
 };
 use anyhow::Context;
@@ -202,13 +202,4 @@ async fn run_controller<C: ControlPlane>(
     };
     inbox.clear();
     result_parts
-}
-
-fn fallback_backoff_next_run(failures: i32) -> NextRun {
-    let minutes = match failures.max(1).min(8) as u32 {
-        1 => 1,
-        2 => 10,
-        more => more * 45,
-    };
-    NextRun::after_minutes(minutes).with_jitter_percent(50)
 }


### PR DESCRIPTION
Implements a number of fixes and improvements to controller error handling.

This addresses an acute issue, where it was possible for a controller to fail in a tight loop. That was happening in cases where auto-discovers or periodic publications were failing, and there was also a failure to publish in response to a change in dependencies. In that case, the next run was computed based on the time of the next desired auto-discover or periodic publication, which was in the past due to the failures.

It also addresses an issue with captures, where a dependency update publication would fail, preventing auto-discovers from being attempted.  In some cases, the dependency update publication was failing due to tables being dropped from a source database, and an auto-discover would have removed the affected bindings, had it been allowed to proceed.

Addressing both of those issues required rethinking how we compose the various low level controller functions (e.g. `update_periodic_publish`, `update_activation`, etc)  into the capture and materialization controllers.

Previously, we would call these functions one at a time, returning immediately if _either_ the function published the spec, or if it failed. Now, we still return immediately if it published the spec, but will continue to execute other controller functions if one of them fails. This ensures that, for example, an auto-discover will still be attempted if a dependency update publication failed.

Additionally, this cleans up how we determine the desired next run time, so that the next run for any particular controller function is determined from either it's success or failure, but not both. In other words, we no longer use `next_periodic_publish` to compute the next run time unless `update_periodic_publish` was successful. Otherwise, we use the backoff from the periodic publish error (which we now make sure to set). This same pattern applies to auto-discovers as well.

Finally, this also addresses a corner case in `coalesce_results`, where there's a raw error without any explicit retry set. Previously, this could incorrectly result in _no_ retry being scheduled, and this updates that to now compute a default retry based on the number of previous controller errors. Additionally, `coalesce_results` now has an explicit check for the case where a controller returns an error and an immediate next run, just in case we discover or add more scenarios where a controller might again fail in a tight loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2073)
<!-- Reviewable:end -->
