### PR TITLE
docs: add `metricAggregations` support for `source-google-analytics-data-api-native`

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/google-analytics-data-api-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics-data-api-native.md
@@ -83,9 +83,19 @@ Fill out the Custom Reports property with a JSON array as a string with the foll
 [{"name": "<report-name>", "dimensions": ["<dimension-name>", ...], "metrics": ["<metric-name>", ...], "dimensionFilter": "<filter-object>", "metricFilter": "<another-filter-object>"}]
 ```
 
-### Sample
+The `TOTAL`, `MAXIMUM`, and `MINIMUM` [metric aggregations](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/MetricAggregation) are supported as well. These aggregates will be emitted as separate documents with the dimension values indicating the type of aggregation, like `RESTRICTED_TOTAL`.
 
-This sample reflects the manual authentication method.
+```json
+[{"name": "<report-name>", "dimensions": ["<dimension-name>", ...], "metrics": ["<metric-name>", ...], "metricAggregations": ["TOTAL", "MAXIMUM", "MINIMUM"]}]
+```
+
+:::tip
+
+After editing custom reports for a capture, always [re-discover](../../../concepts/captures.md#discovery) bindings to ensure the changes to your custom reports are reflected in the associated collections' specs and schemas.
+
+:::
+
+### Sample
 
 ```yaml
 captures:
@@ -94,7 +104,7 @@ captures:
       connector:
         image: ghcr.io/estuary/source-google-analytics-data-api-native:dev
           config:
-            custom_reports: '[{"name": "my_custom_report_with_a_filter", "dimensions": ["browser"], "metrics": ["totalUsers"], "dimensionFilter": {"filter": {"fieldName": "browser", "stringFilter": {"value": "Chrome"}}}}]'
+            custom_reports: '[{"name": "my_custom_report_with_a_filter_and_aggregate", "dimensions": ["browser"], "metrics": ["totalUsers"], "dimensionFilter": {"filter": {"fieldName": "browser", "stringFilter": {"value": "Chrome"}}}, "metricAggregates": ["TOTAL"]}]'
             credentials:
                 credentials_title: OAuth Credentials
                 client_id: <secret>


### PR DESCRIPTION
**Description:**

Documentation updates for https://github.com/estuary/connectors/pull/2685.

Users have also run into issues with editing custom reports, not re-discovering bindings so those changes are reflected in the spec & schema, then run into schema issues. I added a tip to try & help users troubleshoot this when editing custom reports.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2081)
<!-- Reviewable:end -->
