### PR TITLE
Dekaf: E2E tests for group management APIs

### DIFF
--- a/crates/dekaf/tests/e2e/collection_reset.rs
+++ b/crates/dekaf/tests/e2e/collection_reset.rs
@@ -5,6 +5,7 @@ use super::{
         list_offsets_partition_error, metadata_leader_epoch, offset_for_epoch_result,
     },
 };
+use crate::raw_kafka::{offset_commit_partition_error, offset_fetch_partition_result};
 use anyhow::Context;
 use kafka_protocol::ResponseError;
 use serde_json::json;
@@ -657,6 +658,71 @@ async fn test_fetch_response_includes_leader_epoch() -> anyhow::Result<()> {
         "high_watermark should be > 0 after injecting documents, got {}",
         partition.high_watermark
     );
+
+    Ok(())
+}
+
+/// Commit offset, reset collection. OffsetFetch should NOT return the old offset
+#[tokio::test]
+async fn test_offset_isolation_after_reset() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("or_epoch_fetch", FIXTURE).await?;
+
+    env.inject_documents("data", vec![json!({"id": "doc1", "value": "test"})])
+        .await?;
+
+    let info = env.connection_info();
+    let token = env.dekaf_token()?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+    let commit_offset = 1i64;
+
+    let initial_epoch = get_leader_epoch(&env, "test_topic", 0).await?;
+
+    // Commit an offset and verify it is visible before reset.
+    {
+        let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+        let commit_resp = client
+            .offset_commit(&group_id, "test_topic", &[(0, commit_offset)])
+            .await?;
+
+        let commit_error = offset_commit_partition_error(&commit_resp, "test_topic", 0);
+        assert_eq!(commit_error, Some(0), "commit should succeed");
+
+        let fetch_resp = client.offset_fetch(&group_id, "test_topic", &[0]).await?;
+        let result = offset_fetch_partition_result(&fetch_resp, "test_topic", 0)
+            .expect("response should include requested topic and partition");
+
+        assert_eq!(result.error_code, 0, "fetch should succeed");
+        assert_eq!(result.committed_offset, commit_offset);
+        assert_eq!(
+            result.committed_leader_epoch, initial_epoch,
+            "committed_leader_epoch should match initial epoch"
+        );
+    }
+
+    // Perform collection reset
+    perform_collection_reset(&env, "test_topic", 0, initial_epoch, EPOCH_CHANGE_TIMEOUT).await?;
+
+    // OffsetFetch after reset should NOT return the old offset
+    {
+        let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+        let fetch_resp = client.offset_fetch(&group_id, "test_topic", &[0]).await?;
+        let result = offset_fetch_partition_result(&fetch_resp, "test_topic", 0)
+            .expect("response should include requested topic and partition");
+
+        assert_eq!(result.error_code, 0, "fetch should succeed");
+        assert_eq!(
+            result.committed_offset, -1,
+            "offset should not be found after reset (epoch isolation)"
+        );
+        assert_eq!(
+            result.committed_leader_epoch, -1,
+            "no committed epoch when offset not found"
+        );
+    }
 
     Ok(())
 }

--- a/crates/dekaf/tests/e2e/consumer_group.rs
+++ b/crates/dekaf/tests/e2e/consumer_group.rs
@@ -1,0 +1,170 @@
+use super::DekafTestEnv;
+use crate::raw_kafka::{
+    TestKafkaClient, offset_commit_partition_error, offset_fetch_partition_result,
+};
+use serde_json::json;
+
+const FIXTURE: &str = include_str!("fixtures/basic.flow.yaml");
+
+/// Consume messages and commit an offset. Verify the committed offset is readable,
+/// and that a new consumer with the same group.id resumes from that position.
+#[tokio::test]
+async fn test_offset_commit_and_resume() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("cg_commit_resume", FIXTURE).await?;
+
+    env.inject_documents(
+        "data",
+        vec![
+            json!({"id": "first", "value": "1"}),
+            json!({"id": "second", "value": "2"}),
+        ],
+    )
+    .await?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+
+    // First consumer: consume, commit, and read back committed offset
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id)?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch().await?;
+        assert_eq!(records.len(), 2, "first consumer should see all messages");
+
+        // Commit offset after the last record (offset + 1 is next to read)
+        let last_record = records.last().unwrap();
+        let offset = last_record.offset + 1;
+        consumer.commit_offset("test_topic", last_record.partition, offset)?;
+
+        let readback = consumer.committed_offset("test_topic", last_record.partition)?;
+        assert_eq!(readback, Some(offset), "committed offset should match");
+        offset
+    };
+
+    // Inject more data
+    env.inject_documents("data", vec![json!({"id": "third", "value": "3"})])
+        .await?;
+
+    // Second consumer with same group: should resume from committed position
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id)?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch().await?;
+        assert_eq!(
+            records.len(),
+            1,
+            "second consumer should only see new message"
+        );
+        assert_eq!(records[0].value["id"], "third");
+    }
+
+    Ok(())
+}
+
+/// Query metadata for a topic that doesn't exist in the materialization.
+/// Dekaf should return UnknownTopicOrPartition error code.
+#[tokio::test]
+async fn test_unknown_topic_returns_error() -> anyhow::Result<()> {
+    use kafka_protocol::ResponseError;
+
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("cg_unknown_topic", FIXTURE).await?;
+    let info = env.connection_info();
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    // Request metadata for a topic that doesn't exist in the materialization
+    let metadata = client.metadata(&["nonexistent_topic"]).await?;
+
+    let topic = metadata
+        .topics
+        .iter()
+        .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some("nonexistent_topic"))
+        .expect("response should include requested topic");
+
+    assert_eq!(
+        topic.error_code,
+        ResponseError::UnknownTopicOrPartition.code(),
+        "unknown topic should return UnknownTopicOrPartition error"
+    );
+    assert!(
+        topic.partitions.is_empty(),
+        "unknown topic should have no partitions"
+    );
+
+    Ok(())
+}
+/// OffsetFetch for a group that never committed returns committed_offset = -1
+/// and committed_leader_epoch = -1.
+#[tokio::test]
+async fn test_offset_fetch_no_committed_offset() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("om_no_commit", FIXTURE).await?;
+
+    env.inject_documents("data", vec![json!({"id": "doc1", "value": "test"})])
+        .await?;
+
+    let info = env.connection_info();
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    // Use a group that has never committed
+    let group_id = format!("never-committed-{}", uuid::Uuid::new_v4());
+
+    let fetch_resp = client.offset_fetch(&group_id, "test_topic", &[0]).await?;
+
+    let result =
+        offset_fetch_partition_result(&fetch_resp, "test_topic", 0).expect("should have result");
+
+    assert_eq!(result.error_code, 0, "fetch should succeed");
+    assert_eq!(
+        result.committed_offset, -1,
+        "committed_offset should be -1 for never-committed group"
+    );
+    assert_eq!(
+        result.committed_leader_epoch, -1,
+        "committed_leader_epoch should be -1 for never-committed group"
+    );
+
+    Ok(())
+}
+
+/// OffsetCommit for a topic not in the materialization returns UnknownTopicOrPartition.
+#[tokio::test]
+async fn test_offset_commit_unknown_topic() -> anyhow::Result<()> {
+    use kafka_protocol::ResponseError;
+
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("om_unknown_topic", FIXTURE).await?;
+
+    let info = env.connection_info();
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+
+    // Try to commit to a topic that doesn't exist
+    let commit_resp = client
+        .offset_commit(&group_id, "nonexistent_topic", &[(0, 100)])
+        .await?;
+
+    let error = offset_commit_partition_error(&commit_resp, "nonexistent_topic", 0)
+        .expect("response should include requested topic and partition");
+
+    assert_eq!(
+        error,
+        ResponseError::UnknownTopicOrPartition.code(),
+        "commit to unknown topic should return UnknownTopicOrPartition"
+    );
+
+    Ok(())
+}

