### PR TITLE
Phase 4b: Invite SSO enforcement + SSO routing

### DIFF
--- a/.claude/skills/setup-mocksaml/SKILL.md
+++ b/.claude/skills/setup-mocksaml/SKILL.md
@@ -2,7 +2,6 @@
 name: setup-mocksaml
 description: Set up MockSAML as a local SAML IdP for testing SSO flows (grant migration, invite enforcement). Run when setting up a fresh local env or after `supabase db reset`.
 disable-model-invocation: true
-allowed-tools: Bash(*), Read
 ---
 
 # Set Up MockSAML for Local SSO Testing
@@ -50,6 +49,18 @@ If `GOTRUE_SAML_ENABLED=true` is already set, skip to step 6.
 openssl genrsa 2048 > /tmp/saml_key.pem
 ```
 
+GoTrue requires PKCS#1 format. Check the header of the generated key:
+
+```bash
+head -1 /tmp/saml_key.pem
+```
+
+- `BEGIN RSA PRIVATE KEY` → PKCS#1, good to go.
+- `BEGIN PRIVATE KEY` → PKCS#8 (OpenSSL 3.x default). Convert it:
+  ```bash
+  openssl rsa -traditional -in /tmp/saml_key.pem -out /tmp/saml_key.pem
+  ```
+
 Strip to raw base64 (no PEM headers, no newlines):
 
 ```bash
@@ -67,10 +78,28 @@ Capture the current container's env vars, image, and network:
 <docker-prefix> docker inspect supabase_auth_flow --format '{{json .NetworkSettings.Networks}}'
 ```
 
-Stop and remove the old container, then recreate with all original env vars
-plus the SAML vars. **Important:** override `API_EXTERNAL_URL` to include the
-`/auth/v1` prefix — GoTrue uses this to generate the SAML ACS callback URL,
-and without the prefix Kong won't route the callback correctly.
+Build an env file for the new container. Using `--env-file` avoids shell
+parsing issues with values that contain template syntax (e.g.
+`GOTRUE_SMS_TEMPLATE=Your code is {{ .Code }}`).
+
+```bash
+grep -v -E '^(PATH=|API_EXTERNAL_URL=)' /tmp/auth_env.txt > /tmp/auth_env_filtered.txt
+echo "GOTRUE_SAML_ENABLED=true" >> /tmp/auth_env_filtered.txt
+echo "GOTRUE_SAML_PRIVATE_KEY=$SAML_KEY_B64" >> /tmp/auth_env_filtered.txt
+echo "API_EXTERNAL_URL=http://127.0.0.1:5431/auth/v1" >> /tmp/auth_env_filtered.txt
+```
+
+**Important:** the `API_EXTERNAL_URL` override includes the `/auth/v1` prefix —
+GoTrue uses this to generate the SAML ACS callback URL, and without the prefix
+Kong won't route the callback correctly.
+
+If using Lima, copy the env file into the VM before running docker:
+
+```bash
+limactl copy /tmp/auth_env_filtered.txt <vm>:/tmp/auth_env_filtered.txt
+```
+
+Stop and remove the old container, then recreate:
 
 ```bash
 <docker-prefix> docker stop supabase_auth_flow && <docker-prefix> docker rm supabase_auth_flow
@@ -79,10 +108,7 @@ and without the prefix Kong won't route the callback correctly.
   --name supabase_auth_flow \
   --network <network-name> \
   --restart always \
-  -e GOTRUE_SAML_ENABLED=true \
-  -e GOTRUE_SAML_PRIVATE_KEY=$SAML_KEY_B64 \
-  -e API_EXTERNAL_URL=http://127.0.0.1:5431/auth/v1 \
-  <all original -e flags from /tmp/auth_env.txt, excluding PATH= and API_EXTERNAL_URL=> \
+  --env-file /tmp/auth_env_filtered.txt \
   <image> auth
 ```
 
@@ -102,6 +128,15 @@ supabase status --output json
 
 Extract `SERVICE_ROLE_KEY` from the output.
 
+If `supabase status` fails (e.g. Docker runs inside a Lima VM), read the key
+from Kong's config instead — it's always accessible since Kong handles routing:
+
+```bash
+<docker-prefix> docker exec supabase_kong_flow cat /home/kong/kong.yml
+```
+
+Look for the `service_role` JWT in the authorization header rewriting rules.
+
 ### 7. Check if MockSAML is already registered
 
 ```bash
