### PR TITLE
dpc: strip gcpkms:// from encryption

### DIFF
--- a/crates/data-plane-controller/src/controller.rs
+++ b/crates/data-plane-controller/src/controller.rs
@@ -1009,7 +1009,7 @@ async fn encrypt_hmac_keys(kms_key: &str, keys: Vec<String>) -> anyhow::Result<s
         async_process::Command::new(sops).args([
             "--encrypt",
             "--gcp-kms",
-            kms_key,
+            kms_key.strip_prefix("gcpkms://").unwrap(),
             "--input-type",
             "json",
             "--output-type",


### PR DESCRIPTION
**Description:**

- I missed this part during testing as I added it last, the gcpkms:// passed to data-plane-controller's prefix should not be included to work with sops

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2225)
<!-- Reviewable:end -->
