### PR TITLE
basic control-plane and runtime support for task migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,6 +4470,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrate"
+version = "0.0.0"
+dependencies = [
+ "activate",
+ "anyhow",
+ "assemble",
+ "build",
+ "clap 4.5.21",
+ "doc",
+ "extractors",
+ "futures",
+ "gazette",
+ "insta",
+ "itertools 0.10.5",
+ "labels",
+ "models",
+ "ops",
+ "proto-flow",
+ "proto-gazette",
+ "rustls 0.23.10",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tables",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -10,36 +10,39 @@ use std::collections::BTreeMap;
 
 // A Shard or Journal change to be applied.
 #[derive(serde::Serialize)]
-enum Change {
+pub enum Change {
     Shard(consumer::apply_request::Change),
     Journal(broker::apply_request::Change),
 }
 
 // JournalSplit describes a collection partition or a shard recovery log.
 #[derive(Debug, Default, Clone, serde::Serialize)]
-struct JournalSplit {
-    name: String,
-    labels: LabelSet,
-    mod_revision: i64,
-    suspend: Option<journal_spec::Suspend>,
+pub struct JournalSplit {
+    pub name: String,
+    pub labels: LabelSet,
+    pub mod_revision: i64,
+    pub suspend: Option<journal_spec::Suspend>,
 }
 
 // ShardSplit describes a task partition.
 #[derive(Debug, Clone, serde::Serialize)]
-struct ShardSplit {
-    id: String,
-    labels: LabelSet,
-    mod_revision: i64,
+pub struct ShardSplit {
+    pub id: String,
+    pub labels: LabelSet,
+    pub mod_revision: i64,
+    pub primary_hints: Option<recoverylog::FsmHints>,
 }
 
 #[derive(Copy, Clone, Debug)]
-struct TaskTemplate<'a> {
-    shard: &'a ShardSpec,
-    recovery: &'a JournalSpec,
+pub struct TaskTemplate<'a> {
+    pub shard: &'a ShardSpec,
+    pub recovery: &'a JournalSpec,
 }
 
 // Map a CaptureSpec into its activation TaskTemplate.
-fn capture_template(task_spec: Option<&flow::CaptureSpec>) -> anyhow::Result<Option<TaskTemplate>> {
+pub fn capture_template(
+    task_spec: Option<&flow::CaptureSpec>,
+) -> anyhow::Result<Option<TaskTemplate>> {
     let Some(task_spec) = task_spec else {
         return Ok(None);
     };
@@ -61,7 +64,7 @@ fn capture_template(task_spec: Option<&flow::CaptureSpec>) -> anyhow::Result<Opt
 }
 
 // Map a MaterializationSpec into its activation TaskTemplate.
-fn materialization_template(
+pub fn materialization_template(
     task_spec: Option<&flow::MaterializationSpec>,
 ) -> anyhow::Result<Option<TaskTemplate>> {
     let Some(task_spec) = task_spec else {
@@ -86,7 +89,7 @@ fn materialization_template(
 
 // Map a CollectionSpeck into its activation partition template and,
 // if a derivation, its activation TaskTemplate.
-fn collection_template(
+pub fn collection_template(
     task_spec: Option<&flow::CollectionSpec>,
 ) -> anyhow::Result<(Option<&JournalSpec>, Option<TaskTemplate>)> {
     let Some(task_spec) = task_spec else {
@@ -132,17 +135,18 @@ pub async fn activate_capture(
 ) -> anyhow::Result<()> {
     let task_template = capture_template(task_spec)?;
 
-    let changes = converge_task_changes(
+    let (shards, recovery, ops_logs, ops_stats) = fetch_task_splits(
         journal_client,
         shard_client,
         ops::TaskType::Capture,
         capture,
-        task_template,
         ops_logs_template,
         ops_stats_template,
-        initial_splits,
     )
     .await?;
+
+    let shards = apply_initial_splits(task_template, initial_splits, shards)?;
+    let changes = task_changes(task_template, shards, recovery, ops_logs, ops_stats)?;
 
     apply_changes(journal_client, shard_client, changes).await
 }
@@ -159,24 +163,26 @@ pub async fn activate_collection(
 ) -> anyhow::Result<()> {
     let (partition_template, task_template) = collection_template(task_spec)?;
 
-    let (changes_1, changes_2) = futures::try_join!(
-        converge_task_changes(
+    let ((shards, recovery, ops_logs, ops_stats), partitions) = futures::try_join!(
+        fetch_task_splits(
             journal_client,
             shard_client,
             ops::TaskType::Derivation,
             collection,
-            task_template,
             ops_logs_template,
             ops_stats_template,
-            initial_splits,
         ),
-        converge_partition_changes(journal_client, collection, partition_template),
+        fetch_partition_splits(journal_client, collection),
     )?;
+
+    let shards = apply_initial_splits(task_template, initial_splits, shards)?;
+    let changes_1 = partition_changes(partition_template, partitions)?;
+    let changes_2 = task_changes(task_template, shards, recovery, ops_logs, ops_stats)?;
 
     apply_changes(
         journal_client,
         shard_client,
-        changes_1.into_iter().chain(changes_2.into_iter()),
+        changes_1.into_iter().chain(changes_2),
     )
     .await
 }
@@ -193,22 +199,23 @@ pub async fn activate_materialization(
 ) -> anyhow::Result<()> {
     let task_template = materialization_template(task_spec)?;
 
-    let changes = converge_task_changes(
+    let (shards, recovery, ops_logs, ops_stats) = fetch_task_splits(
         journal_client,
         shard_client,
         ops::TaskType::Materialization,
         materialization,
-        task_template,
         ops_logs_template,
         ops_stats_template,
-        initial_splits,
     )
     .await?;
+
+    let shards = apply_initial_splits(task_template, initial_splits, shards)?;
+    let changes = task_changes(task_template, shards, recovery, ops_logs, ops_stats)?;
 
     apply_changes(journal_client, shard_client, changes).await
 }
 
-async fn apply_changes(
+pub async fn apply_changes(
     journal_client: &gazette::journal::Client,
     shard_client: &gazette::shard::Client,
     changes: impl IntoIterator<Item = Change>,
@@ -307,69 +314,59 @@ async fn apply_changes(
     Ok(())
 }
 
-/// Converge a task by listing data-plane ShardSpecs and recovery log
-/// JournalSpecs, and then applying updates to bring them into alignment
-/// with the templated task configuration.
-async fn converge_task_changes<'a>(
+pub async fn fetch_task_splits<'a>(
     journal_client: &gazette::journal::Client,
     shard_client: &gazette::shard::Client,
     task_type: ops::TaskType,
     task_name: &str,
-    template: Option<TaskTemplate<'a>>,
     ops_logs_template: Option<&broker::JournalSpec>,
     ops_stats_template: Option<&broker::JournalSpec>,
-    initial_splits: usize,
-) -> anyhow::Result<Vec<Change>> {
+) -> anyhow::Result<(
+    Vec<ShardSplit>,                                  // Shards.
+    Vec<JournalSplit>,                                // Recovery logs.
+    (String, Option<JournalSpec>, Vec<JournalSplit>), // Ops logs.
+    (String, Option<JournalSpec>, Vec<JournalSplit>), // Ops stats.
+)> {
     let (list_shards, list_recovery) = list_task_request(task_type, task_name);
-    let list_logs = list_ops_journal(journal_client, task_type, task_name, ops_logs_template);
-    let list_stats = list_ops_journal(journal_client, task_type, task_name, ops_stats_template);
+    let list_ops_logs = list_ops_journal(journal_client, task_type, task_name, ops_logs_template);
+    let list_ops_stats = list_ops_journal(journal_client, task_type, task_name, ops_stats_template);
 
     // List task shards, shard recovery logs, task ops logs, and task ops stats concurrently.
-    let (shards, recovery, logs, stats) = futures::join!(
+    let (shards, recovery, ops_logs, ops_stats) = futures::join!(
         shard_client.list(list_shards),
         journal_client.list(list_recovery),
-        list_logs,
-        list_stats,
+        list_ops_logs,
+        list_ops_stats,
     );
 
     // Unpack list responses.
     let shards = unpack_shard_listing(shards?)?;
     let recovery = unpack_journal_listing(recovery?)?;
-    let (ops_logs_name, ops_logs_spec, ops_logs_splits) = logs?;
-    let (ops_stats_name, ops_stats_spec, ops_stats_splits) = stats?;
 
-    let mut changes = task_changes(
-        template,
-        shards,
-        recovery,
-        initial_splits,
-        &ops_logs_name,
-        &ops_stats_name,
-    )?;
-
-    // Apply ops partitions iff the task is active.
-    if matches!(template, Some(template) if !template.shard.disable) {
-        changes.extend(ops_journal_changes(ops_logs_spec, ops_logs_splits));
-        changes.extend(ops_journal_changes(ops_stats_spec, ops_stats_splits));
+    if !shards.is_sorted_by_key(|shard| &shard.id) {
+        anyhow::bail!("shards are not sorted by id");
+    }
+    if !recovery.is_sorted_by_key(|recovery| &recovery.name) {
+        anyhow::bail!("recovery logs are not sorted by name");
     }
 
-    Ok(changes)
+    Ok((shards, recovery, ops_logs?, ops_stats?))
 }
 
-/// Converge a collection by listing data-plane partition JournalSpecs,
-/// and then applying updates to bring them into alignment
-/// with the templated collection configuration.
-async fn converge_partition_changes(
+pub async fn fetch_partition_splits(
     journal_client: &gazette::journal::Client,
-    collection: &models::Collection,
-    template: Option<&JournalSpec>,
-) -> anyhow::Result<Vec<Change>> {
+    collection: &str,
+) -> anyhow::Result<Vec<JournalSplit>> {
     let list_partitions = list_partitions_request(&collection);
 
     let partitions = journal_client.list(list_partitions).await?;
     let partitions = unpack_journal_listing(partitions)?;
 
-    partition_changes(template, partitions)
+    if !partitions.is_sorted_by_key(|partition| &partition.name) {
+        anyhow::bail!("partitions are not sorted by name");
+    }
+
+    Ok(partitions)
 }
 
 /// Build ListRequests of a Task's shard splits and recovery logs.
@@ -402,12 +399,12 @@ fn list_task_request(
 }
 
 /// Build a ListRequest of a collections partitions.
-fn list_partitions_request(collection: &models::Collection) -> broker::ListRequest {
+fn list_partitions_request(collection: &str) -> broker::ListRequest {
     broker::ListRequest {
         selector: Some(LabelSelector {
             include: Some(labels::build_set([
                 ("name:prefix", format!("{collection}/").as_str()),
-                (labels::COLLECTION, collection.as_str()),
+                (labels::COLLECTION, collection),
             ])),
             exclude: None,
         }),
@@ -456,46 +453,17 @@ fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<Jour
     Ok(v)
 }
 
-/// Determine the consumer shard and broker recovery log changes required to
-/// converge from current `shards` and `recovery` splits into the desired state.
-fn task_changes<'a>(
+/// Determine the consumer shard and broker recovery and ops journal changes
+/// required to converge the desired splits towards the `template`.
+pub fn task_changes<'a>(
     template: Option<TaskTemplate<'a>>,
-    mut shards: Vec<ShardSplit>,
+    shards: Vec<ShardSplit>,
     recovery: Vec<JournalSplit>,
-    initial_splits: usize,
-    ops_logs_name: &str,
-    ops_stats_name: &str,
+    ops_logs: (String, Option<JournalSpec>, Vec<JournalSplit>),
+    ops_stats: (String, Option<JournalSpec>, Vec<JournalSplit>),
 ) -> anyhow::Result<Vec<Change>> {
-    // If the task is being upsert-ed, no current shards have its template prefix,
-    // and it's not disabled, then create `initial_splits` new shards.
-    if let Some(template) = template {
-        if !template.shard.disable
-            && !shards
-                .iter()
-                .any(|split| split.id.starts_with(&template.shard.id))
-        {
-            // Invent initial splits.
-            for pivot in 0..initial_splits {
-                let range = flow::RangeSpec {
-                    key_begin: ((1 << 32) * (pivot + 0) / initial_splits) as u32,
-                    key_end: (((1 << 32) * (pivot + 1) / initial_splits) - 1) as u32,
-                    r_clock_begin: 0,
-                    r_clock_end: u32::MAX,
-                };
-                let labels = labels::shard::encode_range_spec(LabelSet::default(), &range);
-                let id = format!(
-                    "{}/{}",
-                    template.shard.id,
-                    labels::shard::id_suffix(&labels)?
-                );
-                shards.push(ShardSplit {
-                    id,
-                    labels,
-                    mod_revision: 0,
-                });
-            }
-        }
-    }
+    let (ops_logs_name, ops_logs_spec, ops_logs_splits) = ops_logs;
+    let (ops_stats_name, ops_stats_spec, ops_stats_splits) = ops_stats;
 
     let mut recovery: BTreeMap<_, _> = recovery
         .into_iter()
@@ -553,8 +521,20 @@ fn task_changes<'a>(
         // control-plane versus the data-plane.
         let mut shard_labels = shard_spec.labels.take().unwrap_or_default();
 
+        let build = labels::values(&shard_labels, labels::BUILD)
+            .first()
+            .map(|l| l.value.clone())
+            .unwrap_or_default();
+
         for label in &split.labels {
-            if !labels::is_data_plane_label(&label.name) {
+            if label.name == labels::BUILD && label.value > build {
+                anyhow::bail!(
+                    "current ShardSpec {} has a newer build then the template ({} vs {})",
+                    shard_spec.id,
+                    label.value,
+                    build
+                );
+            } else if !labels::is_data_plane_label(&label.name) {
                 continue;
             }
             shard_labels = labels::add_value(shard_labels, &label.name, &label.value);
@@ -573,8 +553,8 @@ fn task_changes<'a>(
                 recovery_spec.flags = proto_gazette::broker::journal_spec::Flag::ORdonly as u32;
             }
         }
-        shard_labels = labels::set_value(shard_labels, labels::LOGS_JOURNAL, ops_logs_name);
-        shard_labels = labels::set_value(shard_labels, labels::STATS_JOURNAL, ops_stats_name);
+        shard_labels = labels::set_value(shard_labels, labels::LOGS_JOURNAL, &ops_logs_name);
+        shard_labels = labels::set_value(shard_labels, labels::STATS_JOURNAL, &ops_stats_name);
         shard_spec.labels = Some(shard_labels);
 
         changes.push(Change::Shard(consumer::apply_request::Change {
@@ -598,12 +578,26 @@ fn task_changes<'a>(
         }));
     }
 
+    // Ensure existence of ops partitions iff there's a task shard upsert.
+    if changes.iter().any(|change| {
+        matches!(
+            change,
+            Change::Shard(consumer::apply_request::Change {
+                upsert: Some(_),
+                ..
+            })
+        )
+    }) {
+        changes.extend(ops_journal_changes(ops_logs_spec, ops_logs_splits));
+        changes.extend(ops_journal_changes(ops_stats_spec, ops_stats_splits));
+    }
+
     Ok(changes)
 }
 
 /// Determine the broker partition changes required to converge
-/// from current `partitions` into the desired state.
-fn partition_changes(
+/// the desired `partitions` towards the `template`.
+pub fn partition_changes(
     template: Option<&broker::JournalSpec>,
     partitions: Vec<JournalSplit>,
 ) -> anyhow::Result<Vec<Change>> {
@@ -647,8 +641,20 @@ fn partition_changes(
         };
         let mut spec_labels = spec.labels.take().unwrap_or_default();
 
+        let build = labels::values(&spec_labels, labels::BUILD)
+            .first()
+            .map(|l| l.value.clone())
+            .unwrap_or_default();
+
         for label in &split.labels {
-            if !labels::is_data_plane_label(&label.name) {
+            if label.name == labels::BUILD && label.value > build {
+                anyhow::bail!(
+                    "current JournalSpec {} has a newer build then the template ({} vs {})",
+                    spec.name,
+                    label.value,
+                    build
+                );
+            } else if !labels::is_data_plane_label(&label.name) {
                 continue;
             }
             spec_labels = labels::add_value(spec_labels, &label.name, &label.value);
@@ -670,11 +676,11 @@ fn partition_changes(
     Ok(changes)
 }
 
-fn list_ops_journal_request(
+pub fn ops_partition_spec(
     task_type: ops::TaskType,
     task_name: &str,
     template: &JournalSpec,
-) -> (broker::ListRequest, JournalSpec) {
+) -> JournalSpec {
     let mut spec = template.clone();
     let set = spec.labels.take().unwrap_or_default();
     let set = labels::partition::encode_key_range(set, 0, u32::MAX);
@@ -687,6 +693,16 @@ fn list_ops_journal_request(
         labels::partition::name_suffix(&set).unwrap()
     );
     spec.labels = Some(set);
+
+    spec
+}
+
+fn list_ops_journal_request(
+    task_type: ops::TaskType,
+    task_name: &str,
+    template: &JournalSpec,
+) -> (broker::ListRequest, JournalSpec) {
+    let spec = ops_partition_spec(task_type, task_name, template);
 
     let list_req = broker::ListRequest {
         selector: Some(LabelSelector {
@@ -729,6 +745,50 @@ fn ops_journal_changes(spec: Option<JournalSpec>, splits: Vec<JournalSplit>) -> 
         expect_mod_revision: 0, // Will be created.
         delete: String::new(),
     }))
+}
+
+fn apply_initial_splits<'a>(
+    template: Option<TaskTemplate<'a>>,
+    initial_splits: usize,
+    mut shards: Vec<ShardSplit>,
+) -> anyhow::Result<Vec<ShardSplit>> {
+    let Some(template) = template else {
+        return Ok(shards);
+    };
+    if template.shard.disable {
+        return Ok(shards);
+    }
+    if shards
+        .iter()
+        .any(|split| split.id.starts_with(&template.shard.id))
+    {
+        return Ok(shards);
+    }
+    // The task is being upsert-ed, it's not disabled, and no current shards
+    // have its template prefix.
+
+    // Invent `initial_splits` new shards.
+    for pivot in 0..initial_splits {
+        let range = flow::RangeSpec {
+            key_begin: ((1 << 32) * (pivot + 0) / initial_splits) as u32,
+            key_end: (((1 << 32) * (pivot + 1) / initial_splits) - 1) as u32,
+            r_clock_begin: 0,
+            r_clock_end: u32::MAX,
+        };
+        let labels = labels::shard::encode_range_spec(LabelSet::default(), &range);
+        let id = format!(
+            "{}/{}",
+            template.shard.id,
+            labels::shard::id_suffix(&labels)?
+        );
+        shards.push(ShardSplit {
+            id,
+            labels,
+            mod_revision: 0,
+        });
+    }
+
+    Ok(shards)
 }
 
 /// Map a parent JournalSplit into two subdivided splits.
@@ -954,6 +1014,19 @@ mod test {
             unreachable!()
         };
 
+        let tables::BuiltCollection { spec, .. } = built
+            .built_collections
+            .get_key(&models::Collection::new("ops/tasks/BASE_NAME/stats"))
+            .unwrap();
+
+        let Some(flow::CollectionSpec {
+            partition_template: Some(ops_stats_template),
+            ..
+        }) = spec
+        else {
+            unreachable!()
+        };
+
         let extractors =
             extractors::for_fields(partition_fields, projections, &doc::SerPolicy::noop()).unwrap();
 
@@ -962,6 +1035,15 @@ mod test {
         let mut all_shards_disabled = Vec::new();
         let mut all_recovery = Vec::new();
         let mut all_recovery_disabled = Vec::new();
+
+        let task_template = TaskTemplate {
+            shard: shard_template,
+            recovery: recovery_template,
+        };
+        let disabled_task_template = TaskTemplate {
+            shard: disabled_shard_template,
+            recovery: disabled_recovery_template,
+        };
 
         let mut make_partition = |key_begin, key_end, doc: serde_json::Value, labels: LabelSet| {
             let labels = labels::partition::encode_field_range(
@@ -1084,20 +1166,40 @@ mod test {
             labels::build_set([(labels::CORDON, "true")]),
         );
 
+        let (_, ops_logs_spec) = list_ops_journal_request(
+            ops::TaskType::Derivation,
+            "example/derivation",
+            ops_logs_template,
+        );
+        let (_, ops_stats_spec) = list_ops_journal_request(
+            ops::TaskType::Derivation,
+            "example/derivation",
+            ops_stats_template,
+        );
+        let all_ops = vec![JournalSplit {
+            mod_revision: 123,
+            ..Default::default()
+        }];
+
         // Case: test update of existing specs.
         {
             let partition_changes =
                 partition_changes(Some(&partition_template), all_partitions.clone()).unwrap();
+
             let task_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
+                Some(task_template),
                 all_shards.clone(),
                 all_recovery.clone(),
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    all_ops.clone(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    all_ops.clone(),
+                ),
             )
             .unwrap();
 
@@ -1106,18 +1208,24 @@ mod test {
 
         // Case: test creation of new specs.
         {
+            let shards = apply_initial_splits(Some(task_template), 4, Vec::new()).unwrap();
+
             let partition_changes =
                 partition_changes(Some(&partition_template), Vec::new()).unwrap();
             let task_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
+                Some(task_template),
+                shards,
                 Vec::new(),
-                Vec::new(),
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    Vec::new(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    Vec::new(),
+                ),
             )
             .unwrap();
 
@@ -1126,18 +1234,24 @@ mod test {
 
         // Case: test creation of new specs with no initial splits.
         {
+            let shards = apply_initial_splits(Some(task_template), 0, Vec::new()).unwrap();
+
             let partition_changes =
                 partition_changes(Some(&partition_template), Vec::new()).unwrap();
             let task_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
+                Some(task_template),
+                shards,
                 Vec::new(),
-                Vec::new(),
-                0,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    Vec::new(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    Vec::new(),
+                ),
             )
             .unwrap();
 
@@ -1149,15 +1263,19 @@ mod test {
             let partition_changes =
                 partition_changes(Some(&partition_template), all_partitions.clone()).unwrap();
             let task_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: disabled_shard_template,
-                    recovery: disabled_recovery_template,
-                }),
+                Some(disabled_task_template),
                 all_shards_disabled.clone(),
                 all_recovery_disabled.clone(),
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    all_ops.clone(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    all_ops.clone(),
+                ),
             )
             .unwrap();
 
@@ -1166,6 +1284,8 @@ mod test {
 
         // Case: test creation of new specs when disabled.
         {
+            let shards = apply_initial_splits(Some(disabled_task_template), 4, Vec::new()).unwrap();
+
             let partition_changes =
                 partition_changes(Some(&partition_template), Vec::new()).unwrap();
             let task_changes = task_changes(
@@ -1173,11 +1293,18 @@ mod test {
                     shard: disabled_shard_template,
                     recovery: disabled_recovery_template,
                 }),
+                shards,
                 Vec::new(),
-                Vec::new(),
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    Vec::new(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    Vec::new(),
+                ),
             )
             .unwrap();
 
@@ -1187,13 +1314,21 @@ mod test {
         // Case: test deletion of existing specs.
         {
             let partition_changes = partition_changes(None, all_partitions.clone()).unwrap();
+
             let task_changes = task_changes(
                 None,
                 all_shards.clone(),
                 all_recovery.clone(),
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    all_ops.clone(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    all_ops.clone(),
+                ),
             )
             .unwrap();
 
@@ -1220,18 +1355,24 @@ mod test {
                 *name = name.replace("2020202020202020", "replaced-pub-id");
             }
 
+            let shards = apply_initial_splits(Some(task_template), 4, all_shards).unwrap();
+
             let partition_changes =
                 partition_changes(Some(&partition_template), all_partitions).unwrap();
             let task_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
-                all_shards,
+                Some(task_template),
+                shards,
                 all_recovery,
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (
+                    ops_logs_spec.name.clone(),
+                    Some(ops_logs_spec.clone()),
+                    all_ops.clone(),
+                ),
+                (
+                    ops_stats_spec.name.clone(),
+                    Some(ops_stats_spec.clone()),
+                    all_ops.clone(),
+                ),
             )
             .unwrap();
 
@@ -1246,28 +1387,20 @@ mod test {
             let (clock_lhs, clock_rhs) = map_shard_to_split(parent, false).unwrap();
 
             let key_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
+                Some(task_template),
                 vec![key_lhs.clone(), key_rhs.clone()],
                 vec![all_recovery[0].clone()],
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (ops_logs_spec.name.clone(), None, Vec::new()),
+                (ops_stats_spec.name.clone(), None, Vec::new()),
             )
             .unwrap();
 
             let clock_changes = task_changes(
-                Some(TaskTemplate {
-                    shard: shard_template,
-                    recovery: recovery_template,
-                }),
+                Some(task_template),
                 vec![clock_lhs.clone(), clock_rhs.clone()],
                 vec![all_recovery[0].clone()],
-                4,
-                "ops/logs/name",
-                "ops/stats/name",
+                (ops_logs_spec.name.clone(), None, Vec::new()),
+                (ops_stats_spec.name.clone(), None, Vec::new()),
             )
             .unwrap();
 

--- a/crates/activate/src/snapshots/activate__test__create.snap
+++ b/crates/activate/src/snapshots/activate__test__create.snap
@@ -39,7 +39,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -51,7 +51,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -144,7 +144,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -156,7 +156,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -249,7 +249,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -261,7 +261,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -354,7 +354,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -366,7 +366,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -419,6 +419,118 @@ expression: "(partition_changes, task_changes)"
               "gs://example-bucket/"
             ],
             "refreshInterval": "300s"
+          },
+          "flags": 4,
+          "maxAppendRate": "4194304"
+        }
+      }
+    },
+    {
+      "Journal": {
+        "upsert": {
+          "name": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00",
+          "replication": 3,
+          "labels": {
+            "labels": [
+              {
+                "name": "app.gazette.dev/managed-by",
+                "value": "estuary.dev/flow"
+              },
+              {
+                "name": "content-type",
+                "value": "application/x-ndjson"
+              },
+              {
+                "name": "estuary.dev/build",
+                "value": "0101010101010101"
+              },
+              {
+                "name": "estuary.dev/collection",
+                "value": "ops/tasks/BASE_NAME/logs"
+              },
+              {
+                "name": "estuary.dev/field/kind",
+                "value": "derivation"
+              },
+              {
+                "name": "estuary.dev/field/name",
+                "value": "example%2Fderivation"
+              },
+              {
+                "name": "estuary.dev/key-begin",
+                "value": "00000000"
+              },
+              {
+                "name": "estuary.dev/key-end",
+                "value": "ffffffff"
+              }
+            ]
+          },
+          "fragment": {
+            "length": "536870912",
+            "compressionCodec": "GZIP",
+            "stores": [
+              "gs://example-bucket/"
+            ],
+            "refreshInterval": "300s",
+            "flushInterval": "86400s",
+            "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
+          },
+          "flags": 4,
+          "maxAppendRate": "4194304"
+        }
+      }
+    },
+    {
+      "Journal": {
+        "upsert": {
+          "name": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00",
+          "replication": 3,
+          "labels": {
+            "labels": [
+              {
+                "name": "app.gazette.dev/managed-by",
+                "value": "estuary.dev/flow"
+              },
+              {
+                "name": "content-type",
+                "value": "application/x-ndjson"
+              },
+              {
+                "name": "estuary.dev/build",
+                "value": "0101010101010101"
+              },
+              {
+                "name": "estuary.dev/collection",
+                "value": "ops/tasks/BASE_NAME/stats"
+              },
+              {
+                "name": "estuary.dev/field/kind",
+                "value": "derivation"
+              },
+              {
+                "name": "estuary.dev/field/name",
+                "value": "example%2Fderivation"
+              },
+              {
+                "name": "estuary.dev/key-begin",
+                "value": "00000000"
+              },
+              {
+                "name": "estuary.dev/key-end",
+                "value": "ffffffff"
+              }
+            ]
+          },
+          "fragment": {
+            "length": "536870912",
+            "compressionCodec": "GZIP",
+            "stores": [
+              "gs://example-bucket/"
+            ],
+            "refreshInterval": "300s",
+            "flushInterval": "86400s",
+            "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
           },
           "flags": 4,
           "maxAppendRate": "4194304"

--- a/crates/activate/src/snapshots/activate__test__create_and_delete.snap
+++ b/crates/activate/src/snapshots/activate__test__create_and_delete.snap
@@ -76,7 +76,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -88,7 +88,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -181,7 +181,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -193,7 +193,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -286,7 +286,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -298,7 +298,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -391,7 +391,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -403,7 +403,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",

--- a/crates/activate/src/snapshots/activate__test__shard_splits.snap
+++ b/crates/activate/src/snapshots/activate__test__shard_splits.snap
@@ -35,7 +35,8 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           }
         ]
       },
-      "mod_revision": 111
+      "mod_revision": 111,
+      "primary_hints": null
     },
     {
       "id": "derivation/example/derivation/2020202020202020/20000000-60000000",
@@ -67,7 +68,8 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           }
         ]
       },
-      "mod_revision": 0
+      "mod_revision": 0,
+      "primary_hints": null
     }
   ],
   "clock_splits",
@@ -102,7 +104,8 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           }
         ]
       },
-      "mod_revision": 111
+      "mod_revision": 111,
+      "primary_hints": null
     },
     {
       "id": "derivation/example/derivation/2020202020202020/10000000-80000000",
@@ -134,7 +137,8 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           }
         ]
       },
-      "mod_revision": 0
+      "mod_revision": 0,
+      "primary_hints": null
     }
   ],
   "key_changes",

--- a/crates/activate/src/snapshots/activate__test__shard_splits.snap
+++ b/crates/activate/src/snapshots/activate__test__shard_splits.snap
@@ -171,7 +171,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -187,7 +187,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -283,7 +283,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -299,7 +299,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -396,7 +396,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -412,7 +412,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -508,7 +508,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -524,7 +524,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",

--- a/crates/activate/src/snapshots/activate__test__update-disabled.snap
+++ b/crates/activate/src/snapshots/activate__test__update-disabled.snap
@@ -228,7 +228,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -240,7 +240,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -339,7 +339,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -351,7 +351,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -454,7 +454,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -466,7 +466,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",

--- a/crates/activate/src/snapshots/activate__test__update-disabled.snap
+++ b/crates/activate/src/snapshots/activate__test__update-disabled.snap
@@ -151,6 +151,10 @@ expression: "(partition_changes, task_changes)"
                 "value": "example/collection"
               },
               {
+                "name": "estuary.dev/cordon",
+                "value": "true"
+              },
+              {
                 "name": "estuary.dev/field/a_bool",
                 "value": "%_false"
               },
@@ -178,7 +182,7 @@ expression: "(partition_changes, task_changes)"
             "flushInterval": "900s",
             "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
           },
-          "flags": 4,
+          "flags": 1,
           "maxAppendRate": "4194304",
           "suspend": {
             "level": "PARTIAL",
@@ -433,6 +437,10 @@ expression: "(partition_changes, task_changes)"
                 "value": "0101010101010101"
               },
               {
+                "name": "estuary.dev/cordon",
+                "value": "true"
+              },
+              {
                 "name": "estuary.dev/key-begin",
                 "value": "30000000"
               },
@@ -513,7 +521,7 @@ expression: "(partition_changes, task_changes)"
             ],
             "refreshInterval": "300s"
           },
-          "flags": 4,
+          "flags": 1,
           "maxAppendRate": "4194304",
           "suspend": {
             "level": "FULL",

--- a/crates/activate/src/snapshots/activate__test__update-disabled.snap
+++ b/crates/activate/src/snapshots/activate__test__update-disabled.snap
@@ -254,6 +254,9 @@ expression: "(partition_changes, task_changes)"
           },
           "ringBufferSize": 65536,
           "readChannelSize": 4096
+        },
+        "primaryHints": {
+          "log": "some/log"
         }
       }
     },
@@ -365,6 +368,9 @@ expression: "(partition_changes, task_changes)"
           },
           "ringBufferSize": 65536,
           "readChannelSize": 4096
+        },
+        "primaryHints": {
+          "log": "some/log"
         }
       }
     },
