### PR TITLE
flow-web: bump version to 0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "flow-web"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "console_error_panic_hook",
  "doc",

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flow-web"
 
 # wasm-pack isn't yet fully compatible with workspace inheritance, so we can't use that for these fields
-version = "0.5.12"
+version = "0.5.13"
 authors = ["Estuary developers  <engineering@estuary.dev>"]
 edition = "2021"
 license = "BSL"


### PR DESCRIPTION
This just updates the flow-web version number so that we can release the latest version of the package

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2185)
<!-- Reviewable:end -->
