### PR TITLE
dekaf: Fix task names containing periods

### DIFF
--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -225,7 +225,7 @@ async fn send_sasl_message(
     )
     .await?;
 
-    if resp.error_code > 0 {
+    if resp.error_code != 0 {
         let err = kafka_protocol::ResponseError::try_from_code(resp.error_code)
             .map(|code| format!("{code:?}"))
             .unwrap_or(format!("Unknown error {}", resp.error_code));

--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -239,15 +239,8 @@ impl App {
         username: &str,
         password: &str,
     ) -> Result<SessionAuthentication, DekafError> {
-        let username = if let Ok(decoded) = decode_safe_name(username.to_string()) {
-            decoded
-        } else {
-            username.to_string()
-        };
-
-        if models::Materialization::regex().is_match(username.as_ref())
-            && !username.starts_with("{")
-        {
+        if models::Materialization::regex().is_match(username) && !username.starts_with("{") {
+            let username = username.to_string();
             let listener = self.task_manager.get_listener(&username);
             // Ask the agent for information about this task, as well as a short-lived
             // control-plane access token authorized to interact with the avro schemas table

--- a/crates/dekaf/tests/e2e/auth.rs
+++ b/crates/dekaf/tests/e2e/auth.rs
@@ -1,0 +1,38 @@
+use super::DekafTestEnv;
+use super::raw_kafka::TestKafkaClient;
+
+const PERIOD_FIXTURE: &str = include_str!("fixtures/task_name_auth.flow.yaml");
+
+/// Regression test: task names containing periods must authenticate successfully.
+#[tokio::test]
+async fn test_auth_task_name_with_period() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("auth_period", PERIOD_FIXTURE).await?;
+    let materialization = env.materialization_name().unwrap();
+
+    assert!(
+        materialization.contains('.'),
+        "expected period in task name: {}",
+        materialization
+    );
+
+    let token = env.dekaf_token()?;
+    let mut client =
+        TestKafkaClient::connect(&env.connection_info().broker, materialization, &token).await?;
+
+    let metadata = client.metadata(&[]).await?;
+    let mut topic_names: Vec<_> = metadata
+        .topics
+        .iter()
+        .filter_map(|t| t.name.as_ref().map(|n| n.as_str()))
+        .collect();
+    topic_names.sort();
+    insta::assert_debug_snapshot!(topic_names, @r###"
+    [
+        "test_topic",
+    ]
+    "###);
+
+    Ok(())
+}

--- a/crates/dekaf/tests/e2e/fixtures/task_name_auth.flow.yaml
+++ b/crates/dekaf/tests/e2e/fixtures/task_name_auth.flow.yaml
@@ -1,0 +1,26 @@
+# Regression test fixture for task names containing periods.
+# The materialization name `my.dekaf.task` tests that periods
+# in task names don't break SASL authentication.
+collections:
+    test_data:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+            required: [id]
+        key: [/id]
+
+materializations:
+    my.dekaf.task:
+        endpoint:
+            dekaf:
+                variant: testing
+                config:
+                    token: "test-token"
+                    strict_topic_names: false
+        bindings:
+            - source: test_data
+              resource: { topic_name: test_topic }
+              fields:
+                  recommended: true
+                  exclude: [flow_published_at]

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -2,6 +2,7 @@ mod harness;
 pub mod kafka;
 pub mod raw_kafka;
 
+mod auth;
 mod basic;
 mod collection_reset;
 mod empty_fetch;


### PR DESCRIPTION
Task names containing periods (e.g. `foo.com/tenant/task`) were being corrupted during authentication. The issue: `decode_safe_name()` replaces `.` with `%` then attempts percent-decoding, so `foo.com` becomes `foo%com`, and `%co` is invalid hex, leaving the name corrupted.

The `decode_safe_name` function was added in #1516 to support dot-encoded JSON config objects as usernames (e.g. `{}` encoded for platforms that don't allow `{` in usernames). When materialization task-based auth was introduced in #1665, the dot-encoding was never removed despite no longer having a valid use case: we're no longer trying to do things like stuff JSON objects into usernames.

This PR removes the `decode_safe_name()` call from `authenticate()`. It's still used by `from_downstream_topic_name` for decoding Kafka topic names in order to avoid breaking backwards compatibility.  It also fixes a small bug in Dekaf's Kafka API client (which the e2e test infrastructure uses) that was treating an error code of `-1` as non-terminal.

**NOTE:** This will break any user using `%`-encoded or `.`-encoded SASL usernames (of which there are none at present AFAICT)