### PR TITLE
Docs: Update rollup for UI changes, Dekaf backfills, etc

### DIFF
--- a/site/docs/features/using-dekaf.md
+++ b/site/docs/features/using-dekaf.md
@@ -20,6 +20,7 @@ walk you through the steps to connect to Estuary using Dekaf and its schema regi
 - **Kafka Topic Emulation**: Access Estuary collections as if they were Kafka topics.
 - **Schema Registry Emulation**: Manage and retrieve schemas assigned to Estuary collections, emulating Confluent's
   Schema Registry.
+- **Backfill Support**: Estuary signals to downstream consumers when offsets need to be reset via Kafka leader epochs.
 
 ## Connection Details
 

--- a/site/docs/getting-started/deployment-options.md
+++ b/site/docs/getting-started/deployment-options.md
@@ -74,16 +74,3 @@ our [Slack channel](https://go.estuary.dev/slack) and send us a message!
 - **Cost savings**: Potential to reduce costs by using existing cloud infrastructure and negotiated pricing.
 - **Flexible data residency**: You choose where data is stored and processed, ensuring compliance with regional
   regulations.
-
-## Self-hosting Estuary
-
-The Estuary runtime is available under
-the [Business Source License](https://github.com/estuary/flow/blob/master/LICENSE-BSL). It's possible to self-host Estuary
-using a cloud provider of your choice.
-
-:::caution Beta
-Setup for self-hosting is not covered in this documentation, and full support is not guaranteed at this time.
-We recommend using the [hosted version of Estuary](../concepts/web-app.md) for the best experience.
-If you'd still like to self-host, refer to the [GitHub repository](https://github.com/estuary/flow) or
-the [Estuary Slack](https://join.slack.com/t/estuary-dev/shared_invite/zt-86nal6yr-VPbv~YfZE9Q~6Zl~gmZdFQ).
-:::

--- a/site/docs/getting-started/installation.mdx
+++ b/site/docs/getting-started/installation.mdx
@@ -57,15 +57,18 @@ You can find your available data planes and their authentication details from th
 2. Scroll down to the **Data Planes** table.
 
 3. Find your desired data plane by the **cloud provider** and **region** listing.
+Select it to open additional details about the data plane.
+
+4. Find the **Service Account Identity** field and choose between **AWS** or **GCP** depending on the location of your storage bucket.
 Copy its information for use when setting up your storage bucket permissions:
 
-   * For [GCS buckets](#google-cloud-storage-buckets), copy the **GCP Service Account Email**.
+   * For [GCS buckets](#google-cloud-storage-buckets), the service account identity is the **GCP Service Account Email**.
 
-   * For [S3 buckets](#amazon-s3-buckets), copy the **AWS IAM User ARN**.
+   * For [S3 buckets](#amazon-s3-buckets), the service account identity is the **AWS IAM User ARN**.
 
 :::tip
-When setting up storage, disregard the [CIDR Blocks](/reference/allow-ip-addresses) column of the Data Planes table.
-These IPs can be allowlisted for connectors.
+When setting up storage, disregard the data plane's listed IPs.
+These IPs can be allowlisted for _connectors_.
 
 Storage connected with public data planes should not limit access by IP.
 Storage for private data planes can use [PrivateLink](/private-byoc/privatelink) to restrict access.

--- a/site/docs/getting-started/pricing.md
+++ b/site/docs/getting-started/pricing.md
@@ -53,7 +53,7 @@ The saved payment method will be automatically charged at the end of each billin
 
 ## Estuary for Free
 
-Estuary includes several options for free data movement:
+Estuary includes options for free data movement:
 
 * **Free plan:**
    Use Estuary for free when working with one low-volume data pipeline.
@@ -68,7 +68,3 @@ Estuary includes several options for free data movement:
    Beyond free plan limits, you can trial Estuary using a public deployment for free for 30 days.
 
    If you are interested in trialing a private or BYOC deployment for a proof of concept, [contact us](https://estuary.dev/contact-us).
-
-* **Self hosting:**
-   The Estuary runtime has been made available with specific usage stipulations under the [Business Source License](https://github.com/estuary/flow/blob/master/LICENSE-BSL).
-   Setup and additional self-hosting support are currently not guaranteed and we recommend the hosted version of Estuary for the best experience.

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -40,11 +40,6 @@ To perform an incremental backfill:
 This option is ideal when you want to ensure your collections have the most up-to-date data without
 disrupting your destination systems.
 
-This includes [**Dekaf**](/reference/Connectors/materialization-connectors/Dekaf) materializations:
-because Dekaf simply provides a Kafka interface, the destination schema is managed via the connected service, such as ClickHouse or Tinybird, rather than Estuary.
-To ensure you don't disrupt your setup with these systems, you can use an incremental backfill.
-Using a dataflow reset may require you to manually update your schemas in the 3rd party system as on initial creation for these connectors.
-
 When you perform an incremental backfill, all data is pulled into collections again, and
 materializations that use those collections will read and process this data. How the data is handled
 at the destination depends on your materialization settings:
@@ -118,10 +113,6 @@ To perform a dataflow reset:
 
 This option is ideal when you need a complete refresh of your entire data pipeline, especially when
 you suspect data inconsistencies between source, collections, and destinations.
-
-:::warning
-If your source is connected to a [**Dekaf**](/reference/Connectors/materialization-connectors/Dekaf) materialization (including ClickHouse, Tinybird, StarTree, and more), consider using an **incremental backfill** instead of a dataflow reset to avoid schema mismatches.
-:::
 
 ### Backfill Selection
 

--- a/site/docs/guides/flowctl/ci-cd.md
+++ b/site/docs/guides/flowctl/ci-cd.md
@@ -447,7 +447,9 @@ You can copy the full name of your desired data plane from this listing or retri
 
 2. Choose between the **Public** or **Private** data plane tabs.
 
-3. Next to your desired data plane, click the **Copy** button. The full name of the data plane will be copied to your clipboard.
+3. Select your desired data plane to open further details.
+
+4. Click the **Copy** button next to the **Internal ID** field. The full name of the data plane will be copied to your clipboard.
 
 When publishing resources to a data plane besides the default, make sure to specify this data plane name in an option:
 

--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -22,8 +22,9 @@ To find the correct issuer value:
 2. Select the **Settings** tab.
 
 3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+Select your data plane to open additional configuration details.
 
-4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com`
+4. Copy the value from the **IAM OIDC** field. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com`
 
 For example, these are the issuer values for a few common public data planes:
 

--- a/site/docs/guides/iam-auth/azure.md
+++ b/site/docs/guides/iam-auth/azure.md
@@ -21,8 +21,9 @@ To find the correct issuer value:
 2. Select the **Settings** tab.
 
 3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+Select your data plane to open additional configuration details.
 
-4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
+4. Copy the value from the **IAM OIDC** field. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
 
 For example, these are the issuer values for a few common public data planes:
 

--- a/site/docs/guides/iam-auth/gcp.md
+++ b/site/docs/guides/iam-auth/gcp.md
@@ -25,8 +25,9 @@ To find the correct issuer value:
 2. Select the **Settings** tab.
 
 3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
+Select your data plane to open additional configuration details.
 
-4. Copy the value from the **IAM OIDC** column. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
+4. Copy the value from the **IAM OIDC** field. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
 
 For example, these are the issuer values for a few common public data planes:
 

--- a/site/docs/private-byoc/private-deployments.md
+++ b/site/docs/private-byoc/private-deployments.md
@@ -55,4 +55,4 @@ To find your private data plane's IP addresses and other information:
 
 4. You can toggle between your available private and public data planes.
 
-This table provides information on your private data plane's cloud, region, AWS IAM user ARN, GCP service account email, and CIDR blocks. The CIDR blocks field provides IPv4 and IPv6 (if applicable) addresses.
+5. Select your private data plane to open additional details and configuration, including the data plane's cloud, region, service account identities, and IP addresses.

--- a/site/docs/reference/Connectors/capture-connectors/iterable-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/iterable-native.md
@@ -1,8 +1,8 @@
 # Iterable
 
-This connector captures data from Iterable into Flow collections.
+This connector captures data from Iterable into Estuary collections.
 
-It is available for use in the Flow web application. For local development or open-source workflows, [`ghcr.io/estuary/source-iterable-native:dev`](https://ghcr.io/estuary/source-iterable-native:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
+It is available for use in the Estuary web application. For local development or open-source workflows, [`ghcr.io/estuary/source-iterable-native:dev`](https://ghcr.io/estuary/source-iterable-native:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
 ## Supported data resources
 
@@ -21,7 +21,7 @@ The following data resources are supported:
 | [templates](https://api.iterable.com/api/docs#templates_getTemplates) | Full Refresh |
 | [users](https://api.iterable.com/api/docs#export_startExport) | Incremental |
 
-By default, each resource is mapped to a Flow collection through a separate binding.
+By default, each resource is mapped to an Estuary collection through a separate binding.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ To set up the Iterable source connector, you'll need an Iterable [server-side AP
 
 ## Configuration
 
-You configure connectors either in the Flow web app, or by directly editing the catalog specification file.
+You configure connectors either in the Estuary web app, or by directly editing the catalog specification file.
 See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Iterable source connector.
 
 ### Properties

--- a/site/docs/reference/Connectors/capture-connectors/iterable.md
+++ b/site/docs/reference/Connectors/capture-connectors/iterable.md
@@ -5,6 +5,10 @@ This connector captures data from Iterable into Estuary collections.
 
 It is available for use in the Estuary web application. For local development or open-source workflows, [`ghcr.io/estuary/source-iterable:dev`](https://ghcr.io/estuary/source-iterable:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
+:::warning
+This connector is deprecated. For the best experience, we recommend using our native [Iterable connector](./iterable-native.md) instead.
+:::
+
 ## Supported data resources
 
 The following data resources are supported through the Iterable APIs:

--- a/site/docs/security/allow-ip-addresses.md
+++ b/site/docs/security/allow-ip-addresses.md
@@ -25,7 +25,10 @@ You can find the IP addresses relevant to your use case in the **Admin** section
 
    If you wish to use a public data plane, Estuary offers several options across US, EU, and APAC regions with AWS and GCP.
 
-3. Find the **CIDR Blocks** column in the Data Planes table. This column includes a comma-separated list of IP addresses for that data plane.
+3. Select your desired data plane from the table to open the **Details and Configuration modal**.
+
+4. The **IPs** field provides a comma-separated list of associated IP addresses. You can choose between **v4** and **v6** options.
+Click the clipboard to copy the addresses.
 
    Ensure that these IP addresses are allowlisted on both the source and destination systems that interact with Estuary.
 


### PR DESCRIPTION
**Description:**

Collection of small docs updates including:
* Update instructions around using the Data Planes table to match recent UI changes
* Remove language around Dekaf backfill limitations following Kafka leader epochs work
* Remove mentions of self-hosting as there was feedback that this adds confusion when we don't have docs or other resources to fully support this option
* Still some cleanup around standardizing product name

**Notes for reviewers:**

Thanks for reviewing!
