### PR TITLE
Revert "agent: place discovered schemas into flow://connector-schema sub-schema"

### DIFF
--- a/crates/agent/src/integration_tests/auto_discovers.rs
+++ b/crates/agent/src/integration_tests/auto_discovers.rs
@@ -640,17 +640,12 @@ async fn test_auto_discovers_update_only() {
                 "key": ["/id"]
             },
             "pikas/moss": {
-                "schema": into_wrapped_connector_schema(document_schema(1)),
+                "schema": document_schema(1),
                 "key": ["/id"]
             },
             "pikas/lichen": {
                 "writeSchema": document_schema(1),
-                "readSchema": {
-                  "allOf": [
-                        {"$ref": models::Schema::REF_RELAXED_WRITE_SCHEMA_URL},
-                        {"$ref": models::Schema::REF_INFERRED_SCHEMA_URL},
-                    ]
-                },
+                "readSchema": models::Schema::default_inferred_read_schema(),
                 "key": ["/id"]
             }
         },
@@ -1122,18 +1117,5 @@ fn document_schema(version: usize) -> serde_json::Value {
             "squeaks": { "type": "integer", "maximum": version },
         },
         "required": ["id", "squeaks"]
-    })
-}
-
-fn into_wrapped_connector_schema(mut fixture: serde_json::Value) -> serde_json::Value {
-    let object = fixture.as_object_mut().unwrap();
-    object.insert(
-        "$id".to_string(),
-        serde_json::json!("flow://connector-schema"),
-    );
-
-    serde_json::json!({
-        "$defs": {"flow://connector-schema": fixture},
-        "$ref": "flow://connector-schema",
     })
 }

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-discover.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-discover.snap
@@ -44,7 +44,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/acorns,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
               "key": [
                 "/id"
               ]
@@ -56,7 +56,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/crab_apples,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
               "key": [
                 "/id"
               ]
@@ -68,7 +68,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/walnuts,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":1,"type":"number"}},"required":["id"],"type":"object"},
               "key": [
                 "/id"
               ]

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-publication.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__initial-publication.snap
@@ -14,25 +14,19 @@ expression: published_specs
                     String("/id"),
                 ],
                 "schema": Object {
-                    "$defs": Object {
-                        "flow://connector-schema": Object {
-                            "$id": String("flow://connector-schema"),
-                            "properties": Object {
-                                "id": Object {
-                                    "type": String("string"),
-                                },
-                                "nuttiness": Object {
-                                    "maximum": Number(1),
-                                    "type": String("number"),
-                                },
-                            },
-                            "required": Array [
-                                String("id"),
-                            ],
-                            "type": String("object"),
+                    "properties": Object {
+                        "id": Object {
+                            "type": String("string"),
+                        },
+                        "nuttiness": Object {
+                            "maximum": Number(1),
+                            "type": String("number"),
                         },
                     },
-                    "$ref": String("flow://connector-schema"),
+                    "required": Array [
+                        String("id"),
+                    ],
+                    "type": String("object"),
                 },
             },
         ),
@@ -101,25 +95,19 @@ expression: published_specs
                     String("/id"),
                 ],
                 "schema": Object {
-                    "$defs": Object {
-                        "flow://connector-schema": Object {
-                            "$id": String("flow://connector-schema"),
-                            "properties": Object {
-                                "id": Object {
-                                    "type": String("string"),
-                                },
-                                "nuttiness": Object {
-                                    "maximum": Number(1),
-                                    "type": String("number"),
-                                },
-                            },
-                            "required": Array [
-                                String("id"),
-                            ],
-                            "type": String("object"),
+                    "properties": Object {
+                        "id": Object {
+                            "type": String("string"),
+                        },
+                        "nuttiness": Object {
+                            "maximum": Number(1),
+                            "type": String("number"),
                         },
                     },
-                    "$ref": String("flow://connector-schema"),
+                    "required": Array [
+                        String("id"),
+                    ],
+                    "type": String("object"),
                 },
             },
         ),

