### PR TITLE
dpc: set service-specific envs in entrypoint.sh

### DIFF
--- a/crates/data-plane-controller/entrypoint.sh
+++ b/crates/data-plane-controller/entrypoint.sh
@@ -17,6 +17,13 @@ if [[ "${MODE}" == "service" ]]; then
     printf '%s\n' "${DPC_IAM_CREDENTIALS}" > /root/.aws/credentials
     printf '%s\n' "${DPC_SERVICE_ACCOUNT}" > ${GOOGLE_APPLICATION_CREDENTIALS}
 
+    # AWS profile to expect in ~/.aws/credentials
+    export AWS_PROFILE=data-plane-ops
+    # GCP Service Account JSON credentials path.
+    export GOOGLE_APPLICATION_CREDENTIALS=/etc/data_plane_controller.json
+    # Disable host-key checks when cloning our git repo.
+    export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
+
     chmod 0400 /root/ssh_key
     eval "$(ssh-agent -s)"
     ssh-add /root/ssh_key

--- a/docker/data-plane-controller.Dockerfile
+++ b/docker/data-plane-controller.Dockerfile
@@ -23,13 +23,6 @@ COPY ${TARGETARCH}/data-plane-controller /usr/local/bin/
 COPY ${TARGETARCH}/data-plane-controller-entrypoint.sh /usr/local/bin/
 COPY ${TARGETARCH}/sops /usr/local/bin/
 
-# AWS profile to expect in ~/.aws/credentials
-ENV AWS_PROFILE=data-plane-ops
-# GCP Service Account JSON credentials path.
-ENV GOOGLE_APPLICATION_CREDENTIALS=/etc/data_plane_controller.json
-# Disable host-key checks when cloning our git repo.
-ENV GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
-
 ENV RUST_LOG=info
 
 ENTRYPOINT ["/usr/local/bin/data-plane-controller-entrypoint.sh"]


### PR DESCRIPTION
**Description:**

- These were being set for both service and job, but are only relevant for service, and when set for job they break authentication credentials (which should be obtained from Metadata Server)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

