### PR TITLE
models: accept a `data_plane` field on a StorageDef

### DIFF
--- a/crates/models/src/journals.rs
+++ b/crates/models/src/journals.rs
@@ -265,17 +265,20 @@ pub struct StorageDef {
     /// This can be helpful in performing bucket migrations: adding a new store
     /// to the front of the list causes ongoing data to be written to that location,
     /// while historical data continues to be read and served from the prior stores.
-    ///
-    /// When running `flowctl test`, stores are ignored and a local temporary
-    /// directory is used instead.
     #[validate]
     pub stores: Vec<Store>,
+    /// # Data planes which may be used by tasks or collections under this mapping.
+    ///
+    /// The first data-plane in this list used by default.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data_planes: Vec<String>,
 }
 
 impl StorageDef {
     pub fn example() -> Self {
         Self {
             stores: vec![Store::example()],
+            data_planes: vec!["ops/dp/public/gcp-us-central1-c2".to_string()],
         }
     }
 }

--- a/crates/models/src/snapshots/models__journals__test__storage-json-schema.snap
+++ b/crates/models/src/snapshots/models__journals__test__storage-json-schema.snap
@@ -11,9 +11,17 @@ expression: schema
     "stores"
   ],
   "properties": {
+    "data_planes": {
+      "title": "Data planes which may be used by tasks or collections under this mapping.",
+      "description": "The first data-plane in this list used by default.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "stores": {
       "title": "Stores for journal fragments under this prefix.",
-      "description": "Multiple stores may be specified, and all stores are periodically scanned to index applicable journal fragments. New fragments are always persisted to the first store in the list.\n\nThis can be helpful in performing bucket migrations: adding a new store to the front of the list causes ongoing data to be written to that location, while historical data continues to be read and served from the prior stores.\n\nWhen running `flowctl test`, stores are ignored and a local temporary directory is used instead.",
+      "description": "Multiple stores may be specified, and all stores are periodically scanned to index applicable journal fragments. New fragments are always persisted to the first store in the list.\n\nThis can be helpful in performing bucket migrations: adding a new store to the front of the list causes ongoing data to be written to that location, while historical data continues to be read and served from the prior stores.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/Store"


### PR DESCRIPTION
We're going to incrementally transition the storage mapping concept to also hold details of preferred (eventually: perhaps required) data-plane for new tasks or collections under a prefix.

As a first step, accept a `data_plane` field but don't do anything with it. This will allow us to populate this field and use it within the UI to default the data-plane used in new task creation.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2128)
<!-- Reviewable:end -->
