### PR TITLE
dekaf: Add timeout for metadata requests

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -38,7 +38,11 @@ use log_appender::SESSION_CLIENT_ID_FIELD_MARKER;
 use percent_encoding::{percent_decode_str, utf8_percent_encode};
 use proto_flow::flow;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, sync::Arc, time::SystemTime};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 use tracing_record_hierarchical::SpanExt;
 
 pub struct App {
@@ -260,6 +264,8 @@ impl App {
 
             logging::set_log_level(labels.log_level());
 
+            tracing::info!(task_id = username, "Authenticated");
+
             Ok(SessionAuthentication::Task(TaskAuth::new(
                 self.client_base
                     .clone()
@@ -371,6 +377,7 @@ async fn handle_api(
 ) -> anyhow::Result<()> {
     let start_time = SystemTime::now();
     use messages::*;
+    tracing::debug!(?api_key, v = version, "handling API request");
     let ret = match api_key {
         ApiKey::ApiVersionsKey => {
             // https://github.com/confluentinc/librdkafka/blob/e03d3bb91ed92a38f38d9806b8d8deffe78a1de5/src/rdkafka_request.c#L2823
@@ -413,7 +420,11 @@ async fn handle_api(
         ApiKey::MetadataKey => {
             // https://github.com/confluentinc/librdkafka/blob/e03d3bb91ed92a38f38d9806b8d8deffe78a1de5/src/rdkafka_request.c#L2417
             let (header, request) = dec_request(frame, version)?;
-            Ok(enc_resp(out, &header, session.metadata(request).await?))
+            let metadata_response =
+                tokio::time::timeout(Duration::from_secs(30), session.metadata(request))
+                    .await
+                    .context("metadata request timed out")??;
+            Ok(enc_resp(out, &header, metadata_response))
         }
         ApiKey::FindCoordinatorKey => {
             let (header, request) = dec_request(frame, version)?;

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -542,6 +542,8 @@ pub async fn fetch_dekaf_task_auth(
     String,
     proto_flow::flow::MaterializationSpec,
 )> {
+    let start = std::time::Instant::now();
+
     let request_token = flow_client::client::build_task_authorization_request_token(
         shard_template_id,
         data_plane_fqdn,
@@ -575,6 +577,11 @@ pub async fn fetch_dekaf_task_auth(
         break response;
     };
     let claims = flow_client::parse_jwt_claims(token.as_str())?;
+
+    tracing::info!(
+        runtime_ms = start.elapsed().as_millis(),
+        "fetched dekaf task auth",
+    );
 
     Ok((
         token,


### PR DESCRIPTION
Metadata requests appear to be sometimes hanging forever. We have an idle session timeout, but if a Session is actively handling a request it won't get killed, and if that request never returns then we'll effectively leak that connection.

We still absolutely need to figure out why exactly metadata requests are hanging, but for the moment this _should_ alleviate the unbounded connection growth issue Dekaf is seeing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2102)
<!-- Reviewable:end -->
