### PR TITLE
data-plane-controller: add resource_type to AzurePrivateLink

### DIFF
--- a/crates/data-plane-controller/src/data_plane_fixture.json
+++ b/crates/data-plane-controller/src/data_plane_fixture.json
@@ -29,7 +29,8 @@
     "private_links": [
       {
         "service_name": "service",
-        "location": "eastus"
+        "location": "eastus",
+        "resource_type": "managedInstance"
       }
     ],
     "azure_byoc": {

--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -152,6 +152,7 @@ pub struct AWSPrivateLink {
 pub struct AzurePrivateLink {
     pub service_name: String,
     pub location: String,
+    pub resource_type: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -523,6 +524,7 @@ mod test {
             PrivateLink::Azure(AzurePrivateLink {
                 location: "eastus".to_string(),
                 service_name: "service".to_string(),
+                resource_type: "managedInstance".to_string(),
             }),
         );
         assert_eq!(


### PR DESCRIPTION
**Description:**

- Plumb through Azure private link `resource_type` https://github.com/estuary/est-dry-dock/pull/137

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

