### PR TITLE
docs: clarify flow_published_at microsecond precision

### DIFF
--- a/site/docs/concepts/collections.md
+++ b/site/docs/concepts/collections.md
@@ -63,6 +63,12 @@ to a collection. Essentially, it is a projection of the `_meta/uuid` field, wher
 encoded timestamp component.
 - Availability: The `flow_published_at` field is available in every collection, as it is a derived
 projection from the `_meta/uuid` field.
+- Precision: If multiple documents are captured in a single transaction, each receives a `flow_published_at`
+value that increments by 1 microsecond from the previous document. This means `flow_published_at`
+is guaranteed to be strictly increasing and unique across all documents written by a single
+capture task. Destinations that support microsecond-precision timestamps (including PostgreSQL,
+Snowflake, and BigQuery) will preserve this total ordering, making `flow_published_at` suitable
+as an incremental cursor for polling or dbt models.
 
 For a given document identified by a unique key, the `flow_published_at` field can be used as a proxy for
 the last time the document was modified. This is particularly useful when performing incremental updates

--- a/site/docs/guides/advanced-usage/metadata-fields.md
+++ b/site/docs/guides/advanced-usage/metadata-fields.md
@@ -27,6 +27,8 @@ The `flow_published_at` projection is automatically derived from the UUID's time
 - Incremental processing in materializations (via time travel `notBefore`/`notAfter`)
 - Ordering events chronologically
 
+If multiple documents are captured in a single transaction, each receives a `flow_published_at` value that increments by 1 microsecond from the previous document. This means `flow_published_at` is guaranteed to be strictly increasing and unique across all documents written by a single capture task. Destinations that support microsecond-precision timestamps (including PostgreSQL, Snowflake, and BigQuery) will preserve this total ordering, making `flow_published_at` suitable as an incremental cursor for polling or dbt models.
+
 ### Delete Events
 
 Delete events (`op: "d"`) contain only the document key and `_meta` fields—other fields are omitted. When processing deletes, use the key to identify which document was removed. See the [deletions guide](/reference/deletions/) for handling soft and hard deletes.


### PR DESCRIPTION
## Summary

- Adds precision documentation to `flow_published_at` in both `concepts/collections.md` and `guides/advanced-usage/metadata-fields.md`
- Clarifies that timestamps increment by 1μs per document within a transaction, guaranteeing strict ordering and uniqueness per capture task
- Confirms suitability as an incremental cursor for destinations with microsecond support (PostgreSQL, Snowflake, BigQuery)

## Context

Customer question surfaced that the docs didn't specify `flow_published_at` precision, leading to a theoretical concern about cursor boundary issues when polling materialized tables. The [September 2025 clock change](https://github.com/gazette/core/pull/448) from 100ns to 1μs ticks ensures uniqueness even in microsecond-precision destinations.