### PR TITLE
data-plane-controller: add aws_assume_role.iam_instance_profile

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -126,6 +126,8 @@ pub struct ConnectorLimits {
 pub struct AWSAssumeRole {
     pub role_arn: String,
     pub external_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iam_instance_profile: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/data-plane-controller/src/state_fixture.json
+++ b/crates/data-plane-controller/src/state_fixture.json
@@ -58,7 +58,8 @@
         ],
         "aws_assume_role": {
           "role_arn": "arn:aws:iam::12345678:role/estuary",
-          "external_id": "c90634a4-0000-404d-ba7f-0facfba5b5cd"
+          "external_id": "c90634a4-0000-404d-ba7f-0facfba5b5cd",
+          "iam_instance_profile": "arn:aws:iam::12345678:role/instance"
         },
         "builds_kms_keys": [
           "projects/the-project/locations/us-central1/keyRings/the-key-ring/cryptoKeys/the-key"


### PR DESCRIPTION
**Description:**

- Necessary for testing and releasing https://github.com/estuary/est-dry-dock/pull/156

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2305)
<!-- Reviewable:end -->
