### PR TITLE
dekaf: add missing timeout to `fetch_partitions()` in task manager loop

### DIFF
--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -221,7 +221,8 @@ impl TaskManager {
         // messages emitted by the task manager after that session is closed would be lost.
         // Instead, we'll create a separate log forwarder for this task manager that will report
         // its logs to the correct task's ops logs, irrespective of the session that spawned it.
-        tokio::spawn(logging::forward_logs(
+
+        let handle = tokio::spawn(logging::forward_logs(
             GazetteWriter::new(self.clone()),
             stop_signal.clone(),
             self.clone().run_task_manager(
@@ -232,6 +233,22 @@ impl TaskManager {
                 task_name,
             ),
         ));
+
+        tokio::spawn(async move {
+            let handle_resp = handle.await;
+
+            match handle_resp {
+                Ok(Err(task_mgr_err)) => {
+                    tracing::error!(?task_mgr_err, "run_task_manager error!")
+                }
+                Ok(_) => {
+                    tracing::info!("run_task_manager exited Ok")
+                }
+                Err(e) => {
+                    tracing::error!(?e, "run_task_manager panic!");
+                }
+            }
+        });
 
         TaskStateListener(receiver)
     }
@@ -642,7 +659,12 @@ pub async fn fetch_partitions(
         ..Default::default()
     };
 
+    tracing::info!("Starting to list journals");
     let response = journal_client.list(request).await?;
+
+    let journals_len = response.journals.len();
+
+    tracing::info!(num_journals = journals_len, "Finished listing journals");
 
     let mut partitions = Vec::with_capacity(response.journals.len());
 


### PR DESCRIPTION
## Summary

The Dekaf task manager is responsible for fetching and handing out fresh information about tasks that Dekaf is reading from. In order to do this, it needs to call out to various places: `/authorize/dekaf`, `/authorize/task`, and Gazette for journal info. That journal gRPC listing was the only network call in the task manager loop not wrapped in a timeout. If the RPC hangs for whatever reason, the task manager loop blocks permanently, the cached access token expires, and all sessions receive "Access token has expired and the task manager has been unable to refresh it." indefinitely until the Dekaf process is restarted.

This wraps `fetch_partitions()` in `tokio::time::timeout(timeout, ...)`, matching the pattern used by `get_or_refresh_dekaf_auth()` and `get_or_refresh_journal_client()`.

## Incident context

Recently, we had an incident where a Gazette broker went down for reasons we are still investigating. After the dataplane recovered, 3 of 4 dekaf instances remained permanently stuck. Restarting all dekaf instances immediately resolved the issue.

The stuck instances had zero "Successful task manager run" log entries after the outage began, while the remaining healthy instance continued logging successful runs every 30 seconds. Additionally, sessions were unable to fetch tokens from the task manager due to `Access token has expired and the task manager has been unable to refresh it.`. This is consistent with the task manager loop being blocked on a hung `journal_client.list()` call inside `fetch_partitions()`.