### PR TITLE
docs: Update SSH tunneling infobox with privatelink mention

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -26,7 +26,10 @@ To use this connector, you'll need a MariaDB database setup with the following.
   must be set to an IANA zone name or numerical offset or the capture configured with a `timezone` to use by default.
 
 :::tip Configuration Tip
-To configure this connector to capture data from databases hosted on your internal network, you must set up SSH tunneling. For more specific instructions on setup, see [configure connections with SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Setup

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -36,7 +36,10 @@ To use this connector, you'll need a MySQL database setup with the following.
   must be set to an IANA zone name or numerical offset or the capture configured with a `timezone` to use by default.
 
 :::tip Configuration Tip
-To configure this connector to capture data from databases hosted on your internal network, you must set up SSH tunneling. For more specific instructions on setup, see [configure connections with SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Setup

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/mysql-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/mysql-batch.md
@@ -23,8 +23,10 @@ platforms (including Amazon RDS and Aurora, Google Cloud SQL, Azure Database
 for MySQL, and other managed services), as well as self-hosted instances.
 
 :::tip Configuration Tip
-To capture data from databases hosted on your internal network, you must
-use [SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Prerequisites

--- a/site/docs/reference/Connectors/capture-connectors/OracleDB/oracle-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/OracleDB/oracle-batch.md
@@ -23,8 +23,10 @@ This connector works with Oracle Database 11g and later on major cloud platforms
 as well as self-hosted instances.
 
 :::tip Configuration Tip
-To capture data from databases hosted on your internal network, you must
-use [SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Prerequisites

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -39,7 +39,10 @@ You'll need a PostgreSQL database setup with the following:
   - **For read-only environments**, the capture can operate in read-only mode which does not require a watermarks table. See [Read-Only Captures](#read-only-captures) for details.
 
 :::tip Configuration Tip
-To configure this connector to capture data from databases hosted on your internal network, you must set up SSH tunneling. For more specific instructions on setup, see [configure connections with SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Setup

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -28,7 +28,10 @@ You'll need a Supabase PostgreSQL database setup with the following:
     * In more restricted setups, this must be created manually, but can be created automatically if the connector has suitable permissions.
 
 :::tip Configuration Tip
-To configure this connector to capture data from databases hosted on your internal network, you must set up SSH tunneling. For more specific instructions on setup, see [configure connections with SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ### Direct Database Connection

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
@@ -23,8 +23,10 @@ platforms (including Amazon RDS and Aurora, Google Cloud SQL, Azure Database
 for PostgreSQL, and other managed services), as well as self-hosted instances.
 
 :::tip Configuration Tip
-To capture data from databases hosted on your internal network, you must
-use [SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Prerequisites

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
@@ -23,8 +23,10 @@ This connector works with all supported versions of SQL Server on major cloud pl
 self-hosted instances.
 
 :::tip Configuration Tip
-To capture data from databases hosted on your internal network, you must
-use [SSH tunneling](/guides/connect-network/).
+To capture data from databases hosted on your internal network, you may need to
+use [SSH tunneling](/guides/connect-network/). If you have a
+[private deployment](/getting-started/deployment-options/#private-deployment),
+you can also use private cloud networking features to reach your database.
 :::
 
 ## Prerequisites


### PR DESCRIPTION
**Description:**

As discussed in https://github.com/estuary/flow/pull/2502, updates the "hey you might need to use SSH tunneling if you're on an internal network" infobox in various SQL capture connector docs to also mention private deployments, and just to use the same wording across all the pages for consistency.