### PR TITLE
runtime/capture: Return ~immediately on connector EOF

### DIFF
--- a/crates/runtime/src/capture/serve.rs
+++ b/crates/runtime/src/capture/serve.rs
@@ -268,10 +268,17 @@ pub async fn read_transaction<R: ResponseStream + FusedStream + Unpin>(
             }
             (false, None) => {
                 txn.connector_eof = true;
+                // Were we previously asked to yield, and now we know there's no more data coming?
+                if yield_rx.is_terminated() {
+                    return Ok((accumulator, connector_rx, task, txn));
+                }
             }
             (true, _none) => {
-                // Have we been asked to yield, and either have a non-empty transaction or reached our timeout?
-                if yield_rx.is_terminated() && (txn.checkpoints != 0 || timeout.is_terminated()) {
+                // Have we been asked to yield, and either have a non-empty transaction,
+                // reached our timeout, or the connector has exited?
+                if yield_rx.is_terminated()
+                    && (txn.checkpoints != 0 || timeout.is_terminated() || txn.connector_eof)
+                {
                     return Ok((accumulator, connector_rx, task, txn));
                 }
             }


### PR DESCRIPTION
**Description:**

Adds some extra branches to the runtime logic that accumulates checkpoints, so that in the event of connector EOF we return as soon as yield_rx is signalled, and if yield_rx was previously signalled we return immediately when EOF is detected.

I'm like 95% sure this is the correct fix to the thing where it takes exactly 5 seconds for `flowctl preview` to exit after the connector itself terminates. It definitely works in my testing, the uncertainty is just whether there's some nuanced reason we're not already doing this. But this feels like it's working with the intended behavior and invariants of the function so I think it's correct.

**Workflow steps:**

Before this change it took 5s for a `flowctl preview` invocation to shut down after the connector terminated, and so every capture run in automated black-box tests would take about 5-6s. After this change it's basically instant and each capture takes around 0.5-1.0s, a significant speedup to the full test suite.