### PR TITLE
functions: azure-dpc-oauth for redirect_url of Azure BYOC OAuth

### DIFF
--- a/supabase/functions/azure-dpc-oauth/index.ts
+++ b/supabase/functions/azure-dpc-oauth/index.ts
@@ -1,0 +1,30 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+// Setup type definitions for built-in Supabase Runtime APIs
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+
+Deno.serve(async (req) => {
+  const u = new URL(req.url);
+  const code = u.searchParams.get("code");
+  if (code) {
+    return new Response("data-plane-controller was successfully added to your Azure tenant, now continue with the next steps of https://docs.estuary.dev/guides/byoc/azure/")
+  }
+
+  const error = u.searchParams.get("error");
+  const errorDescription = u.searchParams.get("error_description");
+  return new Response("Failed to add data-plane-controller to your Azure tenant: " + error + ", " + errorDescription, { status: 400 })
+})
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:5431/functions/v1/azure-dpc-oauth' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/


### PR DESCRIPTION
**Description:**

- For adding data-plane-controller app to Azure tenants to enable BYOC, users need to go through an OAuth flow
- We currently redirect to estuary.dev, which doesn't tell customers if the OAuth process was successful or not
- The simplest implementation to show error if there is one, or tell the customer if it was successful, to avoid confusions.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2107)
<!-- Reviewable:end -->
