### PR TITLE
agent: user auth APIs accept and verify request capability, and add user prefix authorization API

### DIFF
--- a/crates/agent/src/api/authorize_user_prefix.rs
+++ b/crates/agent/src/api/authorize_user_prefix.rs
@@ -1,0 +1,520 @@
+use super::{App, Snapshot};
+use crate::api::error::ApiErrorExt;
+use anyhow::Context;
+use axum::http::StatusCode;
+use std::sync::Arc;
+
+type Request = models::authorizations::UserPrefixAuthorizationRequest;
+type Response = models::authorizations::UserPrefixAuthorization;
+
+#[axum::debug_handler]
+#[tracing::instrument(
+    skip(app),
+    err(level = tracing::Level::WARN),
+)]
+pub async fn authorize_user_prefix(
+    axum::extract::State(app): axum::extract::State<Arc<App>>,
+    axum::Extension(super::ControlClaims {
+        sub: user_id,
+        email,
+        ..
+    }): axum::Extension<super::ControlClaims>,
+    super::Request(Request {
+        prefix,
+        data_plane,
+        capability,
+        started_unix,
+    }): super::Request<Request>,
+) -> Result<axum::Json<Response>, crate::api::ApiError> {
+    do_authorize_user_prefix(
+        &app.snapshot,
+        user_id,
+        email,
+        prefix,
+        data_plane,
+        capability,
+        started_unix,
+    )
+    .await
+}
+
+pub async fn do_authorize_user_prefix(
+    snapshot: &std::sync::RwLock<Snapshot>,
+    user_id: uuid::Uuid,
+    email: Option<String>,
+    prefix: models::Prefix,
+    data_plane: models::Name,
+    capability: models::Capability,
+    started_unix: u64,
+) -> Result<axum::Json<Response>, crate::api::ApiError> {
+    let started = chrono::DateTime::from_timestamp(started_unix as i64, 0).unwrap_or_default();
+
+    match Snapshot::evaluate(snapshot, started, |snapshot: &Snapshot| {
+        evaluate_authorization(
+            snapshot,
+            user_id,
+            email.as_ref(),
+            &prefix,
+            &data_plane,
+            capability,
+        )
+    }) {
+        Ok((
+            exp,
+            (encoding_key, mut broker_claims, broker_address, mut reactor_claims, reactor_address),
+        )) => {
+            broker_claims.inner.exp = exp.timestamp() as u64;
+            broker_claims.inner.iat = started.timestamp() as u64;
+            reactor_claims.inner.exp = exp.timestamp() as u64;
+            reactor_claims.inner.iat = started.timestamp() as u64;
+
+            let header = jsonwebtoken::Header::default();
+            let broker_token = jsonwebtoken::encode(&header, &broker_claims, &encoding_key)
+                .context("failed to encode authorized JWT")?;
+            let reactor_token = jsonwebtoken::encode(&header, &reactor_claims, &encoding_key)
+                .context("failed to encode authorized JWT")?;
+
+            Ok(axum::Json(Response {
+                broker_token,
+                broker_address,
+                reactor_token,
+                reactor_address,
+                retry_millis: 0,
+            }))
+        }
+        Err(Ok(backoff)) => Ok(axum::Json(Response {
+            retry_millis: backoff.as_millis() as u64,
+            ..Default::default()
+        })),
+        Err(Err(err)) => Err(err),
+    }
+}
+
+fn evaluate_authorization(
+    snapshot: &Snapshot,
+    user_id: uuid::Uuid,
+    user_email: Option<&String>,
+    prefix: &models::Prefix,
+    data_plane_name: &models::Name,
+    capability: models::Capability,
+) -> Result<
+    (
+        Option<chrono::DateTime<chrono::Utc>>,
+        (
+            jsonwebtoken::EncodingKey,
+            super::DataClaims, // Broker claims.
+            String,            // Broker address.
+            super::DataClaims, // Reactor claims.
+            String,            // Reactor address.
+        ),
+    ),
+    crate::api::ApiError,
+> {
+    if !tables::UserGrant::is_authorized(
+        &snapshot.role_grants,
+        &snapshot.user_grants,
+        user_id,
+        prefix,
+        capability,
+    ) {
+        return Err(anyhow::anyhow!(
+            "{} is not authorized to {prefix} for {capability:?}",
+            user_email.map(String::as_str).unwrap_or("user")
+        )
+        .with_status(StatusCode::FORBIDDEN));
+    }
+
+    if !tables::UserGrant::is_authorized(
+        &snapshot.role_grants,
+        &snapshot.user_grants,
+        user_id,
+        &data_plane_name,
+        models::Capability::Read,
+    ) {
+        return Err(anyhow::anyhow!(
+            "{} is not authorized to {data_plane_name}",
+            user_email.map(String::as_str).unwrap_or("user")
+        )
+        .with_status(StatusCode::FORBIDDEN));
+    }
+
+    let Some(data_plane) = snapshot.data_plane_by_catalog_name(&data_plane_name) else {
+        return Err(anyhow::anyhow!("data-plane {data_plane_name} not found")
+            .with_status(StatusCode::NOT_FOUND));
+    };
+    let Some(encoding_key) = data_plane.hmac_keys.first() else {
+        return Err(
+            anyhow::anyhow!("data-plane {data_plane_name} has no configured HMAC keys")
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR),
+        );
+    };
+    let encoding_key = jsonwebtoken::EncodingKey::from_base64_secret(&encoding_key)
+        .context("invalid data-plane hmac key")?;
+
+    let broker_claims = super::DataClaims {
+        inner: proto_gazette::Claims {
+            cap: super::map_capability_to_gazette(capability),
+            exp: 0, // Filled later.
+            iat: 0, // Filled later.
+            iss: data_plane.data_plane_fqdn.clone(),
+            sub: user_id.to_string(),
+            sel: proto_gazette::broker::LabelSelector {
+                include: Some(labels::build_set([
+                    ("name:prefix", prefix.as_str()),
+                    ("name:prefix", &format!("recovery/capture/{prefix}")),
+                    ("name:prefix", &format!("recovery/derivation/{prefix}")),
+                    ("name:prefix", &format!("recovery/materialize/{prefix}")),
+                ])),
+                exclude: None,
+            },
+        },
+        prefixes: Vec::new(), // TODO(johnny): remove.
+    };
+
+    let reactor_claims = super::DataClaims {
+        inner: proto_gazette::Claims {
+            cap: super::map_capability_to_gazette(capability)
+                | proto_flow::capability::NETWORK_PROXY,
+            exp: 0, // Filled later.
+            iat: 0, // Filled later.
+            iss: data_plane.data_plane_fqdn.clone(),
+            sub: user_id.to_string(),
+            sel: proto_gazette::broker::LabelSelector {
+                include: Some(labels::build_set([
+                    ("id:prefix", format!("capture/{prefix}").as_str()),
+                    ("id:prefix", &format!("derivation/{prefix}")),
+                    ("id:prefix", &format!("materialize/{prefix}")),
+                ])),
+                exclude: None,
+            },
+        },
+        prefixes: Vec::new(), // TODO(johnny): remove.
+    };
+
+    Ok((
+        None, // This API does not enforce cordons.
+        (
+            encoding_key,
+            broker_claims,
+            super::maybe_rewrite_address(true, &data_plane.broker_address),
+            reactor_claims,
+            super::maybe_rewrite_address(true, &data_plane.reactor_address),
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_success_one() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("bobCo/tires/"),
+            models::Name::new("ops/dp/public/plane-two"),
+            models::Capability::Admin,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Ok": [
+            "broker.2",
+            {
+              "cap": 30,
+              "exp": 0,
+              "iat": 0,
+              "iss": "fqdn2",
+              "sel": {
+                "include": {
+                  "labels": [
+                    {
+                      "name": "name",
+                      "value": "bobCo/tires/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/capture/bobCo/tires/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/derivation/bobCo/tires/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/materialize/bobCo/tires/",
+                      "prefix": true
+                    }
+                  ]
+                }
+              },
+              "sub": "20202020-2020-2020-2020-202020202020"
+            },
+            "reactor.2",
+            {
+              "cap": 262174,
+              "exp": 0,
+              "iat": 0,
+              "iss": "fqdn2",
+              "sel": {
+                "include": {
+                  "labels": [
+                    {
+                      "name": "id",
+                      "value": "capture/bobCo/tires/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "id",
+                      "value": "derivation/bobCo/tires/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "id",
+                      "value": "materialize/bobCo/tires/",
+                      "prefix": true
+                    }
+                  ]
+                }
+              },
+              "sub": "20202020-2020-2020-2020-202020202020"
+            }
+          ]
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_success_two() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("acmeCo/shared/stuff/"),
+            models::Name::new("ops/dp/public/plane-two"),
+            models::Capability::Read,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Ok": [
+            "broker.2",
+            {
+              "cap": 10,
+              "exp": 0,
+              "iat": 0,
+              "iss": "fqdn2",
+              "sel": {
+                "include": {
+                  "labels": [
+                    {
+                      "name": "name",
+                      "value": "acmeCo/shared/stuff/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/capture/acmeCo/shared/stuff/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/derivation/acmeCo/shared/stuff/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "name",
+                      "value": "recovery/materialize/acmeCo/shared/stuff/",
+                      "prefix": true
+                    }
+                  ]
+                }
+              },
+              "sub": "20202020-2020-2020-2020-202020202020"
+            },
+            "reactor.2",
+            {
+              "cap": 262154,
+              "exp": 0,
+              "iat": 0,
+              "iss": "fqdn2",
+              "sel": {
+                "include": {
+                  "labels": [
+                    {
+                      "name": "id",
+                      "value": "capture/acmeCo/shared/stuff/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "id",
+                      "value": "derivation/acmeCo/shared/stuff/",
+                      "prefix": true
+                    },
+                    {
+                      "name": "id",
+                      "value": "materialize/acmeCo/shared/stuff/",
+                      "prefix": true
+                    }
+                  ]
+                }
+              },
+              "sub": "20202020-2020-2020-2020-202020202020"
+            }
+          ]
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_not_authorized_to_prefix() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("acmeCo/whoosh/"),
+            models::Name::new("ops/dp/public/plane-two"),
+            models::Capability::Write,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 403,
+            "error": "bob@bob is not authorized to acmeCo/whoosh/ for Write"
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_not_authorized_to_data_plane() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("bobCo/tires/"),
+            models::Name::new("ops/dp/private/something"),
+            models::Capability::Admin,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 403,
+            "error": "bob@bob is not authorized to ops/dp/private/something"
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_data_plane_not_found() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("bobCo/tires/"),
+            models::Name::new("ops/dp/public/plane-missing"),
+            models::Capability::Admin,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 404,
+            "error": "data-plane ops/dp/public/plane-missing not found"
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_capability_to_high() {
+        let outcome = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Prefix::new("acmeCo/shared/stuff/"),
+            models::Name::new("ops/dp/public/plane-two"),
+            models::Capability::Write,
+        )
+        .await;
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 403,
+            "error": "bob@bob is not authorized to acmeCo/shared/stuff/ for Write"
+          }
+        }
+        "###);
+    }
+
+    async fn run(
+        user_id: uuid::Uuid,
+        email: Option<String>,
+        prefix: models::Prefix,
+        data_plane: models::Name,
+        capability: models::Capability,
+    ) -> Result<(String, proto_gazette::Claims, String, proto_gazette::Claims), crate::api::ApiError>
+    {
+        let taken = chrono::Utc::now();
+        let snapshot = Snapshot::build_fixture(Some(taken));
+        let snapshot = std::sync::RwLock::new(snapshot);
+
+        let Response {
+            broker_address,
+            broker_token,
+            reactor_address,
+            reactor_token,
+            retry_millis,
+        } = do_authorize_user_prefix(
+            &snapshot,
+            user_id,
+            email,
+            prefix,
+            data_plane,
+            capability,
+            taken.timestamp() as u64 - 1,
+        )
+        .await?
+        .0;
+
+        if retry_millis != 0 {
+            return Err(anyhow::anyhow!("retry").into());
+        }
+
+        let mut broker_claims = jsonwebtoken::decode::<super::super::DataClaims>(
+            &broker_token,
+            &jsonwebtoken::DecodingKey::from_secret("key3".as_bytes()),
+            &jsonwebtoken::Validation::default(),
+        )
+        .expect("failed to decode response token")
+        .claims
+        .inner;
+
+        let mut reactor_claims = jsonwebtoken::decode::<super::super::DataClaims>(
+            &reactor_token,
+            &jsonwebtoken::DecodingKey::from_secret("key3".as_bytes()),
+            &jsonwebtoken::Validation::default(),
+        )
+        .expect("failed to decode response token")
+        .claims
+        .inner;
+
+        (broker_claims.iat, broker_claims.exp) = (0, 0);
+        (reactor_claims.iat, reactor_claims.exp) = (0, 0);
+
+        Ok((
+            broker_address,
+            broker_claims,
+            reactor_address,
+            reactor_claims,
+        ))
+    }
+}

