### PR TITLE
supabase: add account_suspensions table for deletion lifecycle

### DIFF
--- a/supabase/migrations/20260219170000_account_suspensions.sql
+++ b/supabase/migrations/20260219170000_account_suspensions.sql
@@ -1,0 +1,12 @@
+-- Account suspension tracking for the deletion lifecycle.
+-- One row per suspended user. Deleted automatically when auth.users
+-- is removed (FK cascade) or when the user is unsuspended.
+
+CREATE TABLE internal.account_suspensions (
+    user_id        uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    reason         text NOT NULL,
+    suspended_at   timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE internal.account_suspensions IS
+  'Active account suspensions. Row is deleted when user is expired (via FK cascade) or unsuspended.';


### PR DESCRIPTION
**Description:**

Adds `internal.account_suspensions` table to track active account suspensions as part of the account deletion lifecycle. One row per suspended user. The FK on `auth.users(id)` cascades on delete, so the record is automatically cleaned up when a user is expired. Rows are also deleted explicitly on unsuspend.

**Workflow steps:**

This table will be used by upcoming account lifecycle tooling. The basic operations:
```sql
-- Suspend
INSERT INTO internal.account_suspensions (user_id, reason) VALUES ($1, 'voluntary_deletion');

-- Check status
SELECT suspended_at, reason FROM internal.account_suspensions WHERE user_id = $1;

-- Unsuspend
DELETE FROM internal.account_suspensions WHERE user_id = $1;

-- Batch: find accounts eligible for expiration
SELECT user_id, suspended_at FROM internal.account_suspensions
WHERE suspended_at + interval '30 days' < now();
```

**Documentation links affected:**

None

**Notes for reviewers:**

Single table, no RLS policies needed (internal schema, accessed via direct Postgres with service role). The `reason` column uses free text for now with conventions: `voluntary_deletion`, `non_payment`, `tos_violation`. No enum because we don't want a migration every time we add a reason.