### PR TITLE
dekaf: fix `OffsetFetch` during leader epoch migration

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -627,7 +627,7 @@ fn enc_resp<
 /// NOTE that the output of this function must be deterministic,
 /// that is: it cannot use a random nonce like you normally would
 /// when encrypting data.
-fn to_upstream_topic_name(
+pub fn to_upstream_topic_name(
     topic: TopicName,
     secret: String,
     nonce: String,

--- a/crates/dekaf/tests/e2e/consumer_group.rs
+++ b/crates/dekaf/tests/e2e/consumer_group.rs
@@ -1,0 +1,180 @@
+use super::DekafTestEnv;
+use crate::raw_kafka::{
+    TestKafkaClient, offset_commit_partition_error, offset_fetch_partition_result,
+};
+use serde_json::json;
+
+const FIXTURE: &str = include_str!("fixtures/basic.flow.yaml");
+
+/// Consume messages and commit an offset. Verify the committed offset is readable,
+/// and that a new consumer with the same group.id resumes from that position.
+#[tokio::test]
+async fn test_offset_commit_and_resume() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("cg_commit_resume", FIXTURE).await?;
+
+    env.inject_documents(
+        "data",
+        vec![
+            json!({"id": "first", "value": "1"}),
+            json!({"id": "second", "value": "2"}),
+        ],
+    )
+    .await?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+
+    // First consumer: consume, commit, and read back committed offset
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch().await?;
+        assert_eq!(records.len(), 2, "first consumer should see all messages");
+
+        // Commit offset after the last record (offset + 1 is next to read)
+        let last_record = records.last().unwrap();
+        let offset = last_record.offset + 1;
+        consumer.commit_offset("test_topic", last_record.partition, offset)?;
+    };
+
+    // Inject more data
+    env.inject_documents("data", vec![json!({"id": "third", "value": "3"})])
+        .await?;
+
+    // Second consumer with same group: should resume from committed position
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch().await?;
+        assert_eq!(
+            records.len(),
+            1,
+            "second consumer should only see new message"
+        );
+        assert_eq!(records[0].value["id"], "third");
+    }
+
+    Ok(())
+}
+
+/// Unknown topics should return UnknownTopicOrPartition across APIs.
+#[tokio::test]
+async fn test_unknown_topic_errors() -> anyhow::Result<()> {
+    use kafka_protocol::ResponseError;
+
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("cg_unknown_topic", FIXTURE).await?;
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    // Request metadata for a topic that doesn't exist in the materialization
+    let metadata = client.metadata(&["nonexistent_topic"]).await?;
+
+    let topic = metadata
+        .topics
+        .iter()
+        .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some("nonexistent_topic"))
+        .expect("response should include requested topic");
+
+    assert_eq!(
+        topic.error_code,
+        ResponseError::UnknownTopicOrPartition.code(),
+        "unknown topic should return UnknownTopicOrPartition error"
+    );
+    assert!(
+        topic.partitions.is_empty(),
+        "unknown topic should have no partitions"
+    );
+
+    // Try to commit to a topic that doesn't exist
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+    let commit_resp = client
+        .offset_commit(&group_id, "nonexistent_topic", &[(0, 100)])
+        .await?;
+
+    let error = offset_commit_partition_error(&commit_resp, "nonexistent_topic", 0)
+        .expect("response should include requested topic and partition");
+
+    assert_eq!(
+        error,
+        ResponseError::UnknownTopicOrPartition.code(),
+        "commit to unknown topic should return UnknownTopicOrPartition"
+    );
+
+    Ok(())
+}
+/// OffsetFetch for a group that never committed returns committed_offset = -1
+/// and committed_leader_epoch = -1.
+#[tokio::test]
+async fn test_offset_fetch_no_committed_offset() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("om_no_commit", FIXTURE).await?;
+
+    env.inject_documents("data", vec![json!({"id": "doc1", "value": "test"})])
+        .await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    // Use a group that has never committed
+    let group_id = format!("never-committed-{}", uuid::Uuid::new_v4());
+
+    let fetch_resp = client.offset_fetch(&group_id, "test_topic", &[0]).await?;
+
+    let result =
+        offset_fetch_partition_result(&fetch_resp, "test_topic", 0).expect("should have result");
+
+    assert_eq!(result.error_code, 0, "fetch should succeed");
+    assert_eq!(
+        result.committed_offset, -1,
+        "committed_offset should be -1 for never-committed group"
+    );
+    assert_eq!(
+        result.committed_leader_epoch, -1,
+        "committed_leader_epoch should be -1 for never-committed group"
+    );
+
+    Ok(())
+}
+
+/// OffsetCommit for a topic not in the materialization returns UnknownTopicOrPartition.
+#[tokio::test]
+async fn test_offset_commit_unknown_topic() -> anyhow::Result<()> {
+    use kafka_protocol::ResponseError;
+
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("om_unknown_topic", FIXTURE).await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+
+    // Try to commit to a topic that doesn't exist
+    let commit_resp = client
+        .offset_commit(&group_id, "nonexistent_topic", &[(0, 100)])
+        .await?;
+
+    let error = offset_commit_partition_error(&commit_resp, "nonexistent_topic", 0)
+        .expect("response should include requested topic and partition");
+
+    assert_eq!(
+        error,
+        ResponseError::UnknownTopicOrPartition.code(),
+        "commit to unknown topic should return UnknownTopicOrPartition"
+    );
+
+    Ok(())
+}

