### PR TITLE
validation: relax block redaction errors for inferred schemas

### DIFF
--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -401,6 +401,15 @@ fn walk_collection_schema(
         {
             continue;
         }
+        // Relax errors about `block` redact locations that are required to exist,
+        // if (and only if) this is a read schema using inference.
+        if matches!(
+            err,
+            doc::shape::inspections::Error::BlockRedactionMustExist(_)
+        ) && model.references_inferred_schema()
+        {
+            continue;
+        }
         Error::from(err).push(scope, errors);
     }
 


### PR DESCRIPTION
Allow block redaction strategies on required properties when using schema inference. Intuitively, we're blocking now with the expectation that the location will _become_ "not required".

**Workflow steps:**

It's now possible to add `redact: {strategy: block}` over a location which is currently marked `required` in the inferred schema.

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

