### PR TITLE
agent: Fix alert state serialization

### DIFF
--- a/crates/models/src/status/alerts.rs
+++ b/crates/models/src/status/alerts.rs
@@ -61,10 +61,14 @@ impl<'de> serde::Deserialize<'de> for AlertType {
     }
 }
 
+// TODO(phil): The aliases here can be removed once controllers have run for all currently alerting live specs.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
 pub enum AlertState {
+    #[serde(alias = "Firing")]
     /// The alert is currently firing.
     Firing,
+    #[serde(alias = "Resolved")]
     /// The alert has resolved. Resolved alerts may be retained in the status for a short while.
     Resolved,
 }

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -64,14 +64,14 @@ expression: schema
         {
           "description": "The alert is currently firing.",
           "enum": [
-            "Firing"
+            "firing"
           ],
           "type": "string"
         },
         {
           "description": "The alert has resolved. Resolved alerts may be retained in the status for a short while.",
           "enum": [
-            "Resolved"
+            "resolved"
           ],
           "type": "string"
         }


### PR DESCRIPTION
Fixes a bug with the alert state serialization. These were getting serialized with `PascalCase`, but the `controller_alerts` view expects `lowercase`. This prevented alerts from be fired by controllers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2368)
<!-- Reviewable:end -->
