### PR TITLE
docs: Add error handling and retry guidance for HTTP Ingest connector

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/http-ingest.md
+++ b/site/docs/reference/Connectors/capture-connectors/http-ingest.md
@@ -134,7 +134,7 @@ The HTTP Ingest connector validates all request data against the collection's wr
 
 The connector may occasionally return responses with HTTP 5XX status codes. This most commonly happens when the connector restarts, typically in response to a publication of the capture. These restarts are infrequent and quick (usually less than 5 seconds).
 
-To reliably capture webhook data, the sender must retry any requests that fail with a 5XX status. Many third-party webhook senders handle retries automatically, but there are some exceptions, such as GitHub. When retrying failed webhook requests, we strongly recommend using exponential backoff with random jitter.
+To reliably capture webhook data, the sender must retry any requests that fail with a 5XX status. Many third-party webhook senders handle retries automatically, but there are some exceptions, such as [GitHub](https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries). When retrying failed webhook requests, we strongly recommend using exponential backoff with random jitter.
 
 **Recommended retry strategy:**
 


### PR DESCRIPTION
## Summary

- Adds new "Handling errors and retries" section to HTTP Ingest connector docs
- Documents HTTP 400 responses for schema validation failures
- Documents HTTP 5XX responses during connector restarts (infrequent, typically <5 seconds)
- Provides recommended retry strategy with exponential backoff

## Context

This addresses a recurring customer question about occasional 500 errors during connector restarts. Recent example: https://estuary-dev.slack.com/archives/C06R0CVD0KZ/p1768528893641379

## Test plan

- [ ] Verify docs render correctly in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)