@@ -480,6 +486,9 @@ expression: "(partition_changes, task_changes)"
           },
           "ringBufferSize": 65536,
           "readChannelSize": 4096
+        },
+        "primaryHints": {
+          "log": "some/log"
         }
       }
     },

--- a/crates/activate/src/snapshots/activate__test__update.snap
+++ b/crates/activate/src/snapshots/activate__test__update.snap
@@ -228,7 +228,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -240,7 +240,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -338,7 +338,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -350,7 +350,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",
@@ -453,7 +453,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/logs-journal",
-                "value": "ops/logs/name"
+                "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/rclock-begin",
@@ -465,7 +465,7 @@ expression: "(partition_changes, task_changes)"
               },
               {
                 "name": "estuary.dev/stats-journal",
-                "value": "ops/stats/name"
+                "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
               },
               {
                 "name": "estuary.dev/task-name",

--- a/crates/activate/src/snapshots/activate__test__update.snap
+++ b/crates/activate/src/snapshots/activate__test__update.snap
@@ -151,6 +151,10 @@ expression: "(partition_changes, task_changes)"
                 "value": "example/collection"
               },
               {
+                "name": "estuary.dev/cordon",
+                "value": "true"
+              },
+              {
                 "name": "estuary.dev/field/a_bool",
                 "value": "%_false"
               },
