### PR TITLE
gazette: increase connect timeout to 60s

### DIFF
--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -121,7 +121,11 @@ pub fn dial_channel(endpoint: &str) -> Result<tonic::transport::Channel> {
         // Note this connect_timeout accounts only for TCP connection time and
         // does not apply to time required for TLS or HTTP/2 transport start,
         // which can block indefinitely if the server is bound but not listening.
-        .connect_timeout(Duration::from_secs(5))
+        // Also, this timeout gets split between all of the IP addresses that endpoint
+        // resolves to. Thus, if the endpoint resolves to 10 different addresses, then
+        // the effective timeout per address is 60 / 10 = 6 seconds. This is why
+        // the value is relatively high.
+        .connect_timeout(Duration::from_secs(60))
         // HTTP/2 keep-alive sends a PING frame every interval to confirm the
         // health of the end-to-end HTTP/2 transport. The duration was selected
         // to be compatible with the default grpc server setting of 5 minutes


### PR DESCRIPTION
This addresses a reported flowctl bug, where users are getting connection timeouts when attempting to reach some public data planes. While investigating, I found that the docs for the [connect_timeout function](https://docs.rs/hyper-util/0.1.16/hyper_util/client/legacy/connect/struct.HttpConnector.html#method.set_connect_timeout) say that the given timeout will be divided among all of the IPs that the given hostname resolves to. For example, if the generic gazette endpoint resolved to 20 different possible IP addresses, then the previous 5 second timeout would result in an effective timeout of only 0.25 seconds for each IP. This is just a quick and easy fix to increase the timeout.

Bug report: https://estuary-dev.slack.com/archives/C06R0CVD0KZ/p1754757363648469

Arguably, we should be using different timeout values depending on the context, or perhaps the endpoint. Ideally, we wouldn't be using such a large value in cases where the endpoint will resolve to a single IP, and it's even conceivable that this 60 second timeout could be insufficient if the cluster gets excessively large, and/or the network excessively slow (if some flowctl user is trying to read logs over 3g from their cabin in the woods, or something 🤷 ). But I didn't see an obvious best way to configure the timeouts, and so I thought to just do the simple and easy thing until we decide on a better way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2326)
<!-- Reviewable:end -->
