### PR TITLE
validation: limit captures, derivations, and materializations to 10k bindings

### DIFF
--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -123,6 +123,16 @@ async fn walk_capture<C: Connectors>(
 
     indexed::walk_name(scope, "capture", capture, models::Capture::regex(), errors);
 
+    if bindings_model.len() > crate::MAX_BINDINGS {
+        Error::TooManyBindings {
+            entity: "capture",
+            name: capture.to_string(),
+            count: bindings_model.len(),
+        }
+        .push(scope, errors);
+        return None;
+    }
+
     // Unwrap `endpoint` into a connector type and configuration.
     let (connector_type, config_json): (i32, bytes::Bytes) = match &endpoint {
         models::CaptureEndpoint::Connector(config) => (

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -212,6 +212,16 @@ async fn walk_derivation<C: Connectors>(
         shards,
     } = model;
 
+    if transforms_model.len() > crate::MAX_BINDINGS {
+        Error::TooManyBindings {
+            entity: "derivation",
+            name: collection.to_string(),
+            count: transforms_model.len(),
+        }
+        .push(scope, errors);
+        return None;
+    }
+
     // Unwrap `using` into a connector type and configuration.
     let (connector_type, config_json): (i32, bytes::Bytes) = match &using {
         models::DeriveUsing::Connector(config) => (

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -259,6 +259,12 @@ pub enum Error {
     TouchModelIsDelete,
     #[error("this binding must backfill because its source collection {collection} was reset")]
     SourceCollectionWasReset { collection: String },
+    #[error("{entity} {name} has {count} bindings, which exceeds the maximum of {} bindings", crate::MAX_BINDINGS)]
+    TooManyBindings {
+        entity: &'static str,
+        name: String,
+        count: usize,
+    },
 
     #[error("{entity} {name} maps to storage mapping {partition_mapping}, implying it must have an aligned recovery mapping recovery/{partition_mapping}, but it actually maps to {recovery_mapping}")]
     StorageMappingPrefixMismatch {

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -19,6 +19,10 @@ mod test_step;
 pub use errors::Error;
 pub use noop::NoOpConnectors;
 
+/// Maximum number of bindings allowed in a capture, derivation, or materialization.
+/// We have a hard upper limit of 65,535 because doc::combine uses u16 indices.
+pub const MAX_BINDINGS: usize = 10_000;
+
 /// Connectors is a delegated trait -- provided to validate -- through which
 /// connector validation RPCs are dispatched. Request and Response must always
 /// be Validate / Validated variants, but may include `internal` fields.

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -129,6 +129,16 @@ async fn walk_materialization<C: Connectors>(
         errors,
     );
 
+    if bindings_model.len() > crate::MAX_BINDINGS {
+        Error::TooManyBindings {
+            entity: "materialization",
+            name: materialization.to_string(),
+            count: bindings_model.len(),
+        }
+        .push(scope, errors);
+        return None;
+    }
+
     // Unwrap `endpoint` into a connector type and configuration.
     let (connector_type, config_json): (i32, bytes::Bytes) = match &endpoint {
         models::MaterializationEndpoint::Connector(config) => (

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1577,3 +1577,88 @@ driver:
     );
     insta::assert_debug_snapshot!(outcome);
 }
+
+#[test]
+fn test_capture_too_many_bindings() {
+    let bindings_count = validation::MAX_BINDINGS + 1;
+
+    // Generate patch with too many bindings
+    let mut patch = r##"
+test://example/int-string-captures:
+  captures:
+    testing/s3-source:
+      bindings:
+"##
+    .to_string();
+
+    // Add many bindings
+    for i in 0..bindings_count {
+        patch.push_str(&format!(
+            r##"        - target: testing/int-string
+          resource:
+            stream: "binding{}"
+"##,
+            i
+        ));
+    }
+
+    let errors = common::run_errors(MODEL_YAML, &patch);
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_derivation_too_many_transforms() {
+    let transforms_count = validation::MAX_BINDINGS + 1;
+
+    // Generate patch with too many transforms
+    let mut patch = r##"
+test://example/int-reverse:
+  collections:
+    testing/int-reverse:
+      derive:
+        transforms:
+"##
+    .to_string();
+
+    // Add many transforms
+    for i in 0..transforms_count {
+        patch.push_str(&format!(
+            r##"          - name: transform{}
+            source: testing/int-string
+            shuffle: any
+"##,
+            i
+        ));
+    }
+
+    let errors = common::run_errors(MODEL_YAML, &patch);
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_materialization_too_many_bindings() {
+    let bindings_count = validation::MAX_BINDINGS + 1;
+
+    // Generate patch with too many bindings
+    let mut patch = r##"
+test://example/db-views:
+  materializations:
+    testing/db-views:
+      bindings:
+"##
+    .to_string();
+
+    // Add many bindings
+    for i in 0..bindings_count {
+        patch.push_str(&format!(
+            r##"        - source: testing/int-string
+          resource:
+            table: "table{}"
+"##,
+            i
+        ));
+    }
+
+    let errors = common::run_errors(MODEL_YAML, &patch);
+    insta::assert_debug_snapshot!(errors);
+}

--- a/crates/validation/tests/snapshots/scenario_tests__capture_too_many_bindings.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__capture_too_many_bindings.snap
@@ -1,0 +1,10 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-string-captures#/captures/testing~1s3-source,
+        error: capture testing/s3-source has 10001 bindings, which exceeds the maximum of 10000 bindings,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__derivation_too_many_transforms.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__derivation_too_many_transforms.snap
@@ -1,0 +1,10 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/derive,
+        error: derivation testing/int-reverse has 10001 bindings, which exceeds the maximum of 10000 bindings,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__materialization_too_many_bindings.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__materialization_too_many_bindings.snap
@@ -1,0 +1,10 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/db-views#/materializations/testing~1db-views,
+        error: materialization testing/db-views has 10001 bindings, which exceeds the maximum of 10000 bindings,
+    },
+]


### PR DESCRIPTION
The combiner uses u16 for binding indices, providing a hard upper bound of 65,535 bindings. This change adds validation to enforce a practical limit of 10,000 bindings per task to prevent performance issues and ensure reasonable catalog sizes.

Adds MAX_BINDINGS constant and TooManyBindings error variant, with checks in capture, derivation, and materialization validation paths. Tests verify that exceeding the limit produces appropriate errors.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

