### PR TITLE
Dekaf redirects/migration support

### DIFF
--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -56,6 +56,7 @@ postgrest = { workspace = true }
 prometheus = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true }
 rsasl = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
@@ -94,7 +95,6 @@ locate-bin = { path = "../locate-bin" }
 apache-avro = { workspace = true }
 insta = { workspace = true }
 rdkafka = { workspace = true }
-reqwest = { workspace = true }
 schema_registry_converter = { workspace = true }
 tempfile = { workspace = true }
 tracing-test = { workspace = true }

--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -36,8 +36,10 @@ use aes_siv::{aead::Aead, Aes256SivAead, KeyInit, KeySizeUser};
 use flow_client::client::{refresh_authorizations, RefreshToken};
 use log_appender::SESSION_CLIENT_ID_FIELD_MARKER;
 use percent_encoding::{percent_decode_str, utf8_percent_encode};
+use proto_flow::flow::MaterializationSpec;
 use serde::{Deserialize, Serialize};
 use std::{
+    any,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -69,6 +71,7 @@ pub struct DeprecatedConfigOptions {
     pub deletions: connector::DeletionMode,
 }
 
+#[derive(Clone)]
 pub struct UserAuth {
     client: flow_client::Client,
     refresh_token: RefreshToken,
@@ -77,6 +80,7 @@ pub struct UserAuth {
     config: DeprecatedConfigOptions,
 }
 
+#[derive(Clone)]
 pub struct TaskAuth {
     client: flow_client::Client,
     task_name: String,
@@ -87,9 +91,16 @@ pub struct TaskAuth {
     exp: time::OffsetDateTime,
 }
 
+#[derive(Clone)]
 pub enum SessionAuthentication {
     User(UserAuth),
     Task(TaskAuth),
+    Redirect {
+        target_dataplane_fqdn: String,
+        spec: MaterializationSpec,
+        config: connector::DekafConfig,
+        task_state_listener: task_manager::TaskStateListener,
+    },
 }
 
 impl SessionAuthentication {
@@ -99,6 +110,10 @@ impl SessionAuthentication {
                 std::time::UNIX_EPOCH + std::time::Duration::new(user.claims.exp, 0)
             }
             SessionAuthentication::Task(task) => task.exp.into(),
+            SessionAuthentication::Redirect { .. } => {
+                // Redirects are valid for a short duration
+                SystemTime::now() + std::time::Duration::from_secs(60 * 5)
+            }
         }
     }
 
@@ -106,6 +121,9 @@ impl SessionAuthentication {
         match self {
             SessionAuthentication::User(auth) => auth.authenticated_client().await,
             SessionAuthentication::Task(auth) => auth.authenticated_client().await,
+            SessionAuthentication::Redirect { .. } => {
+                anyhow::bail!("Cannot get flow client for redirected task")
+            }
         }
     }
 
@@ -117,6 +135,9 @@ impl SessionAuthentication {
             SessionAuthentication::Task(auth) => {
                 auth.client = auth.client.clone().with_fresh_gazette_client();
             }
+            SessionAuthentication::Redirect { .. } => {
+                unreachable!("This session is a redirect and cannot communicate with Gazette");
+            }
         }
     }
 
@@ -124,6 +145,7 @@ impl SessionAuthentication {
         match self {
             SessionAuthentication::User(user_auth) => user_auth.config.deletions,
             SessionAuthentication::Task(task_auth) => task_auth.config.deletions,
+            SessionAuthentication::Redirect { config, .. } => config.deletions,
         }
     }
 }
@@ -170,22 +192,60 @@ impl TaskAuth {
     }
     pub async fn authenticated_client(&mut self) -> anyhow::Result<&flow_client::Client> {
         if (self.exp - time::OffsetDateTime::now_utc()).whole_seconds() < 60 {
-            let TaskState {
-                access_token: token,
-                access_token_claims: claims,
-                ..
-            } = self.task_state_listener.get().await?;
-
-            self.client = self
-                .client
-                .clone()
-                .with_user_access_token(Some(token))
-                .with_fresh_gazette_client();
-            self.exp =
-                time::OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(claims.exp as i64);
+            match self.task_state_listener.get().await? {
+                TaskState::Authorized {
+                    access_token: token,
+                    access_token_claims: claims,
+                    ..
+                } => {
+                    self.client = self
+                        .client
+                        .clone()
+                        .with_user_access_token(Some(token))
+                        .with_fresh_gazette_client();
+                    self.exp = time::OffsetDateTime::UNIX_EPOCH
+                        + time::Duration::seconds(claims.exp as i64);
+                }
+                TaskState::Redirect { .. } => {
+                    anyhow::bail!("Task was just moved to a different dataplane, consumer must reconnect to get redirected");
+                }
+            }
         }
 
         Ok(&self.client)
+    }
+
+    pub async fn fetch_all_collection_names(&self) -> anyhow::Result<Vec<String>> {
+        let task_state = self
+            .task_state_listener
+            .get()
+            .await
+            .context("failed to fetch task spec")?;
+
+        let spec = match task_state {
+            TaskState::Authorized { spec, .. } => spec,
+            TaskState::Redirect { spec, .. } => spec,
+        };
+
+        utils::fetch_all_collection_names(&spec)
+    }
+
+    pub async fn get_binding_for_topic(
+        &self,
+        topic_name: &str,
+    ) -> anyhow::Result<Option<proto_flow::flow::materialization_spec::Binding>> {
+        let task_state = self
+            .task_state_listener
+            .get()
+            .await
+            .context("failed to fetch task spec")?;
+
+        let spec = match task_state {
+            TaskState::Authorized { spec, .. } => spec,
+            TaskState::Redirect { spec, .. } => spec,
+        };
+
+        utils::get_binding_for_topic(&spec, topic_name)
     }
 }
 
