### PR TITLE
ensure we're driving connector RPCs to EOF

### DIFF
--- a/crates/agent/src/proxy_connectors.rs
+++ b/crates/agent/src/proxy_connectors.rs
@@ -97,6 +97,15 @@ impl DiscoverConnectors for DataPlaneConnectors {
                 serde_json::to_string(&response).unwrap()
             ),
         };
+        match response_rx.try_next().await? {
+            None => (), // Expected EOF.
+            Some(response) => {
+                anyhow::bail!(
+                    "expected connector to send closing EOF, but got {}",
+                    serde_json::to_string(&response).unwrap()
+                );
+            }
+        }
 
         Ok((spec, discovered))
     }

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -428,6 +428,9 @@ async fn walk_capture<C: Connectors>(
         delete: false,
     };
 
+    std::mem::drop(request_tx);
+    () = super::expect_eof(scope, response_rx, errors).await;
+
     // Compute the dependency hash, now that we're done with any modifications of the model
     let dependency_hash = dependencies.compute_hash(&model);
     Some(tables::BuiltCapture {

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -668,6 +668,9 @@ async fn walk_derivation<C: Connectors>(
         using,
     };
 
+    std::mem::drop(request_tx);
+    () = super::expect_eof(scope, response_rx, errors).await;
+
     Some((
         built_index,
         model,

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -523,6 +523,9 @@ async fn walk_materialization<C: Connectors>(
         delete: false,
     };
 
+    std::mem::drop(request_tx);
+    () = super::expect_eof(scope, response_rx, errors).await;
+
     // Compute the dependency hash after we're done with any potential modifications of the model,
     // since disabling a binding would change the hash.
     let dependency_hash = dependencies.compute_hash(&model);


### PR DESCRIPTION
We get a number of unclean connector proxy shutdown warnings from
reactors, and this is why. We want to ensure we properly close and read
EOF from RPCs. This also ensures we don't miss any final log statements
coming from the connector.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2138)
<!-- Reviewable:end -->
