### PR TITLE
Docs: Connector reference updates

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/datadog-ingest.md
+++ b/site/docs/reference/Connectors/capture-connectors/datadog-ingest.md
@@ -89,6 +89,6 @@ This connector does not yet support webhook signature verification. If this is a
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
 | **** | ResourceConfig |  | object | Required |
-| `/idFromHeader` |  | Set the &#x2F;&#x5F;meta&#x2F;webhookId from the given HTTP header in each request. If not set, then a random id will be generated automatically. If set, then each request will be required to have the header, and the header value will be used as the value of &#x60;&#x2F;&#x5F;meta&#x2F;webhookId&#x60;. | null, string |  |
+| `/idFromHeader` |  | Set the `/_meta/webhookId` from the given HTTP header in each request. If not set, then a random id will be generated automatically. If set, then each request will be required to have the header, and the header value will be used as the value of `/_meta/webhookId`. | null, string |  |
 | `/path` |  | The URL path to use for adding documents to this binding. Defaults to the name of the collection. | null, string |  |
 | `/stream` |  | The name of the binding, which is used as a merge key when doing Discovers. | null, string |

--- a/site/docs/reference/Connectors/capture-connectors/datadog.md
+++ b/site/docs/reference/Connectors/capture-connectors/datadog.md
@@ -16,7 +16,11 @@ By default, each resource is mapped to a Flow collection through a separate bind
 ## Prerequisites
 
 * A Datadog account.
-* A Datadog API key and Application key with `rum_apps_read` permission scope. See Datadog's [documentation](https://docs.datadoghq.com/account_management/api-app-keys) for instructions on generating these credentials.
+* A Datadog API key and Application key with the proper permissions:
+    * `rum_apps_read` permission for RUM data
+    * `logs_read_data` permission for logs data
+
+    See Datadog's [documentation](https://docs.datadoghq.com/account_management/api-app-keys) for instructions on generating these credentials.
 
 ## Configuration
 

--- a/site/docs/reference/Connectors/capture-connectors/netsuite-suiteanalytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/netsuite-suiteanalytics.md
@@ -2,12 +2,12 @@ import ReactPlayer from "react-player";
 
 # NetSuite SuiteAnalytics Connect
 