--- a/crates/flow-client/src/lib.rs
+++ b/crates/flow-client/src/lib.rs
@@ -2,8 +2,8 @@ use anyhow::Context;
 
 pub mod client;
 pub use client::{
-    fetch_task_authorization, fetch_user_collection_authorization, fetch_user_task_authorization,
-    Client,
+    fetch_task_authorization, fetch_user_collection_authorization, fetch_user_prefix_authorization,
+    fetch_user_task_authorization, Client,
 };
 
 pub mod pagination;


### PR DESCRIPTION
User authorization APIs can now escalate the capability of a signed token if the user has sufficient privilege. This can be used for administrative actions like journal splitting.

Also add a new prefix authorization API which signs an authorization token valid for a requested and authorized prefix and capability, directed at a specific data-plane.

Add a new, advanced flowctl subcommand for authorizing and printing environment variables for direct gazette access of an authorized prefix.

**Workflow steps:**

Use `flowctl` to obtain a temporary authorization to an entire (authorized) prefix:
```
johnny@johnny-desktop:~/estuary/flow$ flowctl --profile local raw gazctl-env --data-plane ops/dp/public/local-cluster --prefix ops.us-central1.v1/ 
2025-05-08T16:38:44.477413Z  WARN flow_client::client: authorization service tentatively rejected our request, but we'll retry before failing secs=5.692
export BROKER_ADDRESS=https://gazette.flow.localhost:8080
export BROKER_AUTH_TOKEN=(trim)
export CONSUMER_ADDRESS=https://reactor.flow.localhost:9000
export CONSUMER_AUTH_TOKEN=(trim)
```

