### PR TITLE
control-plane: exclude defunct data planes from snapshots

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,11 @@ test-group = 'serial-db-tests'
 [[profile.default.overrides]]
 filter = 'package(automations) and test(test_fibonacci_bench)'
 test-group = 'serial-db-tests'
+
+# This `server::` filter is overly broad, as not all the tests there actually
+# need the database. But I gave up on listing all the tests individually, as
+# that seems pretty fragile. Probably best to find a different way of grouping
+# tests that need the database.
+[[profile.default.overrides]]
+filter = 'package(control-plane-api) and test(server::)'
+test-group = 'serial-db-tests'

--- a/.sqlx/query-135e56a90465e7efa0822a471f0c0e56a340c3ff7710f753ab8c97df4fd783b7.json
+++ b/.sqlx/query-135e56a90465e7efa0822a471f0c0e56a340c3ff7710f753ab8c97df4fd783b7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            d.id AS \"control_id: models::Id\",\n            d.data_plane_name,\n            d.data_plane_fqdn,\n            d.hmac_keys,\n            d.encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        ",
+  "query": "\n        SELECT\n            d.id AS \"control_id: models::Id\",\n            d.data_plane_name,\n            d.data_plane_fqdn,\n            d.hmac_keys,\n            d.encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        WHERE d.hmac_keys::text <> '{}' or d.encrypted_hmac_keys::text <> '{}'\n        ",
   "describe": {
     "columns": [
       {
@@ -76,5 +76,5 @@
       false
     ]
   },
-  "hash": "48396ee38802bed5dc4497a8690a4c888ef30caf3208b5e5b0033552b8210a04"
+  "hash": "135e56a90465e7efa0822a471f0c0e56a340c3ff7710f753ab8c97df4fd783b7"
 }

--- a/crates/control-plane-api/src/fixtures/data_planes.sql
+++ b/crates/control-plane-api/src/fixtures/data_planes.sql
@@ -2,6 +2,7 @@ do $$
 declare
   data_plane_one_id flowid := '111111111111';
   data_plane_two_id flowid := '222222222222';
+  defunct_data_plane_id flowid := '333333333333';
 
   -- SOPS-encrypted HMAC keys (see .cargo/config.toml for key & secret)
   -- Decrypts to: {"hmac_keys": ["c2VjcmV0", "b3RoZXI="]} (base64 for "secret" and "other")
@@ -60,24 +61,42 @@ begin
     'from.dp.one',
     'from.dp.one',
     true
-  ), (
-    data_plane_two_id,
-    'ops/dp/public/two',
-    'dp.two',
-    '{}',
-    encrypted_keys,
-    'broker.dp.two',
-    'reactor.dp.two',
-    'ops/tasks/public/two/logs',
-    'ops/tasks/public/two/stats',
-    'ops/rollups/L1/public/two/events',
-    'ops/rollups/L1/public/two/inferred',
-    'ops/rollups/L1/public/two/stats',
-    'from.dp.two',
-    'from.dp.two',
-    'from.dp.two',
-    true
-  );
+    ), (
+      data_plane_two_id,
+      'ops/dp/public/two',
+      'dp.two',
+      '{}',
+      encrypted_keys,
+      'broker.dp.two',
+      'reactor.dp.two',
+      'ops/tasks/public/two/logs',
+      'ops/tasks/public/two/stats',
+      'ops/rollups/L1/public/two/events',
+      'ops/rollups/L1/public/two/inferred',
+      'ops/rollups/L1/public/two/stats',
+      'from.dp.two',
+      'from.dp.two',
+      'from.dp.two',
+      true
+    ), (
+    -- Here so we can assert that this gets filtered out during Snapshot refreshes
+      defunct_data_plane_id,
+      'ops/dp/private/defunct',
+      'dp.defunct',
+      '{}',
+      '{}',
+      'broker.dp.defunct',
+      'reactor.dp.defunct',
+      'ops/tasks/private/defunct/logs',
+      'ops/tasks/private/defunct/stats',
+      'ops/rollups/L1/private/defunct/events',
+      'ops/rollups/L1/private/defunct/inferred',
+      'ops/rollups/L1/private/defunct/stats',
+      'from.dp.defunct',
+      'from.dp.defunct',
+      'from.dp.defunct',
+      false
+    );
 
 end
 $$;

--- a/crates/control-plane-api/src/server/snapshot.rs
+++ b/crates/control-plane-api/src/server/snapshot.rs
@@ -451,6 +451,7 @@ pub async fn try_fetch(
             d.ops_logs_name AS "ops_logs_name: models::Collection",
             d.ops_stats_name AS "ops_stats_name: models::Collection"
         FROM data_planes d
+        WHERE d.hmac_keys::text <> '{}' or d.encrypted_hmac_keys::text <> '{}'
         "#,
     )
     .fetch_all(pg_pool)
@@ -581,6 +582,26 @@ impl Snapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_snapshot_fetch(pool: sqlx::PgPool) {
+        let mut decrypted_keys = HashMap::new();
+        let result = try_fetch(&pool, &mut decrypted_keys)
+            .await
+            .expect("snapshot refresh should succeed");
+        assert_eq!(2, result.data_planes.len());
+        assert!(
+            result
+                .data_planes
+                .iter()
+                .find(|dp| dp.data_plane_name.contains("defunct"))
+                .is_none(),
+            "expected the defunct data plane to be excluded"
+        );
+    }
 
     #[test]
     fn test_task_lookups() {


### PR DESCRIPTION
We had data planes rows in production that don't have hmac keys or encrypted hmac keys. They represent data planes that are currently unused, since hmac keys are required in order to interact with data planes. So this updates the snapshot refresh logic to filter them out instead of erroring on them.

I had to deal with a handful of flakey tests in order to make this work, by running all the control_plane_api::server tests sequentially. Hopefully that won't slow down our test runs too much.