### PR TITLE
dekaf: Fix serialization of `get_subject_latest()` for Materialize

### DIFF
--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -108,7 +108,7 @@ async fn get_subject_latest(
         };
 
         let serialized_schema =
-            serde_json::to_value(schema).context("Cannot parse Schema from JSON")?;
+            serde_json::to_string(schema).context("Cannot parse Schema from JSON")?;
 
         Ok(serde_json::json!({
             "id": id,


### PR DESCRIPTION
**Description:**

It looks like I broke this in https://github.com/estuary/flow/pull/2299. `Schema::canonical_form()` totally returns `String`, so we need to match that in order to be compliant with the confluent schema registry. 

Reported by @mdobson [here](https://github.com/mdobson/flow/pull/1), thank you!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2334)
<!-- Reviewable:end -->
