### PR TITLE
agent: detect and disable abandoned tasks

### DIFF
--- a/.sqlx/query-2149ba282c38cb99000cd2707af46d4fa9366e9b1e3042ef2ae4505ac944ea97.json
+++ b/.sqlx/query-2149ba282c38cb99000cd2707af46d4fa9366e9b1e3042ef2ae4505ac944ea97.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-350aaed1473b5348e0109935824ebece1e66020d9232f9bb093e17191dc438ef.json
+++ b/.sqlx/query-350aaed1473b5348e0109935824ebece1e66020d9232f9bb093e17191dc438ef.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select ps.published_at\n        from publication_specs ps\n        where ps.live_spec_id = $1\n            and ps.user_id != $2\n        order by ps.pub_id desc\n        limit 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "published_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Macaddr8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "350aaed1473b5348e0109935824ebece1e66020d9232f9bb093e17191dc438ef"
+}

--- a/.sqlx/query-4a357b6122be7ef9e662ceec1f4413c3d9198dd16a7244ca4ffe87d7dfd3ac7e.json
+++ b/.sqlx/query-4a357b6122be7ef9e662ceec1f4413c3d9198dd16a7244ca4ffe87d7dfd3ac7e.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-6e0fbadb9189ff0265c28b914562034359229c67facc3190e3753a7d1a720dc6.json
+++ b/.sqlx/query-6e0fbadb9189ff0265c28b914562034359229c67facc3190e3753a7d1a720dc6.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }
@@ -68,7 +72,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-779f0a332da437b98ed5a13a3dd87787efd919aa7951ce82ece433ca06a8d066.json
+++ b/.sqlx/query-779f0a332da437b98ed5a13a3dd87787efd919aa7951ce82ece433ca06a8d066.json
@@ -33,7 +33,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/.sqlx/query-7c0252d84eb1a8921d6d05dcc15f5eba9fcfdc5f287057f3548e45198f30fd62.json
+++ b/.sqlx/query-7c0252d84eb1a8921d6d05dcc15f5eba9fcfdc5f287057f3548e45198f30fd62.json
@@ -29,7 +29,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }
@@ -65,7 +69,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/.sqlx/query-7ca23ef428b578f58205cd9f4382da7d48f8243bf91d56fcf10a46ee22c7672d.json
+++ b/.sqlx/query-7ca23ef428b578f58205cd9f4382da7d48f8243bf91d56fcf10a46ee22c7672d.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }
@@ -69,7 +73,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-868f20122f1eca8d0e4e1f2d966200d9660793597e4220188e93c33c0e427e79.json
+++ b/.sqlx/query-868f20122f1eca8d0e4e1f2d966200d9660793597e4220188e93c33c0e427e79.json
@@ -29,7 +29,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-99d545b8046aba7add68b1ec3e4d8dc3729375b72e03afa9c5a256cca4d1208b.json
+++ b/.sqlx/query-99d545b8046aba7add68b1ec3e4d8dc3729375b72e03afa9c5a256cca4d1208b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select ts\n        from catalog_stats_daily\n        where catalog_name = $1\n            and ts > now() - interval '60 days'\n            and (bytes_written_by_me + bytes_read_by_me\n                + bytes_written_to_me + bytes_read_from_me) > 0\n        order by ts desc\n        limit 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "ts",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "99d545b8046aba7add68b1ec3e4d8dc3729375b72e03afa9c5a256cca4d1208b"
+}

--- a/.sqlx/query-9af84f473b7ec724fb6c162537609fba9dbdeb4c9e3ae4fd9b2a9906e995612e.json
+++ b/.sqlx/query-9af84f473b7ec724fb6c162537609fba9dbdeb4c9e3ae4fd9b2a9906e995612e.json
@@ -33,7 +33,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/.sqlx/query-9d8be5fbfc02e5a2f54ae94b4a5440a2d36329f4015012265b6b19459a4c7cd1.json
+++ b/.sqlx/query-9d8be5fbfc02e5a2f54ae94b4a5440a2d36329f4015012265b6b19459a4c7cd1.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-a7160e6f695386d54aec56e4520c3996c960e9230ea290be51e91e92064c6dc6.json
+++ b/.sqlx/query-a7160e6f695386d54aec56e4520c3996c960e9230ea290be51e91e92064c6dc6.json
@@ -30,7 +30,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-dd817d6e59aeabf22c8f388d6b98d8352e2822a9eee3b862d9c4925d14347901.json
+++ b/.sqlx/query-dd817d6e59aeabf22c8f388d6b98d8352e2822a9eee3b862d9c4925d14347901.json
@@ -33,7 +33,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }
@@ -86,7 +90,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/.sqlx/query-ed7adc991c84e3dfb1caeb832decfef4b4241e88ce0678fbc5f3f68fb6fc8526.json
+++ b/.sqlx/query-ed7adc991c84e3dfb1caeb832decfef4b4241e88ce0678fbc5f3f68fb6fc8526.json
@@ -33,7 +33,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/.sqlx/query-ee54cdac0e3fcbeefe9e1d57f11644c79975355e11464ad5d8a2bf3fdf6e8f89.json
+++ b/.sqlx/query-ee54cdac0e3fcbeefe9e1d57f11644c79975355e11464ad5d8a2bf3fdf6e8f89.json
@@ -24,7 +24,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }
@@ -68,7 +72,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-f9bdb488910b3c0207875e2b133dd84483d6338e50f55c3c74b9758bd13a3d34.json
+++ b/.sqlx/query-f9bdb488910b3c0207875e2b133dd84483d6338e50f55c3c74b9758bd13a3d34.json
@@ -34,7 +34,11 @@
                 "data_not_processed_in_interval",
                 "shard_failed",
                 "auto_discover_failed",
-                "background_publication_failed"
+                "background_publication_failed",
+                "task_chronically_failing",
+                "task_auto_disabled_failing",
+                "task_idle",
+                "task_auto_disabled_idle"
               ]
             }
           }

--- a/.sqlx/query-fcaf4e0a176906872ba0c21fd2281ba858918f68134f079ea56f5791cd932e35.json
+++ b/.sqlx/query-fcaf4e0a176906872ba0c21fd2281ba858918f68134f079ea56f5791cd932e35.json
@@ -33,7 +33,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }
@@ -86,7 +90,11 @@
                       "data_not_processed_in_interval",
                       "shard_failed",
                       "auto_discover_failed",
-                      "background_publication_failed"
+                      "background_publication_failed",
+                      "task_chronically_failing",
+                      "task_auto_disabled_failing",
+                      "task_idle",
+                      "task_auto_disabled_idle"
                     ]
                   }
                 }

