### PR TITLE
agent: HMAC encryption fix

### DIFF
--- a/crates/agent/src/api/snapshot.rs
+++ b/crates/agent/src/api/snapshot.rs
@@ -567,6 +567,13 @@ async fn try_fetch(
 
     *decrypted_hmac_keys = data_planes
         .iter()
+        .filter(|dp| {
+            !dp.encrypted_hmac_keys
+                .to_value()
+                .as_object()
+                .unwrap()
+                .is_empty()
+        })
         .map(|dp| (dp.data_plane_name.clone(), dp.hmac_keys.clone()))
         .collect();
 

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -284,24 +284,23 @@ async fn refresh_decrypted_hmac_keys(
     const REFRESH_INTERVAL: chrono::TimeDelta = chrono::TimeDelta::seconds(60);
 
     loop {
-        let mut data_planes: Vec<_> =
-            agent_sql::data_plane::fetch_data_planes(&pg_pool, Vec::new(), "", uuid::Uuid::nil())
-                .await?
-                .into_iter()
-                .filter(|dp| {
-                    !decrypted_hmac_keys
-                        .read()
-                        .unwrap()
-                        .contains_key(&dp.data_plane_name)
-                })
-                .filter(|dp| {
-                    !dp.encrypted_hmac_keys
-                        .to_value()
-                        .as_object()
-                        .unwrap()
-                        .is_empty()
-                })
-                .collect();
+        let mut data_planes: Vec<_> = agent_sql::data_plane::fetch_all_data_planes(&pg_pool)
+            .await?
+            .into_iter()
+            .filter(|dp| {
+                !decrypted_hmac_keys
+                    .read()
+                    .unwrap()
+                    .contains_key(&dp.data_plane_name)
+            })
+            .filter(|dp| {
+                !dp.encrypted_hmac_keys
+                    .to_value()
+                    .as_object()
+                    .unwrap()
+                    .is_empty()
+            })
+            .collect();
 
         futures::future::try_join_all(
             data_planes


### PR DESCRIPTION
**Description:**

- I had updated `fetch_data_planes` so that if no list of data-plane IDs was provided, it would return all data-planes, but I had not realised that there were uses of this function in some parts of the code, notably in `discovers/executor` which did not pass a list of data-plane IDs, but did pass a default data plane name, and they expected a single data-plane to be returned in that case. The change was breaking these scenarios. In my local testings I had only tested with a single test data-plane so this was not caught. I reverted `fetch_data_planes` to its original and instead added a new function for fetching all data planes
- While looking for this bug, I noticed the cache for `decrypted_hmac_keys` would be populated by non-encrypted values as well, so I update the code there to maintain the cache as only actually-decrypted values

Tested by reproducing the issue locally (which required having more than a single data-plane row) and then seeing it resolve by applying this patch

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2228)
<!-- Reviewable:end -->
