### PR TITLE
control plane: only add new tenants to estuary_support/ role

### DIFF
--- a/supabase/migrations/20250502201326_fix-estuary-support.sql
+++ b/supabase/migrations/20250502201326_fix-estuary-support.sql
@@ -1,0 +1,25 @@
+begin;
+
+-- Updates the new tenant trigger to only add newly inserted tenants to the
+-- `estuary_support/` role, so that existing tenants can be removed from that
+-- role without automatically getting re-added.
+drop trigger "Grant support role access to tenants" on public.tenants;
+drop function internal.update_support_role;
+
+create function internal.update_support_role() returns trigger
+language plpgsql as $$
+begin
+    insert into role_grants (subject_role, object_role, capability, detail)
+    values (
+        'estuary_support/',
+        NEW.tenant,
+        'admin',
+        'Automagically grant support role access to new tenant'
+    );
+    return null;
+end;
+$$;
+
+create trigger "Grant support role access to tenants" after insert on public.tenants for each row execute function internal.update_support_role();
+
+commit;


### PR DESCRIPTION
Updates the new tenant provisioning to only add newly created tenants to the `estuary_support/` role.  Previously it was adding all tenants to the role whenever any tenant was provisioned, which would re-add tenants that we had removed. Now they stay removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2127)
<!-- Reviewable:end -->