--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -1,0 +1,1157 @@
+use super::{ControllerState, NextRun, alerts};
+use crate::controllers::activation::has_task_shards;
+use crate::controllers::publication_status::PendingPublication;
+use crate::controlplane::ControlPlane;
+use chrono::{DateTime, Utc};
+use models::status::publications::PublicationStatus;
+use models::status::{AlertType, Alerts};
+
+env_config_interval! {
+    /// ShardFailed must be continuously firing for this long before we consider the task chronically failing.
+    CHRONICALLY_FAILING_THRESHOLD, chrono::Duration::days(30)
+}
+env_config_interval! {
+    /// Grace period after firing the chronically-failing warning before auto-disabling.
+    CHRONICALLY_FAILING_DISABLE_AFTER, chrono::Duration::days(7)
+}
+env_config_interval! {
+    /// Task must have no data movement for this long before we consider it idle.
+    IDLE_THRESHOLD, chrono::Duration::days(30)
+}
+env_config_interval! {
+    /// A user publication within this timeframe will prevent task abandonment alerts from firing and tasks from being disabled.
+    USER_PUB_THRESHOLD, chrono::Duration::days(14)
+}
+env_config_interval! {
+    /// Grace period after firing the idle warning before auto-disabling.
+    IDLE_DISABLE_AFTER, chrono::Duration::days(7)
+}
+env_config_bool! {
+    /// Allows for running the abandonment controller without actually disabling tasks.
+    pub(crate) DISABLE_ABANDONED_TASKS, false
+}
+
+/// Extra field keys stored in alert `extra` maps for notification templates.
+const EXTRA_DISABLE_AT: &str = "disable_at";
+const EXTRA_FAILING_SINCE: &str = "failing_since";
+
+/// Why a task is being auto-disabled, used as the publication detail message.
+#[derive(Debug, PartialEq, Eq)]
+enum DisableReason {
+    ChronicallyFailing,
+    Idle,
+}
+
+#[derive(Clone, Copy, Default)]
+struct AbandonmentTimestamps {
+    last_data_movement_ts: Option<DateTime<Utc>>,
+    last_user_pub_at: Option<DateTime<Utc>>,
+}
+
+impl std::fmt::Display for DisableReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChronicallyFailing => f.write_str("auto-disabling chronically failing task"),
+            Self::Idle => f.write_str("auto-disabling idle task"),
+        }
+    }
+}
+
+pub async fn evaluate_abandoned<C: ControlPlane>(
+    alerts_status: &mut Alerts,
+    publications: &mut PublicationStatus,
+    state: &ControllerState,
+    control_plane: &C,
+) -> anyhow::Result<Option<NextRun>> {
+    // Tasks without shards (disabled, Dekaf, etc.) don't need abandon monitoring.
+    if !has_task_shards(state) {
+        resolve_all_abandon_alerts(alerts_status);
+        return Ok(None);
+    }
+
+    let now = control_plane.current_time();
+    let timestamps = fetch_abandonment_timestamps(alerts_status, state, control_plane, now).await?;
+
+    let disable_reason = evaluate_alerts(alerts_status, state, now, timestamps);
+
+    if let Some(reason) = disable_reason {
+        if DISABLE_ABANDONED_TASKS.get() {
+            if maybe_disable_task(reason, state, publications, control_plane).await? {
+                return Ok(Some(NextRun::immediately()));
+            }
+        }
+    }
+
+    // Safety-net wake: controllers already wake every ~2 hours for shard health
+    // checks, so this 24-hour timer just ensures abandon evaluation isn't skipped
+    // indefinitely if those checks stop scheduling wakes.
+    Ok(Some(NextRun::after_minutes(24 * 60)))
+}
+
+async fn fetch_abandonment_timestamps<C: ControlPlane>(
+    alerts_status: &Alerts,
+    state: &ControllerState,
+    control_plane: &C,
+    now: DateTime<Utc>,
+) -> anyhow::Result<AbandonmentTimestamps> {
+    let last_user_pub_at = control_plane
+        .fetch_last_user_publication_at(state.live_spec_id)
+        .await?;
+
+    let has_failure_alerts = alerts_status.contains_key(&AlertType::ShardFailed)
+        || alerts_status.contains_key(&AlertType::TaskChronicallyFailing);
+    let user_pub_stale = last_user_pub_at.map_or(true, |ts| (now - ts) >= USER_PUB_THRESHOLD.get());
+
+    let last_data_movement_ts = if has_failure_alerts || !user_pub_stale {
+        None
+    } else {
+        control_plane
+            .fetch_last_data_movement_ts(state.catalog_name.clone())
+            .await?
+    };
+
+    Ok(AbandonmentTimestamps {
+        last_data_movement_ts,
+        last_user_pub_at,
+    })
+}
+
+/// Pure evaluation of abandon alert state. Returns `Some(reason)` when the
+/// grace period for an auto-disable sequence has expired and the task should
+/// be disabled, or `None` if no disable is needed.
+fn evaluate_alerts(
+    alerts_status: &mut Alerts,
+    state: &ControllerState,
+    now: DateTime<Utc>,
+    timestamps: AbandonmentTimestamps,
+) -> Option<DisableReason> {
+    // Tasks that are disabled, Dekaf, or lack shards don't get abandonment checks.
+    // Silently resolve any alerts that may have been firing so re-enablement starts clean.
+    let Some(spec) = state.live_spec.as_ref().filter(|_| has_task_shards(state)) else {
+        resolve_all_abandon_alerts(alerts_status);
+        return None;
+    };
+
+    let catalog_type = spec.catalog_type();
+
+    let user_pub_stale = timestamps
+        .last_user_pub_at
+        .map_or(true, |ts| (now - ts) >= USER_PUB_THRESHOLD.get());
+
+    // Sequence 1: Chronically Failing
+    // Fires when ShardFailed has been continuously active for > CHRONICALLY_FAILING_THRESHOLD
+    // and no user has published changes recently (a recent publication signals active debugging).
+    let shard_failed_since = alerts_status
+        .get(&AlertType::ShardFailed)
+        .map(|a| a.first_ts);
+
+    let is_chronically_failing = shard_failed_since
+        .is_some_and(|first_ts| (now - first_ts) >= CHRONICALLY_FAILING_THRESHOLD.get())
+        && user_pub_stale;
+
+    let mut disable_reason = None;
+
+    if is_chronically_failing {
+        let shard_failed_first_ts = shard_failed_since.unwrap();
+
+        // Only fire the alert once. On subsequent evaluations the stored
+        // disable_at and failing_since are the source of truth, so we don't
+        // shift the disable date if the env config changes between runs.
+        if !alerts_status.contains_key(&AlertType::TaskChronicallyFailing) {
+            let failing_since = shard_failed_first_ts.format("%Y-%m-%d").to_string();
+            let disable_at = (now + CHRONICALLY_FAILING_DISABLE_AFTER.get())
+                .format("%Y-%m-%d")
+                .to_string();
+
+            alerts::set_alert_firing(
+                alerts_status,
+                AlertType::TaskChronicallyFailing,
+                now,
+                format!("task shards have been failing since {failing_since}"),
+                1, // Each abandonment alert is only ever fired once.
+                catalog_type,
+            );
+            let alert = alerts_status
+                .get_mut(&AlertType::TaskChronicallyFailing)
+                .expect("just inserted");
+            alert
+                .extra
+                .insert(EXTRA_DISABLE_AT.to_string(), disable_at.into());
+            alert
+                .extra
+                .insert(EXTRA_FAILING_SINCE.to_string(), failing_since.into());
+        }
+
+        let alert = alerts_status
+            .get(&AlertType::TaskChronicallyFailing)
+            .expect("TaskChronicallyFailing alert was just set");
+        let disable_at = alert
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .expect("disable_at was just inserted")
+            .as_str()
+            .expect("disable_at must be a string")
+            .to_string();
+        let failing_since = alert
+            .extra
+            .get(EXTRA_FAILING_SINCE)
+            .expect("failing_since was just inserted")
+            .as_str()
+            .expect("failing_since must be a string")
+            .to_string();
+        let disable_at = chrono::NaiveDate::parse_from_str(&disable_at, "%Y-%m-%d")
+            .expect("disable_at was set from a valid date");
+
+        if now.date_naive() >= disable_at {
+            if !alerts_status.contains_key(&AlertType::TaskAutoDisabledFailing) {
+                alerts::set_alert_firing(
+                    alerts_status,
+                    AlertType::TaskAutoDisabledFailing,
+                    now,
+                    format!("task auto-disabled after shards failing since {failing_since}"),
+                    1,
+                    catalog_type,
+                );
+                alerts_status
+                    .get_mut(&AlertType::TaskAutoDisabledFailing)
+                    .expect("just inserted")
+                    .extra
+                    .insert(
+                        EXTRA_FAILING_SINCE.to_string(),
+                        failing_since.clone().into(),
+                    );
+            }
+            disable_reason = Some(DisableReason::ChronicallyFailing);
+        }
+    } else {
+        alerts::resolve_alert(alerts_status, AlertType::TaskChronicallyFailing);
+        alerts::resolve_alert(alerts_status, AlertType::TaskAutoDisabledFailing);
+    }
+
+    // Sequence 2: Idle Task
+    // Fires when no data has moved AND no user publication for extended periods.
+    // Suppressed when ShardFailed or TaskChronicallyFailing is active to avoid
+    // sending both "your task is failing" and "your task is idle" simultaneously.
+    let has_failure_alerts = alerts_status.contains_key(&AlertType::ShardFailed)
+        || alerts_status.contains_key(&AlertType::TaskChronicallyFailing);
+
+    let data_stale = timestamps
+        .last_data_movement_ts
+        .map_or(true, |ts| (now - ts) >= IDLE_THRESHOLD.get());
+
+    let is_idle = !has_failure_alerts && data_stale && user_pub_stale;
+
+    if is_idle {
+        if !alerts_status.contains_key(&AlertType::TaskIdle) {
+            let disable_at = (now + IDLE_DISABLE_AFTER.get())
+                .format("%Y-%m-%d")
+                .to_string();
+
+            alerts::set_alert_firing(
+                alerts_status,
+                AlertType::TaskIdle,
+                now,
+                format!(
+                    "task has not moved data{}",
+                    timestamps
+                        .last_data_movement_ts
+                        .map(|ts| format!(" since {}", ts.format("%Y-%m-%d")))
+                        .unwrap_or_else(|| " since it was created".to_string())
+                ),
+                1,
+                catalog_type,
+            );
+            alerts_status
+                .get_mut(&AlertType::TaskIdle)
+                .expect("just inserted")
+                .extra
+                .insert(EXTRA_DISABLE_AT.to_string(), disable_at.into());
+        }
+
+        let disable_at = alerts_status
+            .get(&AlertType::TaskIdle)
+            .expect("TaskIdle alert was just set")
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .expect("disable_at was just inserted")
+            .as_str()
+            .expect("disable_at must be a string");
+        let disable_at = chrono::NaiveDate::parse_from_str(disable_at, "%Y-%m-%d")
+            .expect("disable_at was set from a valid date");
+
+        if now.date_naive() >= disable_at {
+            if !alerts_status.contains_key(&AlertType::TaskAutoDisabledIdle) {
+                alerts::set_alert_firing(
+                    alerts_status,
+                    AlertType::TaskAutoDisabledIdle,
+                    now,
+                    "task auto-disabled due to inactivity".to_string(),
+                    1,
+                    catalog_type,
+                );
+            }
+            disable_reason = Some(DisableReason::Idle);
+        }
+    } else {
+        alerts::resolve_alert(alerts_status, AlertType::TaskIdle);
+        alerts::resolve_alert(alerts_status, AlertType::TaskAutoDisabledIdle);
+    }
+
+    disable_reason
+}
+
+/// Publishes the spec with `shards.disable = true`. Returns `true` if the
+/// publication succeeded, signaling the caller to return `NextRun::immediately()`
+/// so the controller re-enters and processes the now-disabled spec.
+async fn maybe_disable_task<C: ControlPlane>(
+    reason: DisableReason,
+    state: &ControllerState,
+    publications: &mut PublicationStatus,
+    control_plane: &C,
+) -> anyhow::Result<bool> {
+    let mut spec = state
+        .live_spec
+        .clone()
+        .expect("must have live spec to disable");
+
+    set_spec_disabled(&mut spec);
+    let mut pending = PendingPublication::update_model(
+        &state.catalog_name,
+        state.last_pub_id,
+        spec,
+        &reason.to_string(),
+    );
+
+    // `finish()` normally fires BackgroundPublicationFailed after repeated
+    // publication failures. Pass None to suppress that: if we're disabling
+    // an abandoned task, an additional alert about the disable publication
+    // failing is just noise. The failure is still recorded in publication
+    // history and we'll retry on the next controller run.
+    let result = pending
+        .finish(state, publications, None, control_plane)
+        .await?;
+    Ok(result.status.is_success())
+}
+
+fn set_spec_disabled(spec: &mut models::AnySpec) {
+    match spec {
+        models::AnySpec::Capture(c) => c.shards.disable = true,
+        models::AnySpec::Collection(c) => {
+            c.derive
+                .as_mut()
+                .expect("collection without derivation should not have task shards")
+                .shards
+                .disable = true;
+        }
+        models::AnySpec::Materialization(m) => m.shards.disable = true,
+        models::AnySpec::Test(_) => unreachable!("tests do not have shards"),
+    }
+}
+
+fn resolve_all_abandon_alerts(alerts_status: &mut Alerts) {
+    alerts::resolve_alert(alerts_status, AlertType::TaskChronicallyFailing);
+    alerts::resolve_alert(alerts_status, AlertType::TaskAutoDisabledFailing);
+    alerts::resolve_alert(alerts_status, AlertType::TaskIdle);
+    alerts::resolve_alert(alerts_status, AlertType::TaskAutoDisabledIdle);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::{Duration, TimeZone};
+    use models::status::{AlertState, ControllerAlert, ControllerStatus};
+    use models::{AnySpec, Id};
+
+    fn fixed_now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap()
+    }
+
+    fn mock_state(live_spec: Option<AnySpec>, created_at: DateTime<Utc>) -> ControllerState {
+        ControllerState {
+            live_spec_id: Id::zero(),
+            catalog_name: "test/task".to_string(),
+            live_spec,
+            built_spec: None,
+            controller_updated_at: created_at,
+            live_spec_updated_at: created_at,
+            created_at,
+            failures: 0,
+            error: None,
+            last_pub_id: Id::zero(),
+            last_build_id: Id::zero(),
+            logs_token: uuid::Uuid::nil(),
+            controller_version: 2,
+            current_status: ControllerStatus::Uninitialized,
+            data_plane_id: Id::zero(),
+            data_plane_name: None,
+            live_dependency_hash: None,
+        }
+    }
+
+    fn enabled_capture() -> AnySpec {
+        AnySpec::Capture(models::CaptureDef {
+            endpoint: models::CaptureEndpoint::Connector(models::ConnectorConfig {
+                image: "source/test:test".to_string(),
+                config: models::RawValue::from_str("{}").unwrap(),
+            }),
+            bindings: vec![],
+            shards: Default::default(),
+            auto_discover: None,
+            interval: std::time::Duration::from_secs(300),
+            redact_salt: None,
+            expect_pub_id: None,
+            delete: false,
+            reset: false,
+        })
+    }
+
+    fn disabled_capture() -> AnySpec {
+        let mut cap = enabled_capture();
+        if let AnySpec::Capture(ref mut c) = cap {
+            c.shards.disable = true;
+        }
+        cap
+    }
+
+    fn enabled_materialization() -> AnySpec {
+        AnySpec::Materialization(models::MaterializationDef {
+            endpoint: models::MaterializationEndpoint::Connector(models::ConnectorConfig {
+                image: "materialize/test:test".to_string(),
+                config: models::RawValue::from_str("{}").unwrap(),
+            }),
+            bindings: vec![],
+            shards: Default::default(),
+            source: None,
+            on_incompatible_schema_change: Default::default(),
+            expect_pub_id: None,
+            delete: false,
+            reset: false,
+        })
+    }
+
+    /// ShardFailed is external state from shard health monitoring, not produced
+    /// by `evaluate_alerts`, so tests must always pre-populate it.
+    fn shard_failed_alert(first_ts: DateTime<Utc>, last_ts: DateTime<Utc>) -> ControllerAlert {
+        ControllerAlert {
+            state: AlertState::Firing,
+            spec_type: models::CatalogType::Capture,
+            first_ts,
+            last_ts: Some(last_ts),
+            error: "shard failed".to_string(),
+            count: 5,
+            resolved_at: None,
+            extra: Default::default(),
+        }
+    }
+
+    // Sequence 1: Chronically Failing
+
+    #[test]
+    fn no_shard_failed_means_not_chronically_failing() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+
+        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "task_idle": {
+            "count": 1,
+            "disable_at": "2025-06-08",
+            "error": "task has not moved data since it was created",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn recent_shard_failed_not_chronically_failing() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(now - Duration::days(10), now),
+        );
+
+        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-05-22T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn recent_user_pub_suppresses_chronically_failing() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(now - Duration::days(35), now),
+        );
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_user_pub_at: Some(now - Duration::days(5)),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-04-27T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn stale_user_pub_does_not_suppress_chronically_failing() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(
+                now - CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(5),
+                now,
+            ),
+        );
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_user_pub_at: Some(now - Duration::days(20)),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-04-27T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_chronically_failing": {
+            "count": 1,
+            "disable_at": "2025-06-08",
+            "error": "task shards have been failing since 2025-04-27",
+            "failing_since": "2025-04-27",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    /// A shard starts failing and stays broken. Over time the controller detects
+    /// chronic failure, warns with a grace period, then auto-disables. When the
+    /// shard later recovers and data starts moving again, all alerts resolve.
+    #[test]
+    fn chronically_failing_lifecycle() {
+        let shard_failed_at = fixed_now();
+        let created_at = shard_failed_at - Duration::days(90);
+        let state = mock_state(Some(enabled_capture()), created_at);
+        let timestamps = AbandonmentTimestamps::default();
+        let mut alerts: Alerts = Default::default();
+
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(shard_failed_at, shard_failed_at),
+        );
+
+        // Tick 1: 29 days of failure, below the 30-day chronically-failing threshold.
+        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(1);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 2: 31 days of failure, over threshold. TaskChronicallyFailing fires
+        // with a 7-day grace period before auto-disable.
+        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(1);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_chronically_failing": {
+            "count": 1,
+            "disable_at": "2025-07-09",
+            "error": "task shards have been failing since 2025-06-01",
+            "failing_since": "2025-06-01",
+            "first_ts": "2025-07-02T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 3: 4 days into grace period, still within the window.
+        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(5);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_chronically_failing": {
+            "count": 1,
+            "disable_at": "2025-07-09",
+            "error": "task shards have been failing since 2025-06-01",
+            "failing_since": "2025-06-01",
+            "first_ts": "2025-07-02T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 4: Grace period expired. The disable_at was set at tick 2
+        // (threshold + 1d) plus DISABLE_AFTER, so we need to reach that date.
+        let chronically_fired_at =
+            shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(1);
+        let now = chronically_fired_at + CHRONICALLY_FAILING_DISABLE_AFTER.get();
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert_eq!(reason, Some(DisableReason::ChronicallyFailing));
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_auto_disabled_failing": {
+            "count": 1,
+            "error": "task auto-disabled after shards failing since 2025-06-01",
+            "failing_since": "2025-06-01",
+            "first_ts": "2025-07-09T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_chronically_failing": {
+            "count": 1,
+            "disable_at": "2025-07-09",
+            "error": "task shards have been failing since 2025-06-01",
+            "failing_since": "2025-06-01",
+            "first_ts": "2025-07-02T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 5: Shard recovers (ShardFailed removed) and data starts moving
+        // again. All failing-sequence alerts resolve cleanly.
+        alerts.remove(&AlertType::ShardFailed);
+        let now =
+            chronically_fired_at + CHRONICALLY_FAILING_DISABLE_AFTER.get() + Duration::days(1);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_data_movement_ts: Some(now - Duration::days(1)),
+                ..Default::default()
+            },
+        );
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    /// Once `TaskChronicallyFailing` fires with a `disable_at` date, that stored
+    /// date is honored on subsequent evaluations rather than being recomputed.
+    /// This prevents the disable date from shifting if the grace-period config
+    /// changes between controller runs.
+    #[test]
+    fn chronically_failing_stored_disable_at_honored() {
+        let base = fixed_now();
+        let shard_failed_at = base - CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(15);
+        let created_at = shard_failed_at - Duration::days(30);
+        let state = mock_state(Some(enabled_capture()), created_at);
+        let timestamps = AbandonmentTimestamps::default();
+        let mut alerts: Alerts = Default::default();
+
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(shard_failed_at, base),
+        );
+
+        // Tick 1: Grace period is 7 days. TaskChronicallyFailing fires with
+        // disable_at = base + 7d.
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        assert!(reason.is_none());
+
+        let original_disable_at = alerts
+            .get(&AlertType::TaskChronicallyFailing)
+            .expect("just fired")
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Shrink the grace period to 1 day. If disable_at were recomputed,
+        // tick 2 would set it to now+1d and immediately trigger auto-disable
+        // on tick 3.
+        CHRONICALLY_FAILING_DISABLE_AFTER.set(Duration::days(1));
+
+        // Tick 2: 3 days later. Past the new 1-day grace period, but still
+        // before the original 7-day disable_at. The stored date wins.
+        let now = base + Duration::days(3);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert!(reason.is_none());
+
+        // Verify the stored disable_at hasn't changed.
+        let current_disable_at = alerts
+            .get(&AlertType::TaskChronicallyFailing)
+            .unwrap()
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(original_disable_at, current_disable_at);
+    }
+
+    // Sequence 2: Idle tasks
+
+    #[test]
+    fn new_task_with_recent_pub_not_idle() {
+        let now = fixed_now();
+
+        // The initial publication that created the task sets last_user_pub_at,
+        // which suppresses idle detection for 14 days.
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(10));
+        let mut alerts: Alerts = Default::default();
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_user_pub_at: Some(now - Duration::days(10)),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    #[test]
+    fn recent_data_movement_prevents_idle() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_data_movement_ts: Some(now - Duration::days(5)),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    #[test]
+    fn recent_user_pub_prevents_idle() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_user_pub_at: Some(now - Duration::days(5)),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    #[test]
+    fn stale_data_but_recent_user_pub_not_idle() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_data_movement_ts: Some(now - IDLE_THRESHOLD.get() - Duration::days(5)),
+                last_user_pub_at: Some(now - Duration::days(3)),
+            },
+        );
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    #[test]
+    fn shard_failed_suppresses_idle() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(now - Duration::days(5), now),
+        );
+
+        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-05-27T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn chronically_failing_suppresses_idle() {
+        let now = fixed_now();
+
+        let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
+        let mut alerts: Alerts = Default::default();
+        alerts.insert(
+            AlertType::ShardFailed,
+            shard_failed_alert(now - Duration::days(40), now),
+        );
+
+        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "shard_failed": {
+            "count": 5,
+            "error": "shard failed",
+            "first_ts": "2025-04-22T12:00:00Z",
+            "last_ts": "2025-06-01T12:00:00Z",
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          },
+          "task_chronically_failing": {
+            "count": 1,
+            "disable_at": "2025-06-08",
+            "error": "task shards have been failing since 2025-04-22",
+            "failing_since": "2025-04-22",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+    }
+
+    /// Full idle lifecycle: task starts healthy, becomes idle, receives a warning
+    /// with grace period, gets auto-disabled after the grace period, and all alerts
+    /// resolve when data starts moving again.
+    #[test]
+    fn idle_lifecycle() {
+        let base = fixed_now();
+        let created_at = base - Duration::days(90);
+        let state = mock_state(Some(enabled_materialization()), created_at);
+        let mut alerts: Alerts = Default::default();
+
+        // Tick 1: Task has recent data movement. No alerts fire.
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            base,
+            AbandonmentTimestamps {
+                last_data_movement_ts: Some(base - Duration::days(1)),
+                ..Default::default()
+            },
+        );
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+
+        // Tick 2: No data movement, no user pub, no failure alerts. TaskIdle fires
+        // with a 7-day grace period.
+        let now = base + IDLE_THRESHOLD.get();
+        let reason = evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "task_idle": {
+            "count": 1,
+            "disable_at": "2025-07-08",
+            "error": "task has not moved data since it was created",
+            "first_ts": "2025-07-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "materialization",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 3: Grace period expired. TaskAutoDisabledIdle fires.
+        let now = now + IDLE_DISABLE_AFTER.get();
+        let reason = evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        assert_eq!(reason, Some(DisableReason::Idle));
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "task_auto_disabled_idle": {
+            "count": 1,
+            "error": "task auto-disabled due to inactivity",
+            "first_ts": "2025-07-08T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "materialization",
+            "state": "firing"
+          },
+          "task_idle": {
+            "count": 1,
+            "disable_at": "2025-07-08",
+            "error": "task has not moved data since it was created",
+            "first_ts": "2025-07-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "materialization",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 4: Data starts moving again. All idle alerts resolve.
+        let now = now + Duration::days(1);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps {
+                last_data_movement_ts: Some(now - Duration::days(1)),
+                ..Default::default()
+            },
+        );
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    /// Once `TaskIdle` fires with a `disable_at` date, that stored date is
+    /// honored on subsequent evaluations rather than being recomputed.
+    #[test]
+    fn idle_stored_disable_at_honored() {
+        let base = fixed_now();
+        let created_at = base - Duration::days(90);
+        let state = mock_state(Some(enabled_materialization()), created_at);
+        let timestamps = AbandonmentTimestamps::default();
+        let mut alerts: Alerts = Default::default();
+
+        // Tick 1: Grace period is 7 days. TaskIdle fires with disable_at = base + 7d.
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        assert!(reason.is_none());
+
+        let original_disable_at = alerts
+            .get(&AlertType::TaskIdle)
+            .expect("just fired")
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Shrink the grace period to 1 day. If disable_at were recomputed,
+        // tick 2 would set it to now+1d and immediately trigger auto-disable
+        // on tick 3.
+        IDLE_DISABLE_AFTER.set(Duration::days(1));
+
+        // Tick 2: 3 days later. Past the new 1-day grace period, but still
+        // before the original 7-day disable_at. The stored date wins.
+        let now = base + Duration::days(3);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        assert!(reason.is_none());
+
+        // Verify the stored disable_at hasn't changed.
+        let current_disable_at = alerts
+            .get(&AlertType::TaskIdle)
+            .unwrap()
+            .extra
+            .get(EXTRA_DISABLE_AT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(original_disable_at, current_disable_at);
+    }
+
+    /// When a task becomes disabled (no shards), all abandonment alerts resolve
+    /// regardless of which sequence produced them.
+    #[test]
+    fn disabled_task_resolves_abandon_alerts() {
+        let base = fixed_now();
+        let created_at = base - Duration::days(90);
+        let state = mock_state(Some(enabled_capture()), created_at);
+        let timestamps = AbandonmentTimestamps::default();
+        let mut alerts: Alerts = Default::default();
+
+        // Tick 1: Task is idle, no data, no user pub.
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
+        {
+          "task_idle": {
+            "count": 1,
+            "disable_at": "2025-06-08",
+            "error": "task has not moved data since it was created",
+            "first_ts": "2025-06-01T12:00:00Z",
+            "last_ts": null,
+            "resolved_at": null,
+            "spec_type": "capture",
+            "state": "firing"
+          }
+        }
+        "#);
+
+        // Tick 2: Task is now disabled. All abandonment alerts resolve.
+        let disabled_state = mock_state(Some(disabled_capture()), created_at);
+        let now = base + Duration::days(1);
+        let reason = evaluate_alerts(&mut alerts, &disabled_state, now, timestamps);
+        assert!(reason.is_none());
+        insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
+    }
+
+    #[test]
+    fn set_spec_disabled_capture() {
+        let mut spec = enabled_capture();
+        set_spec_disabled(&mut spec);
+        match &spec {
+            AnySpec::Capture(c) => assert!(c.shards.disable),
+            _ => panic!("expected capture"),
+        }
+    }
+
+    #[test]
+    fn set_spec_disabled_materialization() {
+        let mut spec = enabled_materialization();
+        set_spec_disabled(&mut spec);
+        match &spec {
+            AnySpec::Materialization(m) => assert!(m.shards.disable),
+            _ => panic!("expected materialization"),
+        }
+    }
+
+    #[test]
+    fn set_spec_disabled_derivation() {
+        let collection: models::CollectionDef = serde_json::from_value(serde_json::json!({
+            "key": ["/id"],
+            "schema": {"type": "object"},
+            "derive": {
+                "using": {"sqlite": {"migrations": []}},
+                "transforms": []
+            }
+        }))
+        .unwrap();
+        let mut spec = AnySpec::Collection(collection);
+        set_spec_disabled(&mut spec);
+        match &spec {
+            AnySpec::Collection(c) => {
+                assert!(c.derive.as_ref().unwrap().shards.disable);
+            }
+            _ => panic!("expected collection"),
+        }
+    }
+}

--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -1,35 +1,10 @@
-use super::{ControllerState, NextRun, alerts};
+use super::{ControllerConfig, ControllerState, NextRun, alerts};
 use crate::controllers::activation::has_task_shards;
 use crate::controllers::publication_status::PendingPublication;
 use crate::controlplane::ControlPlane;
 use chrono::{DateTime, Utc};
 use models::status::publications::PublicationStatus;
 use models::status::{AlertType, Alerts};
-
-env_config_interval! {
-    /// ShardFailed must be continuously firing for this long before we consider the task chronically failing.
-    CHRONICALLY_FAILING_THRESHOLD, chrono::Duration::days(30)
-}
-env_config_interval! {
-    /// Grace period after firing the chronically-failing warning before auto-disabling.
-    CHRONICALLY_FAILING_DISABLE_AFTER, chrono::Duration::days(7)
-}
-env_config_interval! {
-    /// Task must have no data movement for this long before we consider it idle.
-    IDLE_THRESHOLD, chrono::Duration::days(30)
-}
-env_config_interval! {
-    /// A user publication within this timeframe will prevent task abandonment alerts from firing and tasks from being disabled.
-    USER_PUB_THRESHOLD, chrono::Duration::days(14)
-}
-env_config_interval! {
-    /// Grace period after firing the idle warning before auto-disabling.
-    IDLE_DISABLE_AFTER, chrono::Duration::days(7)
-}
-env_config_bool! {
-    /// Allows for running the abandonment controller without actually disabling tasks.
-    pub(crate) DISABLE_ABANDONED_TASKS, false
-}
 
 /// Extra field keys stored in alert `extra` maps for notification templates.
 const EXTRA_DISABLE_AT: &str = "disable_at";
@@ -70,12 +45,14 @@ pub async fn evaluate_abandoned<C: ControlPlane>(
     }
 
     let now = control_plane.current_time();
-    let timestamps = fetch_abandonment_timestamps(alerts_status, state, control_plane, now).await?;
+    let config = control_plane.controller_config();
+    let timestamps =
+        fetch_abandonment_timestamps(alerts_status, state, control_plane, now, &config).await?;
 
-    let disable_reason = evaluate_alerts(alerts_status, state, now, timestamps);
+    let disable_reason = evaluate_alerts(alerts_status, state, now, timestamps, &config);
 
     if let Some(reason) = disable_reason {
-        if DISABLE_ABANDONED_TASKS.get() {
+        if config.disable_abandoned_tasks {
             if maybe_disable_task(reason, state, publications, control_plane).await? {
                 return Ok(Some(NextRun::immediately()));
             }
@@ -93,6 +70,7 @@ async fn fetch_abandonment_timestamps<C: ControlPlane>(
     state: &ControllerState,
     control_plane: &C,
     now: DateTime<Utc>,
+    config: &ControllerConfig,
 ) -> anyhow::Result<AbandonmentTimestamps> {
     let last_user_pub_at = control_plane
         .fetch_last_user_publication_at(state.live_spec_id)
@@ -100,7 +78,8 @@ async fn fetch_abandonment_timestamps<C: ControlPlane>(
 
     let has_failure_alerts = alerts_status.contains_key(&AlertType::ShardFailed)
         || alerts_status.contains_key(&AlertType::TaskChronicallyFailing);
-    let user_pub_stale = last_user_pub_at.map_or(true, |ts| (now - ts) >= USER_PUB_THRESHOLD.get());
+    let user_pub_stale =
+        last_user_pub_at.map_or(true, |ts| (now - ts) >= config.abandon_user_pub_recency);
 
     let last_data_movement_ts = if has_failure_alerts || !user_pub_stale {
         None
@@ -124,6 +103,7 @@ fn evaluate_alerts(
     state: &ControllerState,
     now: DateTime<Utc>,
     timestamps: AbandonmentTimestamps,
+    config: &ControllerConfig,
 ) -> Option<DisableReason> {
     // Tasks that are disabled, Dekaf, or lack shards don't get abandonment checks.
     // Silently resolve any alerts that may have been firing so re-enablement starts clean.
@@ -136,17 +116,17 @@ fn evaluate_alerts(
 
     let user_pub_stale = timestamps
         .last_user_pub_at
-        .map_or(true, |ts| (now - ts) >= USER_PUB_THRESHOLD.get());
+        .map_or(true, |ts| (now - ts) >= config.abandon_user_pub_recency);
 
     // Sequence 1: Chronically Failing
-    // Fires when ShardFailed has been continuously active for > CHRONICALLY_FAILING_THRESHOLD
+    // Fires when ShardFailed has been continuously active for an extended period
     // and no user has published changes recently (a recent publication signals active debugging).
     let shard_failed_since = alerts_status
         .get(&AlertType::ShardFailed)
         .map(|a| a.first_ts);
 
     let is_chronically_failing = shard_failed_since
-        .is_some_and(|first_ts| (now - first_ts) >= CHRONICALLY_FAILING_THRESHOLD.get())
+        .is_some_and(|first_ts| (now - first_ts) >= config.chronically_failing_threshold)
         && user_pub_stale;
 
     let mut disable_reason = None;
@@ -159,7 +139,7 @@ fn evaluate_alerts(
         // shift the disable date if the env config changes between runs.
         if !alerts_status.contains_key(&AlertType::TaskChronicallyFailing) {
             let failing_since = shard_failed_first_ts.format("%Y-%m-%d").to_string();
-            let disable_at = (now + CHRONICALLY_FAILING_DISABLE_AFTER.get())
+            let disable_at = (now + config.chronically_failing_disable_after)
                 .format("%Y-%m-%d")
                 .to_string();
 
@@ -237,13 +217,13 @@ fn evaluate_alerts(
 
     let data_stale = timestamps
         .last_data_movement_ts
-        .map_or(true, |ts| (now - ts) >= IDLE_THRESHOLD.get());
+        .map_or(true, |ts| (now - ts) >= config.abandon_idle_threshold);
 
     let is_idle = !has_failure_alerts && data_stale && user_pub_stale;
 
     if is_idle {
         if !alerts_status.contains_key(&AlertType::TaskIdle) {
-            let disable_at = (now + IDLE_DISABLE_AFTER.get())
+            let disable_at = (now + config.abandon_idle_disable_after)
                 .format("%Y-%m-%d")
                 .to_string();
 
@@ -448,12 +428,19 @@ mod test {
 
     #[test]
     fn no_shard_failed_means_not_chronically_failing() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
         let mut alerts: Alerts = Default::default();
 
-        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -473,6 +460,7 @@ mod test {
 
     #[test]
     fn recent_shard_failed_not_chronically_failing() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -482,7 +470,13 @@ mod test {
             shard_failed_alert(now - Duration::days(10), now),
         );
 
-        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -501,6 +495,7 @@ mod test {
 
     #[test]
     fn recent_user_pub_suppresses_chronically_failing() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -518,6 +513,7 @@ mod test {
                 last_user_pub_at: Some(now - Duration::days(5)),
                 ..Default::default()
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -537,6 +533,7 @@ mod test {
 
     #[test]
     fn stale_user_pub_does_not_suppress_chronically_failing() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -544,7 +541,7 @@ mod test {
         alerts.insert(
             AlertType::ShardFailed,
             shard_failed_alert(
-                now - CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(5),
+                now - config.chronically_failing_threshold - Duration::days(5),
                 now,
             ),
         );
@@ -557,6 +554,7 @@ mod test {
                 last_user_pub_at: Some(now - Duration::days(20)),
                 ..Default::default()
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -590,6 +588,7 @@ mod test {
     /// shard later recovers and data starts moving again, all alerts resolve.
     #[test]
     fn chronically_failing_lifecycle() {
+        let config = ControllerConfig::default();
         let shard_failed_at = fixed_now();
         let created_at = shard_failed_at - Duration::days(90);
         let state = mock_state(Some(enabled_capture()), created_at);
@@ -602,8 +601,8 @@ mod test {
         );
 
         // Tick 1: 29 days of failure, below the 30-day chronically-failing threshold.
-        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        let now = shard_failed_at + config.chronically_failing_threshold - Duration::days(1);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -621,8 +620,8 @@ mod test {
 
         // Tick 2: 31 days of failure, over threshold. TaskChronicallyFailing fires
         // with a 7-day grace period before auto-disable.
-        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        let now = shard_failed_at + config.chronically_failing_threshold + Duration::days(1);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -650,8 +649,8 @@ mod test {
         "#);
 
         // Tick 3: 4 days into grace period, still within the window.
-        let now = shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(5);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        let now = shard_failed_at + config.chronically_failing_threshold + Duration::days(5);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -681,9 +680,9 @@ mod test {
         // Tick 4: Grace period expired. The disable_at was set at tick 2
         // (threshold + 1d) plus DISABLE_AFTER, so we need to reach that date.
         let chronically_fired_at =
-            shard_failed_at + CHRONICALLY_FAILING_THRESHOLD.get() + Duration::days(1);
-        let now = chronically_fired_at + CHRONICALLY_FAILING_DISABLE_AFTER.get();
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+            shard_failed_at + config.chronically_failing_threshold + Duration::days(1);
+        let now = chronically_fired_at + config.chronically_failing_disable_after;
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert_eq!(reason, Some(DisableReason::ChronicallyFailing));
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -724,7 +723,7 @@ mod test {
         // again. All failing-sequence alerts resolve cleanly.
         alerts.remove(&AlertType::ShardFailed);
         let now =
-            chronically_fired_at + CHRONICALLY_FAILING_DISABLE_AFTER.get() + Duration::days(1);
+            chronically_fired_at + config.chronically_failing_disable_after + Duration::days(1);
         let reason = evaluate_alerts(
             &mut alerts,
             &state,
@@ -733,6 +732,7 @@ mod test {
                 last_data_movement_ts: Some(now - Duration::days(1)),
                 ..Default::default()
             },
+            &config,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -744,8 +744,9 @@ mod test {
     /// changes between controller runs.
     #[test]
     fn chronically_failing_stored_disable_at_honored() {
+        let mut config = ControllerConfig::default();
         let base = fixed_now();
-        let shard_failed_at = base - CHRONICALLY_FAILING_THRESHOLD.get() - Duration::days(15);
+        let shard_failed_at = base - config.chronically_failing_threshold - Duration::days(15);
         let created_at = shard_failed_at - Duration::days(30);
         let state = mock_state(Some(enabled_capture()), created_at);
         let timestamps = AbandonmentTimestamps::default();
@@ -758,7 +759,7 @@ mod test {
 
         // Tick 1: Grace period is 7 days. TaskChronicallyFailing fires with
         // disable_at = base + 7d.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config);
         assert!(reason.is_none());
 
         let original_disable_at = alerts
@@ -774,12 +775,12 @@ mod test {
         // Shrink the grace period to 1 day. If disable_at were recomputed,
         // tick 2 would set it to now+1d and immediately trigger auto-disable
         // on tick 3.
-        CHRONICALLY_FAILING_DISABLE_AFTER.set(Duration::days(1));
+        config.chronically_failing_disable_after = Duration::days(1);
 
         // Tick 2: 3 days later. Past the new 1-day grace period, but still
         // before the original 7-day disable_at. The stored date wins.
         let now = base + Duration::days(3);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert!(reason.is_none());
 
         // Verify the stored disable_at hasn't changed.
@@ -798,6 +799,7 @@ mod test {
 
     #[test]
     fn new_task_with_recent_pub_not_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         // The initial publication that created the task sets last_user_pub_at,
@@ -813,6 +815,7 @@ mod test {
                 last_user_pub_at: Some(now - Duration::days(10)),
                 ..Default::default()
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -820,6 +823,7 @@ mod test {
 
     #[test]
     fn recent_data_movement_prevents_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -833,6 +837,7 @@ mod test {
                 last_data_movement_ts: Some(now - Duration::days(5)),
                 ..Default::default()
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -840,6 +845,7 @@ mod test {
 
     #[test]
     fn recent_user_pub_prevents_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -853,6 +859,7 @@ mod test {
                 last_user_pub_at: Some(now - Duration::days(5)),
                 ..Default::default()
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -860,6 +867,7 @@ mod test {
 
     #[test]
     fn stale_data_but_recent_user_pub_not_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -870,9 +878,12 @@ mod test {
             &state,
             now,
             AbandonmentTimestamps {
-                last_data_movement_ts: Some(now - IDLE_THRESHOLD.get() - Duration::days(5)),
+                last_data_movement_ts: Some(
+                    now - config.abandon_idle_threshold - Duration::days(5),
+                ),
                 last_user_pub_at: Some(now - Duration::days(3)),
             },
+            &config,
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -880,6 +891,7 @@ mod test {
 
     #[test]
     fn shard_failed_suppresses_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -889,7 +901,13 @@ mod test {
             shard_failed_alert(now - Duration::days(5), now),
         );
 
-        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -908,6 +926,7 @@ mod test {
 
     #[test]
     fn chronically_failing_suppresses_idle() {
+        let config = ControllerConfig::default();
         let now = fixed_now();
 
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
@@ -917,7 +936,13 @@ mod test {
             shard_failed_alert(now - Duration::days(40), now),
         );
 
-        evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -950,6 +975,7 @@ mod test {
     /// resolve when data starts moving again.
     #[test]
     fn idle_lifecycle() {
+        let config = ControllerConfig::default();
         let base = fixed_now();
         let created_at = base - Duration::days(90);
         let state = mock_state(Some(enabled_materialization()), created_at);
@@ -964,14 +990,21 @@ mod test {
                 last_data_movement_ts: Some(base - Duration::days(1)),
                 ..Default::default()
             },
+            &config,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
 
         // Tick 2: No data movement, no user pub, no failure alerts. TaskIdle fires
         // with a 7-day grace period.
-        let now = base + IDLE_THRESHOLD.get();
-        let reason = evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        let now = base + config.abandon_idle_threshold;
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -989,8 +1022,14 @@ mod test {
         "#);
 
         // Tick 3: Grace period expired. TaskAutoDisabledIdle fires.
-        let now = now + IDLE_DISABLE_AFTER.get();
-        let reason = evaluate_alerts(&mut alerts, &state, now, AbandonmentTimestamps::default());
+        let now = now + config.abandon_idle_disable_after;
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            AbandonmentTimestamps::default(),
+            &config,
+        );
         assert_eq!(reason, Some(DisableReason::Idle));
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -1026,6 +1065,7 @@ mod test {
                 last_data_movement_ts: Some(now - Duration::days(1)),
                 ..Default::default()
             },
+            &config,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -1035,6 +1075,7 @@ mod test {
     /// honored on subsequent evaluations rather than being recomputed.
     #[test]
     fn idle_stored_disable_at_honored() {
+        let mut config = ControllerConfig::default();
         let base = fixed_now();
         let created_at = base - Duration::days(90);
         let state = mock_state(Some(enabled_materialization()), created_at);
@@ -1042,7 +1083,7 @@ mod test {
         let mut alerts: Alerts = Default::default();
 
         // Tick 1: Grace period is 7 days. TaskIdle fires with disable_at = base + 7d.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config);
         assert!(reason.is_none());
 
         let original_disable_at = alerts
@@ -1058,12 +1099,12 @@ mod test {
         // Shrink the grace period to 1 day. If disable_at were recomputed,
         // tick 2 would set it to now+1d and immediately trigger auto-disable
         // on tick 3.
-        IDLE_DISABLE_AFTER.set(Duration::days(1));
+        config.abandon_idle_disable_after = Duration::days(1);
 
         // Tick 2: 3 days later. Past the new 1-day grace period, but still
         // before the original 7-day disable_at. The stored date wins.
         let now = base + Duration::days(3);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config);
         assert!(reason.is_none());
 
         // Verify the stored disable_at hasn't changed.
@@ -1082,6 +1123,7 @@ mod test {
     /// regardless of which sequence produced them.
     #[test]
     fn disabled_task_resolves_abandon_alerts() {
+        let config = ControllerConfig::default();
         let base = fixed_now();
         let created_at = base - Duration::days(90);
         let state = mock_state(Some(enabled_capture()), created_at);
@@ -1089,7 +1131,7 @@ mod test {
         let mut alerts: Alerts = Default::default();
 
         // Tick 1: Task is idle, no data, no user pub.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -1109,7 +1151,7 @@ mod test {
         // Tick 2: Task is now disabled. All abandonment alerts resolve.
         let disabled_state = mock_state(Some(disabled_capture()), created_at);
         let now = base + Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &disabled_state, now, timestamps);
+        let reason = evaluate_alerts(&mut alerts, &disabled_state, now, timestamps, &config);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
     }

--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -3,6 +3,7 @@ use crate::controllers::activation::has_task_shards;
 use crate::controllers::publication_status::PendingPublication;
 use crate::controlplane::ControlPlane;
 use chrono::{DateTime, Utc};
+use models::status::AbandonStatus;
 use models::status::publications::PublicationStatus;
 use models::status::{AlertType, Alerts};
 
@@ -35,6 +36,7 @@ impl std::fmt::Display for DisableReason {
 pub async fn evaluate_abandoned<C: ControlPlane>(
     alerts_status: &mut Alerts,
     publications: &mut PublicationStatus,
+    abandon_status: &mut AbandonStatus,
     state: &ControllerState,
     control_plane: &C,
 ) -> anyhow::Result<Option<NextRun>> {
@@ -46,6 +48,19 @@ pub async fn evaluate_abandoned<C: ControlPlane>(
 
     let now = control_plane.current_time();
     let config = control_plane.controller_config();
+
+    let check_interval_minutes = config.abandon_check_interval.num_minutes().max(1) as u32;
+
+    // Throttle evaluations to avoid excessive catalog_stats_daily queries.
+    if let Some(last) = abandon_status.last_evaluated {
+        let remaining = config.abandon_check_interval - (now - last);
+        if remaining > chrono::Duration::zero() {
+            return Ok(Some(NextRun::after_minutes(
+                remaining.num_minutes().max(1) as u32
+            )));
+        }
+    }
+    abandon_status.last_evaluated = Some(now);
     let timestamps =
         fetch_abandonment_timestamps(alerts_status, state, control_plane, now, &config).await?;
 
@@ -59,10 +74,7 @@ pub async fn evaluate_abandoned<C: ControlPlane>(
         }
     }
 
-    // Safety-net wake: controllers already wake every ~2 hours for shard health
-    // checks, so this 24-hour timer just ensures abandon evaluation isn't skipped
-    // indefinitely if those checks stop scheduling wakes.
-    Ok(Some(NextRun::after_minutes(24 * 60)))
+    Ok(Some(NextRun::after_minutes(check_interval_minutes)))
 }
 
 async fn fetch_abandonment_timestamps<C: ControlPlane>(

--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use super::{ControllerState, NextRun, alerts, backoff_data_plane_activate};
 use crate::{
     controllers::{ControllerErrorExt, Inbox},
@@ -19,42 +17,85 @@ use models::{
 };
 
 /// Helper for getting a `chrono::Duration` from an environment variable, using humantime so it
-/// supports parsing durations like `3h`.
+/// supports parsing durations like `3h`. The value is read once on first access. In test builds,
+/// the value can be overridden via `.set()`.
 macro_rules! env_config_interval {
-    ($var_ident:ident, $default_val:expr) => {
-        static $var_ident: std::sync::LazyLock<chrono::Duration> = std::sync::LazyLock::new(|| {
-            let var_name = stringify!($var_ident);
-            if let Ok(val) = std::env::var(var_name) {
-                let parsed: humantime::Duration = FromStr::from_str(&val)
-                    .unwrap_or_else(|err| panic!("invalid {var_name} value: {err:?}"));
-                chrono::Duration::from_std(parsed.into())
-                    .unwrap_or_else(|_err| panic!("invalid {var_name} value: out of range"))
-            } else {
-                $default_val
-            }
-        });
+    ($(#[$meta:meta])* $var_ident:ident, $default_val:expr) => {
+        $(#[$meta])*
+        static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<chrono::Duration>> =
+            std::sync::LazyLock::new(|| {
+                let var_name = stringify!($var_ident);
+                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
+                    let parsed: humantime::Duration = std::str::FromStr::from_str(&val)
+                        .unwrap_or_else(|err| panic!("invalid {var_name} value: {err:?}"));
+                    chrono::Duration::from_std(parsed.into())
+                        .unwrap_or_else(|_err| panic!("invalid {var_name} value: out of range"))
+                } else {
+                    $default_val
+                })
+            });
     };
 }
 
-// We retain rows in the `shard_failures` table for at most this long. Failures
-// are deleted every time the `build_id` changes, or if they're older than this
-// threshold. The controller keeps a count of recent failures in the status,
-// and it periodically cleans up old failures as long as that count is
-// positive.
-env_config_interval! {SHARD_FAILURE_RETENTION, chrono::Duration::hours(8)}
+/// Helper for getting a `bool` from an environment variable. Accepts `"true"`
+/// (case-insensitive) as the truthy value. The value is read once on first access. In test
+/// builds, the value can be overridden via `.set()`.
+macro_rules! env_config_bool {
+    ($(#[$meta:meta])* $vis:vis $var_ident:ident, $default_val:expr) => {
+        $(#[$meta])*
+        $vis static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<bool>> =
+            std::sync::LazyLock::new(|| {
+                let var_name = stringify!($var_ident);
+                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
+                    val.eq_ignore_ascii_case("true")
+                } else {
+                    $default_val
+                })
+            });
+    };
+}
 
-// We resolve shard failed alerts after this duration has passed since the shards
-// last became healthy.
-env_config_interval! {RESOLVE_SHARD_FAILED_ALERT_AFTER, chrono::Duration::hours(2)}
+/// Helper for getting a numeric value from an environment variable, parsed via `FromStr`.
+/// The value is read once on first access. In test builds, the value can be overridden via `.set()`.
+macro_rules! env_config_num {
+    ($(#[$meta:meta])* $var_ident:ident, $num_ty:ty, $default_val:expr) => {
+        $(#[$meta])*
+        static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<$num_ty>> =
+            std::sync::LazyLock::new(|| {
+                let var_name = stringify!($var_ident);
+                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
+                    std::str::FromStr::from_str(&val)
+                        .unwrap_or_else(|err| panic!("invalid {var_name} value: {err:?}"))
+                } else {
+                    $default_val
+                })
+            });
+    };
+}
+
+env_config_interval! {
+    /// We retain rows in the `shard_failures` table for at most this long. Failures
+    /// are deleted every time the `build_id` changes, or if they're older than this
+    /// threshold. The controller keeps a count of recent failures in the status,
+    /// and it periodically cleans up old failures as long as that count is
+    /// positive.
+    SHARD_FAILURE_RETENTION, chrono::Duration::hours(8)
+}
+
+env_config_interval! {
+    /// We resolve shard failed alerts after this duration has passed since the shards
+    /// last became healthy.
+    RESOLVE_SHARD_FAILED_ALERT_AFTER, chrono::Duration::hours(2)
+}
 env_config_interval! {FLOW_MAX_SHARD_STATUS_INTERVAL, chrono::Duration::hours(2)}
 
-const ALERT_AFTER_SHARD_FAILURES: std::sync::LazyLock<u32> = std::sync::LazyLock::new(|| {
-    if let Ok(val) = std::env::var("ALERT_AFTER_SHARD_FAILURES") {
-        FromStr::from_str(&val).expect("invalid ALERT_AFTER_SHARD_FAILURES")
-    } else {
-        3
-    }
-});
+env_config_num! {ALERT_AFTER_SHARD_FAILURES, u32, 3}
+
+env_config_num! {
+    /// Minimum consecutive Ok health checks before counting as sustained PRIMARY.
+    /// With Ok intervals starting at 3min, the default of 3 means ~6-9 min of healthy operation.
+    SUSTAINED_PRIMARY_MIN_CHECKS, u32, 3
+}
 
 /// Activates the spec in the data plane if necessary.
 pub async fn update_activation<C: ControlPlane>(
@@ -66,7 +107,7 @@ pub async fn update_activation<C: ControlPlane>(
     control_plane: &C,
 ) -> anyhow::Result<Option<NextRun>> {
     let now = control_plane.current_time();
-    let failure_retention_threshold = now - *SHARD_FAILURE_RETENTION;
+    let failure_retention_threshold = now - SHARD_FAILURE_RETENTION.get();
     // Did we receive at least one shard failure message?
     let observed_shard_failures = events
         .iter()
@@ -117,6 +158,7 @@ pub async fn update_activation<C: ControlPlane>(
                 "restarting failed task shards"
             );
             do_activate(now, state, status, control_plane).await?;
+            status.restarts_since_last_primary += 1;
             if has_task_shards(state) {
                 // Reset the shard health status, as we'll need to await another successful check.
                 status.shard_status = Some(ShardStatusCheck {
@@ -246,7 +288,7 @@ async fn handle_shard_failures<C: ControlPlane>(
             .live_spec
             .as_ref()
             .map(|s| s.catalog_type())
-            .filter(|_| status.recent_failure_count >= *ALERT_AFTER_SHARD_FAILURES)
+            .filter(|_| status.recent_failure_count >= ALERT_AFTER_SHARD_FAILURES.get())
         {
             // last_failure should always be present, but this just prevents
             // things from blowing up if someone were to manually edit the
@@ -339,11 +381,10 @@ fn should_resolve_alert(
     }
 
     status.shard_status.as_ref().is_some_and(|s| {
-        s.status == ShardsStatus::Ok && (now - s.first_ts) >= *RESOLVE_SHARD_FAILED_ALERT_AFTER
-    }) && status
-        .last_failure
-        .as_ref()
-        .is_none_or(|fail| fail.ts < now && (now - fail.ts) > *RESOLVE_SHARD_FAILED_ALERT_AFTER)
+        s.status == ShardsStatus::Ok && (now - s.first_ts) >= RESOLVE_SHARD_FAILED_ALERT_AFTER.get()
+    }) && status.last_failure.as_ref().is_none_or(|fail| {
+        fail.ts < now && (now - fail.ts) > RESOLVE_SHARD_FAILED_ALERT_AFTER.get()
+    })
 }
 
 async fn update_shard_health<C: ControlPlane>(
@@ -409,6 +450,8 @@ async fn update_shard_health<C: ControlPlane>(
         last_ts: now,
         status: new_status,
     });
+
+    update_sustained_primary(status, new_status, count);
 
     // If there's been at least 3 failed checks in a row, then consider the
     // shard failed. We require at least 3 failed checks in a row because it's
@@ -482,6 +525,19 @@ fn synthesize_shard_failed_events(
 
 fn is_ops_catalog_task(state: &ControllerState) -> bool {
     state.catalog_name.starts_with("ops/") || state.catalog_name.starts_with("ops.us-central1.v1/")
+}
+
+/// Resets `restarts_since_last_primary` to 0 when shards have been Ok for
+/// enough consecutive checks, indicating sustained healthy operation.
+fn update_sustained_primary(
+    status: &mut ActivationStatus,
+    new_status: ShardsStatus,
+    consecutive_ok_count: u32,
+) {
+    if new_status == ShardsStatus::Ok && consecutive_ok_count >= SUSTAINED_PRIMARY_MIN_CHECKS.get()
+    {
+        status.restarts_since_last_primary = 0;
+    }
 }
 
 fn aggregate_shard_status(
@@ -578,7 +634,7 @@ fn shard_health_check_interval(
     let max_duration = if is_ops_catalog_task(state) {
         Duration::minutes(5)
     } else {
-        *FLOW_MAX_SHARD_STATUS_INTERVAL
+        FLOW_MAX_SHARD_STATUS_INTERVAL.get()
     };
 
     // If the status is OK, then backoff much more quickly
@@ -670,7 +726,7 @@ async fn do_activate<C: ControlPlane>(
     Ok(())
 }
 
-fn has_task_shards(state: &ControllerState) -> bool {
+pub(super) fn has_task_shards(state: &ControllerState) -> bool {
     match state.live_spec.as_ref() {
         Some(&AnySpec::Capture(ref cap)) if !cap.shards.disable => {
             // There's currently no such thing as a dekaf capture, but it seemed best to handle captures and materializations
@@ -801,6 +857,39 @@ mod test {
             ],
         );
         assert_eq!(ShardsStatus::Failed, actual);
+    }
+
+    #[test]
+    fn test_sustained_primary_tracking() {
+        let mut status = ActivationStatus {
+            restarts_since_last_primary: 10,
+            ..Default::default()
+        };
+
+        // Below threshold: no reset
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 1);
+        assert_eq!(status.restarts_since_last_primary, 10);
+
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 2);
+        assert_eq!(status.restarts_since_last_primary, 10);
+
+        // At threshold: resets counter
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 3);
+        assert_eq!(status.restarts_since_last_primary, 0);
+
+        // Above threshold: continues resetting
+        status.restarts_since_last_primary = 5;
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 10);
+        assert_eq!(status.restarts_since_last_primary, 0);
+
+        // Failed status: no reset regardless of count
+        status.restarts_since_last_primary = 7;
+        update_sustained_primary(&mut status, ShardsStatus::Failed, 5);
+        assert_eq!(status.restarts_since_last_primary, 7);
+
+        // Pending status: no reset regardless of count
+        update_sustained_primary(&mut status, ShardsStatus::Pending, 5);
+        assert_eq!(status.restarts_since_last_primary, 7);
     }
 
     #[test]

--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -1,4 +1,4 @@
-use super::{ControllerState, NextRun, alerts, backoff_data_plane_activate};
+use super::{ControllerConfig, ControllerState, NextRun, alerts, backoff_data_plane_activate};
 use crate::{
     controllers::{ControllerErrorExt, Inbox},
     controlplane::ControlPlane,
@@ -16,87 +16,6 @@ use models::{
     },
 };
 
-/// Helper for getting a `chrono::Duration` from an environment variable, using humantime so it
-/// supports parsing durations like `3h`. The value is read once on first access. In test builds,
-/// the value can be overridden via `.set()`.
-macro_rules! env_config_interval {
-    ($(#[$meta:meta])* $var_ident:ident, $default_val:expr) => {
-        $(#[$meta])*
-        static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<chrono::Duration>> =
-            std::sync::LazyLock::new(|| {
-                let var_name = stringify!($var_ident);
-                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
-                    let parsed: humantime::Duration = std::str::FromStr::from_str(&val)
-                        .unwrap_or_else(|err| panic!("invalid {var_name} value: {err:?}"));
-                    chrono::Duration::from_std(parsed.into())
-                        .unwrap_or_else(|_err| panic!("invalid {var_name} value: out of range"))
-                } else {
-                    $default_val
-                })
-            });
-    };
-}
-
-/// Helper for getting a `bool` from an environment variable. Accepts `"true"`
-/// (case-insensitive) as the truthy value. The value is read once on first access. In test
-/// builds, the value can be overridden via `.set()`.
-macro_rules! env_config_bool {
-    ($(#[$meta:meta])* $vis:vis $var_ident:ident, $default_val:expr) => {
-        $(#[$meta])*
-        $vis static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<bool>> =
-            std::sync::LazyLock::new(|| {
-                let var_name = stringify!($var_ident);
-                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
-                    val.eq_ignore_ascii_case("true")
-                } else {
-                    $default_val
-                })
-            });
-    };
-}
-
-/// Helper for getting a numeric value from an environment variable, parsed via `FromStr`.
-/// The value is read once on first access. In test builds, the value can be overridden via `.set()`.
-macro_rules! env_config_num {
-    ($(#[$meta:meta])* $var_ident:ident, $num_ty:ty, $default_val:expr) => {
-        $(#[$meta])*
-        static $var_ident: std::sync::LazyLock<$crate::controllers::EnvConfig<$num_ty>> =
-            std::sync::LazyLock::new(|| {
-                let var_name = stringify!($var_ident);
-                $crate::controllers::EnvConfig::new(if let Ok(val) = std::env::var(var_name) {
-                    std::str::FromStr::from_str(&val)
-                        .unwrap_or_else(|err| panic!("invalid {var_name} value: {err:?}"))
-                } else {
-                    $default_val
-                })
-            });
-    };
-}
-
-env_config_interval! {
-    /// We retain rows in the `shard_failures` table for at most this long. Failures
-    /// are deleted every time the `build_id` changes, or if they're older than this
-    /// threshold. The controller keeps a count of recent failures in the status,
-    /// and it periodically cleans up old failures as long as that count is
-    /// positive.
-    SHARD_FAILURE_RETENTION, chrono::Duration::hours(8)
-}
-
-env_config_interval! {
-    /// We resolve shard failed alerts after this duration has passed since the shards
-    /// last became healthy.
-    RESOLVE_SHARD_FAILED_ALERT_AFTER, chrono::Duration::hours(2)
-}
-env_config_interval! {FLOW_MAX_SHARD_STATUS_INTERVAL, chrono::Duration::hours(2)}
-
-env_config_num! {ALERT_AFTER_SHARD_FAILURES, u32, 3}
-
-env_config_num! {
-    /// Minimum consecutive Ok health checks before counting as sustained PRIMARY.
-    /// With Ok intervals starting at 3min, the default of 3 means ~6-9 min of healthy operation.
-    SUSTAINED_PRIMARY_MIN_CHECKS, u32, 3
-}
-
 /// Activates the spec in the data plane if necessary.
 pub async fn update_activation<C: ControlPlane>(
     status: &mut ActivationStatus,
@@ -107,7 +26,8 @@ pub async fn update_activation<C: ControlPlane>(
     control_plane: &C,
 ) -> anyhow::Result<Option<NextRun>> {
     let now = control_plane.current_time();
-    let failure_retention_threshold = now - SHARD_FAILURE_RETENTION.get();
+    let config = control_plane.controller_config();
+    let failure_retention_threshold = now - config.shard_failure_retention;
     // Did we receive at least one shard failure message?
     let observed_shard_failures = events
         .iter()
@@ -130,6 +50,7 @@ pub async fn update_activation<C: ControlPlane>(
             control_plane,
             now,
             failure_retention_threshold,
+            config.max_shard_status_interval,
         )
         .await;
     }
@@ -146,6 +67,7 @@ pub async fn update_activation<C: ControlPlane>(
             failure_retention_threshold,
             observed_shard_failures,
             next_pending_pub,
+            config.alert_after_shard_failures,
         )
         .await?;
     }
@@ -171,6 +93,7 @@ pub async fn update_activation<C: ControlPlane>(
                     state,
                     0,
                     ShardsStatus::Pending,
+                    config.max_shard_status_interval,
                 ))));
             }
         } else {
@@ -188,9 +111,14 @@ pub async fn update_activation<C: ControlPlane>(
 
     // At this point we're finished with any activations that are needed, and
     // it's time to ensure that task shards have actually started successfully.
-    let next_status_check = update_shard_health(status, control_plane, state).await?;
+    let next_status_check = update_shard_health(status, control_plane, state, &config).await?;
 
-    if should_resolve_alert(state, &*status, now) {
+    if should_resolve_alert(
+        state,
+        &*status,
+        now,
+        config.resolve_shard_failed_alert_after,
+    ) {
         alerts::resolve_alert(alerts_status, AlertType::ShardFailed);
     }
     Ok(next_status_check)
@@ -205,6 +133,7 @@ async fn handle_shard_failures<C: ControlPlane>(
     failure_retention_threshold: DateTime<Utc>,
     observed_shard_failures: usize,
     next_pending_pub: Option<chrono::DateTime<chrono::Utc>>,
+    alert_after_shard_failures: u32,
 ) -> Result<(), anyhow::Error> {
     control_plane
         .delete_shard_failures(
@@ -288,7 +217,7 @@ async fn handle_shard_failures<C: ControlPlane>(
             .live_spec
             .as_ref()
             .map(|s| s.catalog_type())
-            .filter(|_| status.recent_failure_count >= ALERT_AFTER_SHARD_FAILURES.get())
+            .filter(|_| status.recent_failure_count >= alert_after_shard_failures)
         {
             // last_failure should always be present, but this just prevents
             // things from blowing up if someone were to manually edit the
@@ -336,6 +265,7 @@ async fn activate_new_build<C: ControlPlane>(
     control_plane: &C,
     update_started_at: DateTime<Utc>,
     failure_retention_threshold: DateTime<Utc>,
+    max_shard_status_interval: chrono::Duration,
 ) -> Result<Option<NextRun>, anyhow::Error> {
     do_activate(update_started_at, state, status, control_plane).await?;
     let has_task_shards = has_task_shards(state);
@@ -367,6 +297,7 @@ async fn activate_new_build<C: ControlPlane>(
             state,
             0,
             ShardsStatus::Pending,
+            max_shard_status_interval,
         ))),
     )
 }
@@ -375,29 +306,39 @@ fn should_resolve_alert(
     state: &ControllerState,
     status: &ActivationStatus,
     now: DateTime<Utc>,
+    resolve_after: chrono::Duration,
 ) -> bool {
     if !has_task_shards(state) {
         return true;
     }
 
-    status.shard_status.as_ref().is_some_and(|s| {
-        s.status == ShardsStatus::Ok && (now - s.first_ts) >= RESOLVE_SHARD_FAILED_ALERT_AFTER.get()
-    }) && status.last_failure.as_ref().is_none_or(|fail| {
-        fail.ts < now && (now - fail.ts) > RESOLVE_SHARD_FAILED_ALERT_AFTER.get()
-    })
+    status
+        .shard_status
+        .as_ref()
+        .is_some_and(|s| s.status == ShardsStatus::Ok && (now - s.first_ts) >= resolve_after)
+        && status
+            .last_failure
+            .as_ref()
+            .is_none_or(|fail| fail.ts < now && (now - fail.ts) > resolve_after)
 }
 
 async fn update_shard_health<C: ControlPlane>(
     status: &mut ActivationStatus,
     control_plane: &C,
     state: &ControllerState,
+    config: &ControllerConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     let (current_shard_status, count) = status
         .shard_status
         .as_ref()
         .map(|s| (s.status, s.count))
         .unwrap_or((ShardsStatus::Pending, 0));
-    let wait_interval = shard_health_check_interval(state, count, current_shard_status);
+    let wait_interval = shard_health_check_interval(
+        state,
+        count,
+        current_shard_status,
+        config.max_shard_status_interval,
+    );
     let Some(from) = status
         .shard_status
         .as_ref()
@@ -451,7 +392,12 @@ async fn update_shard_health<C: ControlPlane>(
         status: new_status,
     });
 
-    update_sustained_primary(status, new_status, count);
+    update_sustained_primary(
+        status,
+        new_status,
+        count,
+        config.sustained_primary_min_checks,
+    );
 
     // If there's been at least 3 failed checks in a row, then consider the
     // shard failed. We require at least 3 failed checks in a row because it's
@@ -474,7 +420,8 @@ async fn update_shard_health<C: ControlPlane>(
         tracing::warn!(%time_since_activation, "task shards have been Pending for suspiciously long");
     }
 
-    let next_check = shard_health_check_interval(state, count, new_status);
+    let next_check =
+        shard_health_check_interval(state, count, new_status, config.max_shard_status_interval);
     tracing::debug!(%count, ?next_check, ?new_status, "finished task shard health check");
     Ok(Some(NextRun::from_duration(next_check)))
 }
@@ -533,9 +480,9 @@ fn update_sustained_primary(
     status: &mut ActivationStatus,
     new_status: ShardsStatus,
     consecutive_ok_count: u32,
+    sustained_primary_min_checks: u32,
 ) {
-    if new_status == ShardsStatus::Ok && consecutive_ok_count >= SUSTAINED_PRIMARY_MIN_CHECKS.get()
-    {
+    if new_status == ShardsStatus::Ok && consecutive_ok_count >= sustained_primary_min_checks {
         status.restarts_since_last_primary = 0;
     }
 }
@@ -626,6 +573,7 @@ fn shard_health_check_interval(
     state: &ControllerState,
     prev_checks: u32,
     current_status: ShardsStatus,
+    max_shard_status_interval: chrono::Duration,
 ) -> chrono::Duration {
     use chrono::Duration;
 
@@ -634,7 +582,7 @@ fn shard_health_check_interval(
     let max_duration = if is_ops_catalog_task(state) {
         Duration::minutes(5)
     } else {
-        FLOW_MAX_SHARD_STATUS_INTERVAL.get()
+        max_shard_status_interval
     };
 
     // If the status is OK, then backoff much more quickly
@@ -866,29 +814,31 @@ mod test {
             ..Default::default()
         };
 
+        let min_checks = ControllerConfig::default().sustained_primary_min_checks;
+
         // Below threshold: no reset
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 1);
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 1, min_checks);
         assert_eq!(status.restarts_since_last_primary, 10);
 
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 2);
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 2, min_checks);
         assert_eq!(status.restarts_since_last_primary, 10);
 
         // At threshold: resets counter
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 3);
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 3, min_checks);
         assert_eq!(status.restarts_since_last_primary, 0);
 
         // Above threshold: continues resetting
         status.restarts_since_last_primary = 5;
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 10);
+        update_sustained_primary(&mut status, ShardsStatus::Ok, 10, min_checks);
         assert_eq!(status.restarts_since_last_primary, 0);
 
         // Failed status: no reset regardless of count
         status.restarts_since_last_primary = 7;
-        update_sustained_primary(&mut status, ShardsStatus::Failed, 5);
+        update_sustained_primary(&mut status, ShardsStatus::Failed, 5, min_checks);
         assert_eq!(status.restarts_since_last_primary, 7);
 
         // Pending status: no reset regardless of count
-        update_sustained_primary(&mut status, ShardsStatus::Pending, 5);
+        update_sustained_primary(&mut status, ShardsStatus::Pending, 5, min_checks);
         assert_eq!(status.restarts_since_last_primary, 7);
     }
 

--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -80,7 +80,6 @@ pub async fn update_activation<C: ControlPlane>(
                 "restarting failed task shards"
             );
             do_activate(now, state, status, control_plane).await?;
-            status.restarts_since_last_primary += 1;
             if has_task_shards(state) {
                 // Reset the shard health status, as we'll need to await another successful check.
                 status.shard_status = Some(ShardStatusCheck {
@@ -392,13 +391,6 @@ async fn update_shard_health<C: ControlPlane>(
         status: new_status,
     });
 
-    update_sustained_primary(
-        status,
-        new_status,
-        count,
-        config.sustained_primary_min_checks,
-    );
-
     // If there's been at least 3 failed checks in a row, then consider the
     // shard failed. We require at least 3 failed checks in a row because it's
     // possible that the ShardFailed event delivery is simply delayed we don't
@@ -472,19 +464,6 @@ fn synthesize_shard_failed_events(
 
 fn is_ops_catalog_task(state: &ControllerState) -> bool {
     state.catalog_name.starts_with("ops/") || state.catalog_name.starts_with("ops.us-central1.v1/")
-}
-
-/// Resets `restarts_since_last_primary` to 0 when shards have been Ok for
-/// enough consecutive checks, indicating sustained healthy operation.
-fn update_sustained_primary(
-    status: &mut ActivationStatus,
-    new_status: ShardsStatus,
-    consecutive_ok_count: u32,
-    sustained_primary_min_checks: u32,
-) {
-    if new_status == ShardsStatus::Ok && consecutive_ok_count >= sustained_primary_min_checks {
-        status.restarts_since_last_primary = 0;
-    }
 }
 
 fn aggregate_shard_status(
@@ -805,41 +784,6 @@ mod test {
             ],
         );
         assert_eq!(ShardsStatus::Failed, actual);
-    }
-
-    #[test]
-    fn test_sustained_primary_tracking() {
-        let mut status = ActivationStatus {
-            restarts_since_last_primary: 10,
-            ..Default::default()
-        };
-
-        let min_checks = ControllerConfig::default().sustained_primary_min_checks;
-
-        // Below threshold: no reset
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 1, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 10);
-
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 2, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 10);
-
-        // At threshold: resets counter
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 3, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 0);
-
-        // Above threshold: continues resetting
-        status.restarts_since_last_primary = 5;
-        update_sustained_primary(&mut status, ShardsStatus::Ok, 10, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 0);
-
-        // Failed status: no reset regardless of count
-        status.restarts_since_last_primary = 7;
-        update_sustained_primary(&mut status, ShardsStatus::Failed, 5, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 7);
-
-        // Pending status: no reset regardless of count
-        update_sustained_primary(&mut status, ShardsStatus::Pending, 5, min_checks);
-        assert_eq!(status.restarts_since_last_primary, 7);
     }
 
     #[test]

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -3,7 +3,9 @@ use super::{
     ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, backoff_data_plane_activate,
     coalesce_results, dependencies::Dependencies,
 };
-use crate::controllers::{activation, config_update, periodic, publication_status, republish};
+use crate::controllers::{
+    abandon, activation, config_update, periodic, publication_status, republish,
+};
 use anyhow::Context;
 use itertools::Itertools;
 use models::{
@@ -159,6 +161,15 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_result =
+        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
+    if abandon_result
+        .as_ref()
+        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
+    {
+        return Ok(Some(NextRun::immediately()));
+    }
+
     let notify_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)
             .await
@@ -174,6 +185,7 @@ pub async fn update<C: ControlPlane>(
             periodic_result,
             republish_result.map(|_| None),
             activate_result,
+            abandon_result,
             notify_result,
         ],
     )

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -31,6 +31,7 @@ pub async fn update<C: ControlPlane>(
         auto_discover,
         activation,
         config_updates,
+        abandon,
     } = status;
     let auto_discover_result = if model.auto_discover.is_some() && !model.shards.disable {
         let ad_status = auto_discover.get_or_insert_with(AutoDiscoverStatus::default);
@@ -161,14 +162,10 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_status = abandon.get_or_insert_with(Default::default);
     let abandon_result =
-        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
-    if abandon_result
-        .as_ref()
-        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
-    {
-        return Ok(Some(NextRun::immediately()));
-    }
+        abandon::evaluate_abandoned(alerts, publications, abandon_status, state, control_plane)
+            .await;
 
     let notify_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use super::{
-    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, activation,
+    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, abandon, activation,
     backoff_data_plane_activate, backoff_publication_failure, coalesce_results,
     dependencies::Dependencies,
     periodic,
@@ -48,6 +48,15 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_result =
+        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
+    if abandon_result
+        .as_ref()
+        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
+    {
+        return Ok(Some(NextRun::immediately()));
+    }
+
     let notify_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)
             .await
@@ -65,6 +74,7 @@ pub async fn update<C: ControlPlane>(
             published.map(|_| periodic::next_periodic_publish(state)),
             Ok(inferred_schema_next),
             activation_result,
+            abandon_result,
             notify_result,
         ],
     )

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -34,6 +34,7 @@ pub async fn update<C: ControlPlane>(
         publications,
         activation,
         alerts,
+        abandon,
     } = status;
 
     let activation_result = activation::update_activation(
@@ -48,14 +49,10 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_status = abandon.get_or_insert_with(Default::default);
     let abandon_result =
-        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
-    if abandon_result
-        .as_ref()
-        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
-    {
-        return Ok(Some(NextRun::immediately()));
-    }
+        abandon::evaluate_abandoned(alerts, publications, abandon_status, state, control_plane)
+            .await;
 
     let notify_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -1,5 +1,5 @@
 use crate::controllers::{
-    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, activation,
+    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, abandon, activation,
     backoff_data_plane_activate, backoff_publication_failure, coalesce_results, config_update,
     dependencies::Dependencies,
     periodic,
@@ -145,6 +145,15 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_result =
+        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
+    if abandon_result
+        .as_ref()
+        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
+    {
+        return Ok(Some(NextRun::immediately()));
+    }
+
     let observe_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)
             .await
@@ -157,6 +166,7 @@ pub async fn update<C: ControlPlane>(
             observe_result,
             periodic_result,
             activation_result,
+            abandon_result,
             source_capture_published.map(|_| None),
             updated_config_published.map(|_| None),
             dep_result.map(|_| None),

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -131,6 +131,7 @@ pub async fn update<C: ControlPlane>(
         activation,
         alerts,
         publications,
+        abandon,
         ..
     } = status;
     let activation_result = activation::update_activation(
@@ -145,14 +146,10 @@ pub async fn update<C: ControlPlane>(
     .with_retry(backoff_data_plane_activate(state.failures))
     .map_err(Into::into);
 
+    let abandon_status = abandon.get_or_insert_with(Default::default);
     let abandon_result =
-        abandon::evaluate_abandoned(alerts, publications, state, control_plane).await;
-    if abandon_result
-        .as_ref()
-        .is_ok_and(|r| r.is_some_and(|n| n.is_immediately()))
-    {
-        return Ok(Some(NextRun::immediately()));
-    }
+        abandon::evaluate_abandoned(alerts, publications, abandon_status, state, control_plane)
+            .await;
 
     let observe_result =
         publication_status::update_observed_pub_id(publications, alerts, state, control_plane)

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -31,7 +31,7 @@ fn parse_chrono_duration(s: &str) -> Result<chrono::Duration, String> {
 
 /// Configuration values for controller automations, parsed from CLI
 /// arguments and threaded through `ControlPlane`.
-#[derive(Copy, Clone, Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct ControllerConfig {
     /// Retention window for rows in the `shard_failures` table. Failures older
     /// than this are deleted when the controller runs.
@@ -75,6 +75,10 @@ pub struct ControllerConfig {
     /// Whether to actually disable abandoned tasks (vs only alerting).
     #[clap(long, env = "DISABLE_ABANDONED_TASKS", default_value = "false")]
     pub disable_abandoned_tasks: bool,
+    /// Minimum interval between abandonment evaluations for a given task.
+    #[clap(long, env = "ABANDON_CHECK_INTERVAL", default_value = "24h")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub abandon_check_interval: chrono::Duration,
 }
 
 impl Default for ControllerConfig {
@@ -613,6 +617,7 @@ async fn controller_update<C: ControlPlane>(
             catalog_test::update(test_status, state, events, control_plane, t).await?
         }
     };
+
     tracing::info!(?next_run, "finished controller update");
     Ok(next_run)
 }

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -49,9 +49,6 @@ pub struct ControllerConfig {
     /// Number of recent shard failures required to fire a ShardFailed alert.
     #[clap(long, env = "ALERT_AFTER_SHARD_FAILURES", default_value = "3")]
     pub alert_after_shard_failures: u32,
-    /// Consecutive Ok health checks before counting as sustained PRIMARY.
-    #[clap(long, env = "SUSTAINED_PRIMARY_MIN_CHECKS", default_value = "3")]
-    pub sustained_primary_min_checks: u32,
     /// ShardFailed must be continuously firing for this long before the task
     /// is considered chronically failing.
     #[clap(long, env = "CHRONICALLY_FAILING_THRESHOLD", default_value = "30d")]

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-pub(crate) mod activation;
 pub(crate) mod abandon;
+pub(crate) mod activation;
 pub(crate) mod alerts;
 pub(crate) mod capture;
 pub(crate) mod catalog_test;
@@ -25,44 +24,68 @@ use std::fmt::Debug;
 
 pub use executor::{Inbox, LiveSpecControllerExecutor};
 
-/// A configuration value with optional per-thread test overrides.
-/// In test builds, `set()` stores a per-thread override keyed by
-/// `std::thread::ThreadId` (which is never reused), so overrides
-/// are automatically scoped to the calling test.
-pub(super) struct EnvConfig<T: Copy + Send + 'static> {
-    value: T,
-    #[cfg(test)]
-    test_override: std::sync::Mutex<std::collections::HashMap<std::thread::ThreadId, T>>,
+fn parse_chrono_duration(s: &str) -> Result<chrono::Duration, String> {
+    let std_dur = humantime::parse_duration(s).map_err(|e| e.to_string())?;
+    chrono::Duration::from_std(std_dur).map_err(|e| e.to_string())
 }
 
-impl<T: Copy + Send + 'static> EnvConfig<T> {
-    pub fn new(value: T) -> Self {
-        Self {
-            value,
-            #[cfg(test)]
-            test_override: std::sync::Mutex::new(std::collections::HashMap::new()),
-        }
-    }
+/// Configuration values for controller automations, parsed from CLI
+/// arguments and threaded through `ControlPlane`.
+#[derive(Copy, Clone, Debug, clap::Parser)]
+pub struct ControllerConfig {
+    /// Retention window for rows in the `shard_failures` table. Failures older
+    /// than this are deleted when the controller runs.
+    #[clap(long, env = "SHARD_FAILURE_RETENTION", default_value = "8h")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub shard_failure_retention: chrono::Duration,
+    /// How long shard health must be Ok before resolving a ShardFailed alert.
+    #[clap(long, env = "RESOLVE_SHARD_FAILED_ALERT_AFTER", default_value = "2h")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub resolve_shard_failed_alert_after: chrono::Duration,
+    /// Maximum interval between shard health checks.
+    #[clap(long, env = "FLOW_MAX_SHARD_STATUS_INTERVAL", default_value = "2h")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub max_shard_status_interval: chrono::Duration,
+    /// Number of recent shard failures required to fire a ShardFailed alert.
+    #[clap(long, env = "ALERT_AFTER_SHARD_FAILURES", default_value = "3")]
+    pub alert_after_shard_failures: u32,
+    /// Consecutive Ok health checks before counting as sustained PRIMARY.
+    #[clap(long, env = "SUSTAINED_PRIMARY_MIN_CHECKS", default_value = "3")]
+    pub sustained_primary_min_checks: u32,
+    /// ShardFailed must be continuously firing for this long before the task
+    /// is considered chronically failing.
+    #[clap(long, env = "CHRONICALLY_FAILING_THRESHOLD", default_value = "30d")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub chronically_failing_threshold: chrono::Duration,
+    /// Grace period after firing the chronically-failing warning before
+    /// auto-disabling.
+    #[clap(long, env = "CHRONICALLY_FAILING_DISABLE_AFTER", default_value = "7d")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub chronically_failing_disable_after: chrono::Duration,
+    /// Task must have no data movement for this long before we consider it idle.
+    #[clap(long, env = "ABANDON_IDLE_THRESHOLD", default_value = "30d")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub abandon_idle_threshold: chrono::Duration,
+    /// A user publication within this timeframe prevents abandonment alerts
+    /// from firing and tasks from being disabled.
+    #[clap(long, env = "ABANDON_USER_PUB_RECENCY", default_value = "14d")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub abandon_user_pub_recency: chrono::Duration,
+    /// Grace period after firing the idle warning before auto-disabling.
+    #[clap(long, env = "ABANDON_IDLE_DISABLE_AFTER", default_value = "7d")]
+    #[arg(value_parser = parse_chrono_duration)]
+    pub abandon_idle_disable_after: chrono::Duration,
+    /// Whether to actually disable abandoned tasks (vs only alerting).
+    #[clap(long, env = "DISABLE_ABANDONED_TASKS", default_value = "false")]
+    pub disable_abandoned_tasks: bool,
+}
 
-    pub fn get(&self) -> T {
-        #[cfg(test)]
-        if let Some(&v) = self
-            .test_override
-            .lock()
-            .unwrap()
-            .get(&std::thread::current().id())
-        {
-            return v;
-        }
-        self.value
-    }
-
-    #[cfg(test)]
-    pub fn set(&self, value: T) {
-        self.test_override
-            .lock()
-            .unwrap()
-            .insert(std::thread::current().id(), value);
+impl Default for ControllerConfig {
+    fn default() -> Self {
+        // Parse with an empty arg list so every field gets its clap
+        // `default_value`, keeping defaults defined in exactly one place.
+        use clap::Parser;
+        Self::parse_from(std::iter::empty::<&str>())
     }
 }
 

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -1,4 +1,6 @@
+#[macro_use]
 pub(crate) mod activation;
+pub(crate) mod abandon;
 pub(crate) mod alerts;
 pub(crate) mod capture;
 pub(crate) mod catalog_test;
@@ -22,6 +24,47 @@ use sqlx::types::Uuid;
 use std::fmt::Debug;
 
 pub use executor::{Inbox, LiveSpecControllerExecutor};
+
+/// A configuration value with optional per-thread test overrides.
+/// In test builds, `set()` stores a per-thread override keyed by
+/// `std::thread::ThreadId` (which is never reused), so overrides
+/// are automatically scoped to the calling test.
+pub(super) struct EnvConfig<T: Copy + Send + 'static> {
+    value: T,
+    #[cfg(test)]
+    test_override: std::sync::Mutex<std::collections::HashMap<std::thread::ThreadId, T>>,
+}
+
+impl<T: Copy + Send + 'static> EnvConfig<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            #[cfg(test)]
+            test_override: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    pub fn get(&self) -> T {
+        #[cfg(test)]
+        if let Some(&v) = self
+            .test_override
+            .lock()
+            .unwrap()
+            .get(&std::thread::current().id())
+        {
+            return v;
+        }
+        self.value
+    }
+
+    #[cfg(test)]
+    pub fn set(&self, value: T) {
+        self.test_override
+            .lock()
+            .unwrap()
+            .insert(std::thread::current().id(), value);
+    }
+}
 
 /// This version is used to determine if the controller state is compatible with the current
 /// code. Any controller state having a higher version than this will be ignored.
@@ -290,6 +333,10 @@ impl NextRun {
             after_seconds: 0,
             jitter_percent: 0,
         }
+    }
+
+    pub fn is_immediately(&self) -> bool {
+        self.after_seconds == 0
     }
 
     pub fn after_minutes(minutes: u32) -> NextRun {

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -57,6 +57,9 @@ pub struct ConnectorSpec {
 /// other language bindings.
 #[async_trait::async_trait]
 pub trait ControlPlane: Send + Sync {
+    /// Returns the system user id used for automated publications.
+    fn system_user_id(&self) -> Uuid;
+
     /// Returns the current time. Having controllers access the current time through this api
     /// allows tests of controllers to be deterministic.
     fn current_time(&self) -> DateTime<Utc>;
@@ -83,6 +86,16 @@ pub trait ControlPlane: Send + Sync {
     async fn insert_shard_failures(&self, failures: Vec<ShardFailure>) -> anyhow::Result<()>;
 
     async fn get_shard_failures(&self, catalog_name: String) -> anyhow::Result<Vec<ShardFailure>>;
+
+    async fn fetch_last_user_publication_at(
+        &self,
+        live_spec_id: Id,
+    ) -> anyhow::Result<Option<DateTime<Utc>>>;
+
+    async fn fetch_last_data_movement_ts(
+        &self,
+        catalog_name: String,
+    ) -> anyhow::Result<Option<DateTime<Utc>>>;
 
     async fn delete_shard_failures(
         &self,
@@ -302,6 +315,10 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
 
 #[async_trait::async_trait]
 impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> {
+    fn system_user_id(&self) -> Uuid {
+        self.system_user_id
+    }
+
     fn can_auto_discover(&self) -> bool {
         if self.auto_discover_probability == 1.0 {
             return true;
@@ -397,6 +414,24 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
         .fetch_all(&self.pool)
         .await
         .context("fetching shard failures")
+    }
+
+    async fn fetch_last_user_publication_at(
+        &self,
+        live_spec_id: Id,
+    ) -> anyhow::Result<Option<DateTime<Utc>>> {
+        controllers::fetch_last_user_publication_at(live_spec_id, self.system_user_id, &self.pool)
+            .await
+            .context("fetching last user publication")
+    }
+
+    async fn fetch_last_data_movement_ts(
+        &self,
+        catalog_name: String,
+    ) -> anyhow::Result<Option<DateTime<Utc>>> {
+        controllers::fetch_last_data_movement_ts(&catalog_name, &self.pool)
+            .await
+            .context("fetching last data movement")
     }
 
     async fn delete_shard_failures(

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -57,9 +57,6 @@ pub struct ConnectorSpec {
 /// other language bindings.
 #[async_trait::async_trait]
 pub trait ControlPlane: Send + Sync {
-    /// Returns the system user id used for automated publications.
-    fn system_user_id(&self) -> Uuid;
-
     /// Returns the current time. Having controllers access the current time through this api
     /// allows tests of controllers to be deterministic.
     fn current_time(&self) -> DateTime<Utc>;
@@ -320,10 +317,6 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
 
 #[async_trait::async_trait]
 impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> {
-    fn system_user_id(&self) -> Uuid {
-        self.system_user_id
-    }
-
     fn can_auto_discover(&self) -> bool {
         if self.auto_discover_probability == 1.0 {
             return true;

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -65,7 +65,7 @@ pub trait ControlPlane: Send + Sync {
     /// schema update before another update can be attempted.
     fn controller_publication_cooldown(&self) -> chrono::Duration;
 
-    fn controller_config(&self) -> crate::controllers::ControllerConfig;
+    fn controller_config(&self) -> std::sync::Arc<crate::controllers::ControllerConfig>;
 
     /// Returns whether an auto-discover is allowed to happen at this time.
     fn can_auto_discover(&self) -> bool;
@@ -220,7 +220,7 @@ pub struct PGControlPlane<C: DiscoverConnectors + MakeConnectors> {
     pub snapshot_watch: Arc<dyn tokens::Watch<control_plane_api::Snapshot>>,
     pub auto_discover_probability: f64,
     pub controller_publication_cooldown: chrono::Duration,
-    pub controller_config: crate::controllers::ControllerConfig,
+    pub controller_config: std::sync::Arc<crate::controllers::ControllerConfig>,
 }
 
 impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
@@ -244,7 +244,7 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
             snapshot_watch,
             auto_discover_probability,
             controller_publication_cooldown,
-            controller_config,
+            controller_config: std::sync::Arc::new(controller_config),
         }
     }
 
@@ -330,8 +330,8 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
         self.controller_publication_cooldown
     }
 
-    fn controller_config(&self) -> crate::controllers::ControllerConfig {
-        self.controller_config
+    fn controller_config(&self) -> std::sync::Arc<crate::controllers::ControllerConfig> {
+        self.controller_config.clone()
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -68,6 +68,8 @@ pub trait ControlPlane: Send + Sync {
     /// schema update before another update can be attempted.
     fn controller_publication_cooldown(&self) -> chrono::Duration;
 
+    fn controller_config(&self) -> crate::controllers::ControllerConfig;
+
     /// Returns whether an auto-discover is allowed to happen at this time.
     fn can_auto_discover(&self) -> bool;
 
@@ -221,6 +223,7 @@ pub struct PGControlPlane<C: DiscoverConnectors + MakeConnectors> {
     pub snapshot_watch: Arc<dyn tokens::Watch<control_plane_api::Snapshot>>,
     pub auto_discover_probability: f64,
     pub controller_publication_cooldown: chrono::Duration,
+    pub controller_config: crate::controllers::ControllerConfig,
 }
 
 impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
@@ -233,6 +236,7 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
         snapshot_watch: Arc<dyn tokens::Watch<control_plane_api::Snapshot>>,
         auto_discover_probability: f64,
         controller_publication_cooldown: chrono::Duration,
+        controller_config: crate::controllers::ControllerConfig,
     ) -> Self {
         Self {
             pool,
@@ -243,6 +247,7 @@ impl<C: DiscoverConnectors + MakeConnectors> PGControlPlane<C> {
             snapshot_watch,
             auto_discover_probability,
             controller_publication_cooldown,
+            controller_config,
         }
     }
 
@@ -330,6 +335,10 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
 
     fn controller_publication_cooldown(&self) -> chrono::Duration {
         self.controller_publication_cooldown
+    }
+
+    fn controller_config(&self) -> crate::controllers::ControllerConfig {
+        self.controller_config
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -1,6 +1,6 @@
 use crate::{
     ControlPlane,
-    integration_tests::harness::{TestHarness, draft_catalog},
+    integration_tests::harness::{TestHarness, assert_within_minutes, draft_catalog},
     integration_tests::shard_failures::{publish_and_await_ready, shard_ref},
 };
 use models::{CatalogType, status::AlertType};
@@ -155,6 +155,11 @@ async fn test_shard_failed_fires_abandonment_alert(
         extra.get("disable_at").and_then(|v| v.as_str()).is_some(),
         "expected disable_at in alert arguments, got: {extra:?}"
     );
+
+    // The controller should schedule a future wake within the 24h abandon safety-net,
+    // coalesced with the ~2h activation health check interval.
+    let wake_at = harness.assert_controller_pending(catalog_name).await;
+    assert_within_minutes(wake_at, 25 * 60);
 }
 
 /// Idle detection: old task with no data movement and no user publication.
@@ -184,6 +189,9 @@ async fn test_idle_fires_when_no_data_and_old(
         extra.get("disable_at").and_then(|v| v.as_str()).is_some(),
         "expected disable_at in alert arguments, got: {extra:?}"
     );
+
+    let wake_at = harness.assert_controller_pending(catalog_name).await;
+    assert_within_minutes(wake_at, 25 * 60);
 }
 
 /// With DISABLE_ABANDONED_TASKS enabled, the controller publishes

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -1,0 +1,379 @@
+use crate::{
+    ControlPlane,
+    integration_tests::harness::{TestHarness, draft_catalog},
+    integration_tests::shard_failures::{publish_and_await_ready, shard_ref},
+};
+use models::{CatalogType, status::AlertType};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_abandoned_task_detection_and_resolution() {
+    let mut harness = TestHarness::init("test_abandoned_tasks").await;
+    let _user_id = harness.setup_tenant("pandas").await;
+
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "pandas/bamboo": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                "key": ["/id"]
+            },
+            "pandas/luck": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                "key": ["/id"],
+                "derive": {
+                    "using": {
+                        "sqlite": { "migrations": [] }
+                    },
+                    "transforms": [
+                        {
+                            "name": "fromHoots",
+                            "source": "pandas/bamboo",
+                            "lambda": "select $id;",
+                            "shuffle": "any"
+                        }
+                    ]
+                }
+            }
+        },
+        "captures": {
+            "pandas/capture": {
+                "endpoint": {
+                    "connector": {
+                        "image": "source/test:test",
+                        "config": {}
+                    }
+                },
+                "bindings": [
+                    {
+                        "resource": { "table": "bamboo" },
+                        "target": "pandas/bamboo"
+                    }
+                ]
+            }
+        },
+        "materializations": {
+            "pandas/materialize": {
+                "endpoint": {
+                    "connector": {
+                        "image": "materialize/test:test",
+                        "config": {}
+                    }
+                },
+                "bindings": [
+                    {
+                        "resource": { "table": "bamboo" },
+                        "source": "pandas/bamboo"
+                    },
+                    {
+                        "resource": { "table": "luck" },
+                        "source": "pandas/luck"
+                    }
+                ]
+            }
+        }
+    }));
+
+    let result = harness
+        .control_plane()
+        .publish(
+            Some("initial publication".to_string()),
+            Uuid::new_v4(),
+            draft,
+            Some("ops/dp/public/test".to_string()),
+        )
+        .await
+        .expect("initial publish failed");
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.draft_errors()
+    );
+
+    harness.run_pending_controllers(None).await;
+    harness.control_plane().assert_activations(
+        "initial activations",
+        vec![
+            ("pandas/capture", Some(CatalogType::Capture)),
+            ("pandas/materialize", Some(CatalogType::Materialization)),
+            ("pandas/bamboo", Some(CatalogType::Collection)),
+            ("pandas/luck", Some(CatalogType::Collection)),
+        ],
+    );
+
+    // Verify has_task_shards works for materialization and derivation task types
+    // with real built specs. Capture coverage comes from auto-disable below.
+    test_shard_failed_fires_abandonment_alert(
+        &mut harness,
+        CatalogType::Materialization,
+        "pandas/materialize",
+    )
+    .await;
+    test_shard_failed_fires_abandonment_alert(&mut harness, CatalogType::Collection, "pandas/luck")
+        .await;
+
+    // Idle detection exercises `fetch_abandonment_timestamps()` with real SQL
+    // against `publication_specs` and `catalog_stats_daily`.
+    test_idle_fires_when_no_data_and_old(&mut harness, CatalogType::Capture, "pandas/capture")
+        .await;
+
+    // Auto-disable runs last because it leaves the capture disabled.
+    test_auto_disable_publishes_disable(&mut harness, CatalogType::Capture, "pandas/capture").await;
+}
+
+/// ShardFailed firing for > 30 days triggers TaskChronicallyFailing.
+async fn test_shard_failed_fires_abandonment_alert(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "shard_failed over threshold fires");
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Trigger a real ShardFailed alert, then backdate it to 35 days ago (over 30-day threshold).
+    trigger_shard_failed_alert(catalog_name, chrono::Duration::days(35), harness).await;
+
+    // Run the controller again so the abandon logic evaluates the backdated ShardFailed.
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    let _state = harness.run_pending_controller(catalog_name).await;
+
+    let alert = harness
+        .assert_alert_firing(catalog_name, AlertType::TaskChronicallyFailing)
+        .await;
+
+    let extra = &alert.alert.arguments.0;
+    assert!(
+        extra.get("disable_at").and_then(|v| v.as_str()).is_some(),
+        "expected disable_at in alert arguments, got: {extra:?}"
+    );
+}
+
+/// Idle detection: old task with no data movement and no user publication.
+/// In the test DB, catalog_stats_daily is empty and all publications use the
+/// system user, so both last_data_movement_ts and last_user_pub_at are NULL.
+/// Combined with old created_at, this should trigger TaskIdle.
+async fn test_idle_fires_when_no_data_and_old(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "idle fires for old task with no data");
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Make the task old enough (past IDLE_THRESHOLD).
+    push_back_created_at(catalog_name, chrono::Duration::days(45), harness).await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+
+    let _state = harness.run_pending_controller(catalog_name).await;
+
+    let alert = harness
+        .assert_alert_firing(catalog_name, AlertType::TaskIdle)
+        .await;
+
+    let extra = &alert.alert.arguments.0;
+    assert!(
+        extra.get("disable_at").and_then(|v| v.as_str()).is_some(),
+        "expected disable_at in alert arguments, got: {extra:?}"
+    );
+}
+
+/// With DISABLE_ABANDONED_TASKS enabled, the controller publishes
+/// `shards.disable = true` when the chronically-failing grace period expires.
+async fn test_auto_disable_publishes_disable(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "auto-disable publishes shards.disable");
+
+    crate::controllers::abandon::DISABLE_ABANDONED_TASKS.set(true);
+
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Trigger ShardFailed > 30 days, fire TaskChronicallyFailing.
+    trigger_shard_failed_alert(catalog_name, chrono::Duration::days(35), harness).await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    let _state = harness.run_pending_controller(catalog_name).await;
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskChronicallyFailing)
+        .await;
+
+    // Set disable_at to yesterday so the grace period appears expired.
+    // The grace period check compares `now.date_naive() >= disable_at`;
+    // disable_at is immutable once set, so we must update it directly.
+    set_alert_disable_at(
+        catalog_name,
+        AlertType::TaskChronicallyFailing,
+        (chrono::Utc::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+        harness,
+    )
+    .await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+
+    // Run the controller: it should fire TaskAutoDisabledFailing AND publish
+    // shards.disable = true, then re-enter and process the disabled spec.
+    harness.run_pending_controller(catalog_name).await;
+    harness.run_pending_controllers(None).await;
+
+    // Verify the spec is now disabled.
+    let state = harness.get_controller_state(catalog_name).await;
+    let spec = state.live_spec.as_ref().expect("spec should exist");
+    let is_disabled = match spec {
+        models::AnySpec::Capture(c) => c.shards.disable,
+        models::AnySpec::Collection(c) => c.derive.as_ref().map_or(false, |d| d.shards.disable),
+        models::AnySpec::Materialization(m) => m.shards.disable,
+        models::AnySpec::Test(_) => unreachable!(),
+    };
+    assert!(
+        is_disabled,
+        "expected {catalog_name} to be disabled after auto-disable, but shards.disable is false"
+    );
+
+    // All abandon alerts should be cleared on the post-disable controller run.
+    harness
+        .assert_alert_clear(catalog_name, AlertType::TaskChronicallyFailing)
+        .await;
+    harness
+        .assert_alert_clear(catalog_name, AlertType::TaskAutoDisabledFailing)
+        .await;
+
+    crate::controllers::abandon::DISABLE_ABANDONED_TASKS.set(false);
+}
+
+async fn override_shard_status_last_ts(
+    catalog_name: &str,
+    time_ago: chrono::Duration,
+    harness: &mut TestHarness,
+) {
+    let new_ts = (chrono::Utc::now() - time_ago).to_rfc3339();
+
+    sqlx::query!(
+        r#"update controller_jobs set
+        status = jsonb_set(status::jsonb, '{activation, shard_status, last_ts}', to_jsonb($2::text))::json
+        where live_spec_id = (select id from live_specs where catalog_name = $1)
+        and status->'activation'->'shard_status'->>'last_ts' is not null
+        returning 1 as "must_exist: bool";"#,
+        catalog_name,
+        new_ts,
+    )
+    .fetch_one(&harness.pool)
+    .await
+    .expect("failed to override activation shard_health ts");
+}
+
+async fn push_back_created_at(
+    catalog_name: &str,
+    duration: chrono::Duration,
+    harness: &mut TestHarness,
+) {
+    sqlx::query!(
+        r#"update live_specs set created_at = now() - $2::interval
+        where catalog_name = $1
+        returning 1 as "must_exist: bool";"#,
+        catalog_name,
+        duration.to_string() as String,
+    )
+    .fetch_one(&harness.pool)
+    .await
+    .expect("failed to push back created_at");
+}
+
+/// Triggers a real ShardFailed alert by inserting shard failure events and
+/// running the controller to process them. Then pushes back the alert's
+/// first_ts to simulate it being `age` old.
+async fn trigger_shard_failed_alert(
+    catalog_name: &str,
+    age: chrono::Duration,
+    harness: &mut TestHarness,
+) {
+    let state = harness.get_controller_state(catalog_name).await;
+    let shard = shard_ref(state.last_build_id, catalog_name);
+
+    // Insert enough failures to trigger the alert (ALERT_AFTER_SHARD_FAILURES = 3)
+    for _ in 0..3 {
+        harness.fail_shard(&shard).await;
+    }
+
+    // Run the controller to process the failures and fire ShardFailed.
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    let _state = harness.run_pending_controller(catalog_name).await;
+
+    // Verify ShardFailed is now firing.
+    let controller_state = harness.get_controller_state(catalog_name).await;
+    let alerts = controller_state.current_status.alerts_status().unwrap();
+    assert!(
+        alerts.contains_key(&AlertType::ShardFailed),
+        "expected ShardFailed to be firing after injecting failures for {catalog_name}"
+    );
+
+    // Push back the first_ts to simulate the alert being `age` old.
+    push_back_alert_first_ts(catalog_name, AlertType::ShardFailed, age, harness).await;
+}
+
+async fn push_back_alert_first_ts(
+    catalog_name: &str,
+    alert_type: AlertType,
+    by_duration: chrono::Duration,
+    harness: &mut TestHarness,
+) {
+    let alert_key = alert_type.name();
+    let new_ts = (chrono::Utc::now() - by_duration).to_rfc3339();
+
+    let query = format!(
+        "update controller_jobs set \
+         status = jsonb_set(status::jsonb, '{{alerts,{alert_key},first_ts}}', to_jsonb($2::text))::json \
+         where live_spec_id = (select id from live_specs where catalog_name = $1) \
+         and status->'alerts'->'{alert_key}'->>'first_ts' is not null"
+    );
+    tracing::debug!(%catalog_name, %alert_key, %new_ts, %query, "pushing back alert first_ts");
+    let result = sqlx::query(&query)
+        .bind(catalog_name)
+        .bind(&new_ts)
+        .execute(&harness.pool)
+        .await
+        .expect("failed to push back alert first_ts");
+    assert!(
+        result.rows_affected() > 0,
+        "push_back_alert_first_ts for {catalog_name}/{alert_key} updated 0 rows"
+    );
+}
+
+/// Sets the `disable_at` date in an alert's flattened `extra` map.
+/// `disable_at` is immutable once set by `evaluate_alerts`, so this is
+/// the only way to simulate grace period expiry in integration tests.
+async fn set_alert_disable_at(
+    catalog_name: &str,
+    alert_type: AlertType,
+    date: String,
+    harness: &mut TestHarness,
+) {
+    let alert_key = alert_type.name();
+    let query = format!(
+        "update controller_jobs set \
+         status = jsonb_set(status::jsonb, '{{alerts,{alert_key},disable_at}}', to_jsonb($2::text))::json \
+         where live_spec_id = (select id from live_specs where catalog_name = $1) \
+         and status->'alerts'->'{alert_key}'->>'disable_at' is not null"
+    );
+    tracing::debug!(%catalog_name, %alert_key, %date, "setting alert disable_at");
+    let result = sqlx::query(&query)
+        .bind(catalog_name)
+        .bind(&date)
+        .execute(&harness.pool)
+        .await
+        .expect("failed to set alert disable_at");
+    assert!(
+        result.rows_affected() > 0,
+        "set_alert_disable_at for {catalog_name}/{alert_key} updated 0 rows"
+    );
+}

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -174,7 +174,7 @@ async fn test_idle_fires_when_no_data_and_old(
     tracing::info!(%catalog_name, "idle fires for old task with no data");
     publish_and_await_ready(harness, task_type, catalog_name).await;
 
-    // Make the task old enough (past IDLE_THRESHOLD).
+    // Make the task old enough (past the idle threshold).
     push_back_created_at(catalog_name, chrono::Duration::days(45), harness).await;
     override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
 
@@ -194,7 +194,7 @@ async fn test_idle_fires_when_no_data_and_old(
     assert_within_minutes(wake_at, 25 * 60);
 }
 
-/// With DISABLE_ABANDONED_TASKS enabled, the controller publishes
+/// With `disable_abandoned_tasks` enabled, the controller publishes
 /// `shards.disable = true` when the chronically-failing grace period expires.
 async fn test_auto_disable_publishes_disable(
     harness: &mut TestHarness,
@@ -203,7 +203,9 @@ async fn test_auto_disable_publishes_disable(
 ) {
     tracing::info!(%catalog_name, "auto-disable publishes shards.disable");
 
-    crate::controllers::abandon::DISABLE_ABANDONED_TASKS.set(true);
+    let mut config = harness.control_plane().controller_config();
+    config.disable_abandoned_tasks = true;
+    harness.control_plane().set_controller_config(config);
 
     publish_and_await_ready(harness, task_type, catalog_name).await;
 
@@ -255,8 +257,6 @@ async fn test_auto_disable_publishes_disable(
     harness
         .assert_alert_clear(catalog_name, AlertType::TaskAutoDisabledFailing)
         .await;
-
-    crate::controllers::abandon::DISABLE_ABANDONED_TASKS.set(false);
 }
 
 async fn override_shard_status_last_ts(
@@ -308,7 +308,7 @@ async fn trigger_shard_failed_alert(
     let state = harness.get_controller_state(catalog_name).await;
     let shard = shard_ref(state.last_build_id, catalog_name);
 
-    // Insert enough failures to trigger the alert (ALERT_AFTER_SHARD_FAILURES = 3)
+    // Insert enough failures to trigger the alert (default threshold is 3)
     for _ in 0..3 {
         harness.fail_shard(&shard).await;
     }

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -11,6 +11,11 @@ async fn test_abandoned_task_detection_and_resolution() {
     let mut harness = TestHarness::init("test_abandoned_tasks").await;
     let _user_id = harness.setup_tenant("pandas").await;
 
+    // Disable the check interval so evaluations run on every controller wake.
+    let mut config = (*harness.control_plane().controller_config()).clone();
+    config.abandon_check_interval = chrono::Duration::zero();
+    harness.control_plane().set_controller_config(config);
+
     let draft = draft_catalog(serde_json::json!({
         "collections": {
             "pandas/bamboo": {
@@ -203,7 +208,7 @@ async fn test_auto_disable_publishes_disable(
 ) {
     tracing::info!(%catalog_name, "auto-disable publishes shards.disable");
 
-    let mut config = harness.control_plane().controller_config();
+    let mut config = (*harness.control_plane().controller_config()).clone();
     config.disable_abandoned_tasks = true;
     harness.control_plane().set_controller_config(config);
 

--- a/crates/agent/src/integration_tests/auto_discovers.rs
+++ b/crates/agent/src/integration_tests/auto_discovers.rs
@@ -534,6 +534,7 @@ async fn test_auto_discovers_no_evolution() {
     let capture_status = capture_state.current_status.unwrap_capture();
     // Expect to see that the discover succeeded, but that the publication failed.
     insta::assert_json_snapshot!(capture_status, {
+        ".abandon.last_evaluated" => "[ts]",
         ".activation.last_activated" => "[build_id]",
         ".activation.last_activated_at" => "[ts]",
         ".activation.shard_status.first_ts" => "[ts]",
@@ -605,6 +606,9 @@ async fn test_auto_discovers_no_evolution() {
             }
           }
         }
+      },
+      "abandon": {
+        "last_evaluated": "[ts]"
       }
     }
     "###);

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -259,6 +259,7 @@ impl HarnessBuilder {
             snapshot_watch,
             1.0, // auto_discover_probability
             publication_cooldown,
+            crate::controllers::ControllerConfig::default(),
         ));
 
         let controller_exec =
@@ -1779,6 +1780,7 @@ pub struct TestControlPlane {
     pub auto_discover_enabled: bool,
     inner: PGControlPlane<MockDiscoverConnectors>,
     mocks: Arc<Mutex<ControlPlaneMocks>>,
+    controller_config: Arc<Mutex<crate::controllers::ControllerConfig>>,
 }
 
 /// A `Finalize` that can inject build failures in order to test failure scenarios.
@@ -1822,7 +1824,14 @@ impl TestControlPlane {
                 shards: BTreeMap::new(),
             })),
             auto_discover_enabled: true,
+            controller_config: Arc::new(
+                Mutex::new(crate::controllers::ControllerConfig::default()),
+            ),
         }
+    }
+
+    pub fn set_controller_config(&self, config: crate::controllers::ControllerConfig) {
+        *self.controller_config.lock().unwrap() = config;
     }
 
     pub fn reset_activations(&mut self) {
@@ -1945,6 +1954,10 @@ impl ControlPlane for TestControlPlane {
 
     fn controller_publication_cooldown(&self) -> chrono::Duration {
         self.inner.controller_publication_cooldown()
+    }
+
+    fn controller_config(&self) -> crate::controllers::ControllerConfig {
+        *self.controller_config.lock().unwrap()
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]
@@ -2172,4 +2185,13 @@ impl ControlPlane for TestControlPlane {
 enum Either<L, R> {
     L(L),
     R(R),
+}
+
+pub fn assert_within_minutes(wake_at: chrono::DateTime<chrono::Utc>, within_minutes: i64) {
+    let diff = wake_at - chrono::Utc::now();
+    assert!(
+        diff < chrono::Duration::minutes(within_minutes),
+        "expected next run to be within {within_minutes} minutes, but was at {wake_at} ({} minutes)",
+        diff.num_minutes()
+    );
 }

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1944,10 +1944,6 @@ pub fn get_collection_generation_id(state: &ControllerState) -> models::Id {
 
 #[async_trait::async_trait]
 impl ControlPlane for TestControlPlane {
-    fn system_user_id(&self) -> sqlx::types::Uuid {
-        self.inner.system_user_id
-    }
-
     fn can_auto_discover(&self) -> bool {
         self.auto_discover_enabled
     }

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1838,6 +1838,29 @@ impl TestControlPlane {
         mocks.fail_activations.insert(catalog_name.to_string());
     }
 
+    /// Asserts that a specific task was activated, without requiring it to be
+    /// the only activation. Calls `reset_activations` at the end.
+    pub fn assert_activated(&mut self, desc: &str, catalog_name: &str, catalog_type: CatalogType) {
+        let mocks = self.mocks.lock().unwrap();
+        let found = mocks.activations.iter().any(|a| {
+            a.catalog_name == catalog_name
+                && a.catalog_type == catalog_type
+                && a.built_spec.is_some()
+        });
+        assert!(
+            found,
+            "{desc}: expected {catalog_name} ({catalog_type:?}) to be activated, but it was not. \
+             actual activations: {:?}",
+            mocks
+                .activations
+                .iter()
+                .map(|a| a.catalog_name.as_str())
+                .collect::<Vec<_>>()
+        );
+        std::mem::drop(mocks);
+        self.reset_activations();
+    }
+
     /// Asserts that there were calls to activate or delete all the given specs.
     /// If the catalog type is `Some`, then expect an activation, otherwise expect
     /// a deletion. Calls `reset_activations` at the end, assuming assertions pass.
@@ -1912,6 +1935,10 @@ pub fn get_collection_generation_id(state: &ControllerState) -> models::Id {
 
 #[async_trait::async_trait]
 impl ControlPlane for TestControlPlane {
+    fn system_user_id(&self) -> sqlx::types::Uuid {
+        self.inner.system_user_id
+    }
+
     fn can_auto_discover(&self) -> bool {
         self.auto_discover_enabled
     }
@@ -1949,6 +1976,22 @@ impl ControlPlane for TestControlPlane {
 
     async fn get_shard_failures(&self, catalog_name: String) -> anyhow::Result<Vec<ShardFailure>> {
         self.inner.get_shard_failures(catalog_name).await
+    }
+
+    async fn fetch_last_user_publication_at(
+        &self,
+        live_spec_id: Id,
+    ) -> anyhow::Result<Option<DateTime<Utc>>> {
+        self.inner
+            .fetch_last_user_publication_at(live_spec_id)
+            .await
+    }
+
+    async fn fetch_last_data_movement_ts(
+        &self,
+        catalog_name: String,
+    ) -> anyhow::Result<Option<DateTime<Utc>>> {
+        self.inner.fetch_last_data_movement_ts(catalog_name).await
     }
 
     async fn delete_shard_failures(

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1952,8 +1952,8 @@ impl ControlPlane for TestControlPlane {
         self.inner.controller_publication_cooldown()
     }
 
-    fn controller_config(&self) -> crate::controllers::ControllerConfig {
-        *self.controller_config.lock().unwrap()
+    fn controller_config(&self) -> std::sync::Arc<crate::controllers::ControllerConfig> {
+        std::sync::Arc::new(self.controller_config.lock().unwrap().clone())
     }
 
     #[tracing::instrument(level = "debug", err, skip(self))]

--- a/crates/agent/src/integration_tests/inferred_schemas.rs
+++ b/crates/agent/src/integration_tests/inferred_schemas.rs
@@ -1,5 +1,6 @@
 use super::harness::{
-    HarnessBuilder, draft_catalog, get_collection_generation_id, mock_inferred_schema,
+    HarnessBuilder, assert_within_minutes, draft_catalog, get_collection_generation_id,
+    mock_inferred_schema,
 };
 use crate::{controllers::ControllerState, integration_tests::harness::InjectBuildError};
 use chrono::{DateTime, Utc};
@@ -462,13 +463,4 @@ fn get_effective_inferred_schema(state: &ControllerState) -> serde_json::Value {
         );
     };
     schema_val.take()
-}
-
-fn assert_within_minutes(wake_at: DateTime<Utc>, within_minutes: i64) {
-    let diff = wake_at - Utc::now();
-    assert!(
-        diff < chrono::Duration::minutes(within_minutes),
-        "expected next run to be within {within_minutes} minutes, but was at {wake_at} ({} minutes)",
-        diff.num_minutes()
-    );
 }

--- a/crates/agent/src/integration_tests/mod.rs
+++ b/crates/agent/src/integration_tests/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! These tests cover end-to-end scenarios involving the control plane. The data plane and
 //! connectors are not exercised as part of these.
+mod abandoned_tasks;
 mod alerts;
 mod auto_discovers;
 mod collection_resets;

--- a/crates/agent/src/integration_tests/shard_failures.rs
+++ b/crates/agent/src/integration_tests/shard_failures.rs
@@ -526,7 +526,7 @@ async fn test_backoff_repeated_shard_failures(
         .await;
 }
 
-async fn publish_and_await_ready(
+pub(super) async fn publish_and_await_ready(
     harness: &mut TestHarness,
     task_type: models::CatalogType,
     catalog_name: &str,
@@ -573,7 +573,7 @@ async fn publish_and_await_ready(
     );
     harness
         .control_plane()
-        .assert_activations("after publish", vec![(catalog_name, Some(task_type))]);
+        .assert_activated("after publish", catalog_name, task_type);
     assert_status_shards_pending(harness, catalog_name).await;
 
     let activation_status = after_publish.current_status.activation_status().unwrap();
@@ -717,7 +717,7 @@ async fn task_becomes_ok(
     final_ok_state
 }
 
-fn shard_ref(build_id: models::Id, name: &str) -> ShardRef {
+pub(super) fn shard_ref(build_id: models::Id, name: &str) -> ShardRef {
     ShardRef {
         name: name.to_string(),
         build: build_id,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -150,6 +150,9 @@ struct Args {
     #[clap(long, env, default_value = "10m")]
     #[arg(value_parser = humantime::parse_duration)]
     data_movement_alert_interval: std::time::Duration,
+
+    #[command(flatten)]
+    controller_config: agent::controllers::ControllerConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -310,6 +313,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         snapshot_watch.clone(),
         args.auto_discover_probability,
         controller_publication_cooldown,
+        args.controller_config,
     );
 
     // Wire up the agent's API Application and server.

--- a/crates/control-plane-api/src/controllers.rs
+++ b/crates/control-plane-api/src/controllers.rs
@@ -91,6 +91,48 @@ pub async fn fetch_controller_job(
     .await
 }
 
+pub async fn fetch_last_user_publication_at(
+    live_spec_id: Id,
+    system_user_id: Uuid,
+    db: impl sqlx::PgExecutor<'static>,
+) -> sqlx::Result<Option<DateTime<Utc>>> {
+    sqlx::query_scalar!(
+        r#"
+        select ps.published_at
+        from publication_specs ps
+        where ps.live_spec_id = $1
+            and ps.user_id != $2
+        order by ps.pub_id desc
+        limit 1
+        "#,
+        live_spec_id as Id,
+        system_user_id as Uuid,
+    )
+    .fetch_optional(db)
+    .await
+}
+
+pub async fn fetch_last_data_movement_ts(
+    catalog_name: &str,
+    db: impl sqlx::PgExecutor<'static>,
+) -> sqlx::Result<Option<DateTime<Utc>>> {
+    sqlx::query_scalar!(
+        r#"
+        select ts
+        from catalog_stats_daily
+        where catalog_name = $1
+            and ts > now() - interval '60 days'
+            and (bytes_written_by_me + bytes_read_by_me
+                + bytes_written_to_me + bytes_read_from_me) > 0
+        order by ts desc
+        limit 1
+        "#,
+        catalog_name,
+    )
+    .fetch_optional(db)
+    .await
+}
+
 #[tracing::instrument(level = "debug", skip(txn, status, controller_version))]
 pub async fn update_status(
     txn: &mut sqlx::PgConnection,

--- a/crates/models/src/status/abandon.rs
+++ b/crates/models/src/status/abandon.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Status of the abandonment evaluation for a task.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+pub struct AbandonStatus {
+    /// When this spec was last checked for abandonment
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::option_datetime_schema")]
+    pub last_evaluated: Option<DateTime<Utc>>,
+}

--- a/crates/models/src/status/activation.rs
+++ b/crates/models/src/status/activation.rs
@@ -65,7 +65,7 @@ pub struct ActivationStatus {
 
     /// Count of shard failures that have been observed over the last 24 hours for the currently activated
     /// build. This resets to 0 when a newly published build is activated.
-    #[serde(default, skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "crate::is_u32_zero")]
     pub recent_failure_count: u32,
 
     /// The next time at which failed task shards will be re-activated. If this is present, then
@@ -73,16 +73,6 @@ pub struct ActivationStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "crate::option_datetime_schema")]
     pub next_retry: Option<DateTime<Utc>>,
-
-    /// Number of shard restarts since the last sustained PRIMARY status.
-    /// Resets to 0 when shards hold sustained PRIMARY for SUSTAINED_PRIMARY_MIN_CHECKS
-    /// consecutive Ok health checks.
-    #[serde(default, skip_serializing_if = "is_zero")]
-    pub restarts_since_last_primary: u32,
-}
-
-fn is_zero(i: &u32) -> bool {
-    *i == 0
 }
 
 /// The shape of a connector status, which matches that of an ops::Log.
@@ -116,7 +106,6 @@ impl Default for ActivationStatus {
             recent_failure_count: 0,
             next_retry: None,
             shard_status: None,
-            restarts_since_last_primary: 0,
         }
     }
 }

--- a/crates/models/src/status/activation.rs
+++ b/crates/models/src/status/activation.rs
@@ -73,6 +73,12 @@ pub struct ActivationStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "crate::option_datetime_schema")]
     pub next_retry: Option<DateTime<Utc>>,
+
+    /// Number of shard restarts since the last sustained PRIMARY status.
+    /// Resets to 0 when shards hold sustained PRIMARY for SUSTAINED_PRIMARY_MIN_CHECKS
+    /// consecutive Ok health checks.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub restarts_since_last_primary: u32,
 }
 
 fn is_zero(i: &u32) -> bool {
@@ -110,6 +116,7 @@ impl Default for ActivationStatus {
             recent_failure_count: 0,
             next_retry: None,
             shard_status: None,
+            restarts_since_last_primary: 0,
         }
     }
 }

--- a/crates/models/src/status/alerts.rs
+++ b/crates/models/src/status/alerts.rs
@@ -45,36 +45,19 @@ pub enum AlertType {
     /// continue to make progress in between failures, but at a minimum, performance will
     /// be degraded. And in many scenarios, the task will be unable to process data at all.
     ShardFailed,
-    /// Warning that a task has been unable to run for an extended period and will
-    /// be auto-disabled unless someone intervenes.
-    ///
-    /// Fires when all of:
-    /// - `has_task_shards` (enabled, non-Dekaf task with shards)
-    /// - `ShardFailed` has been continuously firing >= `CHRONICALLY_FAILING_THRESHOLD` (30d)
-    /// - No user publication within `USER_PUB_THRESHOLD` (14d)
-    ///
-    /// Resolves when ShardFailed resolves, a user publishes, or the task is disabled.
+    /// Warning that a task has been unable to run for an extended period. It will
+    /// be automatically disabled unless the issue is addressed or a new version
+    /// of the spec is published.
     TaskChronicallyFailing,
-    /// One-shot notification that a chronically failing task has been auto-disabled.
-    ///
-    /// Fires when `TaskChronicallyFailing` has been firing >=
-    /// `CHRONICALLY_FAILING_DISABLE_AFTER` (7d). Publishes `shards.disable = true`,
-    /// after which `has_task_shards` returns false and all abandon alerts resolve.
+    /// The task was automatically disabled because its shards have been
+    /// failing continuously for an extended period without any user intervention.
     TaskAutoDisabledFailing,
-    /// Warning that a task has not moved any data and will be auto-disabled.
-    ///
-    /// Fires when all of:
-    /// - `has_task_shards` (enabled, non-Dekaf task with shards)
-    /// - No `ShardFailed` or `TaskChronicallyFailing` alert is active
-    /// - No data movement in `catalog_stats_daily` within `IDLE_THRESHOLD` (30d)
-    /// - No user publication within `USER_PUB_THRESHOLD` (14d)
-    ///
-    /// Resolves when data moves, a user publishes, ShardFailed fires, or task is disabled.
+    /// Warning that a task has not processed any data for an extended period
+    /// and has not been modified recently. It will be automatically disabled
+    /// unless a new version of the spec is published.
     TaskIdle,
-    /// One-shot notification that an idle task has been auto-disabled.
-    ///
-    /// Fires when `TaskIdle` has been firing >= `IDLE_DISABLE_AFTER` (7d).
-    /// Publishes `shards.disable = true`, after which all abandon alerts resolve.
+    /// The task was automatically disabled because it had not processed any
+    /// data for an extended period and had not been modified recently.
     TaskAutoDisabledIdle,
     /// Triggers when an automated background process needs to publish a spec,
     /// but is unable to because of publication errors. Background publications

--- a/crates/models/src/status/alerts.rs
+++ b/crates/models/src/status/alerts.rs
@@ -45,6 +45,37 @@ pub enum AlertType {
     /// continue to make progress in between failures, but at a minimum, performance will
     /// be degraded. And in many scenarios, the task will be unable to process data at all.
     ShardFailed,
+    /// Warning that a task has been unable to run for an extended period and will
+    /// be auto-disabled unless someone intervenes.
+    ///
+    /// Fires when all of:
+    /// - `has_task_shards` (enabled, non-Dekaf task with shards)
+    /// - `ShardFailed` has been continuously firing >= `CHRONICALLY_FAILING_THRESHOLD` (30d)
+    /// - No user publication within `USER_PUB_THRESHOLD` (14d)
+    ///
+    /// Resolves when ShardFailed resolves, a user publishes, or the task is disabled.
+    TaskChronicallyFailing,
+    /// One-shot notification that a chronically failing task has been auto-disabled.
+    ///
+    /// Fires when `TaskChronicallyFailing` has been firing >=
+    /// `CHRONICALLY_FAILING_DISABLE_AFTER` (7d). Publishes `shards.disable = true`,
+    /// after which `has_task_shards` returns false and all abandon alerts resolve.
+    TaskAutoDisabledFailing,
+    /// Warning that a task has not moved any data and will be auto-disabled.
+    ///
+    /// Fires when all of:
+    /// - `has_task_shards` (enabled, non-Dekaf task with shards)
+    /// - No `ShardFailed` or `TaskChronicallyFailing` alert is active
+    /// - No data movement in `catalog_stats_daily` within `IDLE_THRESHOLD` (30d)
+    /// - No user publication within `USER_PUB_THRESHOLD` (14d)
+    ///
+    /// Resolves when data moves, a user publishes, ShardFailed fires, or task is disabled.
+    TaskIdle,
+    /// One-shot notification that an idle task has been auto-disabled.
+    ///
+    /// Fires when `TaskIdle` has been firing >= `IDLE_DISABLE_AFTER` (7d).
+    /// Publishes `shards.disable = true`, after which all abandon alerts resolve.
+    TaskAutoDisabledIdle,
     /// Triggers when an automated background process needs to publish a spec,
     /// but is unable to because of publication errors. Background publications
     /// are peformed on all specs for a variety of reasons. For example,
@@ -70,6 +101,10 @@ impl AlertType {
             AlertType::FreeTrialEnding => "free_trial_ending",
             AlertType::FreeTrialStalled => "free_trial_stalled",
             AlertType::MissingPaymentMethod => "missing_payment_method",
+            AlertType::TaskChronicallyFailing => "task_chronically_failing",
+            AlertType::TaskAutoDisabledFailing => "task_auto_disabled_failing",
+            AlertType::TaskIdle => "task_idle",
+            AlertType::TaskAutoDisabledIdle => "task_auto_disabled_idle",
             AlertType::BackgroundPublicationFailed => "background_publication_failed",
         }
     }
@@ -78,6 +113,10 @@ impl AlertType {
         &[
             AlertType::AutoDiscoverFailed,
             AlertType::ShardFailed,
+            AlertType::TaskChronicallyFailing,
+            AlertType::TaskAutoDisabledFailing,
+            AlertType::TaskIdle,
+            AlertType::TaskAutoDisabledIdle,
             AlertType::DataMovementStalled,
             AlertType::FreeTrial,
             AlertType::FreeTrialEnding,
@@ -98,6 +137,10 @@ impl AlertType {
             AlertType::FreeTrialStalled => Some("tenant_alerts"),
             AlertType::MissingPaymentMethod => Some("tenant_alerts"),
             AlertType::ShardFailed => None,
+            AlertType::TaskChronicallyFailing => None,
+            AlertType::TaskAutoDisabledFailing => None,
+            AlertType::TaskIdle => None,
+            AlertType::TaskAutoDisabledIdle => None,
             AlertType::BackgroundPublicationFailed => None,
         }
     }
@@ -176,7 +219,10 @@ pub struct ControllerAlert {
     /// The time at which the alert condition resolved. Unset if the alert is firing.
     #[schemars(schema_with = "crate::option_datetime_schema")]
     pub resolved_at: Option<DateTime<Utc>>,
-    // Allows passing arbitrary data as alert arguments, which will be available in alert message templates.
+    /// Additional data available as `arguments.<key>` in notification email
+    /// templates. Serialized with `#[serde(flatten)]` so keys become top-level
+    /// JSON fields alongside `state`, `first_ts`, etc. Avoid using keys that
+    /// collide with the struct's own field names.
     #[serde(flatten)]
     pub extra: BTreeMap<String, serde_json::Value>,
 }

--- a/crates/models/src/status/capture.rs
+++ b/crates/models/src/status/capture.rs
@@ -25,6 +25,8 @@ pub struct CaptureStatus {
     pub auto_discover: Option<AutoDiscoverStatus>,
     #[serde(default, skip_serializing_if = "Alerts::is_empty")]
     pub alerts: Alerts,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abandon: Option<super::AbandonStatus>,
 }
 
 /// A capture binding that has changed as a result of a discover

--- a/crates/models/src/status/collection.rs
+++ b/crates/models/src/status/collection.rs
@@ -17,6 +17,8 @@ pub struct CollectionStatus {
     pub activation: ActivationStatus,
     #[serde(default, skip_serializing_if = "Alerts::is_empty")]
     pub alerts: Alerts,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abandon: Option<super::AbandonStatus>,
 }
 
 /// Status of the inferred schema

--- a/crates/models/src/status/materialization.rs
+++ b/crates/models/src/status/materialization.rs
@@ -21,6 +21,8 @@ pub struct MaterializationStatus {
     pub config_updates: Option<PendingConfigUpdateStatus>,
     #[serde(default, skip_serializing_if = "Alerts::is_empty")]
     pub alerts: Alerts,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abandon: Option<super::AbandonStatus>,
 }
 
 /// Status information about the `sourceCapture`

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -377,6 +377,7 @@ mod test {
                 last_failure: None,
                 recent_failure_count: 3,
                 next_retry: Some("2025-01-02T03:04:05.06Z".parse().unwrap()),
+                ..Default::default()
             },
             config_updates: None,
             source_capture: Some(SourceCaptureStatus {

--- a/crates/models/src/status/mod.rs
+++ b/crates/models/src/status/mod.rs
@@ -1,3 +1,4 @@
+pub mod abandon;
 pub mod activation;
 pub mod alerts;
 pub mod capture;
@@ -16,6 +17,7 @@ use serde::{Deserialize, Serialize};
 pub use self::alerts::{AlertState, AlertType, Alerts, ControllerAlert};
 pub use self::connector::ConnectorStatus;
 pub use self::summary::{StatusSummaryType, Summary};
+pub use abandon::AbandonStatus;
 pub use activation::ActivationStatus;
 pub use capture::AutoDiscoverStatus;
 pub use collection::InferredSchemaStatus;
@@ -160,6 +162,16 @@ impl ControllerStatus {
             ControllerStatus::Collection(status) => Some(&status.alerts),
             ControllerStatus::Materialization(status) => Some(&status.alerts),
             ControllerStatus::Test(status) => Some(&status.alerts),
+            _ => None,
+        }
+    }
+
+    /// Present for captures, collections, and materializations.
+    async fn abandon(&self) -> Option<&AbandonStatus> {
+        match self {
+            ControllerStatus::Capture(status) => status.abandon.as_ref(),
+            ControllerStatus::Collection(status) => status.abandon.as_ref(),
+            ControllerStatus::Materialization(status) => status.abandon.as_ref(),
             _ => None,
         }
     }
@@ -395,6 +407,7 @@ mod test {
                 }),
             },
             alerts: Default::default(),
+            abandon: None,
         });
 
         let as_json = serde_json::to_string_pretty(&status).expect("failed to serialize status");

--- a/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
+++ b/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
@@ -80,6 +80,7 @@ StatusSnapshot {
             },
             config_updates: None,
             alerts: {},
+            abandon: None,
         },
     ),
     json: "{\n  \"type\": \"Materialization\",\n  \"source_capture\": {\n    \"up_to_date\": false,\n    \"add_bindings\": [\n      \"snails/shells\"\n    ]\n  },\n  \"publications\": {\n    \"next_after\": \"2024-01-02T03:04:05.060Z\",\n    \"max_observed_pub_id\": \"0102030405060708\",\n    \"history\": [\n      {\n        \"id\": \"0403020101020304\",\n        \"created\": \"2024-05-30T09:10:11Z\",\n        \"completed\": \"2024-05-30T09:10:11Z\",\n        \"detail\": \"some detail\",\n        \"result\": {\n          \"type\": \"buildFailed\"\n        },\n        \"errors\": [\n          {\n            \"catalog_name\": \"snails/shells\",\n            \"scope\": \"flow://materializations/snails/shells\",\n            \"detail\": \"a_field simply cannot be tolerated\"\n          }\n        ]\n      }\n    ],\n    \"pending_republish\": {\n      \"received_at\": \"2024-01-02T03:03:03.030Z\",\n      \"reason\": \"so we don't starve\",\n      \"last_build_id\": \"0404040404040404\"\n    }\n  },\n  \"activation\": {\n    \"last_activated\": \"0102030404030201\",\n    \"shard_status\": {\n      \"last_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"first_ts\": \"2024-01-02T03:04:05.060Z\",\n      \"status\": \"Pending\"\n    },\n    \"last_activated_at\": \"2024-01-02T03:04:05.060Z\",\n    \"recent_failure_count\": 3,\n    \"next_retry\": \"2025-01-02T03:04:05.060Z\"\n  }\n}",
@@ -160,6 +161,7 @@ StatusSnapshot {
             },
             config_updates: None,
             alerts: {},
+            abandon: None,
         },
     ),
 }

--- a/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
+++ b/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/models/src/status/mod.rs
+assertion_line: 412
 expression: "StatusSnapshot { starting: status, json: as_json, parsed: round_tripped, }"
 ---
 StatusSnapshot {
@@ -77,6 +78,7 @@ StatusSnapshot {
                 next_retry: Some(
                     2025-01-02T03:04:05.060Z,
                 ),
+                restarts_since_last_primary: 0,
             },
             config_updates: None,
             alerts: {},
@@ -157,6 +159,7 @@ StatusSnapshot {
                 next_retry: Some(
                     2025-01-02T03:04:05.060Z,
                 ),
+                restarts_since_last_primary: 0,
             },
             config_updates: None,
             alerts: {},

--- a/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
+++ b/crates/models/src/status/snapshots/models__status__test__materialization-status-round-trip.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/models/src/status/mod.rs
-assertion_line: 412
 expression: "StatusSnapshot { starting: status, json: as_json, parsed: round_tripped, }"
 ---
 StatusSnapshot {
@@ -78,7 +77,6 @@ StatusSnapshot {
                 next_retry: Some(
                     2025-01-02T03:04:05.060Z,
                 ),
-                restarts_since_last_primary: 0,
             },
             config_updates: None,
             alerts: {},
@@ -159,7 +157,6 @@ StatusSnapshot {
                 next_retry: Some(
                     2025-01-02T03:04:05.060Z,
                 ),
-                restarts_since_last_primary: 0,
             },
             config_updates: None,
             alerts: {},

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -44,12 +44,6 @@ expression: schema
           "minimum": 0,
           "type": "integer"
         },
-        "restarts_since_last_primary": {
-          "description": "Number of shard restarts since the last sustained PRIMARY status.\nResets to 0 when shards hold sustained PRIMARY for SUSTAINED_PRIMARY_MIN_CHECKS\nconsecutive Ok health checks.",
-          "format": "uint32",
-          "minimum": 0,
-          "type": "integer"
-        },
         "shard_status": {
           "anyOf": [
             {

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -44,6 +44,12 @@ expression: schema
           "minimum": 0,
           "type": "integer"
         },
+        "restarts_since_last_primary": {
+          "description": "Number of shard restarts since the last sustained PRIMARY status.\nResets to 0 when shards hold sustained PRIMARY for SUSTAINED_PRIMARY_MIN_CHECKS\nconsecutive Ok health checks.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
         "shard_status": {
           "anyOf": [
             {

--- a/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
+++ b/crates/models/src/status/snapshots/models__status__test__status_json_schema.snap
@@ -4,6 +4,20 @@ expression: schema
 ---
 {
   "$defs": {
+    "AbandonStatus": {
+      "description": "Status of the abandonment evaluation for a task.",
+      "properties": {
+        "last_evaluated": {
+          "description": "When this spec was last checked for abandonment",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ActivationStatus": {
       "description": "Status of the task shards running in the data-plane. This records information about\nthe activations of builds in the data-plane, including any subsequent re-activations\ndue to shard failures.",
       "properties": {
@@ -211,6 +225,16 @@ expression: schema
     "CaptureStatus": {
       "description": "Status of a capture controller",
       "properties": {
+        "abandon": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbandonStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "activation": {
           "$ref": "#/$defs/ActivationStatus",
           "default": {}
@@ -270,6 +294,16 @@ expression: schema
     "CollectionStatus": {
       "description": "The status of a collection controller",
       "properties": {
+        "abandon": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbandonStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "activation": {
           "$ref": "#/$defs/ActivationStatus",
           "default": {}
@@ -490,6 +524,16 @@ expression: schema
     "MaterializationStatus": {
       "description": "Status of a materialization controller",
       "properties": {
+        "abandon": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbandonStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "activation": {
           "$ref": "#/$defs/ActivationStatus",
           "default": {}

--- a/crates/models/src/status/summary.rs
+++ b/crates/models/src/status/summary.rs
@@ -214,6 +214,7 @@ mod test {
                 recent_failure_count: 999, // should be ignored
                 next_retry: None,
                 shard_status: None,
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -263,6 +264,7 @@ mod test {
                     last_ts: "2024-02-03T09:10:11Z".parse().unwrap(),
                     status: ShardsStatus::Ok,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         });

--- a/crates/notifications/src/lib.rs
+++ b/crates/notifications/src/lib.rs
@@ -6,6 +6,10 @@ mod free_trial_ending;
 mod free_trial_stalled;
 mod missing_payment_method;
 mod shard_failed;
+mod task_auto_disabled_failing;
+mod task_auto_disabled_idle;
+mod task_chronically_failing;
+mod task_idle;
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -141,6 +145,10 @@ impl Renderer {
         free_trial_ending::register_templates(&mut hb)?;
         missing_payment_method::register_templates(&mut hb)?;
         shard_failed::register_templates(&mut hb)?;
+        task_chronically_failing::register_templates(&mut hb)?;
+        task_auto_disabled_failing::register_templates(&mut hb)?;
+        task_idle::register_templates(&mut hb)?;
+        task_auto_disabled_idle::register_templates(&mut hb)?;
 
         Ok(Renderer {
             dashboard_base_url,
@@ -940,6 +948,78 @@ mod tests {
 
         assert_eq!(&user_a(), &emails[1].recipient);
         assert_eq!("0102030405060708-resolved-1", &emails[1].idempotency_key);
+    }
+
+    #[test]
+    fn test_task_chronically_failing_fired() {
+        let email = test_single_email(
+            AlertType::TaskChronicallyFailing,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_a()],
+                "spec_type": "capture",
+                "count": 42,
+
+                "disable_at": "2025-06-08",
+                "failing_since": "2025-05-01",
+            }),
+            State::Fired,
+        );
+
+        assert_email(
+            &email,
+            user_a(),
+            EXPECT_IDEMPOTENCY_KEY_FIRED,
+            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+        );
+        insta::assert_snapshot!("task_chronically_failing_fired_body", email.body);
+    }
+
+    #[test]
+    fn test_task_chronically_failing_fired_zero_restarts() {
+        let email = test_single_email(
+            AlertType::TaskChronicallyFailing,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_a()],
+                "spec_type": "capture",
+                "count": 0,
+
+                "disable_at": "2025-06-08",
+                "failing_since": "2025-05-01",
+            }),
+            State::Fired,
+        );
+
+        assert_email(
+            &email,
+            user_a(),
+            EXPECT_IDEMPOTENCY_KEY_FIRED,
+            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+        );
+        assert!(
+            email.body.contains("failing since 2025-05-01"),
+            "should include failing_since date"
+        );
+        assert!(
+            email.body.contains("0 time(s)"),
+            "should include restart count"
+        );
+    }
+
+    #[test]
+    fn test_task_chronically_failing_resolved() {
+        expect_no_email(
+            AlertType::TaskChronicallyFailing,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_b()],
+                "spec_type": "capture",
+                "count": 42,
+                "disable_at": "2025-06-08",
+            }),
+            State::Resolved,
+        );
     }
 
     #[test]

--- a/crates/notifications/src/snapshots/notifications__tests__task_chronically_failing_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__task_chronically_failing_fired_body.snap
@@ -1,0 +1,60 @@
+---
+source: crates/notifications/src/lib.rs
+assertion_line: 975
+expression: email.body
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { margin: 0; padding: 0; font-family: Ubuntu, Helvetica, Arial, sans-serif; }
+        .email-container { max-width: 600px; margin: 0 auto; }
+        .email-content { padding: 20px; }
+        .logo { text-align: center; padding: 20px 0; }
+        .divider { border-top: 1px dashed grey; margin: 20px 0; }
+        .dear-line { font-size: 20px; color: #512d0b; font-weight: bold; margin-bottom: 10px; }
+        .body-text { font-size: 17px; line-height: 1.4; margin-bottom: 10px; }
+        .signature { font-size: 14px; color: #000000; margin-top: 15px; }
+        .identifier { background-color: #dadada; padding: 2px 3px; border-radius: 2px; font-family: monospace; font-weight: bold; }
+        a { color: #5072EB; text-decoration: none; }
+        .button {
+            display: inline-block;
+            background-color: #5072EB;
+            color: white;
+            padding: 12px 24px;
+            border-radius: 4px;
+            text-decoration: none;
+            margin: 25px 0 0 0;
+            font-weight: 400;
+            font-size: 17px;
+        }
+        ul { margin: 10px 0; padding-left: 20px; }
+        li { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="logo">
+            <img src="https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//estuary_logo_comfy_14513ca434/estuary_logo_comfy_14513ca434.jpg" alt="Estuary Logo" style="max-width: 200px;">
+        </div>
+        <div class="divider"></div>
+        <div class="email-content">
+            <p class="body-text">
+                Your Estuary capture <span class="identifier">acmeCo/test/capture</span> has been failing since 2025-05-01. We have attempted to restart it 42 time(s) without success.
+            </p>
+            <p class="body-text">
+                If the task is still important to you, please check its configuration and logs for issues preventing it from running successfully. Otherwise, it will be disabled automatically on 2025-06-08.
+            </p>
+            <ul>
+                <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">View the task status and logs</a></li>
+                <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+            </ul>            <div class="signature">
+                Thanks,<br>
+                Estuary Team
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/crates/notifications/src/task_auto_disabled_failing.rs
+++ b/crates/notifications/src/task_auto_disabled_failing.rs
@@ -1,0 +1,33 @@
+use super::template_names;
+use anyhow::Context;
+
+pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyhow::Result<()> {
+    // Only fired templates: this is a one-shot notification. The alert resolves
+    // immediately after firing, and no resolution email is sent.
+    let (fired_subject, fired_body) =
+        template_names(models::status::AlertType::TaskAutoDisabledFailing, false);
+    registry
+        .register_template_string(
+            &fired_subject,
+            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+        )
+        .context("registering task_auto_disabled_failing-fired-subject template")?;
+
+    registry
+        .register_template_string(
+            &fired_body,
+            r#"<p class="body-text">
+    Your Estuary {{arguments.spec_type}} <span class="identifier">{{catalog_name}}</span> has been automatically disabled because it has been failing since {{arguments.failing_since}}.
+</p>
+<p class="body-text">
+    If you still need this task, re-enable it and address any configuration or connectivity issues preventing it from running. Otherwise, no further action is needed.
+</p>
+<ul>
+    <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
+    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+</ul>"#,
+        )
+        .context("registering task_auto_disabled_failing-fired-body template")?;
+
+    Ok(())
+}

--- a/crates/notifications/src/task_auto_disabled_idle.rs
+++ b/crates/notifications/src/task_auto_disabled_idle.rs
@@ -1,0 +1,30 @@
+use super::template_names;
+use anyhow::Context;
+
+pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyhow::Result<()> {
+    // Only fired templates: this is a one-shot notification. The alert resolves
+    // immediately after firing, and no resolution email is sent.
+    let (fired_subject, fired_body) =
+        template_names(models::status::AlertType::TaskAutoDisabledIdle, false);
+    registry
+        .register_template_string(
+            &fired_subject,
+            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+        )
+        .context("registering task_auto_disabled_idle-fired-subject template")?;
+
+    registry
+        .register_template_string(
+            &fired_body,
+            r#"<p class="body-text">
+    Your Estuary {{arguments.spec_type}} <span class="identifier">{{catalog_name}}</span> has been automatically disabled because it has not moved data. If you still need this task, re-enable it and verify that data is flowing. Otherwise, no further action is needed.
+</p>
+<ul>
+    <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
+    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+</ul>"#,
+        )
+        .context("registering task_auto_disabled_idle-fired-body template")?;
+
+    Ok(())
+}

--- a/crates/notifications/src/task_chronically_failing.rs
+++ b/crates/notifications/src/task_chronically_failing.rs
@@ -1,0 +1,34 @@
+use super::template_names;
+use anyhow::Context;
+
+pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyhow::Result<()> {
+    let (fired_subject, fired_body) =
+        template_names(models::status::AlertType::TaskChronicallyFailing, false);
+    registry
+        .register_template_string(
+            &fired_subject,
+            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} is chronically failing"#,
+        )
+        .context("registering task_chronically_failing-fired-subject template")?;
+
+    registry
+        .register_template_string(
+            &fired_body,
+            r#"<p class="body-text">
+    Your Estuary {{arguments.spec_type}} <span class="identifier">{{catalog_name}}</span> has been failing since {{arguments.failing_since}}. We have attempted to restart it {{arguments.count}} time(s) without success.
+</p>
+<p class="body-text">
+    If the task is still important to you, please check its configuration and logs for issues preventing it from running successfully. Otherwise, it will be disabled automatically on {{arguments.disable_at}}.
+</p>
+<ul>
+    <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
+    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+</ul>"#,
+        )
+        .context("registering task_chronically_failing-fired-body template")?;
+
+    // No resolved templates: resolution (via recovery or disable) completes
+    // silently without sending an email.
+
+    Ok(())
+}

--- a/crates/notifications/src/task_idle.rs
+++ b/crates/notifications/src/task_idle.rs
@@ -1,0 +1,30 @@
+use super::template_names;
+use anyhow::Context;
+
+pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyhow::Result<()> {
+    let (fired_subject, fired_body) = template_names(models::status::AlertType::TaskIdle, false);
+    registry
+        .register_template_string(
+            &fired_subject,
+            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has not moved data"#,
+        )
+        .context("registering task_idle-fired-subject template")?;
+
+    registry
+        .register_template_string(
+            &fired_body,
+            r#"<p class="body-text">
+    Your Estuary {{arguments.spec_type}} <span class="identifier">{{catalog_name}}</span> has not moved data in over 30 days. If this task is no longer needed, you can disable or delete it. Otherwise, it will be disabled automatically on {{arguments.disable_at}}.
+</p>
+<ul>
+    <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
+    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+</ul>"#,
+        )
+        .context("registering task_idle-fired-body template")?;
+
+    // No resolved templates: resolution (via recovery or disable) completes
+    // silently without sending an email.
+
+    Ok(())
+}

--- a/supabase/migrations/20260305000000_abandoned_task_alerts.sql
+++ b/supabase/migrations/20260305000000_abandoned_task_alerts.sql
@@ -1,0 +1,4 @@
+ALTER TYPE public.alert_type ADD VALUE IF NOT EXISTS 'task_chronically_failing';
+ALTER TYPE public.alert_type ADD VALUE IF NOT EXISTS 'task_auto_disabled_failing';
+ALTER TYPE public.alert_type ADD VALUE IF NOT EXISTS 'task_idle';
+ALTER TYPE public.alert_type ADD VALUE IF NOT EXISTS 'task_auto_disabled_idle';


### PR DESCRIPTION
## Summary

Implements abandoned task detection from #2710. Two alert sequences identify tasks that are persistently failing or not processing data, warn the user, and then disable the task after a grace period. Auto-disable publication is gated behind `DISABLE_ABANDONED_TASKS` env var (off by default).

## Sequence 1: Chronically Failing tasks

`TaskChronicallyFailing` fires when all of:
- `has_task_shards` is true (enabled, non-Dekaf task with shards)
- `ShardFailed` has been continuously firing >= 30 days (`CHRONICALLY_FAILING_THRESHOLD`)
- No user publication within 14 days (`ABANDON_USER_PUB_RECENCY`)

Since `ShardFailed` only resolves after 2 hours of continuous healthy operation, the 30-day condition means the task has not stayed alive for 2 consecutive hours at any point during that window.

After 7 days (`CHRONICALLY_FAILING_DISABLE_AFTER`), `TaskAutoDisabledFailing` fires and the task is disabled.

Resolves when `ShardFailed` resolves, a user publishes, or the task is disabled. A user publication resets a 14-day suppression window before the alert can re-fire. `ShardFailed.first_ts` (the 30-day clock) is unaffected by publications and only resets when the task recovers for 2+ hours. However, when `TaskChronicallyFailing` resolves and later re-fires, its own `first_ts` (which anchors the 7-day disable grace period) resets to the new fire time.

## Sequence 2: Idle tasks (no data movement)

`TaskIdle` fires when all of:
- `has_task_shards` is true
- No `ShardFailed` or `TaskChronicallyFailing` alert is active
- No data movement in `catalog_stats_daily` within 30 days (`ABANDON_IDLE_THRESHOLD`)
- No user publication within 14 days (`ABANDON_USER_PUB_RECENCY`)

After 7 days (`ABANDON_IDLE_DISABLE_AFTER`), `TaskAutoDisabledIdle` fires and the task is disabled.

Idle detection is suppressed while failure alerts are active. A task that is both failing and idle follows the first sequence only, so users only receive one set of notifications.

## Scenarios

**Task with intermittent 3-hour runs:** Shard reaches PRIMARY, runs for 3 hours, then fails. Each cycle, `ShardFailed` resolves (2+ hours healthy) then re-fires, resetting `ShardFailed.first_ts`. `TaskChronicallyFailing` never fires. This is intentional: the task is doing some work each cycle. If it doesn't move any data during the period where it's `PRIMARY`, the `TaskIdle` alert will take over.

**Healthy task that never moves data:** A task stays in `PRIMARY` with no failures, but no data flows through it (e.g. a Google Sheets capture where the sheet is empty). No `ShardFailed` fires, so the chronically-failing path is never involved. After 30 days with no data movement and no user publication in the preceding 14 days, `TaskIdle` fires. After 37 days total, the task is auto-disabled.

**Failing task that also has no data movement:** A task starts erroring and never moves data. `ShardFailed` fires within hours (after 3 failures), which immediately suppresses `TaskIdle` for as long as it remains active. Even though the task meets all other idle conditions, `TaskIdle` cannot fire while `ShardFailed` or `TaskChronicallyFailing` exists in the alert map. The task follows the chronically-failing path: `TaskChronicallyFailing` at 30 days, auto-disable at 37. If the task later recovers and `ShardFailed` resolves but still has no data movement, idle evaluation resumes and `TaskIdle` can fire on the next evaluation.

**Failing task where user publishes a fix attempt:** `TaskChronicallyFailing` fires on day 30. User publishes on day 31, which resolves the alert silently. If the task continues failing, the alert re-fires on day 45 (when the publication ages past 14 days) with a fresh `TaskChronicallyFailing.first_ts` and a new 7-day grace period. `ShardFailed.first_ts` remains day 0 throughout. The user publication bought 21 extra days total (14 + 7).

**Task re-enabled after auto-disable:** All abandon alerts were silently resolved on disable. On re-enablement, `has_task_shards` returns true and evaluation starts from scratch. For failures, `ShardFailed.first_ts` restarts from zero, so the user has at least 30 + 7 = 37 days before auto-disable. For idle, the re-enablement publication suppresses alerts for 14 days (it updates `last_user_pub_at`), then `TaskIdle` can fire if no data has moved. That gives 14 + 7 = 21 days before auto-disable.

## Rollout

On merge, controllers immediately begin evaluating the four new alert types on every wake cycle. `alert_history` rows will be created for tasks that meet the firing conditions. However, no emails will be sent and no tasks will be disabled:

**No emails:** The `fetch_recipients` query matches `alert_type = any(include_alert_types)` against `alert_subscriptions`. The new alert types are not in `DEFAULT_ALERT_TYPES` (the list applied when creating subscriptions during onboarding), and no existing subscription rows include them. The `alert_history` rows will have empty `recipients` arrays, so the notification task will produce zero emails.

**No disablement:** `DISABLE_ABANDONED_TASKS` defaults to `false`. The controller evaluates alerts and computes `DisableReason`, but skips the `maybe_disable_task` publication.

### Monitoring

```sql
select catalog_name, alert_type, fired_at, arguments
from alert_history
where alert_type in (
  'task_chronically_failing', 'task_auto_disabled_failing',
  'task_idle', 'task_auto_disabled_idle'
)
order by fired_at desc;
```

### Enabling notifications

Two steps, which can be done independently:

1. **New tenants:** Add the four alert types to `DEFAULT_ALERT_TYPES`. New subscriptions created during onboarding will then include them.

2. **Existing tenants:** Run a migration to append the new types to `include_alert_types` for existing `alert_subscriptions` rows:

```sql
update alert_subscriptions
set include_alert_types = include_alert_types
  || '{task_chronically_failing,task_auto_disabled_failing,task_idle,task_auto_disabled_idle}'::alert_type[]
where not include_alert_types @> '{task_chronically_failing}'::alert_type[];
```

### Enabling disablement

Set `DISABLE_ABANDONED_TASKS=true` in the agent env. This should be done >= 7 days after subscribing everyone to the above notifications, otherwise we might disable tasks that didn't get a warning email first.

### Environment variable knobs

| Variable | Default | Description |
|---|---|---|
| `CHRONICALLY_FAILING_THRESHOLD` | 30 days | How long `ShardFailed` must be continuously firing before `TaskChronicallyFailing` fires |
| `CHRONICALLY_FAILING_DISABLE_AFTER` | 7 days | Grace period between `TaskChronicallyFailing` firing and `TaskAutoDisabledFailing` firing (auto-disable) |
| `ABANDON_IDLE_THRESHOLD` | 30 days | How long without data movement (in `catalog_stats_daily`) before `TaskIdle` can fire |
| `ABANDON_USER_PUB_RECENCY` | 14 days | How long without a user publication before either sequence can fire. A user publication within this window suppresses both `TaskChronicallyFailing` and `TaskIdle` |
| `ABANDON_IDLE_DISABLE_AFTER` | 7 days | Grace period between `TaskIdle` firing and `TaskAutoDisabledIdle` firing (auto-disable) |
| `DISABLE_ABANDONED_TASKS` | `false` | When `true`, the controller publishes `shards.disable = true` when an auto-disable alert fires. When `false`, the alerts still fire and appear in `alert_history`, but no publication occurs |
| `ABANDON_CHECK_INTERVAL` | 24 hours | Minimum interval between abandonment evaluations for a given task. Reduces `catalog_stats_daily` query load by skipping re-evaluation when the last check was recent |

Related vars in the activation controller (not introduced here, but relevant to understanding the chronically-failing sequence):
| Variable | Default | Description |
|---|---|---|
| `ALERT_AFTER_SHARD_FAILURES` | 3 | Number of recent shard failures within the retention window needed to fire `ShardFailed` |
| `RESOLVE_SHARD_FAILED_ALERT_AFTER` | 2 hours | Duration of continuous `Ok` shard status needed to resolve `ShardFailed` |

Closes #2710