### PR TITLE
docs: add geo_target_constant to source-google-ads

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/google-ads.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-ads.md
@@ -19,6 +19,7 @@ Resources ending in `_report` represent legacy resources from the [Google Adword
 * [click_view](https://developers.google.com/google-ads/api/reference/rpc/latest/ClickView)
 * [customer](https://developers.google.com/google-ads/api/fields/latest/customer)
 * [geographic_view](https://developers.google.com/google-ads/api/fields/latest/geographic_view)
+* [geo_target_constant](https://developers.google.com/google-ads/api/fields/v22/geo_target_constant)
 * [keyword_view](https://developers.google.com/google-ads/api/fields/latest/keyword_view)
 * [user_location_view](https://developers.google.com/google-ads/api/fields/latest/user_location_view)
 * [account_performance_report](https://developers.google.com/google-ads/api/docs/migration/mapping#account_performance)


### PR DESCRIPTION
**Description:**

Adds a link to the new `geo_target_constant` stream, merged in https://github.com/estuary/connectors/pull/3715

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

