### PR TITLE
postgres: enable tcp keepalives

### DIFF
--- a/supabase/migrations/20260226124102_tcp_keepalives.sql
+++ b/supabase/migrations/20260226124102_tcp_keepalives.sql
@@ -1,0 +1,8 @@
+-- The default value for tcp_keepalives_idle is 2 hours, which is effectively
+-- the lower bound on how long it takes postgres to notice and close a connection
+-- after a client unexpectedly disconnects. That's far too long, especially for our
+-- materialization connectors. This migration tunes the tcp keepalive settings to
+-- allow detecting dead connections much faster.
+alter database postgres set tcp_keepalives_idle = 60;
+alter database postgres set tcp_keepalives_interval = 10;
+alter database postgres set tcp_keepalives_count = 5;


### PR DESCRIPTION
This is meant to address an issue that's been observed a few times with our stats-view materialization.  Those incidents happened due to the connector exiting unexpectedly in the middle of sending a batch of updates to the database.  When that happens, the other timeouts like `idle_in_transaction_session_timeout`, `statement_timeout`, `idle_timeout`, etc. do not take effect because the session is not considered "idle" when it is in "ClientRead" state. Therefore, the only way for the server to detect the disconnected client and terminate the session (which may still be holding locks) is by using tcp keepalive probes.

In [RFC1122](https://www.rfc-editor.org/rfc/rfc1122#page-101), it explicitly states that the _minimum_ default keepalive interval is 2 hours, in order to maintain compatibility with systems that don't support keepalive at all. That means that it will take _at least_ 2 hours before the database server will terminate the session after a client unexpected disconnects in the middle of sending a batch, which is far too long for our purposes.  Two hours surely made sense in 1989, but today keepalives are almost universally supported, at least in our domain. So it seems prudent to lower the idle interval to allow much faster detection of broken connections.