-This connector captures data from Oracle NetSuite into Flow collections. It relies on the SuiteAnalytics Connect feature in order to both load large amounts of data quickly, as well as introspect the available tables, their schemas, keys, and cursor fields.
+This connector captures data from Oracle NetSuite into Flow collections. It uses the SuiteAnalytics Connect feature in order to both load large amounts of data quickly, as well as introspect the available tables, their schemas, keys, and cursor fields.
 
 [`ghcr.io/estuary/source-netsuite:dev`](https://ghcr.io/estuary/source-netsuite:dev) provides the
 latest connector image. You can also follow the link in your browser to see past image versions.
 
-If you don't have SuiteAnalytics Connect, check out our [SuiteTalk REST](../netsuite-suitetalk) connector.
+If you don't have SuiteAnalytics Connect, the connector can be used in SuiteQL mode.
 
 <ReactPlayer controls url="https://www.youtube.com/watch?v=CN3RXry0o9k" />
 
@@ -127,6 +127,7 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 | ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------ | ------ | ---------------- |
 | `/account`                     | Netsuite Account ID    | Netsuite realm/Account ID e.g. 2344535, as for `production` or 2344535_SB1, as for `sandbox` | string | Required         |
 | `/role_id`                    | Role ID                | The ID of the role you created. Defaults to 3, which is the ID of the administrator role.        | int    | 3                |
+| `/connection_type`            | Connection Type        | Type of connection to use. `suiteanalytics` is preferred over `suiteql`.                      | string | Required |
 | `/suiteanalytics_data_source` | Data Source            | Which NetSuite data source to use. Options are `NetSuite.com`, or `NetSuite2.com`                | string | Required         |
 | `/authentication`             | Authentication Details | Credentials to access your NetSuite account                                                      | object | Required         |
 

--- a/site/docs/reference/Connectors/capture-connectors/netsuite-suitetalk.md
+++ b/site/docs/reference/Connectors/capture-connectors/netsuite-suitetalk.md
@@ -1,4 +1,8 @@
-# NetSuite SuiteTalk REST
+# NetSuite SuiteTalk REST (Deprecated)
+
+:::warning
+This connector is deprecated. For new pipelines, we recommend you use our actively maintained [NetSuite connector](./netsuite-suiteanalytics.md) instead.
+:::
 
 This connector captures data from Oracle NetSuite into Flow collections. It connects to the NetSuite Analytics Data Warehouse using the SuiteQL REST endpoint and a custom role.
 

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -1,3 +1,6 @@
+
+import ReactPlayer from "react-player";
+
 # Snowflake
 
 This connector materializes Flow collections into tables in a Snowflake database.
@@ -8,6 +11,8 @@ From there, it transactionally applies the changes to the Snowflake table.
 
 [`ghcr.io/estuary/materialize-snowflake:dev`](https://ghcr.io/estuary/materialize-snowflake:dev) provides the latest connector image. You can also follow the link in your browser to see past image versions.
 
+<ReactPlayer controls url="https://www.youtube.com/watch?v=nC_zDUz4SQw" />
+
 ## Prerequisites
 
 To use this connector, you'll need:
@@ -17,9 +22,8 @@ To use this connector, you'll need:
     * A [schema](https://docs.snowflake.com/en/sql-reference/ddl-database.html) — a logical grouping of database objects — within the target database
     * A virtual warehouse
     * A user with a role assigned that grants the appropriate access levels to these resources.
-    * The correct timezone setting `TIMESTAMP_LTZ` or
-`TIMESTAMP_TZ` (see [Timestamp Data Type Mapping](#timestamp-data-type-mapping))
-    
+    * The correct timezone setting (see [Timestamp Data Type Mapping](#timestamp-data-type-mapping))
+
     See the [script below](#setup) for details.
 * Know your Snowflake account's host URL. This is formatted using your [Snowflake account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used),
 for example, `orgname-accountname.snowflakecomputing.com`.
@@ -75,7 +79,7 @@ grant CREATE SCHEMA, MONITOR, USAGE on database identifier($database_name) to ro
 use role ACCOUNTADMIN;
 grant CREATE INTEGRATION on account to role identifier($estuary_role);
 use role sysadmin;
--- Optional: Set the timestamp type to `TIMESTAMP_TZ`; otherwise defaults to using `TIMESTAMP_LTZ`
+-- Optional: Set the timestamp type to `TIMESTAMP_TZ` or `TIMESTAMP_NTZ`; otherwise defaults to using `TIMESTAMP_LTZ`
 -- ALTER USER $estuary_user SET TIMESTAMP_TYPE_MAPPING = 'TIMESTAMP_TZ';
 COMMIT;
 ```
@@ -281,12 +285,13 @@ Snowpipe Streaming is used by default for [delta updates](#delta-updates) bindin
 
 ## Timestamp Data Type Mapping
 
-Flow materializes timestamp data types as either `TIMESTAMP_LTZ` or
-`TIMESTAMP_TZ` columns in Snowflake. `TIMESTAMP_LTZ` is used unless the
-Snowflake  `TIMESTAMP_TYPE_MAPPING` configuration is set to `TIMESTAMP_TZ`,
-which will cause Flow to use `TIMESTAMP_TZ` columns. Flow never creates columns
-as `TIMESTAMP_NTZ`. See Snowflake documentation on the [`TIMESTAMP_TYPE_MAPPING` configuration](https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping) and
-the [`TIMESTAMP_TZ or TIMESTAMP_LTZ` values](https://docs.snowflake.com/en/sql-reference/data-types-datetime#label-datatypes-timestamp-variations) for more information.
+Flow materializes timestamp data types as `TIMESTAMP_LTZ` columns in Snowflake by default.
+Alternatively, the Snowflake `TIMESTAMP_TYPE_MAPPING` configuration can be specifically set to `TIMESTAMP_TZ` or `TIMESTAMP_NTZ` to use columns of these types.
+
+While Snowflake defaults to `TIMESTAMP_NTZ`, Flow never creates columns with NTZ timestamps unless the user's `TIMESTAMP_TYPE_MAPPING` is specifically configured to use `TIMESTAMP_NTZ`.
+
+See Snowflake documentation on the [`TIMESTAMP_TYPE_MAPPING` configuration](https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping) and
+the [timestamp data types](https://docs.snowflake.com/en/sql-reference/data-types-datetime#label-datatypes-timestamp-variations) for more information.
 
 ## Reserved words
 

--- a/site/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/site/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -126,6 +126,24 @@ You can enable delta updates on a per-binding basis:
     source: ${PREFIX}/${source_collection}
 ```
 
+## Column mapping
+
+If your Databricks setup does not support column alteration, you can enable [column mapping](https://docs.databricks.com/aws/en/delta/column-mapping).
+This requires Delta protocol reader version 2+ and writer version 5+; column mapping will not work well with legacy workloads.
+
+To enable column mapping, along with ensuring the correct protocol versions, you can run:
+```
+ALTER TABLE <table-name>
+SET TBLPROPERTIES (
+  'delta.columnMapping.mode' = 'name'
+);
+ALTER TABLE <table-name>
+SET TBLPROPERTIES (
+  delta.minReaderVersion = 2,
+  delta.minWriterVersion = 5
+);
+```
+
 ## Reserved words
 
 Databricks has a list of reserved words that must be quoted in order to be used as an identifier. Flow automatically quotes fields that are in the reserved words list. You can find this list in Databricks's documentation [here](https://docs.databricks.com/en/sql/language-manual/sql-ref-reserved-words.html) and in the table below.


### PR DESCRIPTION
**Description:**

Rolls up several minor updates to connector reference docs:
* Embeds new Snowflake video
* Fixes Snowflake timestamp information
* Includes script to enable column mapping in Databricks
* Marks old NetSuite connector as deprecated
* Updates Datadog permissions

**Documentation links affected:**

Various connector reference docs

**Notes for reviewers:**

Thanks for reviewing!
