### PR TITLE
docs: document Additional Table Create SQL for creating indexes

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/PostgreSQL.md
@@ -73,6 +73,18 @@ Use the below properties to configure a Postgres materialization, which will dir
 
 Certain managed PostgreSQL implementations may require you to explicitly set the [SSL Mode](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) to connect with Estuary. One example is [Neon](https://neon.tech/docs/connect/connect-securely), which requires the setting `verify-full`. Check your managed PostgreSQL's documentation for details if you encounter errors related to the SSL mode configuration.
 
+#### Additional Table Create SQL
+
+You can use the `additional_table_create_sql` binding property to run custom SQL statements in the same transaction that creates the destination table. This is useful for creating indexes or other table modifications that you want applied automatically — including when a table is re-created due to schema changes.
+
+For example, to create an index on a `dateCreated` column:
+
+```sql
+CREATE INDEX idx_orders_date_created ON orders("dateCreated");
+```
+
+This SQL runs only during table creation. If the table already exists, you'll need to re-backfill the binding for the SQL to execute. Do not include statements that re-create the table itself — the connector handles table creation automatically.
+
 ### Sample
 
 ```yaml

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -93,7 +93,7 @@ Use the below properties to configure a Postgres materialization, which will dir
 
 | Property                       | Title                       | Description                                                                                                        | Type    | Required/Default |
 | ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table.                              | string  |                  |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. See [Additional Table Create SQL](./PostgreSQL.md#additional-table-create-sql) for usage examples. | string  |                  |
 | `/delta_updates`               | Delta Update                | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
 | `/schema`                      | Alternative Schema          | Alternative schema for this table (optional). Overrides schema set in endpoint configuration.                      | string  |                  |
 | **`/table`**                   | Table                       | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -89,7 +89,7 @@ Use the below properties to configure a Postgres materialization, which will dir
 
 | Property                       | Title                       | Description                                                                                                        | Type    | Required/Default |
 | ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table.                              | string  |                  |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. See [Additional Table Create SQL](./PostgreSQL.md#additional-table-create-sql) for usage examples. | string  |                  |
 | `/delta_updates`               | Delta Update                | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
 | `/schema`                      | Alternative Schema          | Alternative schema for this table (optional). Overrides schema set in endpoint configuration.                      | string  |                  |
 | **`/table`**                   | Table                       | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |

--- a/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/supabase.md
+++ b/site/docs/reference/Connectors/materialization-connectors/PostgreSQL/supabase.md
@@ -53,7 +53,7 @@ Use the below properties to configure a Supabase materialization, which will dir
 
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. | string  |   |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. See [Additional Table Create SQL](./PostgreSQL.md#additional-table-create-sql) for usage examples. | string  |   |
 | `/delta_updates` | Delta Update | Should updates to this table be done via delta updates. | boolean | `false` |
 | `/schema` | Alternative Schema | Alternative schema for this table (optional). Overrides schema set in endpoint configuration. | string |   |
 | **`/table`** | Table | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string | Required |

--- a/site/docs/reference/Connectors/materialization-connectors/alloydb.md
+++ b/site/docs/reference/Connectors/materialization-connectors/alloydb.md
@@ -49,7 +49,7 @@ See the table below and the [sample config](#sample).
 
 | Property | Title | Description | Type | Required/Default |
 |---|---|---|---|---|
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. | string |  |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. See [Additional Table Create SQL](./PostgreSQL/PostgreSQL.md#additional-table-create-sql) for usage examples. | string |  |
 | `/delta_updates` | Delta Update | Should updates to this table be done via delta updates. | boolean | `false` |
 | `/schema` | Alternative Schema | Alternative schema for this table (optional). Overrides schema set in endpoint configuration. | string |  |
 | **`/table`** | Table | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string | Required |

--- a/site/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/site/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -68,11 +68,18 @@ Use the below properties to configure a Databricks materialization, which will d
 
 #### Bindings
 
-| Property         | Title              | Description                                                | Type    | Required/Default |
-|------------------|--------------------|------------------------------------------------------------|---------|------------------|
-| **`/table`**     | Table              | Table name                                                 | string  | Required         |
-| `/schema`        | Alternative Schema | Alternative schema for this table                          | string  | Required         |
-| `/delta_updates` | Delta updates      | Whether to use standard or [delta updates](#delta-updates) | boolean | `false`          |
+| Property                       | Title                       | Description                                                  | Type    | Required/Default |
+|--------------------------------|-----------------------------|--------------------------------------------------------------|---------|------------------|
+| **`/table`**                   | Table                       | Table name                                                   | string  | Required         |
+| `/schema`                      | Alternative Schema          | Alternative schema for this table                            | string  | Required         |
+| `/delta_updates`               | Delta updates               | Whether to use standard or [delta updates](#delta-updates)   | boolean | `false`          |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after table is created. | string |                  |
+
+#### Additional Table Create SQL
+
+You can use the `additional_table_create_sql` binding property to run custom SQL statements after the connector creates the destination table. This is useful for creating indexes or other table modifications that you want applied automatically — including when a table is re-created due to schema changes.
+
+This SQL runs only during table creation. If the table already exists, you'll need to re-backfill the binding for the SQL to execute. Do not include statements that re-create the table itself — the connector handles table creation automatically.
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/site/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -73,13 +73,7 @@ Use the below properties to configure a Databricks materialization, which will d
 | **`/table`**                   | Table                       | Table name                                                   | string  | Required         |
 | `/schema`                      | Alternative Schema          | Alternative schema for this table                            | string  | Required         |
 | `/delta_updates`               | Delta updates               | Whether to use standard or [delta updates](#delta-updates)   | boolean | `false`          |
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after table is created. See [Additional Table Create SQL](#additional-table-create-sql) for usage examples. | string |                  |
-
-#### Additional Table Create SQL
-
-You can use the `additional_table_create_sql` binding property to run custom SQL statements after the connector creates the destination table. This is useful for creating indexes or other table modifications that you want applied automatically — including when a table is re-created due to schema changes.
-
-This SQL runs only during table creation. If the table already exists, you'll need to re-backfill the binding for the SQL to execute. Do not include statements that re-create the table itself — the connector handles table creation automatically.
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after table is created. See [Additional Table Create SQL](./PostgreSQL/PostgreSQL.md#additional-table-create-sql) for usage examples. | string |                  |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/site/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -73,7 +73,7 @@ Use the below properties to configure a Databricks materialization, which will d
 | **`/table`**                   | Table                       | Table name                                                   | string  | Required         |
 | `/schema`                      | Alternative Schema          | Alternative schema for this table                            | string  | Required         |
 | `/delta_updates`               | Delta updates               | Whether to use standard or [delta updates](#delta-updates)   | boolean | `false`          |
-| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after table is created. | string |                  |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after table is created. See [Additional Table Create SQL](#additional-table-create-sql) for usage examples. | string |                  |
 
 #### Additional Table Create SQL
 


### PR DESCRIPTION
## Summary

- Adds a usage section to the PostgreSQL materialization docs explaining how to use the `additional_table_create_sql` binding property for creating indexes
- Adds the missing `additional_table_create_sql` property to the Databricks materialization docs bindings table, with a similar usage section
- Includes a `CREATE INDEX` example (Postgres) and notes about when the SQL executes

## Context

This field exists in config reference tables for Postgres-family connectors but the description ("Additional SQL statement(s) to be run in the same transaction that creates the table") doesn't make practical use cases obvious. The only existing usage example is on the TimescaleDB page (for hypertables).

A recent support thread showed this is a common source of confusion — customers aren't sure what the field is for or how to use it for things like creating indexes. Adding concrete examples should reduce repeat questions.

The Databricks connector also implements the field but it was missing from the docs entirely.

## Test plan

- [ ] Verify the Postgres and Databricks pages render correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)