--- a/crates/dekaf/tests/e2e/consumer_group.rs
+++ b/crates/dekaf/tests/e2e/consumer_group.rs
@@ -2,9 +2,12 @@ use super::DekafTestEnv;
 use crate::raw_kafka::{
     TestKafkaClient, offset_commit_partition_error, offset_fetch_partition_result,
 };
+use anyhow::Context;
+use kafka_protocol::{messages::GroupId, protocol::StrBytes};
 use serde_json::json;
 
 const FIXTURE: &str = include_str!("fixtures/basic.flow.yaml");
+const TWO_TOPICS_FIXTURE: &str = include_str!("fixtures/two_topics.flow.yaml");
 
 /// Consume messages and commit an offset. Verify the committed offset is readable,
 /// and that a new consumer with the same group.id resumes from that position.
@@ -146,34 +149,143 @@ async fn test_offset_fetch_no_committed_offset() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// OffsetCommit for a topic not in the materialization returns UnknownTopicOrPartition.
 #[tokio::test]
-async fn test_offset_commit_unknown_topic() -> anyhow::Result<()> {
-    use kafka_protocol::ResponseError;
-
+async fn test_offset_fetch_legacy_fallback() -> anyhow::Result<()> {
     super::init_tracing();
-
-    let env = DekafTestEnv::setup("om_unknown_topic", FIXTURE).await?;
+    let env = DekafTestEnv::setup("legacy_fallback", TWO_TOPICS_FIXTURE).await?;
+    use kafka_protocol::messages as m;
 
     let info = env.connection_info().await?;
     let token = env.dekaf_token()?;
 
-    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+    // Ensure both topics exist.
+    env.inject_documents("data_a", [json!({"id":"a"})]).await?;
+    env.inject_documents("data_b", [json!({"id":"b"})]).await?;
 
-    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+    // Determine the current epoch (binding backfill counter) from Dekaf.
+    let mut dekaf_probe = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+    let list = dekaf_probe
+        .list_offsets_with_epoch("topic_a", 0, -1, -1)
+        .await?;
+    let epoch = list
+        .topics
+        .iter()
+        .find(|t| t.name.as_str() == "topic_a")
+        .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
+        .context("expected ListOffsets response for topic_a partition 0")?
+        .leader_epoch;
+    let epoch_u32 = u32::try_from(epoch).context("epoch must be non-negative")?;
 
-    // Try to commit to a topic that doesn't exist
-    let commit_resp = client
-        .offset_commit(&group_id, "nonexistent_topic", &[(0, 100)])
+    // Build upstream topic names for legacy and epoch-qualified formats.
+    let secret = env.dekaf_encryption_secret()?;
+    let task_name = env
+        .materialization_name()
+        .context("fixture must include a materialization")?
+        .to_string();
+    use dekaf::to_upstream_topic_name;
+    use kafka_protocol::messages::TopicName;
+
+    let epoch_a = to_upstream_topic_name(
+        TopicName::from(StrBytes::from("topic_a")),
+        secret.clone(),
+        task_name.clone(),
+        Some(epoch_u32),
+    );
+    let legacy_b = to_upstream_topic_name(
+        TopicName::from(StrBytes::from("topic_b")),
+        secret.clone(),
+        // Legacy (non-epoch) topic names use the materialization config token as the nonce.
+        // See `Session::get_topic_name_nonce(false)` and `send_legacy_offset_cleanup`.
+        token.clone(),
+        None,
+    );
+
+    // Commit offsets to upstream in a partially-migrated state:
+    // - topic_a has an epoch-qualified committed offset
+    // - topic_b only has a legacy committed offset
+    let mut upstream = env.upstream_kafka_client().await?;
+
+    upstream
+        .ensure_topics(vec![(epoch_a.clone(), 1), (legacy_b.clone(), 1)])
+        .await
+        .context("failed to ensure upstream topics exist")?;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let group_id = GroupId(StrBytes::from_string(format!(
+        "legacy-cg-{}",
+        uuid::Uuid::new_v4()
+    )));
+
+    let commit_header = m::RequestHeader::default()
+        .with_request_api_key(m::ApiKey::OffsetCommit as i16)
+        .with_request_api_version(6);
+    let commit_one = |topic: &m::TopicName, offset: i64| {
+        m::OffsetCommitRequest::default()
+            .with_group_id(group_id.clone())
+            .with_generation_id_or_member_epoch(-1)
+            .with_member_id(StrBytes::from_static_str(""))
+            .with_topics(vec![
+                m::offset_commit_request::OffsetCommitRequestTopic::default()
+                    .with_name(topic.clone())
+                    .with_partitions(vec![
+                        m::offset_commit_request::OffsetCommitRequestPartition::default()
+                            .with_partition_index(0)
+                            .with_committed_offset(offset)
+                            .with_committed_leader_epoch(-1),
+                    ]),
+            ])
+    };
+    upstream
+        .send_request(commit_one(&epoch_a, 5), Some(commit_header.clone()))
+        .await?;
+    upstream
+        .send_request(commit_one(&legacy_b, 7), Some(commit_header.clone()))
         .await?;
 
-    let error = offset_commit_partition_error(&commit_resp, "nonexistent_topic", 0)
-        .expect("response should include requested topic and partition");
+    // Single OffsetFetch request for both topics.
+    let mut dekaf = dekaf::KafkaApiClient::connect(
+        &[format!("tcp://{}", info.broker)],
+        dekaf::KafkaClientAuth::plain(&info.username, &token),
+    )
+    .await?;
+    let fetch_req = m::OffsetFetchRequest::default()
+        .with_group_id(group_id.clone())
+        .with_topics(Some(vec![
+            m::offset_fetch_request::OffsetFetchRequestTopic::default()
+                .with_name(m::TopicName::from(StrBytes::from_string(
+                    "topic_a".to_string(),
+                )))
+                .with_partition_indexes(vec![0]),
+            m::offset_fetch_request::OffsetFetchRequestTopic::default()
+                .with_name(m::TopicName::from(StrBytes::from_string(
+                    "topic_b".to_string(),
+                )))
+                .with_partition_indexes(vec![0]),
+        ]));
+    let fetch_header = m::RequestHeader::default()
+        .with_request_api_key(m::ApiKey::OffsetFetch as i16)
+        .with_request_api_version(7);
 
+    let resp = dekaf.send_request(fetch_req, Some(fetch_header)).await?;
+    let offset_a = resp
+        .topics
+        .iter()
+        .find(|t| t.name.as_str() == "topic_a")
+        .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
+        .context("expected OffsetFetch response for topic_a")?
+        .committed_offset;
+    let offset_b = resp
+        .topics
+        .iter()
+        .find(|t| t.name.as_str() == "topic_b")
+        .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
+        .context("expected OffsetFetch response for topic_b")?
+        .committed_offset;
+
+    assert_eq!(offset_a, 5, "expected topic_a committed offset 5");
     assert_eq!(
-        error,
-        ResponseError::UnknownTopicOrPartition.code(),
-        "commit to unknown topic should return UnknownTopicOrPartition"
+        offset_b, 7,
+        "expected topic_b to fall back to legacy committed offset 7"
     );
 
     Ok(())

--- a/crates/dekaf/tests/e2e/fixtures/two_topics.flow.yaml
+++ b/crates/dekaf/tests/e2e/fixtures/two_topics.flow.yaml
@@ -1,0 +1,51 @@
+collections:
+    test_data_a:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+                value: { type: string }
+            required: [id]
+        key: [/id]
+
+    test_data_b:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+                value: { type: string }
+            required: [id]
+        key: [/id]
+
+captures:
+    source_ingest:
+        endpoint:
+            connector:
+                image: ghcr.io/estuary/source-http-ingest:dev
+                config:
+                    paths: ["/data_a", "/data_b"]
+        bindings:
+            - resource: { path: "/data_a", stream: "/data_a" }
+              target: test_data_a
+            - resource: { path: "/data_b", stream: "/data_b" }
+              target: test_data_b
+
+materializations:
+    dekaf_test:
+        endpoint:
+            dekaf:
+                variant: testing
+                config:
+                    token: "test-token-12345"
+                    strict_topic_names: false
+        bindings:
+            - source: test_data_a
+              resource: { topic_name: topic_a }
+              fields:
+                recommended: true
+                exclude: [flow_published_at]
+            - source: test_data_b
+              resource: { topic_name: topic_b }
+              fields:
+                recommended: true
+                exclude: [flow_published_at]

--- a/crates/dekaf/tests/e2e/harness.rs
+++ b/crates/dekaf/tests/e2e/harness.rs
@@ -311,14 +311,12 @@ impl DekafTestEnv {
         ))
     }
 
