### PR TITLE
data-plane-controller: explicitly drop `logs_tx`

### DIFF
--- a/crates/data-plane-controller/src/lib.rs
+++ b/crates/data-plane-controller/src/lib.rs
@@ -189,6 +189,10 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         )
         .map(|()| anyhow::Result::<()>::Ok(()));
 
+    // When `server` finishes it drops `controller`, which in turn drops all
+    // outstanding references to `logs_tx`, which allows `logs_sink` to finish.
+    std::mem::drop(logs_tx);
+
     let ((), ()) = futures::try_join!(logs_sink, server)?;
 
     Ok(())


### PR DESCRIPTION
`logs_sink` will not exit until all references to `logs_tx` are dropped, and we're still holding one at the time we're awaiting its exit. D'oh.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2150)
<!-- Reviewable:end -->
