### PR TITLE
docs: fix CSV materialization file name examples to show .csv.gz

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
@@ -90,9 +90,9 @@ so they remain lexically sortable. For example, a set of files may be materializ
 given collection:
 
 ```
-bucket/prefix/path/v0000000000/00000000000000000000.csv
-bucket/prefix/path/v0000000000/00000000000000000001.csv
-bucket/prefix/path/v0000000000/00000000000000000002.csv
+bucket/prefix/path/v0000000000/00000000000000000000.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000001.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000002.csv.gz
 ```
 
 Here the values for **bucket** and **prefix** are from your endpoint configuration. The **path** is

--- a/site/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
+++ b/site/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
@@ -78,9 +78,9 @@ so they remain lexically sortable. For example, a set of files may be materializ
 given collection:
 
 ```
-bucket/prefix/path/v0000000000/00000000000000000000.csv
-bucket/prefix/path/v0000000000/00000000000000000001.csv
-bucket/prefix/path/v0000000000/00000000000000000002.csv
+bucket/prefix/path/v0000000000/00000000000000000000.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000001.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000002.csv.gz
 ```
 
 Here the values for **bucket** and **prefix** are from your endpoint configuration. The **path** is


### PR DESCRIPTION
## Summary

- File Names section in both S3 CSV and GCS CSV materialization docs showed `.csv` extensions, but the connectors actually write Gzip-compressed `.csv.gz` files
- Updated examples to match actual output

Flagged by a customer who assumed from the docs that raw uncompressed CSVs would be written.