@@ -114,6 +149,12 @@ register a new one. If reusing, skip to step 9.
 
 ### 8. Register MockSAML as an SSO provider
 
+Ask the user which email domain to associate with the SSO provider (default:
+`example.com`). This controls which email addresses are routed through SAML
+login. MockSAML's default test user is `jackson@example.com`, so `example.com`
+works out of the box — but the user may want a different domain to match their
+test data.
+
 ```bash
 curl -X POST 'http://127.0.0.1:5431/auth/v1/admin/sso/providers' \
   -H 'Authorization: Bearer <SERVICE_ROLE_KEY>' \
@@ -121,7 +162,7 @@ curl -X POST 'http://127.0.0.1:5431/auth/v1/admin/sso/providers' \
   -d '{
     "type": "saml",
     "metadata_url": "https://mocksaml.com/api/saml/metadata",
-    "domains": ["example.com"]
+    "domains": ["<DOMAIN>"]
   }'
 ```
 

--- a/.sqlx/query-62c24bfd77101313d6711554b2a275f088de07743cedd6b96d88c59a8e63256e.json
+++ b/.sqlx/query-62c24bfd77101313d6711554b2a275f088de07743cedd6b96d88c59a8e63256e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT true AS \"exists!\"\n            FROM tenants t\n            WHERE t.tenant = $1\n              AND t.sso_provider_id IS NOT NULL\n              AND NOT EXISTS (\n                SELECT 1 FROM auth.identities ai\n                WHERE ai.user_id = $2\n                  AND ai.provider = 'sso:' || t.sso_provider_id::text\n              )\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "62c24bfd77101313d6711554b2a275f088de07743cedd6b96d88c59a8e63256e"
+}

--- a/.sqlx/query-6b980602f82b52e0f186d532fd5f93141c03a7f704c461194f45047636867855.json
+++ b/.sqlx/query-6b980602f82b52e0f186d532fd5f93141c03a7f704c461194f45047636867855.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    token,\n                    catalog_prefix AS \"catalog_prefix!: String\",\n                    capability AS \"capability!: models::Capability\",\n                    single_use AS \"single_use!: bool\",\n                    detail,\n                    created_at AS \"created_at!: chrono::DateTime<chrono::Utc>\"\n                FROM internal.invite_links\n                WHERE catalog_prefix::text ^@ ANY($1)\n                  AND ($5::text IS NULL OR catalog_prefix::text ^@ $5)\n                  AND ($4::bool IS NULL OR single_use = $4)\n                  AND ($2::uuid IS NULL OR token > $2)\n                ORDER BY token\n                LIMIT $3 + 1\n                ",
+  "query": "\n                SELECT\n                    il.token,\n                    il.catalog_prefix AS \"catalog_prefix!: String\",\n                    il.capability AS \"capability!: models::Capability\",\n                    il.single_use AS \"single_use!: bool\",\n                    il.detail,\n                    il.created_at AS \"created_at!: chrono::DateTime<chrono::Utc>\",\n                    t.sso_provider_id\n                FROM internal.invite_links il\n                LEFT JOIN tenants t ON il.catalog_prefix::text ^@ t.tenant\n                WHERE il.catalog_prefix::text ^@ ANY($1)\n                  AND ($5::text IS NULL OR il.catalog_prefix::text ^@ $5)\n                  AND ($4::bool IS NULL OR il.single_use = $4)\n                  AND ($2::timestamptz IS NULL OR il.created_at < $2)\n                ORDER BY il.created_at DESC\n                LIMIT $3 + 1\n                ",
   "describe": {
     "columns": [
       {
@@ -71,12 +71,17 @@
         "ordinal": 5,
         "name": "created_at!: chrono::DateTime<chrono::Utc>",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "sso_provider_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
       "Left": [
         "TextArray",
-        "Uuid",
+        "Timestamptz",
         "Int4",
         "Bool",
         "Text"
@@ -88,8 +93,9 @@
       false,
       false,
       true,
-      false
+      false,
+      true
     ]
   },
-  "hash": "5c35576f65d7ef76f367b31b2238b49d8fdb0cca095fa3bb08380a62b238c1f3"
+  "hash": "6b980602f82b52e0f186d532fd5f93141c03a7f704c461194f45047636867855"
 }

--- a/.sqlx/query-d66323852c5757f5102115ab5c73e3c180ff3b564cf55aea9dd06c07e0324421.json
+++ b/.sqlx/query-d66323852c5757f5102115ab5c73e3c180ff3b564cf55aea9dd06c07e0324421.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT t.sso_provider_id\n            FROM tenants t\n            WHERE t.tenant = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sso_provider_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "d66323852c5757f5102115ab5c73e3c180ff3b564cf55aea9dd06c07e0324421"
+}