--- a/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__second-discover.snap
+++ b/crates/agent/src/integration_tests/snapshots/agent__integration_tests__user_discovers__second-discover.snap
@@ -41,7 +41,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/acorns,
             expect_pub_id: NULL,
             model: {
-              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
               "key": [
                 "/id"
               ],
@@ -68,7 +68,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/hickory_nuts,
             expect_pub_id: "0000000000000000",
             model: {
-              "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "schema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
               "key": [
                 "/id"
               ]
@@ -80,7 +80,7 @@ DraftCatalog {
             scope: flow://collection/squirrels/walnuts,
             expect_pub_id: NULL,
             model: {
-              "writeSchema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"}},"$ref":"flow://connector-schema"},
+              "writeSchema": {"properties":{"id":{"type":"string"},"nuttiness":{"maximum":2,"type":"number"}},"required":["id"],"type":"object"},
               "readSchema": {"properties":{"drafted":{"type":"string"},"id":{"type":"string"}},"required":["id","drafted"],"type":"object"},
               "key": [
                 "/id"

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -53,8 +53,6 @@ impl Schema {
     pub const REF_WRITE_SCHEMA_URL: &'static str = "flow://write-schema";
     // URL for referencing the write schema of a collection, which may be used within a read schema.
     pub const REF_RELAXED_WRITE_SCHEMA_URL: &'static str = "flow://relaxed-write-schema";
-    // URL for referencing the connector schema of a collection, which may be used within a write schema.
-    pub const REF_CONNECTOR_SCHEMA_URL: &'static str = "flow://connector-schema";
 
     /// Returns true if this Schema references the canonical inferred schema URL.
     pub fn references_inferred_schema(&self) -> bool {
@@ -86,6 +84,18 @@ impl Schema {
         .unwrap()
     }
 
+    /// Default collection `readSchema`,
+    /// used when schema inference is desired.
+    pub fn default_inferred_read_schema() -> Self {
+        let read_schema = serde_json::json!({
+            "allOf": [
+                {"$ref": Self::REF_RELAXED_WRITE_SCHEMA_URL},
+                {"$ref": Self::REF_INFERRED_SCHEMA_URL},
+            ],
+        });
+        Self(crate::RawValue::from_value(&read_schema))
+    }
+
     /// Placeholder definition for `flow://inferred-schema`,
     /// used when an actual inferred schema is not yet available.
     pub fn inferred_schema_placeholder() -> &'static Self {
@@ -102,6 +112,67 @@ impl Schema {
     pub fn to_relaxed_schema(&self) -> serde_json::Result<Self> {
         let relaxed = serde_json::from_str::<RelaxedSchema>(self.get())?;
         Ok(Self(serde_json::value::to_raw_value(&relaxed)?.into()))
+    }
+
+    /// TODO(johnny): This is deprecated and will be removed.
+    pub fn extend_read_bundle(
+        read_bundle: &Self,
+        write_bundle: Option<&Self>,
+        inferred_bundle: Option<&Self>,
+    ) -> Self {
+        let mut defs = Vec::new();
+
+        // Add a definition for the write schema if it's referenced.
+        // We cannot add it in all cases because the existing `read_bundle` and
+        // `write_bundle` may have a common sub-schema defined, and naively adding
+        // it would result in an indexing error due to the duplicate definition.
+        // So, we treat $ref: flow://write-schema as a user assertion that there is
+        // no such conflicting definition (and we may produce an indexing error
+        // later if they're wrong).
+        if let Some(write) = write_bundle.filter(|_| read_bundle.references_write_schema()) {
+            defs.push(AddDef {
+                id: Schema::REF_WRITE_SCHEMA_URL,
+                schema: write,
+                overwrite: true, // always overwrite the write schema definition
+            });
+        }
+
+        if read_bundle.references_inferred_schema() {
+            let inferred = inferred_bundle.unwrap_or(&INFERRED_SCHEMA_PLACEHOLDER);
+            defs.push(AddDef {
+                id: Schema::REF_INFERRED_SCHEMA_URL,
+                schema: inferred,
+                overwrite: true,
+            });
+        }
+
+        Schema::add_defs(read_bundle, &defs)
+            .ok()
+            .unwrap_or_else(|| read_bundle.clone())
+    }
+
+    /// TODO(johnny): This is deprecated and will be removed.
+    pub fn build_read_schema_bundle(read_schema: &Schema, write_schema: &Schema) -> Schema {
+        let mut defs = Vec::new();
+        if read_schema.references_write_schema() {
+            defs.push(AddDef {
+                id: Schema::REF_WRITE_SCHEMA_URL,
+                schema: write_schema,
+                overwrite: true, // always overwrite the write schema definition
+            });
+        }
+        if read_schema.references_inferred_schema() {
+            // The control plane will keep the inferred schema definition up to date,
+            // so we only ever add the placeholder here if it doesn't already exist.
+            defs.push(AddDef {
+                id: Schema::REF_INFERRED_SCHEMA_URL,
+                schema: &INFERRED_SCHEMA_PLACEHOLDER,
+                overwrite: false,
+            });
+        }
+        Schema::add_defs(read_schema, &defs)
+            .ok()
+            .unwrap_or_else(|| read_schema.clone())
     }
 
     /// Extend this Schema with added $defs definitions.


### PR DESCRIPTION
Reverts estuary/flow#2356

a dependency in `source-http-ingest` is having trouble with this schema construction, potentially revert until we get that fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2369)
<!-- Reviewable:end -->
