### PR TITLE
flow-web: use `type` tag for Select / Reject serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "flow-web"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "console_error_panic_hook",
  "doc",

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flow-web"
 
 # wasm-pack isn't yet fully compatible with workspace inheritance, so we can't use that for these fields
-version = "0.5.17"
+version = "0.5.18"
 authors = ["Estuary developers  <engineering@estuary.dev>"]
 edition = "2021"
 license = "BSL"

--- a/crates/flow-web/FIELD_SELECTION.md
+++ b/crates/flow-web/FIELD_SELECTION.md
@@ -80,6 +80,7 @@ interface FieldSelection {
 - **ConnectorOmits**: No connector constraint provided
 - **DuplicateFold**: Ambiguous folded field name
 - **DuplicateLocation**: Location already materialized
+- **ExcludedParent**: Location's parent is excluded by user's field selection
 - **CoveredLocation**: Location covered by parent field
 - **NotSelected**: Doesn't meet selection criteria
 

--- a/crates/validation/src/field_selection.rs
+++ b/crates/validation/src/field_selection.rs
@@ -17,6 +17,7 @@ use tables::EitherOrBoth as EOB;
     serde::Serialize,
     serde::Deserialize,
 )]
+#[serde(tag = "type")]
 pub enum Select {
     #[error("field is within the desired depth")]
     DesiredDepth,
@@ -52,6 +53,7 @@ pub enum Select {
     serde::Serialize,
     serde::Deserialize,
 )]
+#[serde(tag = "type")]
 pub enum Reject {
     #[error("field doesn't meet any selection criteria")]
     NotSelected,


### PR DESCRIPTION
Use the serde "internally tagged enum" pattern for representing Select and Reject, so that the UI has a consistent `type` field for extraction of enum variant.

Update flow-web tests and publish a new version 0.5.18

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2357)
<!-- Reviewable:end -->
