### PR TITLE
models: update interval schema to allow units in days

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -288,7 +288,7 @@ impl ModelDef for AnySpec {
 fn duration_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
     serde_json::from_value(serde_json::json!({
         "type": ["string", "null"],
-        "pattern": "^\\d+(s|m|h)$"
+        "pattern": "^\\d+(s|m|h|d)$"
     }))
     .unwrap()
 }

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -266,7 +266,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "shards": {
           "title": "Template for shards of this capture task.",
@@ -657,7 +657,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "length": {
           "title": "Desired content length of each fragment, in megabytes before compression.",
@@ -674,7 +674,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         }
       },
       "additionalProperties": false
@@ -1178,7 +1178,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "minTxnDuration": {
           "title": "Minimum duration of task transactions.",
@@ -1187,7 +1187,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "readChannelSize": {
           "title": "Size of the reader channel used for decoded documents.",
@@ -1620,7 +1620,7 @@ expression: "&schema"
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "shuffle": {
           "title": "Shuffle by which source documents are mapped to processing shards.",

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -262,7 +262,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "shards": {
           "title": "Template for shards of this capture task.",
@@ -653,7 +653,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "length": {
           "title": "Desired content length of each fragment, in megabytes before compression.",
@@ -670,7 +670,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         }
       },
       "additionalProperties": false
@@ -1174,7 +1174,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "minTxnDuration": {
           "title": "Minimum duration of task transactions.",
@@ -1183,7 +1183,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "readChannelSize": {
           "title": "Size of the reader channel used for decoded documents.",
@@ -1616,7 +1616,7 @@
             "string",
             "null"
           ],
-          "pattern": "^\\d+(s|m|h)$"
+          "pattern": "^\\d+(s|m|h|d)$"
         },
         "shuffle": {
           "title": "Shuffle by which source documents are mapped to processing shards.",


### PR DESCRIPTION
Our current serialization behavior is such that if a user provides a spec with an interval of `24h`, we will serialize it as `1d`. This updates the schema to permit units in days, because currently this causes a validation error in the UI. I'm kicking the can on whether to add months.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2254)
<!-- Reviewable:end -->