--- a/crates/control-plane-api/src/fixtures/sso_tenant.sql
+++ b/crates/control-plane-api/src/fixtures/sso_tenant.sql
@@ -1,0 +1,60 @@
+do $$
+declare
+  data_plane_one_id flowid := '111111111111';
+
+  alice_uid uuid := '11111111-1111-1111-1111-111111111111';
+  bob_uid uuid := '22222222-2222-2222-2222-222222222222';
+  carol_uid uuid := '33333333-3333-3333-3333-333333333333';
+
+  acme_provider_id uuid := 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  other_provider_id uuid := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+  last_pub_id flowid := '000000000002';
+
+begin
+
+  -- SSO providers
+  insert into auth.sso_providers (id) values
+    (acme_provider_id),
+    (other_provider_id)
+  ;
+
+  -- Users
+  insert into auth.users (id, email) values
+    (alice_uid, 'alice@acme.co'),
+    (bob_uid, 'bob@other.co'),
+    (carol_uid, 'carol@example.com')
+  ;
+
+  -- Alice has an SSO identity matching acme's provider.
+  -- GoTrue stores SSO identities with provider = 'sso:<provider_id>'.
+  insert into auth.identities (user_id, provider, provider_id) values
+    (alice_uid, 'sso:' || acme_provider_id::text, acme_provider_id::text)
+  ;
+
+  -- Bob has an SSO identity, but for a different provider.
+  insert into auth.identities (user_id, provider, provider_id) values
+    (bob_uid, 'sso:' || other_provider_id::text, other_provider_id::text)
+  ;
+
+  -- Carol has no SSO identity (social login only).
+
+  -- Tenants: acmeCo/ with SSO, openCo/ without SSO.
+  insert into public.tenants (id, tenant, sso_provider_id) values
+    (internal.id_generator(), 'acmeCo/', acme_provider_id),
+    (internal.id_generator(), 'openCo/', null)
+  ;
+
+  -- Alice is admin on acmeCo/ and openCo/.
+  insert into public.user_grants (user_id, object_role, capability) values
+    (alice_uid, 'acmeCo/', 'admin'),
+    (alice_uid, 'openCo/', 'admin')
+  ;
+
+  -- Give alice read on data planes so specs can resolve.
+  insert into public.role_grants (subject_role, object_role, capability) values
+    ('acmeCo/', 'ops/dp/public/', 'read')
+  ;
+
+end
+$$;

