### PR TITLE
dekaf: Permit session reauthentication where the username doesn't change

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -364,7 +364,10 @@ impl<W: TaskWriter + Clone + 'static> TaskForwarder<W> {
                 maybe_msg = event_stream.next() => {
                     match maybe_msg {
                         Some(TaskWriterMessage::SetTaskName{name, build}) => {
-                            anyhow::bail!("You can't change the task name after it has already been set ({shard_ref:?} -> ({name}, {build}))");
+                            let shard = dekaf_shard_ref(name.clone(), build.clone());
+                            if shard != shard_ref {
+                                anyhow::bail!("You can't change the task name after it has already been set ({shard_ref:?} -> ({name}, {build}))");
+                            }
                         },
                         Some(TaskWriterMessage::Log(mut log)) => {
                             for well_known in WELL_KNOWN_LOG_FIELDS {

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -143,10 +143,6 @@ impl Session {
         &mut self,
         request: messages::SaslHandshakeRequest,
     ) -> anyhow::Result<messages::SaslHandshakeResponse> {
-        if let Some(_) = self.auth {
-            anyhow::bail!("This session is already authenticated")
-        }
-
         let mut response = messages::SaslHandshakeResponse::default();
         response.mechanisms.push(StrBytes::from_static_str("PLAIN"));
 
@@ -161,22 +157,29 @@ impl Session {
         &mut self,
         request: messages::SaslAuthenticateRequest,
     ) -> anyhow::Result<messages::SaslAuthenticateResponse> {
-        if let Some(_) = self.auth {
-            anyhow::bail!("This session is already authenticated")
-        }
-
         let mut it = request
             .auth_bytes
             .split(|b| *b == 0) // SASL uses NULL to separate components.
             .map(std::str::from_utf8);
 
         let _authzid = it.next().context("expected SASL authzid")??;
-        let authcid = it.next().context("expected SASL authcid")??;
-        let password = it.next().context("expected SASL passwd")??;
+        let username = it.next().context("expected SASL authcid (username)")??;
+        let password = it.next().context("expected SASL password")??;
+
+        match &self.auth {
+            Some(SessionAuthentication::Task(auth)) if auth.task_name != username => {
+                return Ok(messages::SaslAuthenticateResponse::default()
+                    .with_error_code(ResponseError::SaslAuthenticationFailed.code())
+                    .with_error_message(Some(StrBytes::from_string(
+                        "Session cannot be reauthenticated with a different username".to_string(),
+                    ))))
+            }
+            _ => {}
+        };
 
         let mut attempts = 0;
         loop {
-            let response = match self.app.authenticate(authcid, password).await {
+            let response = match self.app.authenticate(username, password).await {
                 Ok(auth) => {
                     let mut response = messages::SaslAuthenticateResponse::default();
 


### PR DESCRIPTION
**Description:**

This is happening because sessions now only live for as long as their access token, which is ~1h. The consumer will try to reauthenticate when a session is about to expire, and we should let it.

I'm thinking this will also resolve a lot of customer complaints about noisy auth logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2295)
<!-- Reviewable:end -->
