### PR TITLE
Add geo_region field to AnsibleHost struct

### DIFF
--- a/crates/data-plane-controller/src/stack.rs
+++ b/crates/data-plane-controller/src/stack.rs
@@ -262,6 +262,8 @@ pub struct AnsibleHost {
     pub starting: bool,
     pub stopping: bool,
     pub zone: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geo_region: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
## Summary

Adds optional `geo_region` field to the `AnsibleHost` struct to support geographic region metadata exported by Pulumi in estuary/est-dry-dock#218.

## Changes

- Added `geo_region: Option<String>` field to `AnsibleHost` struct after the `zone` field
- Used `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward compatibility

## Why Optional?

Making this field optional ensures the data-plane controller doesn't crash during rollout if:
- The field isn't present in older Pulumi exports
- Deployment order gets mixed up
- Transitional states occur during rollout

Without this field, the controller silently drops `geo_region` during JSON deserialization, causing Ansible playbooks to fail with "geo_region is undefined".

## Related

- estuary/est-dry-dock#218 - Add geographic region tagging for Tailscale

## Test Plan

- Existing tests continue to pass (test fixtures use empty ansible inventory)
- Field safely defaults to `None` when missing from JSON
- Follows same pattern as other optional fields in the struct