### PR TITLE
Docs: IAM Issuer Consistency

### DIFF
--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -8,7 +8,7 @@ In order to authenticate using AWS IAM, you need a IAM role which has access to 
 
 To create the role, select "AWS Account" and click next, select the required permissions for your resource, set the role name, and create the role.
 
-Next we need to update the maximum session duration for the role, view the role you created and select **Edit** in the summary box.  Set the maximum session duration to 12 hours.
+Next we need to update the maximum session duration for the role, view the role you created and select **Edit** in the summary box. Set the maximum session duration to 12 hours.
 
 For more information about role creation check the [IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html).
 
@@ -26,22 +26,30 @@ To find the correct issuer value:
 3. Find the **Data Planes** table and make sure you're viewing the correct tab for your data plane (either **public** or **private**).
 Select your data plane to open additional configuration details.
 
-4. Copy the value from the **IAM OIDC** field. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com`
+4. Copy the value from the **IAM OIDC** field. This should look something like: `https://openid.estuary.dev/your-data-plane-identifier.dp.estuary-data.com/`
 
 For example, these are the issuer values for a few common public data planes:
 
 | Data Plane | Issuer |
 |---|---|
-| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com |
-| US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com |
-| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com |
-| EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com |
+| US east-1 AWS data plane | `https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/` |
+| US central-1 GCP data plane | `https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/` |
+| US west-2 AWS data plane | `https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/` |
+| EU west-1 AWS data plane | `https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/` |
 
 ![Add Identity Provider](../guide-images/aws-iam-1.png)
 
 # Trust Relationship in Role
 
-Finally, return to the details page of your role, head to "Trust relationships" tab and add the following trust policy, replacing the principal with the ARN of the Identity Provider depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value) you use and `:sub` condition with your tenant name so only tasks from your tenant are allowed to assume this role:
+Finally, return to the details page of your role, head to "Trust relationships" tab and add the following trust policy, replacing:
+
+* The OpenID URL with the correct issuer value for your data plane
+* The principal with the ARN of the Identity Provider depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value) you use
+* The `:sub` condition with your tenant name so only tasks from your tenant are allowed to assume this role
+
+:::tip
+Make sure the `:aud` and `:sub` values use the correct issuer. Minor discrepancies with the value you used for the ARN, such as differences in trailing slashes, will lead to access failures down the line.
+:::
 
 ```json
 {

--- a/site/docs/guides/iam-auth/azure.md
+++ b/site/docs/guides/iam-auth/azure.md
@@ -29,10 +29,10 @@ For example, these are the issuer values for a few common public data planes:
 
 | Data Plane | Issuer |
 |---|---|
-| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
-| US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
-| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
-| EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
+| US east-1 AWS data plane | `https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/` |
+| US central-1 GCP data plane | `https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/` |
+| US west-2 AWS data plane | `https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/` |
+| EU west-1 AWS data plane | `https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/` |
 
 ![Add Federated Credential](../guide-images/azure-iam-2.png)
 

--- a/site/docs/guides/iam-auth/gcp.md
+++ b/site/docs/guides/iam-auth/gcp.md
@@ -33,10 +33,10 @@ For example, these are the issuer values for a few common public data planes:
 
 | Data Plane | Issuer |
 |---|---|
-| US east-1 AWS data plane | https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/ |
-| US central-1 GCP data plane | https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/ |
-| US west-2 AWS data plane | https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/ |
-| EU west-1 AWS data plane | https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/ |
+| US east-1 AWS data plane | `https://openid.estuary.dev/aws-us-east-1-c1.dp.estuary-data.com/` |
+| US central-1 GCP data plane | `https://openid.estuary.dev/gcp-us-central1-c2.dp.estuary-data.com/` |
+| US west-2 AWS data plane | `https://openid.estuary.dev/aws-us-west-2-c1.dp.estuary-data.com/` |
+| EU west-1 AWS data plane | `https://openid.estuary.dev/aws-eu-west-1-c1.dp.estuary-data.com/` |
 
 At this step, take note of the audience value as you will need this when configuring connectors with GCP IAM.
 


### PR DESCRIPTION
**Description:**

Minor updates to IAM auth docs to improve consistency and help users avoid errors down the line.

* Updates issuers in AWS docs to include trailing slashes like in other docs
* Notes where discrepancies in the trust policy can cause failures
* Changes issuer URLs to inline code to make it easier to copy (not automatically turning into links)

**Notes for reviewers:**

Thanks for reviewing!