@@ -220,52 +280,79 @@ impl App {
             let listener = self.task_manager.get_listener(&username);
             // Ask the agent for information about this task, as well as a short-lived
             // control-plane access token authorized to interact with the avro schemas table
-            let TaskState {
-                access_token: token,
-                access_token_claims: claims,
-                spec,
-                ..
-            } = listener.get().await?;
+            match listener.get().await? {
+                TaskState::Authorized {
+                    access_token: token,
+                    access_token_claims: claims,
+                    spec,
+                    ..
+                } => {
+                    // Decrypt this materialization's endpoint config
+                    let config = topology::extract_dekaf_config(&spec).await?;
 
-            // Decrypt this materialization's endpoint config
-            let config = topology::extract_dekaf_config(&spec).await?;
+                    let labels = spec
+                        .shard_template
+                        .as_ref()
+                        .context("missing shard template")?
+                        .labels
+                        .as_ref()
+                        .context("missing shard labels")?;
+                    let labels =
+                        labels::shard::decode_labeling(labels).context("parsing shard labeling")?;
 
-            let labels = spec
-                .shard_template
-                .as_ref()
-                .context("missing shard template")?
-                .labels
-                .as_ref()
-                .context("missing shard labels")?;
-            let labels =
-                labels::shard::decode_labeling(labels).context("parsing shard labeling")?;
+                    // This marks this Session as being associated with the task name contained in `username`.
+                    // We only set this after successfully validating that this task exists and is a Dekaf
+                    // materialization. Otherwise we will either log auth errors attempting to append to
+                    // a journal that doesn't exist, or possibly log confusing errors to a different task's logs entirely.
+                    logging::get_log_forwarder()
+                        .map(|f| f.set_task_name(username.clone(), labels.build.clone()));
 
-            // This marks this Session as being associated with the task name contained in `username`.
-            // We only set this after successfully validating that this task exists and is a Dekaf
-            // materialization. Otherwise we will either log auth errors attempting to append to
-            // a journal that doesn't exist, or possibly log confusing errors to a different task's logs entirely.
-            logging::get_log_forwarder()
-                .map(|f| f.set_task_name(username.clone(), labels.build.clone()));
+                    // 3. Validate that the provided password matches the task's bearer token
+                    if password != config.token {
+                        return Err(DekafError::Authentication(
+                            "Invalid username or password".into(),
+                        ));
+                    }
 
-            // 3. Validate that the provided password matches the task's bearer token
-            if password != config.token {
-                return Err(DekafError::Authentication(
-                    "Invalid username or password".into(),
-                ));
+                    logging::set_log_level(labels.log_level());
+
+                    Ok(SessionAuthentication::Task(TaskAuth::new(
+                        self.client_base
+                            .clone()
+                            .with_user_access_token(Some(token))
+                            .with_fresh_gazette_client(),
+                        username,
+                        config,
+                        listener,
+                        time::OffsetDateTime::UNIX_EPOCH
+                            + time::Duration::seconds(claims.exp as i64),
+                    )))
+                }
+                TaskState::Redirect {
+                    target_dataplane_fqdn,
+                    spec,
+                    ..
+                } => {
+                    // We don't have a dataplane access token when redirecting,
+                    // so we cannot write out any logs. Shutting down the log forwarder
+                    // prevents it from shutting down the session prematurely because
+                    // it can't append any logs.
+                    logging::get_log_forwarder().map(|f| f.shutdown());
+
+                    // Decrypt this materialization's endpoint config
+                    let config = topology::extract_dekaf_config(&spec).await?;
+
+                    // Task has been migrated to a different dataplane.
+                    // Return a redirect authentication that will taint
+                    // the session to cause it to redirected its consumer.
+                    Ok(SessionAuthentication::Redirect {
+                        target_dataplane_fqdn,
+                        spec,
+                        config,
+                        task_state_listener: listener,
+                    })
+                }
             }
-
-            logging::set_log_level(labels.log_level());
-
-            Ok(SessionAuthentication::Task(TaskAuth::new(
-                self.client_base
-                    .clone()
-                    .with_user_access_token(Some(token))
-                    .with_fresh_gazette_client(),
-                username,
-                config,
-                listener,
-                time::OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(claims.exp as i64),
-            )))
         } else if username.contains("{") {
             // Since we don't have a task, we also don't have a logs journal to write to,
             // so we should disable log forwarding for this session.

--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -233,7 +233,7 @@ impl GazetteAppender {
                     target_dataplane_fqdn,
                     ..
                 } => {
-                    anyhow::bail!("Task has been redirected to {}", target_dataplane_fqdn);
+                    unreachable!("Task has been redirected to {}", target_dataplane_fqdn);
                 }
             },
             GazetteAppender::OpsLogs(state) => match state.task_listener.get().await? {
@@ -246,7 +246,7 @@ impl GazetteAppender {
                     target_dataplane_fqdn,
                     ..
                 } => {
-                    anyhow::bail!("Task has been redirected to {}", target_dataplane_fqdn);
+                    unreachable!("Task has been redirected to {}", target_dataplane_fqdn);
                 }
             },
         }

