### PR TITLE
Phil/shard restart backoffs

### DIFF
--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -369,8 +369,11 @@ pub fn coalesce_results(
     // If the controller returned an error and also a desire for an immediate next run,
     // then warn and override the next run to be a few seconds in the future. This is to
     // guard against controllers erroring in a tight loop, which has happened recently.
+    // Log at info level because this is not necessarily indicative of any problems,
+    // but it definitely _would_ indicate a problem if we see this log consistently
+    // repeating for the same spec.
     if !errs.is_empty() && min.as_ref().is_some_and(|n| n.after_seconds == 0) {
-        tracing::warn!("controller returned error and NextRun::immediately, overriding backoff");
+        tracing::info!("controller returned error and NextRun::immediately, overriding backoff");
         min = Some(NextRun {
             after_seconds: 3,
             jitter_percent: 50,


### PR DESCRIPTION
**Description:**

Couple of tiny tweaks to controllers. See [this private slack thread](https://estuaryworkspace.slack.com/archives/C03QBN83GQ4/p1744596825821699) for context on the backoffs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2077)
<!-- Reviewable:end -->
