### PR TITLE
docs: source-stripe-native scheduled backfills and API limitations

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/stripe-realtime.md
+++ b/site/docs/reference/Connectors/capture-connectors/stripe-realtime.md
@@ -5,6 +5,31 @@ This connector captures data from [Stripe's API](https://docs.stripe.com/api) in
 It is available for use in the Estuary web application. For local development or open-source workflows, [`ghcr.io/estuary/source-stripe-native:dev`](https://ghcr.io/estuary/source-stripe-native:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
 
+## Data synchronization
+
+The Stripe connector uses a combination of real-time event streaming and periodic backfills to ensure data consistency. Most streams capture changes in real-time via Stripe's Events API, but some streams require scheduled backfills due to limitations in Stripe's event generation.
+
+### Streams requiring scheduled backfills
+
+The following streams are configured with daily scheduled backfills (at midnight UTC) to ensure eventual consistency:
+
+| Stream | Reason for Scheduled Backfill |
+|--------|-------------------------------|
+| **Accounts** | Stripe's event generation for accounts is inconsistent. While webhooks may receive `account.updated` events, the Events API endpoint may not reliably surface them. This stream uses the list endpoint directly for incremental capture. |
+| **Persons** | Events for person records may not consistently appear in Stripe's Events API. Persons are child records of connected accounts. |
+| **ExternalAccountCards** | Events for external account cards may not consistently appear in Stripe's Events API. These are child records accessed via connected account endpoints. |
+| **ExternalBankAccount** | Events for external bank accounts may not consistently appear in Stripe's Events API. These are child records accessed via connected account endpoints. |
+
+These scheduled backfills provide guaranteed eventual consistency by periodically re-querying the list endpoints, ensuring that no data is missed even if Stripe fails to generate corresponding events.
+
+### Stripe API limitations
+
+The connector handles several known limitations of the Stripe API:
+
+- **Inconsistent event generation**: Stripe's Events API may not surface events for certain resource types, even when corresponding webhooks are delivered. This particularly affects account-related resources.
+- **Connected account child streams**: Resources like Persons, ExternalAccountCards, and ExternalBankAccount must be queried through parent account endpoints (e.g., `/v1/accounts/{id}/persons`), requiring per-account queries when capturing connected accounts.
+- **Events API retention**: Stripe retains events for 30 days. While other resources can backfill beyond this window using their own list endpoints, the Events stream is limited to the most recent 30 days regardless of the configured `start_date`. The connector gracefully handles this by treating Stripe's retention expiry as a completed backfill.
+
 ## Supported data resources
 
 The following data resources are supported through the Stripe API:
@@ -57,6 +82,20 @@ By default, each resource is mapped to an Estuary collection through a separate 
 ### Connected Accounts
 
 This connector can capture data from Stripe Connected Accounts. To enable this feature, set the `capture_connected_accounts` property to `true` in your configuration. When enabled, each document will include an `account_id` field that identifies which account the data belongs to.
+
+#### How connected account capture works
+
+When `capture_connected_accounts` is enabled, the connector handles different streams in different ways:
+
+- **Accounts stream**: Always queries from the platform account using the `/v1/accounts` endpoint to list all connected accounts. This stream does not create per-account subtasks.
+- **Most other streams**: Create per-account subtasks that query each connected account's data using the `Stripe-Account` header to access account-specific resources.
+- **Child streams** (Persons, ExternalAccountCards, ExternalBankAccount): Query each connected account's child resources via parent endpoints (e.g., `/v1/accounts/{id}/persons`).
+
+This architecture ensures efficient data capture while respecting Stripe's API access patterns for connected accounts.
+
+#### Data consistency considerations
+
+For captures with many connected accounts, the connector uses a priority-based rotation system to fairly process accounts based on how recently they were synced. Combined with scheduled backfills for streams with unreliable event generation, this ensures eventual consistency across all connected accounts.
 
 ## Prerequisites
 


### PR DESCRIPTION
**Description:**

This pull request adds detailed documentation to the Stripe docs, focusing on how the connector achieves data consistency and handles Stripe API limitations, especially when capturing data from connected accounts. The updates clarify the connector's synchronization strategy and provide guidance for users working with complex account structures.

**Data synchronization and consistency improvements:**

* Added a new section describing the connector's hybrid approach: real-time event streaming is used for most streams, while daily scheduled backfills are configured for streams where Stripe's Events API is unreliable. This ensures eventual consistency for Accounts, Persons, ExternalAccountCards, and ExternalBankAccount streams.
* Documented known Stripe API limitations, such as inconsistent event generation, the need for per-account queries for child resources, and 30-day event retention. Also described how the connector uses a configurable `start_date` for initial backfill.

**Connected account capture architecture:**

* Added a section explaining how the connector captures data from Stripe Connected Accounts, including the use of the `capture_connected_accounts` property and the inclusion of `account_id` in captured documents.
* Detailed the capture strategy for connected accounts: the Accounts stream uses the platform account, most other streams create per-account subtasks, and child streams query resources via parent account endpoints.
* Explained the connector's priority-based rotation system for syncing many connected accounts, combined with scheduled backfills, to maintain data consistency.

PR for code changes: https://github.com/estuary/connectors/pull/3847

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

