### PR TITLE
DO NOT MERGE: flowctl raw cleanup-ops-journals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "ops",
  "page-turner",
  "pbjson-types",
+ "percent-encoding",
  "portpicker",
  "postgrest",
  "prost",

--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -16,7 +16,7 @@ pub struct Client {
     // Base shard client which is cloned to build token-specific clients.
     shard_client: gazette::shard::Client,
     // Base journal client which is cloned to build token-specific clients.
-    journal_client: gazette::journal::Client,
+    pub journal_client: gazette::journal::Client,
     // Keep a single Postgrest and hand out clones of it in order to maintain
     // a single connection pool. The clones can have different headers while
     // still re-using the same connection pool, so this will work across refreshes.

--- a/crates/flowctl/Cargo.toml
+++ b/crates/flowctl/Cargo.toml
@@ -72,6 +72,7 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 warp = { workspace = true }
+percent-encoding = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/flowctl/src/raw/cleanup_ops_journals.rs
+++ b/crates/flowctl/src/raw/cleanup_ops_journals.rs
@@ -1,0 +1,140 @@
+use std::collections::HashSet;
+
+use anyhow::Context;
+use gazette::{
+    broker::{apply_request::Change, journal_spec::suspend},
+    journal,
+};
+use itertools::Itertools;
+use labels::percent_encoding;
+use proto_gazette::broker;
+
+use crate::collection::CollectionJournalSelector;
+
+#[derive(clap::Args, Debug)]
+pub struct CleanupOpsJournals {
+    #[clap(long, short)]
+    pub for_real: bool,
+}
+
+const EXISTING_TASKS_JSON: &str = include_str!("/Users/phil/projects/flow/existing_tasks.json");
+
+#[derive(serde::Deserialize, Debug)]
+pub struct ExistingTask {
+    catalog_name: String,
+}
+
+impl CleanupOpsJournals {
+    pub async fn cleanup_ops_journals(&self, ctx: &mut crate::CliContext) -> anyhow::Result<()> {
+        let existing_tasks: Vec<ExistingTask> = serde_json::from_str(EXISTING_TASKS_JSON).unwrap();
+        if existing_tasks.is_empty() {
+            anyhow::bail!("no existing tasks");
+        }
+        tracing::warn!(existing_task_count = %existing_tasks.len(), "Cleaning up ops journals");
+
+        let existing_tasks = existing_tasks
+            .into_iter()
+            .map(|t| t.catalog_name)
+            .collect::<HashSet<_>>();
+
+        let deleted_logs = self
+            .cleanup_ops_journals_inner(ctx, "ops.us-central1.v1/logs", &existing_tasks)
+            .await?;
+        let deleted_stats = self
+            .cleanup_ops_journals_inner(ctx, "ops.us-central1.v1/stats", &existing_tasks)
+            .await?;
+        tracing::warn!(deleted_logs = %deleted_logs, deleted_stats = %deleted_stats, "Finished cleaning up logs and stats journals");
+        Ok(())
+    }
+
+    pub async fn cleanup_ops_journals_inner(
+        &self,
+        ctx: &mut crate::CliContext,
+        collection: &str,
+        existing_tasks: &HashSet<String>,
+    ) -> anyhow::Result<i32> {
+        let (journal_name_prefix, client) =
+            flow_client::fetch_user_collection_authorization(&ctx.client, collection, true).await?;
+
+        let selector = CollectionJournalSelector {
+            collection: collection.to_string(),
+            partitions: None,
+        };
+        let label_selector = selector.build_label_selector(journal_name_prefix);
+        let list_reps = client
+            .list(broker::ListRequest {
+                selector: Some(label_selector),
+                ..Default::default()
+            })
+            .await?;
+
+        let task_name_label = format!("{}name", ::labels::FIELD_PREFIX);
+        let mut changes_iter = list_reps
+            .journals
+            .into_iter()
+            .filter_map(|journal| {
+                let Some(spec) = journal.spec else {
+                    return None;
+                };
+                let Some(labels) = spec.labels.as_ref() else {
+                    tracing::warn!("journal missing labels");
+                    return None;
+                };
+
+                let task_values = ::labels::values(labels, &task_name_label);
+                if task_values.len() != 1 {
+                    tracing::warn!(values = %task_values.len(), "task values != 1");
+                    return None;
+                }
+                let task_name = task_values.first().unwrap().value.as_str();
+                let task_name = ::percent_encoding::percent_decode(task_name.as_bytes())
+                    .decode_utf8()
+                    .expect("failed to decode task name")
+                    .into_owned();
+                if existing_tasks.contains(&task_name) {
+                    tracing::warn!(%task_name, journal= %spec.name, "task exists, keeping journal");
+                    return None;
+                }
+
+                let Some(suspend) = spec.suspend.as_ref() else {
+                    tracing::warn!("journal not suspended");
+                    return None;
+                };
+                if suspend.level != suspend::Level::Full as i32 {
+                    tracing::warn!("suspend level != full");
+                    return None;
+                }
+
+                Some(broker::apply_request::Change {
+                    expect_mod_revision: journal.mod_revision,
+                    upsert: None,
+                    delete: spec.name,
+                })
+            })
+            .peekable();
+
+        let mut total_deleted = 0;
+        let batch_size = 120;
+        let mut batch = Vec::with_capacity(batch_size);
+        while let Some(change) = changes_iter.next() {
+            total_deleted += 1;
+            tracing::warn!(expect_mod_revision = change.expect_mod_revision, journal = %change.delete, for_real = self.for_real, "deleting journal");
+            if !self.for_real {
+                continue;
+            }
+            batch.push(change);
+            if batch.len() == batch_size || changes_iter.peek().is_none() {
+                tracing::info!(%total_deleted, "Sending apply request for batch");
+                let changes = std::mem::replace(&mut batch, Vec::with_capacity(batch_size));
+                let _req = broker::ApplyRequest { changes };
+                /*
+                //client.apply(req).await.context("apply request failed")?;
+                 */
+                tracing::info!(%total_deleted, "Finished batch");
+            }
+        }
+        tracing::warn!(%total_deleted, "Finished deleting {collection} journals");
+
+        Ok(total_deleted)
+    }
+}

--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     ops::{OpsCollection, TaskSelector},
 };
 use anyhow::Context;
