### PR TITLE
agent-api: fix sub-second precision mismatch in agent-api causing incorrect terminal authorization errors

### DIFF
--- a/crates/control-plane-api/src/server/authorize_dekaf.rs
+++ b/crates/control-plane-api/src/server/authorize_dekaf.rs
@@ -371,7 +371,9 @@ mod tests {
         let snapshot = Snapshot::build_fixture(Some(taken));
         let snapshot = std::sync::RwLock::new(snapshot);
 
-        claims.iat = taken.timestamp() as u64;
+        // Set iat to 1 second before snapshot.taken so the server definitively has
+        // newer knowledge and returns a terminal error.
+        claims.iat = taken.timestamp() as u64 - 1;
         claims.exp = taken.timestamp() as u64 + 100;
 
         let request_token = jsonwebtoken::encode(

--- a/crates/control-plane-api/src/server/authorize_task.rs
+++ b/crates/control-plane-api/src/server/authorize_task.rs
@@ -527,7 +527,9 @@ mod tests {
         mut claims: proto_gazette::Claims,
     ) -> Result<(String, proto_gazette::Claims), crate::server::error::ApiError> {
         let taken = chrono::Utc::now();
-        let snapshot = Snapshot::build_fixture(Some(taken));
+        // Snapshot is 1 second ahead of `taken` so that iat=0 (using `taken`) is
+        // "before snapshot" and iat=1 is "same second as snapshot"
+        let snapshot = Snapshot::build_fixture(Some(taken + chrono::Duration::seconds(1)));
         let snapshot = std::sync::RwLock::new(snapshot);
 
         claims.iat = claims.iat + taken.timestamp() as u64;


### PR DESCRIPTION
**Description:**

The authorization evaluator compared `snapshot.taken` which contains sub-second precision against the JWT's `iat` claim which only contains second-level precision. This caused the authorization API to return terminal failures when fetching auth within the same second as a snapshot refresh.

Example timeline:
```
> Snapshot fetched at 15:32:44.76
2025-12-18T15:32:44.767374Z INFO control_plane_api::server::snapshot: fetched authorization snapshot collections=8 data_planes=1 migrations=0 role_grants=7 user_grants=4 tasks=7

>  Publication committed at 15:32:44.86
2025-12-18T15:32:44.861475Z INFO try_publish:commit{build_id=13555487ce800352}: control_plane_api::publications: finished publication commit attempt=0 attempt_elapsed_ms=5 commit_elapsed_ms=5 result="success" temp_dashboard_compat="successfully committed publication"

> Task started and attempted to fetch authorization at 15:32:44.98
2025-12-18T15:32:44.981443Z WARN authorize_task: control_plane_api::server::authorize_task: error=status: 412 Precondition Failed, error: task shard capture/test/my-task/source_ingest/13555487ce800352/00000000-00000000 within data-plane local-cluster.dp.estuary-data.com is not known
```

The comparison `snapshot.taken > started` evaluated as: `15:32:44.763 > 15:32:44.000 = TRUE` (terminal failure)

But the snapshot (taken at `.763`) was actually OLDER than the request (`.981`).

The fix is to truncate `snapshot.taken` to seconds when comparing.