### PR TITLE
docs source-kafka: mention no support for schema references

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
+++ b/site/docs/reference/Connectors/capture-connectors/apache-kafka.md
@@ -25,6 +25,7 @@ enable discovery of collection keys if the message key has an associated schema.
   - The endpoint to use for connecting to the schema registry
   - Username for authentication
   - Password for authentication
+- Flat schemas, i.e. no use of schema references (`import`, `$ref`), as these are not currently supported
 
 :::tip
 If you are using the Confluent Cloud Schema Registry, your schema registry


### PR DESCRIPTION
Minor update since we don't support schema references

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2330)
<!-- Reviewable:end -->
