### PR TITLE
ci: run platform build on merges (and manually)

### DIFF
--- a/.github/workflows/platform-build.yaml
+++ b/.github/workflows/platform-build.yaml
@@ -3,9 +3,7 @@ permissions:
   contents: read
 
 on:
-  # TODO(johnny): Only run automatically on merges into the `master` branch.
-  # push:
-  pull_request:
+  push:
     branches: [master]
     paths-ignore:
       - "site/**"


### PR DESCRIPTION
Platform Test is sufficient for PR builds, but we are also able to run builds manually as needed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

