### PR TITLE
more sourced schema tweaks

### DIFF
--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -126,13 +126,13 @@ pub struct Merge {
     /// Relative JSON Pointer(s) which form the key by which the items of merged
     /// Arrays are ordered. `key` is ignored in Object merge contexts, where the
     /// object property is used instead.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key: Vec<Pointer>,
     /// Delete marks that this location should be removed from the document.
     /// Deletion is effected only when a document is fully reduced, so partial
     /// reductions of the document will continue to have deleted locations
     /// up until the point where they're reduced into a base document.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub delete: bool,
 }
 

--- a/crates/doc/src/shape/schema.rs
+++ b/crates/doc/src/shape/schema.rs
@@ -169,16 +169,10 @@ fn to_sub_schema(shape: Shape) -> Schema {
         }
 
         match reduction {
-            Reduction::Unset => {}
+            Reduction::Unset | Reduction::Multiple => {}
             Reduction::Strategy(strategy) => {
                 out.extensions
                     .insert("reduce".to_string(), serde_json::json!(strategy));
-            }
-            Reduction::Multiple => {
-                out.extensions.insert(
-                    "reduce".to_string(),
-                    serde_json::json!("multiple-strategies"),
-                );
             }
         }
 
@@ -282,6 +276,9 @@ mod tests {
                     "minimum": 20,
                     "maximum": 30.0,
                     "default": 25.4,
+                    "reduce": {
+                        "strategy": "sum",
+                    }
                 },
                 "tuple": {
                     "type": "array",
@@ -311,6 +308,9 @@ mod tests {
                 "emptyObj",
                 "str",
             ],
+            "reduce": {
+                "strategy": "merge",
+            }
         });
 
         let curi = url::Url::parse("flow://fixture").unwrap();

--- a/crates/gazette/src/journal/read.rs
+++ b/crates/gazette/src/journal/read.rs
@@ -80,7 +80,7 @@ impl Client {
         // Can we directly read the fragment from cloud storage?
         if let (broker::Status::Ok, false, Some(fragment)) = (
             metadata.status(),
-            metadata.fragment_url.is_empty(),
+            metadata.fragment_url.is_empty() || metadata.fragment_url.starts_with("file://"),
             &metadata.fragment,
         ) {
             if req.offset != metadata.offset {

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -81,15 +81,15 @@ impl Error {
             // At this level, we do not consider BrokerStatus or ConsumerStatus
             // to be transient. Callers may want to special-case certain values
             // as fits their circumstances however.
+            Error::AppendRead(_) => false,
             Error::BearerToken(_) => false,
             Error::BrokerStatus(_) => false,
             Error::ConsumerStatus(_) => false,
             Error::InvalidEndpoint(_) => false,
+            Error::JWT(_) => false,
             Error::Parsing { .. } => false,
             Error::Protocol(_) => false,
             Error::UUID(_) => false,
-            Error::JWT(_) => false,
-            Error::AppendRead(_) => false,
         }
     }
 }

--- a/crates/proto-gazette/src/lib.rs
+++ b/crates/proto-gazette/src/lib.rs
@@ -51,7 +51,7 @@ pub mod capability {
 // Claims reflect the scope of an authorization. They grant the client the
 // indicated Capability against resources matched by the corresponding
 // Selector.
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Claims {
     pub cap: u32,
     pub exp: u64,


### PR DESCRIPTION
**Description:**

* Omit a `reduce` annotation altogether when the inferred reduction strategy is `Reduction::Multiple`
* "fix" local fragment file:// schemes by not attempting to fetch them
* Explicitly error if the connector's SourcedSchema is not closed.
* Catch a spot where we failed to thread-through `x-generation-id`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2126)
<!-- Reviewable:end -->
