### PR TITLE
Docs: Additional storage mapping configuration details

### DIFF
--- a/site/docs/concepts/storage-mappings.md
+++ b/site/docs/concepts/storage-mappings.md
@@ -11,7 +11,7 @@ Data in Flow's cloud storage bucket is deleted 20 days after collection.
 
 For production workflows, you should [set up your own cloud storage bucket as a storage mapping](../getting-started/installation.mdx).
 
-You can set up a bucket lifecycle policy to manage data retention in your storage mapping;
+You can set up a [bucket lifecycle policy](#bucket-lifecycle-policies) to manage data retention in your storage mapping;
 for example, to remove data after six months.
 
 ## Recovery logs
@@ -30,3 +30,85 @@ Flow prunes data from recovery logs once it is no longer required.
 Deleting data from recovery logs while it is still in use can
 cause Flow processing tasks to fail permanently.
 :::
+
+## Bucket lifecycle policies
+
+You can add a lifecycle policy to your storage bucket to limit how long to keep collection data.
+This is similar to Estuary's 20-day limit on collection data when using the trial bucket.
+
+Bucket lifecycle policies should **only** be applied to the `collection-data/` subfolder in a bucket.
+Deleting data in the [`recovery/`](#recovery-logs) folder can cause tasks to fail.
+
+You can apply a lifecycle policy to your storage bucket in:
+
+* [AWS](#add-a-lifecycle-policy-in-aws)
+* [Google Cloud](#add-a-lifecycle-policy-in-gcp)
+* [Azure](#add-a-lifecycle-policy-in-azure)
+
+### Add a lifecycle policy in AWS
+
+To add a lifecycle policy in AWS:
+
+1. Select your storage bucket in the AWS S3 console.
+
+2. If `collection-data/` isn't located at the top level of your bucket, note the full path for the directory.
+
+3. In the **Management** tab, click **Create lifecycle rule**.
+
+4. Add a name for the rule.
+
+5. Choose to **Limit the scope to specific prefixes or tags** and enter the full path for `collection-data/` as the prefix.
+
+6. Select a desired action to take, such as deleting data or setting it to a different storage class.
+
+7. Enter the number of days for the action to take effect and any other information required for the action.
+
+8. Click **Create rule**.
+
+For full instructions on creating and managing a lifecycle policy in AWS, see the [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html).
+
+### Add a lifecycle policy in GCP
+
+To add a lifecycle policy in GCP:
+
+1. Select your storage bucket in the GCP Cloud Storage console.
+
+2. If `collection-data/` isn't located at the top level of your bucket, note the full path for the directory.
+
+3. In the **Lifecycle** tab, click **Add a rule**.
+
+4. Choose a desired action, such as deleting data or setting it to a different storage class, and click **Continue**.
+
+5. Under **Set Rule Scopes**, check **Object name matches prefix** and enter the path for `collection-data/`.
+
+6. Under **Set Conditions**, configure one or more desired conditions, such as age in days.
+
+7. Click **Create**.
+
+For full instructions on creating and managing a lifecycle policy in GCP, see the [Google Cloud docs](https://cloud.google.com/storage/docs/lifecycle).
+
+### Add a lifecycle policy in Azure
+
+To add a lifecycle policy in Azure:
+
+1. Go to your Azure storage account.
+
+2. Note the full path for your `collection-data/` directory, including the container name.
+
+3. Under **Data Management**, select **Lifecycle Management**.
+
+4. In the **List View** tab, click **Add a rule**.
+
+5. Provide a name.
+
+6. Under **Rule scope**, select **Limit blobs with filters**.
+
+7. Choose affected blob types and subtypes and click **Next**.
+
+8. Fill out an if/then rule, choosing a timeline and action to take, such as deleting objects or changing their storage class after a number of days. Click **Next**.
+
+9. Add your `collection-data/` path under **Blob prefix** as a **Filter set**.
+
+10. Click **Add**.
+
+For full instructions on creating and managing a lifecycle policy in Azure, see the [Azure docs](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview).

--- a/site/docs/getting-started/installation.mdx
+++ b/site/docs/getting-started/installation.mdx
@@ -30,6 +30,11 @@ Once you're done, [add the bucket](#add-the-bucket) in Estuary.
 Once your collections begin to persist data, you can view your storage bucket to confirm that the
 bucket is receiving data as expected. This should indicate that your bucket has been set up correctly.
 
+You can also set a [bucket lifecycle policy](../concepts/storage-mappings.md#bucket-lifecycle-policies) to limit
+how long collections keep data.
+Note that lifecycle policies should be specific to the `collection-data/` sub-directory that Estuary creates,
+**not** cover the entire bucket.
+
 ## Google Cloud Storage buckets
 
 You'll need to grant Estuary Flow access to your GCS bucket.
@@ -160,10 +165,16 @@ You'll need to grant Estuary Flow access to your S3 bucket.
 You'll need to grant Estuary Flow access to your storage account and container.
 You'll also need to provide some identifying information.
 
-1. [Create an Azure Blob Storage container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container)
+1. [Create an Azure storage account](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create) if you haven't already.
+
+   Make sure your storage account has the `Hierarchical Namespace` option **disabled**.
+   During storage account creation, you can review this setting in the **Advanced** tab.
+   Under the **Data Lake Storage** section, ensure the hierarchical namespace option is unchecked.
+
+2. Within the storage account, [create an Azure Blob Storage container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container)
    to use with Flow, if you haven't already.
 
-2. Gather the following information. You'll need this when you contact us to complete setup.
+3. Gather the following information. You'll need this when you contact us to complete setup.
 
     - Your **Azure AD tenant ID**. You can find this in the **Azure Active Directory** page.
       ![Azure AD Tenant ID](https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//Azure_AD_Tenant_ID_1b60184837/Azure_AD_Tenant_ID_1b60184837.png)
@@ -177,7 +188,7 @@ You'll also need to provide some identifying information.
    You'll grant Flow access to your storage resources by connecting to Estuary's
    [Azure application](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-application-management).
 
-3. Add Estuary's Azure application to your tenant.
+4. Add Estuary's Azure application to your tenant.
 
 import { AzureAuthorizeComponent } from "./azureAuthorize";
 import BrowserOnly from "@docusaurus/BrowserOnly";
@@ -207,7 +218,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
    </TabItem>
    </Tabs>
 
-4. Grant the application access to your storage account via the
+5. Grant the application access to your storage account via the
    [
    `Storage Blob Data Owner`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-owner)
    IAM role.


### PR DESCRIPTION
**Description:**

Users can get themselves into a bad state when configuring storage mappings in certain ways for certain edge cases. This PR adds info to keep them on the right track. Specifically:

* Adds details on setting up a bucket lifecycle policy for the 3 main cloud providers. All instructions specify using the `collection-data/` subfolder only to avoid affecting recovery logs.
* Notes that Azure storage accounts must currently have hierarchical namespaces disabled.

**Documentation links affected:**

Updates [Configure Cloud Storage](https://docs.estuary.dev/getting-started/installation/) and the [Storage Mappings](https://docs.estuary.dev/concepts/storage-mappings/) concepts page.

**Notes for reviewers:**

Thanks for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2328)
<!-- Reviewable:end -->
