### PR TITLE
runtime: compute flow-connector-init image from $FLOW_VERSION

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,8 @@ jobs:
 
       - run: make install-tools
       - run: go mod download
-      - run: make rust-gnu-test
       - run: make linux-gnu-binaries
+      - run: make rust-gnu-test
 
       - name: Ensure that we didn't dirty the tree.
         run: git clean --force -d && git diff --exit-code || exit 1

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,9 @@ install-tools: ${PKGDIR}/bin/deno ${PKGDIR}/bin/etcd ${PKGDIR}/bin/sops
 .PHONY: rust-gnu-test
 rust-gnu-test:
 	PATH=$$PATH:${PKGDIR}/bin ;\
+	echo $$PATH && \
+	which flow-connector-init && \
+	ls ${PKGDIR}/bin && \
 	cargo test --release --locked --workspace --exclude parser --exclude schemalate --exclude connector-init
 
 .PHONY: rust-musl-test

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ install-tools: ${PKGDIR}/bin/deno ${PKGDIR}/bin/etcd ${PKGDIR}/bin/sops
 
 .PHONY: rust-gnu-test
 rust-gnu-test:
-	PATH=${PKGDIR}/bin:$$PATH ;\
+	PATH=$$PATH:${PKGDIR}/bin ;\
 	cargo test --release --locked --workspace --exclude parser --exclude schemalate --exclude connector-init
 
 .PHONY: rust-musl-test

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -17,8 +17,7 @@ const USAGE_RATE_LABEL: &str = "dev.estuary.usage-rate";
 const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
 const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
-// TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.10-62-g99cb868608";
+const CONNECTOR_INIT_IMAGE: &str = concat!("ghcr.io/estuary/flow:", env!("FLOW_VERSION"));
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,


### PR DESCRIPTION
Rather than hard-coding a specific pin, use the same version as the current build.

This works because an in-progres build prefers a resolved pre-built flow-connector-init binary, and doesn't attempt to pull this image.

