### PR TITLE
Docs: IAM info for new data planes

### DIFF
--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -16,7 +16,9 @@ Next, you need to create an IAM OIDC (OpenID Connect) provider by heading to IAM
 
 | Data Plane | Issuer |
 |---|---|
+| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
 | US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
+| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
 | EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
 
 ![Add Identity Provider](../guide-images/aws-iam-1.png)

--- a/site/docs/guides/iam-auth/azure.md
+++ b/site/docs/guides/iam-auth/azure.md
@@ -15,7 +15,9 @@ Next, you need to create a Federated Credential by heading to Certificates & Sec
 
 | Data Plane | Issuer |
 |---|---|
+| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
 | US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
+| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
 | EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
 
 Now take note of the Application ID and Tenant ID of your App Registration and use it when configuring Azure IAM.

--- a/site/docs/guides/iam-auth/gcp.md
+++ b/site/docs/guides/iam-auth/gcp.md
@@ -17,7 +17,9 @@ Give your workload identity pool your desired name, and select OpenID Connect (O
 | Field | Value |
 |---|---|
 | Provider Name | estuary-flow-google |
+| Issuer (US AWS east-1 data plane) | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
 | Issuer (US GCP central-1 data plane) | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
+| Issuer (US AWS west-2 data plane) | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
 | Issuer (EU AWS west-1 data plane) | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
 
 ![Workload Identity Provider Configuration](../guide-images/gcp-iam-1-provider.png)
@@ -36,7 +38,9 @@ Next, copy the IAM principal you see in the workload identity pool details page 
 
 | Data Plane | SUBJECT_ATTRIBUTE_VALUE |
 |---|---|
+| US east-1 AWS data plane | aws-us-east-1-c1.dp.estuary-data.com |
 | US central-1 GCP data plane | gcp-us-central1-c2.dp.estuary-data.com |
+| US west-2 AWS data plane | aws-us-west-2-c1.dp.estuary-data.com |
 | EU west-1 AWS data plane | aws-eu-west-1-c1.dp.estuary-data.com |
 
 ![Workload Identity Pool Principal](../guide-images/gcp-iam-3-principal.png)


### PR DESCRIPTION
**Description:**

Adds OIDC issuers for new AWS US East 1 and West 2 data planes.

Related to https://github.com/estuary/ui/issues/1831

**Documentation links affected:**

Docs for IAM auth for AWS, Azure, and GCP

**Notes for reviewers:**

Thanks for reviewing!
