### PR TITLE
Docs: Rollup of updates (IAM auth, IP usage, and more)

### DIFF
--- a/site/docs/concepts/README.md
+++ b/site/docs/concepts/README.md
@@ -244,6 +244,7 @@ The exact meaning of a resource is up to the endpoint and its connector. For exa
 
 When you create capture or materialization, it connects a collection to a resource through a **binding**.
 A given capture or materialization may have multiple bindings, which connect multiple collections to different resources.
+For performance, it's recommended that any one task be limited to **500** bindings.
 
 ***
 

--- a/site/docs/getting-started/installation.mdx
+++ b/site/docs/getting-started/installation.mdx
@@ -63,6 +63,14 @@ Copy its information for use when setting up your storage bucket permissions:
 
    * For [S3 buckets](#amazon-s3-buckets), copy the **AWS IAM User ARN**.
 
+:::tip
+When setting up storage, disregard the [CIDR Blocks](/reference/allow-ip-addresses) column of the Data Planes table.
+These IPs can be allowlisted for connectors.
+
+Storage connected with public data planes should not limit access by IP.
+Storage for private data planes can use [PrivateLink](/private-byoc/privatelink) to restrict access.
+:::
+
 ## Google Cloud Storage buckets
 
 You'll need to grant Estuary Flow access to your GCS bucket.

--- a/site/docs/getting-started/sso-setup.md
+++ b/site/docs/getting-started/sso-setup.md
@@ -16,6 +16,7 @@ To enable the SSO option on Estuary's end, [contact support](mailto:support@estu
 1. **Metadata URL or Metadata XML File**
 
    Using the metadata URL is the preferred method of configuring SSO. However, if your provider doesn't support metadata URLs, you may send a metadata XML file instead.
+   For example, see [Supabase's steps](https://supabase.com/docs/guides/platform/sso/azure#upload-saml-metadata) for working with metadata files and URLs for Azure.
 
 2. **Company Domain**
 

--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -12,7 +12,20 @@ For more information about role creation check the [IAM User Guide](https://docs
 
 ## Identity Provider for Estuary
 
-Next, you need to create an IAM OIDC (OpenID Connect) provider by heading to IAM -> Identity Providers and creating a new provider with the Audience set to the ARN of the role you just created and the issuer set to one of the following values:
+Next, you need to create an IAM OIDC (OpenID Connect) provider by heading to IAM -> Identity Providers and creating a new provider with the Audience set to the ARN of the role you just created.
+The **issuer** will depend on your chosen data plane in Estuary.
+
+To find the correct issuer value:
+
+1. Navigate to the [Admin section](https://dashboard.estuary.dev/admin) of your Estuary dashboard.
+
+2. Select the **Settings** tab.
+
+3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+
+4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
+
+For example, these are the issuer values for a few common public data planes:
 
 | Data Plane | Issuer |
 |---|---|

--- a/site/docs/guides/iam-auth/azure.md
+++ b/site/docs/guides/iam-auth/azure.md
@@ -8,10 +8,23 @@ You need to have an Azure App Registration set up which has access to the resour
 
 ## Federated Credentials
 
-Next, you need to create a Federated Credential by heading to Certificates & Secrets section of your app, and creating a new provider with the subject set to your task name and the issuer set to one of the following values:
+Next, you need to create a Federated Credential by heading to Certificates & Secrets section of your app, and creating a new provider.
 
 ![Add Federated Credential](../guide-images/azure-iam-1.png)
-![Add Federated Credential](../guide-images/azure-iam-2.png)
+
+The subject should be set to your task name while the **issuer** will depend on your chosen data plane in Estuary.
+
+To find the correct issuer value:
+
+1. Navigate to the [Admin section](https://dashboard.estuary.dev/admin) of your Estuary dashboard.
+
+2. Select the **Settings** tab.
+
+3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+
+4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
+
+For example, these are the issuer values for a few common public data planes:
 
 | Data Plane | Issuer |
 |---|---|
@@ -19,5 +32,7 @@ Next, you need to create a Federated Credential by heading to Certificates & Sec
 | US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
 | US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
 | EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
+
+![Add Federated Credential](../guide-images/azure-iam-2.png)
 
 Now take note of the Application ID and Tenant ID of your App Registration and use it when configuring Azure IAM.

--- a/site/docs/guides/iam-auth/gcp.md
+++ b/site/docs/guides/iam-auth/gcp.md
@@ -12,15 +12,32 @@ We use [Workload Identity Federation](https://cloud.google.com/iam/docs/workload
 
 ![Workload Identity Create Pool Button](../guide-images/gcp-iam-0-create-pool.png)
 
-Give your workload identity pool your desired name, and select OpenID Connect (OIDC) as the provider, with the details below. If you are using a private deployment or BYOC, your issuer address will be provided to you by our team. At this step, take note of the audience value as you will need this when configuring connectors with GCP IAM:
+Give your workload identity pool your desired name, and select OpenID Connect (OIDC) as the provider.
 
-| Field | Value |
+Set the **provider name** to `estuary-flow-google`.
+
+The **issuer** will depend on your chosen data plane in Estuary.
+
+To find the correct issuer value:
+
+1. Navigate to the [Admin section](https://dashboard.estuary.dev/admin) of your Estuary dashboard.
+
+2. Select the **Settings** tab.
+
+3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+
+4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
+
+For example, these are the issuer values for a few common public data planes:
+
+| Data Plane | Issuer |
 |---|---|
-| Provider Name | estuary-flow-google |
-| Issuer (US AWS east-1 data plane) | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
-| Issuer (US GCP central-1 data plane) | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
-| Issuer (US AWS west-2 data plane) | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
-| Issuer (EU AWS west-1 data plane) | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
+| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
+| US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
+| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
+| EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
+
+At this step, take note of the audience value as you will need this when configuring connectors with GCP IAM.
 
 ![Workload Identity Provider Configuration](../guide-images/gcp-iam-1-provider.png)
 
@@ -34,7 +51,8 @@ Finally set up provider attributes to the following values, replacing your tenan
 
 ![Workload Identity Provider Attributes Configuration](../guide-images/gcp-iam-2-provider-attributes.png)
 
-Next, copy the IAM principal you see in the workload identity pool details page and replace SUBJECT_ATTRIBUTE_VALUE with one of the following values depending on your data plane:
+Next, copy the IAM principal you see in the workload identity pool details page and replace SUBJECT_ATTRIBUTE_VALUE with your data plane domain name.
+This will be the second half of the OpenID issuer value you used before. For example:
 
 | Data Plane | SUBJECT_ATTRIBUTE_VALUE |
 |---|---|

--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -1,4 +1,4 @@
-# Capture connectors
+# Capture Connectors
 
 Estuary's available capture connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.
 
@@ -140,6 +140,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - IBM Db2 Batch
   - [Configuration](./db2-batch.md)
   - Package - ghcr.io/estuary/source-db2-batch:dev
+- Incident.io
+  - [Configuration](./incident-io.md)
+  - Package - ghcr.io/estuary/source-incident-io:dev
 - Intercom
   - [Configuration](./intercom-native.md)
   - Package - ghcr.io/estuary/source-intercom-native:dev
@@ -155,9 +158,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Jira
   - [Configuration](./jira-native.md)
   - Package - ghcr.io/estuary/source-jira-native:dev
-- Klaviyo (deprecated)
-  - [Configuration](./klaviyo.md)
-  - Package - ghcr.io/estuary/source-klaviyo:dev
 - Klaviyo
   - [Configuration](./klaviyo-native.md)
   - Package - ghcr.io/estuary/source-klaviyo-native:dev
@@ -197,6 +197,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - NetSuite
   - [Configuration](./netsuite-suiteanalytics.md)
   - Package - ghcr.io/estuary/source-netsuite:dev
+- OneDrive
+  - [Configuration](./onedrive.md)
+  - Package - ghcr.io/estuary/source-onedrive:dev
 - OracleDB
   - [Configuration](./OracleDB/)
   - Package - ghcr.io/estuary/source-oracle:dev
@@ -218,6 +221,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Qualtrics
   - [Configuration](./qualtrics.md)
   - Package - ghcr.io/estuary/source-qualtrics:dev
+- QuickBooks
+  - [Configuration](./quickbooks.md)
+  - Package - ghcr.io/estuary/source-quickbooks:dev
 - Sage Intacct
   - [Configuration](./sage-intacct.md)
   - Package — ghcr.io/estuary/source-sage-intacct:dev
@@ -233,6 +239,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - SFTP
   - [Configuration](./sftp.md)
   - Package - ghcr.io/estuary/source-sftp:dev
+- SharePoint
+  - [Configuration](./sharepoint.md)
+  - Package - ghcr.io/estuary/source-sharepoint:dev
 - Shopify
   - [Configuration](./shopify.md)
   - Package - ghcr.io/estuary/source-shopify:dev
@@ -290,9 +299,6 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Chargebee (deprecated)
   - [Configuration](./chargebee.md)
   - Package - ghcr.io/estuary/source-chargebee:dev
-- Chargebee Native
-  - [Configuration](./chargebee-native.md)
-  - Package - ghcr.io/estuary/source-chargebee-native:dev
 - Confluence
   - [Configuration](./confluence.md)
   - Package - ghcr.io/estuary/source-confluence:dev
@@ -320,9 +326,6 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Harvest
   - [Configuration](./harvest.md)
   - Package - ghcr.io/estuary/source-harvest:dev
-- Incident.io
-  - [Configuration](./incident-io.md)
-  - Package - ghcr.io/estuary/source-incident-io:dev
 - Instagram
   - [Configuration](./instagram.md)
   - Package - ghcr.io/estuary/source-instagram:dev
@@ -332,6 +335,9 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Jira (deprecated)
   - [Configuration](./jira.md)
   - Package - ghcr.io/estuary/source-jira:dev
+- Klaviyo (deprecated)
+  - [Configuration](./klaviyo.md)
+  - Package - ghcr.io/estuary/source-klaviyo:dev
 - LinkedIn Ads
   - [Configuration](./linkedin-ads.md)
   - Package - ghcr.io/estuary/source-linkedin-ads:dev

--- a/site/docs/reference/Connectors/capture-connectors/chargebee.md
+++ b/site/docs/reference/Connectors/capture-connectors/chargebee.md
@@ -1,10 +1,14 @@
-# Chargebee (deprecated)
+# Chargebee (Deprecated)
 
 This connector captures data from Chargebee into Flow collections.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-chargebee:dev`](https://ghcr.io/estuary/source-chargebee:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+
+:::warning
+This connector is deprecated. For the best experience, we recommend using our native [Chargebee connector](./chargebee-native.md) instead.
+:::
 
 ## Supported data resources
 

--- a/site/docs/reference/Connectors/capture-connectors/facebook-marketing-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/facebook-marketing-native.md
@@ -1,5 +1,5 @@
 
-# Facebook Marketing
+# Facebook Ads (Meta)
 
 This connector captures data from the Facebook Marketing API into Flow collections.
 

--- a/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
+++ b/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
@@ -1,9 +1,13 @@
 
-# Facebook Marketing (deprecated)
+# Facebook Marketing (Deprecated)
 
 This connector captures data from the Facebook Marketing API into Flow collections.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-facebook-marketing:dev`](https://ghcr.io/estuary/source-facebook-marketing:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+
+:::warning
+This connector is deprecated. For the best experience, we recommend using our native [Facebook Ads connector](./facebook-marketing-native.md) instead.
+:::
 
 ## Supported data resources
 

--- a/site/docs/reference/Connectors/capture-connectors/google-ads.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-ads.md
@@ -63,14 +63,14 @@ In the above example, the `customer_id` would be 9876543210.
 #### Multiple Customer Ids
 
 This Source allows for multiple Customer Ids to be selected.
-To allow this, simply add your `customer_id` followed by a comma.
+In the Customer Id field, provide Ids as a comma-delimited list.
 
 Example:
 
-Customer1 = 1234567890
-Customer2 = 9876543210
+* Customer1 = 1234567890
+* Customer2 = 9876543210
 
-customer_id = 1234567890,9876543210
+```customer_id: 1234567890,9876543210```
 
 ### Using OAuth2 to authenticate with Google in the Flow web app
 
@@ -196,6 +196,6 @@ If a query fails to validate against a given Google Ads account, it will be skip
 Due to Google Ads API limitations, ClickView stream queries are executed with a time range limited to one day.
 Also, data can only be requested for periods 90 days before the time of the request.
 
-In pratical terms, this means that you can only search ClickView data limited to 3 months ago. Anything before this is not returned.
+In practical terms, this means that you can only search ClickView data limited to 3 months ago. Anything before this is not returned.
 
 For more information, check [Google's Ads API documentation](https://developers.google.com/google-ads/api/fields/v15/click_view)

--- a/site/docs/reference/Connectors/capture-connectors/klaviyo.md
+++ b/site/docs/reference/Connectors/capture-connectors/klaviyo.md
@@ -1,11 +1,15 @@
 
-# Klaviyo (deprecated)
+# Klaviyo (Deprecated)
 
 This connector captures data from Klaviyo into Flow collections.
 
 It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-klaviyo:dev`](https://ghcr.io/estuary/source-klaviyo:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Flow system.
+
+:::warning
+This connector is deprecated. For the best experience, we recommend using our native [Klaviyo connector](./klaviyo-native.md) instead.
+:::
 
 ## Supported data resources
 

--- a/site/docs/security/allow-ip-addresses.md
+++ b/site/docs/security/allow-ip-addresses.md
@@ -2,11 +2,16 @@
 slug: /reference/allow-ip-addresses/
 ---
 
-# Allowlisting IP Addresses for Estuary Flow
+# Allowlisting IP Addresses for Estuary
 
-When configuring systems that interact with Estuary Flow, it's crucial to ensure that the necessary IP addresses are
-allowlisted. This allows communication between Estuary Flow and your data systems.
+When configuring systems that interact with Estuary, it's crucial to ensure that the necessary IP addresses are
+allowlisted. This allows communication between Estuary and your data systems.
 The IP addresses you need to allowlist depend on the data plane you use.
+
+These fixed IPs can be used in conjunction with _connectors_.
+
+Note that Estuary's storage does not use fixed IPs.
+To limit IP access to collection storage, you will need to set up a [PrivateLink](/private-byoc/privatelink) connection instead.
 
 ## Data Plane IP Addresses
 
@@ -18,7 +23,7 @@ You can find the IP addresses relevant to your use case in the **Admin** section
 
    Make sure to select the desired data plane when configuring a connector as well.
 
-   If you wish to use a public data plane, Estuary offers several options across US and EU regions with AWS and GCP.
+   If you wish to use a public data plane, Estuary offers several options across US, EU, and APAC regions with AWS and GCP.
 
 3. Find the **CIDR Blocks** column in the Data Planes table. This column includes a comma-separated list of IP addresses for that data plane.
 
@@ -51,3 +56,10 @@ While your dashboard is the best location to find accurate, up-to-date IP addres
 
 - `18.200.127.124/32`
 - `34.247.94.19/32`
+
+### APAC
+
+**AWS `ap-southeast-2 c1`:**
+
+- `15.134.198.216/32`
+- `3.24.170.247/32`


### PR DESCRIPTION
**Description:**

Rolling up various miscellaneous edits and requested updates, including:

* Noting the use of PrivateLink rather than IP allowlisting for storage access
* Updating IAM auth info to use the UI
* Noting new APAC data plane
* Adding links to native connectors in deprecated 3rd-party connector docs
* Some nitpicky shuffling in capture readme to put connectors in correct (native/3rd-party) categories

**Documentation links affected:**

Various

**Notes for reviewers:**

Thanks for reviewing!
