### PR TITLE
support "hot" migration through authorization cordons

### DIFF
--- a/crates/agent/src/api/error.rs
+++ b/crates/agent/src/api/error.rs
@@ -100,10 +100,10 @@ mod error_serde {
 }
 
 impl ApiError {
-    pub fn not_found() -> ApiError {
+    pub fn unauthorized(prefix: &str) -> ApiError {
         ApiError::new(
-            StatusCode::NOT_FOUND,
-            anyhow::anyhow!("requested entity does not exist or you are not authorized"),
+            StatusCode::UNAUTHORIZED,
+            anyhow::anyhow!("user is not authorized to {prefix}"),
         )
     }
 

--- a/crates/agent/src/api/public/mod.rs
+++ b/crates/agent/src/api/public/mod.rs
@@ -130,5 +130,7 @@ fn api_docs(api: aide::transform::TransformOpenApi) -> aide::transform::Transfor
             },
         )
         .security_requirement("ApiKey")
-        .default_response_with::<axum::Json<ApiError>, _>(|res| res.example(ApiError::not_found()))
+        .default_response_with::<axum::Json<ApiError>, _>(|res| {
+            res.example(ApiError::unauthorized("acmeCo/anvils/"))
+        })
 }

--- a/crates/models/src/authorizations.rs
+++ b/crates/models/src/authorizations.rs
@@ -2,14 +2,22 @@ use std::cmp::max;
 use validator::Validate;
 
 /// ControlClaims are claims encoded within control-plane access tokens.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ControlClaims {
     // Note that many more fields, such as additional user metadata,
     // are available if we choose to parse them.
-    pub sub: uuid::Uuid,
-    pub email: Option<String>,
+
+    // Unix timestamp, in seconds, at which the token was issued.
     pub iat: u64,
+    // Unix timestamp, in seconds, at which the token expires.
     pub exp: u64,
+    // Authorized User ID.
+    pub sub: uuid::Uuid,
+    // PostgreSQL role to be used for the token.
+    pub role: String,
+    // Authorized user email, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
 }
 
 impl ControlClaims {

--- a/supabase/migrations/20250418224209_cordon.sql
+++ b/supabase/migrations/20250418224209_cordon.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+CREATE TABLE public.data_plane_migrations (
+    id                      public.flowid PRIMARY KEY NOT NULL DEFAULT internal.id_generator(),
+    created_at              TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    active                  BOOLEAN NOT NULL DEFAULT TRUE,
+    catalog_name_or_prefix  TEXT NOT NULL,
+    src_plane_id            public.flowid NOT NULL,
+    tgt_plane_id            public.flowid NOT NULL,
+    cordon_at               TIMESTAMPTZ DEFAULT NOW() + INTERVAL '90 minutes' NOT NULL
+);
+
+END;


### PR DESCRIPTION
**Description:**

This PR updates authorization snapshot mechanisms to introduce a concept of scheduled "cordons", where granted authorizations will bound their expiration time to a future scheduled migration timestamp. Upon reaching this timestamp, authorization APIs ask clients to retry periodically until the cordon condition is resolved.

This allows, for example, a running materialization -- which is _not_ migrated -- to gracefully handle a collection which _is_ migrated. Its reads of the collection proceed normally until the cordon timestamp, at which point it spins attempting to fetch a new authorization. Meanwhile, a migration of the collection is performed, and the cordon condition removed. The materialization authorization request can then proceed, and receives an authorization with an updated data-plane.

Similarly, for captures, cordoning ensures that we cannot have races where a non-migrated capture creates a new physical partition in the source data-plane, while the collection is in the process of migration to a different target data-plane.

Other updates to snapshots include:
* Perform ahead-of-time refreshes on reaching the max refresh interval, so we don't stall requests unnecessarily.
* Add extensive new unit test coverage of various authorization APIs.

Finally, add a "watch" mode to the migration tool which monitors for ready migrations and performs them.


Testing:
* In addition to unit test coverage, I performed extensive local testing using two data-planes where I migrated a variety of collections and tasks using snapshot cordons plus the migration tool running in "watch" mode.


**Workflow steps:**

* Enqueue new rows into `data_plane_migrations` to schedule a future migration.
* Run the `migrate watch` tool to monitor for & run ready migrations.
* Observe that collections and/or tasks are now homed in the target data plane.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2089)
<!-- Reviewable:end -->
