### PR TITLE
agent: improve error message when a tenant's task quota would be exceeded

### DIFF
--- a/crates/agent/src/integration_tests/quotas.rs
+++ b/crates/agent/src/integration_tests/quotas.rs
@@ -55,7 +55,7 @@ async fn test_quota_single_task() {
         errors: [
             (
                 "flow://tenant-quotas/seaTurtles/tasks",
-                "Request to add 1 task(s) would exceed tenant 'seaTurtles/' quota of 2. 2 are currently in use.",
+                "Request to add 1 task(s) would exceed tenant 'seaTurtles/' quota of 2. 2 are currently in use. Reach out to Estuary Support to request an increased task limit for your tenant.",
             ),
         ],
         live_specs: [],
@@ -127,7 +127,7 @@ async fn test_quota_derivations() {
         errors: [
             (
                 "flow://tenant-quotas/seagulls/tasks",
-                "Request to add 1 task(s) would exceed tenant 'seagulls/' quota of 2. 2 are currently in use.",
+                "Request to add 1 task(s) would exceed tenant 'seagulls/' quota of 2. 2 are currently in use. Reach out to Estuary Support to request an increased task limit for your tenant.",
             ),
             (
                 "flow://tenant-quotas/seagulls/collections",

--- a/crates/control-plane-api/src/publications/quotas.rs
+++ b/crates/control-plane-api/src/publications/quotas.rs
@@ -108,7 +108,7 @@ pub async fn check_resource_quotas(
             // exceeds your quota, so long as you remove/disable more tasks than you add.
             if tasks_delta >= 0 && new_tasks_used > tenant.tasks_quota {
                 let value = anyhow::anyhow!(
-                    "Request to add {} task(s) would exceed tenant '{}' quota of {}. {} are currently in use.",
+                    "Request to add {} task(s) would exceed tenant '{}' quota of {}. {} are currently in use. Reach out to Estuary Support to request an increased task limit for your tenant.",
                     tasks_delta,
                     tenant.name,
                     tenant.tasks_quota,


### PR DESCRIPTION
**Description:**

It's not clear from the error message what a user's next steps should be when they're trying to exceed their task quota. Directing them to reach out to support to increase their task quota makes it clear what users should do when they hit this error.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

