### PR TITLE
network: add HSTS header to frontend HTTP responses

### DIFF
--- a/go/network/frontend.go
+++ b/go/network/frontend.go
@@ -393,6 +393,9 @@ func (p *Frontend) serveConnHTTP(user *frontendConn) {
 	var handle = func(w http.ResponseWriter, req *http.Request) {
 		httpStartedCounter.WithLabelValues(task, port, req.Method).Inc()
 
+		// Add HSTS header for all HTTPS responses
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+
 		if user.resolved.portIsPublic {
 			reverse.ServeHTTP(w, req)
 		} else if req.URL.Path == "/auth-redirect" {

--- a/go/network/frontend.go
+++ b/go/network/frontend.go
@@ -23,6 +23,13 @@ import (
 	pc "go.gazette.dev/core/consumer/protocol"
 )
 
+// hstsHeaderValue instructs clients to only ever reach us over HTTPS.
+// We emit it on every HTTPS response, including the best-effort error
+// responses of serveConnErr: a security scanner connecting to the raw
+// address (no matching SNI) is served an error and would otherwise see
+// no HSTS header at all.
+const hstsHeaderValue = "max-age=31536000; includeSubDomains"
+
 // Frontend accepts connections over its configured Listener,
 // matches on the TLS ServerName (SNI), and either:
 //
@@ -393,8 +400,7 @@ func (p *Frontend) serveConnHTTP(user *frontendConn) {
 	var handle = func(w http.ResponseWriter, req *http.Request) {
 		httpStartedCounter.WithLabelValues(task, port, req.Method).Inc()
 
-		// Add HSTS header for all HTTPS responses
-		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		w.Header().Set("Strict-Transport-Security", hstsHeaderValue)
 
 		if user.resolved.portIsPublic {
 			reverse.ServeHTTP(w, req)
@@ -439,9 +445,13 @@ func (f *Frontend) serveConnErr(conn net.Conn, status int, body string) {
 	// We're terminating this connection and sending a best-effort error.
 	// We don't know what the client is, or even if they speak HTTP,
 	// but we do only offer `http/1.1` during ALPN under an error condition.
+	// Emit HSTS on error responses too. Clients that reach us over a raw
+	// address without a matching SNI are served here rather than through
+	// the HTTP handler, and must still be told to prefer HTTPS.
 	var resp, _ = httputil.DumpResponse(&http.Response{
 		ProtoMajor: 1, ProtoMinor: 1,
 		StatusCode: status,
+		Header:     http.Header{"Strict-Transport-Security": []string{hstsHeaderValue}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Close:      true,
 	}, true)

--- a/go/network/frontend_test.go
+++ b/go/network/frontend_test.go
@@ -1,0 +1,119 @@
+package network
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestFrontendHTTPSHeaders(t *testing.T) {
+	// Create a test handler that mimics the frontend's HTTP handler
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		// Add HSTS header for all HTTPS responses (same as in frontend.go)
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		
+		// Simulate a simple response
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}
+
+	// Create a test server with TLS
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	// Create HTTP client that accepts the test server's certificate
+	client := server.Client()
+
+	// Make a request to the test server
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check that HSTS header is present and correct
+	hstsHeader := resp.Header.Get("Strict-Transport-Security")
+	expectedHSTS := "max-age=31536000; includeSubDomains"
+	
+	if hstsHeader != expectedHSTS {
+		t.Errorf("Expected HSTS header %q, got %q", expectedHSTS, hstsHeader)
+	}
+}
+
+func TestFrontendHTTPSHeadersAllPaths(t *testing.T) {
+	// Test that HSTS headers are set for different response paths
+	testCases := []struct {
+		name     string
+		path     string
+		expected int
+	}{
+		{"root path", "/", http.StatusOK},
+		{"auth redirect path", "/auth-redirect", http.StatusOK},
+		{"other path", "/some/path", http.StatusOK},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test handler that sets HSTS for all responses
+			handler := func(w http.ResponseWriter, req *http.Request) {
+				// Add HSTS header for all HTTPS responses
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+				
+				// Simple response for all paths
+				w.WriteHeader(tc.expected)
+				w.Write([]byte("OK"))
+			}
+
+			// Create recorder to capture response
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", tc.path, nil)
+
+			// Call handler
+			handler(recorder, request)
+
+			// Check HSTS header is present
+			hstsHeader := recorder.Header().Get("Strict-Transport-Security")
+			expectedHSTS := "max-age=31536000; includeSubDomains"
+			
+			if hstsHeader != expectedHSTS {
+				t.Errorf("Path %s: Expected HSTS header %q, got %q", tc.path, expectedHSTS, hstsHeader)
+			}
+
+			// Check status code
+			if recorder.Code != tc.expected {
+				t.Errorf("Path %s: Expected status %d, got %d", tc.path, tc.expected, recorder.Code)
+			}
+		})
+	}
+}
+
+func TestFrontendStructCreation(t *testing.T) {
+	// Test that we can create a Frontend struct with minimal dependencies
+	controlAPI, _ := url.Parse("http://localhost:8080")
+	dashboard, _ := url.Parse("http://localhost:3000")
+	
+	// Create a minimal tap (we can't easily test the full Frontend without extensive mocking)
+	tap := &Tap{}
+	
+	// This will fail due to missing raw listener, but tests struct creation
+	_, err := NewFrontend(
+		tap,
+		"test.example.com",
+		controlAPI,
+		dashboard,
+		nil, // networkClient
+		nil, // shardClient  
+		nil, // verifier
+	)
+	
+	// We expect this to fail with the specific error about missing raw listener
+	if err == nil {
+		t.Error("Expected error for missing raw listener")
+	}
+	
+	expectedErr := "Tap has not tapped a raw net.Listener"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error %q, got %q", expectedErr, err.Error())
+	}
+}

--- a/go/network/frontend_test.go
+++ b/go/network/frontend_test.go
@@ -1,119 +1,42 @@
 package network
 
 import (
+	"bufio"
+	"io"
+	"net"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 )
 
-func TestFrontendHTTPSHeaders(t *testing.T) {
-	// Create a test handler that mimics the frontend's HTTP handler
-	handler := func(w http.ResponseWriter, req *http.Request) {
-		// Add HSTS header for all HTTPS responses (same as in frontend.go)
-		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-		
-		// Simulate a simple response
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	}
+// serveConnErr is the best-effort error path taken by connections that never
+// reach the HTTP handler: a raw-address probe with no matching SNI (exactly
+// what a security scanner hits) is answered here, not through serveConnHTTP.
+// These responses must still carry the HSTS header, so exercise the real
+// method and parse the bytes it writes to the connection.
+func TestServeConnErrSetsHSTS(t *testing.T) {
+	// The 404 (no matching SNI) and 503 (shard dial failure) paths are served
+	// over TLS; 421 is served over the raw connection. All flow through here.
+	for _, status := range []int{http.StatusNotFound, http.StatusServiceUnavailable, http.StatusMisdirectedRequest} {
+		var server, client = net.Pipe()
 
-	// Create a test server with TLS
-	server := httptest.NewTLSServer(http.HandlerFunc(handler))
-	defer server.Close()
+		go (&Frontend{}).serveConnErr(server, status, "an error occurred\n")
 
-	// Create HTTP client that accepts the test server's certificate
-	client := server.Client()
+		var resp, err = http.ReadResponse(bufio.NewReader(client), nil)
+		if err != nil {
+			t.Fatalf("status %d: reading response: %v", status, err)
+		}
+		// Drain the body so serveConnErr's Write completes and it closes `server`.
+		var body, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
 
-	// Make a request to the test server
-	resp, err := client.Get(server.URL)
-	if err != nil {
-		t.Fatalf("Failed to make request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Check that HSTS header is present and correct
-	hstsHeader := resp.Header.Get("Strict-Transport-Security")
-	expectedHSTS := "max-age=31536000; includeSubDomains"
-	
-	if hstsHeader != expectedHSTS {
-		t.Errorf("Expected HSTS header %q, got %q", expectedHSTS, hstsHeader)
-	}
-}
-
-func TestFrontendHTTPSHeadersAllPaths(t *testing.T) {
-	// Test that HSTS headers are set for different response paths
-	testCases := []struct {
-		name     string
-		path     string
-		expected int
-	}{
-		{"root path", "/", http.StatusOK},
-		{"auth redirect path", "/auth-redirect", http.StatusOK},
-		{"other path", "/some/path", http.StatusOK},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create a test handler that sets HSTS for all responses
-			handler := func(w http.ResponseWriter, req *http.Request) {
-				// Add HSTS header for all HTTPS responses
-				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-				
-				// Simple response for all paths
-				w.WriteHeader(tc.expected)
-				w.Write([]byte("OK"))
-			}
-
-			// Create recorder to capture response
-			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest("GET", tc.path, nil)
-
-			// Call handler
-			handler(recorder, request)
-
-			// Check HSTS header is present
-			hstsHeader := recorder.Header().Get("Strict-Transport-Security")
-			expectedHSTS := "max-age=31536000; includeSubDomains"
-			
-			if hstsHeader != expectedHSTS {
-				t.Errorf("Path %s: Expected HSTS header %q, got %q", tc.path, expectedHSTS, hstsHeader)
-			}
-
-			// Check status code
-			if recorder.Code != tc.expected {
-				t.Errorf("Path %s: Expected status %d, got %d", tc.path, tc.expected, recorder.Code)
-			}
-		})
-	}
-}
-
-func TestFrontendStructCreation(t *testing.T) {
-	// Test that we can create a Frontend struct with minimal dependencies
-	controlAPI, _ := url.Parse("http://localhost:8080")
-	dashboard, _ := url.Parse("http://localhost:3000")
-	
-	// Create a minimal tap (we can't easily test the full Frontend without extensive mocking)
-	tap := &Tap{}
-	
-	// This will fail due to missing raw listener, but tests struct creation
-	_, err := NewFrontend(
-		tap,
-		"test.example.com",
-		controlAPI,
-		dashboard,
-		nil, // networkClient
-		nil, // shardClient  
-		nil, // verifier
-	)
-	
-	// We expect this to fail with the specific error about missing raw listener
-	if err == nil {
-		t.Error("Expected error for missing raw listener")
-	}
-	
-	expectedErr := "Tap has not tapped a raw net.Listener"
-	if err.Error() != expectedErr {
-		t.Errorf("Expected error %q, got %q", expectedErr, err.Error())
+		if got := resp.Header.Get("Strict-Transport-Security"); got != hstsHeaderValue {
+			t.Errorf("status %d: HSTS header = %q, want %q", status, got, hstsHeaderValue)
+		}
+		if resp.StatusCode != status {
+			t.Errorf("status code = %d, want %d", resp.StatusCode, status)
+		}
+		if string(body) != "an error occurred\n" {
+			t.Errorf("status %d: body = %q, want the error text", status, body)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
• Add Strict-Transport-Security header to all HTTPS responses from the frontend
• Improves security by preventing protocol downgrade attacks
• Header includes includeSubDomains directive for comprehensive protection

## Test plan
- [x] Verify HSTS header is present in HTTP responses
- [x] Confirm no impact on existing functionality



Closes https://github.com/estuary/security/issues/382


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2262)
<!-- Reviewable:end -->
