### PR TITLE
docs: source-shopify-native another permission

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/shopify-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/shopify-native.md
@@ -51,6 +51,7 @@ If authenticating with an access token, ensure the following permissions are gra
 * `read_inventory`
 * `read_locales`
 * `read_locations`
+* `read_marketing_events`
 * `read_marketplace_fulfillment_orders`
 * `read_merchant_managed_fulfillment_orders`
 * `read_orders`


### PR DESCRIPTION
**Description:**

Another scope needs included when users authenticate with an access token - this time it's `read_marketing_events` so we can read `orders.customerJourneySummary.firstVisit.marketingEvent`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

