### PR TITLE
validation: add a new check that backfill counters are monotonic

### DIFF
--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -206,6 +206,13 @@ pub enum Error {
         lhs_index: usize,
         rhs_index: usize,
     },
+    #[error("`backfill` counters may only increase, but the draft {entity} for {resource:?} has a value of {draft}, which is less than the last value {last}")]
+    BindingBackfillDecrease {
+        entity: &'static str,
+        resource: String,
+        draft: u32,
+        last: u32,
+    },
     #[error("connector returned an invalid empty resource path for this {entity} binding")]
     BindingMissingResourcePath { entity: &'static str },
     #[error(transparent)]

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -167,6 +167,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
                     ..Default::default()
                 }),
                 resource_path: validation::load_resource_meta_path(binding.resource.get()),
+                backfill: binding.backfill,
                 ..Default::default()
             })
             .collect();
@@ -242,6 +243,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
                         }),
                         ..Default::default()
                     }),
+                    backfill: transform.backfill,
                     ..Default::default()
                 })
                 .collect();
@@ -315,6 +317,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
                     ..Default::default()
                 }),
                 resource_path: validation::load_resource_meta_path(binding.resource.get()),
+                backfill: binding.backfill,
                 ..Default::default()
             })
             .collect();

--- a/crates/validation/tests/snapshots/transition_tests__updates_with_clobbered_backfill_counter.snap
+++ b/crates/validation/tests/snapshots/transition_tests__updates_with_clobbered_backfill_counter.snap
@@ -1,0 +1,18 @@
+---
+source: crates/validation/tests/transition_tests.rs
+expression: outcome
+---
+[
+    Error {
+        scope: test://example/catalog.yaml#/captures/the~1capture/bindings/0,
+        error: `backfill` counters may only increase, but the draft capture binding for "capture.path" has a value of 0, which is less than the last value 123,
+    },
+    Error {
+        scope: test://example/catalog.yaml#/collections/the~1derivation/derive/transforms/0,
+        error: `backfill` counters may only increase, but the draft derivation transform for "fromCollection" has a value of 0, which is less than the last value 456,
+    },
+    Error {
+        scope: test://example/catalog.yaml#/materializations/the~1materialization/bindings/0,
+        error: `backfill` counters may only increase, but the draft materialization binding for "table.path" has a value of 0, which is less than the last value 789,
+    },
+]

--- a/crates/validation/tests/transition_tests.rs
+++ b/crates/validation/tests/transition_tests.rs
@@ -33,6 +33,47 @@ test://example/catalog.yaml:
 }
 
 #[test]
+fn test_updates_with_clobbered_backfill_counter() {
+    let outcome = common::run_errors(
+        MODEL_YAML,
+        r#"
+
+test://example/catalog.yaml:
+  materializations:
+    the/materialization:
+      bindings:
+        # Simplify to remove spurious additional errors.
+        - source: the/collection
+          resource: { _meta: { path: [table, path] } }
+
+driver:
+  liveCaptures:
+    the/capture:
+      bindings:
+        - target: the/collection
+          resource: { _meta: { path: [capture, path] } }
+          backfill: 123
+
+  liveCollections:
+    the/derivation:
+      derive:
+        transforms:
+          - name: fromCollection
+            source: the/collection
+            backfill: 456
+
+  liveMaterializations:
+    the/materialization:
+      bindings:
+        - source: the/collection
+          resource: { _meta: { path: [table, path] } }
+          backfill: 789
+    "#,
+    );
+    insta::assert_debug_snapshot!(outcome);
+}
+
+#[test]
 fn test_change_collection_key_and_partitions() {
     let errors = common::run_errors(
         MODEL_YAML,


### PR DESCRIPTION
Compare the draft backfill with the last active or inactive spec under the same validated resource path, and ensure that backfills remain monotonic.

This avoids a class of confusing errors where users (typically using flowctl) accidentally clobber the backfill counter of a running task binding.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2129)
<!-- Reviewable:end -->
