### PR TITLE
avro: Escape invalid UTF-8 strings when encoding

### DIFF
--- a/crates/avro/src/snapshots/avro__encode__test__malformed_utf8_string.snap
+++ b/crates/avro/src/snapshots/avro__encode__test__malformed_utf8_string.snap
@@ -1,0 +1,6 @@
+---
+source: crates/avro/src/encode.rs
+assertion_line: 497
+expression: s
+---
+hello�


### PR DESCRIPTION
AVRO strings are to be encoded in UTF-8 according to the spec. We ran into a situation where customer data contained invalid UTF-8 strings, and so in order to conform to the AVRO spec and not confuse consumers, we need to escape invalid byte sequences.

`String::from_utf8_lossy()` will replace any invalid UTF-8 sequences with `U+FFFD REPLACEMENT CHARACTER`, which looks like this: �

Without the change to `maybe_encode()`, this test fails as expected with the following, proving that we were previously passing through invalid UTF-8:
```
---- encode::test::test_malformed_utf8_string stdout ----

thread 'encode::test::test_malformed_utf8_string' panicked at crates/avro/src/encode.rs:479:18:
called `Result::unwrap()` on an `Err` value: Invalid utf-8 string: incomplete utf-8 byte sequence from index 5
```

I also did confirm in a round-trip test that this change prevents `fastavro` from crashing with a `'utf-8' codec can't decode byte 0x.. in position ..` error, which is the original complaint here.