### PR TITLE
Rename storage to spec

### DIFF
--- a/crates/agent/src/integration_tests/graphql/mutations/storage_mappings.rs
+++ b/crates/agent/src/integration_tests/graphql/mutations/storage_mappings.rs
@@ -2,8 +2,8 @@ use crate::integration_tests::harness::TestHarness;
 use serde_json::json;
 
 const CREATE_STORAGE_MAPPING_MUTATION: &str = r#"
-mutation CreateStorageMapping($catalogPrefix: Prefix!, $storage: JSON!) {
-    createStorageMapping(catalogPrefix: $catalogPrefix, storage: $storage) {
+mutation CreateStorageMapping($catalogPrefix: Prefix!, $spec: JSON!) {
+    createStorageMapping(catalogPrefix: $catalogPrefix, spec: $spec) {
         catalogPrefix
     }
 }
@@ -21,7 +21,7 @@ async fn test_create_storage_mapping_validation_errors() {
             CREATE_STORAGE_MAPPING_MUTATION,
             &json!({
                 "catalogPrefix": "aliceCo/sub/",
-                "storage": {
+                "spec": {
                     "stores": [{"provider": "GCS", "bucket": "test-bucket"}],
                     "data_planes": []
                 },
@@ -31,7 +31,7 @@ async fn test_create_storage_mapping_validation_errors() {
     let err = result.unwrap_err().to_string();
 
     assert!(
-        err.contains("storage.data_planes must not be empty"),
+        err.contains("spec.data_planes must not be empty"),
         "expected empty data_planes error, got: {err}"
     );
 
@@ -42,7 +42,7 @@ async fn test_create_storage_mapping_validation_errors() {
             CREATE_STORAGE_MAPPING_MUTATION,
             &json!({
                 "catalogPrefix": "aliceCo/sub/",
-                "storage": {
+                "spec": {
                     "stores": [],
                     "data_planes": ["ops/dp/public/test"]
                 },
@@ -52,7 +52,7 @@ async fn test_create_storage_mapping_validation_errors() {
     let err = result.unwrap_err().to_string();
 
     assert!(
-        err.contains("storage.stores must not be empty"),
+        err.contains("spec.stores must not be empty"),
         "expected empty stores error, got: {err}"
     );
 
@@ -63,7 +63,7 @@ async fn test_create_storage_mapping_validation_errors() {
             CREATE_STORAGE_MAPPING_MUTATION,
             &json!({
                 "catalogPrefix": "aliceCo",
-                "storage": {
+                "spec": {
                     "stores": [{"provider": "GCS", "bucket": "test-bucket"}],
                     "data_planes": ["ops/dp/public/test"]
                 },

--- a/crates/control-plane-api/src/directives/storage_mappings.rs
+++ b/crates/control-plane-api/src/directives/storage_mappings.rs
@@ -168,30 +168,30 @@ pub fn strip_collection_data_suffix(storage: models::StorageDef) -> models::Stor
     }
 }
 
-/// Split a user-provided `StorageDef` into separate collection and recovery storage definitions.
+/// Split a user-provided `StorageDef` into separate collection and recovery spec definitions.
 ///
-/// The collection storage gets `collection-data/` appended to each store's prefix (if not already
-/// present) and retains the data plane assignments. The recovery storage uses the base prefixes
+/// The collection spec gets `collection-data/` appended to each store's prefix (if not already
+/// present) and retains the data plane assignments. The recovery spec uses the base prefixes
 /// (with `collection-data/` stripped if present) and has no data plane assignments.
-pub fn collection_and_recovery_storage_from(
-    storage: models::StorageDef,
+pub fn collection_and_recovery_spec_from(
+    spec: models::StorageDef,
 ) -> (models::StorageDef, models::StorageDef) {
     let models::StorageDef {
         data_planes,
         stores,
-    } = storage;
+    } = spec;
 
-    let collection_storage = append_collection_data_suffix(models::StorageDef {
+    let collection_spec = append_collection_data_suffix(models::StorageDef {
         data_planes,
         stores: stores.clone(),
     });
 
-    let recovery_storage = strip_collection_data_suffix(models::StorageDef {
+    let recovery_spec = strip_collection_data_suffix(models::StorageDef {
         data_planes: Vec::new(),
         stores,
     });
 
-    (collection_storage, recovery_storage)
+    (collection_spec, recovery_spec)
 }
 
 #[cfg(test)]
@@ -214,12 +214,12 @@ mod tests {
 
     #[test]
     fn test_split_appends_collection_data_suffix() {
-        let storage = models::StorageDef {
+        let spec = models::StorageDef {
             data_planes: vec!["ops/dp/public/gcp-us-central1".to_string()],
             stores: vec![gcs_store("my-bucket", "tenant/")],
         };
 
-        let (collection, recovery) = collection_and_recovery_storage_from(storage);
+        let (collection, recovery) = collection_and_recovery_spec_from(spec);
 
         assert_eq!(get_prefix(&collection.stores[0]), "tenant/collection-data/");
         assert_eq!(get_prefix(&recovery.stores[0]), "tenant/");
@@ -227,12 +227,12 @@ mod tests {
 
     #[test]
     fn test_split_does_not_double_append_suffix() {
-        let storage = models::StorageDef {
+        let spec = models::StorageDef {
             data_planes: vec!["ops/dp/public/gcp-us-central1".to_string()],
             stores: vec![gcs_store("my-bucket", "tenant/collection-data/")],
         };
 
-        let (collection, recovery) = collection_and_recovery_storage_from(storage);
+        let (collection, recovery) = collection_and_recovery_spec_from(spec);
 
         assert_eq!(get_prefix(&collection.stores[0]), "tenant/collection-data/");
         assert_eq!(get_prefix(&recovery.stores[0]), "tenant/");
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_split_preserves_data_planes_only_for_collection() {
-        let storage = models::StorageDef {
+        let spec = models::StorageDef {
             data_planes: vec![
                 "ops/dp/public/gcp-us-central1".to_string(),
                 "ops/dp/public/aws-us-east1".to_string(),
@@ -248,7 +248,7 @@ mod tests {
             stores: vec![gcs_store("my-bucket", "tenant/")],
         };
 
-        let (collection, recovery) = collection_and_recovery_storage_from(storage);
+        let (collection, recovery) = collection_and_recovery_spec_from(spec);
 
         assert_eq!(collection.data_planes.len(), 2);
         assert_eq!(collection.data_planes[0], "ops/dp/public/gcp-us-central1");
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_split_handles_multiple_stores() {
-        let storage = models::StorageDef {
+        let spec = models::StorageDef {
             data_planes: vec!["ops/dp/public/gcp-us-central1".to_string()],
             stores: vec![
                 gcs_store("bucket-a", "prefix-a/"),
@@ -266,7 +266,7 @@ mod tests {
             ],
         };
 
-        let (collection, recovery) = collection_and_recovery_storage_from(storage);
+        let (collection, recovery) = collection_and_recovery_spec_from(spec);
 
         assert_eq!(collection.stores.len(), 2);
         assert_eq!(
@@ -285,12 +285,12 @@ mod tests {
 
     #[test]
     fn test_split_handles_empty_prefix() {
-        let storage = models::StorageDef {
+        let spec = models::StorageDef {
             data_planes: vec![],
             stores: vec![gcs_store("my-bucket", "")],
         };
 
-        let (collection, recovery) = collection_and_recovery_storage_from(storage);
+        let (collection, recovery) = collection_and_recovery_spec_from(spec);
 
         assert_eq!(get_prefix(&collection.stores[0]), "collection-data/");
         assert_eq!(get_prefix(&recovery.stores[0]), "");

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -1,5 +1,5 @@
 use crate::directives::storage_mappings::{
-    collection_and_recovery_storage_from, insert_storage_mapping, strip_collection_data_suffix,
+    collection_and_recovery_spec_from, insert_storage_mapping, strip_collection_data_suffix,
     update_storage_mapping, upsert_storage_mapping,
 };
 use async_graphql::{
@@ -55,7 +55,7 @@ pub struct UpdateStorageMappingResult {
 
 fn validate_inputs(
     catalog_prefix: &models::Prefix,
-    storage: &models::StorageDef,
+    spec: &models::StorageDef,
 ) -> async_graphql::Result<()> {
     if let Err(err) = catalog_prefix.validate() {
         return Err(async_graphql::Error::new(format!(
@@ -63,20 +63,18 @@ fn validate_inputs(
         )));
     }
 
-    if let Err(err) = storage.validate() {
+    if let Err(err) = spec.validate() {
         return Err(async_graphql::Error::new(format!(
             "invalid storage definition: {err}"
         )));
     }
-    if storage.data_planes.is_empty() {
+    if spec.data_planes.is_empty() {
         return Err(async_graphql::Error::new(
-            "storage.data_planes must not be empty",
+            "spec.data_planes must not be empty",
         ));
     }
-    if storage.stores.is_empty() {
-        return Err(async_graphql::Error::new(
-            "storage.stores must not be empty",
-        ));
+    if spec.stores.is_empty() {
+        return Err(async_graphql::Error::new("spec.stores must not be empty"));
     }
     Ok(())
 }
@@ -169,24 +167,24 @@ impl StorageMappingsMutation {
         ctx: &Context<'_>,
         catalog_prefix: models::Prefix,
         detail: Option<String>,
-        storage: async_graphql::Json<models::StorageDef>,
+        spec: async_graphql::Json<models::StorageDef>,
     ) -> async_graphql::Result<CreateStorageMappingResult> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
         let snapshot = env.snapshot();
-        let async_graphql::Json(storage) = storage;
+        let async_graphql::Json(spec) = spec;
 
         // Do basic input validation checks first.
-        validate_inputs(&catalog_prefix, &storage)?;
+        validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &storage.data_planes).await?;
+        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
 
-        let data_planes = resolve_data_planes(&snapshot, &storage.data_planes)?;
+        let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
         // Run health checks.
         let health_checks =
-            run_all_health_checks(&catalog_prefix, &data_planes, &storage.stores).await;
+            run_all_health_checks(&catalog_prefix, &data_planes, &spec.stores).await;
         let all_passed = health_checks.iter().all(|c| c.error.is_none());
 
         if !all_passed {
@@ -236,13 +234,13 @@ impl StorageMappingsMutation {
         // A single conceptual "storage mapping" is (today) stored as two
         // distinct rows. They must align, and this alignment is enforced
         // by the `validations` crate.
-        let (collection_storage, recovery_storage) = collection_and_recovery_storage_from(storage);
+        let (collection_spec, recovery_spec) = collection_and_recovery_spec_from(spec);
 
         // Insert collection storage mapping (fails if already exists).
         let inserted = insert_storage_mapping(
             detail.as_deref(),
             catalog_prefix.as_str(),
-            &collection_storage,
+            &collection_spec,
             &mut *txn,
         )
         .await?;
@@ -258,7 +256,7 @@ impl StorageMappingsMutation {
         upsert_storage_mapping(
             detail.as_deref(),
             &format!("recovery/{catalog_prefix}"),
-            &recovery_storage,
+            &recovery_spec,
             &mut txn,
         )
         .await?;
@@ -267,8 +265,8 @@ impl StorageMappingsMutation {
 
         tracing::info!(
             %catalog_prefix,
-            data_planes = ?collection_storage.data_planes,
-            stores_count = ?collection_storage.stores.len(),
+            data_planes = ?collection_spec.data_planes,
+            stores_count = ?collection_spec.stores.len(),
             "created storage mapping"
         );
 
@@ -289,24 +287,24 @@ impl StorageMappingsMutation {
         ctx: &Context<'_>,
         catalog_prefix: models::Prefix,
         detail: Option<String>,
-        storage: async_graphql::Json<models::StorageDef>,
+        spec: async_graphql::Json<models::StorageDef>,
     ) -> async_graphql::Result<UpdateStorageMappingResult> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
         let snapshot = env.snapshot();
-        let async_graphql::Json(storage) = storage;
+        let async_graphql::Json(spec) = spec;
 
         // Do basic input validation checks first.
-        validate_inputs(&catalog_prefix, &storage)?;
+        validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &storage.data_planes).await?;
+        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
 
-        let data_planes = resolve_data_planes(&snapshot, &storage.data_planes)?;
+        let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
         // Run health checks outside of transaction so as not to keep rows locked too long.
         let health_checks =
-            run_all_health_checks(&catalog_prefix, &data_planes, &storage.stores).await;
+            run_all_health_checks(&catalog_prefix, &data_planes, &spec.stores).await;
 
         // Begin a transaction to fetch existing mapping and update.
         let mut txn = env.pg_pool.begin().await?;
@@ -334,7 +332,7 @@ impl StorageMappingsMutation {
         };
 
         // Determine if republish is needed: stores added or removed.
-        let republish = storage.stores != current.0.stores;
+        let republish = spec.stores != current.0.stores;
 
         // Check if any health check failed for a newly added store or data plane.
         let has_new_failures = health_checks.iter().any(|c| {
@@ -359,12 +357,12 @@ impl StorageMappingsMutation {
         // A single conceptual "storage mapping" is (today) stored as two
         // distinct rows. They must align, and this alignment is enforced
         // by the `validations` crate.
-        let (collection_storage, recovery_storage) = collection_and_recovery_storage_from(storage);
+        let (collection_spec, recovery_spec) = collection_and_recovery_spec_from(spec);
 
         let updated = update_storage_mapping(
             detail.as_deref(),
             catalog_prefix.as_str(),
-            &collection_storage,
+            &collection_spec,
             &mut *txn,
         )
         .await?;
@@ -380,7 +378,7 @@ impl StorageMappingsMutation {
         upsert_storage_mapping(
             detail.as_deref(),
             &format!("recovery/{catalog_prefix}"),
-            &recovery_storage,
+            &recovery_spec,
             &mut txn,
         )
         .await?;
@@ -401,8 +399,8 @@ impl StorageMappingsMutation {
 
         tracing::info!(
             %catalog_prefix,
-            data_planes = ?collection_storage.data_planes,
-            stores_count = ?collection_storage.stores.len(),
+            data_planes = ?collection_spec.data_planes,
+            stores_count = ?collection_spec.stores.len(),
             republish,
             "updated storage mapping"
         );
@@ -424,23 +422,23 @@ impl StorageMappingsMutation {
         &self,
         ctx: &Context<'_>,
         catalog_prefix: models::Prefix,
-        storage: async_graphql::Json<models::StorageDef>,
+        spec: async_graphql::Json<models::StorageDef>,
     ) -> async_graphql::Result<ConnectionHealthTestResult> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
         let snapshot = env.snapshot();
-        let async_graphql::Json(storage) = storage;
+        let async_graphql::Json(spec) = spec;
 
         // Do basic input validation checks first.
-        validate_inputs(&catalog_prefix, &storage)?;
+        validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &storage.data_planes).await?;
+        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
 
-        let data_planes = resolve_data_planes(&snapshot, &storage.data_planes)?;
+        let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
         // Run health checks and collect results.
-        let results = run_all_health_checks(&catalog_prefix, &data_planes, &storage.stores).await;
+        let results = run_all_health_checks(&catalog_prefix, &data_planes, &spec.stores).await;
 
         Ok(ConnectionHealthTestResult {
             catalog_prefix,
@@ -542,7 +540,7 @@ pub struct StorageMapping {
     /// Optional description of this storage mapping.
     pub detail: Option<String>,
     /// The storage definition containing stores and data plane assignments.
-    pub storage: async_graphql::Json<models::StorageDef>,
+    pub spec: async_graphql::Json<models::StorageDef>,
     /// The current user's capability to this storage mapping's prefix.
     pub user_capability: models::Capability,
 }
@@ -676,14 +674,14 @@ impl StorageMappingsQuery {
                 })?;
 
                 // Strip "collection-data/" suffix from store prefixes before returning to user.
-                let user_facing_storage = strip_collection_data_suffix(row.spec);
+                let user_facing_spec = strip_collection_data_suffix(row.spec);
 
                 Ok(connection::Edge::new(
                     row.catalog_prefix.clone(),
                     StorageMapping {
                         catalog_prefix: models::Prefix::new(row.catalog_prefix),
                         detail: row.detail,
-                        storage: async_graphql::Json(user_facing_storage),
+                        spec: async_graphql::Json(user_facing_spec),
                         user_capability,
                     },
                 ))

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -706,7 +706,7 @@ type MutationRoot {
 	
 	All health checks must pass before the storage mapping is created.
 	"""
-	createStorageMapping(catalogPrefix: Prefix!, detail: String, storage: JSON!): CreateStorageMappingResult!
+	createStorageMapping(catalogPrefix: Prefix!, detail: String, spec: JSON!): CreateStorageMappingResult!
 	"""
 	Update an existing storage mapping for the given catalog prefix.
 	
@@ -718,7 +718,7 @@ type MutationRoot {
 	storage mapping is updated. Health check failures for existing stores/data planes
 	are allowed (they were already validated when created).
 	"""
-	updateStorageMapping(catalogPrefix: Prefix!, detail: String, storage: JSON!): UpdateStorageMappingResult!
+	updateStorageMapping(catalogPrefix: Prefix!, detail: String, spec: JSON!): UpdateStorageMappingResult!
 	"""
 	Check storage health for a given catalog prefix and storage definition.
 	
@@ -728,7 +728,7 @@ type MutationRoot {
 	Unlike create/update mutations, this does not modify any data and always returns
 	health check results (both successes and failures) rather than erroring on failures.
 	"""
-	testConnectionHealth(catalogPrefix: Prefix!, storage: JSON!): ConnectionHealthTestResult!
+	testConnectionHealth(catalogPrefix: Prefix!, spec: JSON!): ConnectionHealthTestResult!
 	"""
 	Creates a new alert subscription. Returns an error if there is already
 	an existing subscription for the same prefix and email address.
@@ -1250,7 +1250,7 @@ type StorageMapping {
 	"""
 	The storage definition containing stores and data plane assignments.
 	"""
-	storage: JSON!
+	spec: JSON!
 	"""
 	The current user's capability to this storage mapping's prefix.
 	"""


### PR DESCRIPTION
**Description:**

I chose a not-great field name `storage` when first building out the storage mapping gql operations. Better to stick with the name `spec` that's used on the backend. 

No functional changes here.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

