### PR TITLE
gazette/journal: read gzip with multiple members

### DIFF
--- a/crates/gazette/src/journal/read.rs
+++ b/crates/gazette/src/journal/read.rs
@@ -175,7 +175,8 @@ async fn read_fragment_url(
             read_fragment_url_body(co, fragment, raw_reader, req).await
         }
         broker::CompressionCodec::Gzip => {
-            let decoder = async_compression::futures::bufread::GzipDecoder::new(raw_reader);
+            let mut decoder = async_compression::futures::bufread::GzipDecoder::new(raw_reader);
+            decoder.multiple_members(true);
             read_fragment_url_body(co, fragment, decoder, req).await
         }
         broker::CompressionCodec::Zstandard => {


### PR DESCRIPTION
**Description:**

Support reading gzip files with multiple members in the Gazette journal reader.

Required for the gzip files that will be written by Gazette after https://github.com/gazette/core/pull/455 is deployed. Right now this rust journal reader is used by `flowctl` via `collections read` etc.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

