### PR TITLE
dekaf: Build for ARM as well as x86

### DIFF
--- a/.github/workflows/dekaf-ci.yaml
+++ b/.github/workflows/dekaf-ci.yaml
@@ -16,7 +16,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
   SQLX_OFFLINE: "1"
 
 concurrency:
@@ -26,10 +25,17 @@ concurrency:
 jobs:
   build-dekaf:
     runs-on: ubuntu-2404-large
-
-    permissions:
-      contents: read
-      packages: write # Required for pushing to the container registry
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            rust_target: x86_64-unknown-linux-gnu
+            rustflags: "-C link-arg=-fuse-ld=lld"
+          - arch: arm64
+            rust_target: aarch64-unknown-linux-gnu
+            cross_compile: true
+            gcc_package: g++-aarch64-linux-gnu
+            linker: aarch64-linux-gnu-gcc
 
     steps:
       - uses: actions/checkout@v4
@@ -37,11 +43,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           submodules: true
-      - name: Get git describe version
-        id: git-describe
-        run: |
-          VERSION=$(git describe --dirty --tags)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Disable man-db auto-update to speed up apt installs
         run: |
@@ -63,20 +64,73 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          prefix-key: "dekaf-x86_64"
-      - name: Build Dekaf and dependencies
-        run: |
-          cargo build --release --locked -p dekaf
-          mkdir -p .build/dekaf-bin
-          cp target/release/dekaf .build/dekaf-bin/dekaf
-          chmod +x .build/dekaf-bin/dekaf
-          # Build sops using Go
-          go install github.com/getsops/sops/v3/cmd/sops@v3.10.2
-          cp $(go env GOPATH)/bin/sops .build/dekaf-bin/sops
-          chmod +x .build/dekaf-bin/sops
+          prefix-key: "dekaf-${{ matrix.arch }}"
+          key: ${{ matrix.rust_target }}
 
-      - name: Test Dekaf
-        run: cargo test --release --locked -p dekaf
+      - name: Set up for cross-compilation to ${{ matrix.arch }}
+        if: matrix.cross_compile
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.gcc_package }}
+          rustup target add ${{ matrix.rust_target }}
+          echo "CARGO_TARGET_$(echo ${{ matrix.rust_target }} | tr '[:lower:]-' '[:upper:]_')_LINKER=${{ matrix.linker }}" >> $GITHUB_ENV
+
+      - name: Build Dekaf (${{ matrix.arch }})
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: |
+          cargo build --release --locked -p dekaf --target ${{ matrix.rust_target }}
+          mkdir -p artifacts
+          cp target/${{ matrix.rust_target }}/release/dekaf artifacts/dekaf-${{ matrix.arch }}
+          chmod +x artifacts/dekaf-${{ matrix.arch }}
+
+      # Only test on x86 since we can't run ARM binaries on x86 runners
+      - name: Test Dekaf (${{ matrix.arch }})
+        if: matrix.arch == 'amd64'
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo test --release --locked -p dekaf --target ${{ matrix.rust_target }}
+
+      - name: Upload artifact (${{ matrix.arch }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: dekaf-${{ matrix.arch }}
+          path: artifacts/dekaf-${{ matrix.arch }}
+          retention-days: 1
+
+  docker-build:
+    runs-on: ubuntu-2404-large
+    needs: build-dekaf
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: true
+
+      - name: Get git describe version
+        id: git-describe
+        run: |
+          VERSION=$(git describe --dirty --tags)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dekaf-amd64
+          path: .build/dekaf-bin
+
+      - name: Download ARM64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dekaf-arm64
+          path: .build/dekaf-bin
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -84,6 +138,7 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             docker login --username ${{ github.actor }} --password-stdin ghcr.io
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -100,7 +155,7 @@ jobs:
         with:
           context: .build/dekaf-bin
           file: ./crates/dekaf/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/crates/dekaf/Dockerfile
+++ b/crates/dekaf/Dockerfile
@@ -3,18 +3,20 @@ FROM ubuntu:noble
 # Install required packages
 RUN apt update -y \
     && apt install --no-install-recommends -y \
-        ca-certificates \
-        curl \
-        jq \
+    ca-certificates \
+    curl \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the `sops` CLI
+ARG TARGETARCH
 RUN curl -L -o /usr/local/bin/sops \
-      https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.linux.amd64 \
-   && chmod +x /usr/local/bin/sops
+    https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.linux.${TARGETARCH} \
+    && chmod +x /usr/local/bin/sops
 
 # Copy in the dekaf binary
-COPY dekaf /usr/local/bin/
+COPY dekaf-${TARGETARCH} /usr/local/bin/dekaf
+RUN chmod +x /usr/local/bin/dekaf
 
 ENV RUST_LOG=info
 


### PR DESCRIPTION
Concurrently build x86 and arm images for Dekaf and push both architectures to the image registry. Dekaf already built for arm just fine, so this just needed to update CI to do the build and add it to the image.