### PR TITLE
dekaf: Fix missed field folding

### DIFF
--- a/crates/dekaf/src/utils.rs
+++ b/crates/dekaf/src/utils.rs
@@ -100,7 +100,8 @@ pub fn build_field_extractors(
 
                 let avro_field = avro::RecordField {
                     schema: located_shape_to_avro(
-                        json::Location::Root.push_prop(proj.field.as_str()),
+                        json::Location::Root
+                            .push_prop(dekaf_connector::field_fold(&proj.field).as_str()),
                         source_shape.to_owned(),
                         required,
                     ),
@@ -160,7 +161,6 @@ pub fn build_field_extractors(
             .collect_vec(),
     ))
 }
-
 
 pub fn fetch_all_collection_names(spec: &MaterializationSpec) -> anyhow::Result<Vec<String>> {
     spec.bindings

--- a/crates/dekaf/tests/field_extraction_tests.rs
+++ b/crates/dekaf/tests/field_extraction_tests.rs
@@ -222,7 +222,13 @@ async fn test_field_selection_recommended_fields() -> anyhow::Result<()> {
     let docs = vec![json!({
         "key": "first",
         "field_a": "foo",
-        "field_b": "bar"
+        "field_b": "bar",
+        "invoice": {
+            "additional_charges": [
+                { "cost": 12.34 },
+                { "cost": 56.78 }
+            ]
+        }
     })];
 
     for output in roundtrip(fixture_path, serde_to_jsonl(docs)?.as_slice()).await? {

--- a/crates/dekaf/tests/fixtures/field_selection_recommended_fields.yaml
+++ b/crates/dekaf/tests/fixtures/field_selection_recommended_fields.yaml
@@ -10,11 +10,22 @@ collections:
           type: string
         field_b:
           type: string
+        invoice:
+          type: object
+          properties:
+            additional_charges:
+              type: [array, "null"]
+              items:
+                type: object
+                properties:
+                  cost:
+                    type: number
       type: object
       required:
         - key
         - field_a
         - field_b
+        - invoice
 materializations:
   test/materialization:
     endpoint:

--- a/crates/dekaf/tests/snapshots/field_extraction_tests__field_selection_recommended_fields.snap
+++ b/crates/dekaf/tests/snapshots/field_extraction_tests__field_selection_recommended_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/dekaf/tests/dekaf_schema_test.rs
+source: crates/dekaf/tests/field_extraction_tests.rs
 expression: output?
 ---
 Record(
@@ -33,6 +33,54 @@ Record(
                             String(
                                 "null",
                             ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+        (
+            "invoice_additional_charges",
+            Union(
+                0,
+                Array(
+                    [
+                        Record(
+                            [
+                                (
+                                    "cost",
+                                    Union(
+                                        0,
+                                        Double(
+                                            12.34,
+                                        ),
+                                    ),
+                                ),
+                                (
+                                    "_flow_extra",
+                                    Map(
+                                        {},
+                                    ),
+                                ),
+                            ],
+                        ),
+                        Record(
+                            [
+                                (
+                                    "cost",
+                                    Union(
+                                        0,
+                                        Double(
+                                            56.78,
+                                        ),
+                                    ),
+                                ),
+                                (
+                                    "_flow_extra",
+                                    Map(
+                                        {},
+                                    ),
+                                ),
+                            ],
                         ),
                     ],
                 ),


### PR DESCRIPTION
**Description:**

Field folding was applied to the `avro::RecordField.name`, but not applied to the avro schema's location itself.

Without the fix, we see a similar error to the one observed in production:
```
running 1 test
test test_field_selection_recommended_fields ... FAILED

successes:

successes:

failures:

---- test_field_selection_recommended_fields stdout ----

thread 'test_field_selection_recommended_fields' panicked at crates/avro/src/schema.rs:251:28:
called `Result::unwrap()` on an `Err` value: Invalid schema name root.invoice/additional_charges._items._flow_extra.RawJSON. It must match the regex '^((?P<namespace>([A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*)?)\.)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)$'
```
