### PR TITLE
Docs: A few CLI and derivation best practices

### DIFF
--- a/site/docs/concepts/captures.md
+++ b/site/docs/concepts/captures.md
@@ -55,6 +55,22 @@ You may then modify the generated configuration as needed before publishing the 
 Discovers can also be run when editing an existing capture. This is commonly done in order to add new bindings, or update the collection specs and schemas associated with existing bindings.
 :::
 
+### Discovery through `flowctl`
+
+You may also discover all currently available bindings through the `flowctl` CLI for a specific capture:
+
+```shell
+flowctl discover --source flow.yaml
+```
+
+Where the provided `flow.yaml` file includes your capture [specification](#specification).
+If your chosen source `flow.yaml` includes more than one capture specification, you will need to specify one using the command's `--capture` parameter.
+
+This command will invoke the capture's connector from your data plane in order to discover the capture's available bindings.
+Bindings and associated collections are then written back to your local source file.
+
+If you are creating a new capture, you can simply leave the bindings stanza blank (`bindings: []`), and then fill in the details using the `flowctl discover` command.
+
 ## Automatically update captures
 
 You can choose to run periodic discovers in the background by adding the `autoDiscover` property to the capture. Flow will periodically check for changes to the source and re-publish the capture to reflect those changes.

--- a/site/docs/concepts/derivations.md
+++ b/site/docs/concepts/derivations.md
@@ -229,6 +229,26 @@ then that column will become the output document.
 For example `SELECT JSON_OBJECT('a', 1, 'b', JSON('true'));` maps into document `{"a": 1, "b": true}`.
 This can be used to build documents with dynamic top-level properties.
 
+Note that this also allows you to manage Flow's final document specification in ways that SQLite would not otherwise allow.
+SQLite does not support a [boolean data type](https://sqlite.org/datatype3.html#boolean_datatype), instead defaulting to the integers `0` and `1`.
+By selecting a `JSON_OBJECT` with a `JSON('true')` or `JSON('false')` value, the final JSON field will have a boolean type.
+
+You can set a boolean value dynamically with a case statement. For example:
+
+```sql
+select
+  json_object(
+    'id', id,
+    'decision', (
+      case json_extract(document, '$.decision')
+        when 'true' then json('true')
+        when 'false' then json('false')
+        else null
+      end
+    )
+  )
+```
+
 ### Parameters
 
 Your SQL lambda will execute with every source document of the collection it transforms.

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -59,11 +59,17 @@ and delete entities from the catalog.
 
 * `collections` allows you to work with your Flow collections. You can read the data from the collection and output it to stdout, or list the [journals](../concepts/advanced/journals.md) or journal fragments that comprise the collection. [Learn more about reading collections with flowctl](../concepts/collections.md#using-the-flowctl-cli).
 
+* `discover` allows you to discover all currently available bindings for a specific capture.
+This resource discovery mimics discovery in the UI. [Learn more about capture discovery](/concepts/captures/#discovery).
+
 * `draft` provides an alternative method for many of the actions you'd normally perform with `catalog`, but common workflows have more steps.
 
 * `generate` creates stub files and folder structures based on a provided `flow.yaml` file. This is helpful when [creating a derivation locally](../guides/flowctl/create-derivation.md#create-a-derivation-locally).
 
 * `logs` allows you to review or follow logs for a particular task. This can be useful to help debug captures, derivations, and materializations.
+
+* `preview` allows you to preview task output by locally running a capture, derivation, or materialization.
+This lets you confirm expected output before publishing your changes to Estuary.
 
 You can access full documentation of all flowctl subcommands from the command line by passing the `--help` or `-h` flag, for example:
 

--- a/site/docs/reference/deletions.md
+++ b/site/docs/reference/deletions.md
@@ -2,6 +2,31 @@
 
 Estuary supports two categories of deletions: **soft deletes** and **hard deletes**. These deletion types determine how documents are marked and treated within the system. Below is an explanation of each category.
 
+Delete events contain a very limited set of fields compared to create and update events.
+Only the primary key and meta information are present. The `_meta/op` field will be set to `d`.
+For example:
+
+```json
+{
+  "_meta": {
+    "op": "d",
+    "source": {
+      "loc": [
+        516715804872,
+        516715805272,
+        516715805488
+      ],
+      "schema": "public",
+      "table": "shipments",
+      "ts_ms": 1758800000000,
+      "txid": 390000000
+    },
+    "uuid": "abc-123-def-456"
+  },
+  "id": 1234
+}
+```
+
 ## Soft Deletes
 
 Soft deletes occur when a document is marked as deleted but is not physically removed from the destination. Instead, it is flagged for deletion with a specific metadata field.
@@ -29,3 +54,45 @@ Hard deletes go a step further than soft deletes by permanently removing documen
   - MongoDB
   - MotherDuck
   - TimescaleDB
+
+## Deletions and Derivations
+
+When working with derived collections, since you are filtering and transforming the original data collection, you must take care to ensure delete events are still passed along to the materialization.
+
+There are a couple best practices to consider when writing derivations in conjunction with deletions.
+
+**Filtering**
+
+Since delete events lack most document fields, it can be easy to accidentally filter them out from downstream systems.
+
+You may therefore want to explicitly check the `_meta/op` field as part of any filtering statement in your transformation logic.
+For example:
+
+```sql
+WHERE $_meta$op != 'd'
+AND $created_at > '2025-01-01'
+```
+
+**Hard deletions as reduction annotations**
+
+Deletes may sometimes appear without an associated create event for the ID, such as when using multiple filter conditions in your derivation.
+If a delete event is the first time Flow has seen a specific ID, the ID will not be properly passed along for hard deletion in the materialization.
+This is because Flow uses [**reductions**](/concepts/#reductions) to handle hard deletes.
+Essentially, if there isn't already a document for that ID, there is nothing for the new document to _reduce into_.
+
+To handle this edge case, you should ensure there is more than one document for the ID so the deletion reduction can take place.
+A simple solution is to emit a delete event twice in your transformation.
+For example, consider this SQL lambda statement:
+
+```sql
+-- Perform your desired transformation on the data when the event is not 'd'
+SELECT
+  $id,
+  JSON($flow_document)
+WHERE $_meta$op != 'd';
+
+-- In case we run across IDs we haven't seen before, ensure there is already
+-- a document in place so that delete reductions will propagate correctly
+SELECT $id, $_meta where $_meta$op = 'd';
+SELECT $id, $_meta where $_meta$op = 'd';
+```


### PR DESCRIPTION
**Description:**

Adds information and a few best practices around the `flowctl` CLI and derivations:
* Includes the new `flowctl discover` subcommand
* Example on working with booleans with SQLite derivations
* Best practices for deletions and derivations, with info on filtering and double deletion

**Notes for reviewers:**

Thanks for reviewing!
