### PR TITLE
dekaf: Fix `ReadRequest` to return journal write head

### DIFF
--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -413,7 +413,8 @@ impl Collection {
 
         let request = broker::ReadRequest {
             journal: partition.spec.name.clone(),
-            offset: -1, // Fetch write head
+            offset: 0,
+            metadata_only: true,
             ..Default::default()
         };
         let response_stream = self.journal_client.clone().read(request);


### PR DESCRIPTION
**Description:**

Fixes a small but important mistake in https://github.com/estuary/flow/pull/2358, namely that this actually does _not_ work as a way to get a metadata response from the broker in order to fetch the write head of a journal:
```rust
broker::ReadRequest {
    journal: partition.spec.name.clone(),
    offset: -1,
    ..Default::default()
};
```

Instead, the proper incantation is
```
broker::ReadRequest {
    journal: partition.spec.name.clone(),
    offset: 0,
    metadata_only: true,
    ..Default::default()
};
```

Tested locally and on `dekaf-dev`, confirmed this now doesn't error when fetching offsets with a timestamp of `-1`.

```
$ kcat -o beginning  -b dekaf-dev.estuary-data.com:9092 \                                                                                                                                                                                                                                                                   
-X security.protocol=SASL_SSL \
-X sasl.mechanism=PLAIN \
-Q -t "events:0:-1"
events [0] offset 414002872
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/flow/2377)
<!-- Reviewable:end -->
