### PR TITLE
agent-api: filter out stale connector status in status response

### DIFF
--- a/crates/agent/src/api/public/status.rs
+++ b/crates/agent/src/api/public/status.rs
@@ -153,6 +153,15 @@ impl StatusRow {
             controller_status.as_ref(),
             connector_status.as_ref(),
         );
+
+        // Omit the connector status if it's known to be stale.
+        let last_activation_ts = controller_status
+            .as_ref()
+            .and_then(|status| status.activation_status())
+            .and_then(|activation| activation.last_activated_at);
+        connector_status
+            .take_if(|cs| last_activation_ts.is_none_or(|ts| !cs.is_current(last_build_id, ts)));
+
         if summary_only {
             connector_status.take();
             controller_status.take();

--- a/crates/models/src/status/connector.rs
+++ b/crates/models/src/status/connector.rs
@@ -1,4 +1,4 @@
-use crate::status::ShardRef;
+use crate::{status::ShardRef, Id};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,16 @@ pub struct ConnectorStatus {
     /// specific fields and their meanings are entirely up to the connector.
     #[serde(default)]
     pub fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ConnectorStatus {
+    /// Returns true if this connector status comes from the same build, and was
+    /// written after the `last_activation_ts`. If both of those conditions are
+    /// met, then we can assume that the status information is up to date and
+    /// relevant, barring any bugs in the connector itself.
+    pub fn is_current(&self, last_build_id: Id, last_activation_ts: DateTime<Utc>) -> bool {
+        self.shard.build == last_build_id && self.ts > last_activation_ts
+    }
 }
 
 crate::sqlx_json::sqlx_json!(ConnectorStatus);

--- a/crates/models/src/status/summary.rs
+++ b/crates/models/src/status/summary.rs
@@ -84,6 +84,7 @@ impl Summary {
         {
             return Summary::warning("pending data-plane activation");
         }
+        let last_activation_ts = activation_status.last_activated_at.unwrap();
 
         let is_collection = matches!(controller_status, ControllerStatus::Collection(_));
         if disabled && !is_collection {
@@ -131,9 +132,7 @@ impl Summary {
         // acceptable, since we have no better means of determining whether
         // to expect a connector status for a given task.
         let message = if let Some(conn_status) = connector_status.filter(|_| !disabled) {
-            if conn_status.shard.build != activation_status.last_activated
-                || Some(conn_status.ts) < activation_status.last_activated_at
-            {
+            if !conn_status.is_current(last_build_id, last_activation_ts) {
                 return Summary::warning("waiting on connector status");
             }
             conn_status.message.clone()


### PR DESCRIPTION
Updates the `/catalog/status` endpoint to filter our stale connector statuses when generating responses.  A stale status is one that has a non-current build id, or that has a timestamp indicating it was written prior to the most recent activation. In other words, we assume that if a connector emits a status at all, that it will do so upon every successful startup of the connector.

Currently, we are showing stale connector statuses in the UI, which is pretty confusing in cases where shards are failed and the connector status still says it's running. I can't think of a reason why we'd ever want to expose stale connector statuses via the `/catalog/status` endpoint, since users can simply look at the task logs for historical statuses. So I think it's better to filter them on the backend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2213)
<!-- Reviewable:end -->
