### PR TITLE
Add reset functionality for captures and materializations

### DIFF
--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -300,6 +300,7 @@ async fn prepare_discover(
                 expect_pub_id: None,
                 bindings: Vec::new(),
                 delete: false,
+                reset: false,
             };
             draft.captures.insert(tables::DraftCapture {
                 capture: capture_name.clone(),

--- a/crates/models/src/captures.rs
+++ b/crates/models/src/captures.rs
@@ -54,10 +54,16 @@ pub struct CaptureDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Id")]
     pub expect_pub_id: Option<Id>,
-    /// # Delete this capture within the control plane.
+    /// # Delete this capture.
     /// When true, a publication will delete this capture.
     #[serde(default, skip_serializing_if = "super::is_false")]
     pub delete: bool,
+    /// # Reset this capture.
+    /// Publishing a value of `true` will reset this capture, which is
+    /// equivalent to deleting and then re-creating the capture but
+    /// applied as a single publication.
+    #[serde(default, skip_serializing_if = "super::is_false")]
+    pub reset: bool,
 }
 
 /// Settings to determine how Flow should stay abreast of ongoing changes to collections and schemas.
@@ -135,6 +141,7 @@ impl CaptureDef {
             shards: ShardTemplate::default(),
             expect_pub_id: None,
             delete: false,
+            reset: false,
             redact_salt: None,
         }
     }

--- a/crates/models/src/collections.rs
+++ b/crates/models/src/collections.rs
@@ -49,14 +49,16 @@ pub struct CollectionDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Id")]
     pub expect_pub_id: Option<Id>,
-    /// # Delete this collection within the control plane.
+    /// # Delete this collection.
     /// When true, a publication will delete this collection.
     #[serde(default, skip_serializing_if = "super::is_false")]
     pub delete: bool,
-    /// # Reset this collection within the control plane.
-    /// When true, a publication will reset this collection.
-    /// Resetting a collection is equivalent to deleting and then re-creating
-    /// the collection, but is applied as a single publication.
+    /// # Reset this collection.
+    /// Publishing a value of `true` will reset this collection, which is
+    /// equivalent to deleting and then re-creating the collection but
+    /// applied as a single publication.
+    /// If this is a derived collection then the derivation task state is
+    /// also reset, effectively re-building the derivation in its entirety.
     #[serde(default, skip_serializing_if = "super::is_false")]
     pub reset: bool,
 }

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -39,10 +39,16 @@ pub struct MaterializationDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Id")]
     pub expect_pub_id: Option<Id>,
-    /// # Delete this materialization within the control plane.
+    /// # Delete this materialization.
     /// When true, a publication will delete this materialization.
     #[serde(default, skip_serializing_if = "super::is_false")]
     pub delete: bool,
+    /// # Reset this materialization.
+    /// Publishing a value of `true` will reset this materialization, which is
+    /// equivalent to deleting and then re-creating the materialization but
+    /// applied as a single publication.
+    #[serde(default, skip_serializing_if = "super::is_false")]
+    pub reset: bool,
 }
 
 /// An Endpoint connector used for Flow materializations.
@@ -168,6 +174,7 @@ impl MaterializationDef {
             shards: ShardTemplate::default(),
             expect_pub_id: None,
             delete: false,
+            reset: false,
             on_incompatible_schema_change: OnIncompatibleSchemaChange::default(),
         }
     }

--- a/crates/sources/src/inline.rs
+++ b/crates/sources/src/inline.rs
@@ -254,6 +254,7 @@ fn inline_materialization(
         shards: _,
         expect_pub_id: _,
         delete: _,
+        reset: _,
         on_incompatible_schema_change: _,
     } = model;
 

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -243,7 +243,7 @@ expression: "&schema"
           }
         },
         "delete": {
-          "title": "Delete this capture within the control plane.",
+          "title": "Delete this capture.",
           "description": "When true, a publication will delete this capture.",
           "type": "boolean"
         },
@@ -269,6 +269,11 @@ expression: "&schema"
           "title": "Salt used for redacting sensitive fields in captured documents.",
           "description": "When provided, this base64-encoded salt is used instead of a generated one.",
           "type": "string"
+        },
+        "reset": {
+          "title": "Reset this capture.",
+          "description": "Publishing a value of `true` will reset this capture, which is\nequivalent to deleting and then re-creating the capture but\napplied as a single publication.",
+          "type": "boolean"
         },
         "shards": {
           "title": "Template for shards of this capture task.",
@@ -325,7 +330,7 @@ expression: "&schema"
       "type": "object",
       "properties": {
         "delete": {
-          "title": "Delete this collection within the control plane.",
+          "title": "Delete this collection.",
           "description": "When true, a publication will delete this collection.",
           "type": "boolean"
         },
@@ -369,8 +374,8 @@ expression: "&schema"
           "$ref": "#/$defs/Schema"
         },
         "reset": {
-          "title": "Reset this collection within the control plane.",
-          "description": "When true, a publication will reset this collection.\nResetting a collection is equivalent to deleting and then re-creating\nthe collection, but is applied as a single publication.",
+          "title": "Reset this collection.",
+          "description": "Publishing a value of `true` will reset this collection, which is\nequivalent to deleting and then re-creating the collection but\napplied as a single publication.\nIf this is a derived collection then the derivation task state is\nalso reset, effectively re-building the derivation in its entirety.",
           "type": "boolean"
         },
         "schema": {
@@ -935,7 +940,7 @@ expression: "&schema"
           }
         },
         "delete": {
-          "title": "Delete this materialization within the control plane.",
+          "title": "Delete this materialization.",
           "description": "When true, a publication will delete this materialization.",
           "type": "boolean"
         },
@@ -952,6 +957,11 @@ expression: "&schema"
           "title": "Default handling of schema changes that are incompatible with the target resource.",
           "description": "This can be overridden on a per-binding basis.",
           "$ref": "#/$defs/OnIncompatibleSchemaChange"
