### PR TITLE
ops-catalog: one-off script to update L1 reporting for all data planes

### DIFF
--- a/ops-catalog/update-l1-reporting.sh
+++ b/ops-catalog/update-l1-reporting.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-off script to re-publish the catalog-stats and stats collections
+# for all data planes, after updating data-plane-template.bundle.json.
+# Based on the mise/tasks/local/stack script.
+
+DB_URL="${DB_URL:-postgresql://postgres:postgres@localhost:5432/postgres}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE=$(cat "$SCRIPT_DIR/data-plane-template.bundle.json" | sed "s/'/''/g")
+
+# Only data planes in this list will be updated. All others are skipped.
+APPLICABLE_DATA_PLANES=(
+  "ops/dp/public/not-a-real-dataplane"
+  "ops/dp/public/local-cluster"
+)
+
+ALL_DATA_PLANES=$(psql "$DB_URL" -t -A -c \
+  "select data_plane_name from data_planes order by data_plane_name")
+
+# Warn about any entries in APPLICABLE_DATA_PLANES that don't exist in the database.
+for WANTED in "${APPLICABLE_DATA_PLANES[@]}"; do
+  if ! echo "$ALL_DATA_PLANES" | grep -qx "$WANTED"; then
+    echo "Warning: '$WANTED' is not a known data plane" >&2
+  fi
+done
+
+for DATA_PLANE in $ALL_DATA_PLANES; do
+
+  if ! printf '%s\n' "${APPLICABLE_DATA_PLANES[@]}" | grep -qx "$DATA_PLANE"; then
+    echo "Skipping data plane: $DATA_PLANE"
+    continue
+  fi
+
+  BASE_NAME="${DATA_PLANE#ops/dp/}"
+
+  echo "Updating L1 reporting for data plane: $BASE_NAME"
+
+  CATALOG=$(echo "$TEMPLATE" | sed "s|BASE_NAME|$BASE_NAME|g")
+
+  psql "$DB_URL" <<EOF
+begin;
+do \$\$
+declare
+    bundled_catalog_arg json := '$CATALOG';
+    ops_user_id uuid;
+    new_draft_id flowid := internal.id_generator();
+    publication_id flowid := internal.id_generator();
+begin
+    -- Identify user that owns ops specifications.
+    select id into strict ops_user_id from auth.users where email = 'support@estuary.dev';
+
+    -- Create a draft of ops changes.
+    insert into drafts (id, user_id, detail) values
+    (new_draft_id, ops_user_id, 'updating L1 reporting for $BASE_NAME');
+
+    -- Queue a publication of the draft.
+    insert into publications (id, user_id, draft_id, detail, data_plane_name) values
+    (publication_id, ops_user_id, new_draft_id, 'updating L1 reporting for $BASE_NAME', '$DATA_PLANE');
+
+    insert into draft_specs (draft_id, catalog_name, spec_type, spec)
+    select new_draft_id, "key", 'collection'::catalog_spec_type, "value"
+    from json_each(json_extract_path(bundled_catalog_arg, 'collections'))
+    where "key" like '%/catalog-stats' or "key" like '%/stats';
+end \$\$
+language plpgsql;
+commit;
+EOF
+
+  echo "Done: $BASE_NAME. Sleeping 30 seconds..."
+  sleep 30
+done


### PR DESCRIPTION
**Description:**

After updating the `data-plane-template.bundle.json`, we need to re-publish the catalog-stats and stats collections for all data planes.

I'm not intending to merge this or keep it around permanently. If it's something we need to do more of, maybe a new control plane API would make sense.

This should be run after https://github.com/estuary/flow/pull/2676 is merged and the agent-api deployed from it. The L2 derivation will be updated using the `update-l2-reporting` endpoint then too.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

