### PR TITLE
agent: fix follow up scheduling after new build activation

### DIFF
--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -87,7 +87,13 @@ pub async fn update_activation<C: ControlPlane>(
             .await?;
         status.recent_failure_count = 0;
         // We'll check again soon to see whether the shard is actually up
-        return Ok(has_task_shards.then_some(NextRun::after_minutes(5)));
+        return Ok(
+            has_task_shards.then_some(NextRun::from_duration(shard_health_check_interval(
+                state,
+                0,
+                ShardsStatus::Pending,
+            ))),
+        );
     }
 
     // Update our shard failure information. We can skip this if we know that there's


### PR DESCRIPTION
Fixes the `next_run` time after controllers activate a new build. This had a 5m placeholder value mistakenly left in the code, and the fix is to just compute the actual value, which will result in 30s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2212)
<!-- Reviewable:end -->
