### PR TITLE
agent: snapshots shouldn't assume `refresh_tx` hasn't been dropped

### DIFF
--- a/crates/agent/src/api/snapshot.rs
+++ b/crates/agent/src/api/snapshot.rs
@@ -355,9 +355,8 @@ impl Snapshot {
         // We must release our read-lock before we can acquire a write lock.
         std::mem::drop(guard);
 
-        if let Some(tx) = mu.write().unwrap().refresh_tx.take() {
-            () = tx.send(()).unwrap(); // Begin a refresh.
-        }
+        // Take `refresh_tx` and drop to awake receiver.
+        std::mem::drop(mu.write().unwrap().refresh_tx.take());
     }
 
     // If there is a migration which covers `catalog_name`, running in `data_plane`,


### PR DESCRIPTION
Instead, just drop the Tx channel to signal the reciever. Tested on a local stack.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2140)
<!-- Reviewable:end -->