--- a/crates/control-plane-api/src/publications/quotas.rs
+++ b/crates/control-plane-api/src/publications/quotas.rs
@@ -74,11 +74,7 @@ fn get_deltas(built: &build::Output) -> BTreeMap<&str, (i32, i32)> {
 }
 
 fn tenant(name: &impl AsRef<str>) -> &str {
-    let idx = name
-        .as_ref()
-        .find('/')
-        .expect("catalog name must contain at least one /");
-    name.as_ref().split_at(idx + 1).0
+    models::tenant_from(name.as_ref())
 }
 
 pub async fn check_resource_quotas(

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -1,4 +1,4 @@
-use super::filters;
+use super::{TimestampCursor, filters};
 use async_graphql::{Context, types::connection};
 
 /// An invite link that grants access to a catalog prefix.
@@ -16,6 +16,10 @@ pub struct InviteLink {
     pub detail: Option<String>,
     /// When this invite link was created.
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// The SSO provider ID for the invite's tenant, if any.
+    /// When present, the frontend should route the user directly into the SSO
+    /// flow using this provider ID (e.g. via `supabase.auth.signInWithSSO`).
+    pub sso_provider_id: Option<uuid::Uuid>,
 }
 
 /// Result of redeeming an invite link.
@@ -28,7 +32,7 @@ pub struct RedeemInviteLinkResult {
 }
 
 pub type PaginatedInviteLinks = connection::Connection<
-    String,
+    TimestampCursor,
     InviteLink,
     connection::EmptyFields,
     connection::EmptyFields,
@@ -89,41 +93,36 @@ impl InviteLinksQuery {
             ));
         }
 
