### PR TITLE
dpc: add google credentials to both job and service

### DIFF
--- a/crates/data-plane-controller/entrypoint.sh
+++ b/crates/data-plane-controller/entrypoint.sh
@@ -9,20 +9,21 @@ MODE="${1:?Usage: data-plane-controller-entrypoint.sh <job|service> [args...]}"
 # Place the database CA certificate, needed by both modes.
 printf '%s\n' "${CONTROL_PLANE_DB_CA_CERT}" > /etc/db-ca.crt
 
+# GCP Service Account JSON credentials path.
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/data_plane_controller.json
+printf '%s\n' "${DPC_SERVICE_ACCOUNT}" > ${GOOGLE_APPLICATION_CREDENTIALS}
+
 # The service mode requires infrastructure credentials for running
 # Pulumi, Ansible, git operations, and cloud provider interactions.
 if [[ "${MODE}" == "service" ]]; then
     # AWS profile to expect in ~/.aws/credentials
     export AWS_PROFILE=data-plane-ops
-    # GCP Service Account JSON credentials path.
-    export GOOGLE_APPLICATION_CREDENTIALS=/etc/data_plane_controller.json
     # Disable host-key checks when cloning our git repo.
     export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
 
     mkdir -p /root/.aws
     printf '%s\n' "${DPC_GITHUB_SSH_KEY}" > /root/ssh_key
     printf '%s\n' "${DPC_IAM_CREDENTIALS}" > /root/.aws/credentials
-    printf '%s\n' "${DPC_SERVICE_ACCOUNT}" > ${GOOGLE_APPLICATION_CREDENTIALS}
 
     chmod 0400 /root/ssh_key
     eval "$(ssh-agent -s)"


### PR DESCRIPTION
**Description:**

- The job needs GCP credentials to run sops to encrypt hmac key and write it to the table
- This does not affect authentication between job and service since we directly call metadata API for that to get the ID token

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