+    /// Create a high-level consumer connected to Dekaf with a specific group ID.
     pub async fn kafka_consumer_with_group_id(
         &self,
-        dataplane: &str,
         group_id: &str,
     ) -> anyhow::Result<super::kafka::KafkaConsumer> {
-        let username = self.materialization_name().unwrap_or_default();
-        let collections = self.collection_names().map(String::from).collect();
-        let info = connection_info_for_dataplane(dataplane, username, collections).await?;
+        let info = self.connection_info().await?;
         let token = self.dekaf_token()?;
         Ok(super::kafka::KafkaConsumer::with_group_id(
             &info.broker,

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -5,6 +5,7 @@ pub mod raw_kafka;
 mod auth;
 mod basic;
 mod collection_reset;
+mod consumer_group;
 mod empty_fetch;
 mod list_offsets;
 mod migration;

--- a/crates/dekaf/tests/e2e/migration.rs
+++ b/crates/dekaf/tests/e2e/migration.rs
@@ -54,9 +54,7 @@ async fn test_rdkafka_handles_redirect() -> anyhow::Result<()> {
 
     let group_id = format!("migration-group-{}", env.namespace.replace('/', "_"));
 
-    let consumer = env
-        .kafka_consumer_with_group_id("local-cluster", &group_id)
-        .await?;
+    let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
     consumer.subscribe(&["test_topic"])?;
 
     let records_before = consumer.fetch_n_with_commit(3).await?;
@@ -99,9 +97,7 @@ async fn test_rdkafka_handles_redirect() -> anyhow::Result<()> {
     .await?;
 
     // Create new consumer connected to local-cluster, should redirect automatically
-    let consumer = env
-        .kafka_consumer_with_group_id("local-cluster", &group_id)
-        .await?;
+    let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
     consumer.subscribe(&["test_topic"])?;
 
     let records_after = consumer.fetch_n_with_commit(3).await?;

--- a/mise/tasks/ci/dekaf-e2e
+++ b/mise/tasks/ci/dekaf-e2e
@@ -73,6 +73,8 @@ export DEKAF_BROKER="localhost:${DEKAF1_KAFKA_PORT}"
 export DEKAF_REGISTRY="http://localhost:$((DEKAF1_KAFKA_PORT + 1))"
 export SSL_CERT_FILE="${FLOW_LOCAL}/ca.crt"
 export FLOW_ACCESS_TOKEN="${SYSTEM_USER_TOKEN}"
+export DEKAF_UPSTREAM_BROKER_URLS="tcp://localhost:29092"
+export DEKAF_ENCRYPTION_SECRET="test-encryption-secret-32-bytes!"
 
 if [ "${DEBUG}" = "true" ]; then
     export RUST_LOG="debug"


### PR DESCRIPTION
## Problem

While canarying #2497, I noticed some unexpected consumer behavior that looked like a backfill. No backfills were triggered, so I started looking for a bug, and found this.

The context is that #2497 includes a migration that changes the way we map topic names into upstream Kafka topic names for the purposes of serving group management APIs. Specifically, we must now include the leader epoch (materialization binding backfill counter) as part of the topic name, as any committed offsets with one epoch are meaningless in the context of another. 

In order to avoid this exact problem of consumers needing to start over from the beginning, I implemented logic to fall back to the previous topic name mapping in the event that an `OffsetFetch` request found no committed offsets for the requested topic/partition. The bug is that these requests can contain multiple topic/partitions to fetch offsets for, and it would only fall back to looking up "legacy" offsets if _none_ of the requested topic/partitions come back using the new mapping. If even one does, then all the other topic/partitions that haven't been committed yet will show as `committed_offset=-1`, which causes the consumer to apply its `auto.offset.reset` logic and start over.

## Fix
In `crates/dekaf/src/session.rs`, refactored `Session::offset_fetch` to perform fallback fetching per requested topic. I feel like it's actually much easier to follow now as well.
- Query epoch-qualified offsets first.
- If any are missing (`error_code == 0` and `committed_offset == -1`), also query for offsets using the old topic name mapping.
- Merge responses together rather than being all-or-nothing

This prevents offsets from being reported as uncommitted if they haven't been committed yet under the new mapping and others have, avoiding the consumer reset behavior observed after the rollout.
## Tests
`crates/dekaf/tests/e2e/consumer_group.rs` updates `test_offset_fetch_legacy_fallback` with `crates/dekaf/tests/e2e/fixtures/two_topics.flow.yaml` to simulate partial migration, including directly interacting with the test Kafka broker to set up the proper scenario:
- `topic_a` has an epoch-qualified committed offset.
- `topic_b` has only a legacy committed offset.
- A single explicit-topics OffsetFetch must return both offsets.

Before the fix is applied, the test fails showing the unexpected committed offset of `-1`:
```
[ci:dekaf-e2e]  Nextest run ID aafd2f6d-abe1-4521-b8dd-38fe1fcbedd8 with nextest profile: dekaf-e2e
[ci:dekaf-e2e]     Starting 1 test across 1 binary (16 tests and 3 binaries skipped, including 3 binaries via profile.dekaf-e2e.default-filter)
[ci:dekaf-e2e]        START (1/1) dekaf::e2e consumer_group::test_offset_fetch_legacy_fallback
[ci:dekaf-e2e]
[ci:dekaf-e2e] running 1 test
[ci:dekaf-e2e] 2026-02-02T20:19:50.388500Z  INFO e2e::harness: Setting up test environment namespace=test/dekaf/legacy_fallback/d4e4
[ci:dekaf-e2e] 2026-02-02T20:19:54.450455Z  INFO e2e::harness: Publish succeeded
[ci:dekaf-e2e] 2026-02-02T20:19:54.450475Z  INFO e2e::harness: Waiting for shard to become primary task_name=test/dekaf/legacy_fallback/d4e4/source_ingest
[ci:dekaf-e2e]
[ci:dekaf-e2e] thread 'consumer_group::test_offset_fetch_legacy_fallback' (2684572) panicked at crates/dekaf/tests/e2e/consumer_group.rs:314:5:
[ci:dekaf-e2e] assertion `left == right` failed: expected topic_b to fall back to legacy committed offset 7
[ci:dekaf-e2e]   left: -1
[ci:dekaf-e2e]  right: 7
[ci:dekaf-e2e] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[ci:dekaf-e2e] test consumer_group::test_offset_fetch_legacy_fallback ... FAILED
[ci:dekaf-e2e]
[ci:dekaf-e2e] failures:
[ci:dekaf-e2e]
[ci:dekaf-e2e] failures:
[ci:dekaf-e2e]     consumer_group::test_offset_fetch_legacy_fallback
[ci:dekaf-e2e]
[ci:dekaf-e2e] test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 16 filtered out; finished in 18.54s
[ci:dekaf-e2e]
[ci:dekaf-e2e]         FAIL [  18.541s] (1/1) dekaf::e2e consumer_group::test_offset_fetch_legacy_fallback
[ci:dekaf-e2e]   Cancelling due to test failure:
[ci:dekaf-e2e] ────────────
[ci:dekaf-e2e]      Summary [  18.541s] 1 test run: 0 passed, 1 failed, 16 skipped
[ci:dekaf-e2e]         FAIL [  18.541s] (1/1) dekaf::e2e consumer_group::test_offset_fetch_legacy_fallback
[ci:dekaf-e2e] error: test run failed
```
---
**Note:** This branch also includes a couple more e2e tests for consumer group API behavior. I decided to roll #2597 into this PR to make reviewing easier:

- Add consumer-group behavior coverage:
  - Commit and resume with a stable `group.id` (rdkafka), including committed-offset readback
  - `Metadata` and `OffsetCommit` error mapping for unknown topics (`UnknownTopicOrPartition`)
  - `OffsetFetch` behavior for never-committed groups (committed_offset = -1, committed_leader_epoch = -1)
- Collection reset behavior:
  - After a collection reset, OffsetFetch does not return offsets committed under the prior epoch