### PR TITLE
data-plane-controller: install mitogen for ansible

### DIFF
--- a/docker/data-plane-controller.Dockerfile
+++ b/docker/data-plane-controller.Dockerfile
@@ -10,8 +10,12 @@ RUN apt update -y \
         openssh-client \
         python3-certbot-dns-google \
         python3-poetry \
+        python3-pip \
         python3-venv \
    && rm -rf /var/lib/apt/lists/*
+
+# Install the Mitogen strategy plugin for Ansible.
+RUN pip install --break-system-packages mitogen
 
 # Install the `pulumi` CLI.
 RUN curl -fsSL https://get.pulumi.com/ | bash -s


### PR DESCRIPTION
**Description:**

- Verified the image is as expected by building the image locally with mise and verifying the directory below exists and has the relevant code for mitogen
```
/usr/local/lib/python3.12/dist-packages/ansible_mitogen/plugins/strategy
```

See https://github.com/estuary/est-dry-dock/pull/252/changes

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

