### PR TITLE
Add GraphQL query for data-planes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__
 
 # OS generated files
 .DS_Store
+
+.claude/

--- a/.sqlx/query-f81979ab766a313baf27bb7b132e90e506c2b130dccd4496df39ac55dbbf0be0.json
+++ b/.sqlx/query-f81979ab766a313baf27bb7b132e90e506c2b130dccd4496df39ac55dbbf0be0.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n            dp.data_plane_name,\n            dp.cidr_blocks::text[] as \"cidr_blocks!: Vec<String>\",\n            dp.gcp_service_account_email,\n            dp.aws_iam_user_arn,\n            dp.azure_application_name,\n            dp.azure_application_client_id\n        from unnest($1::text[]) as input(name)\n        join data_planes dp on dp.data_plane_name = input.name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "data_plane_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "cidr_blocks!: Vec<String>",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 2,
+        "name": "gcp_service_account_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "aws_iam_user_arn",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "azure_application_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "azure_application_client_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f81979ab766a313baf27bb7b132e90e506c2b130dccd4496df39ac55dbbf0be0"
+}

--- a/crates/control-plane-api/src/fixtures/data_planes.sql
+++ b/crates/control-plane-api/src/fixtures/data_planes.sql
@@ -43,10 +43,15 @@ begin
     ops_l2_events_transform,
     ops_l2_inferred_transform,
     ops_l2_stats_transform,
-    enable_l2
+    enable_l2,
+    cidr_blocks,
+    aws_iam_user_arn,
+    gcp_service_account_email,
+    azure_application_name,
+    azure_application_client_id
   ) values (
     data_plane_one_id,
-    'ops/dp/public/one',
+    'ops/dp/public/aws-us-west-2-c1',
     'dp.one',
     '{}',
     encrypted_keys,
@@ -60,10 +65,15 @@ begin
     'from.dp.one',
     'from.dp.one',
     'from.dp.one',
-    true
+    true,
+    '{10.0.0.0/16,192.168.1.0/24}',
+    'arn:aws:iam::123456789:user/test',
+    'test-gcp-one@estuary-test.iam.gserviceaccount.com',
+    'estuary-test-app-one',
+    '11111111-1111-1111-1111-111111111111'
     ), (
       data_plane_two_id,
-      'ops/dp/public/two',
+      'ops/dp/public/gcp-us-central1-c2',
       'dp.two',
       '{}',
       encrypted_keys,
@@ -77,11 +87,16 @@ begin
       'from.dp.two',
       'from.dp.two',
       'from.dp.two',
-      true
+      true,
+      '{172.16.0.0/12}',
+      'arn:aws:iam::987654321:user/test',
+      'test-gcp-two@estuary-test.iam.gserviceaccount.com',
+      'estuary-test-app-two',
+      '22222222-2222-2222-2222-222222222222'
     ), (
     -- Here so we can assert that this gets filtered out during Snapshot refreshes
       defunct_data_plane_id,
-      'ops/dp/private/defunct',
+      'ops/dp/private/defunct/az-westeurope-c1',
       'dp.defunct',
       '{}',
       '{}',
@@ -95,7 +110,12 @@ begin
       'from.dp.defunct',
       'from.dp.defunct',
       'from.dp.defunct',
-      false
+      false,
+      '{192.168.0.0/16}',
+      'arn:aws:iam::111222333:user/test',
+      'test-gcp-defunct@estuary-test.iam.gserviceaccount.com',
+      'estuary-test-app-defunct',
+      '33333333-3333-3333-3333-333333333333'
     );
 
 end

--- a/crates/control-plane-api/src/server/authorize_user_prefix.rs
+++ b/crates/control-plane-api/src/server/authorize_user_prefix.rs
@@ -601,7 +601,7 @@ mod tests {
             client: server.rest_client(),
             user_tokens: user_tokens.clone(),
             prefix: models::Prefix::new("aliceCo/"),
-            data_plane: models::Name::new("ops/dp/public/one"),
+            data_plane: models::Name::new("ops/dp/public/aws-us-west-2-c1"),
             capability: models::Capability::Write,
         };
         let refresh = tokens::watch(source).ready_owned().await;
@@ -643,7 +643,7 @@ mod tests {
             client: server.rest_client(),
             user_tokens: user_tokens.clone(),
             prefix: models::Prefix::new("Some/Other/Prefix/"),
-            data_plane: models::Name::new("ops/dp/public/one"),
+            data_plane: models::Name::new("ops/dp/public/aws-us-west-2-c1"),
             capability: models::Capability::Write,
         };
         let refresh = tokens::watch(source).ready_owned().await;

