### PR TITLE
package: add packages:write perm back to github token

### DIFF
--- a/.github/workflows/platform-build.yaml
+++ b/.github/workflows/platform-build.yaml
@@ -74,6 +74,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
**Description:**

This permission was swaped out for `contents` in https://github.com/estuary/flow/pull/2572, but it looks like it was required.  Without it we get an error on a previously passing step:
```
ERROR: target derive-typescript: failed to solve: failed to push ghcr.io/estuary/derive-typescript:v0.6.0-89-g0b6cbaae05: denied: installation not allowed to Write organization package
```

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

