### PR TITLE
package: add contents:write perm to github token

### DIFF
--- a/.github/workflows/platform-build.yaml
+++ b/.github/workflows/platform-build.yaml
@@ -73,7 +73,7 @@ jobs:
     needs: [platform-build]
     runs-on: ubuntu-24.04
     permissions:
-      packages: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
**Description:**

This is an attempt to fix an error we have pushing releases in CI:
```
Unexpected error fetching GitHub release for tag refs/heads/master: HttpError: Resource not accessible by integration
```

The [documentation](https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions) for the failing action indicate that we should have this permission.

In [GitHub's docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) it says this about `contents:write`:

> Work with the contents of the repository. For example, contents: read permits an action to list the commits, and contents: write allows the action to create a release.

I removed `packages:write`, it seemed like this permission is all that is required?

