### PR TITLE
Improve expectPubId mismatch error message

### DIFF
--- a/crates/agent/src/integration_tests/locking_retries.rs
+++ b/crates/agent/src/integration_tests/locking_retries.rs
@@ -136,7 +136,7 @@ async fn test_publication_optimistic_locking_failures() {
         vec![
             (
             "flow://collection/mice/does-not-exist".to_string(),
-            "This task was updated while you were editing — please refresh the spec and re-apply your changes.\nThis may have been an automated system update. (expected publication ID 0102030405060708, actual 0000000000000000)".to_string()
+            "This spec was updated while you were editing — please refresh and re-apply your changes.\nThis may have been an automated system update. (expected publication ID 0102030405060708, actual 0000000000000000)".to_string()
             )
         ],
         errors);

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -267,7 +267,7 @@ pub enum Error {
         larger_id: models::Id,
     },
     #[error(
-        "This task was updated while you were editing — please refresh the spec and re-apply your changes.\nThis may have been an automated system update. (expected publication ID {expect_id}, actual {actual_id})"
+        "This spec was updated while you were editing — please refresh and re-apply your changes.\nThis may have been an automated system update. (expected publication ID {expect_id}, actual {actual_id})"
     )]
     ExpectPubIdNotMatched {
         expect_id: models::Id,

--- a/crates/validation/tests/snapshots/transition_tests__insert_but_already_exists.snap
+++ b/crates/validation/tests/snapshots/transition_tests__insert_but_already_exists.snap
@@ -5,27 +5,27 @@ expression: errors
 [
     Error {
         scope: test://example/catalog.yaml#/collections/the~1collection,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 0000000000000000, actual 1010101010101010),
     },
     Error {
         scope: test://example/catalog.yaml#/collections/the~1derivation,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 0000000000000000, actual 1010101010101010),
     },
     Error {
         scope: test://example/catalog.yaml#/tests/the~1test,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 0000000000000000, actual 1010101010101010),
     },
     Error {
         scope: test://example/catalog.yaml#/captures/the~1capture,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 0000000000000000, actual 1010101010101010),
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/the~1materialization,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 0000000000000000, actual 1010101010101010),
     },
 ]

--- a/crates/validation/tests/snapshots/transition_tests__update_but_does_not_exist.snap
+++ b/crates/validation/tests/snapshots/transition_tests__update_but_does_not_exist.snap
@@ -5,7 +5,7 @@ expression: errors
 [
     Error {
         scope: test://example/catalog.yaml#/collections/the~1collection,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 1010101010101010, actual 0000000000000000),
     },
     Error {
@@ -18,22 +18,22 @@ expression: errors
     },
     Error {
         scope: test://example/catalog.yaml#/collections/the~1derivation,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 1010101010101010, actual 0000000000000000),
     },
     Error {
         scope: test://example/catalog.yaml#/tests/the~1test,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 1010101010101010, actual 0000000000000000),
     },
     Error {
         scope: test://example/catalog.yaml#/captures/the~1capture,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 1010101010101010, actual 0000000000000000),
     },
     Error {
         scope: test://example/catalog.yaml#/materializations/the~1materialization,
-        error: This task was updated while you were editing — please refresh the spec and re-apply your changes.
+        error: This spec was updated while you were editing — please refresh and re-apply your changes.
         This may have been an automated system update. (expected publication ID 1010101010101010, actual 0000000000000000),
     },
     Error {


### PR DESCRIPTION
## Summary
- Rewrites the `ExpectPubIdNotMatched` error to be more human-readable: leads with what happened, gives a clear action, and demotes publication IDs to a parenthetical
- Motivated by customer confusion — the current message is truncated in the UI and the hex IDs are not actionable

**Before:**
```
expected publication ID 0000000000000000 was not matched (it's actually 117efc2f6100029f):
your changes have already been published or another publication has modified this spec;
please try again with a fresh copy of the spec.
```

**After:**
```
This task was updated while you were editing — please refresh the spec and re-apply your changes.
This may have been an automated system update. (expected publication ID 0000000000000000, actual 117efc2f6100029f)
```

## Context
This error commonly occurs when automated system updates (e.g. inferred schema changes, auto-discovers, controller convergence) modify a spec while a user is editing it. The old message was written for developers and doesn't help customers understand what to do.

**Question:** Do inferred schema changes still update `last_pub_id`? The Aug 2024 plan (#1520) outlined separating `last_pub_id` from `last_build_id` so that dependency-only changes wouldn't bump `last_pub_id`. If that's been implemented, this error should be less frequent — but when it does occur, it should still be clear.

## Test plan
- [x] `cargo test -p validation -- test_insert_but_already_exists test_update_but_does_not_exist` passes locally
- [ ] Integration test in `locking_retries.rs` updated to match
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)