### PR TITLE
control-plane-api: fix metrics route for axum 0.8

### DIFF
--- a/crates/control-plane-api/src/server/public/mod.rs
+++ b/crates/control-plane-api/src/server/public/mod.rs
@@ -61,7 +61,7 @@ pub(crate) fn api_v1_router(app: Arc<App>) -> axum::Router<Arc<App>> {
                 .route_layer(axum::middleware::from_fn(ensure_accepts_json)),
         )
         .api_route(
-            "/api/v1/metrics/*prefix",
+            "/api/v1/metrics/{*prefix}",
             aide::axum::routing::get(open_metrics::handle_get_metrics),
         )
         .route(


### PR DESCRIPTION
updates the metrics route to be compatible with axum 0.8, which had a breaking change to the route syntax.
