### PR TITLE
billing: Improve performance by using prefix rollups, and more

### DIFF
--- a/crates/billing-integrations/src/send.rs
+++ b/crates/billing-integrations/src/send.rs
@@ -232,12 +232,18 @@ async fn finalize_invoices(
         let stripe_client = stripe_client;
         let pb = pb.clone();
         async move {
-            StripeInvoice::finalize(stripe_client, row.id(), FinalizeInvoiceParams::default())
-                .await
-                .map_err(|e| {
-                    pb.println(format!("Error finalizing invoice {}: {}", row.id(), e));
-                    anyhow::Error::from(e)
-                })?;
+            StripeInvoice::finalize(
+                stripe_client,
+                row.id(),
+                FinalizeInvoiceParams {
+                    auto_advance: Some(true), // Turn on auto-advance to enable automatic retries
+                },
+            )
+            .await
+            .map_err(|e| {
+                pb.println(format!("Error finalizing invoice {}: {}", row.id(), e));
+                anyhow::Error::from(e)
+            })?;
             pb.inc(1);
 
             let invoice =

--- a/crates/billing-integrations/src/stripe_utils.rs
+++ b/crates/billing-integrations/src/stripe_utils.rs
@@ -1,4 +1,6 @@
-use crate::publish::TENANT_METADATA_KEY;
+use crate::publish::{
+    BILLING_PERIOD_END_KEY, BILLING_PERIOD_START_KEY, INVOICE_TYPE_KEY, TENANT_METADATA_KEY,
+};
 use num_format::{Locale, ToFormattedString};
 use serde::{Serialize, de::DeserializeOwned};
 use std::ops::{Deref, DerefMut};
@@ -120,6 +122,14 @@ impl Invoice {
     }
     pub fn status(&self) -> Option<stripe::InvoiceStatus> {
         self.0.status.clone()
+    }
+
+    pub fn period_start(&self) -> Option<String> {
+        self.0
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get(BILLING_PERIOD_START_KEY))
+            .cloned()
     }
 
     pub fn to_table_row(&self) -> Vec<comfy_table::Cell> {


### PR DESCRIPTION
**Description:**

-   Only skip invoices with `NoDataMoved` or `NoFullPipeline` if the customer also does not have a payment method on file. If a customer had billable usage, but then deleted all of their captures or materializations, they wouldn't have gotten an invoice prior to this change. If they have a payment method on file, we can and should bill for this legitimate usage.
  - Fix bug where invoices would get skipped if they didn't have an associated Stripe customer in the database
  - Use pre-aggregated `catalog_stats_monthly` table with exact tenant matching for improved query performance
  - Pre-fetch tenant trial start date from db instead of issuing another query per tenant to fetch it. This dramatically speeds things up
  - Filter manual invoices by `date_start` to only include those beginning within the target month
  - Enable `auto_advance=true` during invoice finalization, allowing Stripe to handle automatic charging and retries
-   Manual invoices for the billing period are now correctly identified and included by fetching all manual invoices and performing date filtering clientside. Stripe's API doesn't support date filters in this case :(