### PR TITLE
agent: generalize publication cooldown

### DIFF
--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -21,6 +21,8 @@ pub async fn update<C: ControlPlane>(
     control_plane: &C,
     model: &models::CaptureDef,
 ) -> anyhow::Result<Option<NextRun>> {
+    publication_status::clear_pending_publication_next_after(&mut status.publications);
+
     let CaptureStatus {
         publications,
         alerts,

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -138,11 +138,18 @@ pub async fn update<C: ControlPlane>(
     // updated_at timestamp of the live spec.
     let periodic_result = periodic_published.map(|_| periodic::next_periodic_publish(state));
 
-    let activate_result =
-        activation::update_activation(activation, alerts, state, events, control_plane)
-            .await
-            .with_retry(backoff_data_plane_activate(state.failures))
-            .map_err(Into::into);
+    let pending_publish = status.publications.next_after;
+    let activate_result = activation::update_activation(
+        activation,
+        alerts,
+        pending_publish,
+        state,
+        events,
+        control_plane,
+    )
+    .await
+    .with_retry(backoff_data_plane_activate(state.failures))
+    .map_err(Into::into);
 
     let notify_result = publication_status::update_notify_dependents(
         &mut status.publications,

--- a/crates/agent/src/controllers/config_update.rs
+++ b/crates/agent/src/controllers/config_update.rs
@@ -35,6 +35,8 @@ where
     if config_update_status.is_none() && !has_config_update_event {
         return Ok(false);
     }
+    // Return a backoff error if we need to wait for the publication cooldown
+    self::publication_status::check_can_publish(publication_status, control_plane)?;
 
     // Since there's either a previous config update that failed or a new config update that needs
     // published, the current config update from Supabase is fetched.

--- a/crates/agent/src/controllers/executor.rs
+++ b/crates/agent/src/controllers/executor.rs
@@ -207,7 +207,8 @@ impl<C: ControlPlane + Send + Sync + 'static> Executor for LiveSpecControllerExe
     task_id = %_task_id,
     live_spec_id = %controller_state.live_spec_id,
     catalog_name = %controller_state.catalog_name,
-    data_plane_id = %controller_state.data_plane_id
+    data_plane_id = %controller_state.data_plane_id,
+    last_build_id = %controller_state.last_build_id
 ))]
 async fn run_controller<C: ControlPlane>(
     task_state: &mut State,

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -548,7 +548,6 @@ async fn controller_update<C: ControlPlane>(
 
 #[cfg(test)]
 mod test {
-    use control_plane_api::server::public;
     use models::status::publications::PUBLICATION_COOLDOWN_ERROR;
 
     use super::*;

--- a/crates/agent/src/controllers/periodic.rs
+++ b/crates/agent/src/controllers/periodic.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use control_plane_api::publications::PublicationResult;
 use models::{ModelDef, status::publications::PublicationStatus};
 
-use crate::ControlPlane;
+use crate::{ControlPlane, controllers::publication_status};
 
 use super::{ControllerErrorExt, ControllerState, NextRun, publication_status::PendingPublication};
 
@@ -69,6 +69,7 @@ pub async fn update_periodic_publish<C: ControlPlane>(
     if !pending.has_pending() {
         return Ok(None);
     }
+    publication_status::check_can_publish(pub_status, control_plane)?;
 
     let pub_result = pending
         .finish(state, pub_status, control_plane)

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -63,7 +63,7 @@ pub trait ControlPlane: Send + Sync {
 
     /// Returns the cooldown period required after a successful inferred
     /// schema update before another update can be attempted.
-    fn inferred_schema_update_cooldown(&self) -> chrono::Duration;
+    fn controller_publication_cooldown(&self) -> chrono::Duration;
 
     /// Returns whether an auto-discover is allowed to happen at this time.
     fn can_auto_discover(&self) -> bool;
@@ -208,7 +208,7 @@ pub struct PGControlPlane<C: DiscoverConnectors + MakeConnectors> {
     pub logs_tx: logs::Tx,
     pub decrypted_hmac_keys: Arc<RwLock<HashMap<String, Vec<String>>>>,
     pub auto_discover_probability: f64,
-    pub inferred_schema_update_cooldown: chrono::Duration,
+    pub controller_publication_cooldown: chrono::Duration,
 }
 
 impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
@@ -221,7 +221,7 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
         logs_tx: logs::Tx,
         decrypted_hmac_keys: Arc<RwLock<HashMap<String, Vec<String>>>>,
         auto_discover_probability: f64,
-        inferred_schema_update_cooldown: chrono::Duration,
+        controller_publication_cooldown: chrono::Duration,
     ) -> Self {
         Self {
             pool,
@@ -232,7 +232,7 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
             logs_tx,
             decrypted_hmac_keys,
             auto_discover_probability,
-            inferred_schema_update_cooldown,
+            controller_publication_cooldown,
         }
     }
 
@@ -306,8 +306,8 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
         rand::random::<f64>() < self.auto_discover_probability
     }
 
-    fn inferred_schema_update_cooldown(&self) -> chrono::Duration {
-        self.inferred_schema_update_cooldown
+    fn controller_publication_cooldown(&self) -> chrono::Duration {
+        self.controller_publication_cooldown
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -135,19 +135,19 @@ pub struct TestHarness {
 
 pub struct HarnessBuilder {
     test_name: String,
-    inferred_schema_cooldown: chrono::Duration,
+    publication_cooldown: chrono::Duration,
 }
 
 impl HarnessBuilder {
     pub fn new(test_name: impl Into<String>) -> HarnessBuilder {
         HarnessBuilder {
             test_name: test_name.into(),
-            inferred_schema_cooldown: chrono::Duration::seconds(0),
+            publication_cooldown: chrono::Duration::seconds(0),
         }
     }
 
-    pub fn with_inferred_schema_cooldown(mut self, cooldown: chrono::Duration) -> Self {
-        self.inferred_schema_cooldown = cooldown;
+    pub fn with_publication_cooldown(mut self, cooldown: chrono::Duration) -> Self {
+        self.publication_cooldown = cooldown;
         self
     }
 
@@ -155,7 +155,7 @@ impl HarnessBuilder {
     pub async fn build(self) -> TestHarness {
         let HarnessBuilder {
             test_name,
-            inferred_schema_cooldown,
+            publication_cooldown,
         } = self;
         // Setup tracing so we can see logs
         let subscriber = tracing_subscriber::FmtSubscriber::builder()
@@ -209,7 +209,7 @@ impl HarnessBuilder {
             logs_tx.clone(),
             std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
             1.0, // auto_discover_probability
-            inferred_schema_cooldown,
+            publication_cooldown,
         ));
 
         let controller_exec =
@@ -1701,8 +1701,8 @@ impl ControlPlane for TestControlPlane {
         self.auto_discover_enabled
     }
 
-    fn inferred_schema_update_cooldown(&self) -> chrono::Duration {
-        self.inner.inferred_schema_update_cooldown()
+    fn controller_publication_cooldown(&self) -> chrono::Duration {
+        self.inner.controller_publication_cooldown()
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]

--- a/crates/agent/src/integration_tests/inferred_schemas.rs
+++ b/crates/agent/src/integration_tests/inferred_schemas.rs
@@ -79,7 +79,6 @@ async fn test_inferred_schema_updates_no_cooldown() {
     );
     assert!(schema_status.schema_md5.is_none());
     assert!(schema_status.next_md5.is_none());
-    assert!(schema_status.next_update_after.is_none());
 
     let mut last_update_time = collection_state.live_spec_updated_at;
     let generation_id = get_collection_generation_id(&collection_state);
@@ -195,7 +194,6 @@ async fn test_inferred_schema_updates_with_cooldown() {
     );
     assert!(schema_status.schema_md5.is_none());
     assert!(schema_status.next_md5.is_none());
-    assert!(schema_status.next_update_after.is_none());
 
     // First inferred schema update
     let generation_id = get_collection_generation_id(&collection_state);
@@ -344,6 +342,7 @@ fn assert_awaiting_publication_cooldown(state: &ControllerState) {
     );
 }
 
+#[allow(deprecated)] // suppress warning for next_update_after
 fn assert_inferred_schema_status_pending(
     state: &ControllerState,
     expect_current_md5: &str,
@@ -372,6 +371,7 @@ fn assert_inferred_schema_status_pending(
     );
 }
 
+#[allow(deprecated)] // suppress warning for next_update_after
 fn assert_inferred_schema_status_completed(
     state: &ControllerState,
     expect_md5: &str,
@@ -398,8 +398,7 @@ fn assert_inferred_schema_status_completed(
     );
     assert!(
         schema_status.next_update_after.is_none(),
-        "expected no pending update, but next_update_at was {:?}",
-        schema_status.next_update_after
+        "next_update_after is deprecated and no longer used",
     );
 }
 

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -102,12 +102,12 @@ struct Args {
     auto_discover_probability: f64,
 
     #[clap(
-        long = "inferred-schema-update-cooldown",
-        env = "INFERRED_SCHEMA_UPDATE_COOLDOWN",
+        long = "controller-publication-cooldown",
+        env = "CONTROLLER_PUBLICATION_COOLDOWN",
         default_value = "0s"
     )]
     #[arg(value_parser = humantime::parse_duration)]
-    inferred_schema_update_cooldown: std::time::Duration,
+    controller_publication_cooldown: std::time::Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -265,8 +265,8 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         decrypted_hmac_keys.clone(),
     ));
 
-    let inferred_schema_update_cooldown =
-        chrono::Duration::from_std(args.inferred_schema_update_cooldown)?;
+    let controller_publication_cooldown =
+        chrono::Duration::from_std(args.controller_publication_cooldown)?;
     let control_plane = agent::PGControlPlane::new(
         pg_pool.clone(),
         system_user_id,
@@ -276,7 +276,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         logs_tx.clone(),
         decrypted_hmac_keys,
         args.auto_discover_probability,
-        inferred_schema_update_cooldown,
+        controller_publication_cooldown,
     );
     let connector_tags_executor = agent::TagExecutor::new(&args.connector_network, &logs_tx);
 

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -638,6 +638,11 @@ This does not include any information on user-initiated publications.
 """
 type PublicationStatus {
 	"""
+	If we are awaiting a cooldown before publishing this spec, this field will be set
+	to the time after which the publication will be retried.
+	"""
+	nextAfter: DateTime
+	"""
 	The publication id at which the controller has last notified dependent
 	specs. A publication of the controlled spec will cause the controller to
 	notify the controllers of all dependent specs. When it does so, it sets

--- a/crates/flowctl/src/catalog/status.graphql
+++ b/crates/flowctl/src/catalog/status.graphql
@@ -72,6 +72,7 @@ fragment SelectStatus on LiveSpecStatus {
             nextRetry
         }
         publications @include(if: $fullStatus) {
+            nextAfter
             history {
                 id
                 created
@@ -112,7 +113,6 @@ fragment SelectStatus on LiveSpecStatus {
             schemaLastUpdated
             schemaMd5
             nextMd5
-            nextUpdateAfter
         }
     }
 }

--- a/crates/models/src/status/collection.rs
+++ b/crates/models/src/status/collection.rs
@@ -46,6 +46,10 @@ pub struct InferredSchemaStatus {
     /// present, it indicates that the controller is waiting on a cooldown
     /// period before publishing the inferred schema, and represents the
     /// approximate time of the next update.
+    #[deprecated(
+        since = "2025-11-24",
+        note = "we now use only the more general `nextAfter` field on the `publications` status"
+    )]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "crate::datetime_schema")]
     pub next_update_after: Option<DateTime<Utc>>,

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -386,6 +386,7 @@ mod test {
             publications: PublicationStatus {
                 max_observed_pub_id: Id::new([1, 2, 3, 4, 5, 6, 7, 8]),
                 history,
+                next_after: Some("2024-01-02T03:04:05.06Z".parse().unwrap()),
             },
             alerts: Default::default(),
         });

--- a/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
+++ b/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
@@ -16,6 +16,9 @@ StatusSnapshot {
                 },
             ),
             publications: PublicationStatus {
+                next_after: Some(
+                    2024-01-02T03:04:05.060Z,
+                ),
                 max_observed_pub_id: 0102030405060708,
                 history: [
                     PublicationInfo {
@@ -72,7 +75,7 @@ StatusSnapshot {
             alerts: {},
         },
     ),
-    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"up_to_date\": false,\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\"\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\",\n    \"shard_status\": {\n      \"last_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"first_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"status\": \"Pending\"\n    },\n    \"last_activated_at\": \"2024-01-02T03:04:05.060Z\",\n    \"recent_failure_count\": 3,\n    \"next_retry\": \"2025-01-02T03:04:05.060Z\"\n  }\n}",
+    json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"up_to_date\": false,\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"next_after\": \"2024-01-02T03:04:05.060Z\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\"\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ]\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\",\n    \"shard_status\": {\n      \"last_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"first_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"status\": \"Pending\"\n    },\n    \"last_activated_at\": \"2024-01-02T03:04:05.060Z\",\n    \"recent_failure_count\": 3,\n    \"next_retry\": \"2025-01-02T03:04:05.060Z\"\n  }\n}",
     parsed: Materialization(
         MaterializationStatus {
             source_capture: Some(
@@ -86,6 +89,9 @@ StatusSnapshot {
                 },
             ),
             publications: PublicationStatus {
+                next_after: Some(
+                    2024-01-02T03:04:05.060Z,
+                ),
                 max_observed_pub_id: 0102030405060708,
                 history: [
                     PublicationInfo {

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -416,6 +416,7 @@ expression: schema
           ]
         },
         "next_update_after": {
+          "deprecated": true,
           "description": "The time of the next scheduled inferred schema update. If this is\npresent, it indicates that the controller is waiting on a cooldown\nperiod before publishing the inferred schema, and represents the\napproximate time of the next update.",
           "format": "date-time",
           "type": [
@@ -622,6 +623,13 @@ expression: schema
         "max_observed_pub_id": {
           "$ref": "#/$defs/Id",
           "description": "The publication id at which the controller has last notified dependent\nspecs. A publication of the controlled spec will cause the controller to\nnotify the controllers of all dependent specs. When it does so, it sets\n`max_observed_pub_id` to the current `last_pub_id`, so that it can avoid\nnotifying dependent controllers unnecessarily."
+        },
+        "next_after": {
+          "description": "If we are awaiting a cooldown before publishing this spec, this field will be set\nto the time after which the publication will be retried.",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Resolves #2505

Replaces the `INFERRED_SCHEMA_UPDATE_COOLDOWN` with a more general `CONTROLLER_PUBLICATION_COOLDOWN`, which applies to all controller-initiated publications. In scenarios where a bunch of collections all have inferred schema updates in rapid succession, this prevents the connected captures and materializations from being repeatedly published in response to changes in the collections. In prod, we've observed that connected tasks are getting published very frequently during those times, and our goals here are to:

- try to reclaim some system capacity that could be used for publication for other tenants, tasks, etc
- prevent repeated publications from causing too many task restarts, and thus impacting task performance

This ended up requiring a bit of refactoring, particularly in the materialization controller.

The cooldown is implemented as a special error. The `RetryableError` type now has an `is_backoff` field, which is used to coalesce multiple different backoff errors into one. This ensures that we have consistent reporting of cooldown errors, even if a controller makes multiple attempts to publish. The status summary logic was also updated to ignore these cooldown errors. Generally, a cooldown error is not a condition that users will care about or be able to act on.