### PR TITLE
billing: Implement `send-invoices` command to handle sending Stripe invoices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "arrow-array"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "0.37.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f14b5943a52cf051bbbbb68538e93a69d1e291934174121e769f4b181113f5"
+checksum = "cecbddf002ad7a13d2041eadf1b234cb3f57653ffdd901a01bc3f1c65aa77440"
 dependencies = [
  "chrono",
  "futures-util",
@@ -1252,8 +1258,11 @@ dependencies = [
  "async-stripe",
  "chrono",
  "clap 4.5.21",
+ "comfy-table",
  "futures",
+ "indicatif",
  "itertools 0.10.5",
+ "num-format",
  "serde",
  "serde_json",
  "sqlx",
@@ -1668,7 +1677,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags 1.3.2",
  "textwrap 0.11.0",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1773,7 +1782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1803,7 +1812,7 @@ dependencies = [
  "crossterm 0.26.1",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1849,6 +1858,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width 0.1.13",
  "windows-sys 0.52.0",
 ]
 
@@ -3411,7 +3421,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf31ab66ed8145a1c7427bd8e9b42a6131bd74ccf444f69b9e620c2e73ded832"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
 ]
 
 [[package]]
@@ -3896,6 +3906,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,7 +4346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4816,6 +4839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec 0.7.6",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4886,6 +4919,12 @@ dependencies = [
  "quote",
  "syn 2.0.74",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -6541,7 +6580,7 @@ dependencies = [
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
  "utf8parse",
  "winapi",
 ]
@@ -7452,7 +7491,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -7978,7 +8017,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -8089,6 +8128,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"
@@ -8528,6 +8573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8600,7 +8655,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async-compression = { version = "0.3", features = [
     "tokio",
     "zstd",
 ] }
-async-stripe = { version = "0.37", features = ["runtime-tokio-hyper"] }
+async-stripe = { version = "0.41", features = ["runtime-tokio-hyper"] }
 async-trait = "0.1"
 atty = "0.2"
 apache-avro = { version = "0.17.0", features = ["snappy"] }
@@ -99,6 +99,8 @@ metrics-exporter-prometheus = "0.15.3"
 prometheus = "0.13.4"
 md5 = "0.7.0"
 num-bigint = "0.4"
+num-format = "0.4"
+indicatif = "0.17"
 
 open = "3"
 

--- a/crates/billing-integrations/Cargo.toml
+++ b/crates/billing-integrations/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 async-stripe = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
+comfy-table = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -23,4 +24,6 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+num-format = { workspace = true }
 itertools = { workspace = true }
+indicatif = { workspace = true }

--- a/crates/billing-integrations/src/lib.rs
+++ b/crates/billing-integrations/src/lib.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 
-mod stripe;
+mod publish;
+mod stripe_utils;
+mod send;
 
 #[derive(Debug, Parser)]
 #[clap(version)]
@@ -12,13 +14,17 @@ pub struct Cli {
 #[derive(Debug, clap::Subcommand)]
 #[clap(rename_all = "kebab-case")]
 pub enum Command {
-    Stripe(stripe::PublishInvoice),
+    PublishInvoices(publish::PublishInvoice),
+    SendInvoices(send::SendInvoices),
 }
 
 impl Cli {
     pub async fn run(&self) -> anyhow::Result<()> {
         match &self.cmd {
-            Command::Stripe(publish_invoice) => stripe::do_publish_invoices(publish_invoice).await,
+            Command::PublishInvoices(publish_invoice) => {
+                publish::do_publish_invoices(publish_invoice).await
+            }
+            Command::SendInvoices(send_invoices) => send::do_send_invoices(send_invoices).await,
         }
     }
 }

--- a/crates/billing-integrations/src/send.rs
+++ b/crates/billing-integrations/src/send.rs
@@ -1,0 +1,374 @@
+use crate::{
+    publish::{BILLING_PERIOD_START_KEY, INVOICE_TYPE_KEY},
+    stripe_utils::{fetch_invoices, Invoice},
+};
+use chrono::{Duration, NaiveDate, Utc};
+use clap::Args;
+use futures::stream::{self, StreamExt};
+use indicatif::{ProgressBar, ProgressStyle};
+use itertools::Itertools;
+use num_format::{Locale, ToFormattedString};
+use std::collections::HashSet;
+use stripe::{Client, FinalizeInvoiceParams, Invoice as StripeInvoice, InvoiceId};
+
+const PROGRESS_BAR_TEMPLATE: &str = "{spinner} [{elapsed_precise}] [{bar:40}] {pos}/{len} {msg}";
+
+#[derive(Debug, Args)]
+#[clap(rename_all = "kebab-case")]
+/// Send all invoices for a specific billing period, charging cards or sending for payment.
+pub struct SendInvoices {
+    /// Stripe API key.
+    #[clap(long)]
+    pub stripe_api_key: String,
+    /// The month to send invoices for, in format "YYYY-MM-DD"
+    #[clap(long)]
+    pub month: NaiveDate,
+}
+
+pub async fn do_send_invoices(cmd: &SendInvoices) -> anyhow::Result<()> {
+    let stripe_client = Client::new(cmd.stripe_api_key.to_owned())
+        .with_strategy(stripe::RequestStrategy::ExponentialBackoff(4));
+    let month_start = cmd.month.format("%Y-%m-%d").to_string();
+    let month_human_repr = cmd.month.format("%B %Y");
+    tracing::info!("Fetching Stripe invoices to send for {month_human_repr}");
+
+    let base_metadata = format!(
+        "metadata[\"{INVOICE_TYPE_KEY}\"]:'final' AND metadata[\"{BILLING_PERIOD_START_KEY}\"]:'{month_start}'"
+    );
+    let draft_query = format!("status:'draft' AND {base_metadata}");
+    let open_query = format!("status:'open' AND {base_metadata}");
+
+    // 1. Fetch any draft invoices. We will endeavor to finalize them so that they can be sent
+    let (mut draft_invoices, mut finalized_invoices) = futures::try_join!(
+        fetch_invoices(&stripe_client, &draft_query),
+        fetch_invoices(&stripe_client, &open_query)
+    )?;
+
+    tracing::info!(
+        "Fetched {} draft invoices for {month_human_repr}.",
+        draft_invoices.len()
+    );
+
+    if !draft_invoices.is_empty() {
+        // 2a. Update collection methods for any drafts that need it
+        draft_invoices = update_draft_collection_methods(&stripe_client, draft_invoices).await?;
+
+        print_invoice_table("Invoices to finalize", &draft_invoices);
+        prompt_to_continue("Enter Y to finalize these invoices, or anything else to abort: ")
+            .await?;
+
+        // 2b. Move the draft invoices to the `open` state
+        finalized_invoices.append(&mut finalize_invoices(&stripe_client, draft_invoices).await?);
+    }
+
+    if finalized_invoices.is_empty() {
+        tracing::info!("No invoices to send for {month_human_repr}");
+        return Ok(());
+    }
+
+    // 3. Send or charge open invoices
+    print_invoice_table("Invoices to send", &finalized_invoices);
+    prompt_to_continue("Enter Y to send these invoices, or anything else to abort: ").await?;
+
+    // We still could theoretically have `open` invoices that are `charge_automatically`
+    // but don't have a default payment method. There's not much we can do about these
+    // since `open` invoices are finalized and cannot be updated. So we show them in the table
+    // but filter them out before the collection step as they'll throw an error if we try.
+    collect_invoices(
+        &stripe_client,
+        finalized_invoices
+            .into_iter()
+            .filter(|inv| {
+                if inv.collection_method().map_or(false, |cm| {
+                    cm == stripe::CollectionMethod::ChargeAutomatically
+                }) && !inv.has_cc()
+                {
+                    return false;
+                } else {
+                    return true;
+                }
+            })
+            .collect::<Vec<_>>(),
+    )
+    .await;
+    Ok(())
+}
+
+/// Invoices that are created with the `charge_automatically` collection method
+/// can only proceed if the customer has a payment method on file. If not, the
+/// invoice's collection method must be changed to 'send_invoice' and a due date
+/// must be set in order to send the notification for manual payment.
+async fn update_draft_collection_methods(
+    stripe_client: &Client,
+    mut to_update: Vec<Invoice>,
+) -> anyhow::Result<Vec<Invoice>> {
+    // Identify invoices that are `charge_automatically` but don't have a default payment method
+    let needs_update: HashSet<InvoiceId> = to_update
+        .iter()
+        .filter(|inv| {
+            inv.collection_method().map_or(false, |cm| {
+                cm == stripe::CollectionMethod::ChargeAutomatically
+            }) && !inv.has_cc()
+        })
+        .map(|inv| inv.id().clone())
+        .collect::<HashSet<_>>();
+
+    // Modify the table row for those that need to be updated showing the transition
+    let table_rows = to_update
+        .iter()
+        .filter_map(|inv| {
+            if needs_update.contains(inv.id()) {
+                let mut row = inv.to_table_row();
+                row[4] = comfy_table::Cell::new("charge_automatically => send_invoice")
+                    .fg(comfy_table::Color::Yellow)
+                    .add_attribute(comfy_table::Attribute::Bold);
+                Some(row)
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+
+    if !table_rows.is_empty() {
+        let table = build_invoice_table(table_rows, None);
+        println!(
+            "\nThe following draft invoices will updated to use the 'send_invoice' collection method:"
+        );
+        println!("{}", table);
+
+        prompt_to_continue("Enter Y to update collection methods, or anything else to abort: ")
+            .await?;
+
+        let to_update = to_update
+            .iter_mut()
+            .filter(|inv| needs_update.contains(inv.id()))
+            .collect::<Vec<_>>();
+        update_collection_methods(
+            stripe_client,
+            to_update,
+            stripe::CollectionMethod::SendInvoice,
+        )
+        .await?;
+    }
+
+    Ok(to_update)
+}
+
+async fn update_collection_methods(
+    stripe_client: &Client,
+    invoices: Vec<&mut Invoice>,
+    method: stripe::CollectionMethod,
+) -> anyhow::Result<()> {
+    #[derive(serde::Serialize)]
+    struct PostBody {
+        collection_method: stripe::CollectionMethod,
+        due_date: Option<i64>,
+    }
+    let pb = ProgressBar::new(invoices.len() as u64);
+    pb.set_message("updating collection method");
+    pb.set_style(ProgressStyle::with_template(PROGRESS_BAR_TEMPLATE).unwrap());
+    for inv in invoices {
+        let res: Result<stripe::Invoice, _> = stripe_client
+            .post_form(
+                &format!("/invoices/{}", inv.id()),
+                PostBody {
+                    collection_method: method,
+                    due_date: Some((Utc::now() + Duration::days(30)).timestamp()),
+                },
+            )
+            .await;
+        match res {
+            Ok(_) => {
+                inv.collection_method = Some(method.clone());
+            }
+            Err(e) => {
+                pb.println(format!(
+                    "Failed to update collection method for invoice {}: {}",
+                    inv.id(),
+                    e
+                ));
+            }
+        }
+        pb.inc(1);
+    }
+    pb.finish_with_message("Collection method update complete");
+    Ok(())
+}
+
+// Finalizes the invoices and re-fetches them to ensure we have the correct state
+// This calls `/invoices/{id}/finalize` to move draft invoices to the `open` state
+async fn finalize_invoices(
+    stripe_client: &Client,
+    to_finalize: Vec<Invoice>,
+) -> anyhow::Result<Vec<Invoice>> {
+    let pb = ProgressBar::new(to_finalize.len() as u64);
+    pb.set_message("finalizing invoices");
+    pb.set_style(ProgressStyle::with_template(PROGRESS_BAR_TEMPLATE).unwrap());
+    let finalize_futs = to_finalize.into_iter().map(|row| {
+        let stripe_client = stripe_client;
+        let pb = pb.clone();
+        async move {
+            StripeInvoice::finalize(stripe_client, row.id(), FinalizeInvoiceParams::default())
+                .await
+                .map_err(|e| {
+                    pb.println(format!("Error finalizing invoice {}: {}", row.id(), e));
+                    anyhow::Error::from(e)
+                })?;
+            pb.inc(1);
+
+            let invoice =
+                StripeInvoice::retrieve(stripe_client, row.id(), vec!["customer"].as_slice())
+                    .await?;
+            Ok(Invoice::from(invoice))
+        }
+    });
+    let finalize_results = stream::iter(finalize_futs)
+        .buffer_unordered(10)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .filter(|res: &anyhow::Result<Invoice>| {
+            if let Err(e) = res {
+                tracing::error!(error = ?e, "Error finalizing invoice");
+                return false;
+            }
+            true
+        })
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+
+    pb.finish_with_message("Finished finalizing invoices");
+
+    Ok(finalize_results)
+}
+
+async fn collect_invoices(stripe_client: &Client, to_send: Vec<Invoice>) {
+    let pb = ProgressBar::new(to_send.len() as u64);
+    pb.set_message("sending invoices");
+    pb.set_style(ProgressStyle::with_template(PROGRESS_BAR_TEMPLATE).unwrap());
+    let send_futs = to_send.into_iter().map(|row| {
+        let stripe_client = stripe_client;
+        let pb = pb.clone();
+        async move {
+            let res = if row.has_cc() {
+                StripeInvoice::pay(stripe_client, row.id()).await
+            } else {
+                stripe_client
+                    .post(&format!("/invoices/{}/send", row.id()))
+                    .await
+            };
+            pb.inc(1);
+            match res {
+                Ok(_) => {
+                    if row.has_cc() {
+                        pb.println(format!(
+                            "Charged card for tenant {} (invoice {})",
+                            row.tenant(),
+                            row.id()
+                        ));
+                    } else {
+                        pb.println(format!(
+                            "Sent invoice for tenant {} (invoice {})",
+                            row.tenant(),
+                            row.id()
+                        ));
+                    }
+                }
+                Err(e) => {
+                    pb.println(format!(
+                        "Error sending/paying invoice {}: {:?}",
+                        row.id(),
+                        e
+                    ));
+                }
+            }
+        }
+    });
+    stream::iter(send_futs)
+        .buffer_unordered(10)
+        .collect::<Vec<_>>()
+        .await;
+    pb.finish_with_message("All invoices sent/paid");
+}
+
+fn build_invoice_table<I>(rows: I, subtotal: Option<f64>) -> comfy_table::Table
+where
+    I: IntoIterator<Item = Vec<comfy_table::Cell>>,
+{
+    let mut table = comfy_table::Table::new();
+    table
+        .load_preset(comfy_table::presets::UTF8_FULL)
+        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+        .apply_modifier(comfy_table::modifiers::UTF8_SOLID_INNER_BORDERS);
+    table.set_header(Invoice::table_header());
+    for row in rows {
+        table.add_row(row);
+    }
+    if let Some(subtotal) = subtotal {
+        let subtotal_int = subtotal.trunc() as i64;
+        let subtotal_cents = (subtotal.fract() * 100.0).round() as u8;
+        let formatted_subtotal = format!(
+            "${}.{:02}",
+            subtotal_int.to_formatted_string(&Locale::en),
+            subtotal_cents
+        );
+        table.add_row(vec![
+            comfy_table::Cell::new("Subtotal").add_attribute(comfy_table::Attribute::Bold),
+            comfy_table::Cell::new(formatted_subtotal).add_attribute(comfy_table::Attribute::Bold),
+            comfy_table::Cell::new(""),
+            comfy_table::Cell::new(""),
+            comfy_table::Cell::new(""),
+            comfy_table::Cell::new(""),
+        ]);
+    }
+    table
+}
+
+fn print_invoice_table(title: &str, rows: &[Invoice]) {
+    let subtotal: f64 = rows.iter().map(|r| r.amount()).sum();
+    let table = build_invoice_table(
+        rows.iter().map(|row| {
+            let cells = row.to_table_row();
+            if row.collection_method().map_or(false, |cm| {
+                cm == stripe::CollectionMethod::ChargeAutomatically
+            }) && !row.has_cc()
+            {
+                let mut red_cells = cells
+                    .into_iter()
+                    .map(|cell| cell.fg(comfy_table::Color::Red))
+                    .collect::<Vec<_>>();
+
+                red_cells[4] = comfy_table::Cell::new("!! Missing default payment method !!")
+                    .fg(comfy_table::Color::Red);
+                red_cells
+            } else {
+                cells
+            }
+        }),
+        Some(subtotal),
+    );
+    println!("\n{title}:");
+    println!("{}", table);
+}
+
+async fn prompt_to_continue(message: &str) -> anyhow::Result<()> {
+    let message = message.to_string();
+    let proceed = tokio::task::spawn_blocking(move || {
+        println!("\n{}", message);
+        let mut buf = String::with_capacity(8);
+        match std::io::stdin().read_line(&mut buf) {
+            Ok(_) => buf.trim().eq_ignore_ascii_case("y"),
+            Err(err) => {
+                tracing::error!(error = %err, "failed to read from stdin");
+                false
+            }
+        }
+    })
+    .await
+    .expect("failed to join spawned task");
+    if proceed {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("Aborted by user."))
+    }
+}

--- a/crates/billing-integrations/src/stripe_utils.rs
+++ b/crates/billing-integrations/src/stripe_utils.rs
@@ -1,0 +1,158 @@
+use crate::publish::TENANT_METADATA_KEY;
+use num_format::{Locale, ToFormattedString};
+use serde::{de::DeserializeOwned, Serialize};
+use std::ops::{Deref, DerefMut};
+use stripe::SearchList;
+
+#[derive(Serialize, Default, Debug)]
+pub struct SearchParams {
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expand: Option<Vec<String>>,
+}
+
+pub async fn stripe_search<R: DeserializeOwned + 'static + Send>(
+    client: &stripe::Client,
+    resource: &str,
+    mut params: SearchParams,
+) -> Result<Vec<R>, stripe::StripeError> {
+    let mut all_data = Vec::new();
+    let mut page = None;
+    loop {
+        if let Some(p) = page {
+            params.page = Some(p);
+        }
+        let resp: SearchList<R> = client
+            .get_query(&format!("/{}/search", resource), &params)
+            .await?;
+        let count = resp.data.len();
+        all_data.extend(resp.data);
+        if count == 0 || !resp.has_more {
+            break;
+        }
+        page = resp.next_page;
+    }
+    Ok(all_data)
+}
+
+pub async fn fetch_invoices(
+    stripe_client: &stripe::Client,
+    query: &str,
+) -> anyhow::Result<Vec<Invoice>> {
+    stripe_search(
+        stripe_client,
+        "invoices",
+        SearchParams {
+            query: query.to_string(),
+            expand: Some(vec!["data.customer".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .map(|invoices| {
+        invoices
+            .into_iter()
+            .map(|inv: stripe::Invoice| Invoice::from(inv))
+            .collect()
+    })
+    .map_err(|e| e.into())
+}
+
+#[derive(Clone, Debug)]
+pub struct Invoice(stripe::Invoice);
+
+impl From<stripe::Invoice> for Invoice {
+    fn from(invoice: stripe::Invoice) -> Self {
+        Invoice(invoice)
+    }
+}
+
+impl Deref for Invoice {
+    type Target = stripe::Invoice;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Invoice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Invoice {
+    pub fn tenant(&self) -> String {
+        self.0
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get(TENANT_METADATA_KEY))
+            .cloned()
+            .unwrap_or_default()
+    }
+    pub fn amount(&self) -> f64 {
+        self.0.amount_due.unwrap_or(0) as f64 / 100.0
+    }
+    pub fn id(&self) -> &stripe::InvoiceId {
+        &self.0.id
+    }
+    pub fn has_cc(&self) -> bool {
+        self.customer()
+            .and_then(|c| c.invoice_settings.as_ref())
+            .and_then(|s| s.default_payment_method.as_ref())
+            .is_some()
+    }
+    pub fn collection_method(&self) -> anyhow::Result<stripe::CollectionMethod> {
+        self.0.collection_method.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invoice {} (customer {}) is missing collection_method",
+                self.0.id,
+                self.customer().map(|c| c.id.clone()).unwrap_or_default()
+            )
+        })
+    }
+    pub fn customer(&self) -> Option<&stripe::Customer> {
+        self.0.customer.as_ref()?.as_object()
+    }
+    pub fn status(&self) -> Option<stripe::InvoiceStatus> {
+        self.0.status.clone()
+    }
+
+    pub fn to_table_row(&self) -> Vec<comfy_table::Cell> {
+        let formatted_amount = format!(
+            "${}",
+            (self.amount() as i64).to_formatted_string(&Locale::en)
+        );
+        let cents = (self.amount().fract() * 100.0).round() as u8;
+        let formatted_amount = format!("{}.{:02}", &formatted_amount, cents);
+        vec![
+            comfy_table::Cell::new(self.tenant()),
+            comfy_table::Cell::new(formatted_amount),
+            comfy_table::Cell::new(self.id()),
+            comfy_table::Cell::new(if self.has_cc() { "yes" } else { "no" }),
+            comfy_table::Cell::new(
+                self.collection_method()
+                    .map_or("<missing>".to_string(), |cm| format!("{}", cm)),
+            ),
+            comfy_table::Cell::new(
+                self.status()
+                    .map_or("<missing>".to_string(), |cm| format!("{}", cm)),
+            ),
+        ]
+    }
+
+    pub fn table_header() -> Vec<&'static str> {
+        vec![
+            "Tenant",
+            "Amount",
+            "Invoice ID",
+            "Has Default Payment Method",
+            "Collection Method",
+            "Status",
+        ]
+    }
+}


### PR DESCRIPTION
**Description:**

* Fetch sendable invoices for the specified month based on metadata created by the `publish-invoices` command
* For draft invoices:
    * Identify invoices set to `charge_automatically` but lacking a customer payment method.
    * Update those invoice's collection method to `send_invoice` and sets a due date.
    * Finalizes all draft invoices.
* Attempts to pay invoices (if `charge_automatically` with a payment method) or sends them (if `send_invoice` or no payment method).

![Screenshot 2025-05-23 at 18 12 21](https://github.com/user-attachments/assets/266fe5e8-bbc3-4068-8ca2-c99d782c10d1)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2173)
<!-- Reviewable:end -->
