### PR TITLE
activate: create ops journals when the task is enabled, even without splits

### DIFF
--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -583,7 +583,8 @@ pub fn task_changes<'a>(
         }));
     }
 
-    // Ensure existence of ops partitions iff there's a task shard upsert.
+    // Ensure existence of ops partitions iff there's a task shard upsert,
+    // or if the template is present and not disabled.
     if changes.iter().any(|change| {
         matches!(
             change,
@@ -592,7 +593,8 @@ pub fn task_changes<'a>(
                 ..
             })
         )
-    }) {
+    }) || matches!(template, Some(template) if !template.shard.disable)
+    {
         changes.extend(ops_journal_changes(ops_logs_spec, ops_logs_splits));
         changes.extend(ops_journal_changes(ops_stats_spec, ops_stats_splits));
     }

--- a/crates/activate/src/snapshots/activate__test__create-no-splits.snap
+++ b/crates/activate/src/snapshots/activate__test__create-no-splits.snap
@@ -4,5 +4,118 @@ expression: "(partition_changes, task_changes)"
 ---
 [
   [],
-  []
+  [
+    {
+      "Journal": {
+        "upsert": {
+          "name": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00",
+          "replication": 3,
+          "labels": {
+            "labels": [
+              {
+                "name": "app.gazette.dev/managed-by",
+                "value": "estuary.dev/flow"
+              },
+              {
+                "name": "content-type",
+                "value": "application/x-ndjson"
+              },
+              {
+                "name": "estuary.dev/build",
+                "value": "0101010101010101"
+              },
+              {
+                "name": "estuary.dev/collection",
+                "value": "ops/tasks/BASE_NAME/logs"
+              },
+              {
+                "name": "estuary.dev/field/kind",
+                "value": "derivation"
+              },
+              {
+                "name": "estuary.dev/field/name",
+                "value": "example%2Fderivation"
+              },
+              {
+                "name": "estuary.dev/key-begin",
+                "value": "00000000"
+              },
+              {
+                "name": "estuary.dev/key-end",
+                "value": "ffffffff"
+              }
+            ]
+          },
+          "fragment": {
+            "length": "536870912",
+            "compressionCodec": "GZIP",
+            "stores": [
+              "gs://example-bucket/"
+            ],
+            "refreshInterval": "300s",
+            "flushInterval": "86400s",
+            "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
+          },
+          "flags": 4,
+          "maxAppendRate": "4194304"
+        }
+      }
+    },
+    {
+      "Journal": {
+        "upsert": {
+          "name": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00",
+          "replication": 3,
+          "labels": {
+            "labels": [
+              {
+                "name": "app.gazette.dev/managed-by",
+                "value": "estuary.dev/flow"
+              },
+              {
+                "name": "content-type",
+                "value": "application/x-ndjson"
+              },
+              {
+                "name": "estuary.dev/build",
+                "value": "0101010101010101"
+              },
+              {
+                "name": "estuary.dev/collection",
+                "value": "ops/tasks/BASE_NAME/stats"
+              },
+              {
+                "name": "estuary.dev/field/kind",
+                "value": "derivation"
+              },
+              {
+                "name": "estuary.dev/field/name",
+                "value": "example%2Fderivation"
+              },
+              {
+                "name": "estuary.dev/key-begin",
+                "value": "00000000"
+              },
+              {
+                "name": "estuary.dev/key-end",
+                "value": "ffffffff"
+              }
+            ]
+          },
+          "fragment": {
+            "length": "536870912",
+            "compressionCodec": "GZIP",
+            "stores": [
+              "gs://example-bucket/"
+            ],
+            "refreshInterval": "300s",
+            "flushInterval": "86400s",
+            "pathPostfixTemplate": "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}"
+          },
+          "flags": 4,
+          "maxAppendRate": "4194304"
+        }
+      }
+    }
+  ]
 ]


### PR DESCRIPTION
This was missed in the previous refactor of `activate`. Dekaf tasks are activated with empty shard splits and an enabled task. We still need to create ops journals for it.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2135)
<!-- Reviewable:end -->