--- a/crates/dekaf/tests/e2e/harness.rs
+++ b/crates/dekaf/tests/e2e/harness.rs
@@ -311,14 +311,12 @@ impl DekafTestEnv {
         ))
     }
 
-    pub async fn kafka_consumer_with_group_id(
+    /// Create a high-level consumer connected to Dekaf with a specific group ID.
+    pub fn kafka_consumer_with_group_id(
         &self,
-        dataplane: &str,
         group_id: &str,
     ) -> anyhow::Result<super::kafka::KafkaConsumer> {
-        let username = self.materialization_name().unwrap_or_default();
-        let collections = self.collection_names().map(String::from).collect();
-        let info = connection_info_for_dataplane(dataplane, username, collections).await?;
+        let info = self.connection_info();
         let token = self.dekaf_token()?;
         Ok(super::kafka::KafkaConsumer::with_group_id(
             &info.broker,

--- a/crates/dekaf/tests/e2e/kafka.rs
+++ b/crates/dekaf/tests/e2e/kafka.rs
@@ -2,7 +2,8 @@ use anyhow::Context;
 use futures::StreamExt;
 use rdkafka::Message;
 use rdkafka::config::RDKafkaLogLevel;
-use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use schema_registry_converter::async_impl::avro::AvroDecoder;
 use schema_registry_converter::async_impl::schema_registry::SrSettings;
 use std::time::Duration;
@@ -157,5 +158,38 @@ impl KafkaConsumer {
     /// Get the inner consumer for advanced operations.
     pub fn inner(&self) -> &StreamConsumer {
         &self.consumer
+    }
+
+    /// Commit a specific offset for a topic/partition.
+    pub fn commit_offset(&self, topic: &str, partition: i32, offset: i64) -> anyhow::Result<()> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(topic, partition, Offset::Offset(offset))
+            .context("failed to add partition offset")?;
+        self.consumer
+            .commit(&tpl, CommitMode::Sync)
+            .context("failed to commit offset")
+    }
+
+    /// Get the committed offset for a topic/partition.
+    /// Returns None if no offset has been committed.
+    pub fn committed_offset(&self, topic: &str, partition: i32) -> anyhow::Result<Option<i64>> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition(topic, partition);
+
+        let committed = self
+            .consumer
+            .committed_offsets(tpl, Duration::from_secs(10))
+            .context("failed to fetch committed offsets")?;
+
+        let offset =
+            committed
+                .find_partition(topic, partition)
+                .and_then(|elem| match elem.offset() {
+                    Offset::Offset(o) => Some(o),
+                    Offset::Invalid => None,
+                    _ => None,
+                });
+
+        Ok(offset)
     }
 }

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -5,6 +5,7 @@ pub mod raw_kafka;
 mod auth;
 mod basic;
 mod collection_reset;
+mod consumer_group;
 mod empty_fetch;
 mod list_offsets;
 mod migration;


### PR DESCRIPTION
This PR adds to the Dekaf e2e test suite to cover consumer group management behavior and its interactions with leader epochs and collection resets.


- Add consumer-group behavior coverage:
  - Commit and resume with a stable `group.id` (rdkafka), including committed-offset readback
  - `Metadata` and `OffsetCommit` error mapping for unknown topics (`UnknownTopicOrPartition`)
  - `OffsetFetch` behavior for never-committed groups (committed_offset = -1, committed_leader_epoch = -1)
- Collection reset behavior:
  - After a collection reset, OffsetFetch does not return offsets committed under the prior epoch