### PR TITLE
flow-web: bump to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "flow-web"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "console_error_panic_hook",
  "doc",

--- a/crates/flow-web/Cargo.toml
+++ b/crates/flow-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flow-web"
 
 # wasm-pack isn't yet fully compatible with workspace inheritance, so we can't use that for these fields
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Estuary developers  <engineering@estuary.dev>"]
 edition = "2021"
 license = "BSL"


### PR DESCRIPTION
**Description:**

No changes to crate APIs, but build in support of the following PR: https://github.com/estuary/flow/pull/2695

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

