### PR TITLE
validation: enforce collection referential integrity, even when a task is disabled

### DIFF
--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -473,7 +473,7 @@ fn walk_capture_binding<'a>(
     }
 
     let live_model = live_bindings_model.get(&model_path);
-    let modified = Some(&&model) != live_model;
+    let modified_target = Some(&model.target) != live_model.map(|l| &l.target);
     let target = &model.target;
 
     // We must resolve the target collection to continue.
@@ -482,7 +482,7 @@ fn walk_capture_binding<'a>(
         "this capture binding",
         target,
         built_collections,
-        modified.then_some(errors),
+        modified_target.then_some(errors),
     ) else {
         model_fixes.push(format!("disabled binding of deleted collection {target}"));
         model.disable = true;

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -467,12 +467,13 @@ fn walk_capture_binding<'a>(
 ) {
     let model_path = super::load_resource_meta_path(model.resource.get());
 
-    if disable || model.disable {
+    if model.disable {
+        // A disabled binding may reference a non-extant collection.
         return (model_path, model, None);
     }
+
     let live_model = live_bindings_model.get(&model_path);
     let modified = Some(&&model) != live_model;
-
     let target = &model.target;
 
     // We must resolve the target collection to continue.
@@ -487,6 +488,11 @@ fn walk_capture_binding<'a>(
         model.disable = true;
         return (model_path, model, None);
     };
+
+    if disable {
+        // Perform no further validations if the task is disabled.
+        return (model_path, model, None);
+    }
 
     // Was this binding's target collection reset under its current backfill count?
     let live_spec = live_bindings_spec.get(model_path.as_slice());

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -717,7 +717,7 @@ fn walk_derive_transform<'a>(
     }
 
     let live_model = live_transforms_model.get(&model.name);
-    let modified = Some(&&model) != live_model;
+    let modified_source = Some(&model.source) != live_model.map(|l| &l.source);
 
     // We must resolve the source collection to continue.
     let (source_name, source_partitions) = match &model.source {
@@ -741,7 +741,7 @@ fn walk_derive_transform<'a>(
         &format!("transform {}", model.name),
         source_name,
         built_collections,
-        modified.then_some(errors),
+        modified_source.then_some(errors),
     ) else {
         model_fixes.push(format!(
             "disabled transform of deleted collection {source_name}"

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -566,9 +566,11 @@ fn walk_materialization_binding<'a>(
 ) {
     let model_path = super::load_resource_meta_path(model.resource.get());
 
-    if disable || model.disable {
+    if model.disable {
+        // A disabled binding may reference a non-extant collection.
         return (model_path, model, false, None);
     }
+
     let live_model = live_bindings_model.get(&model_path);
     let modified = Some(&&model) != live_model;
 
@@ -600,6 +602,11 @@ fn walk_materialization_binding<'a>(
         model.disable = true;
         return (model_path, model, false, None);
     };
+
+    if disable {
+        // Perform no further validations if the task is disabled.
+        return (model_path, model, false, None);
+    }
 
     if let Some(selector) = source_partitions {
         collection::walk_selector(scope, &source_spec, &selector, errors);

--- a/crates/validation/tests/snapshots/transition_tests__deletion_of_used_collection_when_disabled.snap
+++ b/crates/validation/tests/snapshots/transition_tests__deletion_of_used_collection_when_disabled.snap
@@ -24,7 +24,10 @@ Outcome {
                   "disable": true,
                   "target": "the/collection"
                 }
-              ]
+              ],
+              "shards": {
+                "disable": true
+              }
             },
             model_fixes: [
               "disabled binding of deleted collection the/collection"
@@ -57,7 +60,7 @@ Outcome {
                                 nanos: 0,
                             },
                         ),
-                        disable: false,
+                        disable: true,
                         hot_standbys: 0,
                         labels: Some(
                             LabelSet {
@@ -339,7 +342,10 @@ Outcome {
                     "lambda": "select 123 as d_one, 'hello' as d_two;\n",
                     "disable": true
                   }
-                ]
+                ],
+                "shards": {
+                  "disable": true
+                }
               }
             },
             model_fixes: [
@@ -575,7 +581,7 @@ Outcome {
                                         nanos: 0,
                                     },
                                 ),
-                                disable: false,
+                                disable: true,
                                 hot_standbys: 0,
                                 labels: Some(
                                     LabelSet {
@@ -857,7 +863,10 @@ Outcome {
                     "recommended": true
                   }
                 }
-              ]
+              ],
+              "shards": {
+                "disable": true
+              }
             },
             model_fixes: [
               "disabled binding of deleted collection the/collection"
@@ -889,7 +898,7 @@ Outcome {
                                 nanos: 0,
                             },
                         ),
-                        disable: false,
+                        disable: true,
                         hot_standbys: 0,
                         labels: Some(
                             LabelSet {
@@ -1155,7 +1164,10 @@ Outcome {
                   "resource": {"_meta":{"path":["capture","path"]},"table":"foo"},
                   "target": "the/collection"
                 }
-              ]
+              ],
+              "shards": {
+                "disable": true
+              }
             },
             is_touch: 0,
         },
@@ -1194,7 +1206,10 @@ Outcome {
                     },
                     "lambda": "select 123 as d_one, 'hello' as d_two;\n"
                   }
