### PR TITLE
flowctl: automatically encrypt endpoint configs

### DIFF
--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -13,6 +13,7 @@ use flow_client::{
     LOCAL_PG_URL,
 };
 use futures::TryStreamExt;
+use proto_flow::flow;
 use rustls::pki_types::CertificateDer;
 use std::{
     fs::File,
@@ -245,7 +246,13 @@ async fn main() -> anyhow::Result<()> {
         (cli.api_endpoint, cli.api_key)
     };
 
-    let client_base = flow_client::Client::new(cli.agent_endpoint, api_key, api_endpoint, None);
+    let client_base = flow_client::Client::new(
+        cli.agent_endpoint,
+        api_key,
+        api_endpoint,
+        None,
+        ::flow_client::DEFAULT_CONFIG_ENCRYPTION_URL.clone(),
+    );
     let signing_token = jsonwebtoken::EncodingKey::from_base64_secret(&cli.data_plane_access_key)?;
 
     let task_manager = Arc::new(TaskManager::new(

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -21,6 +21,8 @@ pub struct Client {
     // a single connection pool. The clones can have different headers while
     // still re-using the same connection pool, so this will work across refreshes.
     pg_parent: postgrest::Postgrest,
+    // URL of the config encryption service.
+    config_encryption_url: url::Url,
 }
 
 impl Client {
@@ -30,6 +32,7 @@ impl Client {
         pg_api_token: String,
         pg_url: Url,
         user_access_token: Option<String>,
+        config_encryption_url: Url,
     ) -> Self {
         // Build journal and shard clients with an empty default service address.
         // We'll use their with_endpoint_and_metadata() routines to cheaply clone
@@ -56,6 +59,7 @@ impl Client {
             journal_client,
             shard_client,
             user_access_token,
+            config_encryption_url,
         }
     }
 
@@ -166,6 +170,49 @@ impl Client {
             let body = response.text().await?;
             anyhow::bail!("POST {path}: {status}: {body}");
         }
+    }
+
+    /// Calls the endpoint configuration service to encrypt the given endpoint
+    /// configuration, using the provided `endpoint_spec_schema`.
+    pub async fn encrypt_endpoint_config(
+        &self,
+        plaintext_config: &models::RawValue,
+        endpoint_spec_schema: &models::RawValue,
+    ) -> anyhow::Result<models::RawValue> {
+        #[derive(serde::Serialize)]
+        struct EncryptRequest {
+            config: models::RawValue,
+            schema: models::RawValue,
+        }
+
+        let encrypt_endpoint = format!("{}v1/encrypt-config", self.config_encryption_url);
+
+        let request = EncryptRequest {
+            config: plaintext_config.clone(),
+            schema: endpoint_spec_schema.clone(),
+        };
+
+        // The encryption service does not currently require any sort of
+        // authentication, so there's no auth header added here. We'll of course
+        // need to update this if we ever add authentiation to that endpoint.
+        let mut req = self
+            .http_client
+            .post(&encrypt_endpoint)
+            .header("Content-Type", "application/json")
+            .json(&request);
+
+        let response = req.send().await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Config encryption failed: {} {}",
+                response.status(),
+                response.text().await?
+            )
+        }
+
+        let encrypt_response: models::RawValue = response.json().await?;
+        Ok(encrypt_response)
     }
 }
 

--- a/crates/flow-client/src/lib.rs
+++ b/crates/flow-client/src/lib.rs
@@ -57,11 +57,13 @@ lazy_static::lazy_static! {
     pub static ref DEFAULT_AGENT_URL:  url::Url = url::Url::parse("https://agent-api-1084703453822.us-central1.run.app").unwrap();
     pub static ref DEFAULT_DASHBOARD_URL: url::Url = url::Url::parse("https://dashboard.estuary.dev/").unwrap();
     pub static ref DEFAULT_PG_URL: url::Url = url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap();
+    pub static ref DEFAULT_CONFIG_ENCRYPTION_URL: url::Url = url::Url::parse("https://config-encryptions.estuary.dev/").unwrap();
 
     // Used only when profile is "local".
     pub static ref LOCAL_AGENT_URL: url::Url = url::Url::parse("http://localhost:8675/").unwrap();
     pub static ref LOCAL_DASHBOARD_URL: url::Url = url::Url::parse("http://localhost:3000/").unwrap();
     pub static ref LOCAL_PG_URL: url::Url = url::Url::parse("http://localhost:5431/rest/v1").unwrap();
+    pub static ref LOCAL_CONFIG_ENCRYPTION_URL: url::Url = url::Url::parse("http://localhost:8765/").unwrap();
 }
 
 pub const DEFAULT_PG_PUBLIC_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco";

