### PR TITLE
data-plane-controller: Add `Dekaf` role

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -150,6 +150,7 @@ pub enum Role {
     Gazette,
     Reactor,
     Bastion,
+    Dekaf,
 }
 
 /// A Deployment under a rollout will be updated with each data-plane


### PR DESCRIPTION
**Description:**

This lets the data plane controller parse deployments of the `Dekaf` role, and is needed to test the corresponding dry-dock changes to deploy Dekaf in new-style data-planes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2094)
<!-- Reviewable:end -->