@@ -178,7 +182,7 @@ expression: "(partition_changes, task_changes)"
             "flushInterval": "900s",
             "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
           },
-          "flags": 4,
+          "flags": 1,
           "maxAppendRate": "4194304",
           "suspend": {
             "level": "PARTIAL",
@@ -419,6 +423,7 @@ expression: "(partition_changes, task_changes)"
           "hintBackups": 2,
           "maxTxnDuration": "60s",
           "minTxnDuration": "0s",
+          "disable": true,
           "hotStandbys": 3,
           "labels": {
             "labels": [
@@ -429,6 +434,10 @@ expression: "(partition_changes, task_changes)"
               {
                 "name": "estuary.dev/build",
                 "value": "0101010101010101"
+              },
+              {
+                "name": "estuary.dev/cordon",
+                "value": "true"
               },
               {
                 "name": "estuary.dev/key-begin",
@@ -511,7 +520,7 @@ expression: "(partition_changes, task_changes)"
             ],
             "refreshInterval": "300s"
           },
-          "flags": 4,
+          "flags": 1,
           "maxAppendRate": "4194304",
           "suspend": {
             "offset": "445566"

--- a/crates/gazette/src/shard/mod.rs
+++ b/crates/gazette/src/shard/mod.rs
@@ -100,6 +100,26 @@ impl Client {
         check_ok(resp.status(), resp)
     }
 
+    /// Invoke the Gazette shard GetHints RPC.
+    pub async fn get_hints(
+        &self,
+        req: consumer::GetHintsRequest,
+    ) -> Result<consumer::GetHintsResponse, crate::Error> {
+        let mut client = self.into_sub(self.router.route(
+            None,
+            router::Mode::Default,
+            &self.default,
+        )?);
+
+        let resp = client
+            .get_hints(req)
+            .await
+            .map_err(crate::Error::Grpc)?
+            .into_inner();
+
+        check_ok(resp.status(), resp)
+    }
+
     fn into_sub(&self, (channel, _local): (Channel, bool)) -> SubClient {
         proto_grpc::consumer::shard_client::ShardClient::with_interceptor(
             channel,

--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -7,6 +7,7 @@ use proto_gazette::broker::{Label, LabelSet};
 // JournalSpec & ShardSpec labels.
 pub const BUILD: &str = "estuary.dev/build";
 pub const COLLECTION: &str = "estuary.dev/collection";
+pub const CORDON: &str = "estuary.dev/cordon";
 pub const FIELD_PREFIX: &str = "estuary.dev/field/";
 pub const KEY_BEGIN: &str = "estuary.dev/key-begin";
 pub const KEY_BEGIN_MIN: &str = "00000000";
@@ -169,10 +170,10 @@ pub fn remove(mut set: LabelSet, name: &str) -> LabelSet {
 }
 
 // Determine whether `label` is managed by the Flow data-plane,
-// as opposed to the Flow control-plane.
+// as opposed to the Flow control plane.
 // * Data-plane labels exist exclusively within the data-plane,
 //   and use its Etcd as their source of truth.
-// * All other labels are set by the contorl-plane.
+// * All other labels are set by the control plane.
 pub fn is_data_plane_label(label: &str) -> bool {
     // If `label` has FIELD_PREFIX as a prefix, its suffix is an encoded logical partition.
     if label.starts_with(FIELD_PREFIX) {
@@ -180,7 +181,9 @@ pub fn is_data_plane_label(label: &str) -> bool {
     }
     match label {
         // Key and R-Clock splits are performed within the data-plane.
-        KEY_BEGIN | KEY_END | RCLOCK_BEGIN | RCLOCK_END | SPLIT_SOURCE | SPLIT_TARGET => true,
+        CORDON | KEY_BEGIN | KEY_END | RCLOCK_BEGIN | RCLOCK_END | SPLIT_SOURCE | SPLIT_TARGET => {
+            true
+        }
         _ => false,
     }
 }

--- a/crates/migrate/Cargo.toml
+++ b/crates/migrate/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "migrate"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+activate = { path = "../activate" }
+assemble = { path = "../assemble" }
+gazette = { path = "../gazette" }
+labels = { path = "../labels" }
+models = { path = "../models", features = ["sqlx-support"] }
+ops = { path = "../ops" }
+tables = { path = "../tables" }
+proto-flow = { path = "../proto-flow" }
+proto-gazette = { path = "../proto-gazette" }
+
+anyhow = { workspace = true }
+itertools = { workspace = true }
+url = { workspace = true }
+clap = { workspace = true }
+rustls = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+build = { path = "../build" }
+doc = { path = "../doc" }
+extractors = { path = "../extractors" }
+tables = { path = "../tables" }
+
+insta = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }

--- a/crates/migrate/src/lib.rs
+++ b/crates/migrate/src/lib.rs
@@ -1,0 +1,687 @@
+use anyhow::Context;
+use futures::TryStreamExt;
+use gazette::broker::journal_spec;
+use itertools::Itertools;
+use proto_gazette::{broker, consumer};
+
+#[derive(clap::Parser, Debug, serde::Serialize)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// URL of the postgres database.
+    #[clap(
+        long = "database",
+        env = "DATABASE_URL",
+        default_value = "postgres://postgres:postgres@127.0.0.1:5432/postgres"
+    )]
+    database_url: url::Url,
+    /// Path to CA certificate of the database.
+    #[clap(long = "database-ca", env = "DATABASE_CA")]
+    database_ca: Option<String>,
+
+    #[clap(long = "src-data-plane", env = "SRC_DATA_PLANE")]
+    src_data_plane: String,
+    #[clap(long = "tgt-data-plane", env = "TGT_DATA_PLANE")]
+    tgt_data_plane: String,
+    #[clap(long = "catalog-prefix", env = "CATALOG_PREFIX")]
+    catalog_prefix: String,
+}
+
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    let hostname = std::env::var("HOSTNAME").ok();
+    let app_name = if let Some(hostname) = &hostname {
+        hostname.as_str()
+    } else {
+        "migrate-tool"
+    };
+    tracing::info!(args=?ops::DebugJson(&args), app_name, "started!");
+
+    let Args {
+        database_url,
+        database_ca,
+        src_data_plane,
+        tgt_data_plane,
+        catalog_prefix,
+    } = args;
+
+    let mut pg_options = database_url
+        .as_str()
+        .parse::<sqlx::postgres::PgConnectOptions>()
+        .context("parsing database URL")?
+        .application_name(app_name);
+
+    // If a database CA was provided, require that we use TLS with full cert verification.
+    if let Some(ca) = &database_ca {
+        pg_options = pg_options
+            .ssl_mode(sqlx::postgres::PgSslMode::VerifyFull)
+            .ssl_root_cert(ca);
+    } else {
+        // Otherwise, prefer TLS but don't require it.
+        pg_options = pg_options.ssl_mode(sqlx::postgres::PgSslMode::Prefer);
+    }
+
+    let pg_pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(std::time::Duration::from_secs(30))
+        .connect_with(pg_options)
+        .await
+        .context("connecting to database")?;
+
+    /*
+    let shutdown = async {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {
+                tracing::info!("caught shutdown signal, stopping...");
+            }
+            Err(err) => {
+                tracing::error!(?err, "error subscribing to shutdown signal");
+            }
+        }
+    };
+    */
+
+    let src_data_plane = fetch_data_plane(&pg_pool, &src_data_plane).await?;
+    let tgt_data_plane = fetch_data_plane(&pg_pool, &tgt_data_plane).await?;
+
+    // Phase one: identify covered specs in the source data-plane, cordon them,
+    // and migrate them to the target data-plane in a cordoned state.
+    let spec_migrations: Vec<SpecMigration> =
+        fetch_spec_migrations(&pg_pool, &catalog_prefix, src_data_plane.row.control_id)
+            .try_collect()
+            .await?;
+
+    for spec in &spec_migrations {
+        tracing::info!(
+            catalog_name = spec.catalog_name,
+            spec_type = ?unpack_templates(&spec.built_spec)?.0,
+            live_spec_id = ?spec.live_spec_id,
+            "spec to migrate"
+        );
+    }
+
+    () = confirm(
+        "Cordon shards and journals, and copy specs to the target data-plane (phase one)?",
+    )?;
+    let _: Vec<_> = spec_migrations
+        .iter()
+        .map(|spec_migration| phase_one(spec_migration, &src_data_plane, &tgt_data_plane))
+        .collect::<futures::stream::FuturesUnordered<_>>()
+        .try_collect()
+        .await?;
+
+    // Phase two: update the data-plane ID of migrated specs to the target.
+    () = confirm(
+        "Switch the data-plane ID of matched live specs to the target data-plane (phase one)?",
+    )?;
+    let live_spec_ids: Vec<models::Id> = spec_migrations
+        .iter()
+        .map(|spec| spec.live_spec_id)
+        .collect();
+
+    sqlx::query!(
+        r#"UPDATE live_specs SET data_plane_id = $2 WHERE id=ANY($1)"#,
+        live_spec_ids as Vec<models::Id>,
+        tgt_data_plane.row.control_id as models::Id,
+    )
+    .execute(&pg_pool)
+    .await?;
+
+    // Phase three: re-query for live specs that match the prefix and target
+    // data-plane, and un-cordon them. We re-query to pick up any specs which
+    // had previously completed phase one and two, but not three.
+    let spec_migrations: Vec<SpecMigration> =
+        fetch_spec_migrations(&pg_pool, &catalog_prefix, tgt_data_plane.row.control_id)
+            .try_collect()
+            .await?;
+
+    for spec in &spec_migrations {
+        tracing::info!(
+            catalog_name = spec.catalog_name,
+            spec_type = ?unpack_templates(&spec.built_spec)?.0,
+            live_spec_id = ?spec.live_spec_id,
+            "spec to remove cordon"
+        );
+    }
+    () = confirm("Remove cordon on migrated specs?")?;
+
+    let _: Vec<_> = spec_migrations
+        .iter()
+        .map(|spec_migration| phase_three(spec_migration, &tgt_data_plane))
+        .collect::<futures::stream::FuturesUnordered<_>>()
+        .try_collect()
+        .await?;
+
+    Ok(())
+}
+
+// phase_one cordons and suspends shards and journals in the source data-plane,
+// and copies equivalent shard and journal splits into the target data plane.
+async fn phase_one(
+    spec_migration: &SpecMigration,
+    src_data_plane: &DataPlane,
+    tgt_data_plane: &DataPlane,
+) -> anyhow::Result<()> {
+    let SpecMigration {
+        catalog_name,
+        built_spec,
+        live_spec_id: _,
+    } = spec_migration;
+
+    let DataPlane {
+        journal_client: src_journal_client,
+        ops_logs_template: src_ops_logs_template,
+        ops_stats_template: src_ops_stats_template,
+        row: src_data_plane,
+        shard_client: src_shard_client,
+    } = src_data_plane;
+
+    let DataPlane {
+        journal_client: tgt_journal_client,
+        ops_logs_template: tgt_ops_logs_template,
+        ops_stats_template: tgt_ops_stats_template,
+        row: tgt_data_plane,
+        shard_client: tgt_shard_client,
+    } = tgt_data_plane;
+
+    let (task_type, task_template, partition_template) = unpack_templates(built_spec)?;
+
+    // Fetch and cordon shards and journals from the source data-plane.
+    let (mut src_shards, src_recovery, src_partitions) = update_cordon(
+        &src_data_plane.data_plane_name,
+        src_journal_client,
+        src_shard_client,
+        catalog_name,
+        task_type,
+        task_template,
+        partition_template,
+        Some(src_ops_logs_template),
+        Some(src_ops_stats_template),
+        true, // Cordon.
+    )
+    .await?;
+
+    () = attach_shard_primary_hints(src_shard_client, &mut src_shards).await?;
+
+    // Fetch shards and journals from the target data-plane.
+    // They may exist in a cordoned state if we're migrating back.
+    let ((tgt_shards, tgt_recovery, tgt_ops_logs, tgt_ops_stats), tgt_partitions) = futures::try_join!(
+        activate::fetch_task_splits(
+            tgt_journal_client,
+            tgt_shard_client,
+            task_type,
+            catalog_name,
+            Some(tgt_ops_logs_template),
+            Some(tgt_ops_stats_template),
+        ),
+        activate::fetch_partition_splits(tgt_journal_client, catalog_name),
+    )?;
+
+    let shards: Vec<activate::ShardSplit> = merge_splits(
+        src_shards,
+        tgt_shards,
+        |l, r| l.id.cmp(&r.id),
+        |s| &mut s.mod_revision,
+    );
+    let recovery: Vec<activate::JournalSplit> = merge_splits(
+        src_recovery,
+        tgt_recovery,
+        |l, r| l.name.cmp(&r.name),
+        |s| &mut s.mod_revision,
+    );
+    let partitions: Vec<activate::JournalSplit> = merge_splits(
+        src_partitions,
+        tgt_partitions,
+        |l, r| l.name.cmp(&r.name),
+        |s| &mut s.mod_revision,
+    );
+
+    let mut changes =
+        activate::task_changes(task_template, shards, recovery, tgt_ops_logs, tgt_ops_stats)?;
+    changes.extend(activate::partition_changes(partition_template, partitions)?);
+
+    print_changes(&changes, &tgt_data_plane.data_plane_name);
+    () = activate::apply_changes(tgt_journal_client, tgt_shard_client, changes).await?;
+
+    Ok(())
+}
+
+fn print_changes(changes: &[activate::Change], data_plane: &str) {
+    for change in changes {
+        match change {
+            activate::Change::Journal(broker::apply_request::Change {
+                upsert: Some(upsert),
+                expect_mod_revision,
+                ..
+            }) => {
+                let cordon =
+                    !labels::values(upsert.labels.as_ref().unwrap(), labels::CORDON).is_empty();
+                tracing::info!(data_plane, name=%upsert.name, cordon, suspend=?upsert.suspend, %expect_mod_revision, "journal upsert");
+            }
+            activate::Change::Journal(broker::apply_request::Change {
+                upsert: None,
+                expect_mod_revision,
+                delete,
+            }) => {
+                tracing::info!(data_plane, name=%delete, %expect_mod_revision, "journal delete");
+            }
+
+            activate::Change::Shard(consumer::apply_request::Change {
+                upsert: Some(upsert),
+                expect_mod_revision,
+                primary_hints,
+                ..
+            }) => {
+                let cordon =
+                    !labels::values(upsert.labels.as_ref().unwrap(), labels::CORDON).is_empty();
+                tracing::info!(data_plane, id=%upsert.id, cordon, hints=primary_hints.is_some(), %expect_mod_revision, "shard upsert");
+            }
+            activate::Change::Shard(consumer::apply_request::Change {
+                upsert: None,
+                expect_mod_revision,
+                delete,
+                ..
+            }) => {
+                tracing::info!(data_plane, id=%delete, %expect_mod_revision, "shard delete");
+            }
+        }
+    }
+}
+
+async fn phase_three(
+    spec_migration: &SpecMigration,
+    tgt_data_plane: &DataPlane,
+) -> anyhow::Result<()> {
+    let SpecMigration {
+        catalog_name,
+        built_spec,
+        live_spec_id: _,
+    } = spec_migration;
+
+    let DataPlane {
+        journal_client: tgt_journal_client,
+        ops_logs_template: tgt_ops_logs_template,
+        ops_stats_template: tgt_ops_stats_template,
+        row: tgt_data_plane,
+        shard_client: tgt_shard_client,
+    } = tgt_data_plane;
+
+    let (task_type, task_template, partition_template) = unpack_templates(built_spec)?;
+
+    // Fetch and cordon shards and journals from the source data-plane.
+    let (_shards, _recovery, _partitions) = update_cordon(
+        &tgt_data_plane.data_plane_name,
+        tgt_journal_client,
+        tgt_shard_client,
+        catalog_name,
+        task_type,
+        task_template,
+        partition_template,
+        Some(tgt_ops_logs_template),
+        Some(tgt_ops_stats_template),
+        false, // Cordon.
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn update_cordon<'a>(
+    data_plane_name: &str,
+    journal_client: &gazette::journal::Client,
+    shard_client: &gazette::shard::Client,
+    catalog_name: &str,
+    task_type: ops::TaskType,
+    task_template: Option<activate::TaskTemplate<'a>>,
+    partition_template: Option<&'a broker::JournalSpec>,
+    ops_logs_template: Option<&broker::JournalSpec>,
+    ops_stats_template: Option<&broker::JournalSpec>,
+    cordon: bool,
+) -> anyhow::Result<(
+    Vec<activate::ShardSplit>,
+    Vec<activate::JournalSplit>,
+    Vec<activate::JournalSplit>,
+)> {
+    loop {
+        let ((mut shards, recovery, ops_logs, ops_stats), mut partitions) = futures::try_join!(
+            activate::fetch_task_splits(
+                journal_client,
+                shard_client,
+                task_type,
+                catalog_name,
+                ops_logs_template,
+                ops_stats_template,
+            ),
+            activate::fetch_partition_splits(journal_client, &catalog_name)
+        )?;
+
+        let it1 = shards.iter_mut().map(|shard| &mut shard.labels);
+        let it2 = partitions.iter_mut().map(|journal| &mut journal.labels);
+
+        if apply_cordon_label(cordon, it1.chain(it2)) {
+            let mut changes =
+                activate::task_changes(task_template, shards, recovery, ops_logs, ops_stats)?;
+            changes.extend(activate::partition_changes(partition_template, partitions)?);
+
+            print_changes(&changes, data_plane_name);
+            () = activate::apply_changes(journal_client, shard_client, changes).await?;
+
+            continue; // Loop to try again.
+        }
+        if cordon {
+            if apply_journal_suspension(journal_client, recovery.iter().chain(partitions.iter()))
+                .await?
+            {
+                continue; // Loop to try again.
+            }
+        }
+
+        return Ok((shards, recovery, partitions));
+    }
+}
+
+fn apply_cordon_label<'a>(
+    cordon: bool,
+    it: impl Iterator<Item = &'a mut broker::LabelSet>,
+) -> bool {
+    let mut changed = false;
+
+    for set in it {
+        let present = !labels::values(set, labels::CORDON).is_empty();
+
+        if cordon {
+            if !present {
+                *set = labels::add_value(std::mem::take(set), labels::CORDON, "1");
+                changed = true;
+            }
+        } else {
+            if present {
+                *set = labels::remove(std::mem::take(set), labels::CORDON);
+                changed = true;
+            }
+        }
+    }
+    changed
+}
+
+async fn apply_journal_suspension<'a>(
+    journal_client: &gazette::journal::Client,
+    it: impl Iterator<Item = &'a activate::JournalSplit>,
+) -> anyhow::Result<bool> {
+    use futures::TryStreamExt;
+
+    let to_suspend = futures::stream::FuturesUnordered::<_>::new();
+
+    for journal in it {
+        if matches!(&journal.suspend, Some(journal_spec::Suspend { level, .. }) if *level != 0) {
+            continue; // Already suspended.
+        }
+
+        let response = journal_client.append(
+            broker::AppendRequest {
+                journal: journal.name.clone(),
+                suspend: broker::append_request::Suspend::Now as i32,
+                ..Default::default()
+            },
+            || futures::stream::empty(),
+        );
+
+        to_suspend.push(async move {
+            futures::pin_mut!(response);
+
+            loop {
+                match response.try_next().await {
+                    Err(gazette::RetryError {
+                        inner: gazette::Error::BrokerStatus(broker::Status::Suspended),
+                        ..
+                    }) => {
+                        tracing::info!(name=%journal.name, "suspended journal");
+                        return Ok(());
+                    }
+                    Err(gazette::RetryError {
+                        attempt,
+                        inner: err,
+                    }) if attempt < 5 && err.is_transient() => {
+                        tracing::warn!(attempt, ?err, "failed to suspend journal (will retry)");
+                    }
+                    Ok(Some(response)) => {
+                        anyhow::bail!("received unexpected AppendResponse {response:?} (wanted SUSPENDED status)")
+                    }
+                    Ok(None) => anyhow::bail!("received unexpected EOF (wanted AppendResponse)"),
+                    Err(gazette::RetryError { inner: err, .. }) => return Err(err.into()),
+                }
+            }
+        });
+    }
+
+    let suspended: Vec<()> = to_suspend
+        .try_collect()
+        .await
+        .context("failed to suspend journals")?;
+
+    Ok(!suspended.is_empty())
+}
+
+async fn attach_shard_primary_hints(
+    shard_client: &gazette::shard::Client,
+    shards: &mut [activate::ShardSplit],
+) -> anyhow::Result<()> {
+    use futures::TryStreamExt;
+
+    let _: Vec<()> = shards
+        .iter_mut()
+        .map(|shard| async {
+            let hints = shard_client
+                .get_hints(consumer::GetHintsRequest {
+                    shard: shard.id.clone(),
+                    ..Default::default()
+                })
+                .await?;
+
+            if let Some(hints) = hints.primary_hints {
+                shard.primary_hints = hints.hints;
+            }
+
+            Ok::<_, gazette::Error>(())
+        })
+        .collect::<futures::stream::FuturesUnordered<_>>()
+        .try_collect()
+        .await?;
+
+    Ok(())
+}
+
+fn merge_splits<S>(
+    src: Vec<S>,
+    tgt: Vec<S>,
+    cmp_fn: impl Fn(&S, &S) -> std::cmp::Ordering,
+    mod_revision_fn: impl Fn(&mut S) -> &mut i64,
+) -> Vec<S> {
+    src.into_iter()
+        .merge_join_by(tgt, cmp_fn)
+        .map(|eob| match eob {
+            itertools::EitherOrBoth::Left(mut src) => {
+                *mod_revision_fn(&mut src) = 0; // Doesn't exist in target data-plane.
+                src
+            }
+            itertools::EitherOrBoth::Right(tgt) => tgt,
+            itertools::EitherOrBoth::Both(mut src, mut tgt) => {
+                *mod_revision_fn(&mut src) = *mod_revision_fn(&mut tgt);
+                src
+            }
+        })
+        .collect()
+}
+
+struct DataPlane {
+    row: tables::DataPlane,
+    shard_client: gazette::shard::Client,
+    journal_client: gazette::journal::Client,
+    ops_logs_template: broker::JournalSpec,
+    ops_stats_template: broker::JournalSpec,
+}
+
+async fn fetch_data_plane(pg_pool: &sqlx::PgPool, name: &str) -> anyhow::Result<DataPlane> {
+    let row = sqlx::query_as!(
+        tables::DataPlane,
+        r#"
+        SELECT
+            id AS "control_id: models::Id",
+            data_plane_name,
+            data_plane_fqdn,
+            false AS "is_default!: bool",
+            hmac_keys,
+            broker_address,
+            reactor_address,
+            ops_logs_name AS "ops_logs_name: models::Collection",
+            ops_stats_name AS "ops_stats_name: models::Collection"
+        FROM data_planes
+        WHERE data_plane_name = $1
+        "#,
+        name
+    )
+    .fetch_one(pg_pool)
+    .await
+    .with_context(|| format!("failed to fetch data-plane {name}"))?;
+
+    // Resolve ops collection templates for this data-plane.
+    let r = sqlx::query!(
+        r#"
+        SELECT
+            l.built_spec->'partitionTemplate' AS "logs!:  sqlx::types::Json<broker::JournalSpec>",
+            s.built_spec->'partitionTemplate' AS "stats!: sqlx::types::Json<broker::JournalSpec>"
+        FROM live_specs l, live_specs s
+        WHERE l.catalog_name = $1 AND l.spec_type = 'collection'
+        AND   s.catalog_name = $2 AND s.spec_type = 'collection'
+        "#,
+        &row.ops_logs_name,
+        &row.ops_stats_name,
+    )
+    .fetch_one(pg_pool)
+    .await
+    .context("failed to fetch data-plane ops collections")?;
+    let (ops_logs_template, ops_stats_template) = (r.logs.0, r.stats.0);
+
+    let mut metadata = gazette::Metadata::default();
+    metadata
+        .signed_claims(
+            proto_gazette::capability::APPEND
+                | proto_gazette::capability::APPLY
+                | proto_gazette::capability::LIST
+                | proto_gazette::capability::READ,
+            &row.data_plane_fqdn,
+            std::time::Duration::from_secs(300),
+            &row.hmac_keys,
+            broker::LabelSelector::default(),
+            "migrate-tool",
+        )
+        .context("failed to sign claims for data-plane")?;
+
+    // Create the journal and shard clients that are used for interacting with the data plane
+    let router = gazette::Router::new("local");
+    let journal_client =
+        gazette::journal::Client::new(row.broker_address.clone(), metadata.clone(), router.clone());
+    let shard_client = gazette::shard::Client::new(row.reactor_address.clone(), metadata, router);
+
+    Ok(DataPlane {
+        row,
+        shard_client,
+        journal_client,
+        ops_logs_template,
+        ops_stats_template,
+    })
+}
+
+struct SpecMigration {
+    catalog_name: String,
+    live_spec_id: models::Id,
+    built_spec: proto_flow::AnyBuiltSpec,
+}
+
+fn fetch_spec_migrations<'a>(
+    pg_pool: &'a sqlx::PgPool,
+    catalog_prefix: &'a str,
+    data_plane_id: models::Id,
+) -> impl futures::Stream<Item = anyhow::Result<SpecMigration>> + 'a {
+    sqlx::query!(
+        r#"
+        SELECT
+            id AS "id: models::Id",
+            catalog_name,
+            spec_type AS "spec_type!: models::CatalogType",
+            built_spec AS "built_spec!: sqlx::types::Json<models::RawValue>"
+        FROM live_specs
+        WHERE starts_with(catalog_name, $1)
+        AND   built_spec IS NOT NULL
+        AND   data_plane_id = $2
+        "#,
+        catalog_prefix,
+        data_plane_id as models::Id,
+    )
+    .fetch(pg_pool)
+    .map_err(|err| anyhow::anyhow!(err))
+    .and_then(|r| async move {
+        let spec = match r.spec_type {
+            models::CatalogType::Capture => {
+                proto_flow::AnyBuiltSpec::Capture(serde_json::from_str(r.built_spec.get())?)
+            }
+            models::CatalogType::Collection => {
+                proto_flow::AnyBuiltSpec::Collection(serde_json::from_str(r.built_spec.get())?)
+            }
+            models::CatalogType::Materialization => {
+                proto_flow::AnyBuiltSpec::Materialization(serde_json::from_str(r.built_spec.get())?)
+            }
+            models::CatalogType::Test => {
+                proto_flow::AnyBuiltSpec::Test(serde_json::from_str(r.built_spec.get())?)
+            }
+        };
+
+        Ok(SpecMigration {
+            catalog_name: r.catalog_name,
+            live_spec_id: r.id,
+            built_spec: spec,
+        })
+    })
+}
+
+fn unpack_templates<'a>(
+    built_spec: &'a proto_flow::AnyBuiltSpec,
+) -> anyhow::Result<(
+    ops::TaskType,
+    Option<activate::TaskTemplate<'a>>,
+    Option<&'a broker::JournalSpec>,
+)> {
+    Ok(match built_spec {
+        proto_flow::AnyBuiltSpec::Capture(spec) => {
+            let task_template = activate::capture_template(Some(spec))?;
+            (ops::TaskType::Capture, task_template, None)
+        }
+        proto_flow::AnyBuiltSpec::Collection(spec) => {
+            let (partition_template, task_template) = activate::collection_template(Some(spec))?;
+            (ops::TaskType::Derivation, task_template, partition_template)
+        }
+        proto_flow::AnyBuiltSpec::Materialization(spec) => {
+            let task_template = activate::materialization_template(Some(&spec))?;
+            (ops::TaskType::Materialization, task_template, None)
+        }
+        proto_flow::AnyBuiltSpec::Test(_spec) => (ops::TaskType::InvalidType, None, None),
+    })
+}
+
+fn confirm(prompt: &str) -> anyhow::Result<()> {
+    use std::io::{self, Write};
+
+    loop {
+        // Print the prompt without a newline and flush to ensure it's shown immediately.
+        print!("{} [y/N]: ", prompt);
+        std::io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        if let Err(err) = io::stdin().read_line(&mut input) {
+            anyhow::bail!("failed to read confirmation ({err})");
+        }
+
+        match input.trim().to_lowercase().as_str() {
+            "y" | "yes" => return Ok(()),
+            "n" | "no" | "" => anyhow::bail!("Aborting."),
+            _ => println!("Please enter 'y' or 'n'."),
+        }
+    }
+}

