### PR TITLE
dekaf: Fix performance issue caused by excessive `TaskState` cloning

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -151,7 +151,7 @@ impl GazetteWriter {
 
         let initial_state = task_listener.get().await?;
 
-        let (ops_logs_journal, ops_stats_journal) = match initial_state {
+        let (ops_logs_journal, ops_stats_journal) = match initial_state.as_ref() {
             crate::task_manager::TaskState::Authorized {
                 ops_logs_journal,
                 ops_stats_journal,
@@ -226,10 +226,11 @@ impl GazetteAppender {
 
     async fn get_client(&self) -> anyhow::Result<journal::Client> {
         match self {
-            GazetteAppender::OpsStats(state) => match state.task_listener.get().await? {
+            GazetteAppender::OpsStats(state) => match state.task_listener.get().await?.as_ref() {
                 crate::task_manager::TaskState::Authorized {
                     ops_stats_client, ..
                 } => ops_stats_client
+                    .clone()
                     .map(|(client, _claims)| client)
                     .map_err(|err| err.into()),
                 crate::task_manager::TaskState::Redirect {
@@ -239,10 +240,11 @@ impl GazetteAppender {
                     anyhow::bail!("Task has been redirected to {}", target_dataplane_fqdn);
                 }
             },
-            GazetteAppender::OpsLogs(state) => match state.task_listener.get().await? {
+            GazetteAppender::OpsLogs(state) => match state.task_listener.get().await?.as_ref() {
                 crate::task_manager::TaskState::Authorized {
                     ops_logs_client, ..
                 } => ops_logs_client
+                    .clone()
                     .map(|(client, _claims)| client)
                     .map_err(|err| err.into()),
                 crate::task_manager::TaskState::Redirect {

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -150,7 +150,7 @@ impl Read {
 
         let task_state = listener.get().await?;
 
-        let partitions = match task_state {
+        let partitions = match task_state.as_ref() {
             crate::task_manager::TaskState::Authorized { partitions, .. } => partitions,
             crate::task_manager::TaskState::Redirect {
                 target_dataplane_fqdn,
@@ -161,6 +161,7 @@ impl Read {
         };
 
         let (client, claims, _) = partitions
+            .to_owned()
             .into_iter()
             .find_map(|(k, v)| {
                 if k == partition_template_name {

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -97,7 +97,7 @@ impl Session {
     async fn get_redirect_address(&self) -> anyhow::Result<Option<(String, i32)>> {
         let fqdn = match self.auth.as_ref() {
             Some(SessionAuthentication::Task(auth)) => {
-                match auth.task_state_listener.get().await? {
+                match auth.task_state_listener.get().await?.as_ref() {
                     TaskState::Redirect {
                         target_dataplane_fqdn,
                         ..


### PR DESCRIPTION
**Description:**

`task_state_listener.get()` was cloning the whole `TaskState` upon every call, even if it hadn't changed. https://github.com/estuary/flow/pull/2314 introduced a bunch more frequent calls to this function, with the assumption that calling it would be cheap. Changing it to return an Arc: 

```rust
pub async fn get(&self) -> anyhow::Result<Arc<TaskState>>
```

fixed the issue entirely.  Also included is a small change to logging to backoff if we get an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2362)
<!-- Reviewable:end -->
