### PR TITLE
Graphql schema / types package

### DIFF
--- a/.github/workflows/publish-gql-types.yaml
+++ b/.github/workflows/publish-gql-types.yaml
@@ -1,0 +1,59 @@
+name: Publish GraphQL Types Package
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - packages/gql-types/package.json
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Check if version already published
+        id: check
+        working-directory: packages/gql-types
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+
+          if npm view "@estuarydev/gql-types@$LOCAL_VERSION" version 2>/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION already published, skipping."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION not yet published, will publish."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build package
+        if: steps.check.outputs.published == 'false'
+        working-directory: packages/gql-types
+        run: |
+          cp ../../crates/flow-client/control-plane-api.graphql schema/
+          npm install
+          npx graphql-codegen
+          npx tsc
+
+      - name: Publish
+        if: steps.check.outputs.published == 'false'
+        working-directory: packages/gql-types
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/gql-types/.gitignore
+++ b/packages/gql-types/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+dist/
+src/
+schema/control-plane-api.graphql

--- a/packages/gql-types/README.md
+++ b/packages/gql-types/README.md
@@ -1,0 +1,68 @@
+# @estuarydev/gql-types
+
+TypeScript types and GraphQL SDL for the Estuary control plane API.
+
+The schema is defined in Rust via `async-graphql` in `crates/control-plane-api/`
+and extracted to `crates/flow-client/control-plane-api.graphql` at build time.
+This package makes that schema and generated base TypeScript types available to frontend.
+
+## Publishing
+
+CI publishes to npm automatically when the version in `package.json` is bumped and merged to `master`.
+
+To release a new version:
+
+1. Update the schema (modify the Rust GraphQL types, then run
+   `cargo build -p flow-client --features generate` to regenerate the SDL)
+2. Bump the version in this `package.json` following semver:
+   - Patch (`0.1.1`): bug fixes, doc-only changes
+   - Minor (`0.2.0`): new types, fields, queries, or mutations (additive)
+   - Major (`1.0.0`, `2.0.0`): removed or renamed types/fields (breaking)
+3. Commit both the updated SDL and the version bump
+4. Merge to `master` — CI publishes automatically
+
+### Pre-releases
+
+For parallel frontend/backend development on a feature branch:
+
+1. Set the version to e.g. `0.2.0-invite-links.0` in `package.json`
+2. Trigger the workflow manually via `workflow_dispatch` on your branch
+3. The frontend can install `@estuarydev/gql-types@0.2.0-invite-links.0`
+
+## Local development
+
+To use unpublished schema changes locally:
+
+```bash
+# In the flow repo — regenerate SDL from Rust (if schema changed)
+cargo build -p flow-client --features generate
+
+# Build the package and create a global npm link
+./scripts/link-gql-types.sh
+
+# In the frontend repo — use the local version
+npm link @estuarydev/gql-types
+```
+
+Re-run `./scripts/link-gql-types.sh` after each schema change.
+Run `npm unlink @estuarydev/gql-types` in the frontend to revert to the published version.
+
+## Frontend usage
+
+Install the package:
+
+```bash
+npm install @estuarydev/gql-types
+```
+
+Import types directly:
+
+```typescript
+import type { LiveSpec, Alert, Capability } from "@estuarydev/gql-types";
+```
+
+The raw SDL is also available for local codegen (e.g. generating typed urql hooks):
+
+```
+node_modules/@estuarydev/gql-types/schema/control-plane-api.graphql
+```

--- a/packages/gql-types/codegen.ts
+++ b/packages/gql-types/codegen.ts
@@ -1,0 +1,27 @@
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'schema/control-plane-api.graphql',
+  generates: {
+    'src/types.ts': {
+      plugins: ['typescript'],
+      config: {
+        scalars: {
+          DateTime: 'string',
+          Id: 'string',
+          JSON: 'unknown',
+          JSONObject: 'Record<string, unknown>',
+          UUID: 'string',
+          Prefix: 'string',
+          Name: 'string',
+          Collection: 'string',
+          Url: 'string',
+        },
+        enumsAsTypes: true,
+        skipTypename: true,
+      },
+    },
+  },
+}
+
+export default config

--- a/packages/gql-types/package.json
+++ b/packages/gql-types/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@estuarydev/gql-types",
+  "version": "0.1.0",
+  "description": "GraphQL schema and TypeScript types for the Estuary control plane API",
+  "license": "BSL-1.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/estuary/flow",
+    "directory": "packages/gql-types"
+  },
+  "types": "dist/types.d.ts",
+  "files": [
+    "dist/",
+    "schema/"
+  ],
+  "scripts": {
+    "codegen": "graphql-codegen",
+    "build": "graphql-codegen && tsc"
+  },
+  "devDependencies": {
+    "@graphql-codegen/cli": "^5.0.0",
+    "@graphql-codegen/typescript": "^4.0.0",
+    "graphql": "^16.0.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "graphql": "^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20",
+    "npm": "^10"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/gql-types/tsconfig.json
+++ b/packages/gql-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/scripts/link-gql-types.sh
+++ b/scripts/link-gql-types.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../packages/gql-types"
+
+SDL=../../crates/flow-client/control-plane-api.graphql
+if [[ ! -f "$SDL" ]]; then
+  echo "SDL not found at $SDL"
+  echo "Run: cargo build -p flow-client --features generate"
+  exit 1
+fi
+
+cp "$SDL" schema/
+rm -rf dist/
+npm install --silent
+npm run build
+npm link
+
+echo ""
+echo "Linked @estuarydev/gql-types locally."
+echo "Run 'npm link @estuarydev/gql-types' in your frontend repo to use it."


### PR DESCRIPTION
## Summary

- Add `@estuarydev/gql-types` npm package that publishes the GraphQL schema SDL and generated base ts types to npmjs.com
- Add CI workflow to auto-publish when the `@estuarydev/gql-types` package version is bumped and merged to master
- Publishes with `--provenance` for supply chain security — each version is signed with an OIDC attestation linking it back to the exact commit and CI workflow run
- Add `scripts/link-gql-types.sh` for local development without publishing
- Package contents are ephemeral - they're generated and published to npmjs without being saved to the flow repo

## Details

**Publishing**:
- CI checks if the version in `package.json` is already published; only publishes new versions
- Pre-releases from feature branches via `workflow_dispatch`
- Versioning is explicit semver — bump `package.json` alongside schema changes

**Local dev**:
- `./scripts/link-gql-types.sh` builds the package from the local SDL and `npm link`s it
- Frontend uses `npm link @estuarydev/gql-types` to pick up unpublished changes immediately