--- a/crates/control-plane-api/src/server/create_data_plane.rs
+++ b/crates/control-plane-api/src/server/create_data_plane.rs
@@ -102,6 +102,14 @@ pub async fn create_data_plane(
     std::mem::drop(name); // Use `base_name` only.
 
     let data_plane_name = format!("ops/dp/{base_name}");
+
+    if super::public::graphql::parse_data_plane_name(&data_plane_name).is_none() {
+        return Err(tonic::Status::invalid_argument(format!(
+            "data plane name '{data_plane_name}' does not match the expected format (e.g., 'ops/dp/public/aws-us-east-1-c1')",
+        ))
+        .into());
+    }
+
     let ops_l1_inferred_name = format!("ops/rollups/L1/{base_name}/inferred-schemas");
     let ops_l1_stats_name = format!("ops/rollups/L1/{base_name}/catalog-stats");
     let ops_l1_events_name = format!("ops/rollups/L1/{base_name}/events");

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -1,0 +1,425 @@
+use async_graphql::{
+    Context, SimpleObject,
+    types::connection::{self, Connection},
+};
+use std::collections::HashMap;
+
+const DEFAULT_PAGE_SIZE: usize = 50;
+
+/// Cloud provider where the data plane is hosted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, async_graphql::Enum)]
+pub enum DataPlaneCloudProvider {
+    Aws,
+    Azure,
+    Gcp,
+    Local,
+}
+
+/// A data plane where tasks execute and collections are stored.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct DataPlane {
+    /// Name of this data-plane under the catalog namespace.
+    pub data_plane_name: String,
+    /// Fully-qualified domain name of this data-plane.
+    pub data_plane_fqdn: String,
+    /// Address of reactors within the data-plane.
+    pub reactor_address: String,
+    /// The current user's capability to this data plane's name prefix.
+    pub user_capability: models::Capability,
+    /// Cloud provider where this data-plane is hosted.
+    pub cloud_provider: DataPlaneCloudProvider,
+    /// Cloud region where this data-plane is hosted.
+    /// For example: "us-east-1" (AWS), "us-central1" (GCP), "eastus" (Azure).
+    pub region: String,
+    /// Tag (cluster) identifier within the region.
+    pub tag: String,
+    /// Whether this is a public data-plane.
+    pub is_public: bool,
+    /// CIDR blocks for this data-plane.
+    pub cidr_blocks: Vec<String>,
+    /// GCP service account email for this data-plane.
+    pub gcp_service_account_email: Option<String>,
+    /// AWS IAM user ARN for this data-plane.
+    pub aws_iam_user_arn: Option<String>,
+    /// Azure application name for this data-plane.
+    pub azure_application_name: Option<String>,
+    /// Azure application client ID for this data-plane.
+    pub azure_application_client_id: Option<String>,
+}
+
+/// Fetches detail fields for the given data plane names from the database.
+/// Returns a map from data_plane_name to its detail fields.
+async fn fetch_data_plane_details(
+    pg_pool: &sqlx::PgPool,
+    names: &[String],
+) -> async_graphql::Result<HashMap<String, DataPlaneDetails>> {
+    tracing::debug!(count = names.len(), "loading data_plane details");
+
+    let names_ref: Vec<&str> = names.iter().map(String::as_str).collect();
+
+    let rows = sqlx::query!(
+        r#"select
+            dp.data_plane_name,
+            dp.cidr_blocks::text[] as "cidr_blocks!: Vec<String>",
+            dp.gcp_service_account_email,
+            dp.aws_iam_user_arn,
+            dp.azure_application_name,
+            dp.azure_application_client_id
+        from unnest($1::text[]) as input(name)
+        join data_planes dp on dp.data_plane_name = input.name
+        "#,
+        &names_ref as &[&str],
+    )
+    .fetch_all(pg_pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.data_plane_name,
+                DataPlaneDetails {
+                    cidr_blocks: row.cidr_blocks,
+                    gcp_service_account_email: row.gcp_service_account_email,
+                    aws_iam_user_arn: row.aws_iam_user_arn,
+                    azure_application_name: row.azure_application_name,
+                    azure_application_client_id: row.azure_application_client_id,
+                },
+            )
+        })
+        .collect())
+}
+
+struct DataPlaneDetails {
+    cidr_blocks: Vec<String>,
+    gcp_service_account_email: Option<String>,
+    aws_iam_user_arn: Option<String>,
+    azure_application_name: Option<String>,
+    azure_application_client_id: Option<String>,
+}
+
+/// Parses a data plane name into its component parts.
+/// Returns None if the name format is invalid.
+///
+/// Expected formats:
+/// - Cloud: "ops/dp/public/aws-us-east-1-c1" or "ops/dp/private/gcp-us-central1-c2"
+/// - Local: "ops/dp/local/local-foo" (any suffix after "local-")
+pub(crate) fn parse_data_plane_name(
+    name: &str,
+) -> Option<(DataPlaneCloudProvider, String, String, bool)> {
+    let last_segment = name.rsplit('/').next()?;
+    let (provider_str, after_provider) = last_segment.split_once('-')?;
+
+    match provider_str {
+        "local" => Some((
+            DataPlaneCloudProvider::Local,
+            "local".to_string(),
+            "c1".to_string(),
+            true,
+        )),
+        "aws" | "az" | "azure" | "gcp" => {
+            // Must have privacy indicator in path.
+            if !name.contains("ops/dp/private/") && !name.starts_with("ops/dp/public/") {
+                return None;
+            }
+
+            // Parse tag (cluster) suffix (e.g., "-c1", "-c5").
+            let idx = after_provider.rfind("-c")?;
+            let tag = &after_provider[idx + 1..];
+            if tag.len() < 2 || !tag[1..].chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
+
+            let region = &after_provider[..idx];
+            if region.is_empty() {
+                return None;
+            }
+
+            let cloud_provider = match provider_str {
+                "aws" => DataPlaneCloudProvider::Aws,
+                "az" | "azure" => DataPlaneCloudProvider::Azure,
+                "gcp" => DataPlaneCloudProvider::Gcp,
+                _ => unreachable!(),
+            };
+
+            let is_public = name.starts_with("ops/dp/public/");
+            Some((
+                cloud_provider,
+                region.to_string(),
+                tag.to_string(),
+                is_public,
+            ))
+        }
+        _ => None,
+    }
+}
+
+pub type PaginatedDataPlanes = Connection<
+    String,
+    DataPlane,
+    connection::EmptyFields,
+    connection::EmptyFields,
+    connection::DefaultConnectionName,
+    connection::DefaultEdgeName,
+    connection::DisableNodesField,
+>;
+
+#[derive(Debug, Default)]
+pub struct DataPlanesQuery;
+
+#[async_graphql::Object]
+impl DataPlanesQuery {
+    /// Returns data planes accessible to the current user.
+    ///
+    /// Results are paginated and sorted by data_plane_name.
+    /// Only data planes the user has at least read capability to are returned.
+    pub async fn data_planes(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> async_graphql::Result<PaginatedDataPlanes> {
+        let env = ctx.data::<crate::Envelope>()?;
+        let claims = env.claims()?;
+        let snapshot = env.snapshot();
+
+        // Filter to only data planes the user can read and that have valid names.
+        let accessible_data_planes: Vec<&tables::DataPlane> = snapshot
+            .data_planes
+            .iter()
+            .filter(|dp| {
+                if parse_data_plane_name(&dp.data_plane_name).is_none() {
+                    tracing::warn!(data_plane_name = %dp.data_plane_name, "skipping data plane with unparseable name");
+                    return false;
+                }
+                tables::UserGrant::is_authorized(
+                        &snapshot.role_grants,
+                        &snapshot.user_grants,
+                        claims.sub,
+                        &dp.data_plane_name,
+                        models::Capability::Read,
+                    )
+            })
+            .collect();
+
+        // Apply cursor-based pagination.
+        let (rows, has_prev, has_next) =
+            connection::query_with::<String, _, _, _, async_graphql::Error>(
+                after,
+                before,
+                first,
+                last,
+                |after, before, first, last| async move {
+                    let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE);
+                    if limit == 0 {
+                        return Ok((Vec::new(), false, false));
+                    }
+
+                    // Sort by data_plane_name for consistent pagination.
+                    let mut sorted: Vec<&tables::DataPlane> = accessible_data_planes.clone();
+                    sorted.sort_by(|a, b| a.data_plane_name.cmp(&b.data_plane_name));
+
+                    let result = if before.is_some() || last.is_some() {
+                        // Backward pagination
+                        let filtered: Vec<_> = sorted
+                            .into_iter()
+                            .filter(|dp| {
+                                before
+                                    .as_ref()
+                                    .map(|b| dp.data_plane_name.as_str() < b.as_str())
+                                    .unwrap_or(true)
+                            })
+                            .collect();
+
+                        let total = filtered.len();
+                        let skip = total.saturating_sub(limit);
+                        let rows: Vec<_> = filtered.into_iter().skip(skip).collect();
+                        let has_prev = skip > 0;
+                        (rows, has_prev, before.is_some())
+                    } else {
+                        // Forward pagination
+                        let rows: Vec<_> = sorted
+                            .into_iter()
+                            .filter(|dp| {
+                                after
+                                    .as_ref()
+                                    .map(|a| dp.data_plane_name.as_str() > a.as_str())
+                                    .unwrap_or(true)
+                            })
+                            .take(limit)
+                            .collect();
+
+                        let has_next = rows.len() == limit;
+                        (rows, after.is_some(), has_next)
+                    };
+
+                    async_graphql::Result::Ok(result)
+                },
+            )
+            .await?;
+
+        // Preserve sorted order from pagination before moving into HashMap.
+        let names: Vec<String> = rows.iter().map(|dp| dp.data_plane_name.clone()).collect();
+
+        // Build row data map for attach_user_capabilities.
+        let row_data: HashMap<String, &tables::DataPlane> = rows
+            .into_iter()
+            .map(|dp| (dp.data_plane_name.clone(), dp))
+            .collect();
+
+        // Fetch detail fields from the database for all data planes in this page.
+        let details_map = fetch_data_plane_details(&env.pg_pool, &names).await?;
+
+        let edges = crate::server::attach_user_capabilities(
+            env.snapshot(),
+            env.claims()?,
+            names.into_iter(),
+            |data_plane_name, user_capability| {
+                let dp = row_data.get(&data_plane_name)?;
+                let (cloud_provider, region, tag, is_public) =
+                    parse_data_plane_name(&data_plane_name).expect("name validated by pre-filter");
+                let details = details_map.get(&data_plane_name);
+                Some(connection::Edge::new(
+                    data_plane_name.clone(),
+                    DataPlane {
+                        data_plane_name,
+                        data_plane_fqdn: dp.data_plane_fqdn.clone(),
+                        reactor_address: dp.reactor_address.clone(),
+                        user_capability: user_capability
+                            .expect("capability guaranteed by pre-filter"),
+                        cloud_provider,
+                        region,
+                        tag,
+                        is_public,
+                        cidr_blocks: details.map(|d| d.cidr_blocks.clone()).unwrap_or_default(),
+                        gcp_service_account_email: details
+                            .and_then(|d| d.gcp_service_account_email.clone()),
+                        aws_iam_user_arn: details.and_then(|d| d.aws_iam_user_arn.clone()),
+                        azure_application_name: details
+                            .and_then(|d| d.azure_application_name.clone()),
+                        azure_application_client_id: details
+                            .and_then(|d| d.azure_application_client_id.clone()),
+                    },
+                ))
+            },
+        );
+
+        let mut conn = PaginatedDataPlanes::new(has_prev, has_next);
+        conn.edges = edges;
+        Ok(conn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_server;
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_graphql_data_planes(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server =
+            test_server::TestServer::start(pool.clone(), test_server::snapshot(pool, false).await)
+                .await;
+
+        let token = server.make_access_token(uuid::Uuid::from_bytes([0x11; 16]), None);
+
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        dataPlanes {
+                            edges {
+                                node {
+                                    dataPlaneName
+                                    dataPlaneFqdn
+                                    reactorAddress
+                                    cloudProvider
+                                    region
+                                    tag
+                                    isPublic
+                                    userCapability
+                                    cidrBlocks
+                                    gcpServiceAccountEmail
+                                    awsIamUserArn
+                                    azureApplicationName
+                                    azureApplicationClientId
+                                }
+                            }
+                        }
+                    }
+                "#
+                }),
+                Some(&token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!(response);
+    }
+
+    #[test]
+    fn parses_aws_public() {
+        let (provider, region, tag, is_public) =
+            parse_data_plane_name("ops/dp/public/aws-us-east-1-c1").unwrap();
+        assert_eq!(provider, DataPlaneCloudProvider::Aws);
+        assert_eq!(region, "us-east-1");
+        assert_eq!(tag, "c1");
+        assert!(is_public);
+    }
+
+    #[test]
+    fn parses_gcp_private() {
+        let (provider, region, tag, is_public) =
+            parse_data_plane_name("ops/dp/private/estuary/gcp-us-central1-c5").unwrap();
+        assert_eq!(provider, DataPlaneCloudProvider::Gcp);
+        assert_eq!(region, "us-central1");
+        assert_eq!(tag, "c5");
+        assert!(!is_public);
+    }
+
+    #[test]
+    fn parses_azure_variants() {
+        // "az" prefix
+        let (provider, region, tag, _) =
+            parse_data_plane_name("ops/dp/private/EastPack/az-australiaeast-c1").unwrap();
+        assert_eq!(provider, DataPlaneCloudProvider::Azure);
+        assert_eq!(region, "australiaeast");
+        assert_eq!(tag, "c1");
+
+        // "azure" prefix
+        let (provider, region, tag, _) =
+            parse_data_plane_name("ops/dp/private/AccumTech/azure-eastus-c1").unwrap();
+        assert_eq!(provider, DataPlaneCloudProvider::Azure);
+        assert_eq!(region, "eastus");
+        assert_eq!(tag, "c1");
+    }
+
+    #[test]
+    fn parses_local() {
+        let (provider, region, tag, is_public) =
+            parse_data_plane_name("ops/dp/local/local-foo").unwrap();
+        assert_eq!(provider, DataPlaneCloudProvider::Local);
+        assert_eq!(region, "local");
+        assert_eq!(tag, "c1");
+        assert!(is_public);
+    }
+
+    #[test]
+    fn rejects_invalid_names() {
+        // Missing privacy indicator
+        assert!(parse_data_plane_name("ops/dp/aws-us-east-1-c1").is_none());
+        // Unknown provider
+        assert!(parse_data_plane_name("ops/dp/public/unknown-us-east-1-c1").is_none());
+        // Missing cluster suffix
+        assert!(parse_data_plane_name("ops/dp/public/aws-us-east-1").is_none());
+        // Non-numeric cluster
+        assert!(parse_data_plane_name("ops/dp/public/aws-us-east-1-ca").is_none());
+    }
+}

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -6,6 +6,8 @@ use axum::response::IntoResponse;
 
 mod alert_subscriptions;
 mod alerts;
