### PR TITLE
runtime: fix batched RocksDB state merges to preserve null deletion markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6985,6 +6985,7 @@ dependencies = [
  "proto-flow",
  "proto-gazette",
  "proto-grpc",
+ "quickcheck",
  "reqwest 0.12.23",
  "rocksdb",
  "serde",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -68,3 +68,4 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+quickcheck = { workspace = true }


### PR DESCRIPTION
## Summary

- Reapplies the batched merge operator for RocksDB connector state (previously reverted), which processes large operand lists in bounded-memory batches to avoid OOM on merge-heavy workloads
- Fixes a correctness bug where non-first batches used `full` reduction, causing LWW delete to strip null deletion markers within the batch instead of preserving them for re-merge with the base value. Now only the first batch (which contains the base/initial value) uses `full`; subsequent batches use associative reduction.
- Adds targeted regression tests and a QuickCheck fuzz suite for the batched merge path

## Background

RocksDB merge operators for connector state use the RFC 7396 merge-patch schema,
where `null` values are deletion markers that remove the corresponding property
from the base object during full reduction. When many operands accumulate
(e.g. 50k+ cursor updates), the merge operator processes them in batches to
bound memory usage.

The bug: all batches were passed the caller's `full` flag. Batches after the
first contain only operands (no base value), so `full=true` caused null markers
to be consumed within the batch — deleting properties that should only be deleted
when the batch output is later merged with the actual base. The fix restricts
`full` to only the first batch of each iteration, which always contains the
base value.

## What changed

**`crates/runtime/src/rocksdb.rs`**

- Extracted testable `do_merge(full, key, inputs, schema, batch_byte_target, batch_op_target)` from the RocksDB-specific `do_merge_rocks` wrapper, enabling direct unit testing without a RocksDB instance
- Added `is_first_batch` tracking: only the first batch per iteration uses `full` reduction; subsequent batches use associative (partial) reduction to preserve null deletion markers
- Added `batch_op_target` parameter (document count limit per batch) alongside the existing byte threshold, enabling deterministic batch boundaries in tests

## Testing

The `doc` crate already has extensive merge-patch test coverage:

- **`doc/tests/merge_patch_fuzz.rs`** — QuickCheck tests for `reduce_stack` and `reduce_combiner` paths, verifying associative vs. full reduction semantics against `json_patch::merge`
- **`doc/tests/spill_merge_fuzz.rs`** — QuickCheck tests for merge behavior across spill/memtable boundaries
- **`doc/src/reduce/strategy.rs`** — Unit tests for RFC 7396 merge-patch examples, null deletion in both associative and full modes, nested object merging, and type-switching edge cases
- **`doc/src/combine/memtable.rs`** — Snapshot tests for merge-patch reduction sequences through the combiner, including hold-back semantics and non-associative stacking

This PR adds coverage specifically for the RocksDB batched merge path, which sits above the `doc` reduction layer:

- [x] `test_null_deletion_survives_batching` — targeted regression: null markers must survive batch boundaries and correctly delete properties when re-merged with the base
- [x] `test_merge_many_operands_batched` — integration test through a real RocksDB instance with 50k operands
- [x] `fuzz_batched_merge_matches_reference` — QuickCheck (1000 cases): random merge-patch sequences at batch sizes 2, 3, 5, and unbounded, verifying both full-merge and partial-then-full-merge paths match `json_patch::merge`


