### PR TITLE
docs: fix SSH command extra backslash

### DIFF
--- a/site/docs/guides/connect-network.md
+++ b/site/docs/guides/connect-network.md
@@ -191,11 +191,11 @@ Assuming you have a database running on a host named `db.example.com`, on port 5
 
 
 ```bash
-ssh -o 'ConnectTimeout=5s' \\
-    -o 'ServerAliveInterval=30' \\
-    -i bastion.key \\
-    -N -T \\
-    -R 8080:db.example.com:5678 \\
+ssh -o 'ConnectTimeout=5s' \
+    -o 'ServerAliveInterval=30' \
+    -i bastion.key \
+    -N -T \
+    -R 8080:db.example.com:5678 \
     ssh://tunnel@bastion.your-bastion-host.com:2222
 ```
 


### PR DESCRIPTION
**Description:**

minor issue I noticed

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2230)
<!-- Reviewable:end -->
