### PR TITLE
dekaf: Fix client timeouts by `flush()`ing response stream after writing, also fix race condition in `TaskManager`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.16.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4201daa155c4f91c80c7e265a6d6ca52b256981fbd2a4793c5f532167e8194c0"
+checksum = "6509e79955e012e08bce83c5f8ef2a40c69ed1c807ec7c4f7670f70a5feb1e5b"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ jemallocator = { version = "0", features = ["profiling"] }
 jemalloc-ctl = "0"
 json-patch = "4"
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
-kafka-protocol = "0"
+kafka-protocol = "0.15"
 lazy_static = "1"
 libc = "0"
 librocksdb-sys = { version = "0", default-features = false, features = [

--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -3,7 +3,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, TryStreamExt};
 use kafka_protocol::{
     error::ParseResponseErrorCode,
-    messages::{self, ApiKey},
+    messages::{self, ApiKey, ApiVersionsRequest},
     protocol::{self, Decodable, Encodable, Request},
 };
 use rsasl::{config::SASLConfig, mechname::Mechname, prelude::SASLClient};
@@ -257,7 +257,11 @@ async fn get_versions(
         messages::ApiVersionsRequest::default()
             .with_client_software_name(protocol::StrBytes::from_static_str("Dekaf"))
             .with_client_software_version(protocol::StrBytes::from_static_str("1.0")),
-        None,
+        Some(
+            messages::RequestHeader::default()
+                .with_request_api_key(ApiVersionsRequest::KEY)
+                .with_request_api_version(3),
+        ),
     )
     .await?;
     match versions.error_code.err() {

--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -444,6 +444,7 @@ async fn serve(
                     .await?;
 
                     () = w.write_all(&mut out).await?;
+                    w.flush().await?;
                     out.clear();
                 }
                 _ = tokio::time::sleep(idle_timeout) => {

--- a/crates/dekaf/src/registry.rs
+++ b/crates/dekaf/src/registry.rs
@@ -19,10 +19,10 @@ pub fn build_router(app: Arc<App>) -> axum::Router<()> {
     let schema_router = axum::Router::new()
         .route("/subjects", get(all_subjects))
         .route(
-            "/subjects/:subject/versions/latest",
+            "/subjects/{subject}/versions/latest",
             get(get_subject_latest),
         )
-        .route("/schemas/ids/:id", get(get_schema_by_id))
+        .route("/schemas/ids/{id}", get(get_schema_by_id))
         .layer(axum::middleware::from_fn_with_state(
             app.clone(),
             authenticate_and_proxy,

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -438,8 +438,9 @@ impl Collection {
                     if e.inner.is_transient() {
                         continue;
                     } else {
+                        let msg = e.inner.to_string();
                         return Err(anyhow::Error::new(e.inner).context(format!(
-                            "failed to fetch write head after {} retries",
+                            "failed to fetch write head after {} retries: {msg}",
                             e.attempt
                         )));
                     }

--- a/crates/gazette/src/journal/mod.rs
+++ b/crates/gazette/src/journal/mod.rs
@@ -32,7 +32,10 @@ impl Client {
                 suffix: endpoint,
             },
             metadata,
-            http: reqwest::Client::default(),
+            // Use HTTP/1 for fetching fragments, as storage backends may have
+            // restricted HTTP/2 flow control and we may have concurrent streams
+            // with high throughput / stuffed flow control windows.
+            http: reqwest::Client::builder().http1_only().build().unwrap(),
             router,
         }
     }

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -134,6 +134,7 @@ pub fn dial_channel(endpoint: &str) -> Result<tonic::transport::Channel> {
         // connection unexpectedly.
         // See: https://github.com/grpc/grpc/blob/master/doc/keepalive.md
         .http2_keep_alive_interval(std::time::Duration::from_secs(301))
+        .initial_connection_window_size(i32::MAX as u32)
         .tls_config(
             tonic::transport::ClientTlsConfig::new()
                 .with_native_roots()


### PR DESCRIPTION
The symptoms of this bug are sessions erroring with `Access token has expired and the task manager has been unable to refresh it.` after previously seeing logs about `TaskManager hasn't had any listeners for a while, shutting down`. This indicates that `TaskManager::get_listener` is handing out `TaskStateListeners` with zombie/closed watch channels. I don't quite know yet what is causing this, but there are a few different suspicious things going on:

### Evidence:
```
2025-10-15T09:13:31.165290Z  INFO dekaf_session{session_client_id="..." task_name="same_task_anon"}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:45972}:fetch{max_wait_ms=2000}: dekaf::session: started read journal="..."

2025-10-15T09:13:33.961402Z  INFO dekaf_session:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:47618}: dekaf: accepted client connection
2025-10-15T09:13:34.388407Z  WARN dekaf_session:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:47618}: dekaf: error=TLS handshake failed
Caused by:
    received corrupt message of type InvalidContentType

... A bunch more reads

2025-10-15T09:14:29.021495Z  WARN dekaf_session:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:39244}: dekaf: error=TLS handshake failed
Caused by:
    peer is incompatible: SignatureAlgorithmsExtensionRequired

... Then we see a few of these:
2025-10-15T09:31:26.471808Z  WARN dekaf_session{session_client_id="..." task_name="same_task_anon"}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:5450}: dekaf: error=failed to fetch write head after 0 retries

... Then the task manager shuts down:

2025-10-15T09:36:25.144      INFO dekaf_session{session_client_id="..." task_name="same_task_anon"}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:19700}:authenticate{username="same_task_anon"}:get_listener{task_name="same_task_anon"}:dekaf_session:run_task_manager{activity_signal=true task_name="same_task_anon"}: dekaf::task_manager: TaskManager hasn't had any listeners for a while, shutting down waited_for=180.000355597s

Then, after two hours of no activity:

2025-10-15T11:44:46.621243Z  INFO dekaf_session:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:34166}: dekaf: accepted client connection
2025-10-15T11:44:46.625663Z  INFO dekaf_session{session_client_id="..."}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:34166}: dekaf: Got client ID!
2025-10-15T11:44:46.628074Z  WARN dekaf_session{session_client_id="..."}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:34166}:authenticate{username="same_task_anon"}: dekaf: error=Unknown(Access token has expired and the task manager has been unable to refresh it.
2025-10-15T11:44:55.045412Z  INFO dekaf_session{session_client_id="..."}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:44035}:authenticate{username="same_task_anon"}:get_listener{task_name="same_task_anon"}: dekaf::task_manager: Spawning new task processor
2025-10-15T11:44:55.630168Z  WARN dekaf_session{session_client_id="..."}:serve{idle_timeout=300s tls_handshake_timeout=10s addr=[...]:34166}:authenticate{username="same_task_anon"}: dekaf: error=Unknown(Access token has expired and the task manager has been unable to refresh it.
```

I'm not sure whether the invalid TLS errors are relevant, I kind of think not, but this is the first time I've seen them. I _do_ suspect that the `failed to fetch write head after 0 retries` error is meaningful, but not quite sure how yet since I'm unable to see the actual error contents.

I'm still trying to find the exact race condition, but it seems likely that it's somehow caused by a task manager shutting down while there are still sessions active. If this happened even once, then the presence of those existing sessions would keep the strong `Arc`s alive, and prevent a new `TaskManager` from spawning. 