### PR TITLE
Dekaf: Collection of small updates

### DIFF
--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -542,6 +542,8 @@ pub async fn fetch_dekaf_task_auth(
     String,
     proto_flow::flow::MaterializationSpec,
 )> {
+    let start = std::time::Instant::now();
+
     let request_token = flow_client::client::build_task_authorization_request_token(
         shard_template_id,
         data_plane_fqdn,
@@ -575,6 +577,11 @@ pub async fn fetch_dekaf_task_auth(
         break response;
     };
     let claims = flow_client::parse_jwt_claims(token.as_str())?;
+
+    tracing::info!(
+        runtime_ms = start.elapsed().as_millis(),
+        "fetched dekaf task auth",
+    );
 
     Ok((
         token,

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -42,10 +42,10 @@ impl TaskAuth {
                 .bindings
                 .iter()
                 .map(|b| {
-                    b.collection
-                        .as_ref()
-                        .context("MaterializationSpec missing `collection`")
-                        .map(|c| c.name.clone())
+                    b.resource_path
+                        .first()
+                        .cloned()
+                        .ok_or(anyhow::anyhow!("missing resource path"))
                 })
                 .collect::<Result<Vec<_>, _>>(),
             Err(e) => anyhow::bail!("failed to fetch task spec: {e:?}"),

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -194,7 +194,9 @@ impl Collection {
             None
         };
 
-        let partitions = Self::fetch_partitions(&journal_client, collection_name, selector).await?;
+        let partitions =
+            Self::fetch_partitions(&journal_client, partition_template_name.as_str(), selector)
+                .await?;
 
         tracing::debug!(?partitions, "Got partitions");
 
@@ -319,12 +321,12 @@ impl Collection {
     #[tracing::instrument(skip(journal_client))]
     async fn fetch_partitions(
         journal_client: &journal::Client,
-        collection: &str,
+        name_prefix: &str,
         partition_selector: Option<broker::LabelSelector>,
     ) -> anyhow::Result<Vec<Partition>> {
         let request = broker::ListRequest {
             selector: Some(partition_selector.unwrap_or(broker::LabelSelector {
-                include: Some(labels::build_set([(labels::COLLECTION, collection)])),
+                include: Some(labels::build_set([("name:prefix", name_prefix)])),
                 exclude: None,
             })),
             ..Default::default()


### PR DESCRIPTION
**Description:**

* Adds a timeout to `Metadata` API calls, as we found out that these were hanging indefinitely, and consumers were just opening more and more connections as a result. I'd like to have a more global timeout, but that's complicated by the fact that some requests are potentially long-running, such as `Fetch` with its `max_wait_ms` parameter. So I went with a more targeted timeout to start with.
* Skip calls to `dekaf::topology::Collection::fetch_spec()` if they're not needed -- this reduces the query load on supabase
* Switch from partition selectors using `estuary.dev/collection` when there is no binding partition selector to `name:prefix`. Combined with https://github.com/estuary/flow/pull/2108 to include `name:prefix` in partition selectors themselves, this will cause all calls to `fetch_partitions` to use `name:prefix`.
  **Note:** AFAIK, the only case where we won't have a binding partition selector is when a connection is using the old user-token auth which we're getting rid of ASAP. So the [change in this PR](https://github.com/estuary/flow/pull/2109/commits/cb484de24028ebaad5ddf44ec44ba95cb9df90e2) is only applicable to sessions using user-token auth, of which there are almost none at this point.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2109)
<!-- Reviewable:end -->
