### PR TITLE
iam-auth: allow setting iam azure scope in connector spec

### DIFF
--- a/crates/iam-auth/src/config.rs
+++ b/crates/iam-auth/src/config.rs
@@ -28,6 +28,10 @@ pub struct GCPConfig {
 pub struct AzureConfig {
     pub azure_client_id: String,
     pub azure_tenant_id: String,
+
+    /// Scope is set in the connector spec.
+    #[serde(skip)]
+    pub azure_scope: Option<String>,
 }
 
 impl IAMAuthConfig {

--- a/crates/iam-auth/src/lib.rs
+++ b/crates/iam-auth/src/lib.rs
@@ -5,5 +5,5 @@ pub mod tokens;
 
 // Re-export main types and functions for convenient access
 pub use config::{AWSConfig, AzureConfig, GCPConfig, IAMAuthConfig};
-pub use schema::{extract_iam_auth_from_connector_config, has_credentials_iam_auth_annotation};
+pub use schema::extract_iam_auth_from_connector_config;
 pub use tokens::{AWSTokens, AzureTokens, GCPTokens, IAMTokens};

--- a/crates/iam-auth/src/providers/azure.rs
+++ b/crates/iam-auth/src/providers/azure.rs
@@ -18,6 +18,7 @@ pub async fn generate_tokens(config: &AzureConfig, task_name: &str) -> anyhow::R
         &signed_jwt,
         &config.azure_tenant_id,
         &config.azure_client_id,
+        config.azure_scope.as_deref(),
     )
     .await?;
 
@@ -31,6 +32,7 @@ async fn exchange_azure_jwt_for_app_registration_token(
     jwt_token: &str,
     tenant_id: &str,
     target_client_id: &str,
+    scope: Option<&str>,
 ) -> anyhow::Result<String> {
     use reqwest::header::CONTENT_TYPE;
     use std::collections::HashMap;
@@ -45,7 +47,10 @@ async fn exchange_azure_jwt_for_app_registration_token(
     );
     params.insert("client_assertion", jwt_token);
     params.insert("client_id", target_client_id);
-    params.insert("scope", "https://graph.microsoft.com/.default");
+    params.insert(
+        "scope",
+        scope.unwrap_or("https://graph.microsoft.com/.default"),
+    );
 
     let response = client
         .post(&format!(


### PR DESCRIPTION
**Description:**

In Azure, the scope for the IAM token needs to match the service API that will be used.  In the past, we always used the graph.microsoft.com scope, but services such as Azure SQL require a different scope.  With this change, the connector can specify the scope it needs in the connector spec.

**Workflow steps:**

A connector author sets the `x-iam-azure-scope` annotation in the /credentials section of the connect spec to the needed scope.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)