### PR TITLE
migrate: add /443 port default for cordon label

### DIFF
--- a/crates/migrate/src/lib.rs
+++ b/crates/migrate/src/lib.rs
@@ -112,10 +112,14 @@ async fn phase_one(
 
     // Munge FQDNs for use within Gazette label values:
     // - https://flow.localhost:9000 => flow.localhost/9000
-    // - https://reactor.aws-eu-west-1-c1.dp.estuary-data.com => reactor.aws-eu-west-1-c1.dp.estuary-data.com
+    // - https://reactor.aws-eu-west-1-c1.dp.estuary-data.com => reactor.aws-eu-west-1-c1.dp.estuary-data.com/443
     let munge_fqdn = |fqdn: &str| {
         let fqdn = fqdn.strip_prefix("https://").unwrap_or(fqdn);
-        fqdn.replace(":", "/")
+        if fqdn.contains(':') {
+            fqdn.replace(":", "/")
+        } else {
+            format!("{}/443", fqdn)
+        }
     };
 
     // Fetch and cordon shards and journals from the source data-plane.


### PR DESCRIPTION
The cordon label must include the TCP port to which we'll forward. If not present (always true in production) then assume HTTPS

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2215)
<!-- Reviewable:end -->
