### PR TITLE
agent: skip authorization checks for controller-initiated discovers

### DIFF
--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -491,6 +491,7 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
         };
         let req = Discover {
             user_id: *system_user_id,
+            filter_user_authz: false,
             capture_name,
             draft,
             update_only,

--- a/crates/agent/src/discovers/executor.rs
+++ b/crates/agent/src/discovers/executor.rs
@@ -287,6 +287,7 @@ async fn prepare_discover(
 
     Ok(Discover {
         user_id,
+        filter_user_authz: true,
         capture_name,
         data_plane,
         draft,


### PR DESCRIPTION
Updates discovers to skip authorization checks for discovers that are performed by controllers.  Previously, we'd be relying on the `estuary_support/` role to allow auto-discovers to properly resolve live specs, which caused auto-discovers to fail for tenants that weren't covered by that role grant.

Also updates the integration test setup to remove the `estuary_support/` role. This was sufficent to reproduce the issue wth auto-discovers, and seemed like a good idea generally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2180)
<!-- Reviewable:end -->
