### PR TITLE
mise: don't time out active vscode session

### DIFF
--- a/mise/tasks/vm/files/idle-shutdown.sh
+++ b/mise/tasks/vm/files/idle-shutdown.sh
@@ -42,6 +42,13 @@ has_ssh_sessions() {
         return 0
     fi
 
+    # Check for sshd child processes (any connection, regardless of port).
+    # The listener process contains "[listener]", connection processes don't.
+    # This catches non-PTY connections like VS Code Remote SSH.
+    if pgrep -a sshd | grep -qv '\[listener\]'; then
+        return 0
+    fi
+
     return 1
 }
 


### PR DESCRIPTION
**Description:**

VSCode remote SSH connects without allocating a PTY, so sessions don't appear in `who` output. The idle shutdown script only checked for `pts/` entries, missing these connections and shutting down the VM while in use.

Add a check for sshd child processes to catch any SSH connection regardless of whether it allocates a PTY.

ex from a vscode remote ssh instance:
```
$ who   <---- no output 
$ pgrep -a sshd 
1395 sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
1404 sshd: joseph [priv]
1925 sshd: joseph@notty
```

I... _think_ this new check is purely a superset of the existing `who | grep -qE 'pts/'` check, but I'm not deeply familiar with these particular linux concepts (TTY/PTYs etc) so I'm not positive.