### PR TITLE
go/network: forward migrated connector network requests

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -125,7 +125,7 @@ local_resource(
         "BROKER_TRUSTED_CA_FILE": CA_CERT_PATH,
         "CONSUMER_ALLOW_ORIGIN": "http://localhost:3000",
         "CONSUMER_AUTH_KEYS": AUTH_KEYS,
-        "CONSUMER_HOST": "reactor.flow.localhost",
+        "CONSUMER_HOST": "flow.localhost", # Connector networking must match *.flow.localhost.
         "CONSUMER_LIMIT": "1024",
         "CONSUMER_PEER_CA_FILE": CA_CERT_PATH,
         "CONSUMER_PORT": "%d" % port,
@@ -141,8 +141,9 @@ local_resource(
         "FLOW_DATA_PLANE_FQDN": "local-cluster.dp.estuary-data.com",
         "FLOW_NETWORK": "supabase_network_flow",
         "LOG_LEVEL": "info",
+        "SSL_CERT_FILE": CA_CERT_PATH,
     },
-    links='https://reactor.flow.localhost:%d/debug/pprof' % port,
+    links='https://flow.localhost:%d/debug/pprof' % port,
     resource_deps=['etcd'],
     readiness_probe=probe(
         initial_delay_secs=5,
@@ -182,7 +183,7 @@ local_resource(
             "category": {\
                 "manual": {\
                     "brokerAddress": "https://gazette.flow.localhost:8080",\
-                    "reactorAddress": "https://reactor.flow.localhost:9000",\
+                    "reactorAddress": "https://flow.localhost:9000",\
                     "hmacKeys": ["%s"]\
                 }\
             }\
@@ -287,7 +288,7 @@ local_resource(
 #        "BROKER_TRUSTED_CA_FILE": CA_CERT_PATH,
 #        "CONSUMER_ALLOW_ORIGIN": "http://localhost:3000",
 #        "CONSUMER_AUTH_KEYS": OTHER_AUTH_KEYS,
-#        "CONSUMER_HOST": "other-reactor.flow.localhost",
+#        "CONSUMER_HOST": "flow.localhost", # Connector networking must match *.flow.localhost.
 #        "CONSUMER_LIMIT": "1024",
 #        "CONSUMER_PEER_CA_FILE": CA_CERT_PATH,
 #        "CONSUMER_PORT": "%d" % port,
@@ -303,8 +304,9 @@ local_resource(
 #        "FLOW_DATA_PLANE_FQDN": "other-cluster.dp.estuary-data.com",
 #        "FLOW_NETWORK": "supabase_network_flow",
 #        "LOG_LEVEL": "info",
+#        "SSL_CERT_FILE": CA_CERT_PATH,
 #    },
-#    links='https://other-reactor.flow.localhost:%d/debug/pprof' % port,
+#    links='https://flow.localhost:%d/debug/pprof' % port,
 #    resource_deps=['etcd'],
 #    readiness_probe=probe(
 #        initial_delay_secs=5,
@@ -323,7 +325,7 @@ local_resource(
 #            "category": {\
 #                "manual": {\
 #                    "brokerAddress": "https://other-gazette.flow.localhost:8180",\
-#                    "reactorAddress": "https://other-reactor.flow.localhost:9100",\
+#                    "reactorAddress": "https://flow.localhost:9100",\
 #                    "hmacKeys": ["%s"]\
 #                }\
 #            }\

--- a/go/labels/labels.go
+++ b/go/labels/labels.go
@@ -63,7 +63,8 @@ const (
 	LogsJournal = "estuary.dev/logs-journal"
 	// Journal to which task stats are directed.
 	StatsJournal = "estuary.dev/stats-journal"
-
+	// Hostname of the shard's task under the connector networking feature.
+	// Present only on shards of tasks that use the connector networking feature.
 	Hostname = "estuary.dev/hostname"
 
 	// ExposePort is the label key that is used to identify ports to be exposed by the container.

--- a/go/network/sni_test.go
+++ b/go/network/sni_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/estuary/flow/go/labels"
@@ -8,6 +9,97 @@ import (
 	pb "go.gazette.dev/core/broker/protocol"
 	pc "go.gazette.dev/core/consumer/protocol"
 )
+
+func TestParseSNI(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		expect    parsedSNI
+		expectErr string // Expected error string, empty if no error
+	}{
+		{
+			name:  "valid two-part SNI",
+			input: "hostname123-8080",
+			expect: parsedSNI{
+				hostname: "hostname123",
+				port:     "8080",
+			},
+			expectErr: "",
+		},
+		{
+			name:  "valid four-part SNI",
+			input: "hostxyz-keybegin-rclockbegin-443",
+			expect: parsedSNI{
+				hostname:    "hostxyz",
+				port:        "443",
+				keyBegin:    "keybegin",
+				rClockBegin: "rclockbegin",
+			},
+			expectErr: "",
+		},
+		{
+			name:      "invalid SNI - too few parts",
+			input:     "hostnameonly",
+			expectErr: "expected two or four subdomain components, not 1",
+		},
+		{
+			name:      "invalid SNI - too many parts",
+			input:     "a-b-c-d-e",
+			expectErr: "expected two or four subdomain components, not 5",
+		},
+		{
+			name:      "invalid SNI - three parts",
+			input:     "a-b-c",
+			expectErr: "expected two or four subdomain components, not 3",
+		},
+		{
+			name:      "invalid SNI - non-numeric port",
+			input:     "hostname123-portabc",
+			expectErr: "failed to parse subdomain port number",
+		},
+		{
+			name:      "invalid SNI - non-numeric port in four-part",
+			input:     "hostname123-key-rclock-portabc",
+			expectErr: "failed to parse subdomain port number",
+		},
+		{
+			name:      "invalid two-part SNI - empty hostname",
+			input:     "-12345",
+			expectErr: "hostname is empty",
+		},
+		{
+			name:      "invalid four-part SNI - empty keyBegin",
+			input:     "h---1",
+			expectErr: "keyBegin is empty",
+		},
+		{
+			name:      "invalid four-part SNI - empty hostname",
+			input:     "-key1-rclock1-123",
+			expectErr: "hostname is empty",
+		},
+		{
+			name:      "invalid four-part SNI - empty rClockBegin",
+			input:     "host1-key1--123",
+			expectErr: "rClockBegin is empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseSNI(tc.input)
+
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, parsed)
+				// Test round-tripping
+				require.Equal(t, tc.input, parsed.String(), fmt.Sprintf("String() representation mismatch for input: %s", tc.input))
+			}
+		})
+	}
+}
 
 func TestResolveSNIMapping(t *testing.T) {
 	var (


### PR DESCRIPTION
Refine the semantics of the `estuary.dev/cordon` label to reflect the destination FQDN of a migrated journal or task.

Next, update connector networking to be aware of cordons. If there's a non-empty cordon value, presume it's a destination FQDN and dial a proxied TLS connection to the destination, passing through the parsed SNI and connector port protocol.

Refactor protocol handling to avoid overwritting the resolvedSNI.portProtocol. Instead, we can examine the negotiated protocol of the frontend connection for metrics.

Also improve error checks and test coverage of SNI parsing.

Tested on a local stack with migrations of:
* source-hello-world
* source-http-ingest
* materialize-sqlite

**Workflow steps:**

* Migrate a connector which uses the connector networking feature from one data-plane to another.
* Observe that the connector's address under the _old_ data-plane is still functional and forwards public-port connections (such as source-http-ingest) to the new data-plane.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2142)
<!-- Reviewable:end -->
