### PR TITLE
Disable user tracking on AI widget in docs

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -69,6 +69,7 @@ const config = {
       "data-modal-disclaimer": "This AI assistant answers questions using Estuary's [documentation](https://docs.estuary.dev/), [blogs](https://estuary.dev/blog/), and additional resources. If you can't find your answer, join us on [Slack](https://go.estuary.dev/slack).",
       "data-modal-example-questions": "How does CDC work in Estuary?,How can I deploy to a private cloud?,How do I connect to PostgreSQL?,Is Estuary Flow scalable?",
       "data-uncertain-answer-callout": "I may not have all of the information on that topic. I bet someone can answer it in [Slack](https://go.estuary.dev/slack).",
+      "data-user-analytics-cookie-enabled": false,
     },
   ],
 


### PR DESCRIPTION
**Description:**

By default, Kapa now tracks users anonymously. This update explicitly [disables this feature](https://docs.kapa.ai/integrations/website-widget/user-tracking#disabling-user-tracking).

Closes #2246 

**Notes for reviewers:**

Thanks for reviewing!
