### PR TITLE
validation: keep as document field when incompatible

### DIFF
--- a/crates/validation/src/field_selection.rs
+++ b/crates/validation/src/field_selection.rs
@@ -490,7 +490,7 @@ pub fn group_outcomes(
             (Some(select), Some(reject)) => EOB::Both(select, reject),
         };
 
-        if let EOB::Left(_select) = &outcome {
+        if outcome.has_left() {
             // Track selected fold and pointer for subsequent evaluations.
             if field_ptr != "" {
                 selected_ptrs.push(field_ptr);
@@ -857,6 +857,20 @@ validated:
             GroupByKey,
         )
         "###);
+    }
+
+    #[test]
+    fn test_document_field_incompatible() {
+        let snap = run_test(
+            include_str!("field_selection.fixture.yaml"),
+            r##"
+model:
+    recommended: true
+validated:
+    flow_document: { type: INCOMPATIBLE, reason: "wrong type" }
+"##,
+        );
+        insta::assert_debug_snapshot!(snap.selection);
     }
 
     #[test]

--- a/crates/validation/src/snapshots/validation__field_selection__tests__document_field_incompatible.snap
+++ b/crates/validation/src/snapshots/validation__field_selection__tests__document_field_incompatible.snap
@@ -1,0 +1,31 @@
+---
+source: crates/validation/src/field_selection.rs
+expression: snap.selection
+---
+FieldSelection {
+    keys: [
+        "an_int",
+        "a_bool",
+    ],
+    values: [
+        "ABool",
+        "ADateTime",
+        "AMap",
+        "AnArray",
+        "AnInt",
+        "NestedFoo",
+        "_meta/op",
+        "a_date_time",
+        "a_map",
+        "a_num1",
+        "an_array",
+        "an_array_redux",
+        "flow_published_at",
+        "nested",
+        "nested/bar",
+    ],
+    document: "flow_document",
+    field_config_json_map: {
+        "nested": b"{\"cfg\":42}",
+    },
+}


### PR DESCRIPTION
**Description:**

If the document field is incompatible, the materialization will need to be backfilled.  Previously we would lose track of the document fields special status and select it as a value.

**Workflow steps:**

No changes.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)