### PR TITLE
docs: add query tag documentation to Snowflake and Databricks connectors

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -313,6 +313,16 @@ Available options in Estuary include:
 You do not need to explicitly set the [`TIMESTAMP_TYPE_MAPPING` configuration](https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping) in Snowflake.
 However, if you do, the value in Snowflake **must** match the value in Estuary.
 
+## Query Tags
+
+The Snowflake connector automatically sets a [query tag](https://docs.snowflake.com/en/sql-reference/parameters#query-tag) on every session. The tag has the format `materialization_name:<task_name>`, where `<task_name>` is the full name of your Estuary materialization task.
+
+This requires no configuration. You can use query tags to:
+
+* **Monitor queries**: Filter [QUERY_HISTORY](https://docs.snowflake.com/en/sql-reference/functions/query_history) by `QUERY_TAG` to see all queries originating from a specific materialization.
+* **Attribute costs**: Break down warehouse costs per materialization task using the query tag in your Snowflake usage reports.
+* **Debug issues**: Quickly identify which materialization task generated a particular query.
+
 ## Reserved words
 
 Snowflake has a list of reserved words that must be quoted in order to be used as an identifier. Estuary automatically quotes fields that are in the reserved words list. You can find this list in Snowflake's documentation [here](https://docs.snowflake.com/en/sql-reference/reserved-keywords.html) and in the table below.

--- a/site/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/site/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -142,6 +142,16 @@ SET TBLPROPERTIES (
 );
 ```
 
+## Query Tags
+
+The Databricks connector automatically sets a [query tag](https://docs.databricks.com/en/sql/user/queries/query-tags.html) on every session. The tag has the format `materialization_name:<task_name>`, where `<task_name>` is the full name of your Estuary materialization task.
+
+This requires no configuration. You can use query tags to:
+
+* **Monitor queries**: Filter the Databricks [query history](https://docs.databricks.com/en/sql/user/queries/query-history.html) to see all queries originating from a specific materialization.
+* **Attribute costs**: Break down warehouse costs per materialization task using query tags.
+* **Debug issues**: Quickly identify which materialization task generated a particular query.
+
 ## Reserved words
 
 Databricks has a list of reserved words that must be quoted in order to be used as an identifier. Estuary automatically quotes fields that are in the reserved words list. You can find this list in Databricks's documentation [here](https://docs.databricks.com/en/sql/language-manual/sql-ref-reserved-words.html) and in the table below.


### PR DESCRIPTION
Document the automatic query tagging behavior for these connectors.

**Description:**

Just documentation changes.

**Workflow steps:**

n/a

**Documentation links affected:**

- https://docs.estuary.dev/reference/Connectors/materialization-connectors/Snowflake/
- https://docs.estuary.dev/reference/Connectors/materialization-connectors/databricks/

**Notes for reviewers:**

Helps https://github.com/estuary/connectors/issues/3469

