### PR TITLE
dpc: set concurrency on job to 10

### DIFF
--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -120,6 +120,7 @@ jobs:
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
             DPC_SERVICE_URL=${{ needs.deploy-service.outputs.service-url }}
             DPC_CONCURRENCY=10
+            DPC_SERVICE_ACCOUNT=DPC_SERVICE_ACCOUNT:latest
             NO_COLOR=1
 
           secrets: |-


### PR DESCRIPTION
**Description:**

- allow the dpc job to poll 10 tasks at a time and send to service

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

