### PR TITLE
dekaf: Drop `ListOffsets` max version to match `kafka-protocol`

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -2302,7 +2302,7 @@ impl Session {
             ApiVersion::default()
                 .with_api_key(ApiKey::ListOffsets as i16)
                 .with_min_version(4)
-                .with_max_version(10),
+                .with_max_version(9),
             ApiVersion::default()
                 .with_api_key(ApiKey::Fetch as i16)
                 // This is another non-obvious requirement in librdkafka. If we advertise <4 as a minimum here, some clients'


### PR DESCRIPTION
**Description:**

Dekaf advertised ListOffsets API versions 4-10 in `ApiVersionsResponse`, but the version of `kafka-protocol` we're on only implements versions 0-9. Clients were trying to negotiate v10 based on the advertisement, and then crashing because it wasn't actually supported.

This drops the advertised max version down without needing to upgrade `kafka-protocol`.

V4 introduced leader epoch support, so that's the correct lower bound. Versions 5-9 are identical in terms of the fields Dekaf uses, they differ mainly in terms of internal representation. V10+ is likely also fine, it just requires upgrading `kafka-protocol` which is a larger scope of work.