### PR TITLE
dekaf: Fix partially suspended journals returning zero offsets

### DIFF
--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -105,16 +105,6 @@ pub struct PartitionOffset {
     pub mod_time: i64,
 }
 
-impl Default for PartitionOffset {
-    fn default() -> Self {
-        Self {
-            mod_time: -1, // UNKNOWN_TIMESTAMP
-            fragment_start: 0,
-            offset: 0,
-        }
-    }
-}
-
 const OFFSET_REQUEST_EARLIEST: i64 = -2;
 const OFFSET_REQUEST_LATEST: i64 = -1;
 
@@ -381,12 +371,13 @@ impl Collection {
                 }
             }
             _ => {
-                // If fully suspended, return the suspend offset. There will be no fragments.
+                // If fully suspended, there are no actual fragments to search through, so we have no way to correlate
+                // timestamps with offsets. Kafka returns UNKNOWN_OFFSET in this case, so we do the same.
                 if let Some(suspend) = &partition.spec.suspend {
                     if suspend.level == journal_spec::suspend::Level::Full as i32 {
                         return Ok(Some(PartitionOffset {
                             fragment_start: suspend.offset,
-                            offset: suspend.offset,
+                            offset: -1,   // UNKNOWN_OFFSET
                             mod_time: -1, // UNKNOWN_TIMESTAMP
                         }));
                     }
@@ -425,10 +416,20 @@ impl Collection {
                         offset: spec.begin,
                         mod_time: spec.mod_time,
                     }),
-                    // No fragments found. This can happen if there are no fragments at all, or if the requested timestamp is
-                    // after the latest fragment's begin_mod_time and there is no currently open fragment. In this case, return
-                    // the high-water mark as the requested timestamp is beyond any known offset.
-                    None => self.fetch_write_head(partition_index).await?,
+                    // The cases where this line hits are:
+                    // * `suspend::Level::Partial` so there is no open fragment, and the provided timestamp is after any
+                    //    existing persisted fragment's `mod_time` (and there cannot be an open fragment since the journal is partially suspended)
+                    // * Not suspended, and either all fragments have expired from cloud storage, no data has ever been written,
+                    //   or the provided timestamp is after any persisted fragment's `mod_time` and there is no open fragment
+                    //   (maybe the collection hasn't seen any new data for longer than its flush interval?)
+                    // Both of these cases are the same case as above when the journal is fully suspended: a request for offsets
+                    // when there are no covering fragments. As I discovered above, Kafka returns `UNKNOWN_OFFSET` (-1) in this case,
+                    // so I believe that Dekaf should too.
+                    None => Some(PartitionOffset {
+                        fragment_start: -1,
+                        offset: -1,   // UNKNOWN_OFFSET
+                        mod_time: -1, // UNKNOWN_TIMESTAMP
+                    }),
                     Some(broker::fragments_response::Fragment { spec: None, .. }) => {
                         anyhow::bail!("fragment missing spec");
                     }


### PR DESCRIPTION
**Description:**

Partially suspended journals were incorrectly returning a value of 0 as the high-watermark, confusing some consumers and preventing them from reading data. The issue occurred because fragment listings with `begin_mod_time=i64::MAX` return empty for partially suspended journals, since there is no open fragment.

The new behavior is now:

-   **Request earliest offset**
    -   `suspend::Level::Full`: `suspend.offset`
    -   `suspend::Level::Partial | suspend::Level::None`: fragment listing with `begin_mod_time = 0`, return 0th fragment's `begin`
-   **Request latest offset**
    -   `suspend::Level::Full | suspend::Level::Partial`: `suspend.offset`
    -   `suspend::Level::None`: write offset returned by non-blocking read at offset = -1
        -   This is different than before where we would issue a fragment listing with max `begin_mod_time`. The behavior ought to be the same, but this is more correct.

---

## Testing

**Collection:** `joseph/test-dekaf-migrations/events`
**Materialization**: `joseph/test-dekaf-migrations/dekaf-generic`
**Data Plane**: `gcp: us-central1 c1`

### Request latest offset against `dekaf-dev` pre-deploy, pre-suspend
```
$ kcat -o beginning  -b dekaf-dev.estuary-data.com:9092 \
-X security.protocol=SASL_SSL \
-X sasl.mechanism=PLAIN \
-X sasl.username='joseph/test-dekaf-migrations/dekaf-generic' \
-X sasl.password="..." -Q -t "events2:0:-1"
events2 [0] offset 414002871
```

### Suspending
```
$ flowctl raw gazctl-env --data-plane ops/dp/public/gcp-us-central1-c1 --prefix joseph/test-dekaf-migrations/ --admin

export BROKER_ADDRESS=https://us-central1.v1.estuary-data.dev
... redacted ...

$ flowctl-go journals suspend -l name=joseph/test-dekaf-migrations/events/11eaa81bb5000214/pivot=00 --force

$ flowctl-go journals list -l name:prefix=joseph/test-dekaf-migrations/events -ojson | jq

{
  "status": "OK",
  ...
    "suspend": {
	  "level": "PARTIAL",
	  "offset": "414002872"
    }
  ...
}
```

### Request latest offset against `dekaf-dev` pre-deploy, post-suspend: ❌
```
$ kcat -o beginning  -b dekaf-dev.estuary-data.com:9092 \   -X security.protocol=SASL_SSL \
-X sasl.mechanism=PLAIN \
-X sasl.username='joseph/test-dekaf-migrations/dekaf-generic' \
-X sasl.password="..." -Q -t "events2:0:-1"
events2 [0] offset 0
```

### Request latest offset against `dekaf-dev` post-deploy, post-suspend: ✅
```
$ kcat -o beginning  -b dekaf-dev.estuary-data.com:9092 \   
-X security.protocol=SASL_SSL \
-X sasl.mechanism=PLAIN \
-X sasl.username='joseph/test-dekaf-migrations/dekaf-generic' \
-X sasl.password="..." -Q -t "events2:0:-1"
events2 [0] offset 414002872
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2358)
<!-- Reviewable:end -->