+        },
+        "reset": {
+          "title": "Reset this materialization.",
+          "description": "Publishing a value of `true` will reset this materialization, which is\nequivalent to deleting and then re-creating the materialization but\napplied as a single publication.",
+          "type": "boolean"
         },
         "shards": {
           "title": "Template for shards of this materialization task.",

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -297,6 +297,8 @@ pub enum Error {
     TouchModelIsDelete,
     #[error("this binding must backfill because its source collection {collection} was reset")]
     SourceCollectionWasReset { collection: String },
+    #[error("materialization {materialization} uses Dekaf endpoint which cannot be reset")]
+    DekafMaterializationCannotReset { materialization: String },
     #[error(
         "{entity} {name} has {count} bindings, which exceeds the maximum of {} bindings",
         crate::MAX_BINDINGS

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -139,6 +139,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
             interval: std::time::Duration::from_secs(32),
             shards: models::ShardTemplate::default(),
             delete: false,
+            reset: false,
             redact_salt: None,
         };
         let shard_template = proto_gazette::consumer::ShardSpec {
@@ -294,6 +295,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
             shards: models::ShardTemplate::default(),
             source: None,
             delete: false,
+            reset: false,
             on_incompatible_schema_change: Default::default(),
         };
         let shard_template = proto_gazette::consumer::ShardSpec {

--- a/crates/validation/tests/snapshots/field_selection_conflicts__abort.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__abort.snap
@@ -66,6 +66,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [],

--- a/crates/validation/tests/snapshots/field_selection_conflicts__backfill_binding.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__backfill_binding.snap
@@ -66,6 +66,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/field_selection_conflicts__disable_binding.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__disable_binding.snap
@@ -53,6 +53,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/field_selection_conflicts__disable_task.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__disable_task.snap
@@ -53,6 +53,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding.snap
@@ -63,6 +63,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding_with_reset.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding_with_reset.snap
@@ -63,6 +63,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/group_by_conflicts__disable_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__disable_binding.snap
@@ -53,6 +53,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/group_by_conflicts__disable_task.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__disable_task.snap
@@ -53,6 +53,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [

--- a/crates/validation/tests/snapshots/group_by_conflicts__noop_with_delta_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__noop_with_delta_binding.snap
@@ -63,6 +63,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [],

--- a/crates/validation/tests/snapshots/group_by_conflicts__noop_with_manual_group_by.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__noop_with_manual_group_by.snap
@@ -68,6 +68,7 @@ expression: "(selections, errors)"
                     },
                     expect_pub_id: None,
                     delete: false,
+                    reset: false,
                 },
             ),
             [],

--- a/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
+++ b/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
@@ -69,6 +69,7 @@ expression: "(&outcome.built_materializations[0].model,\n&outcome.built_material
             },
             expect_pub_id: None,
             delete: false,
