### PR TITLE
dekaf: cap per-partition fetch reads with a configurable combined limit

### DIFF
--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -142,6 +142,14 @@ pub struct Cli {
     /// can be up to 130K in size.
     #[arg(long, env = "READ_BUFFER_CHUNK_LIMIT", default_value = "20")]
     read_buffer_chunk_limit: usize,
+    /// Total byte budget for all partitions in a single Fetch request.
+    /// Divided evenly across fetched partitions to cap per-partition reads.
+    #[arg(
+        long,
+        env = "COMBINED_PARTITION_FETCH_LIMIT",
+        default_value = "52428800"
+    )]
+    combined_partition_fetch_limit: usize,
 
     #[command(flatten)]
     tls: Option<TlsArgs>,
@@ -394,6 +402,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                                 upstream_kafka_urls.clone(),
                                 upstream_auth.clone(),
                                 cli.read_buffer_chunk_limit,
+                                cli.combined_partition_fetch_limit,
                             ),
                             socket,
                             tls_acceptor.clone(),

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -64,6 +64,8 @@ pub struct Session {
     upstream_auth: KafkaClientAuth,
     // Number of ReadResponses to buffer in PendingReads
     read_buffer_size: usize,
+    // Total byte budget for a Fetch, divided evenly across partitions to cap per-partition reads.
+    combined_partition_fetch_limit: usize,
 }
 
 impl Session {
@@ -73,6 +75,7 @@ impl Session {
         broker_urls: Vec<String>,
         upstream_auth: KafkaClientAuth,
         read_buffer_size: usize,
+        combined_partition_fetch_limit: usize,
     ) -> Self {
         Self {
             app,
@@ -80,6 +83,7 @@ impl Session {
             broker_urls,
             upstream_auth,
             read_buffer_size,
+            combined_partition_fetch_limit,
             reads: HashMap::new(),
             auth: None,
             secret,
@@ -630,6 +634,9 @@ impl Session {
 
         let timeout = std::time::Duration::from_millis(max_wait_ms as u64);
 
+        let total_partitions: usize = topic_requests.iter().map(|t| t.partitions.len()).sum();
+        let per_partition_limit = self.combined_partition_fetch_limit / total_partitions.max(1);
+
         // Start reads for all partitions which aren't already pending.
         for topic_request in topic_requests {
             let mut key = (from_downstream_topic_name(topic_request.topic.clone()), 0);
@@ -939,7 +946,8 @@ impl Session {
                                 .await?
                                 .next_batch(
                                     crate::read::ReadTarget::Bytes(
-                                        partition_request.partition_max_bytes as usize,
+                                        (partition_request.partition_max_bytes as usize)
+                                            .min(per_partition_limit),
                                     ),
                                     timeout,
                                 ),
@@ -1078,6 +1086,15 @@ impl Session {
                     }
                 };
 
+                let batch_bytes = batch.as_ref().map_or(0, |b| b.len());
+                metrics::histogram!(
+                    "dekaf_fetch_partition_bytes",
+                    "topic_name" => key.0.to_string(),
+                    "partition_index" => key.1.to_string(),
+                    "task_name" => task_name.to_string(),
+                )
+                .record(batch_bytes as f64);
+
                 let mut partition_data = PartitionData::default()
                     .with_partition_index(partition_request.partition)
                     // `kafka-protocol` encodes None here using a length of -1, but librdkafka client library
@@ -1094,12 +1111,15 @@ impl Session {
                         pending.last_write_head = read.last_write_head;
                         pending.last_accessed = std::time::Instant::now();
                         pending.handle = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
-                            propagate_task_forwarder(read.next_batch(
-                                crate::read::ReadTarget::Bytes(
-                                    partition_request.partition_max_bytes as usize,
+                            propagate_task_forwarder(
+                                read.next_batch(
+                                    crate::read::ReadTarget::Bytes(
+                                        (partition_request.partition_max_bytes as usize)
+                                            .min(per_partition_limit),
+                                    ),
+                                    timeout,
                                 ),
-                                timeout,
-                            )),
+                            ),
                         ));
 
                         partition_data = partition_data


### PR DESCRIPTION
Dekaf placed no upper bound on how much data it buffered per Fetch request. A consumer could send large `partition_max_bytes` values across many partitions and cause unbounded memory growth.

This adds a `--combined-partition-fetch-limit` / `COMBINED_PARTITION_FETCH_LIMIT` config (default 50MB) that caps the total bytes read across all partitions in a Fetch. The limit is divided evenly across all fetched partitions, and each partition's read target is capped at `min(partition_max_bytes, limit / num_partitions)`.

* `fetch.max_bytes` from the client remains ignored because it is meant as an after-the-fact cap on response size, not a pre-flight allocation. Dividing it across partitions would starve active partitions when most partitions in the request are idle, which is a common pattern when consumers subscribe to many partitions but only a few have data.
  * In the future, I could see logic that 
* `max_wait_ms` is not capped since bounded bytes prevent resource overcommit regardless of wait duration
* Adds `dekaf_fetch_partition_bytes` histogram to track the actual byte size of each partition's fetch response