### PR TITLE
dekaf: Fix user-token auth for a little while longer

### DIFF
--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -416,7 +416,7 @@ impl Collection {
         user_auth: &UserAuth,
         collection_name: &str,
     ) -> anyhow::Result<journal::Client> {
-        let (_, journal_client) =
+        let (_, journal_client, _) =
             flow_client::fetch_user_collection_authorization(&user_auth.client, collection_name)
                 .await?;
 

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -342,7 +342,7 @@ pub async fn fetch_user_task_authorization(
 pub async fn fetch_user_collection_authorization(
     client: &Client,
     collection: &str,
-) -> anyhow::Result<(String, gazette::journal::Client)> {
+) -> anyhow::Result<(String, gazette::journal::Client, proto_gazette::Claims)> {
     let started_unix = std::time::SystemTime::now()
         .duration_since(std::time::SystemTime::UNIX_EPOCH)
         .unwrap()
@@ -376,6 +376,8 @@ pub async fn fetch_user_collection_authorization(
         break response;
     };
 
+    let claims = parse_jwt_claims(&broker_token)?;
+
     tracing::debug!(
         broker_address,
         broker_token,
@@ -390,7 +392,7 @@ pub async fn fetch_user_collection_authorization(
         .journal_client
         .with_endpoint_and_metadata(broker_address, md);
 
-    Ok((journal_name_prefix, journal_client))
+    Ok((journal_name_prefix, journal_client, claims))
 }
 
 #[tracing::instrument(skip(client), err)]

--- a/crates/flowctl/src/collection/mod.rs
+++ b/crates/flowctl/src/collection/mod.rs
@@ -184,7 +184,7 @@ async fn do_list_fragments(
         since,
     }: &ListFragmentsArgs,
 ) -> Result<(), anyhow::Error> {
-    let (journal_name_prefix, client) =
+    let (journal_name_prefix, client, _claims) =
         flow_client::fetch_user_collection_authorization(&ctx.client, &selector.collection).await?;
 
     let list_resp = client
@@ -224,7 +224,7 @@ async fn do_list_journals(
     ctx: &mut crate::CliContext,
     selector: &CollectionJournalSelector,
 ) -> Result<(), anyhow::Error> {
-    let (journal_name_prefix, client) =
+    let (journal_name_prefix, client, _claims) =
         flow_client::fetch_user_collection_authorization(&ctx.client, &selector.collection).await?;
 
     let list_resp = client

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -62,7 +62,7 @@ pub async fn read_collection(
         );
     }
 
-    let (journal_name_prefix, journal_client) =
+    let (journal_name_prefix, journal_client, _claims) =
         flow_client::fetch_user_collection_authorization(&ctx.client, &selector.collection).await?;
 
     let list_resp = journal_client

--- a/crates/flowctl/src/preview/journal_reader.rs
+++ b/crates/flowctl/src/preview/journal_reader.rs
@@ -41,7 +41,7 @@ impl Reader {
             // Concurrently fetch authorizations for all sourced collections.
             let sources = futures::future::try_join_all(sources.iter().map(|source| {
                 flow_client::fetch_user_collection_authorization(&self.client, &source.collection)
-                    .map_ok(move |(_journal_name_prefix, client)| (source, client))
+                    .map_ok(move |(_journal_name_prefix, client, _claims)| (source, client))
             }))
             .await?;
 


### PR DESCRIPTION
**Description:**

We still have some users on user-refresh-token auth, which https://github.com/estuary/flow/pull/2158 broke. This fixes the particular problem, while still retaining the correct token refresh logic.

I know the additional abstraction of `JournalClientProvider` feels a bit excessive for something that's soon going to get disabled anyway, but I've been using it locally while figuring out the right way to mock things in order to support e2e testing, and it's actually working out pretty nicely.   

Tested locally and on `dekaf-dev` that both refresh-token and materialization token auth work correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2196)
<!-- Reviewable:end -->
