### PR TITLE
parser: use an exact sized integer type for skip lines

### DIFF
--- a/crates/parser/src/config/character_separated.rs
+++ b/crates/parser/src/config/character_separated.rs
@@ -40,10 +40,10 @@ pub struct AdvancedCsvConfig {
     /// Skip a number of lines at the beginning of the file before parsing begins.
     /// This is useful for skipping over metadata that is sometimes added to the top of files.
     #[serde(default, skip_serializing_if = "is_zero")]
-    pub skip_lines: usize,
+    pub skip_lines: u64,
 }
 
-fn is_zero(i: &usize) -> bool {
+fn is_zero(i: &u64) -> bool {
     *i == 0
 }
 

--- a/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
+++ b/crates/parser/src/config/snapshots/parser__config__test__config_schema_is_generated.snap
@@ -467,7 +467,7 @@ expression: schema
                 "skipLines": {
                   "description": "Skip a number of lines at the beginning of the file before parsing begins.\nThis is useful for skipping over metadata that is sometimes added to the top of files.",
                   "type": "integer",
-                  "format": "uint",
+                  "format": "uint64",
                   "minimum": 0
                 }
               }

--- a/crates/parser/src/input/mod.rs
+++ b/crates/parser/src/input/mod.rs
@@ -83,7 +83,7 @@ impl Input {
         }
     }
 
-    pub fn skip_lines(self, lines: usize) -> io::Result<Self> {
+    pub fn skip_lines(self, lines: u64) -> io::Result<Self> {
         let mut reader = self.into_buffered_stream(8192);
         let mut ignore_buf = Vec::new();
         let mut skipped_bytes = 0;


### PR DESCRIPTION
**Description:**

Using a usize field set the format to uint in the schema, which wasn't one of the supported values.  By using u64 the format becomes uint64.

**Workflow steps:**

None

**Documentation links affected:**

None

**Notes for reviewers:**

When connectors are built, we fetch [the dev flow binaries](https://github.com/estuary/connectors/blob/main/fetch-flow.sh), which should deploy this new flow-parser on the next connector build.

