### PR TITLE
agent(`/authorize/dekaf`): Return control-plane `dekaf` token even when redirecting

### DIFF
--- a/crates/agent/src/api/authorize_dekaf.rs
+++ b/crates/agent/src/api/authorize_dekaf.rs
@@ -112,13 +112,9 @@ pub async fn do_authorize_dekaf<'a>(
                 email: None,
             };
 
-            // Only return a token if we are not redirecting
-            let token = if redirect_fqdn.is_none() {
+            let token =
                 jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, control_key)
-                    .context("failed to encode authorized JWT")?
-            } else {
-                "".to_string()
-            };
+                    .context("failed to encode authorized JWT")?;
 
             Ok(axum::Json(Response {
                 token,


### PR DESCRIPTION
**Description:**

It turns out that the schema registry doesn't support HTTP redirects, so in order for Dekaf redirects to work, _any_ instance must be able to serve _all_ schema registry requests. This lays the groundwork for that by modifying https://github.com/estuary/flow/pull/2285 so that `/authorize/dekaf` returns the necessary token even when a request is a redirect.

Tested this working end to end with a dual-dataplane local stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2292)
<!-- Reviewable:end -->
