### PR TITLE
dekaf: Revert build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - "site/**"
   pull_request:
-    branches: [master, dekaf/revert-cherry-picked]
+    branches: [master, dekaf/revert-base]
     paths-ignore:
       - "site/**"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - "site/**"
   pull_request:
-    branches: [master]
+    branches: [master, dekaf/revert-cherry-picked]
     paths-ignore:
       - "site/**"
 

--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -50,6 +50,9 @@ impl StatsAggregator {
         if let Some(out) = &stats.out {
             ops::merge_docs_and_bytes(out, &mut binding.out);
         }
+        if let Some(last_source_published_at) = stats.last_source_published_at {
+            binding.last_source_published_at = Some(last_source_published_at);
+        }
     }
 
     // If any stats have been written, return them and reset the counter. Otherwise None

--- a/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats.snap
+++ b/crates/dekaf/src/snapshots/dekaf__log_appender__tests__test_stats.snap
@@ -9,6 +9,7 @@ expression: captured_logs
     },
     "materialize": {
       "test_collection": {
+        "lastSourcePublishedAt": "1970-01-01T00:00:06.000000007+00:00",
         "left": {
           "bytesTotal": 2,
           "docsTotal": 1


### PR DESCRIPTION
I started from the build of Dekaf we'd like to revert back to, `ghcr.io/estuary/flow:v0.5.11-272-gbe1988e8d2`, created `dekaf/revert-base` at its commit of `be1988e8d2`, and then cherry-picked https://github.com/estuary/flow/pull/2320 ontop of it.

This essentially reverts all of the changes in https://github.com/estuary/ops/pull/838 while keeping the fix for `last_source_published_at`.

_So long as_ we don't have anyone using Dekaf redirects in production, which is true given that I don't see any `Task has been redirected` logs in `dekaf.estuary-data.com` other than my testing, all of the rest of these changes are QoL improvements that _should_ be safe to revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2324)
<!-- Reviewable:end -->
