### PR TITLE
Phil/moar indexes

### DIFF
--- a/supabase/migrations/20250711115313_catalog-stats-indexes.sql
+++ b/supabase/migrations/20250711115313_catalog-stats-indexes.sql
@@ -40,7 +40,6 @@ select cron.schedule('reindex-catalog-stats-hourly', '6 6 * * 2', 'reindex index
 
 commit;
 
-create index concurrently catalog_stats_hourly_ts_idx on public.catalog_stats_hourly
-  using brin(ts) with (pages_per_range = 32, autosummarize = on);
+create index concurrently catalog_stats_hourly_ts_idx on public.catalog_stats_hourly(ts);
 comment on index public.catalog_stats_hourly_ts_idx is
   'Used by the delete_old_hourly_stats function to enable faster deletions';

--- a/supabase/migrations/20250717120814_alert-subscriptions-idx.sql
+++ b/supabase/migrations/20250717120814_alert-subscriptions-idx.sql
@@ -1,0 +1,3 @@
+
+-- Used by the UI in order to query alert subscriptions by tenant.
+create index concurrently alert_subscriptions_catalog_prefix_idx on public.alert_subscriptions(catalog_prefix);


### PR DESCRIPTION
Rolls up a couple of database index changes. The change to the `catalog_stats_hourly` index has already been made, and this just updates the migration to match prod.

The migration to add the index on `alert_subscriptions` is still pending. This is to address statement timeouts that are being observed in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2287)
<!-- Reviewable:end -->
