### PR TITLE
CSV connector docs update (GZip)

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
@@ -7,7 +7,7 @@ description: This connector materializes delta updates of Estuary collections in
 This connector materializes [delta updates](/concepts/materialization/#delta-updates) of
 Estuary collections into files in an S3 bucket per the CSV format described in
 [RFC-4180](https://www.rfc-editor.org/rfc/rfc4180.html). The CSV files are compressed using Gzip
-compression.
+compression and written to S3 as `.csv.gz` files.
 
 The delta updates are batched within Estuary, converted to CSV files, and then pushed to the S3 bucket
 at a time interval that you set. Files are limited to a configurable maximum size. Each materialized
@@ -87,9 +87,9 @@ so they remain lexically sortable. For example, a set of files may be materializ
 given collection:
 
 ```
-bucket/prefix/path/v0000000000/00000000000000000000.csv
-bucket/prefix/path/v0000000000/00000000000000000001.csv
-bucket/prefix/path/v0000000000/00000000000000000002.csv
+bucket/prefix/path/v0000000000/00000000000000000000.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000001.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000002.csv.gz
 ```
 
 Here the values for **bucket** and **prefix** are from your endpoint configuration. The **path** is

--- a/site/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
+++ b/site/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
@@ -7,7 +7,7 @@ description: This connector materializes delta updates of Estuary collections in
 This connector materializes [delta updates](/concepts/materialization/#delta-updates) of
 Estuary collections into files in a GCS bucket per the CSV format described in
 [RFC-4180](https://www.rfc-editor.org/rfc/rfc4180.html). The CSV files are compressed using Gzip
-compression.
+compression and written to GCS as `.csv.gz` files.
 
 The delta updates are batched within Estuary, converted to CSV files, and then pushed to the S3 bucket
 at a time interval that you set. Files are limited to a configurable maximum size. Each materialized
@@ -74,9 +74,9 @@ so they remain lexically sortable. For example, a set of files may be materializ
 given collection:
 
 ```
-bucket/prefix/path/v0000000000/00000000000000000000.csv
-bucket/prefix/path/v0000000000/00000000000000000001.csv
-bucket/prefix/path/v0000000000/00000000000000000002.csv
+bucket/prefix/path/v0000000000/00000000000000000000.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000001.csv.gz
+bucket/prefix/path/v0000000000/00000000000000000002.csv.gz
 ```
 
 Here the values for **bucket** and **prefix** are from your endpoint configuration. The **path** is


### PR DESCRIPTION
**Description:**

Clarify that CSV file materializations write gzip-compressed `.csv.gz` files to object storage, not plain `.csv` files. Updates both the GCS CSV and S3 CSV connector docs.

**Workflow steps:**

N/A, docs-only fix

**Documentation links affected:**

- [CSV Files in Google GCS](https://docs.estuary.dev/reference/Connectors/materialization-connectors/google-gcs-csv/) — intro sentence and file name examples updated to show .csv.gz
- [CSV Files in Amazon S3](https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-csv/) — same two fixes

**Notes for reviewers:**

Verified against connector source code - the extension field in CommonConfig() is hardcoded to `.csv.gz`, and `filesink.go` uses it directly as the filename suffix when writing to the object store.