### PR TITLE
data-plane-controller: resource_type is optional

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -152,6 +152,7 @@ pub struct AWSPrivateLink {
 pub struct AzurePrivateLink {
     pub service_name: String,
     pub location: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub resource_type: String,
 }
 


### PR DESCRIPTION
**Description:**

This was causing an error because the `config` would not have `resource_type` yet... while `private_links` would have it. Tested it locally by reproducing the error and then fixing it with the patch.

The error was:
```
failed to fetch data-plane row
Caused by:
 0: error occurred while decoding column 1: data did not match any variant of untagged enum PrivateLink at line 1 column 1178
    1: data did not match any variant of untagged enum PrivateLink at line 1 column 1178
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

