### PR TITLE
simd-doc: fix incorrect indirect str length calculation

### DIFF
--- a/crates/simd-doc/src/ffi/simd-doc.hpp
+++ b/crates/simd-doc/src/ffi/simd-doc.hpp
@@ -98,12 +98,23 @@ inline bool is_indirect_str(const uint32_t w)
 
 inline uint32_t encode_indirect_str_length(uint32_t len)
 {
-    return 0b10000000 | (len & 0b00111111) | ((len & 0b11000000) << 2);
+    // Precondition: len <= 0x3FFFFFFF
+    return
+        // Low 6 bits remain as-is.
+        (len & 0b00111111u)
+        // High 2 bits are set to 0b10 (bit 7 set, bit 6 left clear).
+        | 0b10000000u
+        // Remaining bits are shifted up by 2 (from bits 6.. to bits 8..).
+        | ((len & 0b11111111111111111111111111000000u) << 2);
 }
 
 inline uint32_t decode_indirect_str_length(uint32_t w)
 {
-    return (w & 0b00111111) | ((w >> 2) & 0b11000000);
+    return
+        // Mask off the high 2 bits.
+        (w & 0b00111111u)
+        // Remaining bits are shifted down by 2.
+        | ((w & 0b11111111111111111111111100000000u) >> 2);
 }
 
 inline size_t decode_inline_str_length(uint64_t value)

--- a/crates/simd-doc/src/tests/fixtures.rs
+++ b/crates/simd-doc/src/tests/fixtures.rs
@@ -66,6 +66,12 @@ fn test_simd_and_fallback_results_are_equal() {
         {"\u{0}": "null char at start"},
         {"key\u{0}": "null char in middle"},
         {"key\u{0}\u{0}": "double null chars"},
+        "0123456789abcdef",
+        "0123456789abcdef".repeat(11),
+        "0123456789abcdef".repeat(111),
+        "0123456789abcdef".repeat(1111),
+        "0123456789abcdef".repeat(11111),
+        "0123456789abcdef".repeat(45111), // Any larger overflows the 1MB limit.
     ]);
     let cases: Vec<Value> = serde_json::from_value(cases).unwrap();
 
@@ -75,10 +81,10 @@ fn test_simd_and_fallback_results_are_equal() {
         serde_json::to_writer(&mut input, &doc).unwrap();
         input.push(b'\n');
     }
+    let mut failed = false;
+
     let (transcoded, fallback) = transcoded_and_fallback(&mut input);
     assert_eq!(transcoded.offset, fallback.offset);
-
-    let mut failed = false;
 
     for ((case, (s_doc, s_next_offset)), (f_doc, f_next_offset)) in
         cases.iter().zip(transcoded.iter()).zip(fallback.iter())


### PR DESCRIPTION
This calculation was subtly incorrect on longer strings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