--- a/crates/flowctl/src/catalog/test.rs
+++ b/crates/flowctl/src/catalog/test.rs
@@ -16,13 +16,13 @@ pub struct TestArgs {
 /// and discoverable to users. There's also no need for any confirmation steps, since we're not
 /// actually modifying the published specs.
 pub async fn do_test(ctx: &mut CliContext, args: &TestArgs) -> anyhow::Result<()> {
-    let (draft_catalog, _validations) =
+    let (mut draft_catalog, _validations) =
         local_specs::load_and_validate(&ctx.client, &args.source).await?;
 
     let draft = draft::create_draft(&ctx.client).await?;
     println!("Created draft: {}", &draft.id);
     tracing::info!(draft_id = %draft.id, "created draft");
-    let spec_rows = draft::upsert_draft_specs(&ctx.client, draft.id, &draft_catalog).await?;
+    let spec_rows = draft::author(&ctx.client, draft.id, &mut draft_catalog).await?;
     println!("Running tests for catalog items:");
     ctx.write_all(spec_rows, ())?;
     println!("Starting tests...");

--- a/crates/flowctl/src/draft/encrypt.rs
+++ b/crates/flowctl/src/draft/encrypt.rs
@@ -1,0 +1,166 @@
+use crate::Client;
+use anyhow::Context;
+use models::RawValue;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Encrypts any task endpoint configurations that are not already encrypted.
+/// The encryption is performed by calling the config encryption service endpoint,
+/// passing the `connector_tags.endpoint_spec_schema` for the connector image. If
+/// no `connector_tags` row is found, then encryption will be skipped.
+pub async fn encrypt_endpoint_configs(
+    draft: &mut tables::DraftCatalog,
+    client: &Client,
+) -> anyhow::Result<()> {
+    // Simple cache of `connector_tags.endpoint_spec_schema` values, keyed on
+    // the full image + tag. This is just to avoid repeated calls to fetch the
+    // schemas for catalogs with many tasks.
+    let mut schema_cache: HashMap<String, Option<RawValue>> = HashMap::new();
+
+    for capture in draft.captures.iter_mut() {
+        if let Some(models::CaptureEndpoint::Connector(connector)) =
+            capture.model.as_mut().map(|model| &mut model.endpoint)
+        {
+            if !is_encrypted(&connector.config) {
+                let schema =
+                    fetch_or_cache_schema(&connector.image, &mut schema_cache, client).await?;
+
+                if let Some(endpoint_spec_schema) = schema {
+                    connector.config = encrypt_config(
+                        client,
+                        capture.capture.as_str(),
+                        models::CatalogType::Capture,
+                        &connector.config,
+                        &endpoint_spec_schema,
+                    )
+                    .await?;
+                } else {
+                    tracing::warn!(
+                        capture = %capture.capture,
+                        image = %connector.image,
+                        "Unable to encrypt the endpoint configuration for this task because no endpoint spec schema was found, continuing with plain-text"
+                    );
+                }
+            }
+        }
+    }
+
+    for materialization in draft.materializations.iter_mut() {
+        if let Some(models::MaterializationEndpoint::Connector(connector)) = materialization
+            .model
+            .as_mut()
+            .map(|model| &mut model.endpoint)
+        {
+            if !is_encrypted(&connector.config) {
+                let schema =
+                    fetch_or_cache_schema(&connector.image, &mut schema_cache, client).await?;
+
+                if let Some(endpoint_spec_schema) = schema {
+                    connector.config = encrypt_config(
+                        client,
+                        materialization.materialization.as_str(),
+                        models::CatalogType::Materialization,
+                        &connector.config,
+                        &endpoint_spec_schema,
+                    )
+                    .await?;
+                } else {
+                    tracing::warn!(
+                        materialization = %materialization.materialization,
+                        image = %connector.image,
+                        "Unable to encrypt the endpoint configuration for this task because no endpoint spec schema was found, continuing with plain-text"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn encrypt_config(
+    client: &crate::Client,
+    task_name: &str,
+    task_type: models::CatalogType,
+    config: &RawValue,
+    schema: &RawValue,
+) -> anyhow::Result<RawValue> {
+    tracing::debug!(?task_name, %task_type, "encrypting task endpoint config");
+    let encrypted = client
+        .encrypt_endpoint_config(config, schema)
+        .await
+        .with_context(|| format!("encrypting endpoint config for {task_type} '{task_name}'"))?;
+    tracing::info!(%task_name, %task_type, "successfully encrypted endpoint configuration");
+    Ok(encrypted)
+}
+
+fn is_encrypted(config: &RawValue) -> bool {
+    // Check if the config contains a "sops" property with any object value
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(config.get()) {
+        if let Some(obj) = value.as_object() {
+            if let Some(sops_value) = obj.get("sops") {
+                return sops_value.is_object();
+            }
+        }
+    }
+    false
+}
+
+async fn fetch_or_cache_schema(
+    image: &str,
+    cache: &mut HashMap<String, Option<RawValue>>,
+    client: &Client,
+) -> anyhow::Result<Option<RawValue>> {
+    if let Some(cached) = cache.get(image) {
+        return Ok(cached.clone());
+    }
+
+    let (image_name, image_tag) = models::split_image_tag(image);
+
+    // Query the connector_tags table via PostgREST with a join
+    let response = client
+        .pg_client()
+        .from("connectors")
+        .select("connector_tags(endpoint_spec_schema)")
+        .eq("image_name", &image_name)
+        .eq("connector_tags.image_tag", &image_tag)
+        .single()
+        .execute()
+        .await?;
+
+    if response.status().is_success() {
+        let body = response.text().await?;
+        let row: ConnectorRow =
+            serde_json::from_str(&body).context("failed to parse connector response")?;
+
+        // Extract the endpoint_spec_schema from the first (and only) connector_tag
+        let schema = row
+            .connector_tags
+            .into_iter()
+            .next()
+            .and_then(|tag| tag.endpoint_spec_schema);
+
+        cache.insert(image.to_string(), schema.clone());
+        Ok(schema)
+    } else if response.status() == 404 {
+        // No schema found for this connector
+        cache.insert(image.to_string(), None);
+        Ok(None)
+    } else {
+        anyhow::bail!(
+            "Failed to fetch connector schema: {} {}",
+            response.status(),
+            response.text().await?
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectorRow {
+    connector_tags: Vec<ConnectorTagRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectorTagRow {
+    endpoint_spec_schema: Option<RawValue>,
+}

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -13,7 +13,9 @@ use author::do_author;
 mod develop;
 use develop::do_develop;
 
-pub use author::upsert_draft_specs;
+mod encrypt;
+
+pub use author::author;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]


### PR DESCRIPTION
**Description:**

Updates flowctl to always and automatically encrypt any unencrypted endpoint configs.  There's no reason to ever use plain text credentials, so there's no option to disable encryption. The encryption happens whenever we upsert to `draft_specs` for any reason, which means that endpoint configs will be encrypted whenever users run any of the following commands:
- `draft author`
- `catalog test`
- `catalog publish`

Encryption will be skipped for any tasks that don't have their connector as part of `connector_tags`.  This is because we currently need to pull the `endpoint_spec_schema` from the `connector_tags` table.  A future improvement can allow flowctl to run the `spec` RPC to get the endpoint spec schemas of connectors that don't have a `connector_tags` row.

The local endpoint configs are never updated as part of this. If users desire to replace their local plain text configs with the encrypted ones, then it's recommended that they run `draft author` followed by `draft develop` with `--overwrite`.

**Workflow steps:**

- Create a `flow.yaml` with at least one capture and/or materialization using an un-encrypted endpoint config
- run `flowctl catalog test|publish` and expect that the `draft_specs` have encrypted endpoint configs
- run `flowctl draft author` and expect that the `draft_specs` should have encrypted the endpoint config
- run `flowctl draft develop --overwrite`, and expect that the local endpoint config has now been encrypted
- In all cases, endpoint configs that are already encrypted should not be modified at all

Some other tests that I ran:

- try the above with both inlined and externalized endpoint configs
- Include a task that uses a connector that _isn't_ in `connector_tags`, and expect that it logs a warning but continues to still author|test|publish

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2294)
<!-- Reviewable:end -->