+use cleanup_ops_journals::CleanupOpsJournals;
 use doc::combine;
 use std::{
     io::{self, Write},
@@ -11,6 +12,7 @@ use std::{
 };
 use tables::CatalogResolver;
 
+mod cleanup_ops_journals;
 mod discover;
 mod materialize_fixture;
 mod oauth;
@@ -71,6 +73,8 @@ pub enum Command {
     /// Print environment variables for working with a given data-plane
     /// and prefix using Gazette's `gazctl`.
     GazctlEnv(GazctlEnv),
+
+    CleanupOpsJournals(CleanupOpsJournals),
 }
 
 #[derive(Debug, clap::Args)]
@@ -233,6 +237,7 @@ impl Advanced {
             Command::BearerLogs(bearer_logs) => bearer_logs.run(ctx).await,
             Command::ListShards(selector) => shards::do_list_shards(ctx, selector).await,
             Command::GazctlEnv(gazctl_env) => gazctl_env.run(ctx).await,
+            Command::CleanupOpsJournals(cleanup) => cleanup.cleanup_ops_journals(ctx).await,
         }
     }
 }


### PR DESCRIPTION
Adds a script for cleaning up old ops collection journals in cronut. These were left over from tasks that are deleted. This requires a json file with all the existing task names in cronut, so that it doesn't delete those journals.  I used the following query to get that:

```
select ls.catalog_name
from live_specs ls
join data_planes dp on ls.data_plane_id = dp.id
where dp.data_plane_name = 'ops/dp/public/gcp-us-central1-c1'
and (
  spec_type = any('{capture, materialization}')
  or (spec_type = 'collection' and spec->'derive' is not null)
)
order by ls.catalog_name;
```

The script won't delete any journals unless they're fully suspended and the task name does _not_ exist in those query results. In total, it's expected to delete about 20k journals.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2341)
<!-- Reviewable:end -->
