### PR TITLE
Phil/inferred cooloff

### DIFF
--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -165,8 +165,11 @@ impl TagExecutor {
         let log_handler =
             logs::ops_handler(self.logs_tx.clone(), "spec".to_string(), row.logs_token);
 
+        // We always pass `Local` here because we need the runtime to publish
+        // the container ports so we can connect directly to it. This is safe
+        // only because we control which images can appear in `connectors`.
         let runtime = Runtime::new(
-            runtime::Plane::Public,
+            runtime::Plane::Local,
             self.connector_network.clone(),
             log_handler,
             None, // no need to change log level

--- a/crates/agent/src/controllers/catalog_test.rs
+++ b/crates/agent/src/controllers/catalog_test.rs
@@ -20,13 +20,17 @@ pub async fn update<C: ControlPlane>(
             error_on_deleted_dependencies,
         )
         .await?
+        .is_some()
     {
         // We've successfully published against the latest versions of the dependencies
         status.passing = true;
         return Ok(Some(NextRun::immediately()));
     }
 
-    if periodic::update_periodic_publish(state, &mut status.publications, control_plane).await? {
+    if periodic::update_periodic_publish(state, &mut status.publications, control_plane)
+        .await?
+        .is_some()
+    {
         // We've successfully published against the latest versions of the dependencies
         status.passing = true;
         return Ok(Some(NextRun::immediately()));

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -100,6 +100,14 @@ struct Args {
         default_value = "1.0"
     )]
     auto_discover_probability: f64,
+
+    #[clap(
+        long = "inferred-schema-update-cooldown",
+        env = "INFERRED_SCHEMA_UPDATE_COOLDOWN",
+        default_value = "0s"
+    )]
+    #[arg(value_parser = humantime::parse_duration)]
+    inferred_schema_update_cooldown: std::time::Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -257,6 +265,8 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         decrypted_hmac_keys.clone(),
     ));
 
+    let inferred_schema_update_cooldown =
+        chrono::Duration::from_std(args.inferred_schema_update_cooldown)?;
     let control_plane = agent::PGControlPlane::new(
         pg_pool.clone(),
         system_user_id,
@@ -266,6 +276,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         logs_tx.clone(),
         decrypted_hmac_keys,
         args.auto_discover_probability,
+        inferred_schema_update_cooldown,
     );
     let connector_tags_executor = agent::TagExecutor::new(&args.connector_network, &logs_tx);
 

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -315,6 +315,19 @@ type InferredSchemaStatus {
 	on the next controller run, which would update the hash but not actually modify the schema.
 	"""
 	schemaMd5: String
+	"""
+	The md5 of the inferred schema that will next be applied. If this is
+	present, it indicates that the controller is waiting on a cooldown
+	period before publishing this inferred schema.
+	"""
+	nextMd5: String
+	"""
+	The time of the next scheduled inferred schema update. If this is
+	present, it indicates that the controller is waiting on a cooldown
+	period before publishing the inferred schema, and represents the
+	approximate time of the next update.
+	"""
+	nextUpdateAfter: DateTime
 }
 
 """

--- a/crates/flowctl/src/catalog/status.graphql
+++ b/crates/flowctl/src/catalog/status.graphql
@@ -108,6 +108,12 @@ fragment SelectStatus on LiveSpecStatus {
                 }
             }
         }
+        inferredSchema {
+            schemaLastUpdated
+            schemaMd5
+            nextMd5
+            nextUpdateAfter
+        }
     }
 }
 

--- a/crates/models/src/status/collection.rs
+++ b/crates/models/src/status/collection.rs
@@ -35,4 +35,18 @@ pub struct InferredSchemaStatus {
     /// on the next controller run, which would update the hash but not actually modify the schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema_md5: Option<String>,
+
+    /// The md5 of the inferred schema that will next be applied. If this is
+    /// present, it indicates that the controller is waiting on a cooldown
+    /// period before publishing this inferred schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_md5: Option<String>,
+
+    /// The time of the next scheduled inferred schema update. If this is
+    /// present, it indicates that the controller is waiting on a cooldown
+    /// period before publishing the inferred schema, and represents the
+    /// approximate time of the next update.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::datetime_schema")]
+    pub next_update_after: Option<DateTime<Utc>>,
 }

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -408,6 +408,20 @@ expression: schema
     "InferredSchemaStatus": {
       "description": "Status of the inferred schema",
       "properties": {
+        "next_md5": {
+          "description": "The md5 of the inferred schema that will next be applied. If this is\npresent, it indicates that the controller is waiting on a cooldown\nperiod before publishing this inferred schema.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "next_update_after": {
+          "description": "The time of the next scheduled inferred schema update. If this is\npresent, it indicates that the controller is waiting on a cooldown\nperiod before publishing the inferred schema, and represents the\napproximate time of the next update.",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
         "schema_last_updated": {
           "description": "The time at which the inferred schema was last published. This will only\nbe present if the inferred schema was published at least once.",
           "format": "date-time",


### PR DESCRIPTION
**Description:**

Resolves #2488 

Introduces the `INFERRED_SCHEMA_UPDATE_COOLDOWN` env variable (or cli argument), which limits the frequency of inferred schema updates on a per-collection basis. This can be set to `5m`, for example, to ensure that controllers will only try to publish inferred schema updates every 5 minutes. If an inferred schema update is observed prior to that, the controller will wait until the cooldown has elapsed before publishing it, and will set the `nextMd5` and `nextUpdateAfter` fields in the inferred schema status.

Note that any publication of the collection will always update the inferred schema. So there's still cases where inferred schema updates could happen more frequently, for example on derivations that get published in response to changes in their source collections. We might also consider limiting the frequency of publications in response to dependency changes, but I'm leaving that for a separate PR, if ever.

Also fixes a bug in `connector_tags.rs`, which prevented those jobs from succeeding.