+            reset: false,
         },
     ),
     [

--- a/crates/validation/tests/snapshots/transition_tests__reset_capture.snap
+++ b/crates/validation/tests/snapshots/transition_tests__reset_capture.snap
@@ -1,0 +1,585 @@
+---
+source: crates/validation/tests/transition_tests.rs
+expression: outcome.built_captures
+---
+[
+    BuiltCapture {
+        capture: the/capture,
+        scope: test://example/catalog.yaml#/captures/the~1capture,
+        control_id: "1111111111111101",
+        data_plane_id: "1212121212121201",
+        expect_pub_id: "1010101010101010",
+        expect_build_id: "1010101010101010",
+        model: {
+          "endpoint": {
+            "connector": {
+              "image": "an/image",
+              "config": {"a":"config"}
+            }
+          },
+          "bindings": [
+            {
+              "resource": {"_meta":{"path":["capture","path"]},"table":"foo"},
+              "target": "the/collection"
+            }
+          ]
+        },
+        model_fixes: [
+          "reset capture to new generation 2020202020202020"
+        ],
+        validated: Validated {
+            bindings: [
+                Binding {
+                    resource_path: [
+                        "capture",
+                        "path",
+                    ],
+                },
+            ],
+        },
+        spec: CaptureSpec {
+            name: "the/capture",
+            connector_type: Image,
+            config_json: b"{\"image\":\"an/image\",\"config\":{\"a\":\"config\"}}",
+            bindings: [
+                Binding {
+                    resource_config_json: b"{\"table\":\"foo\"}",
+                    resource_path: [
+                        "capture",
+                        "path",
+                    ],
+                    collection: Some(
+                        CollectionSpec {
+                            name: "the/collection",
+                            write_schema_json: b"{\"$id\":\"test://example/catalog.yaml?ptr=/collections/the~1collection/schema\",\"properties\":{\"f_one\":{\"type\":\"integer\"},\"f_two\":{\"type\":\"string\"},\"f_x\":false},\"required\":[\"f_one\",\"f_two\"],\"type\":\"object\"}",
+                            read_schema_json: b"",
+                            key: [
+                                "/f_one",
+                            ],
+                            uuid_ptr: "/_meta/uuid",
+                            partition_fields: [],
+                            projections: [
+                                Projection {
+                                    ptr: "/f_one",
+                                    field: "F1",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "integer",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: Some(
+                                                Numeric {
+                                                    has_minimum: false,
+                                                    minimum: 0.0,
+                                                    has_maximum: false,
+                                                    maximum: 0.0,
+                                                },
+                                            ),
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_two",
+                                    field: "F2",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "",
+                                                    content_encoding: "",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_x",
+                                    field: "FX",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Cannot,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/_meta/flow_truncated",
+                                    field: "_meta/flow_truncated",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "boolean",
+                                            ],
+                                            string: None,
+                                            title: "Flow truncation indicator",
+                                            description: "Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system.",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_one",
+                                    field: "f_one",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: true,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "integer",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: Some(
+                                                Numeric {
+                                                    has_minimum: false,
+                                                    minimum: 0.0,
+                                                    has_maximum: false,
+                                                    maximum: 0.0,
+                                                },
+                                            ),
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_two",
+                                    field: "f_two",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "",
+                                                    content_encoding: "",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_x",
+                                    field: "f_x",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Cannot,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "",
+                                    field: "flow_document",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "object",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/_meta/uuid",
+                                    field: "flow_published_at",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "date-time",
+                                                    content_encoding: "uuid",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "Flow Publication Time",
+                                            description: "Flow publication date-time of this document",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                            ],
+                            ack_template_json: b"{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                            partition_template: Some(
+                                JournalSpec {
+                                    name: "the/collection/0000000000000001",
+                                    replication: 3,
+                                    labels: Some(
+                                        LabelSet {
+                                            labels: [
+                                                Label {
+                                                    name: "app.gazette.dev/managed-by",
+                                                    value: "estuary.dev/flow",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "content-type",
+                                                    value: "application/x-ndjson",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "estuary.dev/build",
+                                                    value: "2121212121212121",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "estuary.dev/collection",
+                                                    value: "the/collection",
+                                                    prefix: false,
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                    fragment: Some(
+                                        Fragment {
+                                            length: 536870912,
+                                            compression_codec: Gzip,
+                                            stores: [
+                                                "s3://a-bucket/",
+                                            ],
+                                            refresh_interval: Some(
+                                                Duration {
+                                                    seconds: 300,
+                                                    nanos: 0,
+                                                },
+                                            ),
+                                            retention: None,
+                                            flush_interval: Some(
+                                                Duration {
+                                                    seconds: 86400,
+                                                    nanos: 0,
+                                                },
+                                            ),
+                                            path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                                        },
+                                    ),
+                                    flags: 4,
+                                    max_append_rate: 4194304,
+                                    suspend: None,
+                                },
+                            ),
+                            derivation: None,
+                        },
+                    ),
+                    backfill: 0,
+                    state_key: "capture%2Fpath",
+                },
+            ],
+            interval_seconds: 300,
+            shard_template: Some(
+                ShardSpec {
+                    id: "capture/the/capture/2020202020202020",
+                    sources: [],
+                    recovery_log_prefix: "recovery",
+                    hint_prefix: "/estuary/flow/hints",
+                    hint_backups: 2,
+                    max_txn_duration: Some(
+                        Duration {
+                            seconds: 1,
+                            nanos: 0,
+                        },
+                    ),
+                    min_txn_duration: Some(
+                        Duration {
+                            seconds: 0,
+                            nanos: 0,
+                        },
+                    ),
+                    disable: false,
+                    hot_standbys: 0,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/log-level",
+                                    value: "info",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-name",
+                                    value: "the/capture",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-type",
+                                    value: "capture",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    disable_wait_for_ack: false,
+                    ring_buffer_size: 65536,
+                    read_channel_size: 4096,
+                },
+            ),
+            recovery_log_template: Some(
+                JournalSpec {
+                    name: "recovery/capture/the/capture/2020202020202020",
+                    replication: 3,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "content-type",
+                                    value: "application/x-gazette-recoverylog",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-name",
+                                    value: "the/capture",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-type",
+                                    value: "capture",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    fragment: Some(
+                        Fragment {
+                            length: 268435456,
+                            compression_codec: Snappy,
+                            stores: [
+                                "s3://a-bucket/",
+                            ],
+                            refresh_interval: Some(
+                                Duration {
+                                    seconds: 300,
+                                    nanos: 0,
+                                },
+                            ),
+                            retention: None,
+                            flush_interval: Some(
+                                Duration {
+                                    seconds: 172800,
+                                    nanos: 0,
+                                },
+                            ),
+                            path_postfix_template: "",
+                        },
+                    ),
+                    flags: 4,
+                    max_append_rate: 4194304,
+                    suspend: None,
+                },
+            ),
+            network_ports: [],
+            inactive_bindings: [],
+            redact_salt: b"pass-through-capture-salt",
+        },
+        previous_spec: CaptureSpec {
+            name: "the/capture",
+            connector_type: Image,
+            config_json: b"",
+            bindings: [
+                Binding {
+                    resource_config_json: b"",
+                    resource_path: [
+                        "capture",
+                        "path",
+                    ],
+                    collection: Some(
+                        CollectionSpec {
+                            name: "the/collection",
+                            write_schema_json: b"",
+                            read_schema_json: b"",
+                            key: [],
+                            uuid_ptr: "",
+                            partition_fields: [],
+                            projections: [],
+                            ack_template_json: b"",
+                            partition_template: Some(
+                                JournalSpec {
+                                    name: "the/collection/0000000000000001",
+                                    replication: 0,
+                                    labels: None,
+                                    fragment: None,
+                                    flags: 0,
+                                    max_append_rate: 0,
+                                    suspend: None,
+                                },
+                            ),
+                            derivation: None,
+                        },
+                    ),
+                    backfill: 0,
+                    state_key: "",
+                },
+            ],
+            interval_seconds: 100,
+            shard_template: Some(
+                ShardSpec {
+                    id: "capture/the/capture/0000000000000001",
+                    sources: [],
+                    recovery_log_prefix: "",
+                    hint_prefix: "",
+                    hint_backups: 0,
+                    max_txn_duration: None,
+                    min_txn_duration: None,
+                    disable: false,
+                    hot_standbys: 0,
+                    labels: None,
+                    disable_wait_for_ack: false,
+                    ring_buffer_size: 0,
+                    read_channel_size: 0,
+                },
+            ),
+            recovery_log_template: Some(
+                JournalSpec {
+                    name: "recovery/capture/the/capture/0000000000000001",
+                    replication: 0,
+                    labels: None,
+                    fragment: None,
+                    flags: 0,
+                    max_append_rate: 0,
+                    suspend: None,
+                },
+            ),
+            network_ports: [],
+            inactive_bindings: [],
+            redact_salt: b"pass-through-capture-salt",
+        },
+        is_touch: 0,
+        dependency_hash: 5b38dc32c776e2b2,
+    },
+]

--- a/crates/validation/tests/snapshots/transition_tests__reset_derivation.snap
+++ b/crates/validation/tests/snapshots/transition_tests__reset_derivation.snap
@@ -1,0 +1,1246 @@
+---
+source: crates/validation/tests/transition_tests.rs
+expression: outcome.built_collections
+---
+[
+    BuiltCollection {
+        collection: the/collection,
+        scope: test://example/catalog.yaml#/collections/the~1collection,
+        control_id: "1111111111111102",
+        data_plane_id: "1212121212121202",
+        expect_pub_id: "1010101010101010",
+        expect_build_id: "1010101010101010",
+        model: {
+          "schema": {"$id":"test://example/catalog.yaml?ptr=/collections/the~1collection/schema","properties":{"f_one":{"type":"integer"},"f_two":{"type":"string"},"f_x":false},"required":["f_one","f_two"],"type":"object"},
+          "key": [
+            "/f_one"
+          ],
+          "projections": {
+            "F1": "/f_one",
+            "F2": "/f_two",
+            "FX": "/f_x"
+          }
+        },
+        model_fixes: [
+          "removed projection FY: /f_y, which is no longer in the schema"
+        ],
+        validated: NULL,
+        spec: CollectionSpec {
+            name: "the/collection",
+            write_schema_json: b"{\"$id\":\"test://example/catalog.yaml?ptr=/collections/the~1collection/schema\",\"properties\":{\"f_one\":{\"type\":\"integer\"},\"f_two\":{\"type\":\"string\"},\"f_x\":false},\"required\":[\"f_one\",\"f_two\"],\"type\":\"object\"}",
+            read_schema_json: b"",
+            key: [
+                "/f_one",
+            ],
+            uuid_ptr: "/_meta/uuid",
+            partition_fields: [],
+            projections: [
+                Projection {
+                    ptr: "/f_one",
+                    field: "F1",
+                    explicit: true,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "integer",
+                            ],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: Some(
+                                Numeric {
+                                    has_minimum: false,
+                                    minimum: 0.0,
+                                    has_maximum: false,
+                                    maximum: 0.0,
+                                },
+                            ),
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/f_two",
+                    field: "F2",
+                    explicit: true,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "string",
+                            ],
+                            string: Some(
+                                String {
+                                    content_type: "",
+                                    format: "",
+                                    content_encoding: "",
+                                    max_length: 0,
+                                },
+                            ),
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/f_x",
+                    field: "FX",
+                    explicit: true,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Cannot,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/_meta/flow_truncated",
+                    field: "_meta/flow_truncated",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "boolean",
+                            ],
+                            string: None,
+                            title: "Flow truncation indicator",
+                            description: "Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system.",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/f_one",
+                    field: "f_one",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: true,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "integer",
+                            ],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: Some(
+                                Numeric {
+                                    has_minimum: false,
+                                    minimum: 0.0,
+                                    has_maximum: false,
+                                    maximum: 0.0,
+                                },
+                            ),
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/f_two",
+                    field: "f_two",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "string",
+                            ],
+                            string: Some(
+                                String {
+                                    content_type: "",
+                                    format: "",
+                                    content_encoding: "",
+                                    max_length: 0,
+                                },
+                            ),
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/f_x",
+                    field: "f_x",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Cannot,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "",
+                    field: "flow_document",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "object",
+                            ],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/_meta/uuid",
+                    field: "flow_published_at",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "string",
+                            ],
+                            string: Some(
+                                String {
+                                    content_type: "",
+                                    format: "date-time",
+                                    content_encoding: "uuid",
+                                    max_length: 0,
+                                },
+                            ),
+                            title: "Flow Publication Time",
+                            description: "Flow publication date-time of this document",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+            ],
+            ack_template_json: b"{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+            partition_template: Some(
+                JournalSpec {
+                    name: "the/collection/0000000000000001",
+                    replication: 3,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "content-type",
+                                    value: "application/x-ndjson",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/collection",
+                                    value: "the/collection",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    fragment: Some(
+                        Fragment {
+                            length: 536870912,
+                            compression_codec: Gzip,
+                            stores: [
+                                "s3://a-bucket/",
+                            ],
+                            refresh_interval: Some(
+                                Duration {
+                                    seconds: 300,
+                                    nanos: 0,
+                                },
+                            ),
+                            retention: None,
+                            flush_interval: Some(
+                                Duration {
+                                    seconds: 86400,
+                                    nanos: 0,
+                                },
+                            ),
+                            path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                        },
+                    ),
+                    flags: 4,
+                    max_append_rate: 4194304,
+                    suspend: None,
+                },
+            ),
+            derivation: None,
+        },
+        previous_spec: CollectionSpec {
+            name: "the/collection",
+            write_schema_json: b"{\"x-live\":\"schema\"}",
+            read_schema_json: b"",
+            key: [
+                "/f_one",
+            ],
+            uuid_ptr: "/_meta/uuid",
+            partition_fields: [],
+            projections: [],
+            ack_template_json: b"",
+            partition_template: Some(
+                JournalSpec {
+                    name: "the/collection/0000000000000001",
+                    replication: 0,
+                    labels: None,
+                    fragment: None,
+                    flags: 0,
+                    max_append_rate: 0,
+                    suspend: None,
+                },
+            ),
+            derivation: None,
+        },
+        is_touch: 0,
+        dependency_hash: NULL,
+    },
+    BuiltCollection {
+        collection: the/derivation,
+        scope: test://example/catalog.yaml#/collections/the~1derivation,
+        control_id: "1111111111111103",
+        data_plane_id: "1212121212121203",
+        expect_pub_id: "1010101010101010",
+        expect_build_id: "1010101010101010",
+        model: {
+          "schema": {"$id":"test://example/catalog.yaml?ptr=/collections/the~1derivation/schema","properties":{"d_one":{"type":"integer"},"d_two":{"type":"string"}},"required":["d_one","d_two"],"type":"object"},
+          "key": [
+            "/d_one"
+          ],
+          "derive": {
+            "using": {
+              "sqlite": {}
+            },
+            "transforms": [
+              {
+                "name": "fromCollection",
+                "source": {
+                  "name": "the/collection"
+                },
+                "shuffle": {
+                  "key": [
+                    "/f_two"
+                  ]
+                },
+                "lambda": "select 123 as d_one, 'hello' as d_two;\n"
+              }
+            ]
+          }
+        },
+        model_fixes: [
+          "reset collection to new generation 2020202020202020"
+        ],
+        validated: Validated {
+            transforms: [
+                Transform {
+                    read_only: true,
+                },
+            ],
+            generated_files: {},
+        },
+        spec: CollectionSpec {
+            name: "the/derivation",
+            write_schema_json: b"{\"$id\":\"test://example/catalog.yaml?ptr=/collections/the~1derivation/schema\",\"properties\":{\"d_one\":{\"type\":\"integer\"},\"d_two\":{\"type\":\"string\"}},\"required\":[\"d_one\",\"d_two\"],\"type\":\"object\"}",
+            read_schema_json: b"",
+            key: [
+                "/d_one",
+            ],
+            uuid_ptr: "/_meta/uuid",
+            partition_fields: [],
+            projections: [
+                Projection {
+                    ptr: "/_meta/flow_truncated",
+                    field: "_meta/flow_truncated",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "boolean",
+                            ],
+                            string: None,
+                            title: "Flow truncation indicator",
+                            description: "Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system.",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/d_one",
+                    field: "d_one",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: true,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "integer",
+                            ],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: Some(
+                                Numeric {
+                                    has_minimum: false,
+                                    minimum: 0.0,
+                                    has_maximum: false,
+                                    maximum: 0.0,
+                                },
+                            ),
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/d_two",
+                    field: "d_two",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "string",
+                            ],
+                            string: Some(
+                                String {
+                                    content_type: "",
+                                    format: "",
+                                    content_encoding: "",
+                                    max_length: 0,
+                                },
+                            ),
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "",
+                    field: "flow_document",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "object",
+                            ],
+                            string: None,
+                            title: "",
+                            description: "",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+                Projection {
+                    ptr: "/_meta/uuid",
+                    field: "flow_published_at",
+                    explicit: false,
+                    is_partition_key: false,
+                    is_primary_key: false,
+                    inference: Some(
+                        Inference {
+                            types: [
+                                "string",
+                            ],
+                            string: Some(
+                                String {
+                                    content_type: "",
+                                    format: "date-time",
+                                    content_encoding: "uuid",
+                                    max_length: 0,
+                                },
+                            ),
+                            title: "Flow Publication Time",
+                            description: "Flow publication date-time of this document",
+                            default_json: b"",
+                            secret: false,
+                            exists: Must,
+                            numeric: None,
+                            array: None,
+                            enum_json_vec: [],
+                            reduce: Unset,
+                            redact: Unset,
+                        },
+                    ),
+                },
+            ],
+            ack_template_json: b"{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+            partition_template: Some(
+                JournalSpec {
+                    name: "the/derivation/2020202020202020",
+                    replication: 3,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "content-type",
+                                    value: "application/x-ndjson",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/collection",
+                                    value: "the/derivation",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    fragment: Some(
+                        Fragment {
+                            length: 536870912,
+                            compression_codec: Gzip,
+                            stores: [
+                                "s3://a-bucket/",
+                            ],
+                            refresh_interval: Some(
+                                Duration {
+                                    seconds: 300,
+                                    nanos: 0,
+                                },
+                            ),
+                            retention: None,
+                            flush_interval: Some(
+                                Duration {
+                                    seconds: 86400,
+                                    nanos: 0,
+                                },
+                            ),
+                            path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                        },
+                    ),
+                    flags: 4,
+                    max_append_rate: 4194304,
+                    suspend: None,
+                },
+            ),
+            derivation: Some(
+                Derivation {
+                    connector_type: Sqlite,
+                    config_json: b"{}",
+                    transforms: [
+                        Transform {
+                            name: "fromCollection",
+                            collection: Some(
+                                CollectionSpec {
+                                    name: "the/collection",
+                                    write_schema_json: b"{\"$id\":\"test://example/catalog.yaml?ptr=/collections/the~1collection/schema\",\"properties\":{\"f_one\":{\"type\":\"integer\"},\"f_two\":{\"type\":\"string\"},\"f_x\":false},\"required\":[\"f_one\",\"f_two\"],\"type\":\"object\"}",
+                                    read_schema_json: b"",
+                                    key: [
+                                        "/f_one",
+                                    ],
+                                    uuid_ptr: "/_meta/uuid",
+                                    partition_fields: [],
+                                    projections: [
+                                        Projection {
+                                            ptr: "/f_one",
+                                            field: "F1",
+                                            explicit: true,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "integer",
+                                                    ],
+                                                    string: None,
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: Some(
+                                                        Numeric {
+                                                            has_minimum: false,
+                                                            minimum: 0.0,
+                                                            has_maximum: false,
+                                                            maximum: 0.0,
+                                                        },
+                                                    ),
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/f_two",
+                                            field: "F2",
+                                            explicit: true,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "string",
+                                                    ],
+                                                    string: Some(
+                                                        String {
+                                                            content_type: "",
+                                                            format: "",
+                                                            content_encoding: "",
+                                                            max_length: 0,
+                                                        },
+                                                    ),
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/f_x",
+                                            field: "FX",
+                                            explicit: true,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [],
+                                                    string: None,
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Cannot,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/_meta/flow_truncated",
+                                            field: "_meta/flow_truncated",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "boolean",
+                                                    ],
+                                                    string: None,
+                                                    title: "Flow truncation indicator",
+                                                    description: "Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system.",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/f_one",
+                                            field: "f_one",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: true,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "integer",
+                                                    ],
+                                                    string: None,
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: Some(
+                                                        Numeric {
+                                                            has_minimum: false,
+                                                            minimum: 0.0,
+                                                            has_maximum: false,
+                                                            maximum: 0.0,
+                                                        },
+                                                    ),
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/f_two",
+                                            field: "f_two",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "string",
+                                                    ],
+                                                    string: Some(
+                                                        String {
+                                                            content_type: "",
+                                                            format: "",
+                                                            content_encoding: "",
+                                                            max_length: 0,
+                                                        },
+                                                    ),
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/f_x",
+                                            field: "f_x",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [],
+                                                    string: None,
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Cannot,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "",
+                                            field: "flow_document",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "object",
+                                                    ],
+                                                    string: None,
+                                                    title: "",
+                                                    description: "",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                        Projection {
+                                            ptr: "/_meta/uuid",
+                                            field: "flow_published_at",
+                                            explicit: false,
+                                            is_partition_key: false,
+                                            is_primary_key: false,
+                                            inference: Some(
+                                                Inference {
+                                                    types: [
+                                                        "string",
+                                                    ],
+                                                    string: Some(
+                                                        String {
+                                                            content_type: "",
+                                                            format: "date-time",
+                                                            content_encoding: "uuid",
+                                                            max_length: 0,
+                                                        },
+                                                    ),
+                                                    title: "Flow Publication Time",
+                                                    description: "Flow publication date-time of this document",
+                                                    default_json: b"",
+                                                    secret: false,
+                                                    exists: Must,
+                                                    numeric: None,
+                                                    array: None,
+                                                    enum_json_vec: [],
+                                                    reduce: Unset,
+                                                    redact: Unset,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    ack_template_json: b"{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                                    partition_template: Some(
+                                        JournalSpec {
+                                            name: "the/collection/0000000000000001",
+                                            replication: 3,
+                                            labels: Some(
+                                                LabelSet {
+                                                    labels: [
+                                                        Label {
+                                                            name: "app.gazette.dev/managed-by",
+                                                            value: "estuary.dev/flow",
+                                                            prefix: false,
+                                                        },
+                                                        Label {
+                                                            name: "content-type",
+                                                            value: "application/x-ndjson",
+                                                            prefix: false,
+                                                        },
+                                                        Label {
+                                                            name: "estuary.dev/build",
+                                                            value: "2121212121212121",
+                                                            prefix: false,
+                                                        },
+                                                        Label {
+                                                            name: "estuary.dev/collection",
+                                                            value: "the/collection",
+                                                            prefix: false,
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                            fragment: Some(
+                                                Fragment {
+                                                    length: 536870912,
+                                                    compression_codec: Gzip,
+                                                    stores: [
+                                                        "s3://a-bucket/",
+                                                    ],
+                                                    refresh_interval: Some(
+                                                        Duration {
+                                                            seconds: 300,
+                                                            nanos: 0,
+                                                        },
+                                                    ),
+                                                    retention: None,
+                                                    flush_interval: Some(
+                                                        Duration {
+                                                            seconds: 86400,
+                                                            nanos: 0,
+                                                        },
+                                                    ),
+                                                    path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                                                },
+                                            ),
+                                            flags: 4,
+                                            max_append_rate: 4194304,
+                                            suspend: None,
+                                        },
+                                    ),
+                                    derivation: None,
+                                },
+                            ),
+                            partition_selector: Some(
+                                LabelSelector {
+                                    include: Some(
+                                        LabelSet {
+                                            labels: [
+                                                Label {
+                                                    name: "estuary.dev/collection",
+                                                    value: "the/collection",
+                                                    prefix: false,
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                    exclude: Some(
+                                        LabelSet {
+                                            labels: [],
+                                        },
+                                    ),
+                                },
+                            ),
+                            priority: 0,
+                            read_delay_seconds: 0,
+                            shuffle_key: [
+                                "/f_two",
+                            ],
+                            shuffle_lambda_config_json: b"",
+                            lambda_config_json: b"\"select 123 as d_one, 'hello' as d_two;\\n\"",
+                            read_only: true,
+                            journal_read_suffix: "derive/the/derivation/fromCollection",
+                            not_before: None,
+                            not_after: None,
+                            backfill: 0,
+                        },
+                    ],
+                    shuffle_key_types: [
+                        String,
+                    ],
+                    shard_template: Some(
+                        ShardSpec {
+                            id: "derivation/the/derivation/2020202020202020",
+                            sources: [],
+                            recovery_log_prefix: "recovery",
+                            hint_prefix: "/estuary/flow/hints",
+                            hint_backups: 2,
+                            max_txn_duration: Some(
+                                Duration {
+                                    seconds: 1,
+                                    nanos: 0,
+                                },
+                            ),
+                            min_txn_duration: Some(
+                                Duration {
+                                    seconds: 0,
+                                    nanos: 0,
+                                },
+                            ),
+                            disable: false,
+                            hot_standbys: 0,
+                            labels: Some(
+                                LabelSet {
+                                    labels: [
+                                        Label {
+                                            name: "app.gazette.dev/managed-by",
+                                            value: "estuary.dev/flow",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/build",
+                                            value: "2121212121212121",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/log-level",
+                                            value: "info",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/task-name",
+                                            value: "the/derivation",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/task-type",
+                                            value: "derivation",
+                                            prefix: false,
+                                        },
+                                    ],
+                                },
+                            ),
+                            disable_wait_for_ack: false,
+                            ring_buffer_size: 65536,
+                            read_channel_size: 4096,
+                        },
+                    ),
+                    recovery_log_template: Some(
+                        JournalSpec {
+                            name: "recovery/derivation/the/derivation/2020202020202020",
+                            replication: 3,
+                            labels: Some(
+                                LabelSet {
+                                    labels: [
+                                        Label {
+                                            name: "app.gazette.dev/managed-by",
+                                            value: "estuary.dev/flow",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "content-type",
+                                            value: "application/x-gazette-recoverylog",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/build",
+                                            value: "2121212121212121",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/task-name",
+                                            value: "the/derivation",
+                                            prefix: false,
+                                        },
+                                        Label {
+                                            name: "estuary.dev/task-type",
+                                            value: "derivation",
+                                            prefix: false,
+                                        },
+                                    ],
+                                },
+                            ),
+                            fragment: Some(
+                                Fragment {
+                                    length: 268435456,
+                                    compression_codec: Snappy,
+                                    stores: [
+                                        "s3://a-bucket/",
+                                    ],
+                                    refresh_interval: Some(
+                                        Duration {
+                                            seconds: 300,
+                                            nanos: 0,
+                                        },
+                                    ),
+                                    retention: None,
+                                    flush_interval: Some(
+                                        Duration {
+                                            seconds: 172800,
+                                            nanos: 0,
+                                        },
+                                    ),
+                                    path_postfix_template: "",
+                                },
+                            ),
+                            flags: 4,
+                            max_append_rate: 4194304,
+                            suspend: None,
+                        },
+                    ),
+                    network_ports: [],
+                    inactive_transforms: [],
+                    redact_salt: b"pass-through-derivation-salt",
+                },
+            ),
+        },
+        previous_spec: CollectionSpec {
+            name: "the/derivation",
+            write_schema_json: b"{\"x-live\":\"schema\"}",
+            read_schema_json: b"",
+            key: [
+                "/d_one",
+            ],
+            uuid_ptr: "/_meta/uuid",
+            partition_fields: [],
+            projections: [],
+            ack_template_json: b"",
+            partition_template: Some(
+                JournalSpec {
+                    name: "the/derivation/0000000000000001",
+                    replication: 0,
+                    labels: None,
+                    fragment: None,
+                    flags: 0,
+                    max_append_rate: 0,
+                    suspend: None,
+                },
+            ),
+            derivation: Some(
+                Derivation {
+                    connector_type: Sqlite,
+                    config_json: b"",
+                    transforms: [
+                        Transform {
+                            name: "fromCollection",
+                            collection: Some(
+                                CollectionSpec {
+                                    name: "the/collection",
+                                    write_schema_json: b"",
+                                    read_schema_json: b"",
+                                    key: [],
+                                    uuid_ptr: "",
+                                    partition_fields: [],
+                                    projections: [],
+                                    ack_template_json: b"",
+                                    partition_template: Some(
+                                        JournalSpec {
+                                            name: "the/collection/0000000000000001",
+                                            replication: 0,
+                                            labels: None,
+                                            fragment: None,
+                                            flags: 0,
+                                            max_append_rate: 0,
+                                            suspend: None,
+                                        },
+                                    ),
+                                    derivation: None,
+                                },
+                            ),
+                            partition_selector: None,
+                            priority: 0,
+                            read_delay_seconds: 0,
+                            shuffle_key: [],
+                            shuffle_lambda_config_json: b"",
+                            lambda_config_json: b"",
+                            read_only: false,
+                            journal_read_suffix: "",
+                            not_before: None,
+                            not_after: None,
+                            backfill: 0,
+                        },
+                    ],
+                    shuffle_key_types: [],
+                    shard_template: Some(
+                        ShardSpec {
+                            id: "derivation/the/derivation/0000000000000001",
+                            sources: [],
+                            recovery_log_prefix: "",
+                            hint_prefix: "",
+                            hint_backups: 0,
+                            max_txn_duration: None,
+                            min_txn_duration: None,
+                            disable: false,
+                            hot_standbys: 0,
+                            labels: None,
+                            disable_wait_for_ack: false,
+                            ring_buffer_size: 0,
+                            read_channel_size: 0,
+                        },
+                    ),
+                    recovery_log_template: Some(
+                        JournalSpec {
+                            name: "recovery/derivation/the/derivation/0000000000000001",
+                            replication: 0,
+                            labels: None,
+                            fragment: None,
+                            flags: 0,
+                            max_append_rate: 0,
+                            suspend: None,
+                        },
+                    ),
+                    network_ports: [],
+                    inactive_transforms: [],
+                    redact_salt: b"pass-through-derivation-salt",
+                },
+            ),
+        },
+        is_touch: 0,
+        dependency_hash: 5b38dc32c776e2b2,
+    },
+]

--- a/crates/validation/tests/snapshots/transition_tests__reset_materialization.snap
+++ b/crates/validation/tests/snapshots/transition_tests__reset_materialization.snap
@@ -1,0 +1,670 @@
+---
+source: crates/validation/tests/transition_tests.rs
+expression: outcome.built_materializations
+---
+[
+    BuiltMaterialization {
+        materialization: the/materialization,
+        scope: test://example/catalog.yaml#/materializations/the~1materialization,
+        control_id: "1111111111111104",
+        data_plane_id: "1212121212121204",
+        expect_pub_id: "1010101010101010",
+        expect_build_id: "1010101010101010",
+        model: {
+          "endpoint": {
+            "connector": {
+              "image": "other/image",
+              "config": {"a":"config"}
+            }
+          },
+          "bindings": [
+            {
+              "resource": {"_meta":{"path":["table","path"]},"table":"bar"},
+              "source": "the/collection",
+              "fields": {
+                "require": {
+                  "F1": {},
+                  "f_two": {}
+                },
+                "exclude": [
+                  "F2"
+                ],
+                "recommended": true
+              }
+            }
+          ]
+        },
+        model_fixes: [
+          "removed dropped exclude projection FY of source collection the/collection",
+          "removed dropped exclude projection does/not/exist of source collection the/collection",
+          "reset materialization to new generation 2020202020202020"
+        ],
+        validated: Validated {
+            bindings: [
+                Binding {
+                    case_insensitive_fields: false,
+                    constraints: {
+                        "F1": Constraint {
+                            r#type: FieldOptional,
+                            reason: "optional",
+                            folded_field: "",
+                        },
+                        "f_one": Constraint {
+                            r#type: LocationRecommended,
+                            reason: "recommended",
+                            folded_field: "",
+                        },
+                        "f_two": Constraint {
+                            r#type: FieldRequired,
+                            reason: "field required",
+                            folded_field: "",
+                        },
+                        "flow_document": Constraint {
+                            r#type: LocationRequired,
+                            reason: "location required",
+                            folded_field: "",
+                        },
+                    },
+                    resource_path: [
+                        "table",
+                        "path",
+                    ],
+                    delta_updates: false,
+                    ser_policy: None,
+                },
+            ],
+        },
+        spec: MaterializationSpec {
+            name: "the/materialization",
+            connector_type: Image,
+            config_json: b"{\"image\":\"other/image\",\"config\":{\"a\":\"config\"}}",
+            bindings: [
+                Binding {
+                    resource_config_json: b"{\"table\":\"bar\"}",
+                    resource_path: [
+                        "table",
+                        "path",
+                    ],
+                    collection: Some(
+                        CollectionSpec {
+                            name: "the/collection",
+                            write_schema_json: b"{\"$id\":\"test://example/catalog.yaml?ptr=/collections/the~1collection/schema\",\"properties\":{\"f_one\":{\"type\":\"integer\"},\"f_two\":{\"type\":\"string\"},\"f_x\":false},\"required\":[\"f_one\",\"f_two\"],\"type\":\"object\"}",
+                            read_schema_json: b"",
+                            key: [
+                                "/f_one",
+                            ],
+                            uuid_ptr: "/_meta/uuid",
+                            partition_fields: [],
+                            projections: [
+                                Projection {
+                                    ptr: "/f_one",
+                                    field: "F1",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "integer",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: Some(
+                                                Numeric {
+                                                    has_minimum: false,
+                                                    minimum: 0.0,
+                                                    has_maximum: false,
+                                                    maximum: 0.0,
+                                                },
+                                            ),
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_two",
+                                    field: "F2",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "",
+                                                    content_encoding: "",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_x",
+                                    field: "FX",
+                                    explicit: true,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Cannot,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/_meta/flow_truncated",
+                                    field: "_meta/flow_truncated",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "boolean",
+                                            ],
+                                            string: None,
+                                            title: "Flow truncation indicator",
+                                            description: "Indicates whether any of the materialized values for this row have been truncated to make them fit inside the limitations of the destination system.",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_one",
+                                    field: "f_one",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: true,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "integer",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: Some(
+                                                Numeric {
+                                                    has_minimum: false,
+                                                    minimum: 0.0,
+                                                    has_maximum: false,
+                                                    maximum: 0.0,
+                                                },
+                                            ),
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_two",
+                                    field: "f_two",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "",
+                                                    content_encoding: "",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/f_x",
+                                    field: "f_x",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Cannot,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "",
+                                    field: "flow_document",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "object",
+                                            ],
+                                            string: None,
+                                            title: "",
+                                            description: "",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                                Projection {
+                                    ptr: "/_meta/uuid",
+                                    field: "flow_published_at",
+                                    explicit: false,
+                                    is_partition_key: false,
+                                    is_primary_key: false,
+                                    inference: Some(
+                                        Inference {
+                                            types: [
+                                                "string",
+                                            ],
+                                            string: Some(
+                                                String {
+                                                    content_type: "",
+                                                    format: "date-time",
+                                                    content_encoding: "uuid",
+                                                    max_length: 0,
+                                                },
+                                            ),
+                                            title: "Flow Publication Time",
+                                            description: "Flow publication date-time of this document",
+                                            default_json: b"",
+                                            secret: false,
+                                            exists: Must,
+                                            numeric: None,
+                                            array: None,
+                                            enum_json_vec: [],
+                                            reduce: Unset,
+                                            redact: Unset,
+                                        },
+                                    ),
+                                },
+                            ],
+                            ack_template_json: b"{\"_meta\":{\"ack\":true,\"uuid\":\"DocUUIDPlaceholder-329Bb50aa48EAa9ef\"}}",
+                            partition_template: Some(
+                                JournalSpec {
+                                    name: "the/collection/0000000000000001",
+                                    replication: 3,
+                                    labels: Some(
+                                        LabelSet {
+                                            labels: [
+                                                Label {
+                                                    name: "app.gazette.dev/managed-by",
+                                                    value: "estuary.dev/flow",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "content-type",
+                                                    value: "application/x-ndjson",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "estuary.dev/build",
+                                                    value: "2121212121212121",
+                                                    prefix: false,
+                                                },
+                                                Label {
+                                                    name: "estuary.dev/collection",
+                                                    value: "the/collection",
+                                                    prefix: false,
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                    fragment: Some(
+                                        Fragment {
+                                            length: 536870912,
+                                            compression_codec: Gzip,
+                                            stores: [
+                                                "s3://a-bucket/",
+                                            ],
+                                            refresh_interval: Some(
+                                                Duration {
+                                                    seconds: 300,
+                                                    nanos: 0,
+                                                },
+                                            ),
+                                            retention: None,
+                                            flush_interval: Some(
+                                                Duration {
+                                                    seconds: 86400,
+                                                    nanos: 0,
+                                                },
+                                            ),
+                                            path_postfix_template: "utc_date={{.Spool.FirstAppendTime.Format \"2006-01-02\"}}/utc_hour={{.Spool.FirstAppendTime.Format \"15\"}}",
+                                        },
+                                    ),
+                                    flags: 4,
+                                    max_append_rate: 4194304,
+                                    suspend: None,
+                                },
+                            ),
+                            derivation: None,
+                        },
+                    ),
+                    partition_selector: Some(
+                        LabelSelector {
+                            include: Some(
+                                LabelSet {
+                                    labels: [
+                                        Label {
+                                            name: "estuary.dev/collection",
+                                            value: "the/collection",
+                                            prefix: false,
+                                        },
+                                    ],
+                                },
+                            ),
+                            exclude: Some(
+                                LabelSet {
+                                    labels: [],
+                                },
+                            ),
+                        },
+                    ),
+                    priority: 0,
+                    field_selection: Some(
+                        FieldSelection {
+                            keys: [
+                                "f_one",
+                            ],
+                            values: [
+                                "F1",
+                                "f_two",
+                            ],
+                            document: "flow_document",
+                            field_config_json_map: {
+                                "F1": b"{}",
+                                "f_two": b"{}",
+                            },
+                        },
+                    ),
+                    delta_updates: false,
+                    deprecated_shuffle: None,
+                    journal_read_suffix: "materialize/the/materialization/table%2Fpath",
+                    not_before: None,
+                    not_after: None,
+                    backfill: 0,
+                    state_key: "table%2Fpath",
+                    ser_policy: None,
+                },
+            ],
+            shard_template: Some(
+                ShardSpec {
+                    id: "materialize/the/materialization/2020202020202020",
+                    sources: [],
+                    recovery_log_prefix: "recovery",
+                    hint_prefix: "/estuary/flow/hints",
+                    hint_backups: 2,
+                    max_txn_duration: Some(
+                        Duration {
+                            seconds: 1200,
+                            nanos: 0,
+                        },
+                    ),
+                    min_txn_duration: Some(
+                        Duration {
+                            seconds: 0,
+                            nanos: 0,
+                        },
+                    ),
+                    disable: false,
+                    hot_standbys: 0,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/log-level",
+                                    value: "info",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-name",
+                                    value: "the/materialization",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-type",
+                                    value: "materialization",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    disable_wait_for_ack: false,
+                    ring_buffer_size: 65536,
+                    read_channel_size: 4096,
+                },
+            ),
+            recovery_log_template: Some(
+                JournalSpec {
+                    name: "recovery/materialize/the/materialization/2020202020202020",
+                    replication: 3,
+                    labels: Some(
+                        LabelSet {
+                            labels: [
+                                Label {
+                                    name: "app.gazette.dev/managed-by",
+                                    value: "estuary.dev/flow",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "content-type",
+                                    value: "application/x-gazette-recoverylog",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/build",
+                                    value: "2121212121212121",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-name",
+                                    value: "the/materialization",
+                                    prefix: false,
+                                },
+                                Label {
+                                    name: "estuary.dev/task-type",
+                                    value: "materialization",
+                                    prefix: false,
+                                },
+                            ],
+                        },
+                    ),
+                    fragment: Some(
+                        Fragment {
+                            length: 268435456,
+                            compression_codec: Snappy,
+                            stores: [
+                                "s3://a-bucket/",
+                            ],
+                            refresh_interval: Some(
+                                Duration {
+                                    seconds: 300,
+                                    nanos: 0,
+                                },
+                            ),
+                            retention: None,
+                            flush_interval: Some(
+                                Duration {
+                                    seconds: 172800,
+                                    nanos: 0,
+                                },
+                            ),
+                            path_postfix_template: "",
+                        },
+                    ),
+                    flags: 4,
+                    max_append_rate: 4194304,
+                    suspend: None,
+                },
+            ),
+            network_ports: [],
+            inactive_bindings: [],
+        },
+        previous_spec: MaterializationSpec {
+            name: "the/materialization",
+            connector_type: Image,
+            config_json: b"",
+            bindings: [
+                Binding {
+                    resource_config_json: b"",
+                    resource_path: [
+                        "table",
+                        "path",
+                    ],
+                    collection: Some(
+                        CollectionSpec {
+                            name: "the/collection",
+                            write_schema_json: b"",
+                            read_schema_json: b"",
+                            key: [],
+                            uuid_ptr: "",
+                            partition_fields: [],
+                            projections: [],
+                            ack_template_json: b"",
+                            partition_template: Some(
+                                JournalSpec {
+                                    name: "the/collection/0000000000000001",
+                                    replication: 0,
+                                    labels: None,
+                                    fragment: None,
+                                    flags: 0,
+                                    max_append_rate: 0,
+                                    suspend: None,
+                                },
+                            ),
+                            derivation: None,
+                        },
+                    ),
+                    partition_selector: None,
+                    priority: 0,
+                    field_selection: None,
+                    delta_updates: false,
+                    deprecated_shuffle: None,
+                    journal_read_suffix: "",
+                    not_before: None,
+                    not_after: None,
+                    backfill: 0,
+                    state_key: "",
+                    ser_policy: None,
+                },
+            ],
+            shard_template: Some(
+                ShardSpec {
+                    id: "materialize/the/materialization/0000000000000001",
+                    sources: [],
+                    recovery_log_prefix: "",
+                    hint_prefix: "",
+                    hint_backups: 0,
+                    max_txn_duration: None,
+                    min_txn_duration: None,
+                    disable: false,
+                    hot_standbys: 0,
+                    labels: None,
+                    disable_wait_for_ack: false,
+                    ring_buffer_size: 0,
+                    read_channel_size: 0,
+                },
+            ),
+            recovery_log_template: Some(
+                JournalSpec {
+                    name: "recovery/materialize/the/materialization/0000000000000001",
+                    replication: 0,
+                    labels: None,
+                    fragment: None,
+                    flags: 0,
+                    max_append_rate: 0,
+                    suspend: None,
+                },
+            ),
+            network_ports: [],
+            inactive_bindings: [],
+        },
+        is_touch: 0,
+        dependency_hash: 5b38dc32c776e2b2,
+    },
+]

--- a/crates/validation/tests/transition_tests.rs
+++ b/crates/validation/tests/transition_tests.rs
@@ -461,6 +461,48 @@ test://example/catalog.yaml:
 }
 
 #[test]
+fn test_reset_capture() {
+    let outcome = common::run(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  captures:
+    the/capture:
+      reset: true
+"#,
+    );
+    insta::assert_debug_snapshot!(outcome.built_captures);
+}
+
+#[test]
+fn test_reset_materialization() {
+    let outcome = common::run(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  materializations:
+    the/materialization:
+      reset: true
+"#,
+    );
+    insta::assert_debug_snapshot!(outcome.built_materializations);
+}
+
+#[test]
+fn test_reset_derivation() {
+    let outcome = common::run(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  collections:
+    the/derivation:
+      reset: true
+"#,
+    );
+    insta::assert_debug_snapshot!(outcome.built_collections);
+}
+
+#[test]
 fn test_disable_live_bindings() {
     let outcome = common::run(
         MODEL_YAML,

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -239,7 +239,7 @@
           }
         },
         "delete": {
-          "title": "Delete this capture within the control plane.",
+          "title": "Delete this capture.",
           "description": "When true, a publication will delete this capture.",
           "type": "boolean"
         },
@@ -265,6 +265,11 @@
           "title": "Salt used for redacting sensitive fields in captured documents.",
           "description": "When provided, this base64-encoded salt is used instead of a generated one.",
           "type": "string"
+        },
+        "reset": {
+          "title": "Reset this capture.",
+          "description": "Publishing a value of `true` will reset this capture, which is\nequivalent to deleting and then re-creating the capture but\napplied as a single publication.",
+          "type": "boolean"
         },
         "shards": {
           "title": "Template for shards of this capture task.",
@@ -321,7 +326,7 @@
       "type": "object",
       "properties": {
         "delete": {
-          "title": "Delete this collection within the control plane.",
+          "title": "Delete this collection.",
           "description": "When true, a publication will delete this collection.",
           "type": "boolean"
         },
@@ -365,8 +370,8 @@
           "$ref": "#/$defs/Schema"
         },
         "reset": {
-          "title": "Reset this collection within the control plane.",
-          "description": "When true, a publication will reset this collection.\nResetting a collection is equivalent to deleting and then re-creating\nthe collection, but is applied as a single publication.",
+          "title": "Reset this collection.",
+          "description": "Publishing a value of `true` will reset this collection, which is\nequivalent to deleting and then re-creating the collection but\napplied as a single publication.\nIf this is a derived collection then the derivation task state is\nalso reset, effectively re-building the derivation in its entirety.",
           "type": "boolean"
         },
         "schema": {
@@ -931,7 +936,7 @@
           }
         },
         "delete": {
-          "title": "Delete this materialization within the control plane.",
+          "title": "Delete this materialization.",
           "description": "When true, a publication will delete this materialization.",
           "type": "boolean"
         },
@@ -948,6 +953,11 @@
           "title": "Default handling of schema changes that are incompatible with the target resource.",
           "description": "This can be overridden on a per-binding basis.",
           "$ref": "#/$defs/OnIncompatibleSchemaChange"
+        },
+        "reset": {
+          "title": "Reset this materialization.",
+          "description": "Publishing a value of `true` will reset this materialization, which is\nequivalent to deleting and then re-creating the materialization but\napplied as a single publication.",
+          "type": "boolean"
         },
         "shards": {
           "title": "Template for shards of this materialization task.",


### PR DESCRIPTION
Extends the existing collection reset feature to also support resetting captures and materializations. When `reset: true` is published for a task, it regenerates the shard ID prefix, effectively resetting all task state while applying the change as a single publication (rather than requiring separate delete and create operations).

For derived collections, the reset flag now also applies to the derivation task state, effectively re-building the derivation in its entirety rather than just resetting the collection journals.

Implementation details:
- Added `reset` field to CaptureDef and MaterializationDef models
- Updated derivation validation to reset task state when collection is reset
- Updated validation logic to regenerate shard IDs when reset is true
- Added check preventing reset of Dekaf materializations
