### PR TITLE
agent: initialize `data_planes` in onboarding directive

### DIFF
--- a/crates/agent/src/directives/beta_onboard.rs
+++ b/crates/agent/src/directives/beta_onboard.rs
@@ -281,6 +281,9 @@ mod test {
           {
             "prefix": "AcmeTenant/",
             "storageMapping": {
+              "data_planes": [
+                "ops/dp/public/test"
+              ],
               "stores": [
                 {
                   "bucket": "estuary-trial",


### PR DESCRIPTION
Begin populating the new `data_planes` field with public data-planes at the time of user onboarding.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2154)
<!-- Reviewable:end -->