-        connection::query(
+        connection::query_with::<TimestampCursor, _, _, _, async_graphql::Error>(
             after,
             None,
             first,
             None,
-            |after: Option<String>, _, first, _| async move {
-                let after_token: Option<uuid::Uuid> = match after {
-                    Some(s) => Some(
-                        s.parse()
-                            .map_err(|_| async_graphql::Error::new("invalid cursor"))?,
-                    ),
-                    None => None,
-                };
-
+            |after, _, first, _| async move {
+                let after_created_at = after.map(|c| c.0);
                 let limit = first.unwrap_or(DEFAULT_PAGE_SIZE);
 
                 let rows = sqlx::query!(
                     r#"
                 SELECT
-                    token,
-                    catalog_prefix AS "catalog_prefix!: String",
-                    capability AS "capability!: models::Capability",
-                    single_use AS "single_use!: bool",
-                    detail,
-                    created_at AS "created_at!: chrono::DateTime<chrono::Utc>"
-                FROM internal.invite_links
-                WHERE catalog_prefix::text ^@ ANY($1)
-                  AND ($5::text IS NULL OR catalog_prefix::text ^@ $5)
-                  AND ($4::bool IS NULL OR single_use = $4)
-                  AND ($2::uuid IS NULL OR token > $2)
-                ORDER BY token
+                    il.token,
+                    il.catalog_prefix AS "catalog_prefix!: String",
+                    il.capability AS "capability!: models::Capability",
+                    il.single_use AS "single_use!: bool",
+                    il.detail,
+                    il.created_at AS "created_at!: chrono::DateTime<chrono::Utc>",
+                    t.sso_provider_id
+                FROM internal.invite_links il
+                LEFT JOIN tenants t ON il.catalog_prefix::text ^@ t.tenant
+                WHERE il.catalog_prefix::text ^@ ANY($1)
+                  AND ($5::text IS NULL OR il.catalog_prefix::text ^@ $5)
+                  AND ($4::bool IS NULL OR il.single_use = $4)
+                  AND ($2::timestamptz IS NULL OR il.created_at < $2)
+                ORDER BY il.created_at DESC
                 LIMIT $3 + 1
                 "#,
                     &admin_prefixes,
-                    after_token,
+                    after_created_at,
                     limit as i64,
                     single_use_eq,
                     prefix_starts_with.as_deref(),
@@ -137,9 +136,8 @@ impl InviteLinksQuery {
                     .into_iter()
                     .take(limit)
                     .map(|r| {
-                        let cursor = r.token.to_string();
                         connection::Edge::new(
-                            cursor,
+                            TimestampCursor(r.created_at),
                             InviteLink {
                                 token: r.token,
                                 catalog_prefix: models::Prefix::new(&r.catalog_prefix),
@@ -147,14 +145,15 @@ impl InviteLinksQuery {
                                 single_use: r.single_use,
                                 detail: r.detail,
                                 created_at: r.created_at,
+                                sso_provider_id: r.sso_provider_id,
                             },
                         )
                     })
                     .collect();
 
-                let mut conn = connection::Connection::new(after_token.is_some(), has_next);
+                let mut conn = connection::Connection::new(after_created_at.is_some(), has_next);
                 conn.edges = edges;
-                async_graphql::Result::<PaginatedInviteLinks>::Ok(conn)
+                Ok(conn)
             },
         )
         .await
@@ -203,6 +202,22 @@ impl InviteLinksMutation {
         .fetch_one(&env.pg_pool)
         .await?;
 
+        // Look up the tenant's SSO provider so the frontend can route the
+        // invite recipient directly into the correct SSO flow.
+        let tenant = models::tenant_from(catalog_prefix.as_str());
+
+        let sso_provider_id = sqlx::query_scalar!(
+            r#"
+            SELECT t.sso_provider_id
+            FROM tenants t
+            WHERE t.tenant = $1
+            "#,
+            tenant,
+        )
+        .fetch_optional(&env.pg_pool)
+        .await?
+        .flatten();
+
         tracing::info!(
             %catalog_prefix,
             ?capability,
@@ -217,6 +232,7 @@ impl InviteLinksMutation {
             single_use,
             detail,
             created_at: row.created_at,
+            sso_provider_id,
         })
     }
 
@@ -254,6 +270,40 @@ impl InviteLinksMutation {
                 return Err(async_graphql::Error::new("Invalid invite link"));
             }
         };
+
+        // If the invite's tenant has an SSO provider configured, verify the
+        // redeeming user has an identity linked to that tenant's SSO provider.
+        //
+        // We check auth.identities rather than session-level claims (e.g. amr)
+        // because Supabase Auth excludes SAML SSO from identity linking — a user
+        // with an SSO identity row can only have obtained it by authenticating
+        // through SAML. If this assumption changes, we should check the JWT's
+        // amr claim to verify the current session used SSO.
+        let tenant = models::tenant_from(&invite.catalog_prefix);
+
+        let sso_requirement_not_satisfied = sqlx::query_scalar!(
+            r#"
+            SELECT true AS "exists!"
+            FROM tenants t
+            WHERE t.tenant = $1
+              AND t.sso_provider_id IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM auth.identities ai
+                WHERE ai.user_id = $2
+                  AND ai.provider = 'sso:' || t.sso_provider_id::text
+              )
+            "#,
+            tenant,
+            claims.sub,
+        )
+        .fetch_optional(&mut *txn)
+        .await?;
+
+        if sso_requirement_not_satisfied.is_some() {
+            return Err(async_graphql::Error::new(format!(
+                "This organization requires SSO authentication. Please sign in via SSO to redeem this invite."
+            )));
+        }
 
         // Delete single-use invite links upon redemption.
         if invite.single_use {
@@ -1116,6 +1166,300 @@ mod test {
             parent_filter_edges.len(),
             4,
             "parent prefix filter returns all invite links under the grant"
+        );
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "sso_tenant"))
+    )]
+    async fn test_redeem_invite_sso_enforcement(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+
+        let alice_token =
+            server.make_access_token(uuid::Uuid::from_bytes([0x11; 16]), Some("alice@acme.co"));
+        let bob_token =
+            server.make_access_token(uuid::Uuid::from_bytes([0x22; 16]), Some("bob@other.co"));
+        let carol_token = server.make_access_token(
+            uuid::Uuid::from_bytes([0x33; 16]),
+            Some("carol@example.com"),
+        );
+
+        // Alice (matching SSO) creates an invite link for acmeCo/.
+        // The response should include ssoProviderId.
+        let create_response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($prefix: Prefix!, $capability: Capability!) {
+                        createInviteLink(
+                            catalogPrefix: $prefix
+                            capability: $capability
+                            singleUse: false
+                        ) { token ssoProviderId }
+                    }"#,
+                    "variables": {
+                        "prefix": "acmeCo/",
+                        "capability": "write"
+                    }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        let invite_token = create_response["data"]["createInviteLink"]["token"]
+            .as_str()
+            .expect("should have token");
+
+        // ssoProviderId should be the acme provider UUID.
+        assert_eq!(
+            create_response["data"]["createInviteLink"]["ssoProviderId"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "invite for SSO tenant should include ssoProviderId"
+        );
+
+        // Bob (SSO identity for a different provider) is rejected.
+        let bob_redeem: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": invite_token }
+                }),
+                Some(&bob_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_sso_wrong_provider", bob_redeem);
+
+        // Carol (no SSO identity) is rejected.
+        let carol_redeem: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": invite_token }
+                }),
+                Some(&carol_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_sso_no_identity", carol_redeem);
+
+        // Alice (matching SSO identity) succeeds.
+        let alice_redeem: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": invite_token }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_sso_matching", alice_redeem);
+
+        // Create an invite on openCo/ (no SSO) — Bob can redeem it.
+        // Insert directly since Bob lacks admin on openCo.
+        let open_token: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO internal.invite_links (catalog_prefix, capability, single_use) \
+             VALUES ('openCo/', 'read', false) RETURNING token",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let bob_open_redeem: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": open_token }
+                }),
+                Some(&bob_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_no_sso_enforcement", bob_open_redeem);
+
+        // Sub-prefix invite: acmeCo/production/ should still be covered by
+        // the SSO enforcement on tenant acmeCo/.
+        let sub_prefix_token: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO internal.invite_links (catalog_prefix, capability, single_use) \
+             VALUES ('acmeCo/production/', 'read', false) RETURNING token",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Bob (wrong SSO provider) is rejected for the sub-prefix too.
+        let bob_sub_prefix: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": sub_prefix_token }
+                }),
+                Some(&bob_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_sso_sub_prefix_rejected", bob_sub_prefix);
+
+        // Alice (matching SSO) succeeds for the sub-prefix.
+        let alice_sub_prefix: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": sub_prefix_token }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        insta::assert_json_snapshot!("redeem_sso_sub_prefix_allowed", alice_sub_prefix);
+
+        // Verify createInviteLink for a non-SSO tenant returns null ssoProviderId.
+        // Alice already has admin on openCo/ via fixture.
+        let open_create: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($prefix: Prefix!, $capability: Capability!) {
+                        createInviteLink(
+                            catalogPrefix: $prefix
+                            capability: $capability
+                        ) { token ssoProviderId }
+                    }"#,
+                    "variables": {
+                        "prefix": "openCo/",
+                        "capability": "read"
+                    }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        assert!(
+            open_create["data"]["createInviteLink"]["ssoProviderId"].is_null(),
+            "invite for non-SSO tenant should have null ssoProviderId"
+        );
+
+        // createInviteLink for a sub-prefix under an SSO tenant should still
+        // return the tenant's ssoProviderId (the tenant lookup strips to the
+        // root prefix before the first '/').
+        let sub_create: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($prefix: Prefix!, $capability: Capability!) {
+                        createInviteLink(
+                            catalogPrefix: $prefix
+                            capability: $capability
+                        ) { token ssoProviderId }
+                    }"#,
+                    "variables": {
+                        "prefix": "acmeCo/production/",
+                        "capability": "read"
+                    }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        assert_eq!(
+            sub_create["data"]["createInviteLink"]["ssoProviderId"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "invite for sub-prefix under SSO tenant should include ssoProviderId"
+        );
+
+        // Single-use invite on SSO tenant: rejection should NOT consume the
+        // invite. Create a single-use invite, have a non-SSO user attempt to
+        // redeem it (rejected), then verify the matching SSO user can still
+        // redeem it successfully.
+        let single_use_create: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($prefix: Prefix!, $capability: Capability!) {
+                        createInviteLink(
+                            catalogPrefix: $prefix
+                            capability: $capability
+                            singleUse: true
+                        ) { token }
+                    }"#,
+                    "variables": {
+                        "prefix": "acmeCo/",
+                        "capability": "read"
+                    }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        let single_use_token = single_use_create["data"]["createInviteLink"]["token"]
+            .as_str()
+            .expect("should have token");
+
+        // Carol (no SSO identity) is rejected — invite should survive.
+        let carol_single_use: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": single_use_token }
+                }),
+                Some(&carol_token),
+            )
+            .await;
+
+        assert!(
+            carol_single_use["errors"].is_array(),
+            "non-SSO user should be rejected for SSO tenant single-use invite"
+        );
+
+        // Alice (matching SSO) can still redeem the single-use invite,
+        // proving the earlier rejection did not consume it.
+        let alice_single_use: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation($token: UUID!) {
+                        redeemInviteLink(token: $token) { catalogPrefix capability }
+                    }"#,
+                    "variables": { "token": single_use_token }
+                }),
+                Some(&alice_token),
+            )
+            .await;
+
+        assert!(
+            alice_single_use["data"]["redeemInviteLink"]["catalogPrefix"]
+                .as_str()
+                .is_some(),
+            "matching SSO user should redeem single-use invite after prior SSO rejection"
         );
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -1,8 +1,25 @@
 //! GraphQL API
 //!
 //! The `QueryRoot`