-                ]
+                ],
+                "shards": {
+                  "disable": true
+                }
               }
             },
             is_touch: 0,
@@ -1238,7 +1253,10 @@ Outcome {
                     "recommended": true
                   }
                 }
-              ]
+              ],
+              "shards": {
+                "disable": true
+              }
             },
             is_touch: 0,
         },
@@ -1248,7 +1266,7 @@ Outcome {
             resource: test://example/catalog.yaml,
             content_type: "CATALOG",
             content: ".. binary ..",
-            content_dom: {"captures":{"the/capture":{"bindings":[{"resource":{"_meta":{"path":["capture","path"]},"table":"foo"},"target":"the/collection"}],"endpoint":{"connector":{"config":{"a":"config"},"image":"an/image"}},"expectPubId":"10:10:10:10:10:10:10:10"}},"collections":{"the/collection":{"delete":true,"expectPubId":"10:10:10:10:10:10:10:10","key":["/f_one"],"projections":{"F1":"/f_one","F2":"/f_two","FX":"/f_x","FY":"/f_y"},"schema":{"properties":{"f_one":{"type":"integer"},"f_two":{"type":"string"},"f_x":false},"required":["f_one","f_two"],"type":"object"}},"the/derivation":{"derive":{"transforms":[{"lambda":"select 123 as d_one, 'hello' as d_two;\n","name":"fromCollection","shuffle":{"key":["/f_two"]},"source":{"name":"the/collection"}}],"using":{"sqlite":{}}},"expectPubId":"10:10:10:10:10:10:10:10","key":["/d_one"],"schema":{"properties":{"d_one":{"type":"integer"},"d_two":{"type":"string"}},"required":["d_one","d_two"],"type":"object"}}},"materializations":{"the/materialization":{"bindings":[{"fields":{"exclude":["F2","FY","does/not/exist"],"include":{"F1":{},"f_two":{}},"recommended":true},"resource":{"_meta":{"path":["table","path"]},"table":"bar"},"source":"the/collection"}],"endpoint":{"connector":{"config":{"a":"config"},"image":"other/image"}},"expectPubId":"10:10:10:10:10:10:10:10"}}},
+            content_dom: {"captures":{"the/capture":{"bindings":[{"resource":{"_meta":{"path":["capture","path"]},"table":"foo"},"target":"the/collection"}],"endpoint":{"connector":{"config":{"a":"config"},"image":"an/image"}},"expectPubId":"10:10:10:10:10:10:10:10","shards":{"disable":true}}},"collections":{"the/collection":{"delete":true,"expectPubId":"10:10:10:10:10:10:10:10","key":["/f_one"],"projections":{"F1":"/f_one","F2":"/f_two","FX":"/f_x","FY":"/f_y"},"schema":{"properties":{"f_one":{"type":"integer"},"f_two":{"type":"string"},"f_x":false},"required":["f_one","f_two"],"type":"object"}},"the/derivation":{"derive":{"shards":{"disable":true},"transforms":[{"lambda":"select 123 as d_one, 'hello' as d_two;\n","name":"fromCollection","shuffle":{"key":["/f_two"]},"source":{"name":"the/collection"}}],"using":{"sqlite":{}}},"expectPubId":"10:10:10:10:10:10:10:10","key":["/d_one"],"schema":{"properties":{"d_one":{"type":"integer"},"d_two":{"type":"string"}},"required":["d_one","d_two"],"type":"object"}}},"materializations":{"the/materialization":{"bindings":[{"fields":{"exclude":["F2","FY","does/not/exist"],"include":{"F1":{},"f_two":{}},"recommended":true},"resource":{"_meta":{"path":["table","path"]},"table":"bar"},"source":"the/collection"}],"endpoint":{"connector":{"config":{"a":"config"},"image":"other/image"}},"expectPubId":"10:10:10:10:10:10:10:10","shards":{"disable":true}}}},
         },
     ],
     storage_mappings: [

--- a/crates/validation/tests/transition_tests.rs
+++ b/crates/validation/tests/transition_tests.rs
@@ -341,6 +341,48 @@ test://example/catalog.yaml:
   collections:
     the/collection:
       delete: true
+  tests: null
+
+driver:
+  captures:
+    the/capture:
+      bindings: []
+  derivations:
+    the/derivation:
+      shuffleKeyTypes: []
+      transforms: []
+  materializations:
+    the/materialization:
+      bindings: []
+"#,
+    );
+    insta::assert_debug_snapshot!(outcome);
+}
+
+#[test]
+fn test_deletion_of_used_collection_when_disabled() {
+    let outcome = common::run(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  collections:
+    the/collection:
+      delete: true
+
+    the/derivation:
+      derive:
+        shards: {disable: true}
+
+  captures:
+    the/capture:
+      shards: {disable: true}
+
+  materializations:
+    the/materialization:
+      shards: {disable: true}
+
+  tests: null
+
 driver:
   captures:
     the/capture:


### PR DESCRIPTION
In the typical UX, if one disables a task and then deletes a collection which it references, than the task's binding will be disabled.

Or, if one attempts to publish a new binding of a disabled task for which the collection doesn't exist, then they will get an error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2147)
<!-- Reviewable:end -->
