### PR TITLE
Block redact strategies on /_meta and /_meta/uuid in collection schemas

### DIFF
--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -180,6 +180,17 @@ fn walk_collection(
         errors,
     )?;
 
+    // Check that /_meta and /_meta/uuid are not redacted, as redaction would
+    // destroy the UUID placeholder that the runtime depends on.
+    if read_model.is_some() {
+        check_uuid_ptr_not_redacted(scope.push_prop("writeSchema"), &write_spec.spec, errors);
+        if let Some(read) = &read_spec {
+            check_uuid_ptr_not_redacted(scope.push_prop("readSchema"), &read.spec, errors);
+        }
+    } else {
+        check_uuid_ptr_not_redacted(scope.push_prop("schema"), &write_spec.spec, errors);
+    }
+
     let effective_read_spec = read_spec
         .as_ref()
         .map(|Schema { spec, .. }| spec)
@@ -775,6 +786,25 @@ pub fn skim_projections(
     );
 
     projection_specs
+}
+
+fn check_uuid_ptr_not_redacted(scope: Scope, spec: &schema::Schema, errors: &mut tables::Errors) {
+    for ptr_str in [UUID_PTR, "/_meta"] {
+        let ptr = json::Pointer::from(ptr_str);
+        let (shape, exists) = spec.shape.locate(&ptr);
+
+        if matches!(exists, doc::shape::location::Exists::Cannot) {
+            continue;
+        }
+        if !matches!(shape.redact, doc::shape::Redact::Unset) {
+            Error::UuidPtrHasRedact {
+                ptr: ptr_str.to_string(),
+                schema: spec.curi.clone(),
+                strategy: shape.redact.clone(),
+            }
+            .push(scope, errors);
+        }
+    }
 }
 
 struct Schema {

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -145,6 +145,15 @@ pub enum Error {
         schema: Url,
         strategy: doc::shape::Redact,
     },
+    #[error(
+        "location {ptr} has a `redact` strategy, which is disallowed because /_meta/uuid \
+         holds the runtime document UUID"
+    )]
+    UuidPtrHasRedact {
+        ptr: String,
+        schema: Url,
+        strategy: doc::shape::Redact,
+    },
     #[error("{category} projection {field} does not exist in collection {collection}")]
     NoSuchProjection {
         category: String,

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1704,6 +1704,39 @@ test://example/int-reverse:
 }
 
 #[test]
+fn test_uuid_ptr_has_redact_block() {
+    let errors = common::run_errors(
+        MODEL_YAML,
+        r#"
+test://example/int-string.schema:
+  properties:
+    _meta:
+      type: object
+      properties:
+        uuid:
+          type: string
+          redact: { strategy: block }
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_meta_has_redact() {
+    let errors = common::run_errors(
+        MODEL_YAML,
+        r#"
+test://example/int-string.schema:
+  properties:
+    _meta:
+      type: object
+      redact: { strategy: sha256 }
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
 fn test_materialization_too_many_bindings() {
     let bindings_count = validation::MAX_BINDINGS + 1;
 

--- a/crates/validation/tests/snapshots/scenario_tests__meta_has_redact.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__meta_has_redact.snap
@@ -1,0 +1,55 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 1736
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/schema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/schema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/readSchema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/writeSchema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/writeSchema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/readSchema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/writeSchema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/writeSchema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string.v2/schema,
+        error: /_meta has 'sha256' redact strategy but cannot be a string (types are "object"),
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string.v2/schema,
+        error: location /_meta has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__uuid_ptr_has_redact_block.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__uuid_ptr_has_redact_block.snap
@@ -1,0 +1,31 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 1721
+expression: errors
+---
+[
+    Error {
+        scope: test://example/int-reverse#/collections/testing~1int-reverse/schema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string/schema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/writeSchema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-ref-write-schema/readSchema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/writeSchema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string.v2/schema,
+        error: location /_meta/uuid has a `redact` strategy, which is disallowed because /_meta/uuid holds the runtime document UUID,
+    },
+]


### PR DESCRIPTION
**Description:**

Redacting /_meta or /_meta/uuid would destroy the UUID placeholder that the runtime depends on. This adds a validation check that rejects schemas with redact strategies on those locations, and hardens the Go runtime so that a missing UUID placeholder is recovered as an error (with a logged stack trace) rather than crashing the process.

**Workflow steps:**

Attempting to redact `/_meta/` or `/_meta/uuid` now generates a publication error.
At runtime, a former "missing UUID" panic is now an error with a log.
