### PR TITLE
storage mapping hotfixes

### DIFF
--- a/crates/flowctl/src/discover/mod.rs
+++ b/crates/flowctl/src/discover/mod.rs
@@ -64,6 +64,7 @@ async fn do_discover(ctx: &mut crate::CliContext, args: &Discover) -> anyhow::Re
 
         live.data_planes
             .get_by_key(&data_plane_id)
+            .filter(|dp| dp.control_id != models::Id::zero()) // NoOpCatalogResolver fixture.
             .with_context(|| {
                 format!("couldn't resolve data-plane {data_plane_id}; you may not have access")
             })?

--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -244,13 +244,13 @@ impl Resolver {
     async fn resolve_specs(&self, catalog_names: &[&str]) -> anyhow::Result<tables::LiveCatalog> {
         use models::CatalogType;
 
-        // If we're unauthenticated then return a placeholder LiveCatalog.
+        // Use NoOpCatalogResolver to prime with a catch-all storage mapping.
+        let mut live = build::NoOpCatalogResolver.resolve(Vec::new()).await;
+
+        // If we're unauthenticated then return the placeholder LiveCatalog.
         if !self.client.is_authenticated() {
-            return Ok(build::NoOpCatalogResolver
-                .resolve(catalog_names.to_vec())
-                .await);
+            return Ok(live);
         }
-        let mut live = tables::LiveCatalog::default();
 
         // Query storage mappings from the tenants of `catalog_names`.
         #[derive(serde::Deserialize)]

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -324,6 +324,7 @@ fn walk_prefix<'a>(
         if !partition
             .data_planes
             .contains(&explicit_plane.data_plane_name)
+            && partition.catalog_prefix.as_str() != "ops/"
         {
             Error::DataPlaneNotInStorageMapping {
                 entity,


### PR DESCRIPTION
**Description:**

* Supplement fetched storage mappings with the "catch-all" mapping of NoOpCatalogResolver, to work around too-restrictive RBAC handling in the legacy in-DB access grant implementation.
* Special case `ops/` storage mapping, allowing its publications to explicitly name any data-plane without having to track them in `storage_mappings`.

Tested using `flowctl catalog pull-specs` and `flowctl discover` from an authenticated personal account, and also un-authenticated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

