### PR TITLE
agent: place discovered schemas into flow://connector-schema sub-schema

### DIFF
--- a/crates/agent/src/discovers/specs.rs
+++ b/crates/agent/src/discovers/specs.rs
@@ -230,7 +230,7 @@ pub fn merge_collections(
     for binding in used_bindings {
         let Binding {
             target,
-            document_schema,
+            document_schema: connector_schema,
             collection_key,
             is_fallback_key,
             resource_path,
@@ -314,42 +314,35 @@ pub fn merge_collections(
             draft_model.key = discovered_key;
         }
 
-        if draft_model.read_schema.is_some() {
-            if is_schema_changed(&document_schema, draft_model.write_schema.as_ref()) {
-                tracing::debug!(
-                    %collection,
-                    "discovered writeSchema change"
-                );
-                modified = true;
-                draft_model.write_schema = Some(document_schema);
-            }
-        } else if let Some(initial_read_schema) = initializes_read_schema(&document_schema) {
-            modified = true;
-            draft_model.write_schema = Some(document_schema);
-            draft_model.schema = None;
-
+        // Determine the status of the collection's schema vs write/read schema.
+        let effective_write_schema = if draft_model.read_schema.is_some() {
+            // Collection is using separate read & write schemas.
+            // The read schema has been initialized and we do not modify it.
+            &mut draft_model.write_schema
+        } else if let Some(initial_read_schema) = initializes_read_schema(&connector_schema) {
+            // Migrate singular `schema` into separate read & write schemas.
+            draft_model.write_schema = draft_model.schema.take();
             draft_model.read_schema = Some(models::Schema::new(models::RawValue::from_value(
                 &initial_read_schema,
             )));
-        } else if uses_inferred_schema(&document_schema) {
-            tracing::debug!(
-                %collection,
-                "discovered new use of inferred schema, initializing readSchema with placeholder"
-            );
-            // This is either a new collection, or else discovery has just started asking for
-            // the inferred schema. In either case, we must initialize the read schema with the
-            // inferred schema placeholder.
             modified = true;
-            draft_model.read_schema = Some(models::Schema::default_inferred_read_schema());
-            draft_model.write_schema = Some(document_schema);
-            draft_model.schema = None;
-        } else if is_schema_changed(&document_schema, draft_model.schema.as_ref()) {
+            &mut draft_model.write_schema
+        } else {
+            // Collection uses a single schema for read & write.
+            &mut draft_model.schema
+        };
+
+        // Does the connector's schema update the effective write schema?
+        if let Some(updated) =
+            update_connector_schema(effective_write_schema.as_ref(), &connector_schema)
+                .context("failed to update write schema with connector schema")?
+        {
             tracing::debug!(
                 %collection,
                 "discovered schema change"
             );
+            *effective_write_schema = Some(updated);
             modified = true;
-            draft_model.schema = Some(document_schema);
         }
 
         if modified {
@@ -366,32 +359,24 @@ pub fn merge_collections(
     Ok(modified_collections)
 }
 
-fn uses_inferred_schema(schema: &models::Schema) -> bool {
-    matches!(
-        // Does the connector use schema inference?
-        schema.to_value().get(X_INFER_SCHEMA),
-        Some(serde_json::Value::Bool(true))
-    )
-}
-
 fn initializes_read_schema(schema: &models::Schema) -> Option<serde_json::Value> {
-    match schema.to_value().get(X_INITIAL_READ_SCHEMA) {
-        // Does the connector specify an initial read schema
-        Some(extension @ serde_json::Value::Object(_)) => Some(extension.clone()),
-        _ => None,
+    // Does the connector provide an explicit initial read schema?
+    if let Some(initial) = schema.to_value().get(X_INITIAL_READ_SCHEMA) {
+        return Some(initial.clone());
     }
-}
 
-/// Returns whether the discovered schema is different from the current schema.
-/// This currently checks whether the schemas are byte-for-byte identical, which
-/// means that insignificant serialization differences will be treated as
-/// "changed". But it would probably also be correct, and potentially
-/// beneficial, to ignore insignificant serialization differences.
-fn is_schema_changed(discovered: &models::Schema, current: Option<&models::Schema>) -> bool {
-    let Some(current_schema) = current else {
-        return true;
-    };
-    return current_schema != discovered;
+    // Does the connector use the legacy schema inference annotation?
+    // If so, initialize with a default read schema.
+    if let Some(serde_json::Value::Bool(true)) = schema.to_value().get(X_INFER_SCHEMA) {
+        return Some(serde_json::json!({
+            "allOf": [
+                {"$ref": models::Schema::REF_RELAXED_WRITE_SCHEMA_URL},
+                {"$ref": models::Schema::REF_INFERRED_SCHEMA_URL},
+            ],
+        }));
+    }
+
+    None
 }
 
 fn normalize_recommended_name(name: &str) -> String {
@@ -401,6 +386,37 @@ fn normalize_recommended_name(name: &str) -> String {
         .map(|m| models::collate::normalize(m.as_str().chars()).collect::<String>());
 
     parts.join("_")
+}
+
+fn update_connector_schema(
+    current: Option<&models::Schema>,
+    connector_schema: &models::Schema,
+) -> serde_json::Result<Option<models::Schema>> {
+    let base = match current {
+        // If the current schema includes the connector schema URL in any capacity
+        // (including an inert $defs, or even just the $id), then presume it's
+        // been migrated already.
+        Some(s) if s.get().contains(models::Schema::REF_CONNECTOR_SCHEMA_URL) => s.clone(),
+
+        // Otherwise, this schema is being initialized or is being migrated
+        // to have an embedded flow://connector-schema.
+        _ => models::Schema::new(models::RawValue::from_value(&serde_json::json!({
+            "$ref": models::Schema::REF_CONNECTOR_SCHEMA_URL
+        }))),
+    };
+
+    let updated = base.add_defs(&[models::schemas::AddDef {
+        id: models::Schema::REF_CONNECTOR_SCHEMA_URL,
+        schema: connector_schema,
+        overwrite: true,
+    }])?;
+
+    // Return the updated schema only if it's actually changed.
+    if current != Some(&updated) {
+        Ok(Some(updated))
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]
@@ -637,7 +653,7 @@ mod tests {
                 scope: flow://collection/case/1,
                 expect_pub_id: "0000000000000000",
                 model: {
-                  "schema": {"const": 42},
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":42}},"$ref":"flow://connector-schema"},
                   "key": [
                     "/foo",
                     "/bar"
@@ -650,7 +666,7 @@ mod tests {
                 scope: flow://collection/case/2,
                 expect_pub_id: NULL,
                 model: {
-                  "schema": {"const": 42},
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":42}},"$ref":"flow://connector-schema"},
                   "key": [
                     "/foo",
                     "/bar"
@@ -678,7 +694,7 @@ mod tests {
                 scope: flow://collection/case/3,
                 expect_pub_id: NULL,
                 model: {
-                  "schema": {"const": 42},
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":42}},"$ref":"flow://connector-schema"},
                   "key": [
                     "/one",
                     "/two"
@@ -691,7 +707,7 @@ mod tests {
                 scope: flow://collection/case/4,
                 expect_pub_id: NULL,
                 model: {
-                  "writeSchema": { "const": "write!", "x-infer-schema": true },
+                  "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":"write!","x-infer-schema":true}},"$ref":"flow://connector-schema"},
                   "readSchema": {"const":"read!"},
                   "key": [
                     "/foo",
@@ -705,7 +721,7 @@ mod tests {
                 scope: flow://collection/case/5,
                 expect_pub_id: "0000000000000000",
                 model: {
-                  "writeSchema": { "const": "write!", "x-infer-schema": true },
+                  "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":"write!","x-infer-schema":true}},"$ref":"flow://connector-schema"},
                   "readSchema": {"allOf":[{"$ref":"flow://relaxed-write-schema"},{"$ref":"flow://inferred-schema"}]},
                   "key": [
                     "/key"
@@ -718,7 +734,7 @@ mod tests {
                 scope: flow://collection/case/6,
                 expect_pub_id: "0000000000000000",
                 model: {
-                  "writeSchema": { "const": "write!", "x-infer-schema": true },
+                  "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":"write!","x-infer-schema":true}},"$ref":"flow://connector-schema"},
                   "readSchema": {"allOf":[{"$ref":"flow://relaxed-write-schema"},{"$ref":"flow://inferred-schema"}]},
                   "key": [
                     "/key"
@@ -731,7 +747,7 @@ mod tests {
                 scope: flow://collection/case/7,
                 expect_pub_id: NULL,
                 model: {
-                  "schema": {"const": 42},
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":42}},"$ref":"flow://connector-schema"},
                   "key": [
                     "/chosen",
                     "/key"
@@ -744,7 +760,7 @@ mod tests {
                 scope: flow://collection/case/8,
                 expect_pub_id: "0000000000000000",
                 model: {
-                  "writeSchema": { "const": "write!", "x-initial-read-schema": {"type": "object", "properties": {"id": {"type": "string"}}} },
+                  "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","const":"write!","x-initial-read-schema":{"type": "object", "properties": {"id": {"type": "string"}}}}},"$ref":"flow://connector-schema"},
                   "readSchema": {"properties":{"id":{"type":"string"}},"type":"object"},
                   "key": [
                     "/id"
@@ -1081,5 +1097,122 @@ mod tests {
                 "test case: {name}"
             );
         }
+    }
+
+    #[test]
+    fn test_connector_schema_update() {
+        // Test that update_connector_schema correctly handles various cases
+        let connector_schema =
+            models::Schema::new(models::RawValue::from_value(&serde_json::json!({
+                "type": "object",
+                "properties": {"id": {"type": "string"}}
+            })));
+
+        // Case 1: No existing schema - should create new with connector schema reference
+        let updated = update_connector_schema(None, &connector_schema)
+            .unwrap()
+            .unwrap();
+        insta::assert_json_snapshot!(updated.to_value(), @r###"
+        {
+          "$defs": {
+            "flow://connector-schema": {
+              "$id": "flow://connector-schema",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "$ref": "flow://connector-schema"
+        }
+        "###);
+
+        // Case 2: Existing schema without connector reference - should replace with new structure
+        let existing = models::Schema::new(
+            models::RawValue::from_str(
+                r#"{"type": "object", "properties": {"old": {"type": "string"}}}"#,
+            )
+            .unwrap(),
+        );
+        let updated = update_connector_schema(Some(&existing), &connector_schema)
+            .unwrap()
+            .unwrap();
+        insta::assert_json_snapshot!(updated.to_value(), @r###"
+        {
+          "$defs": {
+            "flow://connector-schema": {
+              "$id": "flow://connector-schema",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "$ref": "flow://connector-schema"
+        }
+        "###);
+
+        // Case 3: Existing schema with connector reference - should preserve outer structure
+        let existing_with_ref = models::Schema::new(
+            models::RawValue::from_str(
+                r#"{
+                "$defs": {
+                    "flow://connector-schema": {
+                        "$id": "flow://connector-schema",
+                        "const": "old"
+                    }
+                },
+                "$ref": "flow://connector-schema",
+                "properties": {
+                    "userExtension": {"type": "string"}
+                }
+            }"#,
+            )
+            .unwrap(),
+        );
+        let updated = update_connector_schema(Some(&existing_with_ref), &connector_schema)
+            .unwrap()
+            .unwrap();
+        insta::assert_json_snapshot!(updated.to_value(), @r###"
+        {
+          "$defs": {
+            "flow://connector-schema": {
+              "$id": "flow://connector-schema",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "$ref": "flow://connector-schema",
+          "properties": {
+            "userExtension": {
+              "type": "string"
+            }
+          }
+        }
+        "###);
+
+        // Case 4: Existing schema already reflects connector schema
+        let existing_complete =
+            models::Schema::new(models::RawValue::from_value(&serde_json::json!({
+                "$ref": "flow://connector-schema",
+                "title": "Example user modification",
+                "$defs": {
+                    "flow://connector-schema": {
+                        "$id": "flow://connector-schema",
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}}
+                    }
+                }
+            })));
+        let result = update_connector_schema(Some(&existing_complete), &connector_schema).unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/agent/src/integration_tests/auto_discovers.rs
+++ b/crates/agent/src/integration_tests/auto_discovers.rs
@@ -640,12 +640,17 @@ async fn test_auto_discovers_update_only() {
                 "key": ["/id"]
             },
             "pikas/moss": {
-                "schema": document_schema(1),
+                "schema": into_wrapped_connector_schema(document_schema(1)),
                 "key": ["/id"]
             },
             "pikas/lichen": {
                 "writeSchema": document_schema(1),
-                "readSchema": models::Schema::default_inferred_read_schema(),
+                "readSchema": {
+                  "allOf": [
+                        {"$ref": models::Schema::REF_RELAXED_WRITE_SCHEMA_URL},
+                        {"$ref": models::Schema::REF_INFERRED_SCHEMA_URL},
+                    ]
+                },
                 "key": ["/id"]
             }
         },
@@ -1117,5 +1122,18 @@ fn document_schema(version: usize) -> serde_json::Value {
             "squeaks": { "type": "integer", "maximum": version },
         },
         "required": ["id", "squeaks"]
+    })
+}
+
+fn into_wrapped_connector_schema(mut fixture: serde_json::Value) -> serde_json::Value {
+    let object = fixture.as_object_mut().unwrap();
+    object.insert(
+        "$id".to_string(),
+        serde_json::json!("flow://connector-schema"),
+    );
+
+    serde_json::json!({
+        "$defs": {"flow://connector-schema": fixture},
+        "$ref": "flow://connector-schema",
     })
 }

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-discover.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-discover.snap
@@ -44,7 +44,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/acorns,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
+              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "key": [
                 "/id"
               ]
@@ -56,7 +56,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/crab_apples,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
+              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "key": [
                 "/id"
               ]
@@ -68,7 +68,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/walnuts,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
+              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "key": [
                 "/id"
               ]

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-publication.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-publication.snap
@@ -14,19 +14,25 @@ expression: published_specs
                     String("/id"),
                 ],
                 "schema": Object {
-                    "properties": Object {
-                        "id": Object {
-                            "type": String("string"),
-                        },
-                        "nuttiness": Object {
-                            "maximum": Number(1),
-                            "type": String("number"),
+                    "$defs": Object {
+                        "flow://connector-schema": Object {
+                            "$id": String("flow://connector-schema"),
+                            "properties": Object {
+                                "id": Object {
+                                    "type": String("string"),
+                                },
+                                "nuttiness": Object {
+                                    "maximum": Number(1),
+                                    "type": String("number"),
+                                },
+                            },
+                            "required": Array [
+                                String("id"),
+                            ],
+                            "type": String("object"),
                         },
                     },
-                    "required": Array [
-                        String("id"),
-                    ],
-                    "type": String("object"),
+                    "$ref": String("flow://connector-schema"),
                 },
             },
         ),
@@ -95,19 +101,25 @@ expression: published_specs
                     String("/id"),
                 ],
                 "schema": Object {
-                    "properties": Object {
-                        "id": Object {
-                            "type": String("string"),
-                        },
-                        "nuttiness": Object {
-                            "maximum": Number(1),
-                            "type": String("number"),
+                    "$defs": Object {
+                        "flow://connector-schema": Object {
+                            "$id": String("flow://connector-schema"),
+                            "properties": Object {
+                                "id": Object {
+                                    "type": String("string"),
+                                },
+                                "nuttiness": Object {
+                                    "maximum": Number(1),
+                                    "type": String("number"),
+                                },
+                            },
+                            "required": Array [
+                                String("id"),
+                            ],
+                            "type": String("object"),
                         },
                     },
-                    "required": Array [
-                        String("id"),
-                    ],
-                    "type": String("object"),
+                    "$ref": String("flow://connector-schema"),
                 },
             },
         ),

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__second-discover.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__second-discover.snap
@@ -41,7 +41,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/acorns,
             expect_pub_id: NULL,
             model: {
-              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
+              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "key": [
                 "/id"
               ],
@@ -68,7 +68,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/hickory_nuts,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
+              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "key": [
                 "/id"
               ]
@@ -80,7 +80,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/walnuts,
             expect_pub_id: NULL,
             model: {
-              "writeSchema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
+              "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
               "readSchema": {"properties":{"drafted":{"type":"string"},"id":{"type":"string"}},"required":["id","drafted"],"type":"object"},
               "key": [
                 "/id"


### PR DESCRIPTION
Adopt a pattern similar to flow://inferred-schema where the connector-supplied schema is an overwritten sub-definition of the collection's write schema.

This allows users to "take control" of their write schema by adding additional top-level keywords or, if they choose, electing to not use `$ref: flow://connector-schema` at all.

In the garden path case, auto-discovery will continue to periodically update the sub-schema, and user keywords are preserved and applied atop the most recent update.


**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2356)
<!-- Reviewable:end -->
