### PR TITLE
Dekaf: namespace group IDs and invalidate topic state when binding is backfilled or collection is reset

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -143,9 +143,14 @@ impl GazetteWriter {
         &self,
         task_name: &str,
     ) -> anyhow::Result<(GazetteAppender, GazetteAppender)> {
-        let task_listener = self.task_manager.get_listener(task_name).await;
+        let task_listener = self
+            .task_manager
+            .get_listener(task_name)
+            .await
+            .wait_until_ready()
+            .await?;
 
-        let initial_state = task_listener.get().await?;
+        let initial_state = task_listener.get()?;
 
         Ok((
             GazetteAppender::OpsLogs(GazetteAppenderState {
@@ -210,15 +215,13 @@ impl GazetteAppender {
         match self {
             GazetteAppender::OpsStats(state) => state
                 .task_listener
-                .get()
-                .await?
+                .get()?
                 .ops_stats_client
                 .map(|(client, _claims)| client)
                 .map_err(|err| err.into()),
             GazetteAppender::OpsLogs(state) => state
                 .task_listener
-                .get()
-                .await?
+                .get()?
                 .ops_logs_client
                 .map(|(client, _claims)| client)
                 .map_err(|err| err.into()),

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1335,24 +1335,24 @@ impl Session {
     }
 
     fn encrypt_topic_name(&self, name: TopicName) -> anyhow::Result<TopicName> {
-        Ok(to_upstream_topic_name(
+        to_upstream_topic_name(
             name,
             self.secret.to_owned(),
             match self.auth.as_ref().context("Must be authenticated")? {
                 SessionAuthentication::User(auth) => auth.claims.sub.to_string(),
                 SessionAuthentication::Task(auth) => auth.config.token.to_string(),
             },
-        ))
+        )
     }
     fn decrypt_topic_name(&self, name: TopicName) -> anyhow::Result<TopicName> {
-        Ok(from_upstream_topic_name(
+        from_upstream_topic_name(
             name,
             self.secret.to_owned(),
             match self.auth.as_ref().context("Must be authenticated")? {
                 SessionAuthentication::User(auth) => auth.claims.sub.to_string(),
                 SessionAuthentication::Task(auth) => auth.config.token.to_string(),
             },
-        ))
+        )
     }
 
     fn encode_topic_name(&self, name: String) -> anyhow::Result<TopicName> {

--- a/crates/dekaf/tests/dekaf_integration_test.rs
+++ b/crates/dekaf/tests/dekaf_integration_test.rs
@@ -476,6 +476,9 @@ async fn test_field_selection_specific() -> anyhow::Result<()> {
             deletions: dekaf::connector::DeletionMode::Kafka,
             strict_topic_names: false,
             token: "1234".to_string(),
+            advanced: dekaf::connector::Advanced {
+                feature_flags: vec!["no_namespaced_ids".to_string()],
+            },
         },
         json!({
             "schema": {
@@ -526,6 +529,9 @@ async fn test_field_selection_recommended() -> anyhow::Result<()> {
             deletions: dekaf::connector::DeletionMode::Kafka,
             strict_topic_names: false,
             token: "1234".to_string(),
+            advanced: dekaf::connector::Advanced {
+                feature_flags: vec!["no_namespaced_ids".to_string()],
+            },
         },
         json!({
             "schema": {
@@ -573,6 +579,9 @@ async fn test_field_selection_flow_document() -> anyhow::Result<()> {
             deletions: dekaf::connector::DeletionMode::Kafka,
             strict_topic_names: false,
             token: "1234".to_string(),
+            advanced: dekaf::connector::Advanced {
+                feature_flags: vec!["no_namespaced_ids".to_string()],
+            },
         },
         json!({
             "schema": {
@@ -628,6 +637,9 @@ async fn test_meta_is_deleted() -> anyhow::Result<()> {
             deletions: dekaf::connector::DeletionMode::CDC,
             strict_topic_names: false,
             token: "1234".to_string(),
+            advanced: dekaf::connector::Advanced {
+                feature_flags: vec!["no_namespaced_ids".to_string()],
+            },
         },
         json!({
             "schema": {
@@ -697,6 +709,9 @@ async fn test_fields_not_required() -> anyhow::Result<()> {
             deletions: dekaf::connector::DeletionMode::Kafka,
             strict_topic_names: false,
             token: "1234".to_string(),
+            advanced: dekaf::connector::Advanced {
+                feature_flags: vec!["no_namespaced_ids".to_string()],
+            },
         },
         json!({
             "schema": {


### PR DESCRIPTION
### Add `advanced.namespaced_ids` to Dekaf endpoint config

This flag will cause topics and groups to be namespaced when reported to/from upstream Kafka. This fixes a few problems described in https://github.com/estuary/flow/issues/2060

Specifically:
* Stop passing `token` to `to_upstream_topic_name`, as the net effect was breaking your consumer group if you changed your token.
* Namespacing group IDs to the materialization so that multiple consumers can share the same group ID without worrying about conflicts
  * **Note:** This doesn't save you from having multiple consumers of the _same_ task step on eachother's toes, like we saw happen last week. This is still a thing that can happen, and I haven't been able to think of a good way to mitigate it. Just don't run multiple consumers of the same task with the same group ID. Tinybird [tells you not to](https://www.tinybird.co/docs/forward/get-data-in/connectors/kafka#create-a-kafka-data-source), and we should probably do the same in our docs.
* Include the partition template name and binding state key in the mapped topic names. This causes backfills and collection resets to propagate to consumers as a fresh topic with no committed offsets.

##### Post-deploy steps:
Setting `advanced.namespaced_ids` to true will cause all of your committed offset state to be effectively reset, so it's set to false by default if not specified. After this change is deployed, we'll want to manually go and publish all Dekaf materializations with this field explicitly set to false. Then we can change its default value to true, and the net effect will be that all _new_ Dekaf materializations will have this turned on by default, leaving existing ones alone.

#### Other changes

We currently have a couple of consumers of materializations where the token changed after the group/topics had offsets committed. This is causing sessions to panic, and while we're actually handling that correctly because they're each an isolated Tokio task, I realized that we are "leaking" `dekaf_total_connections` -- we increment the counter when the connection is established, but panic before we can decrement it. So I refactored the way we report that metric to handle panic'd sessions.

I also fixed the panic by removing a couple of `unwrap()`s which I thought wouldn't fail, but do in this circumstance.

Fixes #2083, fixes #2060

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2093)
<!-- Reviewable:end -->
