### PR TITLE
runtime: add tunable schema complexity limits and `x-initial-read-schema`

### DIFF
--- a/crates/doc/src/shape/mod.rs
+++ b/crates/doc/src/shape/mod.rs
@@ -236,6 +236,20 @@ fn impute_property_shape(
     }
 }
 
+/// X_INFER_SCHEMA is a JSON-Schema annotation optionally added to binding schemas
+/// emitted by connectors during discovery. If present, it will be union'd with the
+/// collection's inferred schema ref to form the discovered collection's read schema.
+pub const X_INFER_SCHEMA: &str = "x-infer-schema";
+
+/// X_INITIAL_READ_SCHEMA is a JSON-Schema annotation optionally added to binding schemas
+/// emitted by connectors during discovery. If present, it will be used as the
+/// collection's initial read schema.
+pub const X_INITIAL_READ_SCHEMA: &str = "x-initial-read-schema";
+
+/// X_COMPLEXITY_LIMIT is a JSON-Schema annotation added to emitted inferred schemas that
+/// allows for the modification of the default complexity limit applied to inferred schemas.
+pub const X_COMPLEXITY_LIMIT: &str = "x-complexity-limit";
+
 #[cfg(test)]
 // Map a JSON schema, in YAML form, into a Shape.
 fn shape_from(schema_yaml: &str) -> Shape {

--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -1,5 +1,6 @@
 use super::{indexed, schema, storage_mapping, walk_transition, Error, Scope};
-use json::schema::types;
+use doc::shape::X_INITIAL_READ_SCHEMA;
+use json::schema::{types, Keyword};
 use proto_flow::flow;
 use std::collections::BTreeMap;
 use tables::EitherOrBoth as EOB;


### PR DESCRIPTION
**Description:**

* Add `x-initial-read-schema` annotation for connector-specified initial read schemas
  * `x-inferred-schema: true` will continue to work
* Implement dynamic complexity limits: for the moment just bump the cap to 10k for SourcedSchema bindings, leaving it at 1k for all others
* Thread complexity limits through `jsonSchemaMerge` reduction annotation via `x-complexity-limit`

### Testing:
* ✅ Capture from connector using SourcedSchema (`source-postgres`) emits `x-complexity-limit: 10000`
![Screenshot 2025-07-08 at 15 22 04](https://github.com/user-attachments/assets/41787468-e937-452d-bb03-4b4b03684bf6)
* ✅ Capture from connector **not** using SourcedSchema (`source-hello-world`) emits `x-complexity-limit: 1000`
![Screenshot 2025-07-08 at 15 25 57](https://github.com/user-attachments/assets/382e8358-8539-43b1-96a0-4fb226a9b1ee)
* ✅ `x-complexity-limit` is respected by the reducer https://github.com/estuary/flow/blob/c5cd44b5da79a085bff0693d09b6cc75b3cdeccd/crates/doc/src/reduce/strategy.rs#L1304-L1335
* ✅ `x-initial-read-schema` emitted by a connector during discover gets set as the read schema of the collection
https://github.com/estuary/flow/blob/c5cd44b5da79a085bff0693d09b6cc75b3cdeccd/crates/agent/src/discovers/specs.rs#L736-L748

Closes https://github.com/estuary/flow/issues/2229

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2263)
<!-- Reviewable:end -->
