### PR TITLE
agent: tweaks some logging for controllers

### DIFF
--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -259,8 +259,6 @@ pub async fn update_activation<C: ControlPlane>(
 
     if should_resolve_alert(state, &*status, now) {
         alerts::resolve_alert(alerts_status, AlertType::ShardFailed);
-    } else {
-        tracing::warn!("NOT RESOLVING ALERT");
     }
     Ok(next_status_check)
 }


### PR DESCRIPTION
- Removes a spammy warning that had gotten left in by mistake
- Log final deletions at info level so they're visible in grafana
- log task_id to aid in debugging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2273)
<!-- Reviewable:end -->
