### PR TITLE
docs: update source-shopify-native scopes required for access token auth

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/shopify-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/shopify-native.md
@@ -32,6 +32,8 @@ The following data resources are supported through the Shopify API:
    * Product Metafields
 * [Smart Collections](https://shopify.dev/docs/api/admin-graphql/2025-04/queries/collections)
    * Smart Collection Metafields
+* [Subscription Contracts](https://shopify.dev/docs/api/admin-graphql/2025-04/queries/subscriptioncontracts)
+
 
 By default, each resource is mapped to a Flow collection through a separate binding.
 
@@ -58,6 +60,7 @@ If authenticating with an access token, ensure the following permissions are gra
 * `read_payment_terms`
 * `read_products`
 * `read_publications`
+* `read_own_subscription_contracts`
 
 ### Bulk Query Operation Limitations
 


### PR DESCRIPTION
**Description:**

Updates the docs for `source-shopify-native` to include `read_own_subscription_contracts` scope for access token authentication.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

