### PR TITLE
docs/source-postgres-batch: Quick draft of something less awful

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
@@ -12,7 +12,7 @@ update events, and typically has a smaller impact on the source database.
 However, the batch connector is the right choice when:
 
 - Your PostgreSQL instance doesn't support logical replication
-- You need to capture from a read replica on PostgreSQL <=15
+- You need to capture from a read replica on PostgreSQL \<=15
 - You need to capture from database views
 - You want to execute ad-hoc or custom queries
 


### PR DESCRIPTION
**Description:**

The current source-postgres-batch docs are a placeholder which I threw together ages ago when we first rushed it into production, and at this point the connector is a lot more sophisticated and also it's getting enough use that it should really be properly documented.

The replacement in this commit isn't amazing either, but it's a strict improvement over the current state of affairs.

Hopefully sometime soon I'll spend a little while improving the various other batch SQL connector docs using this as a template.