### PR TITLE
flowctl support improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
 name = "flowctl"
 version = "0.0.0"
 dependencies = [
+ "activate",
  "anyhow",
  "assemble",
  "assert_cmd",

--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -434,7 +434,7 @@ fn unpack_shard_listing(resp: consumer::ListResponse) -> anyhow::Result<Vec<Shar
 }
 
 /// Unpack a broker ListResponse into its structured collection splits.
-fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<JournalSplit>> {
+pub fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<JournalSplit>> {
     let mut v = Vec::new();
 
     for resp in resp.journals {
@@ -799,8 +799,9 @@ fn apply_initial_splits<'a>(
 }
 
 /// Map a parent JournalSplit into two subdivided splits.
-#[allow(dead_code)]
-fn map_partition_to_split(parent: &JournalSplit) -> anyhow::Result<(JournalSplit, JournalSplit)> {
+pub fn map_partition_to_split(
+    parent: &JournalSplit,
+) -> anyhow::Result<(JournalSplit, JournalSplit)> {
     let (parent_begin, parent_end) = labels::partition::decode_key_range(&parent.labels)?;
 
     let pivot = ((parent_begin as u64 + parent_end as u64 + 1) / 2) as u32;

--- a/crates/agent/src/api/snapshot.rs
+++ b/crates/agent/src/api/snapshot.rs
@@ -558,6 +558,8 @@ impl Snapshot {
             ("bobCo/widgets/mangoes", 2),
             ("bobCo/widgets/squashes", 2),
             ("bobCo/anvils/peaches", 2),
+            ("bobCo/tires/collection", 2),
+            ("aliceCo/wonderland/data", 2),
             ("ops/tasks/public/plane-two/logs", 2),
             ("ops/tasks/public/plane-two/stats", 2),
         ]
@@ -639,9 +641,16 @@ impl Snapshot {
                 object_role: models::Prefix::new("ops/dp/public/"),
                 capability: models::Capability::Read,
             },
+            tables::RoleGrant {
+                subject_role: models::Prefix::new("aliceCo/"),
+                object_role: models::Prefix::new("ops/dp/public/"),
+                capability: models::Capability::Read,
+            },
         ];
 
         let user_grants = vec![
+            // bob@bob has write to bobCo/ and admin to bobCo/tires/,
+            // but does not have estuary_support/.
             tables::UserGrant {
                 user_id: uuid::Uuid::from_bytes([32; 16]),
                 object_role: models::Prefix::new("bobCo/"),
@@ -650,6 +659,17 @@ impl Snapshot {
             tables::UserGrant {
                 user_id: uuid::Uuid::from_bytes([32; 16]),
                 object_role: models::Prefix::new("bobCo/tires/"),
+                capability: models::Capability::Admin,
+            },
+            // alice@alice has admin to aliceCo/ and estuary_support/
+            tables::UserGrant {
+                user_id: uuid::Uuid::from_bytes([64; 16]),
+                object_role: models::Prefix::new("aliceCo/"),
+                capability: models::Capability::Admin,
+            },
+            tables::UserGrant {
+                user_id: uuid::Uuid::from_bytes([64; 16]),
+                object_role: models::Prefix::new("estuary_support/"),
                 capability: models::Capability::Admin,
             },
         ];
@@ -674,6 +694,16 @@ impl Snapshot {
             ),
             (
                 "bobCo/anvils/materialize-orange",
+                models::CatalogType::Materialization,
+                2,
+            ),
+            (
+                "aliceCo/wonderland/materialize-tea",
+                models::CatalogType::Materialization,
+                2,
+            ),
+            (
+                "bobCo/tires/materialize-wheels",
                 models::CatalogType::Materialization,
                 2,
             ),

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -416,9 +416,12 @@ impl Collection {
         user_auth: &UserAuth,
         collection_name: &str,
     ) -> anyhow::Result<journal::Client> {
-        let (_, journal_client) =
-            flow_client::fetch_user_collection_authorization(&user_auth.client, collection_name)
-                .await?;
+        let (_, journal_client) = flow_client::fetch_user_collection_authorization(
+            &user_auth.client,
+            collection_name,
+            false,
+        )
+        .await?;
 
         Ok(journal_client)
     }

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -342,6 +342,7 @@ pub async fn fetch_user_task_authorization(
 pub async fn fetch_user_collection_authorization(
     client: &Client,
     collection: &str,
+    admin: bool,
 ) -> anyhow::Result<(String, gazette::journal::Client)> {
     let started_unix = std::time::SystemTime::now()
         .duration_since(std::time::SystemTime::UNIX_EPOCH)
@@ -360,7 +361,11 @@ pub async fn fetch_user_collection_authorization(
                 &models::authorizations::UserCollectionAuthorizationRequest {
                     started_unix,
                     collection: models::Collection::new(collection),
-                    capability: models::Capability::Read,
+                    capability: if admin {
+                        models::Capability::Admin
+                    } else {
+                        models::Capability::Read
+                    },
                 },
             )
             .await?;

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+activate = { path = "../activate" }
 assemble = { path = "../assemble" }
 async-process = { path = "../async-process" }
 build = { path = "../build" }

--- a/crates/flowctl/src/collection/read/mod.rs
+++ b/crates/flowctl/src/collection/read/mod.rs
@@ -63,7 +63,8 @@ pub async fn read_collection(
     }
 
     let (journal_name_prefix, journal_client) =
-        flow_client::fetch_user_collection_authorization(&ctx.client, &selector.collection).await?;
+        flow_client::fetch_user_collection_authorization(&ctx.client, &selector.collection, false)
+            .await?;
 
     let list_resp = journal_client
         .list(broker::ListRequest {

--- a/crates/flowctl/src/generate/mod.rs
+++ b/crates/flowctl/src/generate/mod.rs
@@ -452,7 +452,6 @@ mod test {
 
     // Map a JSON schema, in YAML form, into a Shape.
     fn shape_from(schema_yaml: &str) -> Shape {
-
         let url = url::Url::parse("http://example/schema").unwrap();
         let schema: serde_json::Value = serde_yaml::from_str(schema_yaml).unwrap();
         let schema =
@@ -483,7 +482,10 @@ mod test {
         "#,
         );
 
-        let cfg = stub_config(&obj, Some(&models::Collection::new("my-tenant/my-task/my-collection")));
+        let cfg = stub_config(
+            &obj,
+            Some(&models::Collection::new("my-tenant/my-task/my-collection")),
+        );
 
         insta::assert_json_snapshot!(cfg);
     }

--- a/crates/flowctl/src/preview/journal_reader.rs
+++ b/crates/flowctl/src/preview/journal_reader.rs
@@ -40,8 +40,12 @@ impl Reader {
         let reader = coroutines::try_coroutine(move |mut co| async move {
             // Concurrently fetch authorizations for all sourced collections.
             let sources = futures::future::try_join_all(sources.iter().map(|source| {
-                flow_client::fetch_user_collection_authorization(&self.client, &source.collection)
-                    .map_ok(move |(_journal_name_prefix, client)| (source, client))
+                flow_client::fetch_user_collection_authorization(
+                    &self.client,
+                    &source.collection,
+                    false,
+                )
+                .map_ok(move |(_journal_name_prefix, client)| (source, client))
             }))
             .await?;
 


### PR DESCRIPTION
**Description:**

- `flowctl raw gazctl-env` now offers a --name alternative, which looks up the data-plane
- add `flowctl collections split-journals` for splitting the journals of a collection
- lock down user authorization admin requests to estuary_support/ staff

We can make split-journals self-service if we add a a control plane API which ensures (for example) users aren't creating 100k journals.

This requires corresponding gazette PR: https://github.com/gazette/core/pull/434

**Workflow steps:**

* Use new flowctl commands

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2221)
<!-- Reviewable:end -->
