### PR TITLE
dekaf: Don't transform schemas into canonical form in `/subjects/:subject/versions/latest`

### DIFF
--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -107,9 +107,12 @@ async fn get_subject_latest(
             (value_id, &collection.value_schema)
         };
 
+        let serialized_schema =
+            serde_json::to_value(schema).context("Cannot parse Schema from JSON")?;
+
         Ok(serde_json::json!({
             "id": id,
-            "schema": schema.canonical_form(),
+            "schema": serialized_schema,
             "schemaType": "AVRO",
             "subject": subject,
             "version": 1,


### PR DESCRIPTION
**Description:**

This got missed when we did https://github.com/estuary/flow/pull/1956, and an integration partner just pointed it out as a discrepancy when investigating an issue.

Currently, `/schemas/ids/:id` returns the full-fat schema whereas `/subjects/:subject/versions/latest` returns the canonical form which is missing a lot of data.

Tested this locally with kcat and on `dekaf-dev`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2299)
<!-- Reviewable:end -->
