### PR TITLE
dpc: private_links is array of JSONs, not JSON of arrays

### DIFF
--- a/crates/data-plane-controller/src/controller.rs
+++ b/crates/data-plane-controller/src/controller.rs
@@ -914,7 +914,7 @@ async fn fetch_row_state(
             logs_token,
             data_plane_name,
             data_plane_fqdn,
-            private_links AS "private_links: sqlx::types::Json<Vec<stack::PrivateLink>>",
+            private_links AS "private_links: Vec<sqlx::types::Json<stack::PrivateLink>>",
             pulumi_key AS "pulumi_key",
             pulumi_stack AS "pulumi_stack!"
         FROM data_planes
@@ -952,7 +952,7 @@ async fn fetch_row_state(
         last_pulumi_up: chrono::DateTime::default(),
         last_refresh: chrono::DateTime::default(),
         logs_token: row.logs_token,
-        private_links: row.private_links.0,
+        private_links: row.private_links.into_iter().map(|link| link.0).collect(),
         stack,
         stack_name: row.pulumi_stack,
         status: Status::Idle,


### PR DESCRIPTION
**Description:**

- I tested this with the preview-local command but this part of the logic was not tested properly. The column is of type `json[]`, so it must be represented as `Vec<Json<PrivateLink>>` rather than `Json<Vec<PrivateLink>>`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2166)
<!-- Reviewable:end -->
