### PR TITLE
validation: allow key fields with write-schema defaults despite inferred schema additionalProperties

### DIFF
--- a/crates/avro/src/schema.rs
+++ b/crates/avro/src/schema.rs
@@ -5,12 +5,16 @@ use json::schema::types;
 use std::fmt::Write;
 
 /// Map a Shape at the given location into an AVRO schema.
-/// If the location is not required and has no default, it may implicitly be none.
+/// If the location is not required and has no non-null default, it may implicitly be none.
 pub fn shape_to_avro(loc: json::Location, shape: doc::Shape, required: bool) -> avro::Schema {
     let mut type_ = shape.type_;
 
     // Is this location nullable ? NULL may union with any other schema.
-    let nullable = if shape.type_.overlaps(types::NULL) || (!required && shape.default.is_none()) {
+    // A null default is equivalent to no default for nullability: the field
+    // can be absent and absence maps to null.
+    let nullable = if shape.type_.overlaps(types::NULL)
+        || (!required && shape.default.as_ref().map_or(true, |d| d.0.is_null()))
+    {
         type_ = type_ - types::NULL;
         true
     } else {

--- a/crates/doc/src/shape/intersect.rs
+++ b/crates/doc/src/shape/intersect.rs
@@ -2,7 +2,6 @@
 // Intersected Shapes impose *all* of their constraints,
 // like a JSON Schema `allOf` keyword.
 use super::*;
-use crate::FailedValidation;
 use itertools::{EitherOrBoth, Itertools};
 
 impl Reduce {
@@ -254,7 +253,7 @@ impl Shape {
         let reduce = lhs.reduce.intersect(rhs.reduce);
         let redact = lhs.redact.intersect(rhs.redact);
         let provenance = lhs.provenance.intersect(rhs.provenance);
-        let default = intersect_default(type_, lhs.default, rhs.default);
+        let default = lhs.default.or(rhs.default);
         let secret = lhs.secret.or(rhs.secret);
 
         let mut annotations = rhs.annotations;
@@ -326,32 +325,6 @@ pub fn intersect_enum(
                 });
             let it = filter_enums_to_types(type_, it);
             Some(it.collect())
-        }
-    }
-}
-
-pub fn intersect_default(
-    type_: types::Set,
-    lhs: Option<Box<(Value, Option<FailedValidation>)>>,
-    rhs: Option<Box<(Value, Option<FailedValidation>)>>,
-) -> Option<Box<(Value, Option<FailedValidation>)>> {
-    match (lhs, rhs) {
-        (None, None) => None,
-        (Some(l), None) | (None, Some(l)) => {
-            if type_.overlaps(types::Set::for_node(&l.as_ref().0)) {
-                Some(l)
-            } else {
-                None
-            }
-        }
-        (Some(l), Some(r)) => {
-            if type_.overlaps(types::Set::for_node(&l.as_ref().0)) {
-                Some(l)
-            } else if type_.overlaps(types::Set::for_node(&r.as_ref().0)) {
-                Some(r)
-            } else {
-                None
-            }
         }
     }
 }
@@ -455,7 +428,10 @@ mod test {
             serde_json::json!("hello")
         );
 
-        let shape = shape_from(
+        // default is an annotation: even though the intersected type narrows
+        // to STRING (excluding null), the default is preserved because it was
+        // locally valid against its containing schema.
+        let shape_with_null_default = shape_from(
             r#"
             allOf:
                 - type: ["string", "null"]
@@ -464,6 +440,9 @@ mod test {
             "#,
         );
 
-        assert_eq!(shape.default, None);
+        assert_eq!(
+            shape_with_null_default.default.unwrap().as_ref().0,
+            serde_json::json!(null)
+        );
     }
 }

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -73,36 +73,40 @@ impl Schema {
             return Ok(());
         }
 
-        // When read_exists is Cannot but has a default, we skipped the
-        // PtrCannotExist error above. The read shape's type is INVALID in
-        // this case, so key-specific checks against it are meaningless.
-        if read_exists != Exists::Cannot {
-            if !read_shape.type_.is_keyable_type() {
-                return Err(Error::KeyWrongType {
-                    ptr: ptr.to_string(),
-                    type_: read_shape.type_,
-                    schema: read.curi.clone(),
-                });
-            }
+        // When the location Cannot exist but has a default, the shape type
+        // is INVALID. Union with the default value's type so the keyable
+        // check passes when the default itself is a keyable type.
+        let default_type = read_shape
+            .default
+            .as_ref()
+            .map(|d| types::Set::for_node(&d.0))
+            .unwrap_or(types::INVALID);
+        let effective_type = read_shape.type_ | default_type;
 
-            if !matches!(
-                read_shape.reduce,
-                shape::Reduce::Unset
-                    | shape::Reduce::Strategy(doc::reduce::Strategy::LastWriteWins(_)),
-            ) {
-                return Err(Error::KeyHasReduce {
-                    ptr: ptr.to_string(),
-                    schema: read.curi.clone(),
-                    strategy: read_shape.reduce.clone(),
-                });
-            }
-            if !matches!(read_shape.redact, shape::Redact::Unset) {
-                return Err(Error::KeyHasRedact {
-                    ptr: ptr.to_string(),
-                    schema: read.curi.clone(),
-                    strategy: read_shape.redact.clone(),
-                });
-            }
+        if !effective_type.is_keyable_type() {
+            return Err(Error::KeyWrongType {
+                ptr: ptr.to_string(),
+                type_: read_shape.type_,
+                schema: read.curi.clone(),
+            });
+        }
+
+        if !matches!(
+            read_shape.reduce,
+            shape::Reduce::Unset | shape::Reduce::Strategy(doc::reduce::Strategy::LastWriteWins(_)),
+        ) {
+            return Err(Error::KeyHasReduce {
+                ptr: ptr.to_string(),
+                schema: read.curi.clone(),
+                strategy: read_shape.reduce.clone(),
+            });
+        }
+        if !matches!(read_shape.redact, shape::Redact::Unset) {
+            return Err(Error::KeyHasRedact {
+                ptr: ptr.to_string(),
+                schema: read.curi.clone(),
+                strategy: read_shape.redact.clone(),
+            });
         }
 
         if let Some(write) = write {
@@ -120,21 +124,18 @@ impl Schema {
             }
 
             // Keyed location types may differ only in null-ability between
-            // the read and write schemas. Skip when the read type is INVALID
-            // (Cannot-exist location with a default).
-            if read_exists != Exists::Cannot {
-                let read_type = read_shape.type_ - types::NULL;
-                let write_type = write_shape.type_ - types::NULL;
+            // the read and write schemas.
+            let read_type = effective_type - types::NULL;
+            let write_type = write_shape.type_ - types::NULL;
 
-                if read_type != write_type {
-                    return Err(Error::KeyReadWriteTypesDiffer {
-                        ptr: ptr.to_string(),
-                        read_type,
-                        read_schema: read.curi.clone(),
-                        write_type,
-                        write_schema: write.curi.clone(),
-                    });
-                }
+            if read_type != write_type {
+                return Err(Error::KeyReadWriteTypesDiffer {
+                    ptr: ptr.to_string(),
+                    read_type,
+                    read_schema: read.curi.clone(),
+                    write_type,
+                    write_schema: write.curi.clone(),
+                });
             }
         }
 

--- a/crates/validation/src/schema.rs
+++ b/crates/validation/src/schema.rs
@@ -61,7 +61,7 @@ impl Schema {
                 ptr: ptr.to_string(),
                 schema: read.curi.clone(),
             });
-        } else if read_exists == Exists::Cannot {
+        } else if read_exists == Exists::Cannot && read_shape.default.is_none() {
             return Err(Error::PtrCannotExist {
                 ptr: ptr.to_string(),
                 schema: read.curi.clone(),
@@ -73,41 +73,46 @@ impl Schema {
             return Ok(());
         }
 
-        if !read_shape.type_.is_keyable_type() {
-            return Err(Error::KeyWrongType {
-                ptr: ptr.to_string(),
-                type_: read_shape.type_,
-                schema: read.curi.clone(),
-            });
-        }
+        // When read_exists is Cannot but has a default, we skipped the
+        // PtrCannotExist error above. The read shape's type is INVALID in
+        // this case, so key-specific checks against it are meaningless.
+        if read_exists != Exists::Cannot {
+            if !read_shape.type_.is_keyable_type() {
+                return Err(Error::KeyWrongType {
+                    ptr: ptr.to_string(),
+                    type_: read_shape.type_,
+                    schema: read.curi.clone(),
+                });
+            }
 
-        if !matches!(
-            read_shape.reduce,
-            shape::Reduce::Unset | shape::Reduce::Strategy(doc::reduce::Strategy::LastWriteWins(_)),
-        ) {
-            return Err(Error::KeyHasReduce {
-                ptr: ptr.to_string(),
-                schema: read.curi.clone(),
-                strategy: read_shape.reduce.clone(),
-            });
-        }
-        if !matches!(read_shape.redact, shape::Redact::Unset) {
-            return Err(Error::KeyHasRedact {
-                ptr: ptr.to_string(),
-                schema: read.curi.clone(),
-                strategy: read_shape.redact.clone(),
-            });
+            if !matches!(
+                read_shape.reduce,
+                shape::Reduce::Unset
+                    | shape::Reduce::Strategy(doc::reduce::Strategy::LastWriteWins(_)),
+            ) {
+                return Err(Error::KeyHasReduce {
+                    ptr: ptr.to_string(),
+                    schema: read.curi.clone(),
+                    strategy: read_shape.reduce.clone(),
+                });
+            }
+            if !matches!(read_shape.redact, shape::Redact::Unset) {
+                return Err(Error::KeyHasRedact {
+                    ptr: ptr.to_string(),
+                    schema: read.curi.clone(),
+                    strategy: read_shape.redact.clone(),
+                });
+            }
         }
 
         if let Some(write) = write {
             let (write_shape, write_exists) = write.shape.locate(&json::Pointer::from(ptr));
-
             if write_exists == Exists::Implicit {
                 return Err(Error::PtrIsImplicit {
                     ptr: ptr.to_string(),
                     schema: write.curi.clone(),
                 });
-            } else if write_exists == Exists::Cannot {
+            } else if write_exists == Exists::Cannot && write_shape.default.is_none() {
                 return Err(Error::PtrCannotExist {
                     ptr: ptr.to_string(),
                     schema: write.curi.clone(),
@@ -115,18 +120,21 @@ impl Schema {
             }
 
             // Keyed location types may differ only in null-ability between
-            // the read and write schemas.
-            let read_type = read_shape.type_ - types::NULL;
-            let write_type = write_shape.type_ - types::NULL;
+            // the read and write schemas. Skip when the read type is INVALID
+            // (Cannot-exist location with a default).
+            if read_exists != Exists::Cannot {
+                let read_type = read_shape.type_ - types::NULL;
+                let write_type = write_shape.type_ - types::NULL;
 
-            if read_type != write_type {
-                return Err(Error::KeyReadWriteTypesDiffer {
-                    ptr: ptr.to_string(),
-                    read_type: read_type,
-                    read_schema: read.curi.clone(),
-                    write_type: write_type,
-                    write_schema: write.curi.clone(),
-                });
+                if read_type != write_type {
+                    return Err(Error::KeyReadWriteTypesDiffer {
+                        ptr: ptr.to_string(),
+                        read_type,
+                        read_schema: read.curi.clone(),
+                        write_type,
+                        write_schema: write.curi.clone(),
+                    });
+                }
             }
         }
 

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1609,8 +1609,7 @@ fn test_key_with_write_default_allowed_despite_inferred_addl_props_false() {
     // When a collection key includes a field (/_meta/store) that is defined
     // in the write schema with a default value, but hasn't yet been observed
     // in the inferred schema (which has additionalProperties: false on _meta),
-    // validation currently raises PtrCannotExist because the read-schema
-    // intersection drops the default when type becomes INVALID.
+    // validation allows it because the default annotation survives intersection.
     let outcome = common::run(
         r##"
 driver:
@@ -1690,7 +1689,8 @@ test://example/catalog.yaml:
 #[test]
 fn test_key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false() {
     // Same scenario as above but using the exact schema structure from the
-    // source-shopify-native connector with $ref chains.
+    // source-shopify-native connector with $ref chains. The default annotation
+    // survives intersection, so validation allows the key field.
     let outcome = common::run(
         r##"
 driver:

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1605,6 +1605,194 @@ test://example/catalog.yaml:
 }
 
 #[test]
+fn test_key_with_write_default_allowed_despite_inferred_addl_props_false() {
+    // When a collection key includes a field (/_meta/store) that is defined
+    // in the write schema with a default value, but hasn't yet been observed
+    // in the inferred schema (which has additionalProperties: false on _meta),
+    // validation currently raises PtrCannotExist because the read-schema
+    // intersection drops the default when type becomes INVALID.
+    let outcome = common::run(
+        r##"
+driver:
+  dataPlanes:
+    "1d:1d:1d:1d:1d:1d:1d:1d": {}
+
+  liveInferredSchemas:
+    testing/multi-store:
+      type: object
+      properties:
+        id:
+          type: string
+        _meta:
+          type: object
+          properties:
+            uuid:
+              type: string
+          additionalProperties: false
+          required: [uuid]
+      required: [id, _meta]
+      additionalProperties: false
+      x-collection-generation-id: 0000000000000001
+
+  liveCollections:
+    testing/multi-store:
+      key: [/id]
+      lastPubId: "10:10:10:10:10:10:10:10"
+      controlId: "11:11:11:11:11:11:11:02"
+      dataPlaneId: "1d:1d:1d:1d:1d:1d:1d:1d"
+
+test://example/catalog.yaml:
+  collections:
+    testing/multi-store:
+      key: ["/_meta/store", "/id"]
+
+      writeSchema:
+        type: object
+        properties:
+          id:
+            type: string
+          _meta:
+            type: object
+            properties:
+              store:
+                type: string
+                default: ""
+        required: [id]
+        x-infer-schema: true
+
+      readSchema:
+        $defs:
+          flow://inferred-schema:
+            $id: flow://inferred-schema
+            type: object
+            properties:
+              id:
+                type: string
+              _meta:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                additionalProperties: false
+                required: [uuid]
+            required: [id, _meta]
+            additionalProperties: false
+            x-collection-generation-id: 0000000000000001
+        allOf:
+          - $ref: flow://relaxed-write-schema
+          - $ref: flow://inferred-schema
+"##,
+        "{}",
+    );
+    insta::assert_debug_snapshot!(outcome.errors);
+}
+
+#[test]
+fn test_key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false() {
+    // Same scenario as above but using the exact schema structure from the
+    // source-shopify-native connector with $ref chains.
+    let outcome = common::run(
+        r##"
+driver:
+  dataPlanes:
+    "1d:1d:1d:1d:1d:1d:1d:1d": {}
+
+  liveInferredSchemas:
+    testing/multi-store:
+      type: object
+      properties:
+        id:
+          type: string
+        _meta:
+          type: object
+          properties:
+            uuid:
+              type: string
+          additionalProperties: false
+          required: [uuid]
+      required: [id, _meta]
+      additionalProperties: false
+      x-collection-generation-id: 0000000000000001
+
+  liveCollections:
+    testing/multi-store:
+      key: [/id]
+      lastPubId: "10:10:10:10:10:10:10:10"
+      controlId: "11:11:11:11:11:11:11:02"
+      dataPlaneId: "1d:1d:1d:1d:1d:1d:1d:1d"
+
+test://example/catalog.yaml:
+  collections:
+    testing/multi-store:
+      key: ["/_meta/store", "/id"]
+
+      writeSchema:
+        $defs:
+          "flow://connector-schema":
+            $id: "flow://connector-schema"
+            $defs:
+              Meta:
+                properties:
+                  op:
+                    default: u
+                    description: "Operation type (c: Create, u: Update, d: Delete)"
+                    enum: [c, u, d]
+                    title: Op
+                    type: string
+                  row_id:
+                    default: -1
+                    description: "Row ID of the Document, counting up from zero, or -1 if not known"
+                    title: Row Id
+                    type: integer
+                  store:
+                    default: ""
+                    description: The Shopify store this document belongs to
+                    title: Store
+                    type: string
+                title: Meta
+                type: object
+            additionalProperties: true
+            properties:
+              _meta:
+                $ref: "#/$defs/Meta"
+                description: Document metadata
+              id:
+                title: Id
+                type: string
+            required: [id]
+            title: ShopifyGraphQLResource
+            type: object
+            x-infer-schema: true
+        $ref: "flow://connector-schema"
+
+      readSchema:
+        $defs:
+          flow://inferred-schema:
+            $id: flow://inferred-schema
+            type: object
+            properties:
+              id:
+                type: string
+              _meta:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                additionalProperties: false
+                required: [uuid]
+            required: [id, _meta]
+            additionalProperties: false
+            x-collection-generation-id: 0000000000000001
+        allOf:
+          - $ref: flow://relaxed-write-schema
+          - $ref: flow://inferred-schema
+"##,
+        "{}",
+    );
+    insta::assert_debug_snapshot!(outcome.errors);
+}
+
+#[test]
 fn test_collection_inferred_schema_add_blocking() {
     // A redact annotation on a required write schema property raises an error.
     let outcome = common::run_errors(

--- a/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_allowed_despite_inferred_addl_props_false.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_allowed_despite_inferred_addl_props_false.snap
@@ -1,11 +1,6 @@
 ---
 source: crates/validation/tests/scenario_tests.rs
-assertion_line: 1687
+assertion_line: 1686
 expression: outcome.errors
 ---
-[
-    Error {
-        scope: test://example/catalog.yaml#/collections/testing~1multi-store/key/0,
-        error: location /_meta/store is prohibited from ever existing by the schema test://example/catalog.yaml?ptr=/collections/testing~1multi-store/readSchema,
-    },
-]
+[]

--- a/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_allowed_despite_inferred_addl_props_false.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_allowed_despite_inferred_addl_props_false.snap
@@ -1,0 +1,11 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 1687
+expression: outcome.errors
+---
+[
+    Error {
+        scope: test://example/catalog.yaml#/collections/testing~1multi-store/key/0,
+        error: location /_meta/store is prohibited from ever existing by the schema test://example/catalog.yaml?ptr=/collections/testing~1multi-store/readSchema,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false.snap
@@ -3,9 +3,4 @@ source: crates/validation/tests/scenario_tests.rs
 assertion_line: 1792
 expression: outcome.errors
 ---
-[
-    Error {
-        scope: test://example/catalog.yaml#/collections/testing~1multi-store/key/0,
-        error: location /_meta/store is prohibited from ever existing by the schema test://example/catalog.yaml?ptr=/collections/testing~1multi-store/readSchema,
-    },
-]
+[]

--- a/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__key_with_write_default_via_ref_chain_allowed_despite_inferred_addl_props_false.snap
@@ -1,0 +1,11 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+assertion_line: 1792
+expression: outcome.errors
+---
+[
+    Error {
+        scope: test://example/catalog.yaml#/collections/testing~1multi-store/key/0,
+        error: location /_meta/store is prohibited from ever existing by the schema test://example/catalog.yaml?ptr=/collections/testing~1multi-store/readSchema,
+    },
+]


### PR DESCRIPTION
**Description:**

## Summary

- Treats `default` as a pure annotation during schema intersection, preserving it through `allOf` composition even when the intersected type is `INVALID`
- Adds `&& default.is_none()` guards to `PtrCannotExist` checks in `walk_ptr()` so locations with a default bypass the error
- Fixes the source-shopify-native scenario where `/_meta/store` has a write-schema default but the inferred schema hasn't observed it yet

## Problem

When a collection key includes a field (e.g. `/_meta/store`) defined in the write schema with `default: ""`, but the inferred schema has `additionalProperties: false` on the parent object and hasn't observed the field yet, publication fails with:

> location /_meta/store is prohibited from ever existing by the schema

The root cause is in `intersect_default()`: the inferred schema's `additionalProperties: false` imputes a false schema for unobserved properties, and intersecting with the write schema produces `type_: INVALID`. `intersect_default()` then drops the default because its type (`STRING`) doesn't overlap with `INVALID`, even though the default was valid in its originating schema.

## Fix

`default` is an annotation, not a validation keyword. Local validation already rejects mismatched defaults (e.g. `type: integer, default: "hello"`) at the schema that directly contains them. The intersection doesn't need to re-validate.

- **`intersect_default()`**: Replaced with `lhs.default.or(rhs.default)`, matching how `title`, `description`, and `reduce` are intersected
- **`walk_ptr()`**: Added `&& read_shape.default.is_none()` / `&& write_shape.default.is_none()` to `Cannot`-exist checks. When `read_exists` is `Cannot` with a default, skips read-side key checks (type, reduce, redact) since the `INVALID` shape is not meaningful
- **`shape_to_avro()`**: Updated the nullable check to treat a null default as equivalent to no default. When `default` is preserved as `Some(null)` through intersection, the field must still be nullable in the Avro schema since absence maps to null

## Test plan

- [x] Added two scenario tests demonstrating the bug (simple write schema + $ref chain matching source-shopify-native)
- [x] Updated `intersect_default` unit test to reflect annotation semantics
- [x] All 124 doc lib tests pass
- [x] All 75 validation scenario tests pass
- [x] Full validation test suite (124 tests across all test files) passes
- [x] All 10 dekaf field extraction tests pass (including `test_allof_with_null_default`)
- [x] All 2 avro crate tests pass

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

