### PR TITLE
dpc: connector limits configuration

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -114,6 +114,14 @@ pub struct DataPlane {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub private_links: Vec<PrivateLink>,
     pub deployments: Vec<Deployment>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connector_limits: Option<ConnectorLimits>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ConnectorLimits {
+    pub cpu: String,
+    pub memory: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/data-plane-controller/src/state_fixture.json
+++ b/crates/data-plane-controller/src/state_fixture.json
@@ -63,7 +63,11 @@
         "builds_kms_keys": [
           "projects/the-project/locations/us-central1/keyRings/the-key-ring/cryptoKeys/the-key"
         ],
-        "control_plane_api": "https://agent-api-amj6adhsnq-uc.a.run.app/"
+        "control_plane_api": "https://agent-api-amj6adhsnq-uc.a.run.app/",
+        "connector_limits": {
+          "cpu": "200m",
+          "memory": "1g"
+        }
       }
     },
     "encryptedkey": "encryptedkey",

--- a/crates/data-plane-controller/tests/snapshots/test_initial_convergence_and_release__test.snap
+++ b/crates/data-plane-controller/tests/snapshots/test_initial_convergence_and_release__test.snap
@@ -172,7 +172,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 0
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -768,7 +772,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -890,7 +898,11 @@ expression: trace.lock().unwrap().as_slice()
                 "step": 3
               }
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -1392,7 +1404,11 @@ expression: trace.lock().unwrap().as_slice()
                 "step": 3
               }
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -1514,7 +1530,11 @@ expression: trace.lock().unwrap().as_slice()
                 "step": 3
               }
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -2012,7 +2032,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -2130,7 +2154,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -2612,7 +2640,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }

--- a/crates/data-plane-controller/tests/snapshots/test_preview__test.snap
+++ b/crates/data-plane-controller/tests/snapshots/test_preview__test.snap
@@ -172,7 +172,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 0
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -882,7 +886,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }

--- a/crates/data-plane-controller/tests/snapshots/test_private_links__private_links.snap
+++ b/crates/data-plane-controller/tests/snapshots/test_private_links__private_links.snap
@@ -182,7 +182,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 0
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }
@@ -788,7 +792,11 @@ expression: trace.lock().unwrap().as_slice()
               "desired": 4,
               "current": 4
             }
-          ]
+          ],
+          "connector_limits": {
+            "cpu": "200m",
+            "memory": "1g"
+          }
         }
       }
     }

--- a/crates/data-plane-controller/tests/util.rs
+++ b/crates/data-plane-controller/tests/util.rs
@@ -128,7 +128,11 @@ pub fn initial_state() -> stack::State {
       "builds_kms_keys": [
         "projects/example/key"
       ],
-      "control_plane_api": "https://example.api/"
+      "control_plane_api": "https://example.api/",
+      "connector_limits": {
+        "cpu": "200m",
+        "memory": "1g"
+      }
     }))
     .unwrap();
 


### PR DESCRIPTION
**Description:**

- Ran tests without adding `connector_limits` to state fixture, tests pass
- Ran tests after adding `connector_limits`, tests pass and can see `connector_limits` as part of the configuration now

Sister pull-request: https://github.com/estuary/est-dry-dock/pull/114

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2167)
<!-- Reviewable:end -->
