### PR TITLE
docs/source-sqlserver-batch: Mentioned wrong technology

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
@@ -11,10 +11,9 @@ update events, and typically has a smaller impact on the source database.
 
 However, the batch connector is the right choice when:
 
-- Your SQL Server instance doesn't support Change Tracking (e.g., some managed services)
+- Your SQL Server instance doesn't support CDC (e.g., some managed services)
 - You need to capture from database views
 - You want to execute ad-hoc or custom queries
-- You need to capture from a read replica that doesn't have Change Tracking enabled
 
 ## Supported versions and platforms
 


### PR DESCRIPTION
**Description:**

Whoops, somehow I ended up with "Change Tracking" where it should say "CDC", and also carried over the read replica bullet point to SQL Server where it doesn't really make sense (in SQL Server we're perfectly happy capturing from read replicas so long as the primary instance has CDC enabled, so really it just comes down to "can you turn on CDC" here).