### PR TITLE
docs: add details on `flow_document` being excluded by default with delta updates + field selection workaround

### DIFF
--- a/site/docs/guides/customize-dataflows/customize-materialization-fields.md
+++ b/site/docs/guides/customize-dataflows/customize-materialization-fields.md
@@ -235,7 +235,7 @@ When using **delta updates** in a materialization, Flow's default field selectio
 ### Default Behavior
 
 With delta updates enabled, the `flow_document` field is **excluded by default** from the materialization.
-This is because delta updates don't require Flow to perform reductions, making the full document technically unnecessary.
+This is because delta updates don't require Estuary to perform reductions, making the full document technically unnecessary.
 
 ### Including `flow_document` with Delta Updates
 


### PR DESCRIPTION
**Description:**
Details of current behavior where `flow_document` is excluded from field selection by default if delta updates is enabled and how to manually include it if needed.

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**
https://docs.estuary.dev/guides/customize-materialization-fields/

**Notes for reviewers:**

(anything that might help someone review this PR)

