### PR TITLE
agent-api(`/authorize/dekaf`): Handle redirects when `iss`uing dataplane differs from `sub`ject's host dataplane

### DIFF
--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -539,7 +539,7 @@ async fn fetch_dekaf_task_auth(
         ops_logs_journal,
         ops_stats_journal,
         task_spec,
-        retry_millis: _,
+        ..
     } = loop {
         let response: models::authorizations::DekafAuthResponse = client
             .agent_unary(

--- a/crates/models/src/authorizations.rs
+++ b/crates/models/src/authorizations.rs
@@ -230,6 +230,9 @@ pub struct DekafAuthResponse {
     /// # Number of milliseconds to wait before retrying the request.
     /// Non-zero if and only if token is not set.
     pub retry_millis: u64,
+    /// # Target dataplane FQDN for redirect when task has been migrated
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redirect_dataplane_fqdn: Option<String>,
 }
 
 const fn capability_read() -> crate::Capability {


### PR DESCRIPTION
**Description:**

When a dekaf materialization is migrated, its host dataplane will change. Correspondingly, Dekaf needs to know about this in order to redirect consumers. As such, we now return enough information to serve that redirect:

* The FQDN of the new host dataplane
* The `MaterializationSpec` so that Dekaf can still advertise the correct topics. Without this, consumers will think there are no topics available.

This is part of https://github.com/estuary/flow/issues/2261, and needed in order to test out the [Dekaf changes](https://github.com/estuary/flow/pull/2276) on `dekaf-dev`.

I tested this locally with a 2-dataplane stack in conjunction with #2276 and it worked wonderfully

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2285)
<!-- Reviewable:end -->
