### PR TITLE
dpc: allow_cidrs for data planes

### DIFF
--- a/crates/data-plane-controller/src/data_plane_fixture.json
+++ b/crates/data-plane-controller/src/data_plane_fixture.json
@@ -4,6 +4,7 @@
     "deployments": [],
     "gcp_project": "testing-ground-123456",
     "ssh_subnets": [],
+    "allow_cidrs": [],
     "data_buckets": [
       "gs://estuary-trial",
       "gs://estuary-flow-poc"
@@ -28,6 +29,7 @@
     "deployments": [],
     "gcp_project": "testing-ground-123456",
     "ssh_subnets": [],
+    "allow_cidrs": [],
     "data_buckets": [
       "gs://estuary-trial",
       "gs://estuary-flow-poc"
@@ -56,6 +58,27 @@
     "deployments": [],
     "gcp_project": "testing-ground-123456",
     "ssh_subnets": [],
+    "allow_cidrs": [],
+    "data_buckets": [
+      "gs://estuary-trial",
+      "gs://estuary-flow-poc"
+    ],
+    "builds_kms_keys": [
+      "projects/testing-ground-123456/locations/us-central1/keyRings/catalog-sops/cryptoKeys/config-encryptor"
+    ],
+    "private_links": [],
+    "control_plane_api": "https://agent-api.app/"
+  },
+  "allow_cidrs": {
+    "builds_root": "gs://estuary-control/builds/",
+    "deployments": [],
+    "gcp_project": "testing-ground-123456",
+    "ssh_subnets": [],
+    "allow_cidrs": [
+      "10.0.0.0/16",
+      "192.168.1.0/24",
+      "172.16.0.0/12"
+    ],
     "data_buckets": [
       "gs://estuary-trial",
       "gs://estuary-flow-poc"

--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -112,6 +112,8 @@ pub struct DataPlane {
     pub gcp_project: String,
     pub ssh_subnets: Vec<ipnetwork::IpNetwork>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_cidrs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub private_links: Vec<PrivateLink>,
     pub deployments: Vec<Deployment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -552,6 +554,14 @@ mod test {
             Some(GCPBYOC {
                 project_id: "12345678".to_string(),
             }),
+        );
+
+        let allow_cidrs_parsed =
+            serde_json::from_value::<DataPlane>(fixtures.get("allow_cidrs").unwrap().clone())
+                .unwrap();
+        assert_eq!(
+            allow_cidrs_parsed.allow_cidrs,
+            vec!["10.0.0.0/16", "192.168.1.0/24", "172.16.0.0/12"]
         );
     }
 

--- a/crates/data-plane-controller/src/state_fixture.json
+++ b/crates/data-plane-controller/src/state_fixture.json
@@ -52,6 +52,7 @@
           "2600:1900:4000:97c7::/128",
           "34.136.233.238/32"
         ],
+        "allow_cidrs": [],
         "data_buckets": [
           "gs://estuary-trial",
           "gs://estuary-flow-poc"

--- a/crates/data-plane-controller/tests/util.rs
+++ b/crates/data-plane-controller/tests/util.rs
@@ -122,6 +122,7 @@ pub fn initial_state() -> stack::State {
         "12.34.56.78/32",
         "2600:1234:5000:6000::/128"
       ],
+      "allow_cidrs": [],
       "data_buckets": [
         "gs://example-bucket"
       ],


### PR DESCRIPTION
**Description:**

- allow setting a custom allow_cidrs config for data planes. See https://github.com/estuary/est-dry-dock/pull/165

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2327)
<!-- Reviewable:end -->
