### PR TITLE
dekaf: Proactively update token in `Read` machinery

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -217,7 +217,7 @@ impl App {
         if models::Materialization::regex().is_match(username.as_ref())
             && !username.starts_with("{")
         {
-            let listener = self.task_manager.get_listener(&username).await;
+            let listener = self.task_manager.get_listener(&username);
             // Ask the agent for information about this task, as well as a short-lived
             // control-plane access token authorized to interact with the avro schemas table
             let TaskState {

--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -143,7 +143,7 @@ impl GazetteWriter {
         &self,
         task_name: &str,
     ) -> anyhow::Result<(GazetteAppender, GazetteAppender)> {
-        let task_listener = self.task_manager.get_listener(task_name).await;
+        let task_listener = self.task_manager.get_listener(task_name);
 
         let initial_state = task_listener.get().await?;
 

--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -137,7 +137,7 @@ impl TaskManager {
     /// Returns a [`tokio::sync::watch::Receiver`] that will receive updates to the task state.
     /// The receiver is weakly referenced, so it may be dropped if no one is listening.
     #[tracing::instrument(skip(self))]
-    pub async fn get_listener(self: &std::sync::Arc<Self>, task_name: &str) -> TaskStateListener {
+    pub fn get_listener(self: &std::sync::Arc<Self>, task_name: &str) -> TaskStateListener {
         // Scope to force the `tasks` lock to be released before awaiting
         let (sender, receiver, activity_signal) = {
             let mut tasks_guard = self.tasks.lock().unwrap();


### PR DESCRIPTION
**Description:**

Since https://github.com/estuary/flow/pull/2131 went out, we're seeing infrequent but consistent Dekaf logs like this:

```
WARN dekaf_session:serve{idle_timeout=300s}: dekaf: error=status: Unauthenticated, message: "verifying Authorization: token has invalid claims: token is expired", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }

WARN dekaf_session:serve{idle_timeout=300s}: dekaf: error=status: DeadlineExceeded, message: "context deadline exceeded", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }

WARN dekaf_session:serve{idle_timeout=300s}:fetch{max_wait_ms=500}:next_batch: dekaf::read: Retrying transient read error error=UnexpectedEof
```

The problem is, since `TaskManager` now hands out cached tokens, simply fetching a new token isn't enough to guarantee its lifetime anymore.

Originally, we would time out Read requests after 5 minutes ([for reasons](https://github.com/estuary/flow/pull/1736)), fetch a fresh token and start reading again. But now that the tokens are cached until 60s before they expire, reads started < 5 minutes before token expiration will eventually run into a "token expired" error as they'll be using a cached token that expires before the scheduled TTL of the read.

This isn't a problem from a functionality perspective as those reads will shut down and a new read will get started with the newly refreshed token, but we should fix it nevertheless. So instead, let's refactor `Read` to be responsible for keeping its `ReadJsonLines` up to date with fresh tokens.

I _suspect_ that the 5 minute `Read` timeout can also be done away with, as IIRC it was ultimately fixed by an update to the data-plane gateway, but I'd rather make that change separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2158)
<!-- Reviewable:end -->
