### PR TITLE
data-plane-controller: set private_links from column in data_planes

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -40,6 +40,8 @@ pub struct State {
     pub last_refresh: chrono::DateTime<chrono::Utc>,
     // Token to which controller logs are directed.
     pub logs_token: sqlx::types::Uuid,
+    // Private links configuration for this data-plane
+    pub private_links: Vec<PrivateLink>,
     // Pulumi configuration for this data-plane.
     pub stack: PulumiStack,
     // Name of the data-plane "stack" within the Pulumi tooling.

--- a/crates/data-plane-controller/src/state_fixture.json
+++ b/crates/data-plane-controller/src/state_fixture.json
@@ -75,5 +75,6 @@
   "last_refresh": "2025-02-26T15:23:07.693050947Z",
   "data_plane_id": "1122334455667788",
   "deploy_branch": "main",
-  "last_pulumi_up": "2025-02-26T15:46:19.720962982Z"
+  "last_pulumi_up": "2025-02-26T15:46:19.720962982Z",
+  "private_links": []
 }

--- a/crates/data-plane-controller/tests/snapshots/test_private_links__private_links.snap
+++ b/crates/data-plane-controller/tests/snapshots/test_private_links__private_links.snap
@@ -1,0 +1,838 @@
+---
+source: crates/data-plane-controller/tests/test_private_links.rs
+expression: trace.lock().unwrap().as_slice()
+---
+[
+  {
+    "Cmd": [
+      "git-clone",
+      "git clone git@github.com:estuary/ops.git ."
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "SetEncryption"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clone",
+      "git clone git@github.com:estuary/est-dry-dock.git ."
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/test-branch"
+    ]
+  },
+  {
+    "Cmd": [
+      "python-venv",
+      "python3.12 -m venv ./venv"
+    ]
+  },
+  {
+    "Cmd": [
+      "poetry-install",
+      "poetry install"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-change-secrets-provider",
+      "pulumi stack init test-stack --secrets-provider testing --non-interactive"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Stack": {
+      "secretsprovider": "testing",
+      "encryptedkey": "test-fixture",
+      "config": {
+        "est-dry-dock:model": {
+          "name": "test-plane",
+          "fqdn": "test-plane.estuary.dev",
+          "builds_root": "gs://estuary-control/builds/",
+          "builds_kms_keys": [
+            "projects/example/key"
+          ],
+          "control_plane_api": "https://example.api/",
+          "data_buckets": [
+            "gs://example-bucket"
+          ],
+          "gcp_project": "some-gcp-project",
+          "ssh_subnets": [
+            "12.34.56.78/32",
+            "2600:1234:5000:6000::/128"
+          ],
+          "private_links": [
+            {
+              "region": "us-west-2",
+              "az_ids": [
+                "a",
+                "b"
+              ],
+              "service_name": "service"
+            }
+          ],
+          "deployments": [
+            {
+              "role": "etcd",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "quay.io/coreos/etcd:v3.5",
+              "desired": 3,
+              "current": 0
+            },
+            {
+              "role": "reactor",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "ghcr.io/estuary/flow:v2.3.4",
+              "desired": 1,
+              "current": 0
+            },
+            {
+              "role": "gazette",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "ghcr.io/gazette/broker:v1.2.3",
+              "desired": 4,
+              "current": 0
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Status": "Idle"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "PulumiRefresh"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/test-branch"
+    ]
+  },
+  {
+    "Cmd": [
+      "python-venv",
+      "python3.12 -m venv ./venv"
+    ]
+  },
+  {
+    "Cmd": [
+      "poetry-install",
+      "poetry install"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-refresh",
+      "pulumi refresh --stack test-stack --diff --non-interactive --skip-preview --yes --expect-no-changes"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "Idle"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "PulumiUp1"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/test-branch"
+    ]
+  },
+  {
+    "Cmd": [
+      "python-venv",
+      "python3.12 -m venv ./venv"
+    ]
+  },
+  {
+    "Cmd": [
+      "poetry-install",
+      "poetry install"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-up-one",
+      "pulumi up --stack test-stack --diff --non-interactive --skip-preview --yes"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-stack-history",
+      "pulumi stack history --stack test-stack --json --page-size 1"
+    ]
+  },
+  {
+    "Log": [
+      "controller",
+      "Waiting 0ns for DNS propagation."
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "AwaitDNS1"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "Ansible"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/test-branch"
+    ]
+  },
+  {
+    "Cmd": [
+      "python-venv",
+      "python3.12 -m venv ./venv"
+    ]
+  },
+  {
+    "Cmd": [
+      "poetry-install",
+      "poetry install"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-stack-output",
+      "pulumi stack output --stack test-stack --json --non-interactive --show-secrets"
+    ]
+  },
+  {
+    "Cmd": [
+      "ansible-install",
+      "./venv/bin/ansible-galaxy install --role-file requirements.yml"
+    ]
+  },
+  {
+    "Cmd": [
+      "ansible-playbook",
+      "./venv/bin/ansible-playbook data-plane.ansible.yaml"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Exports": {
+      "aws_iam_user_arn": "arn:aws:iam::123456:user/data-planes/data-plane-abcd",
+      "aws_link_endpoints": [
+        {
+          "dns_entries": [
+            {
+              "dns_name": "vpce-123-abc.vpce-svc-foo.us-east-1.vpce.amazonaws.com",
+              "hosted_zone_id": "ZZ1"
+            },
+            {
+              "dns_name": "vpce-123-abc-us-east-1a.vpce-svc-foo.us-east-1.vpce.amazonaws.com",
+              "hosted_zone_id": "ZZ1"
+            }
+          ],
+          "service_name": "com.amazonaws.vpce.us-east-1.vpce-svc-foo"
+        }
+      ],
+      "azure_application_client_id": "12345678-1234-1234-1234-123456789abc",
+      "azure_application_name": "data-plane-123.dp.estuary-data.com",
+      "azure_link_endpoints": [
+        {
+          "ip": "10.0.0.2",
+          "service_name": "/subscriptions/subscriptionId/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/svc-bar"
+        }
+      ],
+      "bastion_tunnel_private_key": "bastion_tunnel_private_key fixture",
+      "cidr_blocks": [
+        "2600:1234:567:8900::/56",
+        "12.34.56.78/32",
+        "23.45.67.89/32"
+      ],
+      "gcp_service_account_email": "data-plane-abcd@project.iam.gserviceaccount.com",
+      "hmac_keys": [
+        "a2V5MQ==",
+        "a2V5Mg==",
+        "a2V5Mw=="
+      ],
+      "ssh_key": ""
+    }
+  },
+  {
+    "Status": "PulumiUp2"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/test-branch"
+    ]
+  },
+  {
+    "Cmd": [
+      "python-venv",
+      "python3.12 -m venv ./venv"
+    ]
+  },
+  {
+    "Cmd": [
+      "poetry-install",
+      "poetry install"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-up-two",
+      "pulumi up --stack test-stack --diff --non-interactive --skip-preview --yes"
+    ]
+  },
+  {
+    "Cmd": [
+      "pulumi-stack-history",
+      "pulumi stack history --stack test-stack --json --page-size 1"
+    ]
+  },
+  {
+    "Log": [
+      "controller",
+      "Waiting 0ns for DNS propagation."
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "AwaitDNS2"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Stack": {
+      "secretsprovider": "testing",
+      "encryptedkey": "test-fixture",
+      "config": {
+        "est-dry-dock:model": {
+          "name": "test-plane",
+          "fqdn": "test-plane.estuary.dev",
+          "builds_root": "gs://estuary-control/builds/",
+          "builds_kms_keys": [
+            "projects/example/key"
+          ],
+          "control_plane_api": "https://example.api/",
+          "data_buckets": [
+            "gs://example-bucket"
+          ],
+          "gcp_project": "some-gcp-project",
+          "ssh_subnets": [
+            "12.34.56.78/32",
+            "2600:1234:5000:6000::/128"
+          ],
+          "private_links": [
+            {
+              "region": "us-west-2",
+              "az_ids": [
+                "a",
+                "b"
+              ],
+              "service_name": "service"
+            }
+          ],
+          "deployments": [
+            {
+              "role": "etcd",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "quay.io/coreos/etcd:v3.5",
+              "desired": 3,
+              "current": 3
+            },
+            {
+              "role": "reactor",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "ghcr.io/estuary/flow:v2.3.4",
+              "desired": 1,
+              "current": 1
+            },
+            {
+              "role": "gazette",
+              "template": {
+                "os_id": 2284,
+                "plan": "vc2-1c-2gb",
+                "provider": "vultr",
+                "region": "ord"
+              },
+              "oci_image": "ghcr.io/gazette/broker:v1.2.3",
+              "desired": 4,
+              "current": 4
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Status": "Idle"
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-clean",
+      "git clean --force"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  },
+  {
+    "Status": "Idle"
+  }
+]

--- a/crates/data-plane-controller/tests/snapshots/test_private_links__private_links_inconsistent.snap
+++ b/crates/data-plane-controller/tests/snapshots/test_private_links__private_links_inconsistent.snap
@@ -1,0 +1,24 @@
+---
+source: crates/data-plane-controller/tests/test_private_links.rs
+expression: trace.lock().unwrap().as_slice()
+---
+[
+  {
+    "Cmd": [
+      "git-clone",
+      "git clone git@github.com:estuary/ops.git ."
+    ]
+  },
+  {
+    "Cmd": [
+      "git-fetch",
+      "git fetch"
+    ]
+  },
+  {
+    "Cmd": [
+      "git-checkout",
+      "git checkout --detach --force --quiet origin/master"
+    ]
+  }
+]

--- a/crates/data-plane-controller/tests/test_private_links.rs
+++ b/crates/data-plane-controller/tests/test_private_links.rs
@@ -1,0 +1,147 @@
+use data_plane_controller::{controller, stack};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex},
+};
+
+mod util;
+use util::{initial_state, mock_emit_log_fn, mock_run_cmd_fn, TraceEntry};
+
+#[tokio::test]
+async fn test_private_links() {
+    let trace = Arc::new(Mutex::new(Vec::new()));
+
+    let controller = data_plane_controller::Controller {
+        dns_ttl: std::time::Duration::ZERO,
+        dry_dock_remote: "git@github.com:estuary/est-dry-dock.git".to_string(),
+        ops_remote: "git@github.com:estuary/ops.git".to_string(),
+        secrets_provider: "testing".to_string(),
+        state_backend: "file:///tmp/pulumi-test-state".parse().unwrap(),
+        emit_log_fn: mock_emit_log_fn(trace.clone()),
+        run_cmd_fn: mock_run_cmd_fn(trace.clone()),
+    };
+
+    let mut state: Option<stack::State> = None;
+    let mut inbox: VecDeque<(models::Id, Option<controller::Message>)> = VecDeque::new();
+    let mut checkouts: HashMap<String, tempfile::TempDir> = HashMap::new();
+    let mut row_state = initial_state();
+    row_state.private_links = vec![stack::PrivateLink::AWS(stack::AWSPrivateLink {
+        az_ids: vec!["a".to_string(), "b".to_string()],
+        region: "us-west-2".to_string(),
+        service_name: "service".to_string(),
+    })];
+
+    inbox.push_back((
+        models::Id::zero(),
+        Some(controller::Message::Start(row_state.data_plane_id)),
+    ));
+    inbox.push_back((models::Id::zero(), Some(controller::Message::Enable)));
+
+    for _ in 0..50 {
+        let outcome = controller
+            .on_poll(
+                models::Id::new([42; 8]), // Task ID.
+                &mut state,
+                &mut inbox,
+                &mut checkouts,
+                Vec::new(),
+                row_state.clone(),
+            )
+            .await
+            .expect("on_poll failed");
+
+        let mut trace = trace.lock().unwrap();
+
+        if let Some(exports) = outcome.publish_exports {
+            trace.push(TraceEntry::Exports(exports));
+        }
+        if let Some(stack) = outcome.publish_stack {
+            trace.push(TraceEntry::Stack(stack.clone()));
+            row_state.stack = stack;
+        }
+        trace.push(TraceEntry::Status(outcome.status));
+
+        if matches!(outcome.status, stack::Status::Idle) && outcome.sleep.as_secs() > 0 {
+            break;
+        }
+    }
+
+    insta::assert_json_snapshot!(trace.lock().unwrap().as_slice());
+}
+
+#[tokio::test]
+async fn test_private_links_inconsistent() {
+    let trace = Arc::new(Mutex::new(Vec::new()));
+
+    let controller = data_plane_controller::Controller {
+        dns_ttl: std::time::Duration::ZERO,
+        dry_dock_remote: "git@github.com:estuary/est-dry-dock.git".to_string(),
+        ops_remote: "git@github.com:estuary/ops.git".to_string(),
+        secrets_provider: "testing".to_string(),
+        state_backend: "file:///tmp/pulumi-test-state".parse().unwrap(),
+        emit_log_fn: mock_emit_log_fn(trace.clone()),
+        run_cmd_fn: mock_run_cmd_fn(trace.clone()),
+    };
+
+    let mut state: Option<stack::State> = None;
+    let mut inbox: VecDeque<(models::Id, Option<controller::Message>)> = VecDeque::new();
+    let mut checkouts: HashMap<String, tempfile::TempDir> = HashMap::new();
+    let mut row_state = initial_state();
+    row_state.stack.config.model.private_links =
+        vec![stack::PrivateLink::AWS(stack::AWSPrivateLink {
+            az_ids: vec!["b".to_string(), "a".to_string()],
+            region: "us-east-2".to_string(),
+            service_name: "service".to_string(),
+        })];
+    row_state.private_links = vec![stack::PrivateLink::AWS(stack::AWSPrivateLink {
+        az_ids: vec!["a".to_string(), "b".to_string()],
+        region: "us-west-2".to_string(),
+        service_name: "service".to_string(),
+    })];
+
+    inbox.push_back((
+        models::Id::zero(),
+        Some(controller::Message::Start(row_state.data_plane_id)),
+    ));
+    inbox.push_back((models::Id::zero(), Some(controller::Message::Enable)));
+
+    for _ in 0..50 {
+        let output = controller
+            .on_poll(
+                models::Id::new([42; 8]), // Task ID.
+                &mut state,
+                &mut inbox,
+                &mut checkouts,
+                Vec::new(),
+                row_state.clone(),
+            )
+            .await;
+
+        if let Err(err) = output {
+            assert_eq!(
+                err.to_string(),
+                "cannot set both config.private_links and private_links, prefer the latter."
+            );
+            break;
+        };
+
+        let outcome = output.unwrap();
+
+        let mut trace = trace.lock().unwrap();
+
+        if let Some(exports) = outcome.publish_exports {
+            trace.push(TraceEntry::Exports(exports));
+        }
+        if let Some(stack) = outcome.publish_stack {
+            trace.push(TraceEntry::Stack(stack.clone()));
+            row_state.stack = stack;
+        }
+        trace.push(TraceEntry::Status(outcome.status));
+
+        if matches!(outcome.status, stack::Status::Idle) && outcome.sleep.as_secs() > 0 {
+            break;
+        }
+    }
+
+    insta::assert_json_snapshot!(trace.lock().unwrap().as_slice());
+}

--- a/crates/data-plane-controller/tests/util.rs
+++ b/crates/data-plane-controller/tests/util.rs
@@ -151,5 +151,6 @@ pub fn initial_state() -> stack::State {
         pending_converge: false, // Start false, should be set by diffing
         publish_exports: None,
         publish_stack: None,
+        private_links: Vec::new(),
     }
 }

--- a/supabase/migrations/20250520122010_data_plane_private_links.sql
+++ b/supabase/migrations/20250520122010_data_plane_private_links.sql
@@ -1,0 +1,9 @@
+-- Add private_links as a separate column to data_planes
+
+begin;
+
+ALTER TABLE public.data_planes ADD private_links json[] not null default array[]::json[];
+
+GRANT SELECT(private_links) ON public.data_planes TO authenticated;
+
+commit;


### PR DESCRIPTION
**Description:**

My plan for releasing this:
1. Run the SQL migration to add the column
2. Run a SQL command to copy the existing value of private_links from `config` and put it in the `private_links` column
3. Run preview on test data-planes with this branch to make sure nothing will change as a result of the release (see https://github.com/estuary/est-dry-dock/pull/109)
4. Run preview on other data-planes but with this branch (after merging https://github.com/estuary/flow/pull/2164) to make sure nothing is changing
5. Release

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2163)
<!-- Reviewable:end -->
