### PR TITLE
agent: clear inbox when executing an already completed directive

### DIFF
--- a/crates/agent/src/directives/mod.rs
+++ b/crates/agent/src/directives/mod.rs
@@ -95,6 +95,7 @@ impl automations::Executor for DirectiveHandler {
                 "skipping directive application because job status is not queued"
             );
             txn.rollback().await?;
+            inbox.clear();
             return Ok(automations::Action::Done);
         }
 


### PR DESCRIPTION
Due to the way directives are handled, it's possible for an applied directive to already be completed when the executor runs. The agent expects this and returns `Action::Done` for such tasks, but we neglected to clear the task inbox first. This caused the automations server to re-enqueue the task instead of deleting it.  This clears the inbox, allowing the task to be removed.