### PR TITLE
go/*: some minor tweaks to reduce Go allocations

### DIFF
--- a/go/bindings/task_service.go
+++ b/go/bindings/task_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/experimental"
 )
 
 type TaskService struct {
@@ -120,6 +121,7 @@ func NewTaskService(
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize)),
+		experimental.WithRecvBufferPool(grpc.NewSharedBufferPool()),
 	)
 
 	if err != nil {


### PR DESCRIPTION
**Description:**

This is the consolation prize for all that profiling work, a couple bits of very low-hanging fruit which should be fairly uncontroversial improvements.

In my benchmarking these improve throughput by about 2-3MBps on a wide range of document sizes by reducing some unnecessary allocations in the hot path of document processing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2345)
<!-- Reviewable:end -->