Then use it with gazctl or flowctl-go [corresponding Gazette PR](https://github.com/gazette/core/pull/432):

```
johnny@johnny-desktop:~/gazette$ .build/amd64/gazctl  shards list -l ''
+--------------------------------------------------------------------------------------+---------+
|                                          ID                                          | STATUS  |
+--------------------------------------------------------------------------------------+---------+
| derivation/ops.us-central1.v1/catalog-stats-L2/1114a1376c000046/00000000-00000000    | PRIMARY |
| derivation/ops.us-central1.v1/events/L2/1114a1376c000046/00000000-00000000           | PRIMARY |
| derivation/ops.us-central1.v1/inferred-schemas/L2/1114a1376c000046/00000000-00000000 | PRIMARY |
| materialize/ops.us-central1.v1/stats-view/1114a13f78800046/00000000-00000000         | PRIMARY |
+--------------------------------------------------------------------------------------+---------+
johnny@johnny-desktop:~/gazette$ .build/amd64/gazctl  journals list -l ''
+-----------------------------------------------------------------------------------------------+
|                                             NAME                                              |
+-----------------------------------------------------------------------------------------------+
| ops.us-central1.v1/catalog-stats-L2/1114a1376c000046/pivot=00                                 |
| ops.us-central1.v1/events/L2/1114a1376c000046/event_type=connectorStatus/pivot=00             |
| ops.us-central1.v1/inferred-schemas/L2/1114a1376c000046/pivot=00                              |
| recovery/derivation/ops.us-central1.v1/catalog-stats-L2/1114a1376c000046/00000000-00000000    |
| recovery/derivation/ops.us-central1.v1/events/L2/1114a1376c000046/00000000-00000000           |
| recovery/derivation/ops.us-central1.v1/inferred-schemas/L2/1114a1376c000046/00000000-00000000 |
| recovery/materialize/ops.us-central1.v1/stats-view/1114a13f78800046/00000000-00000000         |
+-----------------------------------------------------------------------------------------------+
```

Example of a prefix which is not allowed at the requested capability:

```
johnny@johnny-desktop:~/estuary/flow$ flowctl --profile local raw gazctl-env --data-plane ops/dp/public/local-cluster --prefix ops.us-central1.v1/ --admin
2025-05-08T16:39:44.150048Z  WARN flow_client::client: authorization service tentatively rejected our request, but we'll retry before failing secs=3.523
2025-05-08T16:39:47.676877Z ERROR flow_client::client: error=POST /authorize/user/prefix: 403 Forbidden: {"status":403,"error":"johnny@foobar is not authorized to ops.us-central1.v1/ for Admin"}
Error: POST /authorize/user/prefix: 403 Forbidden: {"status":403,"error":"johnny@foobar is not authorized to ops.us-central1.v1/ for Admin"}
```


**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2133)
<!-- Reviewable:end -->
