### PR TITLE
validation: adjust Reject ordering

### DIFF
--- a/crates/validation/src/snapshots/validation__field_selection__tests__incompatible_and_ambiguous.snap
+++ b/crates/validation/src/snapshots/validation__field_selection__tests__incompatible_and_ambiguous.snap
@@ -1,0 +1,71 @@
+---
+source: crates/validation/src/field_selection.rs
+expression: snap
+---
+Snap {
+    selects: [
+        (
+            "Foo",
+            DesiredDepth,
+        ),
+        (
+            "flow_published_at",
+            CoreMetadata,
+        ),
+        (
+            "foo",
+            CurrentValue,
+        ),
+        (
+            "foo",
+            DesiredDepth,
+        ),
+        (
+            "id",
+            DesiredDepth,
+        ),
+    ],
+    rejects: [
+        (
+            "Foo",
+            ConnectorIncompatible {
+                reason: "wrong type",
+            },
+        ),
+    ],
+    group_by: [],
+    document: None,
+    field_outcomes: {
+        "Foo": Right(
+            DuplicateFold {
+                folded_field: "Foo",
+                other_field: "foo",
+            },
+        ),
+        "_meta/flow_truncated": Right(
+            ConnectorOmits,
+        ),
+        "flow_document": Right(
+            ConnectorOmits,
+        ),
+        "flow_published_at": Right(
+            ConnectorOmits,
+        ),
+        "foo": Left(
+            CurrentValue,
+        ),
+        "id": Left(
+            DesiredDepth,
+        ),
+    },
+    selection: FieldSelection {
+        keys: [],
+        values: [
+            "foo",
+            "id",
+        ],
+        document: "",
+        field_config_json_map: {},
+    },
+    conflicts: [],
+}


### PR DESCRIPTION
Reject::ConnectorIncompatible must be lower-rank than Reject::DuplicateFold.

If two fields are ambiguous, we want to reject the second field due to the DuplicateFold instead of ConnectorIncompatible. The former will cause the field to simply not be included, while the latter will trigger the onIncompatibleSchemaChange action.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

