### PR TITLE
migrate: improve error instrumentation and reduce concurrency

### DIFF
--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -57,7 +57,7 @@ pub struct RetryError {
 impl Error {
     pub fn with_attempt(self, attempt: usize) -> RetryError {
         RetryError {
-            attempt: attempt,
+            attempt,
             inner: self,
         }
     }
@@ -75,6 +75,18 @@ impl Error {
                 tonic::Code::Unavailable => true,
                 tonic::Code::Cancelled => true,
                 tonic::Code::Aborted => true,
+
+                // Broken transports are Unknown with specific messages.
+                tonic::Code::Unknown
+                    if matches!(
+                        status.message(),
+                        "h2 protocol error: error reading a body from connection"
+                            | "transport error"
+                    ) =>
+                {
+                    true
+                }
+
                 _ => false, // Others are not.
             },
 


### PR DESCRIPTION
`migrate` was using FuturesUnordered, which meant that all gRPC requests were essentially dispatched simultaneously. We observed repeating transport errors (reset TCP connections), and the suspicion is that we were triggering load shedding of the Go gRPC internals when migrating larger tenants with lots of requests.

Improve various `migrate` error contexts.

Also refine a few Gazette client APIs.

Tested on a local stack with an absurdly large fixture of ~50 captures and ~2k collections, which brought my dev machine to its knees. Even with that I wasn't able to replicate the TCP resets observed in production, but I did find some other edges to smooth.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2268)
<!-- Reviewable:end -->
