### PR TITLE
Docs: Add Bauplan connector variant

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -30,7 +30,7 @@ In the future, other open-source materialization connectors from third parties c
   * [Configuration](./SQLServer/amazon-rds-sqlserver.md)
   * Package - ghcr.io/estuary/materialize-amazon-rds-sqlserver:v2
 * Apache Iceberg Tables
-  * [Configuration](./apache-iceberg.md)
+  * [Configuration](./apache-iceberg/apache-iceberg.md)
   * Package — ghcr.io/estuary/materialize-iceberg:v1
 * Apache Iceberg Tables in S3 (delta updates)
   * [Configuration](./amazon-s3-iceberg.md)
@@ -53,6 +53,9 @@ In the future, other open-source materialization connectors from third parties c
 * Azure SQL Server
   * [Configuration](./SQLServer/)
   * Package - ghcr.io/estuary/materialize-sqlserver:v2
+* Bauplan
+  * [Configuration](./apache-iceberg/bauplan.md)
+  * Package - ghcr.io/estuary/materialize-bauplan:v1
 * Bytewax
   * [Configuration](./Dekaf/bytewax.md)
 * ClickHouse

--- a/site/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
@@ -170,7 +170,7 @@ user, for example by attaching a policy to the user like this:
    integration settings**, ensure **Allow external engines to access data in
    Amazon S3 locations with full table access** is **enabled** by checking the
    box for it.
-![Configuring Lake Formation application integration settings](../connector-images/materialize-iceberg-lf-application-integration.png)
+![Configuring Lake Formation application integration settings](../../connector-images/materialize-iceberg-lf-application-integration.png)
 
 4) Grant `DATA_LOCATION_ACCESS` to the registered location for the catalog user:
 ```

--- a/site/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
+++ b/site/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
@@ -1,0 +1,19 @@
+# Bauplan
+
+[Bauplan](https://www.bauplan.io) is a serverless data lake platform built natively on Apache Iceberg. It provides a managed REST catalog so you can run SQL and Python queries directly on your Iceberg tables without managing catalog infrastructure yourself.
+
+This connector materializes Estuary collections into Bauplan as Iceberg tables. The connector is a variant of the [Apache Iceberg connector](./apache-iceberg.md). The setup steps are the same — refer to that page for the full configuration reference, including EMR Serverless setup. The only Bauplan-specific configuration is the catalog connection below.
+
+:::tip
+For a complete end-to-end setup guide, see the Bauplan documentation: **[Estuary via EMR](https://docs.bauplanlabs.com/integrations/data_int_and_etl/estuary)**
+:::
+
+## Catalog Configuration
+
+Bauplan exposes a standard Iceberg REST catalog endpoint. When configuring the materialization, use the following:
+
+- **Base URL**: Your Bauplan REST catalog URL (available from your Bauplan account)
+- **Warehouse**: Your Bauplan warehouse name
+- **Catalog Authentication**: Select **OAuth 2.0 Client Credentials** and supply the client ID and secret from your Bauplan account
+
+For all other configuration options (EMR Serverless compute, staging bucket, IAM roles, bindings), refer to the [Apache Iceberg connector docs](./apache-iceberg.md).


### PR DESCRIPTION
**Description:**

* Adds a docs page for the Bauplan connector (`materialize-bauplan`), a variant of the Iceberg connector
* Restructures Iceberg connector docs into a subdirectory to nest Bauplan alongside it using the same pattern as other variants
* Adds Bauplan to list of connectors in root level README

**Documentation links affected:**

Apache Iceberg materialization docs

**Notes for reviewers:**

Based off of #2747 to clear the slate after running into file renaming issues
