### PR TITLE
json: validate all occurrences of duplicate object properties

### DIFF
--- a/crates/doc/src/validation.rs
+++ b/crates/doc/src/validation.rs
@@ -174,3 +174,159 @@ pub fn error_filter<'s>(outcome: Outcome<'s>) -> Option<Outcome<'s>> {
         _ => Some(outcome),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::HeapNode;
+
+    #[test]
+    fn test_duplicate_properties() {
+        // HeapNode preserves duplicate properties (unlike serde_json::Value).
+        // This tests that each occurrence of a duplicate property is validated.
+        // We test this functionality here to avoid introducing `doc` as a
+        // dev-dependency of the `json` crate.
+
+        struct Case {
+            name: &'static str,
+            doc: &'static str,
+            schema: serde_json::Value,
+            expect_valid: bool,
+            expect_type_errors: usize,
+            expect_missing_errors: usize,
+        }
+
+        let cases = [
+            Case {
+                name: "both duplicates valid",
+                doc: r#"{"foo": "a", "foo": "b"}"#,
+                schema: serde_json::json!({"properties": {"foo": {"type": "string"}}}),
+                expect_valid: true,
+                expect_type_errors: 0,
+                expect_missing_errors: 0,
+            },
+            Case {
+                name: "one duplicate invalid",
+                doc: r#"{"foo": "a", "foo": 42}"#,
+                schema: serde_json::json!({"properties": {"foo": {"type": "string"}}}),
+                expect_valid: false,
+                expect_type_errors: 1,
+                expect_missing_errors: 0,
+            },
+            Case {
+                name: "both duplicates invalid",
+                doc: r#"{"foo": 42, "foo": 99}"#,
+                schema: serde_json::json!({"properties": {"foo": {"type": "string"}}}),
+                expect_valid: false,
+                expect_type_errors: 2,
+                expect_missing_errors: 0,
+            },
+            Case {
+                name: "required with duplicates present (both invalid type)",
+                doc: r#"{"foo": 1, "foo": 2}"#,
+                schema: serde_json::json!({
+                    "properties": {"foo": {"type": "string"}},
+                    "required": ["foo"]
+                }),
+                expect_valid: false,
+                expect_type_errors: 2,
+                expect_missing_errors: 0, // foo IS present, just wrong type
+            },
+            Case {
+                name: "missing required after duplicates",
+                doc: r#"{"aaa": 1, "aaa": 2, "zzz": 3}"#,
+                schema: serde_json::json!({
+                    "properties": {
+                        "aaa": {"type": "integer"},
+                        "missing": {"type": "integer"}
+                    },
+                    "required": ["missing"]
+                }),
+                expect_valid: false,
+                expect_type_errors: 0,
+                expect_missing_errors: 1,
+            },
+            Case {
+                name: "three duplicates all invalid",
+                doc: r#"{"foo": 1, "foo": 2, "foo": 3}"#,
+                schema: serde_json::json!({"properties": {"foo": {"type": "string"}}}),
+                expect_valid: false,
+                expect_type_errors: 3,
+                expect_missing_errors: 0,
+            },
+            Case {
+                name: "multiple properties each with duplicates",
+                doc: r#"{"aaa": 1, "aaa": 2, "bbb": 3, "bbb": 4}"#,
+                schema: serde_json::json!({
+                    "properties": {
+                        "aaa": {"type": "string"},
+                        "bbb": {"type": "string"}
+                    }
+                }),
+                expect_valid: false,
+                expect_type_errors: 4,
+                expect_missing_errors: 0,
+            },
+            Case {
+                name: "duplicates not matching any schema property",
+                doc: r#"{"unknown": 1, "unknown": 2}"#,
+                schema: serde_json::json!({"properties": {"other": {"type": "integer"}}}),
+                expect_valid: true, // additionalProperties defaults to true
+                expect_type_errors: 0,
+                expect_missing_errors: 0,
+            },
+        ];
+
+        for case in cases {
+            // Parse doc as HeapNode to preserve duplicates
+            let alloc = HeapNode::new_allocator();
+            let mut de = serde_json::Deserializer::from_str(case.doc);
+            let heap_doc = HeapNode::from_serde(&mut de, &alloc)
+                .unwrap_or_else(|e| panic!("{}: failed to parse doc: {}", case.name, e));
+
+            let schema = json::schema::build::build_schema::<crate::Annotation>(
+                &url::Url::parse("https://example.com/test.json").unwrap(),
+                &case.schema,
+            )
+            .unwrap_or_else(|e| panic!("{}: failed to build schema: {:?}", case.name, e));
+
+            let mut builder = json::schema::index::Builder::new();
+            builder.add(&schema).unwrap();
+            builder.verify_references().unwrap();
+            let index = builder.into_index();
+
+            let mut validator = json::Validator::new(&index);
+            let (valid, outcomes) = validator.validate(&schema, &heap_doc, |o| Some(o));
+
+            assert_eq!(
+                valid, case.expect_valid,
+                "{}: expected valid={}, got valid={}\noutcomes: {:?}",
+                case.name, case.expect_valid, valid, outcomes
+            );
+
+            let type_errors = outcomes
+                .iter()
+                .filter(|o| matches!(o.outcome, json::validator::Outcome::TypeNotMet(_)))
+                .count();
+            assert_eq!(
+                type_errors, case.expect_type_errors,
+                "{}: expected {} type errors, got {}\noutcomes: {:?}",
+                case.name, case.expect_type_errors, type_errors, outcomes
+            );
+
+            let missing_errors = outcomes
+                .iter()
+                .filter(|o| {
+                    matches!(
+                        o.outcome,
+                        json::validator::Outcome::MissingRequiredProperty(_)
+                    )
+                })
+                .count();
+            assert_eq!(
+                missing_errors, case.expect_missing_errors,
+                "{}: expected {} missing errors, got {}\noutcomes: {:?}",
+                case.name, case.expect_missing_errors, missing_errors, outcomes
+            );
+        }
+    }
+}


### PR DESCRIPTION
Previously, when a document had duplicate property names (e.g., `{"foo": 1, "foo": 2}`), only the first occurrence was validated against the schema's `properties.foo`. Subsequent duplicates were treated as additional/unevaluated properties.

Fix by using a peekable iterator to look ahead at the next property. The counter is only incremented when processing the last occurrence of a duplicate, allowing all occurrences to match against the same schema property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Notes for reviewers:**

Confirmed that local repro of production schema validation is resolved with this change.