-use async_graphql::{EmptySubscription, Schema};
+use async_graphql::{EmptySubscription, Schema, types::connection};
 use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
+
+/// A `CursorType` that is just a RFC3339 UTC timestamp.
+/// Used by any paginated connection that cursors on `created_at` or similar.
+pub struct TimestampCursor(pub DateTime<Utc>);
+impl connection::CursorType for TimestampCursor {
+    type Error = chrono::ParseError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        let dt = DateTime::parse_from_rfc3339(s)?;
+        Ok(Self(dt.to_utc()))
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.0.to_rfc3339()
+    }
+}
 
 mod alert_subscriptions;
 mod alerts;

--- a/crates/control-plane-api/src/server/public/graphql/publication_history.rs
+++ b/crates/control-plane-api/src/server/public/graphql/publication_history.rs
@@ -98,20 +98,7 @@ impl async_graphql::dataloader::Loader<LastPublicationInfoKey> for PgDataLoader 
     }
 }
 
-/// A `CursorType` that is just a RFC3339 UTC timestamp
-pub struct TimestampCursor(DateTime<Utc>);
-impl connection::CursorType for TimestampCursor {
-    type Error = chrono::ParseError;
-
-    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
-        let dt = DateTime::parse_from_rfc3339(s)?;
-        Ok(Self(dt.to_utc()))
-    }
-
-    fn encode_cursor(&self) -> String {
-        self.0.to_rfc3339()
-    }
-}
+use super::TimestampCursor;
 
 pub type SpecHistoryConnection = async_graphql::connection::Connection<
     TimestampCursor,

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_no_sso_enforcement.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_no_sso_enforcement.snap
@@ -1,0 +1,12 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: bob_open_redeem
+---
+{
+  "data": {
+    "redeemInviteLink": {
+      "capability": "read",
+      "catalogPrefix": "openCo/"
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_matching.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_matching.snap
@@ -1,0 +1,12 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: alice_redeem
+---
+{
+  "data": {
+    "redeemInviteLink": {
+      "capability": "write",
+      "catalogPrefix": "acmeCo/"
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_no_identity.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_no_identity.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: carol_redeem
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 25,
+          "line": 3
+        }
+      ],
+      "message": "This organization requires SSO authentication. Please sign in via SSO to redeem this invite.",
+      "path": [
+        "redeemInviteLink"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_sub_prefix_allowed.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_sub_prefix_allowed.snap
@@ -1,0 +1,12 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: alice_sub_prefix
+---
+{
+  "data": {
+    "redeemInviteLink": {
+      "capability": "read",
+      "catalogPrefix": "acmeCo/production/"
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_sub_prefix_rejected.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_sub_prefix_rejected.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: bob_sub_prefix
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 25,
+          "line": 3
+        }
+      ],
+      "message": "This organization requires SSO authentication. Please sign in via SSO to redeem this invite.",
+      "path": [
+        "redeemInviteLink"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_wrong_provider.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__redeem_sso_wrong_provider.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/invite_links.rs
+expression: bob_redeem
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 25,
+          "line": 3
+        }
+      ],
+      "message": "This organization requires SSO authentication. Please sign in via SSO to redeem this invite.",
+      "path": [
+        "redeemInviteLink"
+      ]
+    }
+  ]
+}

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -557,6 +557,12 @@ type InviteLink {
 	When this invite link was created.
 	"""
 	createdAt: DateTime!
+	"""
+	The SSO provider ID for the invite's tenant, if any.
+	When present, the frontend should route the user directly into the SSO
+	flow using this provider ID (e.g. via `supabase.auth.signInWithSSO`).
+	"""
+	ssoProviderId: UUID
 }
 
 type InviteLinkConnection {

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -54,6 +54,7 @@ pub use raw_value::RawValue;
 pub use references::{
     CATALOG_PREFIX_RE, Capture, Collection, CompositeKey, Field, JsonPointer, Materialization,
     Name, PartitionField, Prefix, RelativeUrl, StorageEndpoint, TOKEN_RE, Test, Token, Transform,
+    tenant_from,
 };
 pub use schemas::Schema;
 pub use shards::ShardTemplate;

--- a/crates/models/src/references.rs
+++ b/crates/models/src/references.rs
@@ -233,6 +233,15 @@ string_reference_types! {
     pub struct StorageEndpoint("StorageEndpoint::schema", pattern = ENDPOINT_RE, example = "storage.example.com");
 }
 
+/// Extract the tenant prefix (e.g. "acmeCo/") from a catalog name or prefix.
+/// The input must contain at least one '/'.
+pub fn tenant_from(prefix: &str) -> &str {
+    let idx = prefix
+        .find('/')
+        .expect("prefix must contain at least one /");
+    &prefix[..idx + 1]
+}
+
 impl RelativeUrl {
     pub fn example_relative() -> Self {
         Self("../path/to/local.yaml".to_owned())


### PR DESCRIPTION
- Reject invite redemption when the invite's tenant has `sso_provider_id IS NOT NULL` and the redeeming user lacks a matching SSO identity (`auth.identities.provider_id = tenants.sso_provider_id`). 
- Keyed on `sso_provider_id IS NOT NULL`. 
- This gates **new** grant creation via invites as soon as a tenant has SSO configured.
- Fix invite link query ordering (order by created_at desc)

Additionally, route invite links directly into the SSO flow:

- `createInviteLink` looks up the tenant's `sso_provider_id` and includes it in the returned link/metadata
- Add `ssoProvider` ID to the invite link URL (e.g. `?grantToken=...&ssoProvider=...`)
- Dashboard reads `ssoProvider` from query params and calls GoTrue `POST /auth/v1/sso` directly

These ship together because rejecting non-SSO invite redemption without routing users to the correct SSO flow would be a dead end.


**Verify:**

- [ ] SSO user (matching provider) redeems invite for SSO tenant → success
- [ ] SSO user from Tenant A's provider tries to redeem invite for Tenant B (different `sso_provider_id`) → rejected with clear error
- [ ] Non-SSO user tries to redeem invite for SSO tenant → rejected with clear error
- [ ] Non-SSO user redeems invite for tenant without `sso_provider_id` → unaffected
- [ ] SSO user redeems invite for tenant without `sso_provider_id` → unaffected (no restriction)
- [ ] Invite for sub-prefix under SSO tenant → same enforcement applies
- [ ] Invite link for SSO tenant includes `ssoProvider` param → user routed directly into SSO flow