--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -25,7 +25,7 @@ pub fn build_router(app: Arc<App>) -> axum::Router<()> {
         .route("/schemas/ids/:id", get(get_schema_by_id))
         .layer(axum::middleware::from_fn_with_state(
             app.clone(),
-            authenticate_and_redirect,
+            authenticate_and_proxy,
         ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(app);
@@ -176,7 +176,66 @@ where
     }
 }
 
-async fn authenticate_and_redirect(
+async fn proxy_request_to_target(
+    target_dataplane_fqdn: String,
+    uri: axum::http::Uri,
+    auth: headers::Authorization<headers::authorization::Basic>,
+) -> Response {
+    let client = reqwest::Client::new();
+
+    let target_url = format!(
+        "https://dekaf.{}{}",
+        target_dataplane_fqdn,
+        uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/")
+    );
+
+    match client
+        .get(&target_url)
+        .basic_auth(auth.username(), Some(auth.password()))
+        .send()
+        .await
+    {
+        Ok(response) => {
+            let status = response.status();
+            let headers = response.headers().clone();
+
+            match response.bytes().await {
+                Ok(body) => {
+                    let mut response = axum::response::Response::new(axum::body::Body::from(body));
+                    *response.status_mut() = axum::http::StatusCode::from_u16(status.as_u16())
+                        .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+
+                    // Copy relevant headers from the proxied response
+                    for (name, value) in headers.iter() {
+                        if let Ok(header_name) =
+                            axum::http::HeaderName::from_bytes(name.as_str().as_bytes())
+                        {
+                            if let Ok(header_value) =
+                                axum::http::HeaderValue::from_bytes(value.as_bytes())
+                            {
+                                response.headers_mut().insert(header_name, header_value);
+                            }
+                        }
+                    }
+
+                    response
+                }
+                Err(err) => {
+                    let err = format!("Failed to read response body: {err:#?}");
+                    tracing::error!(err, "proxy request failed");
+                    (axum::http::StatusCode::BAD_GATEWAY, err).into_response()
+                }
+            }
+        }
+        Err(err) => {
+            let err = format!("Failed to proxy request to {}: {err:#?}", target_url);
+            tracing::error!(err, "proxy request failed");
+            (axum::http::StatusCode::BAD_GATEWAY, err).into_response()
+        }
+    }
+}
+
+async fn authenticate_and_proxy(
     axum::extract::State(app): axum::extract::State<Arc<App>>,
     axum_extra::TypedHeader(auth): axum_extra::TypedHeader<
         headers::Authorization<headers::authorization::Basic>,
@@ -189,18 +248,7 @@ async fn authenticate_and_redirect(
         Ok(SessionAuthentication::Redirect {
             target_dataplane_fqdn,
             ..
-        }) => {
-            let redirect_url = format!(
-                "https://{}{}",
-                target_dataplane_fqdn,
-                uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/")
-            );
-            (
-                axum::http::StatusCode::TEMPORARY_REDIRECT,
-                [("Location", redirect_url)],
-            )
-                .into_response()
-        }
+        }) => proxy_request_to_target(target_dataplane_fqdn, uri, auth).await,
         Ok(auth) => {
             // Insert the authentication into request extensions so handlers can access it
             req.extensions_mut().insert(auth);

--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -1,6 +1,10 @@
 use super::App;
-use crate::{from_downstream_topic_name, to_downstream_topic_name, SessionAuthentication};
+use crate::{
+    from_downstream_topic_name, to_downstream_topic_name, DekafError, SessionAuthentication,
+};
 use anyhow::Context;
+use axum::extract::Request;
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum_extra::headers;
 use itertools::Itertools;
@@ -19,6 +23,10 @@ pub fn build_router(app: Arc<App>) -> axum::Router<()> {
             get(get_subject_latest),
         )
         .route("/schemas/ids/:id", get(get_schema_by_id))
+        .layer(axum::middleware::from_fn_with_state(
+            app.clone(),
+            authenticate_and_redirect,
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(app);
 
@@ -28,17 +36,13 @@ pub fn build_router(app: Arc<App>) -> axum::Router<()> {
 // List all collections as "subjects", which are generally Kafka topics in the ecosystem.
 #[tracing::instrument(skip_all)]
 async fn all_subjects(
-    axum::extract::State(app): axum::extract::State<Arc<App>>,
-    axum_extra::TypedHeader(auth): axum_extra::TypedHeader<
-        headers::Authorization<headers::authorization::Basic>,
-    >,
+    axum::extract::Extension(mut auth): axum::extract::Extension<SessionAuthentication>,
 ) -> Response {
     wrap(async move {
-        let mut auth = app.authenticate(auth.username(), auth.password()).await?;
-
-        let strict_topic_names = match auth {
-            SessionAuthentication::User(ref auth) => auth.config.strict_topic_names,
-            SessionAuthentication::Task(ref auth) => auth.config.strict_topic_names,
+        let strict_topic_names = match &auth {
+            SessionAuthentication::User(auth) => auth.config.strict_topic_names,
+            SessionAuthentication::Task(auth) => auth.config.strict_topic_names,
+            SessionAuthentication::Redirect { config, .. } => config.strict_topic_names,
         };
 
         auth.fetch_all_collection_names()
@@ -65,17 +69,12 @@ async fn all_subjects(
 }
 
 // Fetch the "latest" schema for a subject (collection).
-#[tracing::instrument(skip(app, auth))]
+#[tracing::instrument(skip(auth))]
 async fn get_subject_latest(
-    axum::extract::State(app): axum::extract::State<Arc<App>>,
-    axum_extra::TypedHeader(auth): axum_extra::TypedHeader<
-        headers::Authorization<headers::authorization::Basic>,
-    >,
+    axum::extract::Extension(mut auth): axum::extract::Extension<SessionAuthentication>,
     axum::extract::Path(subject): axum::extract::Path<String>,
 ) -> Response {
     wrap(async move {
-        let mut auth = app.authenticate(auth.username(), auth.password()).await?;
-
         let (is_key, collection) = if subject.ends_with("-value") {
             (false, &subject[..subject.len() - 6])
         } else if subject.ends_with("-key") {
@@ -121,16 +120,12 @@ async fn get_subject_latest(
 
 // Fetch the schema with the given ID.
 // Schemas are content-addressed and immutable, so an ID uniquely identifies a Avro schema.
-#[tracing::instrument(skip(app, auth))]
+#[tracing::instrument(skip(auth))]
 async fn get_schema_by_id(
-    axum::extract::State(app): axum::extract::State<Arc<App>>,
-    axum_extra::TypedHeader(auth): axum_extra::TypedHeader<
-        headers::Authorization<headers::authorization::Basic>,
-    >,
+    axum::extract::Extension(mut auth): axum::extract::Extension<SessionAuthentication>,
     axum::extract::Path(id): axum::extract::Path<u32>,
 ) -> Response {
     wrap(async move {
-        let mut auth = app.authenticate(auth.username(), auth.password()).await?;
         let client = &auth.flow_client().await?.pg_client();
 
         #[derive(serde::Deserialize)]
@@ -177,6 +172,49 @@ where
             let err = format!("{err:#?}");
             tracing::warn!(err, "request failed");
             (axum::http::StatusCode::BAD_REQUEST, err).into_response()
+        }
+    }
+}
+
+async fn authenticate_and_redirect(
+    axum::extract::State(app): axum::extract::State<Arc<App>>,
+    axum_extra::TypedHeader(auth): axum_extra::TypedHeader<
+        headers::Authorization<headers::authorization::Basic>,
+    >,
+    uri: axum::http::Uri,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    match app.authenticate(auth.username(), auth.password()).await {
+        Ok(SessionAuthentication::Redirect {
+            target_dataplane_fqdn,
+            ..
+        }) => {
+            let redirect_url = format!(
+                "https://{}{}",
+                target_dataplane_fqdn,
+                uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/")
+            );
+            (
+                axum::http::StatusCode::TEMPORARY_REDIRECT,
+                [("Location", redirect_url)],
+            )
+                .into_response()
+        }
+        Ok(auth) => {
+            // Insert the authentication into request extensions so handlers can access it
+            req.extensions_mut().insert(auth);
+            next.run(req).await
+        }
+        Err(DekafError::Authentication(auth_err)) => {
+            let err = format!("{auth_err:#?}");
+            tracing::warn!(err, "authentication failed");
+            (axum::http::StatusCode::UNAUTHORIZED, err).into_response()
+        }
+        Err(err) => {
+            let err = format!("{err:#?}");
+            tracing::error!(err, "unexpected error during authentication");
+            (axum::http::StatusCode::INTERNAL_SERVER_ERROR, err).into_response()
         }
     }
 }

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -105,7 +105,8 @@ impl Session {
             Ok(client)
         } else {
             let (auth, urls) = match self.auth {
-                Some(SessionAuthentication::Task(_)) => (
+                Some(SessionAuthentication::Task(_))
+                | Some(SessionAuthentication::Redirect { .. }) => (
                     KafkaClientAuth::MSK {
                         aws_region: self.msk_region.clone(),
                         provider: aws_config::from_env()
@@ -118,9 +119,6 @@ impl Session {
                     },
                     self.broker_urls.as_slice(),
                 ),
-                Some(SessionAuthentication::Redirect { .. }) => {
-                    anyhow::bail!("Redirected sessions cannot create kafka clients");
-                }
                 Some(SessionAuthentication::User(_)) => {
                     if let (Some(username), Some(password), Some(urls)) = (
                         &self.legacy_mode_broker_username,

--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -48,20 +48,28 @@ pub type Result<T> = core::result::Result<T, SharedError>;
 const TASK_TIMEOUT: Duration = Duration::from_secs(60 * 3);
 
 #[derive(Clone)]
-pub struct TaskState {
-    // Control-plane access token
-    pub access_token: String,
-    pub access_token_claims: AccessTokenClaims,
-    pub ops_logs_journal: String,
-    pub ops_stats_journal: String,
-    pub spec: proto_flow::flow::MaterializationSpec,
-    /// Sorted by collection's partition template name
-    pub partitions: Vec<(
-        String,
-        Result<(journal::Client, proto_gazette::Claims, Vec<Partition>)>,
-    )>,
-    pub ops_logs_client: Result<(journal::Client, proto_gazette::Claims)>,
-    pub ops_stats_client: Result<(journal::Client, proto_gazette::Claims)>,
+pub enum TaskState {
+    /// Task is authorized and running in this dataplane
+    Authorized {
+        // Control-plane access token
+        access_token: String,
+        access_token_claims: AccessTokenClaims,
+        ops_logs_journal: String,
+        ops_stats_journal: String,
+        spec: proto_flow::flow::MaterializationSpec,
+        /// Sorted by collection's partition template name
+        partitions: Vec<(
+            String,
+            Result<(journal::Client, proto_gazette::Claims, Vec<Partition>)>,
+        )>,
+        ops_logs_client: Result<(journal::Client, proto_gazette::Claims)>,
+        ops_stats_client: Result<(journal::Client, proto_gazette::Claims)>,
+    },
+    /// Task has been migrated to a different dataplane
+    Redirect {
+        target_dataplane_fqdn: String,
+        spec: proto_flow::flow::MaterializationSpec,
+    },
 }
 
 /// A wrapper around a TaskManager receiver that provides a method to get the current state.
@@ -244,95 +252,134 @@ impl TaskManager {
                 }
             }
 
+            let mut has_been_migrated = false;
+
             let loop_result: Result<()> = async {
                 // For the moment, let's just refresh this every tick in order to have relatively
                 // fresh MaterializationSpecs, even if the access token may live for a while.
-                let (access_token, access_token_claims, ops_logs_journal, ops_stats_journal, spec) =
-                    fetch_dekaf_task_auth(
-                        &self.client,
-                        &task_name,
-                        &self.data_plane_fqdn,
-                        &self.data_plane_signer,
-                    )
-                    .await
-                    .context("error fetching dekaf task auth")?;
-
-                partitions_and_clients = update_partition_info(
+                let dekaf_auth = fetch_dekaf_task_auth(
                     &self.client,
+                    &task_name,
                     &self.data_plane_fqdn,
                     &self.data_plane_signer,
-                    &task_name,
-                    &spec,
-                    std::mem::take(&mut partitions_and_clients),
-                )
-                .await?;
-
-                let logs_client_result = get_or_refresh_journal_client(
-                    &self.client,
-                    &self.data_plane_fqdn,
-                    &self.data_plane_signer,
-                    &task_name,
-                    proto_flow::capability::AUTHORIZE | proto_gazette::capability::APPEND,
-                    broker::LabelSelector {
-                        include: Some(labels::build_set([("name", ops_logs_journal.as_str())])),
-                        exclude: None,
-                    },
-                    cached_ops_logs_client
-                        .as_ref()
-                        .and_then(|r| r.as_ref().ok()),
                 )
                 .await
-                .map_err(SharedError::from);
-                cached_ops_logs_client = Some(logs_client_result);
+                .context("error fetching dekaf task auth")?;
 
-                let stats_client_result = get_or_refresh_journal_client(
-                    &self.client,
-                    &self.data_plane_fqdn,
-                    &self.data_plane_signer,
-                    &task_name,
-                    proto_flow::capability::AUTHORIZE | proto_gazette::capability::APPEND,
-                    broker::LabelSelector {
-                        include: Some(labels::build_set([("name", ops_stats_journal.as_str())])),
-                        exclude: None,
-                    },
-                    cached_ops_stats_client
-                        .as_ref()
-                        .and_then(|r| r.as_ref().ok()),
-                )
-                .await
-                .map_err(SharedError::from);
-                cached_ops_stats_client = Some(stats_client_result);
+                match dekaf_auth {
+                    DekafTaskAuth::Redirect {
+                        target_dataplane_fqdn,
+                        spec,
+                    } => {
+                        if !has_been_migrated {
+                            has_been_migrated = true;
 
-                let _ = sender.send(Some(Ok(TaskState {
-                    access_token,
-                    access_token_claims,
-                    ops_logs_journal,
-                    ops_stats_journal,
-                    spec,
-                    partitions: partitions_and_clients
-                        .iter()
-                        .sorted_by_key(|(k, _)| k.as_str())
-                        .map(|(k, v)| {
-                            let mapped_val = match v {
-                                Ok(p) => Ok(p.clone()),
-                                Err(e) => Err(e.clone()),
-                            };
-                            let res = (k.clone(), mapped_val);
+                            tracing::info!(
+                                task_name = %task_name,
+                                target_dataplane = %target_dataplane_fqdn,
+                                "Task has been migrated to different dataplane"
+                            );
+                        }
 
-                            res
-                        })
-                        .collect_vec(),
-                    ops_logs_client: cached_ops_logs_client
-                        .as_ref()
-                        .expect("this is guarinteed to be present")
-                        .clone(),
-                    ops_stats_client: cached_ops_stats_client
-                        .as_ref()
-                        .expect("this is guarinteed to be present")
-                        .clone(),
-                })));
+                        let _ = sender.send(Some(Ok(TaskState::Redirect {
+                            target_dataplane_fqdn: target_dataplane_fqdn,
+                            spec,
+                        })));
 
-                Ok(())
+                        Ok(())
+                    }
+                    DekafTaskAuth::Auth {
+                        token: access_token,
+                        claims: access_token_claims,
+                        ops_logs_journal,
+                        ops_stats_journal,
+                        spec,
+                    } => {
+                        // Continue with normal processing
+                        partitions_and_clients = update_partition_info(
+                            &self.client,
+                            &self.data_plane_fqdn,
+                            &self.data_plane_signer,
+                            &task_name,
+                            &spec,
+                            std::mem::take(&mut partitions_and_clients),
+                        )
+                        .await?;
+
+                        let logs_client_result = get_or_refresh_journal_client(
+                            &self.client,
+                            &self.data_plane_fqdn,
+                            &self.data_plane_signer,
+                            &task_name,
+                            proto_flow::capability::AUTHORIZE | proto_gazette::capability::APPEND,
+                            broker::LabelSelector {
+                                include: Some(labels::build_set([(
+                                    "name",
+                                    ops_logs_journal.as_str(),
+                                )])),
+                                exclude: None,
+                            },
+                            cached_ops_logs_client
+                                .as_ref()
+                                .and_then(|r| r.as_ref().ok()),
+                        )
+                        .await
+                        .map_err(SharedError::from);
+                        cached_ops_logs_client = Some(logs_client_result);
+
+                        let stats_client_result = get_or_refresh_journal_client(
+                            &self.client,
+                            &self.data_plane_fqdn,
+                            &self.data_plane_signer,
+                            &task_name,
+                            proto_flow::capability::AUTHORIZE | proto_gazette::capability::APPEND,
+                            broker::LabelSelector {
+                                include: Some(labels::build_set([(
+                                    "name",
+                                    ops_stats_journal.as_str(),
+                                )])),
+                                exclude: None,
+                            },
+                            cached_ops_stats_client
+                                .as_ref()
+                                .and_then(|r| r.as_ref().ok()),
+                        )
+                        .await
+                        .map_err(SharedError::from);
+                        cached_ops_stats_client = Some(stats_client_result);
+
+                        let _ = sender.send(Some(Ok(TaskState::Authorized {
+                            access_token,
+                            access_token_claims,
+                            ops_logs_journal,
+                            ops_stats_journal,
+                            spec,
+                            partitions: partitions_and_clients
+                                .iter()
+                                .sorted_by_key(|(k, _)| k.as_str())
+                                .map(|(k, v)| {
+                                    let mapped_val = match v {
+                                        Ok(p) => Ok(p.clone()),
+                                        Err(e) => Err(e.clone()),
+                                    };
+                                    let res = (k.clone(), mapped_val);
+
+                                    res
+                                })
+                                .collect_vec(),
+                            ops_logs_client: cached_ops_logs_client
+                                .as_ref()
+                                .expect("this is guarinteed to be present")
+                                .clone(),
+                            ops_stats_client: cached_ops_stats_client
+                                .as_ref()
+                                .expect("this is guarinteed to be present")
+                                .clone(),
+                        })));
+
+                        Ok(())
+                    }
+                } // End of match
             }
             .await;
 
@@ -512,19 +559,30 @@ pub async fn fetch_partitions(
 pub struct AccessTokenClaims {
     pub exp: u64,
 }
+
+pub enum DekafTaskAuth {
+    /// Task has been migrated to a different dataplane, and the session should redirect to it.
+    Redirect {
+        target_dataplane_fqdn: String,
+        spec: MaterializationSpec,
+    },
+    /// Task authorization data.
+    Auth {
+        token: String,
+        claims: AccessTokenClaims,
+        ops_logs_journal: String,
+        ops_stats_journal: String,
+        spec: MaterializationSpec,
+    },
+}
+
 #[tracing::instrument(skip(client, data_plane_signer), err)]
 async fn fetch_dekaf_task_auth(
     client: &flow_client::Client,
     shard_template_id: &str,
     data_plane_fqdn: &str,
     data_plane_signer: &jsonwebtoken::EncodingKey,
-) -> anyhow::Result<(
-    String,
-    AccessTokenClaims,
-    String,
-    String,
-    proto_flow::flow::MaterializationSpec,
-)> {
+) -> anyhow::Result<DekafTaskAuth> {
     let start = std::time::Instant::now();
 
     let request_token = flow_client::client::build_task_authorization_request_token(
@@ -539,6 +597,7 @@ async fn fetch_dekaf_task_auth(
         ops_logs_journal,
         ops_stats_journal,
         task_spec,
+        redirect_dataplane_fqdn,
         ..
     } = loop {
         let response: models::authorizations::DekafAuthResponse = client
@@ -559,6 +618,35 @@ async fn fetch_dekaf_task_auth(
         }
         break response;
     };
+
+    let parsed_spec = serde_json::from_str(
+        task_spec
+            .ok_or(anyhow::anyhow!(
+                "task_spec is only None when we need to retry the auth request"
+            ))?
+            .get(),
+    )?;
+
+    // Check if we got a redirect response
+    if let Some(redirect_fqdn) = redirect_dataplane_fqdn {
+        tracing::debug!(
+            redirect_target = redirect_fqdn,
+            "task has been migrated to different dataplane, returning redirect"
+        );
+        metrics::counter!(
+            "dekaf_fetch_auth",
+            "endpoint" => "/authorize/dekaf",
+            "redirect" => "true",
+            "task_name" => shard_template_id.to_owned()
+        )
+        .increment(1);
+
+        return Ok(DekafTaskAuth::Redirect {
+            target_dataplane_fqdn: redirect_fqdn,
+            spec: parsed_spec,
+        });
+    }
+
     let claims = flow_client::parse_jwt_claims(token.as_str())?;
 
     tracing::debug!(
@@ -566,18 +654,19 @@ async fn fetch_dekaf_task_auth(
         "fetched dekaf task auth",
     );
 
-    metrics::counter!("dekaf_fetch_auth", "endpoint" => "/authorize/dekaf", "task_name" => shard_template_id.to_owned()).increment(1);
-    Ok((
+    metrics::counter!(
+        "dekaf_fetch_auth",
+        "endpoint" => "/authorize/dekaf",
+        "redirect" => "false",
+        "task_name" => shard_template_id.to_owned()
+    )
+    .increment(1);
+
+    Ok(DekafTaskAuth::Auth {
         token,
         claims,
         ops_logs_journal,
         ops_stats_journal,
-        serde_json::from_str(
-            task_spec
-                .ok_or(anyhow::anyhow!(
-                    "task_spec is only None when we need to retry the auth request"
-                ))?
-                .get(),
-        )?,
-    ))
+        spec: parsed_spec,
+    })
 }

--- a/crates/dekaf/src/utils.rs
+++ b/crates/dekaf/src/utils.rs
@@ -3,7 +3,7 @@ use avro::{located_shape_to_avro, shape_to_avro};
 use doc::shape::location;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use proto_flow::flow;
+use proto_flow::flow::{self, MaterializationSpec};
 use std::{borrow::Cow, iter};
 
 lazy_static! {
@@ -218,4 +218,32 @@ pub fn build_LEGACY_field_extractors(
             )],
         ))
     }
+}
+
+pub fn fetch_all_collection_names(spec: &MaterializationSpec) -> anyhow::Result<Vec<String>> {
+    spec.bindings
+        .iter()
+        .map(|b| {
+            b.resource_path
+                .first()
+                .cloned()
+                .ok_or(anyhow::anyhow!("missing resource path"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+pub fn get_binding_for_topic(
+    spec: &MaterializationSpec,
+    topic_name: &str,
+) -> anyhow::Result<Option<proto_flow::flow::materialization_spec::Binding>> {
+    Ok(spec
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding
+                .resource_path
+                .first()
+                .is_some_and(|path| path == topic_name)
+        })
+        .map(|b| b.clone()))
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -111,6 +111,17 @@ begin
   returning id strict into connector_id;
   insert into public.connector_tags (connector_id, image_tag) values (connector_id, ':dev');
 
+  insert into public.connectors (image_name, title, short_description, logo_url, external_url, recommended) values (
+    'ghcr.io/estuary/dekaf-generic',
+    json_build_object('en-US','Dekaf'),
+    json_build_object('en-US','Pull from Estuary using the Kafka API.'),
+    json_build_object('en-US','https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//thumbnail_Group_22747_3_a3bd271619/thumbnail_Group_22747_3_a3bd271619.png'),
+    'https://docs.estuary.dev/guides/dekaf_reading_collections_from_kafka',
+    true
+  )
+  returning id strict into connector_id;
+  insert into public.connector_tags (connector_id, image_tag) values (connector_id, ':v1');
+
 end;
 $$ language plpgsql;
 


### PR DESCRIPTION
Use the Kafka metadata API to redirect consumers to the correct Dekaf instance by advertising it as the leader and sole replica node for all topics when authenticating to a Dekaf instance that lives in a different dataplane than the task in question. 

That results in `librdkafka` debug log output like this:

```
%7|1753295815.118|RECV|joseph_testing#consumer-1| [thrd:sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap: Received MetadataResponse (v12, 139 bytes, CorrId 4, rtt 42.87ms)
%7|1753295815.121|METADATA|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap: ===== Received metadata (for 1 requested topics): connected =====
%7|1753295815.121|METADATA|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap: ClusterId: estuary-dekaf, ControllerId: 1
%7|1753295815.121|METADATA|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap: 1 brokers, 1 topics
%7|1753295815.121|METADATA|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap:   Broker #0/1: dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092 NodeId 1
%7|1753295815.122|WAKEUPFD|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1: Enabled low-latency ops queue wake-ups
%7|1753295815.122|BROKER|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1: Added new broker with NodeId 1
%7|1753295815.122|METADATA|joseph_testing#consumer-1| [thrd:main]: sasl_ssl://dekaf-dev.estuary-data.com:9092/bootstrap:   Topic events with 1 partitions
%7|1753295815.122|STATE|joseph_testing#consumer-1| [thrd:main]: Topic events changed state unknown -> exists
%7|1753295815.122|BRKDELGT|joseph_testing#consumer-1| [thrd:main]: events [0]: delegate to broker sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1 (rktp 0x13d809800, term 0, ref 3)
%7|1753295815.122|BRKDELGT|joseph_testing#consumer-1| [thrd:main]: events [0]: delegating to broker sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1 for partition with 0 messages (0 bytes) queued
%7|1753295815.122|BRKMIGR|joseph_testing#consumer-1| [thrd:main]: Migrating topic events [0] 0x13d809800 from (none) to sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1 (sending PARTITION_JOIN to sasl_ssl://dekaf.gcp-us-central1-c2.dp.estuary-data.com:9092/1)
```

### `/authorize/dekaf` changes:
* https://github.com/estuary/flow/pull/2285
* ~https://github.com/estuary/flow/pull/2292~ 

I decided to deal with the schema registry issue by proxying schema registry requests to their corresponding Dekaf instance, as it was the far simpler solution.

### Issue:
Closes #2261

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2276)
<!-- Reviewable:end -->
