### PR TITLE
dekaf: Fix refreshing MSK tokens

### DIFF
--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -634,8 +634,9 @@ impl KafkaClientAuth {
                 cached,
             } => {
                 if let Some((cfg, exp)) = cached {
-                    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
-                    if (*exp as u128) - now < 30 {
+                    let now_seconds = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+                    // Use a 30-second buffer before expiration to refresh the token.
+                    if *exp as u64 > now_seconds + 30 {
                         return Ok(cfg.clone());
                     }
                 }


### PR DESCRIPTION
**Description:**

The intent was always to refresh tokens once they have less than 30s of life left, but the existing code was refreshing once they have less than 30 _milliseconds_ of life left. If the refresh took >30ms, which is entirely plausible, the Kafka client would attempt to use an expired token, get an authorization error, and pass that along to the client which would log noisily and make people think there's something wrong.
