### PR TITLE
agent: strip _meta properties from resource configs

### DIFF
--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -381,7 +381,7 @@ fn walk_capture_binding<'a>(
     )?;
 
     let request = capture::request::validate::Binding {
-        resource_config_json: resource.to_string(),
+        resource_config_json: crate::strip_resource_meta(resource),
         collection: Some(spec),
         backfill: *backfill,
     };

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -421,6 +421,20 @@ where
     }
 }
 
+// Strip /_meta from a resource config, before sending it to a connector.
+// TODO(johnny): We intend to remove this once connectors are updated.
+fn strip_resource_meta(resource: &models::RawValue) -> String {
+    type Skim = std::collections::BTreeMap<String, models::RawValue>;
+
+    let Ok(mut resource) = serde_json::from_str::<Skim>(resource.get()) else {
+        return resource.get().to_string();
+    };
+    _ = resource.remove("_meta");
+
+    let resource: Box<str> = serde_json::value::to_raw_value(&resource).unwrap().into();
+    resource.into()
+}
+
 #[cfg(test)]
 mod test {
     use tables::{BuiltCollection, DraftCollection, LiveCollection};

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -529,7 +529,7 @@ fn walk_materialization_binding<'a>(
     super::temporary_cross_data_plane_read_check(scope, source, data_plane_id, errors);
 
     let request = materialize::request::validate::Binding {
-        resource_config_json: resource.to_string(),
+        resource_config_json: crate::strip_resource_meta(resource),
         collection: Some(source_spec),
         field_config_json_map,
         backfill: *backfill,


### PR DESCRIPTION
Strips _meta properties from connector resource configs when performing Validate RPCs.  This property gets added by newer agent versions, so this commit just gives us something to rollback to, should the need arise.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2145)
<!-- Reviewable:end -->
