### PR TITLE
Docs: Explicitly trigger backfill for xmin backfill

### DIFF
--- a/site/docs/reference/backfilling-data.md
+++ b/site/docs/reference/backfilling-data.md
@@ -108,6 +108,8 @@ To configure this option:
 
 4. Fill out the "Minimum Backfill XID" or "Maximum Backfill XID" field with the `xmin` value you retrieved.
 
-5. Save and publish your changes.
+5. Click "Backfill"
+
+6. Save and publish your changes.
 
 In rare cases, this method may not work as expected, as in situations where a database has already filled up its entire `xmin` space. In such cases of `xmin` wrapping, using both Minimum and Maximum Backfill XID fields can help narrow down a specific range to backfill.


### PR DESCRIPTION
Docs: Explicitly mention triggering backfill for xmin backfill, as it's required but not mentioned in the step by step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2227)
<!-- Reviewable:end -->
