### PR TITLE
data-plane-controller: roll out one deployment per role

### DIFF
--- a/crates/data-plane-controller/src/snapshots/data_plane_controller__stack__test__simulate_chained_surge_releases.snap
+++ b/crates/data-plane-controller/src/snapshots/data_plane_controller__stack__test__simulate_chained_surge_releases.snap
@@ -83,6 +83,21 @@ expression: "&simulate_rollout(&mut stack.config.model, releases)"
       },
       "oci_image": "ghcr.io/gazette/broker:v1",
       "desired": 9,
+      "current": 9
+    }
+  ],
+  [
+    {
+      "role": "gazette",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "r5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "ghcr.io/gazette/broker:v1",
+      "desired": 9,
       "current": 9,
       "rollout": {
         "target": 0,
@@ -125,6 +140,21 @@ expression: "&simulate_rollout(&mut stack.config.model, releases)"
         "step": 100
       }
     },
+    {
+      "role": "gazette",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "r5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "ghcr.io/gazette/broker:v2",
+      "desired": 9,
+      "current": 9
+    }
+  ],
+  [
     {
       "role": "gazette",
       "template": {

--- a/crates/data-plane-controller/src/snapshots/data_plane_controller__stack__test__simulate_multi_az_etcd_releases.snap
+++ b/crates/data-plane-controller/src/snapshots/data_plane_controller__stack__test__simulate_multi_az_etcd_releases.snap
@@ -1,0 +1,409 @@
+---
+source: crates/data-plane-controller/src/stack.rs
+expression: "&simulate_rollout(&mut stack.config.model, releases)"
+---
+[
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 0,
+      "current": 1,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      }
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 0,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 0,
+      "current": 1,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      }
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 0,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 0,
+      "current": 1,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      }
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 0,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 0,
+      "rollout": {
+        "target": 1,
+        "step": 1
+      }
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "b"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "c"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 1
+    }
+  ]
+]

--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -168,7 +168,7 @@ pub struct AzurePrivateLink {
     pub resource_type: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     Etcd,
@@ -430,6 +430,14 @@ impl DataPlane {
             changed = deployment.step_rollout() || changed;
         }
 
+        // Collect roles that currently have active rollouts.
+        let mut roles_in_rollout: std::collections::HashSet<_> = self
+            .deployments
+            .iter()
+            .filter(|d| d.rollout.is_some())
+            .map(|d| d.role.clone())
+            .collect();
+
         // Find deployments which match a release, and start new a rollout.
         let mut added = Vec::new();
 
@@ -437,6 +445,14 @@ impl DataPlane {
             if last.rollout.is_some() {
                 continue; // Must complete current rollout before starting a next.
             }
+
+            // Skip if this role already has an active rollout.
+            if roles_in_rollout.contains(&last.role) {
+                continue;
+            }
+
+            roles_in_rollout.insert(last.role.clone());
+
             let Some(release) = releases.iter().find(|r| r.prev_image == last.oci_image) else {
                 continue;
             };
@@ -768,6 +784,20 @@ mod test {
                 step: 7,
             },
         ];
+
+        insta::assert_json_snapshot!(&simulate_rollout(&mut stack.config.model, releases));
+    }
+
+    #[test]
+    fn simulate_multi_az_etcd_releases() {
+        let State { mut stack, .. } =
+            serde_json::from_str(include_str!("state_fixture_multiaz_etcd.json")).unwrap();
+
+        let releases = &[Release {
+            prev_image: "quay.io/coreos/etcd:v3.5.17".to_string(),
+            next_image: "quay.io/coreos/etcd:next".to_string(),
+            step: -1,
+        }];
 
         insta::assert_json_snapshot!(&simulate_rollout(&mut stack.config.model, releases));
     }

--- a/crates/data-plane-controller/src/state_fixture_multiaz_etcd.json
+++ b/crates/data-plane-controller/src/state_fixture_multiaz_etcd.json
@@ -1,0 +1,89 @@
+{
+  "stack": {
+    "config": {
+      "est-dry-dock:model": {
+        "fqdn": "the-subdomain.dp.estuary-data.com",
+        "name": "ops/dp/private/AcmeCo/aws-us-west-2-c1",
+        "builds_root": "gs://estuary-control/builds/",
+        "deployments": [
+          {
+            "role": "etcd",
+            "current": 1,
+            "desired": 1,
+            "template": {
+              "zone": "a",
+              "region": "us-west-2",
+              "provider": "aws",
+              "ami_image_id": "ami-01a8b7cc84780badb",
+              "instance_type": "m5d.large"
+            },
+            "oci_image": "quay.io/coreos/etcd:v3.5.17"
+          },
+          {
+            "role": "etcd",
+            "current": 1,
+            "desired": 1,
+            "template": {
+              "zone": "b",
+              "region": "us-west-2",
+              "provider": "aws",
+              "ami_image_id": "ami-01a8b7cc84780badb",
+              "instance_type": "m5d.large"
+            },
+            "oci_image": "quay.io/coreos/etcd:v3.5.17"
+          },
+          {
+            "role": "etcd",
+            "current": 1,
+            "desired": 1,
+            "template": {
+              "zone": "c",
+              "region": "us-west-2",
+              "provider": "aws",
+              "ami_image_id": "ami-01a8b7cc84780badb",
+              "instance_type": "m5d.large"
+            },
+            "oci_image": "quay.io/coreos/etcd:v3.5.17"
+          }
+        ],
+        "gcp_project": "the-gcp-project",
+        "ssh_subnets": [
+          "35.209.143.159/32",
+          "2600:1900:4000:97c7::/128",
+          "34.136.233.238/32"
+        ],
+        "allow_cidrs": [],
+        "data_buckets": [
+          "gs://estuary-trial",
+          "gs://estuary-flow-poc"
+        ],
+        "gcp_byoc": {
+          "project_id": "test-project"
+        },
+        "aws_assume_role": {
+          "role_arn": "arn:aws:iam::12345678:role/estuary",
+          "external_id": "c90634a4-0000-404d-ba7f-0facfba5b5cd",
+          "iam_instance_profile": "arn:aws:iam::12345678:role/instance"
+        },
+        "builds_kms_keys": [
+          "projects/the-project/locations/us-central1/keyRings/the-key-ring/cryptoKeys/the-key"
+        ],
+        "control_plane_api": "https://agent-api-amj6adhsnq-uc.a.run.app/",
+        "connector_limits": {
+          "cpu": "200m",
+          "memory": "1g"
+        }
+      }
+    },
+    "encryptedkey": "encryptedkey",
+    "secretsprovider": "gcpkms://projects/the-project/locations/us-central1/keyRings/the-key-ring/cryptoKeys/the-key"
+  },
+  "status": "Idle",
+  "logs_token": "4cb6ceef-36bc-4f57-89b9-8e4b11f82f0b",
+  "stack_name": "private-AcmeCo-aws-us-west-2-c1",
+  "last_refresh": "2025-02-26T15:23:07.693050947Z",
+  "data_plane_id": "1122334455667788",
+  "deploy_branch": "main",
+  "last_pulumi_up": "2025-02-26T15:46:19.720962982Z",
+  "private_links": []
+}


### PR DESCRIPTION
**Description:**

- Roll out a single deployment of each role at once. This allows for multi-az etcd rollouts. This also makes normal rollouts take longer because they cannot run in parallel. It is possible for us to apply this only to etcd releases to avoid slowing down other releases.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

