### PR TITLE
flowctl: change default data plane to c2

### DIFF
--- a/crates/flowctl/src/catalog/publish.rs
+++ b/crates/flowctl/src/catalog/publish.rs
@@ -13,7 +13,7 @@ pub struct Publish {
     #[clap(long)]
     auto_approve: bool,
     /// Data-plane into which created specifications will be placed.
-    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c1")]
+    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c2")]
     default_data_plane: String,
 }
 

--- a/crates/flowctl/src/catalog/test.rs
+++ b/crates/flowctl/src/catalog/test.rs
@@ -7,7 +7,7 @@ pub struct TestArgs {
     #[clap(long)]
     source: String,
     /// Data-plane into which created specifications will be placed.
-    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c1")]
+    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c2")]
     default_data_plane: String,
 }
 

--- a/crates/flowctl/src/draft/mod.rs
+++ b/crates/flowctl/src/draft/mod.rs
@@ -81,7 +81,7 @@ pub enum Command {
 #[clap(rename_all = "kebab-case")]
 pub struct Publish {
     /// Data-plane into which created specifications will be placed.
-    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c1")]
+    #[clap(long, default_value = "ops/dp/public/gcp-us-central1-c2")]
     default_data_plane: String,
 }
 

--- a/site/docs/guides/flowctl/ci-cd.md
+++ b/site/docs/guides/flowctl/ci-cd.md
@@ -424,7 +424,7 @@ The `catalog publish` command will [automatically encrypt any secrets](../../con
 
 ### Choosing a Data Plane
 
-The `catalog publish` command defaults to publishing resources to the `ops/dp/public/gcp-us-central1-c1` data plane.
+The `catalog publish` command defaults to publishing resources to the `ops/dp/public/gcp-us-central1-c2` data plane.
 You can also specify a different public data plane or your own [private or BYOC](../../private-byoc/README.md) data plane.
 
 You can retrieve the full name of your desired data plane from the dashboard:
@@ -440,7 +440,7 @@ You can retrieve the full name of your desired data plane from the dashboard:
 When publishing resources to a data plane besides the default, make sure to specify this data plane name in an option:
 
 ```
-flowctl catalog publish --default-data-plane ops/dp/public/aws-eu-west-1-c1 --source ./flow.yaml
+flowctl catalog publish --default-data-plane ops/dp/public/aws-eu-west-1-c2 --source ./flow.yaml
 ```
 
 All resources that interact with each other (such as derivations or materializations along with their relevant sources) must be part of the same data plane.


### PR DESCRIPTION
Updates the default values for the `--default-data-plane` argument to be the new public data plane, since Cronut is being decomissioned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2303)
<!-- Reviewable:end -->
