### PR TITLE
Fix deployment workflows to use Platform Build commit SHA

### DIFF
--- a/.github/workflows/deploy-agent-api.yaml
+++ b/.github/workflows/deploy-agent-api.yaml
@@ -13,11 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git describe to find tags
 
       - name: Get image tag
         id: image-tag
         run: |
-          TAG="dev-next"
+          TAG=$(git describe --tags --always)
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "image=us-central1-docker.pkg.dev/estuary-control/ghcr/estuary/control-plane-agent:${TAG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0  # Required for git describe to find tags
 
       - name: Get image tag

--- a/.github/workflows/deploy-oidc-discovery-server.yaml
+++ b/.github/workflows/deploy-oidc-discovery-server.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0  # Required for git describe to find tags
 
       - name: Get image tag


### PR DESCRIPTION
## Problem

The deployment workflows were failing because they were trying to pull Docker images that don't exist yet. There were two separate issues:

### Issue 1: Race Condition (data-plane-controller, oidc-discovery-server)

1. Platform Build runs on commit X, builds and pushes image with tag from commit X (e.g., `v0.6.0-83-g5d38214`)
2. Deployment workflow triggers via `workflow_run`, but by the time it starts, master has advanced to commit Y
3. Deployment workflow checks out current HEAD (commit Y) and runs `git describe --tags`
4. Gets tag for commit Y (e.g., `v0.6.0-84-g9f21abc`) which doesn't exist in the registry yet
5. Image pull fails

### Issue 2: Non-existent dev-next Tag (agent-api)

The agent-api workflow was hardcoded to deploy `dev-next` tag, but Platform Build doesn't push `dev-next` tags - it only pushes version tags from `git describe` (e.g., `v0.6.0-116-gbc1bb91ac8`).

## Solution

### For automated deployments (workflow_run triggered)

Use `github.event.workflow_run.head_sha` to checkout the **exact commit** that triggered Platform Build:

```yaml
- name: Checkout
  uses: actions/checkout@v4
  with:
    ref: ${{ github.event.workflow_run.head_sha || github.sha }}
    fetch-depth: 0
```

This ensures `git describe` runs against the same commit Platform Build used, generating matching tags.

### For manual deployments (workflow_dispatch)

Use `git describe --tags --always` to get the actual version tag of the checked out commit:

```yaml
- name: Get image tag
  run: |
    TAG=$(git describe --tags --always)
```

This deploys whatever version is checked out, as long as Platform Build has already built it.

## Changes

- [.github/workflows/deploy-data-plane-controller.yaml](.github/workflows/deploy-data-plane-controller.yaml#L23) - Added `ref:` to checkout Platform Build commit
- [.github/workflows/deploy-oidc-discovery-server.yaml](.github/workflows/deploy-oidc-discovery-server.yaml#L23) - Added `ref:` to checkout Platform Build commit
- [.github/workflows/deploy-agent-api.yaml](.github/workflows/deploy-agent-api.yaml#L22) - Changed from `dev-next` to `git describe`

## Testing

After this fix:
1. Automated deployments checkout the exact commit Platform Build just finished
2. They run `git describe --tags` on that commit
3. Get the same tag Platform Build used
4. Successfully pull image from Artifact Registry proxy
5. Manual agent-api deployments deploy whatever commit is checked out

## References

- [GitHub Docs - workflow_run context](https://github.com/orgs/community/discussions/48857)