### PR TITLE
Revert "dekaf: Upon migration, return appropriate error codes to force consumers to refresh their metadata caches"

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -236,7 +236,7 @@ impl GazetteAppender {
                     target_dataplane_fqdn,
                     ..
                 } => {
-                    anyhow::bail!("Task has been redirected to {}", target_dataplane_fqdn);
+                    unreachable!("Task has been redirected to {}", target_dataplane_fqdn);
                 }
             },
             GazetteAppender::OpsLogs(state) => match state.task_listener.get().await? {
@@ -249,7 +249,7 @@ impl GazetteAppender {
                     target_dataplane_fqdn,
                     ..
                 } => {
-                    anyhow::bail!("Task has been redirected to {}", target_dataplane_fqdn);
+                    unreachable!("Task has been redirected to {}", target_dataplane_fqdn);
                 }
             },
         }

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -175,16 +175,8 @@ impl Collection {
 
                 let partitions = match state {
                     TaskState::Authorized { partitions, .. } => partitions,
-                    TaskState::Redirect {
-                        target_dataplane_fqdn,
-                        spec,
-                        ..
-                    } => {
-                        return Err(
-                            crate::DekafError::from_redirect(target_dataplane_fqdn, spec)
-                                .await?
-                                .into(),
-                        );
+                    TaskState::Redirect { .. } => {
+                        bail!("cannot fetch partitions in redirected task session");
                     }
                 };
 
@@ -197,18 +189,8 @@ impl Collection {
                     .map(|(client, _, parts)| (client, parts))
                     .map_err(|e| anyhow::Error::from(e))?
             }
-            SessionAuthentication::Redirect {
-                target_dataplane_fqdn,
-                spec,
-                config,
-                ..
-            } => {
-                return Err(crate::DekafError::TaskRedirected {
-                    target_dataplane_fqdn: target_dataplane_fqdn.clone(),
-                    spec: spec.clone(),
-                    config: config.clone(),
-                }
-                .into());
+            SessionAuthentication::Redirect { .. } => {
+                bail!("cannot fetch partitions in redirected session");
             }
         };
 


### PR DESCRIPTION
Reverts estuary/flow#2314

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2363)
<!-- Reviewable:end -->