--- a/crates/migrate/src/main.rs
+++ b/crates/migrate/src/main.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+
+fn main() -> Result<(), anyhow::Error> {
+    // Required in order for libraries to use `rustls` for TLS.
+    // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install default crypto provider");
+
+    // Use reasonable defaults for printing structured logs to stderr.
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(if matches!(std::env::var("NO_COLOR"), Ok(v) if v == "1") {
+            false
+        } else {
+            true
+        })
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
+
+    let args = migrate::Args::parse();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    let result = runtime.block_on(runtime.spawn(async move { migrate::run(args).await }));
+
+    runtime.shutdown_timeout(std::time::Duration::from_secs(5));
+    result?
+}

--- a/crates/proto-gazette/src/consumer.rs
+++ b/crates/proto-gazette/src/consumer.rs
@@ -385,6 +385,12 @@ pub mod apply_request {
         /// Shard to be deleted. expect_mod_revision must not be zero.
         #[prost(string, tag = "3")]
         pub delete: ::prost::alloc::string::String,
+        /// (Optional) Primary hints to set for the shard. This is rarely required,
+        /// as shards start with an empty recovery log and track their own hints,
+        /// but is useful in some advanced migration scenarios.
+        /// If set, then this Change must be an upsert.
+        #[prost(message, optional, tag = "4")]
+        pub primary_hints: ::core::option::Option<super::super::recoverylog::FsmHints>,
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/proto-gazette/src/consumer.serde.rs
+++ b/crates/proto-gazette/src/consumer.serde.rs
@@ -127,6 +127,9 @@ impl serde::Serialize for apply_request::Change {
         if !self.delete.is_empty() {
             len += 1;
         }
+        if self.primary_hints.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("consumer.ApplyRequest.Change", len)?;
         if self.expect_mod_revision != 0 {
             #[allow(clippy::needless_borrow)]
@@ -138,6 +141,9 @@ impl serde::Serialize for apply_request::Change {
         }
         if !self.delete.is_empty() {
             struct_ser.serialize_field("delete", &self.delete)?;
+        }
+        if let Some(v) = self.primary_hints.as_ref() {
+            struct_ser.serialize_field("primaryHints", v)?;
         }
         struct_ser.end()
     }
@@ -153,6 +159,8 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
             "expectModRevision",
             "upsert",
             "delete",
+            "primary_hints",
+            "primaryHints",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -160,6 +168,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
             ExpectModRevision,
             Upsert,
             Delete,
+            PrimaryHints,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -184,6 +193,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                             "expectModRevision" | "expect_mod_revision" => Ok(GeneratedField::ExpectModRevision),
                             "upsert" => Ok(GeneratedField::Upsert),
                             "delete" => Ok(GeneratedField::Delete),
+                            "primaryHints" | "primary_hints" => Ok(GeneratedField::PrimaryHints),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -206,6 +216,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                 let mut expect_mod_revision__ = None;
                 let mut upsert__ = None;
                 let mut delete__ = None;
+                let mut primary_hints__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::ExpectModRevision => {
@@ -228,12 +239,19 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                             }
                             delete__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::PrimaryHints => {
+                            if primary_hints__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("primaryHints"));
+                            }
+                            primary_hints__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(apply_request::Change {
                     expect_mod_revision: expect_mod_revision__.unwrap_or_default(),
                     upsert: upsert__,
                     delete: delete__.unwrap_or_default(),
+                    primary_hints: primary_hints__,
                 })
             }
         }

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.etcd.io/etcd/api/v3 v3.5.17
 	go.etcd.io/etcd/client/v3 v3.5.17
