### PR TITLE
oidc-discovery-server: update axum route syntax

### DIFF
--- a/crates/oidc-discovery-server/src/lib.rs
+++ b/crates/oidc-discovery-server/src/lib.rs
@@ -79,7 +79,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
 
     let app = Router::new()
         .route(
-            "/:data_plane_fqdn/.well-known/openid-configuration",
+            "/{data_plane_fqdn}/.well-known/openid-configuration",
             get(openid_configuration),
         )
         .with_state(Arc::new(state));


### PR DESCRIPTION
The syntax for path parameters changed, and it broke the server. This ought to fix it.