### PR TITLE
parser: add tilde (~) delimiter support

### DIFF
--- a/crates/parser/src/config/character_separated.rs
+++ b/crates/parser/src/config/character_separated.rs
@@ -143,6 +143,8 @@ pub enum Delimiter {
     Semicolon,
     #[serde(rename = "\t")]
     Tab,
+    #[serde(rename = "~")]
+    Tilde,
     #[serde(rename = "\x0B")]
     VerticalTab,
     #[serde(rename = "\x1F")]
@@ -165,6 +167,7 @@ impl Delimiter {
             Delimiter::Space => b' ',
             Delimiter::Semicolon => b';',
             Delimiter::Tab => b'\t',
+            Delimiter::Tilde => b'~',
             Delimiter::VerticalTab => 0x0B,
             Delimiter::UnitSeparator => 0x1F,
             Delimiter::SOH => 0x01,
@@ -180,6 +183,7 @@ impl EnumSelection for Delimiter {
             Delimiter::Space => "Space (0x20)",
             Delimiter::Semicolon => "Semicolon (;)",
             Delimiter::Tab => "Tab (0x09)",
+            Delimiter::Tilde => "Tilde (~)",
             Delimiter::VerticalTab => "Vertical Tab (0x0B)",
             Delimiter::UnitSeparator => "Unit Separator (0x1F)",
             Delimiter::SOH => "SOH (0x01)",

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -140,6 +140,11 @@ expression: schema
                       "const": "\t"
                     },
                     {
+                      "title": "Tilde (~)",
+                      "default": "~",
+                      "const": "~"
+                    },
+                    {
                       "title": "Vertical Tab (0x0B)",
                       "default": "\u000b",
                       "const": "\u000b"


### PR DESCRIPTION
**Description:**

Add `~` as a supported delimiter in the parser.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

