### PR TITLE
docs: clarify AWS IAM setup docs

### DIFF
--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -4,24 +4,28 @@ Flow supports IAM authentication with Amazon Web Services such as RDS and S3 usi
 
 ## Role with Resource Access
 
-In order to authenticate using AWS IAM, you need to have a role set up which has access to the resource you are trying to authenticate with. Follow the guide [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html) to create a role which has access to your resource and allows a maximum session of 12 hours.
+In order to authenticate using AWS IAM, you need a IAM role which has access to the resource you are trying to authenticate with.  Before we can setup the Identity Provider and the Role's Trust Relationship we need to know the Role ARN, so initially we will just create a placeholder role and later update it with the final Trust Relationship.
+
+To create the role, select "AWS Account" and click next, select the required permissions for your resource, set the role name, and create the role.
+
+For more information about role creation check the [IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html).
 
 ## Identity Provider for Estuary
 
 Next, you need to create an IAM OIDC (OpenID Connect) provider by heading to IAM -> Identity Providers and creating a new provider with the Audience set to the ARN of the role you just created and the issuer set to one of the following values:
-
-![Add Identity Provider](../guide-images/aws-iam-1.png)
 
 | Data Plane | Issuer |
 |---|---|
 | US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
 | EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
 
+![Add Identity Provider](../guide-images/aws-iam-1.png)
+
 # Trust Relationship in Role
 
-Finally, in the details page of your role, head to "Trust relationships" tab and add the following trust policy, replacing the principal with one of the AWS user ARNs in the table below depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value) you use and `:sub` condition with your tenant name so only tasks from your tenant are allowed to assume this role:
+Finally, return to the details page of your role, head to "Trust relationships" tab and add the following trust policy, replacing the principal with the ARN of the Identity Provider depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value) you use and `:sub` condition with your tenant name so only tasks from your tenant are allowed to assume this role:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [


### PR DESCRIPTION
**Description:**

This change updates the documentation for setting up a AWS IAM.  There is a circular dependency between the Role and the identity provider, each needs the ARN of the other to be created, and this makes things a bit confusing.  However, I could not find a way to resolve this.  I investigated switching the order but it ended up being more complicated.  In the end I just added additional detail primarily to the role creation step.