+mod data_planes;
+pub(crate) use data_planes::parse_data_plane_name;
 pub mod id;
 mod live_spec_refs;
 mod live_specs;
@@ -31,6 +33,7 @@ pub struct QueryRoot(
     prefixes::PrefixesQuery,
     alert_subscriptions::AlertSubscriptionsQuery,
     storage_mappings::StorageMappingsQuery,
+    data_planes::DataPlanesQuery,
 );
 
 // Represents the portion of the GraphQL schema that deals with mutations.

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__data_planes__tests__graphql_data_planes.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__data_planes__tests__graphql_data_planes.snap
@@ -1,0 +1,52 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/data_planes.rs
+assertion_line: 364
+expression: response
+---
+{
+  "data": {
+    "dataPlanes": {
+      "edges": [
+        {
+          "node": {
+            "awsIamUserArn": "arn:aws:iam::123456789:user/test",
+            "azureApplicationClientId": "11111111-1111-1111-1111-111111111111",
+            "azureApplicationName": "estuary-test-app-one",
+            "cidrBlocks": [
+              "10.0.0.0/16",
+              "192.168.1.0/24"
+            ],
+            "cloudProvider": "AWS",
+            "dataPlaneFqdn": "dp.one",
+            "dataPlaneName": "ops/dp/public/aws-us-west-2-c1",
+            "gcpServiceAccountEmail": "test-gcp-one@estuary-test.iam.gserviceaccount.com",
+            "isPublic": true,
+            "reactorAddress": "reactor.dp.one",
+            "region": "us-west-2",
+            "tag": "c1",
+            "userCapability": "read"
+          }
+        },
+        {
+          "node": {
+            "awsIamUserArn": "arn:aws:iam::987654321:user/test",
+            "azureApplicationClientId": "22222222-2222-2222-2222-222222222222",
+            "azureApplicationName": "estuary-test-app-two",
+            "cidrBlocks": [
+              "172.16.0.0/12"
+            ],
+            "cloudProvider": "GCP",
+            "dataPlaneFqdn": "dp.two",
+            "dataPlaneName": "ops/dp/public/gcp-us-central1-c2",
+            "gcpServiceAccountEmail": "test-gcp-two@estuary-test.iam.gserviceaccount.com",
+            "isPublic": true,
+            "reactorAddress": "reactor.dp.two",
+            "region": "us-central1",
+            "tag": "c2",
+            "userCapability": "read"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -168,7 +168,7 @@ enum AlertType {
 	are peformed on all specs for a variety of reasons. For example,
 	updating inferred schemas, or updating materialization bindings to match
 	the source capture. When these publications fail, tasks are likely to
-	stop functioning correctly until the issue can be address.
+	stop functioning correctly until the issue can be addressed.
 	"""
 	background_publication_failed
 }
@@ -361,6 +361,100 @@ type CreateStorageMappingResult {
 	The catalog prefix for which the storage mapping was created.
 	"""
 	catalogPrefix: Prefix!
+}
+
+"""
+A data plane where tasks execute and collections are stored.
+"""
+type DataPlane {
+	"""
+	Name of this data-plane under the catalog namespace.
+	"""
+	dataPlaneName: String!
+	"""
+	Fully-qualified domain name of this data-plane.
+	"""
+	dataPlaneFqdn: String!
+	"""
+	Address of reactors within the data-plane.
+	"""
+	reactorAddress: String!
+	"""
+	The current user's capability to this data plane's name prefix.
+	"""
+	userCapability: Capability!
+	"""
+	Cloud provider where this data-plane is hosted.
+	"""
+	cloudProvider: DataPlaneCloudProvider!
+	"""
+	Cloud region where this data-plane is hosted.
+	For example: "us-east-1" (AWS), "us-central1" (GCP), "eastus" (Azure).
+	"""
+	region: String!
+	"""
+	Tag (cluster) identifier within the region.
+	"""
+	tag: String!
+	"""
+	Whether this is a public data-plane.
+	"""
+	isPublic: Boolean!
+	"""
+	CIDR blocks for this data-plane.
+	"""
+	cidrBlocks: [String!]!
+	"""
+	GCP service account email for this data-plane.
+	"""
+	gcpServiceAccountEmail: String
+	"""
+	AWS IAM user ARN for this data-plane.
+	"""
+	awsIamUserArn: String
+	"""
+	Azure application name for this data-plane.
+	"""
+	azureApplicationName: String
+	"""
+	Azure application client ID for this data-plane.
+	"""
+	azureApplicationClientId: String
+}
+
+"""
+Cloud provider where the data plane is hosted.
+"""
+enum DataPlaneCloudProvider {
+	AWS
+	AZURE
+	GCP
+	LOCAL
+}
+
+type DataPlaneConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [DataPlaneEdge!]!
+}
+
+"""
+An edge in a connection.
+"""
+type DataPlaneEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DataPlane!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """
@@ -836,6 +930,13 @@ type QueryRoot {
 	Results are paginated and sorted by catalog_prefix.
 	"""
 	storageMappings(by: StorageMappingsBy!, after: String, before: String, first: Int, last: Int): StorageMappingConnection!
+	"""
+	Returns data planes accessible to the current user.
+	
+	Results are paginated and sorted by data_plane_name.
+	Only data planes the user has at least read capability to are returned.
+	"""
+	dataPlanes(after: String, before: String, first: Int, last: Int): DataPlaneConnection!
 }
 
 type RepublishRequested {


### PR DESCRIPTION
**Description:**

- Add a new dataPlanes GraphQL query 
- Parse data plane names to extract structured cloudProvider, region, tag (cluster), and isPublic fields for the GraphQL response so the client doesn't have to
- Lazy fetch cloud credential fields needed for storage mappings: 

```rust
cidr_blocks: Vec<String>,
gcp_service_account_email: Option<String>,
aws_iam_user_arn: Option<String>,
azure_application_name: Option<String>,
azure_application_client_id: Option<String>,
```

example gql query:

```gql
query {
  dataPlanes {
    edges {
      cursor
      node {
        dataPlaneName
        cloudProvider
        region
        isPublic
        tag
        userCapability
      }
    }
  }
}
```

```json
{
  "data": {
    "dataPlanes": {
      "edges": [
        {
          "cursor": "ops/dp/public/aws-us-east-1-c1",
          "node": {
            "dataPlaneName": "ops/dp/public/aws-us-east-1-c1",
            "cloudProvider": "AWS",
            "region": "us-east-1",
            "isPublic": true,
            "tag": "1",
            "userCapability": "read"
          }
        },
        {
          "cursor": "ops/dp/public/local-cluster",
          "node": {
            "dataPlaneName": "ops/dp/public/local-cluster",
            "cloudProvider": "LOCAL",
            "region": "local",
            "isPublic": true,
            "tag": "1",
            "userCapability": "read"
          }
        }
      ]
    }
  }
}
```
