### PR TITLE
agent: log in json format by default

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -160,6 +160,7 @@ local_resource(
     --allow-origin http://localhost:3000 \
     --api-port 8675 \
     --serve-handlers \
+    --log-format text \
     ' % (REPO_BASE),
     serve_env={
         "BIN_DIR": '%s/flow/.build/package/bin' % REPO_BASE,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -77,6 +77,15 @@ struct Args {
     )]
     #[arg(value_parser = humantime::parse_duration)]
     heartbeat_timeout: std::time::Duration,
+
+    #[clap(long = "log-format", env = "LOG_FORMAT", default_value = "json")]
+    log_format: LogFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+enum LogFormat {
+    Text,
+    Json,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -86,18 +95,19 @@ fn main() -> Result<(), anyhow::Error> {
         .install_default()
         .expect("failed to install default crypto provider");
 
-    // Use reasonable defaults for printing structured logs to stderr.
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_ansi(if matches!(std::env::var("NO_COLOR"), Ok(v) if v == "1") {
-            false
-        } else {
-            true
-        })
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
-
     let args = Args::parse();
+
+    // Use reasonable defaults for printing structured logs to stderr.
+    let builder = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
+    if args.log_format == LogFormat::Json {
+        tracing::subscriber::set_global_default(builder.json().finish())
+            .expect("setting tracing default failed");
+    } else {
+        let no_color = matches!(std::env::var("NO_COLOR"), Ok(v) if v == "1");
+        tracing::subscriber::set_global_default(builder.with_ansi(!no_color).finish())
+            .expect("setting tracing default failed");
+    };
     tracing::info!(?args, "started!");
 
     let runtime = tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
Changes agent to log in JSON format by default, so that we can more easily use logs in Grafana.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2284)
<!-- Reviewable:end -->
