### PR TITLE
docs/concepts/flowctl: Corrected KMS information

### DIFF
--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -232,10 +232,6 @@ are encrypted. In this case, you own the KMS key and grant Estuary access for
 decryption. `flowctl` will not modify endpoint configurations that have already
 been encrypted.
 
-:::important
-Using an external KMS is only supported when using a GCP data plane and a GCP KMS.
-:::
-
 The examples below provide a useful reference.
 
 #### Example: Protect a configuration
@@ -285,16 +281,10 @@ as `sops` finds it within its metadata section.
 
 :::important
 When deploying catalogs onto the managed Flow runtime, you must grant access to
-decrypt your GCP KMS key to the Flow runtime service account for your data plane.
-
-The service account email varies by data plane, but for `gcp-us-central1-c2` it is:
-
-```
-flow-258@helpful-kingdom-273219.iam.gserviceaccount.com
-```
-
-The account email for other data planes can be obtained from Estuary support
-upon request.
+decrypt your KMS key to the appropriate identity for your data plane and KMS.
+These identities vary by data plane, find yours under
+[Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings)
+in the Estuary dashboard.
 :::
 
 #### Example: Protect portions of a configuration


### PR DESCRIPTION
**Description:**

Turns out that the previous docs PR (https://github.com/estuary/flow/pull/2518) was incorrect and actually our support for external KMSes is much more solid than I was told, so really we just need to point users at the appropriate settings page in the UI and allude to the existence of different identities for different data planes.