### PR TITLE
dekaf: set RecordBatch `partition_leader_epoch` from `binding_backfill_counter`

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -51,6 +51,12 @@ pub struct Read {
     deletes: DeletionMode,
 
     pub(crate) rewrite_offsets_from: Option<i64>,
+
+    // Leader epoch for this partition, used in RecordBatch headers.
+    // Must match the epoch reported in OffsetFetch's committed_leader_epoch
+    // so that librdkafka's epoch-aware commit filtering doesn't silently
+    // skip offset commits.
+    partition_leader_epoch: i32,
 }
 
 pub enum BatchResult {
@@ -132,6 +138,7 @@ impl Read {
             rewrite_offsets_from,
             deletes: auth.deletions(),
             offset_start: offset,
+            partition_leader_epoch: collection.binding_backfill_counter as i32,
         })
     }
 
@@ -442,7 +449,7 @@ impl Read {
                 headers: Default::default(),
                 key,
                 offset: kafka_offset,
-                partition_leader_epoch: 1,
+                partition_leader_epoch: self.partition_leader_epoch,
                 producer_epoch: 1,
                 producer_id: producer.as_i64(),
                 sequence: kafka_offset as i32,

--- a/crates/dekaf/tests/e2e/collection_reset.rs
+++ b/crates/dekaf/tests/e2e/collection_reset.rs
@@ -662,6 +662,99 @@ async fn test_fetch_response_includes_leader_epoch() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// This catches a bug where the RecordBatch `partition_leader_epoch` didn't match
+/// the `committed_leader_epoch` returned by OffsetFetch. librdkafka compares these
+/// two values in `rd_kafka_fetch_pos_cmp` to decide whether a commit is needed:
+/// if `stored_pos.leader_epoch < committed_pos.leader_epoch`, the commit is silently
+/// skipped. After a reset the OffsetFetch epoch advances (to `binding_backfill_counter`)
+/// but the RecordBatch epoch must also match, otherwise the second-generation consumer's
+/// commits are all silently dropped, causing offset regression on the third generation.
+#[tokio::test]
+async fn test_commits_persist_across_rebalances_after_reset() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("commits_after_reset", FIXTURE).await?;
+
+    // Inject a document so the journal exists and Dekaf can report partitions in metadata.
+    env.inject_documents("data", vec![json!({"id": "0", "value": "pre-reset"})])
+        .await?;
+
+    let initial_epoch = get_leader_epoch(&env, "test_topic", 0).await?;
+
+    // Reset the collection so binding_backfill_counter increments (epoch 1 -> 2).
+    perform_collection_reset(&env, "test_topic", 0, initial_epoch, EPOCH_CHANGE_TIMEOUT).await?;
+
+    let group_id = format!("test-group-{}", uuid::Uuid::new_v4());
+
+    // Inject 3 documents into the reset collection.
+    env.inject_documents(
+        "data",
+        vec![
+            json!({"id": "a", "value": "1"}),
+            json!({"id": "b", "value": "2"}),
+            json!({"id": "c", "value": "3"}),
+        ],
+    )
+    .await?;
+
+    // Generation 1 (post-reset): consume all 4 docs (reset-trigger + a, b, c) and commit.
+    // This succeeds even with the bug because the initial OffsetFetch returns
+    // committed_leader_epoch=-1 (no prior commits), which bypasses librdkafka's
+    // epoch comparison in rd_kafka_fetch_pos_cmp.
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch_n_with_state_commit(4).await?;
+        assert_eq!(records.len(), 4, "gen 1 should consume all 4 docs");
+    }
+
+    // Inject 1 more document.
+    env.inject_documents("data", vec![json!({"id": "d", "value": "4"})])
+        .await?;
+
+    // Generation 2: should resume after gen 1's commit and see only doc "d".
+    // Commits via commit_consumer_state. With the bug, this commit is silently
+    // skipped: the RecordBatch partition_leader_epoch is hardcoded to 1, so
+    // stored_pos.leader_epoch=1. But Dekaf's OffsetFetch returns
+    // committed_leader_epoch=2 (binding_backfill_counter), so
+    // committed_pos.leader_epoch=2. librdkafka sees stored(1) < committed(2)
+    // and skips the commit (returning NoOffset, which mirrors the silent skip
+    // that auto-commit consumers would experience).
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch_n_with_state_commit(1).await?;
+        assert_eq!(records.len(), 1, "gen 2 should see only doc d");
+        assert_eq!(records[0].value["id"], "d");
+    }
+
+    // Inject 1 more document.
+    env.inject_documents("data", vec![json!({"id": "e", "value": "5"})])
+        .await?;
+
+    // Generation 3: should resume after gen 2's commit and see only doc "e".
+    // With the bug, gen 2's commit was silently dropped, so this consumer
+    // falls back to gen 1's committed position and sees both "d" and "e".
+    {
+        let consumer = env.kafka_consumer_with_group_id(&group_id).await?;
+        consumer.subscribe(&["test_topic"])?;
+
+        let records = consumer.fetch().await?;
+        assert_eq!(
+            records.len(),
+            1,
+            "gen 3 should see only doc e (gen 2's commit must have persisted), but got {} records: {:?}",
+            records.len(),
+            records.iter().map(|r| &r.value["id"]).collect::<Vec<_>>()
+        );
+        assert_eq!(records[0].value["id"], "e");
+    }
+
+    Ok(())
+}
+
 /// Commit offset, reset collection. OffsetFetch should NOT return the old offset
 #[tokio::test]
 async fn test_offset_isolation_after_reset() -> anyhow::Result<()> {

--- a/crates/dekaf/tests/e2e/kafka.rs
+++ b/crates/dekaf/tests/e2e/kafka.rs
@@ -155,6 +155,77 @@ impl KafkaConsumer {
         Ok(records)
     }
 
+    /// Fetch exactly N records, then commit via `commit_consumer_state`.
+    ///
+    /// Unlike `fetch_n_with_commit` (which uses `commit_message`), this method
+    /// commits through librdkafka's stored-position path: `rd_kafka_commit(rk, NULL, ...)`.
+    /// That path compares the stored position's `leader_epoch` (from the RecordBatch)
+    /// against the committed position's `leader_epoch` (from OffsetFetch) via
+    /// `rd_kafka_fetch_pos_cmp`. If `stored < committed`, the commit is silently
+    /// skipped and `NoOffset` is returned.
+    pub async fn fetch_n_with_state_commit(&self, n: usize) -> anyhow::Result<Vec<DecodedRecord>> {
+        const TIMEOUT: Duration = Duration::from_secs(180);
+        let deadline = std::time::Instant::now() + TIMEOUT;
+
+        let mut records = Vec::new();
+        let mut stream = self.consumer.stream();
+
+        while records.len() < n {
+            if std::time::Instant::now() > deadline {
+                anyhow::bail!("timeout waiting for {} records, got {}", n, records.len());
+            }
+
+            match tokio::time::timeout(Duration::from_secs(30), stream.next()).await {
+                Ok(Some(Ok(msg))) => {
+                    let key = self
+                        .decoder
+                        .decode(msg.key())
+                        .await
+                        .context("failed to decode key")?;
+                    let value = self
+                        .decoder
+                        .decode(msg.payload())
+                        .await
+                        .context("failed to decode value")?;
+
+                    records.push(DecodedRecord {
+                        topic: msg.topic().to_string(),
+                        partition: msg.partition(),
+                        offset: msg.offset(),
+                        key: apache_avro::from_value(&key.value)?,
+                        value: apache_avro::from_value(&value.value)?,
+                    });
+                }
+                Ok(Some(Err(e))) => return Err(e.into()),
+                Ok(None) => break,
+                Err(_) => continue, // per-message timeout, retry
+            }
+        }
+
+        // commit_consumer_state uses rd_kafka_commit(rk, NULL, ...) which goes
+        // through rd_kafka_fetch_pos_cmp. If the RecordBatch partition_leader_epoch
+        // doesn't match the committed_leader_epoch from OffsetFetch, the commit
+        // is silently skipped (returning NoOffset). In a real consumer using
+        // auto-commit, this skip is silent. We match that behavior here by
+        // treating NoOffset as a no-op rather than an error.
+        match self
+            .consumer
+            .commit_consumer_state(rdkafka::consumer::CommitMode::Sync)
+        {
+            Ok(()) => {}
+            Err(rdkafka::error::KafkaError::ConsumerCommit(
+                rdkafka::types::RDKafkaErrorCode::NoOffset,
+            )) => {
+                tracing::warn!(
+                    "commit_consumer_state returned NoOffset (commit silently skipped due to epoch mismatch)"
+                );
+            }
+            Err(e) => return Err(e).context("failed to commit consumer state"),
+        }
+
+        Ok(records)
+    }
+
     /// Get the inner consumer for advanced operations.
     pub fn inner(&self) -> &StreamConsumer {
         &self.consumer


### PR DESCRIPTION
## Problem

A consumer reading from Dekaf after a collection reset and subsequent session disconnects/reconnects would silently lose offset commits. After the first consumer session committed successfully, subsequent generations' commits were dropped, causing consumers to re-read messages they had already processed. The root cause was a mismatch between two places where Dekaf reports the leader epoch: the `partition_leader_epoch` in RecordBatch headers (hardcoded to `1`) and the `committed_leader_epoch` in OffsetFetch responses (derived from `binding_backfill_counter`, which increments on reset). librdkafka compares these two values internally and refuses to commit when the RecordBatch epoch is behind the OffsetFetch epoch.

This wasn't caught in testing because it requires the consumer to experience a rebalance or some other circumstance causing it to reconnect, which doesn't happen very often in practice.

## Fix

`crates/dekaf/src/read.rs` sets `partition_leader_epoch: self.partition_leader_epoch` instead of hardcoding `1`. The `partition_leader_epoch` field is initialized from `collection.binding_backfill_counter`, keeping RecordBatch epochs consistent with OffsetFetch's `committed_leader_epoch`.

## Test

`test_commits_persist_across_rebalances_after_reset` in `crates/dekaf/tests/e2e/collection_reset.rs` reproduces the scenario that the customer reported: a consumer initially works fine, is able to commit offsets, and then after reconnecting/collection reset, offset commits appear to be silently skipped, causing _subsequent_ reconnections to roll back to the last committed offset from the initial connection (resulting in duplicate records being seen by the consumer).

The test uses `commit_consumer_state` (`rd_kafka_commit(rk, NULL, ...)`) rather than `commit_message`, because `commit_message` constructs a raw offset without leader epoch and bypasses `rd_kafka_fetch_pos_cmp` entirely.

### Before fix (Dekaf serving `partition_leader_epoch: 1`)

```
2026-02-20T18:12:45.135858Z  INFO e2e::harness: Shard is primary task_name=test/dekaf/commits_after_reset/329c/source_ingest
2026-02-20T18:12:45.135870Z  INFO e2e::collection_reset: Injecting document to create new journal
2026-02-20T18:12:45.175779Z  INFO e2e::harness: Injecting documents count=1 path=data
2026-02-20T18:12:45.284784Z  INFO e2e::collection_reset: Waiting for epoch change and partitions topic=test_topic partition=0 previous_epoch=1 timeout_secs=30
2026-02-20T18:12:55.288608Z  INFO e2e::collection_reset: Epoch changed and partitions available topic=test_topic partition=0 previous_epoch=1 new_epoch=2
2026-02-20T18:12:55.288649Z  INFO e2e::collection_reset: Collection reset completed initial_epoch=1 new_epoch=2
2026-02-20T18:12:55.330229Z  INFO e2e::harness: Injecting documents count=3 path=data
test collection_reset::test_commits_persist_across_rebalances_after_reset has been running for over 60 seconds
2026-02-20T18:12:59.122673Z  INFO e2e::harness: Injecting documents count=1 path=data
2026-02-20T18:13:02.657697Z  WARN e2e::kafka: commit_consumer_state returned NoOffset (commit skipped due to epoch mismatch)
2026-02-20T18:13:02.800396Z  INFO e2e::harness: Injecting documents count=1 path=data

thread 'collection_reset::test_commits_persist_across_rebalances_after_reset' (265698) panicked at crates/dekaf/tests/e2e/collection_reset.rs:748:9:
assertion `left == right` failed: gen 3 should see only doc e (gen 2's commit must have persisted), but got 2 records: [String("d"), String("e")]
  left: 2
 right: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test collection_reset::test_commits_persist_across_rebalances_after_reset ... FAILED

```

After the fix is applied, the test passes. 

