### PR TITLE
data-plane-controller: dns_name should be optional for Azure privatelink

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -163,6 +163,7 @@ pub struct AWSPrivateLink {
 pub struct AzurePrivateLink {
     pub service_name: String,
     pub location: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub dns_name: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub resource_type: String,


### PR DESCRIPTION
**Description:**

dns_name should be optional

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