-	go.gazette.dev/core v0.100.1-0.20250331163603-c99d751f846d
-	golang.org/x/net v0.37.0
+	go.gazette.dev/core v0.100.1-0.20250417154141-b0b9a483aa14
+	golang.org/x/net v0.38.0
 	google.golang.org/api v0.126.0
 	google.golang.org/grpc v1.65.0
 )

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.17 h1:XxnDXAWq2pnxqx76ljWwiQ9jylbpC4rvkAeRVOU
 go.etcd.io/etcd/client/pkg/v3 v3.5.17/go.mod h1:4DqK1TKacp/86nJk4FLQqo6Mn2vvQFBmruW3pP14H/w=
 go.etcd.io/etcd/client/v3 v3.5.17 h1:o48sINNeWz5+pjy/Z0+HKpj/xSnBkuVhVvXkjEXbqZY=
 go.etcd.io/etcd/client/v3 v3.5.17/go.mod h1:j2d4eXTHWkT2ClBgnnEPm/Wuu7jsqku41v9DZ3OtjQo=
-go.gazette.dev/core v0.100.1-0.20250331163603-c99d751f846d h1:RQRWjhsBQP6cTLdtHF4Fq0ao/pLQZPGlI33jm4NL8fM=
-go.gazette.dev/core v0.100.1-0.20250331163603-c99d751f846d/go.mod h1:Z8BQRgeWdgc3OmjxwEmXqfq5UJfG53MLpBM/vhzzga0=
+go.gazette.dev/core v0.100.1-0.20250417154141-b0b9a483aa14 h1:DnBcggSInLcsKJDXRMJkjssi7+rCM4lCTlB438sMmtU=
+go.gazette.dev/core v0.100.1-0.20250417154141-b0b9a483aa14/go.mod h1:WK/NPg8XSABEwrtlxcFx2t/jZYETIKjW0hywktRA5Z0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -485,8 +485,8 @@ golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go/labels/labels.go
+++ b/go/labels/labels.go
@@ -16,6 +16,9 @@ const (
 	// Collection is the name of the Estuary collection for which this Journal
 	// holds documents.
 	Collection = "estuary.dev/collection"
+	// Cordon is a label that indicates that this journal or shard is cordoned
+	// due to an ongoing data-plane migration.
+	Cordon = "estuary.dev/cordon"
 	// Field is a logical partition of the Collection that's implemented by this
 	// journal.
 	FieldPrefix = "estuary.dev/field/"
@@ -95,6 +98,8 @@ func IsRuntimeLabel(label string) bool {
 
 	switch label {
 	case
+		// Cordoning is tracked in the data-plane.
+		Cordon,
 		// Key splits are performed dynamically by the runtime.
 		KeyBegin, KeyEnd,
 		// R-Clock splits are performed dynamically by the runtime.


### PR DESCRIPTION
**Description:**

* [required] Handle (in the runtime) a task which is migrated and awakes in a new data-plane, and must discard its stats ACK intent.
* [nice to have] support a new `estuary.dev/cordon` data-plane label, which is attached to ShardSpecs and JournalSpecs to disable them / mark them read-only, and preserved in future activations
* [nice to have] refactor `activate` and add new checks against races and expected ordering
* [nice to have] shard Apply RPC supports setting `primary_hints`, and related support in `gazette` & `activate`
* [nice to have] `migrate` crate implementing a prototype CLI for task and collection migration

Future PRs will include:
* a prototype migration CLI for task migration
* authorization API support for cordoning of tasks to support hot migration without task failure

Issue #2069 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2079)
<!-- Reviewable:end -->
