### PR TITLE
data-plane-controller: read private_links from row

### DIFF
--- a/crates/data-plane-controller/src/job/executor.rs
+++ b/crates/data-plane-controller/src/job/executor.rs
@@ -186,6 +186,11 @@ impl Executor {
         let sleep = match state_ref.status {
             Status::Idle => self.on_idle(state_ref, inbox, releases, row_state).await?,
             status => {
+                // Refresh private_links from the current DB row on every poll,
+                // so that retries pick up changes made to the data_planes table.
+                state_ref.stack.config.model.private_links =
+                    row_state.stack.config.model.private_links;
+
                 // For all non-Idle statuses, dispatch to service worker.
                 let action =
                     Action::from_status(status).context("cannot convert status to action")?;


### PR DESCRIPTION
**Description:**

- A regression in #2647 was causing broken private links configurations to get stuck in the task "state" and not be reloaded from the table row. This is a fix.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

