### PR TITLE
Docs: Remove GitPod from flowctl instructions and tutorials

### DIFF
--- a/site/docs/getting-started/tutorials/samples/continuous-materialized-view/flow.yaml
+++ b/site/docs/getting-started/tutorials/samples/continuous-materialized-view/flow.yaml
@@ -24,9 +24,7 @@ collections:
       - /date
     derive:
       using:
-        sqlite:
-          migrations:
-            - user-fact-table.migration.0.sql
+        sqlite: {}
       transforms:
         - name: dailychangesbyuser
           source: demo/wikipedia/recentchange

--- a/site/docs/guides/flatten-array.md
+++ b/site/docs/guides/flatten-array.md
@@ -3,7 +3,7 @@
 This guide will show you how to flatten an array field in a collection by creating a TypeScript derivation in Estuary Flow.
 
 :::note
-We'll be using GitPod and TypeScript for our derivation in this guide. Check out our other guides if you're interested in [creating derivations locally with `flowctl`](./flowctl/create-derivation.md) or [using SQL for transformations](./derivation_tutorial_sql.md).
+We'll be using TypeScript for our derivation in this guide. Check out our other guides if you're interested in [using SQL for transformations](./derivation_tutorial_sql.md).
 :::
 
 The collection we'll be working with (`user_content`) contains a field called `tags`, which is an array of objects. Each object in the array has a name and a value. We'll be flattening this array into a new collection, with two separate fields: `tag_name` and `tag_value`.
@@ -36,84 +36,60 @@ The resulting data will have the following structure:
 }
 ```
 
-## Step 1: Set up your GitPod environment
+## Step 1: Set up your development environment
 
-1. In the Estuary Flow dashboard, click on the **Collections** tab.
-2. Select the checkbox next to the collection you want to work with.
-3. Click on the **Transform** button at the top of the table.
-4. Select **TypeScript** as the language, and give your new derived collection a name.
-5. Click **Proceed to GitPod** to open the GitPod environment.
-
-The GitPod environment will generate a file structure and stub files to get you started. This may take a few moments.
+1. Ensure you have `flowctl` [installed and authenticated](/guides/get-started-with-flowctl).
+2. In the Estuary Flow dashboard, note the name of the collection you'd like to transform.
+3. In your local development environment, create a working directory with a new `flow.yaml` file.
 
 ## Step 2: Set up your schema
 
-In a folder called `<your_tenant>`, you'll find a file called `flow.yaml`. This file contains the schema for your derived collection. You'll need to modify this file to match the structure of the data you're working with.
+Open your new `flow.yaml` file. This file will contain the schema for your derived collection. You'll need to modify this file to match what we want our derived collection to look like.
 
-1. Open the `flow.yaml` file in the GitPod environment.
+We'll be using the `tags` field from the original data, so we'll need to add a new property for each field we want to include in the derived collection. We'll also need to set a key for the derived collection.
 
-   Your schema should look something like this:
+Your `flow.yaml` file will therefore look something like this:
 
-   ```yaml
-   ---
-   collections:
-     <your_tenant>/<derivation_name>:
-       schema:
-         type: object
-         properties:
-           your_key:
-             type: string
-         required:
-           - your_key
-       key:
-         - /your_key
-       derive:
-         using:
-           typescript:
-             module: <derivation_name>.ts
-         transforms:
-           - name: user_content
-             source: <your_tenant>/<capture_name>/public/<collection_name>
-             shuffle: any
-   ```
+```yaml
+---
+collections:
+  <your_tenant>/<derivation_name>:
+    schema:
+      type: object
+      properties:
+        tag_name:
+          type: string
+        tag_value:
+          type: string
+      required:
+        - tag_name
+        - tag_value
+    key:
+      - /tag_name
+    derive:
+      using:
+        typescript:
+          module: <derivation_name>.ts
+      transforms:
+        - name: user_content
+          source: <your_tenant>/<capture_name>/public/<collection_name>
+          shuffle: any
+```
 
-2. We need to modify the schema to match what we want our derived collection to look like. We'll be using the `tags` field from the original data, so we'll need to add a new property for each field we want to include in the derived collection. We'll also need to set a key for the derived collection.
-
-   These updates to the `flow.yaml` file will look something like this:
-
-   ```yaml
-   ---
-   collections:
-     <your_tenant>/<derivation_name>:
-       schema:
-         type: object
-         properties:
-           tag_name:
-             type: string
-           tag_value:
-             type: string
-         required:
-           - tag_name
-           - tag_value
-       key:
-         - /tag_name
-       derive:
-         using:
-           typescript:
-             module: <derivation_name>.ts
-         transforms:
-           - name: user_content
-             source: <your_tenant>/<capture_name>/public/<collection_name>
-             shuffle: any
-   ```
-
-3. Save the `flow.yaml` file.
+Copy this into your `flow.yaml` file. Replace resource names within angle brackets (eg. `<your_tenant>`) with your own information and save your changes.
 
 ## Step 3: Write your TypeScript derivation
 
-In the GitPod environment, you'll find a file called `<derivation_name>.ts` in the same folder as the `flow.yaml` file you just edited. This is where you'll write your TypeScript code to flatten the array.
+Note that the YAML specification references a TypeScript file (`<derivation_name>.ts`) that doesn't exist yet.
+You can generate a stub file for your TypeScript transformation using:
 
-1. Open the `<derivation_name>.ts` file in the GitPod environment.
+```bash
+flowctl generate --source flow.yaml
+```
+
+This file is where you'll write your TypeScript code to flatten the array.
+
+1. Open the new `<derivation_name>.ts` file.
 
    You'll see a basic structure for your TypeScript code. It should look something like this:
 
@@ -165,14 +141,13 @@ In the GitPod environment, you'll find a file called `<derivation_name>.ts` in t
 
 ## Step 4: Preview your derivation
 
-1. In the GitPod environment, open a terminal.
-2. Run the following command to test your derivation:
+1. Run the following command to test your derivation:
 
    ```bash
    flowctl preview --source flow.yaml
    ```
 
-3. This will show you a preview of the derived collection, including the flattened fields. Make sure everything looks good.
+2. This will show you a preview of the derived collection, including the flattened fields. Make sure everything looks good.
 
    For example, an original row like this:
 
@@ -206,7 +181,7 @@ In the GitPod environment, you'll find a file called `<derivation_name>.ts` in t
    }
    ```
 
