### PR TITLE
dpc: pass through all_ports field for GCP PSC forwarding rules

### DIFF
--- a/crates/data-plane-controller/src/shared/data_plane_fixture.json
+++ b/crates/data-plane-controller/src/shared/data_plane_fixture.json
@@ -108,7 +108,8 @@
         "service_attachment": "projects/customer-project/regions/us-central1/serviceAttachments/customer-db",
         "region": "us-central1",
         "dns_zone_name": "estuary-psc",
-        "dns_record_names": ["customer-db", "customer-api"]
+        "dns_record_names": ["customer-db", "customer-api"],
+        "all_ports": true
       }
     ],
     "gcp_byoc": {

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -639,6 +639,7 @@ mod test {
                 region: "us-central1".to_string(),
                 dns_zone_name: "estuary-psc".to_string(),
                 dns_record_names: vec!["customer-db".to_string(), "customer-api".to_string()],
+                all_ports: true,
             }),
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- Add `all_ports: bool` field to `GCPPrivateServiceConnect` in the DPC's stack config
- Uses `#[serde(default)]` so existing PSC entries without the field deserialize as `false`
- Required so the DPC passes `all_ports` through to the Pulumi stack YAML, where est-dry-dock uses it to set `all_ports=True` on GCP forwarding rules

Port-mapped PSC endpoints (e.g. MongoDB Atlas) require forwarding on all ports (1024-65535). Without this, the DPC silently drops the field and Pulumi never sees it.

Companion PR: estuary/est-dry-dock#265

**Deploy order**: est-dry-dock#265 must be merged first (its Pydantic model has `extra="forbid"`, so it would reject the field if the DPC starts serializing it before the Pulumi code knows about it).

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Run `pulumi preview` on an existing data plane to confirm no unintended changes