### PR TITLE
Remove unmaintained wee_alloc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,6 @@ dependencies = [
  "validation",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "wee_alloc",
 ]
 
 [[package]]
@@ -4528,12 +4527,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "metrics"
@@ -8595,18 +8588,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,10 +212,6 @@ validator = { version = "0.15", features = ["derive"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 wasm-bindgen = "0.2.100"
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however. It is an optional dependency for WASM modules.
-wee_alloc = { version = "0.4" }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 yaml-merge-keys = { version = "0.5", features = ["serde_yaml"] }
 zip = "0.5"

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -49,9 +49,6 @@ serde-wasm-bindgen = { workspace = true }
 # `console_error_panic_hook` pulls in the Rust panic machinery to cause any panics to get
 # logged using `console.error`. It is enabled by default.
 console_error_panic_hook = { workspace = true, optional = true }
-# This is a smaller (in terms of compiled code size) allocator that we _might_
-# try to use to keep the WASM module small. It is disabled by default.
-wee_alloc = { workspace = true, optional = true }
 
 # this is not a workspace dependency because it's only a transitive dependency, and it's only included here
 # because we need to enable the "js" feature when building for wasm

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -13,11 +13,6 @@ pub mod collection;
 pub mod field_selection;
 mod utils;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
 extern "C" {


### PR DESCRIPTION
Switch flow-web crate from wee_alloc to Rust's default allocator for wasm32 targets. The wee_alloc crate is unmaintained and the default allocator now provides better performance and maintenance.

Changes:
- Remove wee_alloc dependency from workspace Cargo.toml
- Remove wee_alloc feature from flow-web/Cargo.toml
- Remove wee_alloc global allocator setup from flow-web/src/lib.rs

🤖 Generated with [Claude Code](https://claude.ai/code)