-4. Once you've confirmed your results, you can proceed to publish your derivation to Estuary Flow:
+3. Once you've confirmed your results, you can proceed to publish your derivation to Estuary Flow:
 
    ```bash
    flowctl catalog publish --source flow.yaml

--- a/site/docs/guides/flowctl/create-derivation.md
+++ b/site/docs/guides/flowctl/create-derivation.md
@@ -19,73 +19,86 @@ If you don't have an account yet, [go to the web app](https://dashboard.estuary.
 * An existing Flow **collection**. Typically, you create this through a **capture** in the Flow web application.
 If you need help, see the [guide to create a Data Flow](../create-dataflow.md).
 
-* A development environment to work with flowctl. Choose between:
+* The `flowctl` CLI [installed and authenticated](/guides/get-started-with-flowctl).
 
-   * [GitPod](https://www.gitpod.io/), the cloud development environment integrated with Flow.
-   GitPod comes ready for derivation writing, with stubbed out files and flowctl installed. You'll need a GitHub or Google account to log in.
+   You can authorize `flowctl` with a refresh token:
 
-   * Your local development environment. [Install flowctl locally](../get-started-with-flowctl.md).
+   1. [Generate an Estuary Flow refresh token](/guides/how_to_generate_refresh_token).
 
-## Get started with GitPod
+   2. Run `flowctl auth token --token <paste-token-here>`
 
-You'll write your derivation using GitPod, a cloud development environment integrated in the Flow web app.
+## Create a derivation locally
 
-1. Navigate to the [Collections](https://dashboard.estuary.dev/collections) page in Flow.
+In Estuary, a derivation is a new collection that has been **derived** from an existing source collection.
 
-2. Click on the **New Transformation** button.
+You can create a new `flow.yaml` with your derivation specification and publish it to Estuary.
+For this example, we will add our new derived collection to our source collection spec.
 
-   The **Derive A New Collection** pop-up window appears.
+1. Locate the source collection for your derivation. Either:
 
-3. In the **Available Collections** dropdown, select the collection you want to use as the source.
+   * Check the web app's **Collections**.
+   All published entities to which you have access are listed and can be searched.
 
-   For example, if your organization is `acmeCo`, you might choose the `acmeCo/resources/anvils` collection.
+   * Run `flowctl catalog list --collections`. This command returns a complete list of collections to which you have access.
+   You can refine by specifying a `--prefix`.
 
-4. Set the transformation language to either **SQL** or **TypeScript**.
+2. Pull the source collection locally using the full collection name.
 
-   SQL transformations can be a more approachable place to start if you're new to derivations.
-   TypeScript transformations can provide more resiliency against failures through static type checking.
+   ```console
+   flowctl catalog pull-specs --name acmeCo/resources/anvils
+   ```
 
-5. Give your derivation a name. From the dropdown, choose the name of your catalog prefix and append a unique name, for example `acmeCo/resources/anvil-status`.
+   The source files are written to your current working directory.
 
-6. Click **Proceed to GitPod** to create your development environment. Sign in with one of the available account types.
-
-7. On the **New Workspace** screen, keep the **Context URL** option selected and click **Continue.**
-
-   A GitPod development environment opens.
-   A stubbed-out derivation with a transformation has already been created for you in the language you chose. Next, you'll locate and open the source files.
-
-8. Each slash-delimited prefix of your derivation name has become a folder. Open the nested folders to find the `flow.yaml` file with the derivation specification.
+3. Each slash-delimited prefix of your collection name has become a folder. Open the nested folders to find the `flow.yaml` file with the collection specification.
 
    Following the example above, you'd open the folders called `acmeCo`, then `resources` to find the correct `flow.yaml` file.
 
-   The file contains a placeholder collection specification and schema for the derivation.
+   The file contains the source collection specification and schema.
 
-   In the same folder, you'll also find supplementary TypeScript or SQL files you'll need for your transformation.
+4. Add the derivation as a second collection in the `flow.yaml` file.
 
-[Continue with SQL](#add-a-sql-derivation-in-gitpod)
+   1. Write the [schema](/concepts/schemas) you'd like your derivation to conform to and specify the [collection key](/concepts/collections/#keys). Reference the source collection's schema, and keep in mind the transformation required to get from the source schema to the new schema.
 
-[Continue with TypeScript](#add-a-typescript-derivation-in-gitpod)
+   2. Add the `derive` stanza. See examples for [SQL](#add-a-sql-derivation) and [TypeScript](#add-a-sql-derivation) below. Give your transform a unique name.
 
-:::info Authentication
+5. Stub out the SQL or TypeScript files for your transform.
 
-When you first connect to GitPod, you will have already authenticated Flow, but if you leave GitPod opened for too long, you may have to reauthenticate Flow. To do this:
+   ```console
+   flowctl generate --source flow.yaml
+   ```
 
-1. [Generate an Estuary Flow refresh token](/guides/how_to_generate_refresh_token).
+6. Locate the generated file, likely in the same subdirectory as the `flow.yaml` file you've been working in.
 
-2. Run `flowctl auth token --token <paste-token-here>` in the GitPod terminal.
-:::
+7. Write your transformation.
 
-## Add a SQL derivation in GitPod
+8. Preview the derivation locally.
+
+   ```console
+   flowctl preview --source flow.yaml
+   ```
+
+9. If the preview output appears how you'd expect, **publish** the derivation.
+
+   ```console
+   flowctl catalog publish --source flow.yaml
+   ```
+
+The derivation you created is now live and ready for further use.
+You can access it from the web application and [materialize it to a destination](../create-dataflow.md#create-a-materialization),
+just as you would any other Flow collection.
+
+## Add a SQL derivation
 
 If you chose **SQL** as your transformation language, follow these steps.
 
-Along with the derivation's `flow.yaml` you found in the previous steps, there are two other files:
+Along with the derivation's `flow.yaml` you worked with in the previous steps, you may generate two types of SQL file:
 
 * A **lambda** file. This is where you'll write your first SQL transformation.
 Its name follows the pattern `derivation-name.lambda.source-collection-name.sql`.
 Using the example above, it'd be called `anvil-status.lambda.anvils.sql`.
 
-* A **migrations** file. [Migrations](../../concepts/derivations.md#migrations) allow you to leverage other features of the sqlite database that backs your derivation by creating tables, indices, views, and more.
+* A **migrations** file. [Migrations](/concepts/derivations/#migrations) allow you to leverage other features of the sqlite database that backs your derivation by creating tables, indices, views, and more.
 Its name follows the pattern `derivation-name.migration.0.sql`.
 Using the example above, it'd be called `anvil-status.migration.0.sql`.
 
@@ -117,7 +130,7 @@ Using the example above, it'd be called `anvil-status.migration.0.sql`.
 
    Note the stubbed out schema and key.
 
-2. Write the [schema](../../concepts/schemas.md) you'd like your derivation to conform to and specify its [collection key](../../concepts/collections.md#keys). Keep in mind:
+2. Write the [schema](/concepts/schemas) you'd like your derivation to conform to and specify its [collection key](/concepts/collections/#keys). Keep in mind:
 
    * The source collection's schema.
 
@@ -130,13 +143,21 @@ Using the example above, it'd be called `anvil-status.migration.0.sql`.
 :::info Tip
 For help writing your derivation, start with these examples:
 
-* [Continuous materialized view tutorial](../../getting-started/tutorials/continuous-materialized-view.md)
-* [Acme Bank examples](../../getting-started/tutorials/derivations_acmebank.md)
+* [Continuous materialized view tutorial](/getting-started/tutorials/continuous-materialized-view)
+* [Acme Bank examples](/getting-started/tutorials/derivations_acmebank)
 
-The main [derivations page](../../concepts/derivations.md) includes many other examples and in-depth explanations of how derivations work.
+The main [derivations page](/concepts/derivations) includes many other examples and in-depth explanations of how derivations work.
 :::
 
 5. If necessary, open the migration file and write your migration.
+
+   If you won't be using a migration, you can omit the `migrations` stanza:
+
+   ```yaml
+   derive:
+     using:
+       sqlite: {}
+   ```
 
 6. Preview the derivation locally.
 
@@ -154,11 +175,11 @@ The derivation you created is now live and ready for further use.
 You can access it from the web application and [materialize it to a destination](../create-dataflow.md#create-a-materialization),
 just as you would any other Flow collection.
 
-## Add a TypeScript derivation in GitPod
+## Add a TypeScript derivation
 
 If you chose **TypeScript** as your transformation language, follow these steps.
 
-Along with the derivation's `flow.yaml` you found in the previous steps, there's another file for the TypeScript transformation.
+Along with the derivation's `flow.yaml` you worked with in the previous steps, you can create a file to handle the TypeScript transformation.
 It follows the naming convention `derivation-name.ts`.
 Using the example above, it'd be called `anvil-status.ts`.
 
@@ -188,7 +209,7 @@ Using the example above, it'd be called `anvil-status.ts`.
 
    Note the stubbed out schema and key.
 
-2. Write the [schema](../../concepts/schemas.md) you'd like your derivation to conform to and specify the [collection key](../../concepts/collections.md#keys). Keep in mind:
+2. Write the [schema](/concepts/schemas) you'd like your derivation to conform to and specify the [collection key](/concepts/collections/#keys). Keep in mind:
 
    * The source collection's schema.
 
@@ -215,70 +236,6 @@ The main [derivations page](../../concepts/derivations.md) includes many other e
    ```console
    flowctl catalog publish --source flow.yaml
    ```
-
-The derivation you created is now live and ready for further use.
-You can access it from the web application and [materialize it to a destination](../create-dataflow.md#create-a-materialization),
-just as you would any other Flow collection.
-
-## Create a derivation locally
-
-Creating a derivation locally is largely the same as using GitPod, but has some extra steps. Those extra steps are explained here, but you'll find more useful context in the sections above.
-
-1. Authorize flowctl.
-
-   1. [Generate an Estuary Flow refresh token](/guides/how_to_generate_refresh_token).
-
-   2. Run `flowctl auth token --token <paste-token-here>` in your local environment.
-
-2. Locate the source collection for your derivation.
-
-   * Check the web app's **Collections**.
-   All published entities to which you have access are listed and can be searched.
-
-   * Run `flowctl catalog list --collections`. This command returns a complete list of collections to which you have access.
-   You can refine by specifying a `--prefix`.
-
-3. Pull the source collection locally using the full collection name.
-
-   ```console
-   flowctl catalog pull-specs --name acmeCo/resources/anvils
-   ```
-
-   The source files are written to your current working directory.
-
-4. Each slash-delimited prefix of your collection name has become a folder. Open the nested folders to find the `flow.yaml` file with the collection specification.
-
-   Following the example above, you'd open the folders called `acmeCo`, then `resources` to find the correct `flow.yaml` file.
-
-   The file contains the source collection specification and schema.
-
-5. Add the derivation as a second collection in the `flow.yaml` file.
-
-   1. Write the [schema](../../concepts/schemas.md) you'd like your derivation to conform to and specify the [collection key](../../concepts/collections.md#keys). Reference the source collection's schema, and keep in mind the transformation required to get from the source schema to the new schema.
-
-   2. Add the `derive` stanza. See examples for [SQL](#add-a-sql-derivation-in-gitpod) and [TypeScript](#add-a-sql-derivation-in-gitpod) above. Give your transform a unique name.
-
-6. Stub out the SQL or TypeScript files for your transform.
-
-   ```console
-   flowctl generate --source flow.yaml
-   ```
-
-7. Locate the generated file, likely in the same subdirectory as the `flow.yaml` file you've been working in.
-
-8. Write your transformation.
-
-9. Preview the derivation locally.
-
-```console
-flowctl preview --source flow.yaml
-```
-
-10. If the preview output appears how you'd expect, **publish** the derivation.
-
-```console
-flowctl catalog publish --source flow.yaml
-```
 
 The derivation you created is now live and ready for further use.
 You can access it from the web application and [materialize it to a destination](../create-dataflow.md#create-a-materialization),


### PR DESCRIPTION
**Description:**

GitPod has been sunset and our integration for derivations no longer works. This PR updates docs to remove outdated information, focusing on a CLI-first approach to working with derivations.

**Documentation links affected:**

Affected docs include:
- [Create a derivation with flowctl](https://docs.estuary.dev/guides/flowctl/create-derivation/)
- [How to flatten an array using TypeScript](https://docs.estuary.dev/guides/flatten-array/)
- [Create a real-time materialized view in PostgreSQL](https://docs.estuary.dev/getting-started/tutorials/continuous-materialized-view/)

**Notes for reviewers:**

Thanks for reviewing!
