### PR TITLE
dekaf: Fix propagation of `last_source_published_at` in stats documents

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -51,6 +51,9 @@ impl StatsAggregator {
         if let Some(out) = &stats.out {
             ops::merge_docs_and_bytes(out, &mut binding.out);
         }
+        if let Some(last_source_published_at) = stats.last_source_published_at {
+            binding.last_source_published_at = Some(last_source_published_at);
+        }
     }
 
     // If any stats have been written, return them and reset the counter. Otherwise None

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats.snap
@@ -9,6 +9,7 @@ expression: captured_logs
     },
     "materialize": {
       "test_collection": {
+        "lastSourcePublishedAt": "1970-01-01T00:00:06.000000007+00:00",
         "left": {
           "bytesTotal": 2,
           "docsTotal": 1


### PR DESCRIPTION
**Description:**

This was just never getting set on emitted stats documents, even through we were recording it at read time correctly.

**Testing:**

Confirmed that this emits `lastSourcePublishedAt` whereas it didn't before: 
```json
{
  "_meta": {
    "uuid": "f0e9592d-72f3-11f0-8000-1dede6ce7f7c"
  },
  "materialize": {
    "joseph/c2-to-c1-test/hello/events": {
      "lastSourcePublishedAt": "2025-08-06T18:34:08.431948212+00:00",
      "out": {
        "bytesTotal": 9407679,
        "docsTotal": 77913
      },
      "right": {
        "bytesTotal": 9407679,
        "docsTotal": 77913
      }
    }
  },
  "shard": {
    "build": "11fa3c5c178000e4",
    "keyBegin": "00000000",
    "kind": "materialization",
    "name": "joseph/c2-to-c1-test/dekaf/dekaf-generic",
    "rClockBegin": "00000000"
  },
  "ts": "2025-08-06T18:34:09.292934193+00:00"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2320)
<!-- Reviewable:end -->
