### PR TITLE
dekaf: Report protocol message versions in metrics

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -541,7 +541,7 @@ async fn handle_api(
     };
     let handle_duration = SystemTime::now().duration_since(start_time)?;
 
-    metrics::histogram!("dekaf_api_call_time", "api_key" => format!("{:?}",api_key))
+    metrics::histogram!("dekaf_api_call_time", "api_key" => format!("{:?}",api_key), "request_version" => version.to_string())
         .record(handle_duration.as_secs_f32() as f64);
 
     ret


### PR DESCRIPTION
**Description:**

One of the options for supporting [collection reset](https://github.com/estuary/flow/issues/2376) will require bumping the minimum supported message version for a few of the messages Dekaf supports. This will expose visibility into the versions that are currently being used.