### PR TITLE
agent: Address some PR feedback

### DIFF
--- a/crates/doc/src/shape/mod.rs
+++ b/crates/doc/src/shape/mod.rs
@@ -246,8 +246,8 @@ pub const X_INFER_SCHEMA: &str = "x-infer-schema";
 /// collection's initial read schema.
 pub const X_INITIAL_READ_SCHEMA: &str = "x-initial-read-schema";
 
-/// X_COMPLEXITY_LIMIT is a JSON-Schema annotation added to emitted inferred schemas that
-/// allows for the modification of the default complexity limit applied to inferred schemas.
+/// X_COMPLEXITY_LIMIT is a JSON-Schema annotation optionally added to binding schemas that
+/// specifies the complexity limit applied to collection's inferred schema.
 pub const X_COMPLEXITY_LIMIT: &str = "x-complexity-limit";
 
 #[cfg(test)]

--- a/crates/runtime/src/capture/task.rs
+++ b/crates/runtime/src/capture/task.rs
@@ -83,6 +83,14 @@ impl Task {
                 crate::X_GENERATION_ID.to_string(),
                 serde_json::Value::String(binding.collection_generation_id.to_string()),
             );
+            
+            // Initialize complexity limit with default value
+            by_index[index].annotations.insert(
+                doc::shape::X_COMPLEXITY_LIMIT.to_string(),
+                serde_json::Value::Number(serde_json::Number::from(
+                    doc::shape::limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT
+                )),
+            );
         }
         by_index
     }


### PR DESCRIPTION
**Description:**

This addresses the remaining PR feedback from https://github.com/estuary/flow/pull/2263

* use remove() to avoid cloning in initializes_read_schema
* simplify initial read schema discovery codepaths
* simplify setting `x-complexity-limit` on inferred schemas
  * Initialize shapes with default complexity limit annotation
  * Raise complexity limit to 10,000 when sourced schemas are applied in apply_sourced_schemas

Tested this locally with a `hello-world` and `postgres` connector, confirming that their behavior is expected: hello-world has `x-complexity-limit: 1000` and postgres has `x-complexity-limit: 10000`
<img width="1133" height="675" alt="Screenshot 2025-09-05 at 12 19 51" src="https://github.com/user-attachments/assets/7ea138cb-cd0f-4c40-9fc4-d82ee928de9b" />
<img width="1206" height="756" alt="Screenshot 2025-09-05 at 12 19 33" src="https://github.com/user-attachments/assets/57ad4160-5d5d-4c1b-8d2d-e098cdc9df21" />



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2304)
<!-- Reviewable:end -->
