### PR TITLE
Dekaf: Prevent accumulation of Read RPCs due to abandoned journal reads

### DIFF
--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -91,6 +91,10 @@ pub struct Cli {
     #[arg(long, env = "IDLE_SESSION_TIMEOUT", value_parser = humantime::parse_duration, default_value = "30s")]
     idle_session_timeout: std::time::Duration,
 
+    /// How long an active read can exist without being polled in a Fetch request before it gets shut down for inactivity.
+    #[arg(long, env = "STALE_READ_TIMEOUT", value_parser = humantime::parse_duration, default_value = "1m")]
+    stale_read_timeout: std::time::Duration,
+
     /// How long to cache materialization specs and other task metadata for before refreshing
     #[arg(long, env = "TASK_REFRESH_INTERVAL", value_parser = humantime::parse_duration, default_value = "30s")]
     task_refresh_interval: std::time::Duration,
@@ -394,6 +398,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                             tls_acceptor.clone(),
                             addr,
                             cli.idle_session_timeout,
+                            cli.stale_read_timeout,
                             cli.tls_handshake_timeout,
                             task_cancellation,
                             connection_limit.clone()
@@ -424,6 +429,7 @@ async fn serve(
     tls_acceptor: Option<Arc<tokio_rustls::TlsAcceptor>>,
     addr: std::net::SocketAddr,
     idle_timeout: std::time::Duration,
+    stale_read_timeout: std::time::Duration,
     tls_handshake_timeout: std::time::Duration,
     stop: tokio_util::sync::CancellationToken,
     connection_limit: Arc<tokio::sync::Semaphore>,
@@ -464,6 +470,11 @@ async fn serve(
 
     metrics::gauge!("dekaf_total_connections").increment(1);
 
+    // Reap reads for partitions the client has stopped fetching. Fires every idle_timeout
+    // regardless of request activity.
+    let mut reap_interval =
+        tokio::time::interval_at(tokio::time::Instant::now() + idle_timeout, idle_timeout);
+
     let result = async {
         loop {
             tokio::select! {
@@ -484,6 +495,9 @@ async fn serve(
                 }
                 _ = stop.cancelled() => {
                     anyhow::bail!("signalled to stop")
+                }
+                _ = reap_interval.tick() => {
+                    session.reap_stale_reads(stale_read_timeout);
                 }
             }
         }

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -29,6 +29,9 @@ struct PendingRead {
     offset: i64,          // Journal offset to be completed by this PendingRead.
     last_write_head: i64, // Most-recent observed journal write head.
     leader_epoch: i32,    // Leader epoch (binding backfill counter) for this read.
+    // Last time this read was included in a Fetch request. Used to reap reads for
+    // partitions the client has stopped fetching.
+    last_accessed: std::time::Instant,
     handle: tokio_util::task::AbortOnDropHandle<anyhow::Result<(Read, BatchResult)>>,
 }
 
@@ -53,7 +56,7 @@ enum PartitionOffsetOutcome {
 pub struct Session {
     app: Arc<App>,
     client: Option<KafkaApiClient>,
-    reads: HashMap<(TopicName, i32), (PendingRead, std::time::Instant)>,
+    reads: HashMap<(TopicName, i32), PendingRead>,
     secret: String,
     auth: Option<SessionAuthentication>,
     data_preview_state: SessionDataPreviewState,
@@ -560,6 +563,19 @@ impl Session {
         }
     }
 
+    /// Reap pending reads that haven't been accessed within `max_idle`. Called periodically
+    /// by the connection handler so that reads for partitions the client has stopped fetching
+    /// are cleaned up regardless of whether Fetch requests are still arriving.
+    pub fn reap_stale_reads(&mut self, max_idle: std::time::Duration) {
+        let before = self.reads.len();
+        self.reads
+            .retain(|_, pending| pending.last_accessed.elapsed() <= max_idle);
+        let reaped = before - self.reads.len();
+        if reaped > 0 {
+            tracing::info!(reaped, remaining = self.reads.len(), "reaped stale reads");
+        }
+    }
+
     /// Fetch records from select "partitions" (journals) and "topics" (collections).
     #[tracing::instrument(
         skip_all,
@@ -682,25 +698,10 @@ impl Session {
                     }
                 };
 
-                let pending_info = self
-                    .reads
-                    .get(&key)
-                    .map(|(p, s)| (p.offset, p.leader_epoch, s.elapsed()));
+                let pending_info = self.reads.get(&key).map(|p| (p.offset, p.leader_epoch));
 
                 match pending_info {
-                    Some((_, _, elapsed)) if elapsed > std::time::Duration::from_secs(60 * 5) => {
-                        metrics::counter!(
-                            "dekaf_fetch_requests",
-                            "topic_name" => key.0.to_string(),
-                            "partition_index" => key.1.to_string(),
-                            "task_name" => task_name.to_string(),
-                            "state" => "read_expired"
-                        )
-                        .increment(1);
-                        tracing::debug!(lifetime=?elapsed, topic_name=?key.0,partition_index=?key.1, "Restarting expired Read");
-                        self.reads.remove(&key);
-                    }
-                    Some((pending_offset, pending_epoch, _)) if pending_offset == fetch_offset => {
+                    Some((pending_offset, pending_epoch)) if pending_offset == fetch_offset => {
                         // Validate pending read's epoch is still current
                         let auth = self.auth.as_ref().unwrap();
                         let current_epoch = Collection::new(&auth, &key.0)
@@ -875,6 +876,7 @@ impl Session {
                     offset: fetch_offset,
                     last_write_head: fetch_offset,
                     leader_epoch: collection.binding_backfill_counter as i32,
+                    last_accessed: std::time::Instant::now(),
                     handle: tokio_util::task::AbortOnDropHandle::new(match data_preview_params {
                         // Startree: 0, Tinybird: 12
                         Some(PartitionOffset {
@@ -954,16 +956,13 @@ impl Session {
                     "started read",
                 );
 
-                if let Some((old, started_at)) = self
-                    .reads
-                    .insert(key.clone(), (pending, std::time::Instant::now()))
-                {
+                if let Some(old) = self.reads.insert(key.clone(), pending) {
                     tracing::warn!(
                         topic = topic_request.topic.as_str(),
                         partition = partition_request.partition,
                         old_offset = old.offset,
                         new_offset = fetch_offset,
-                        read_lifetime = ?started_at.elapsed(),
+                        read_lifetime = ?old.last_accessed.elapsed(),
                         "discarding pending read due to offset jump",
                     );
                 }
@@ -980,7 +979,7 @@ impl Session {
             for partition_request in &topic_request.partitions {
                 key.1 = partition_request.partition;
 
-                let Some((pending, _)) = self.reads.get_mut(&key) else {
+                let Some(pending) = self.reads.get_mut(&key) else {
                     // No pending read. Check if this is due to epoch validation failure
                     let auth = self.auth.as_ref().unwrap();
                     match Collection::new(&auth, &key.0).await {
@@ -1093,6 +1092,7 @@ impl Session {
                     SessionDataPreviewState::NotDataPreview => {
                         pending.offset = read.offset;
                         pending.last_write_head = read.last_write_head;
+                        pending.last_accessed = std::time::Instant::now();
                         pending.handle = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
                             propagate_task_forwarder(read.next_batch(
                                 crate::read::ReadTarget::Bytes(

--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -221,7 +221,8 @@ impl TaskManager {
         // messages emitted by the task manager after that session is closed would be lost.
         // Instead, we'll create a separate log forwarder for this task manager that will report
         // its logs to the correct task's ops logs, irrespective of the session that spawned it.
-        tokio::spawn(logging::forward_logs(
+
+        let handle = tokio::spawn(logging::forward_logs(
             GazetteWriter::new(self.clone()),
             stop_signal.clone(),
             self.clone().run_task_manager(
@@ -232,6 +233,22 @@ impl TaskManager {
                 task_name,
             ),
         ));
+
+        tokio::spawn(async move {
+            let handle_resp = handle.await;
+
+            match handle_resp {
+                Ok(Err(task_mgr_err)) => {
+                    tracing::error!(?task_mgr_err, "run_task_manager error!")
+                }
+                Ok(_) => {
+                    tracing::info!("run_task_manager exited Ok")
+                }
+                Err(e) => {
+                    tracing::error!(?e, "run_task_manager panic!");
+                }
+            }
+        });
 
         TaskStateListener(receiver)
     }
@@ -642,7 +659,12 @@ pub async fn fetch_partitions(
         ..Default::default()
     };
 
+    tracing::info!("Starting to list journals");
     let response = journal_client.list(request).await?;
+
+    let journals_len = response.journals.len();
+
+    tracing::info!(num_journals = journals_len, "Finished listing journals");
 
     let mut partitions = Vec::with_capacity(response.journals.len());
 

--- a/crates/dekaf/src/task_manager.rs
+++ b/crates/dekaf/src/task_manager.rs
@@ -538,18 +538,26 @@ async fn update_partition_info(
                 }
             };
 
-            let partition_result = fetch_partitions(
-                &journal_client,
-                &collection_spec.name,
-                partition_selector
+            let partition_result = match tokio::time::timeout(
+                timeout,
+                fetch_partitions(
+                    &journal_client,
+                    &collection_spec.name,
+                    partition_selector,
+                ),
             )
             .await
-            .map(|partitions| {
-                (journal_client, claims, partitions)
-            })
-            .map_err(|e| {
-                SharedError::from(e.context(format!("Partition fetch failed for collection '{}'", collection_spec.name)))
-            });
+            {
+                Ok(Ok(partitions)) => Ok((journal_client, claims, partitions)),
+                Ok(Err(e)) => Err(SharedError::from(e.context(format!(
+                    "Partition fetch failed for collection '{}'",
+                    collection_spec.name
+                )))),
+                Err(_) => Err(SharedError::from(anyhow::anyhow!(
+                    "Timed out fetching partitions for collection '{}'",
+                    collection_spec.name
+                ))),
+            };
 
             // Return the result associated with this template name
             (template_name, partition_result)


### PR DESCRIPTION
## Summary

Periodically reap abandoned Read RPCs, dropping any `PendingRead` not consumed by a `Fetch` request within `STALE_READ_TIMEOUT` (default 1m). This prevents once-Fetched but now abandoned Reads from accumulating stalled gRPC streams that exhaust the HTTP/2 connection-level flow control window and block all broker responses, including partition List RPCs

Additionally,
- Add a 30-second timeout to `fetch_partitions()` List RPCs in the task manager loop. It isn't expected that this codepath actually gets hit, and is indicative of a problem if it is. Leaving this timeout in here mainly to prove to ourselves via logging that it's not happening.
- We realized that if the TaskManager returns `Err` or panics, we would never know. Added logic to capture the task handle and log if it errors or panics. 