### PR TITLE
dekaf: Fix `OffsetCommitResponse` topic names

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1405,6 +1405,9 @@ impl Session {
                 let encrypted_name = topic.name.clone();
                 let decrypted_name = self.decrypt_topic_name(topic.name.to_owned())?;
 
+                // Restore plaintext topic name for the response
+                topic.name = decrypted_name.clone();
+
                 let collection_partitions = &collections
                     .iter()
                     .find(|(topic_name, _)| topic_name == &decrypted_name)


### PR DESCRIPTION
**Description:**

Topic names are encrypted when sent to upstream Kafka for group management requests. In other places, we map the topic names in proxied responses back to their plaintext value before sending the response along to the client. It appears we forgot to do that for `OffsetCommitResponse`. We got a report from a user of `franz-go` that it's complaining about this with the following message:

```
broker replied to our OffsetCommitRequest incorrectly! Topic at request index 0: <plaintext_topic_name>, reply at index: <encrypted_topic_name>; num partitions on request topic: 1, in reply: 1, we cannot handle this!
```