### PR TITLE
docs: move marketing_emails stream to native Hubspot capture connector

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
+++ b/site/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
@@ -18,6 +18,7 @@ The connector automatically discovers bindings for the following HubSpot resourc
 * [Form Submissions](https://developers.hubspot.com/docs/reference/api/marketing/forms/v1)
 * [Forms](https://developers.hubspot.com/docs/reference/api/marketing/forms/v3)
 * [Line Items](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/line-items)
+* [Marketing Emails](https://developers.hubspot.com/docs/api-reference/marketing-marketing-emails-v3/marketing-emails/get-marketing-v3-emails-)
 * [Owners](https://developers.hubspot.com/beta-docs/reference/api/crm/owners/v2)
 * [Products](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/products)
 * [Properties](https://developers.hubspot.com/docs/api/crm/properties)

--- a/site/docs/reference/Connectors/capture-connectors/HubSpot.md
+++ b/site/docs/reference/Connectors/capture-connectors/HubSpot.md
@@ -41,7 +41,6 @@ The following data resources are supported for all subscription levels:
 The following data resources are supported for pro accounts (set **Subscription type** to `pro` in the [configuration](#endpoint)):
 
 * [Feedback Submissions](https://developers.hubspot.com/docs/api/crm/feedback-submissions)
-* [Marketing Emails](https://legacydocs.hubspot.com/docs/methods/cms_email/get-all-marketing-email-statistics)
 * [Workflows](https://legacydocs.hubspot.com/docs/methods/workflows/v3/get_workflows)
 
 ## Prerequisites


### PR DESCRIPTION
**Description:**

Documentation updates for https://github.com/estuary/connectors/pull/3326 and https://github.com/estuary/connectors/pull/3337.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

