### PR TITLE
field selection tweaks & fix local stacks

### DIFF
--- a/crates/agent/src/api/create_data_plane.rs
+++ b/crates/agent/src/api/create_data_plane.rs
@@ -27,7 +27,7 @@ pub struct Manual {
     /// HMAC keys of the data-plane.
     hmac_keys: Vec<String>,
     /// HMAC keys of the data-plane in encrypted sops format
-    encrypted_hmac_keys: serde_json::Value,
+    encrypted_hmac_keys: models::RawValue,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema, Validate)]
@@ -119,7 +119,7 @@ pub async fn create_data_plane(
             format!("https://gazette.{data_plane_fqdn}"),
             format!("https://reactor.{data_plane_fqdn}"),
             Vec::new(),
-            serde_json::json!({}),
+            models::RawValue::from_string("{}".to_string()).unwrap(),
         ),
         Category::Manual(Manual {
             broker_address,
@@ -179,7 +179,7 @@ pub async fn create_data_plane(
             -- Don't replace non-empty hmac_keys with empty ones.
             hmac_keys = case when array_length($13, 1) > 0 then $13
                         else data_planes.hmac_keys end,
-            encrypted_hmac_keys = case when length($14::text) > 2 then $14::json
+            encrypted_hmac_keys = case when length($14::text) > 2 then $14
                         else data_planes.encrypted_hmac_keys end
         returning logs_token
         ;
@@ -197,7 +197,7 @@ pub async fn create_data_plane(
         broker_address,
         reactor_address,
         &hmac_keys,
-        encrypted_hmac_keys,
+        serde_json::to_value(encrypted_hmac_keys).unwrap(),
         !hmac_keys.is_empty(), // Enable L2 if HMAC keys are defined at creation.
         pulumi_stack,
     )

--- a/crates/validation/src/field_selection.fixture.yaml
+++ b/crates/validation/src/field_selection.fixture.yaml
@@ -138,7 +138,7 @@ collection:
               strategy: merge
       - $ref: "#MyTable"
 model:
-  recommended: true
+  recommended: 100
   groupBy: [an_int, a_bool]
   require:
     nested: { cfg: 42 }

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -308,7 +308,8 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
         let bindings: Vec<flow::materialization_spec::Binding> = mock
             .bindings
             .iter()
-            .map(|binding| flow::materialization_spec::Binding {
+            .enumerate()
+            .map(|(index, binding)| flow::materialization_spec::Binding {
                 collection: Some(flow::CollectionSpec {
                     name: binding.source.collection().to_string(),
                     partition_template: Some(proto_gazette::broker::JournalSpec {
@@ -319,6 +320,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
                 }),
                 resource_path: validation::load_resource_meta_path(binding.resource.get()),
                 backfill: binding.backfill,
+                field_selection: mock.last_fields.get(index).cloned(),
                 ..Default::default()
             })
             .collect();
@@ -486,6 +488,8 @@ struct MockLiveMaterialization {
     last_build_id: Option<models::Id>,
     #[serde(default)]
     bindings: Vec<models::MaterializationBinding>,
+    #[serde(default)]
+    last_fields: Vec<flow::FieldSelection>,
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
+++ b/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
@@ -1,0 +1,79 @@
+---
+source: crates/validation/tests/transition_tests.rs
+expression: "(&outcome.built_materializations[0].model,\n&outcome.built_materializations[0].model_fixes)"
+---
+(
+    Some(
+        MaterializationDef {
+            source: None,
+            on_incompatible_schema_change: Backfill,
+            endpoint: Connector(
+                ConnectorConfig {
+                    image: "other/image",
+                    config: RawValue(
+                        {"a":"config"},
+                    ),
+                },
+            ),
+            bindings: [
+                MaterializationBinding {
+                    resource: RawValue(
+                        {"_meta":{"path":["table","path"]},"table":"bar"},
+                    ),
+                    source: Collection(
+                        Collection(
+                            "the/collection",
+                        ),
+                    ),
+                    disable: false,
+                    priority: 0,
+                    fields: MaterializationFields {
+                        group_by: [
+                            Field(
+                                "F1",
+                            ),
+                        ],
+                        require: {
+                            Field(
+                                "F1",
+                            ): RawValue(
+                                {},
+                            ),
+                            Field(
+                                "f_two",
+                            ): RawValue(
+                                {},
+                            ),
+                        },
+                        exclude: [
+                            Field(
+                                "F2",
+                            ),
+                        ],
+                        recommended: Bool(
+                            true,
+                        ),
+                    },
+                    backfill: 0,
+                    on_incompatible_schema_change: None,
+                },
+            ],
+            shards: ShardTemplate {
+                disable: false,
+                min_txn_duration: None,
+                max_txn_duration: None,
+                hot_standbys: None,
+                ring_buffer_size: None,
+                read_channel_size: None,
+                log_level: None,
+            },
+            expect_pub_id: None,
+            delete: false,
+        },
+    ),
+    [
+        "added groupBy for migrated non-canonical key",
+        "removed dropped exclude projection FY of source collection the/collection",
+        "removed dropped exclude projection does/not/exist of source collection the/collection",
+    ],
+)

--- a/crates/validation/tests/transition_tests.rs
+++ b/crates/validation/tests/transition_tests.rs
@@ -531,3 +531,21 @@ driver:
     );
     insta::assert_debug_snapshot!(errors);
 }
+
+#[test]
+fn test_group_by_migration() {
+    let outcome = common::run(
+        MODEL_YAML,
+        r#"
+driver:
+  liveMaterializations:
+    the/materialization:
+      lastFields:
+        - keys: [F1] # Not f_one, which is canonical.
+    "#,
+    );
+    insta::assert_debug_snapshot!((
+        &outcome.built_materializations[0].model,
+        &outcome.built_materializations[0].model_fixes
+    ));
+}


### PR DESCRIPTION
**Description:**

* When `recommended: true`, don't select object leaves to maintain legacy selection behavior in this case
* Add temporary migration handling to populate `groupBy` clause when the current key is non-canonical.
* Streamline encrypted HMAC key handling for "manual" (local) data-planes.

Tested on a local stack by creating two collections, one with a projection of the collection key, the other without.
I confirmed that we added a `groupBy` to only the intended collection, and that thereafter the field selection logging output no differences.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2231)
<!-- Reviewable:end -->
