### PR TITLE
Docs: Include `flowctl` automatic encryption capabilities

### DIFF
--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -180,7 +180,7 @@ The only time a credential needs to be directly accessed is when Flow initiates 
 Flow integrates with Mozilla’s [sops](https://github.com/mozilla/sops) tool,
 which can encrypt and protect credentials.
 It stores a `sops`-protected configuration in its encrypted form,
-and decrypts it only when invoking a connector on the your behalf.
+and decrypts it only when invoking a connector on your behalf.
 
 sops, short for “Secrets Operations,” is a tool that encrypts the values of a JSON or YAML document
 against a key management system (KMS) such as Google Cloud Platform KMS, Azure Key Vault, or Hashicorp Vault.
@@ -190,12 +190,44 @@ and creates a request trace which can be logged and audited.
 It's also possible to revoke access to the KMS,
 which immediately and permanently removes access to the protected credential.
 
-When you use the Flow web application, Flow automatically
+When you use the Flow web application or `flowctl`, Flow automatically
 adds `sops` protection to sensitive fields on your behalf.
+
+Most workflows can make use of this built-in encryption mechanism.
+There is also the option to configure your own encryption with `sops` to maintain strict control over your encryption process.
+
+### Using `flowctl`'s auto-encryption
+
+Starting with version 0.5.18, `flowctl` will automatically encrypt plain-text connector endpoint configurations when you run one of the following commands:
+
+* `draft author`
+* `catalog test`
+* `catalog publish`
+
+These commands use the same encryption mechanism as the dashboard and ensure that your secrets are encrypted whenever you send your specifications to Estuary.
+
+This does not, by default, encrypt secrets in your local environment.
+If you want to encrypt local files, you can overwrite your local plain-text configuration with Estuary's encrypted version. To do so, run:
+
+```bash
+flowctl draft author --source your/flow.yaml
+flowctl draft develop --overwrite
+```
+
+This will send a draft specification to Estuary without publishing it yet.
+Estuary will encrypt the configuration as part of the `draft author` command, and you can pull this version back to overwrite your local file.
+
+### Controlling encryption with `sops`
+
 You can also implement `sops` manually if you are writing a Flow specification locally.
+
+This can be useful if you need to maintain strict control over how credentials are encrypted.
+In this case, you own the KMS key and grant Estuary access for decryption.
+`flowctl` will not modify endpoint configurations that have already been encrypted.
+
 The examples below provide a useful reference.
 
-### Example: Protect a configuration
+#### Example: Protect a configuration
 
 Suppose you're given a connector configuration:
 
@@ -251,7 +283,7 @@ flow-258@helpful-kingdom-273219.iam.gserviceaccount.com
 
 :::
 
-### Example: Protect portions of a configuration
+#### Example: Protect portions of a configuration
 
 Endpoint configurations are typically a mix of sensitive and non-sensitive values.
 It can be cumbersome when `sops` protects an entire configuration document as you

--- a/site/docs/guides/flowctl/ci-cd.md
+++ b/site/docs/guides/flowctl/ci-cd.md
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 While Estuary's UI is a convenient way to create and manage resources, some users may prefer to treat their captures, materializations, and other resources as infrastructure-as-code.
 This allows resource specifications to be checked into your own version control system with a clearly logged history of changes.
-You can then set your infa-as-code repositories up with a CI/CD pipeline to automate deployment.
+You can then set your infra-as-code repositories up with a CI/CD pipeline to automate deployment.
 
 This guide will show you how to configure Estuary Flow resources programmatically for use in CI/CD workflows or other automation.
 
@@ -45,7 +45,6 @@ At a minimum, the configuration will need to specify:
 * The capture name
 * The connector image for the capture
 * Any credentials needed for source system authentication
-    * These ideally should be [encrypted](#encrypting-secrets)
 * The resource streams from the source system you wish to use
 
 Consider these example specifications:
@@ -304,7 +303,6 @@ The configuration, at a minimum, will need to specify:
 * The materialization name
 * The connector image for the materialization
 * Any credentials needed for destination system authentication
-    * These ideally should be [encrypted](#encrypting-secrets)
 * The data collections to use as sources and which tables they should map to
 
 Consider this example specification:
@@ -339,13 +337,6 @@ materializations:
 
 </TabItem>
 </Tabs>
-
-### Encrypting Secrets
-
-Passwords, authentication tokens, and other sensitive information in your specifications should be encrypted.
-If you create resources through the UI, Estuary will do this for you. In an automation setting, you will need to encrypt sensitive information yourself.
-
-See the section on [`sops`](../../concepts/flowctl.md#protecting-secrets) for guidance and examples.
 
 ## Testing Specifications
 
@@ -428,6 +419,8 @@ flowctl catalog publish --source <SOURCE>
 ```
 
 The command's default behavior is to summarize the resource configurations to publish and prompt for confirmation. You can skip this prompt with the `--auto-approve` option.
+
+The `catalog publish` command will [automatically encrypt any secrets](../../concepts/flowctl.md#using-flowctls-auto-encryption) in your endpoint configurations.
 
 ### Choosing a Data Plane
 


### PR DESCRIPTION
**Description:**

Following #2294, updates docs around `flowctl` and protecting secrets. Adds information on automatic encryption with `flowctl` and clarifies manual `sops` process.

**Documentation links affected:**

Updates:
* [`flowctl` concepts page](https://docs.estuary.dev/concepts/flowctl/)
* [CI/CD guide](https://docs.estuary.dev/guides/flowctl/ci-cd/)

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2301)
<!-- Reviewable:end -->
