### PR TITLE
agent: expose `DISABLE_IDLE_TASKS` and `DISABLE_FAILING_TASKS` separately

### DIFF
--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -67,7 +67,11 @@ pub async fn evaluate_abandoned<C: ControlPlane>(
     let disable_reason = evaluate_alerts(alerts_status, state, now, timestamps, &config);
 
     if let Some(reason) = disable_reason {
-        if config.disable_abandoned_tasks {
+        let should_disable = match reason {
+            DisableReason::Idle => config.disable_idle_tasks,
+            DisableReason::ChronicallyFailing => config.disable_failing_tasks,
+        };
+        if should_disable {
             if maybe_disable_task(reason, state, publications, control_plane).await? {
                 return Ok(Some(NextRun::immediately()));
             }

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -72,9 +72,12 @@ pub struct ControllerConfig {
     #[clap(long, env = "ABANDON_IDLE_DISABLE_AFTER", default_value = "7d")]
     #[arg(value_parser = parse_chrono_duration)]
     pub abandon_idle_disable_after: chrono::Duration,
-    /// Whether to actually disable abandoned tasks (vs only alerting).
-    #[clap(long, env = "DISABLE_ABANDONED_TASKS", default_value = "false")]
-    pub disable_abandoned_tasks: bool,
+    /// Whether to actually disable idle tasks (vs only alerting).
+    #[clap(long, env = "DISABLE_IDLE_TASKS", default_value = "false")]
+    pub disable_idle_tasks: bool,
+    /// Whether to actually disable chronically failing tasks (vs only alerting).
+    #[clap(long, env = "DISABLE_FAILING_TASKS", default_value = "false")]
+    pub disable_failing_tasks: bool,
     /// Minimum interval between abandonment evaluations for a given task.
     #[clap(long, env = "ABANDON_CHECK_INTERVAL", default_value = "24h")]
     #[arg(value_parser = parse_chrono_duration)]

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -131,8 +131,14 @@ async fn test_abandoned_task_detection_and_resolution() {
     test_idle_fires_when_no_data_and_old(&mut harness, CatalogType::Capture, "pandas/capture")
         .await;
 
-    // Auto-disable runs last because it leaves the capture disabled.
-    test_auto_disable_publishes_disable(&mut harness, CatalogType::Capture, "pandas/capture").await;
+    // Auto-disable runs last because it leaves tasks disabled.
+    test_auto_disable_idle(
+        &mut harness,
+        CatalogType::Materialization,
+        "pandas/materialize",
+    )
+    .await;
+    test_auto_disable_failing(&mut harness, CatalogType::Capture, "pandas/capture").await;
 }
 
 /// ShardFailed firing for > 30 days triggers TaskChronicallyFailing.
@@ -199,17 +205,76 @@ async fn test_idle_fires_when_no_data_and_old(
     assert_within_minutes(wake_at, 25 * 60);
 }
 
-/// With `disable_abandoned_tasks` enabled, the controller publishes
-/// `shards.disable = true` when the chronically-failing grace period expires.
-async fn test_auto_disable_publishes_disable(
+/// With `disable_idle_tasks` enabled, the controller publishes
+/// `shards.disable = true` when the idle grace period expires.
+async fn test_auto_disable_idle(
     harness: &mut TestHarness,
     task_type: CatalogType,
     catalog_name: &str,
 ) {
-    tracing::info!(%catalog_name, "auto-disable publishes shards.disable");
+    tracing::info!(%catalog_name, "idle auto-disable publishes shards.disable");
 
     let mut config = (*harness.control_plane().controller_config()).clone();
-    config.disable_abandoned_tasks = true;
+    config.disable_idle_tasks = true;
+    harness.control_plane().set_controller_config(config);
+
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Make the task old enough and trigger TaskIdle.
+    push_back_created_at(catalog_name, chrono::Duration::days(45), harness).await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    harness.run_pending_controller(catalog_name).await;
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskIdle)
+        .await;
+
+    // Expire the grace period and run the controller to auto-disable.
+    set_alert_disable_at(
+        catalog_name,
+        AlertType::TaskIdle,
+        (chrono::Utc::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+        harness,
+    )
+    .await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+
+    harness.run_pending_controller(catalog_name).await;
+    harness.run_pending_controllers(None).await;
+
+    let state = harness.get_controller_state(catalog_name).await;
+    let spec = state.live_spec.as_ref().expect("spec should exist");
+    let is_disabled = match spec {
+        models::AnySpec::Capture(c) => c.shards.disable,
+        models::AnySpec::Collection(c) => c.derive.as_ref().map_or(false, |d| d.shards.disable),
+        models::AnySpec::Materialization(m) => m.shards.disable,
+        models::AnySpec::Test(_) => unreachable!(),
+    };
+    assert!(
+        is_disabled,
+        "expected {catalog_name} to be disabled after idle auto-disable, but shards.disable is false"
+    );
+
+    harness
+        .assert_alert_clear(catalog_name, AlertType::TaskIdle)
+        .await;
+    harness
+        .assert_alert_clear(catalog_name, AlertType::TaskAutoDisabledIdle)
+        .await;
+}
+
+/// With `disable_failing_tasks` enabled, the controller publishes
+/// `shards.disable = true` when the chronically-failing grace period expires.
+async fn test_auto_disable_failing(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "failing auto-disable publishes shards.disable");
+
+    let mut config = (*harness.control_plane().controller_config()).clone();
+    config.disable_failing_tasks = true;
     harness.control_plane().set_controller_config(config);
 
     publish_and_await_ready(harness, task_type, catalog_name).await;

--- a/crates/agent/src/integration_tests/abandoned_tasks.rs
+++ b/crates/agent/src/integration_tests/abandoned_tasks.rs
@@ -131,6 +131,20 @@ async fn test_abandoned_task_detection_and_resolution() {
     test_idle_fires_when_no_data_and_old(&mut harness, CatalogType::Capture, "pandas/capture")
         .await;
 
+    // Flag-isolation: verify that only the matching flag triggers auto-disable.
+    test_idle_flag_does_not_disable_failing_task(
+        &mut harness,
+        CatalogType::Capture,
+        "pandas/capture",
+    )
+    .await;
+    test_failing_flag_does_not_disable_idle_task(
+        &mut harness,
+        CatalogType::Materialization,
+        "pandas/materialize",
+    )
+    .await;
+
     // Auto-disable runs last because it leaves tasks disabled.
     test_auto_disable_idle(
         &mut harness,
@@ -203,6 +217,134 @@ async fn test_idle_fires_when_no_data_and_old(
 
     let wake_at = harness.assert_controller_pending(catalog_name).await;
     assert_within_minutes(wake_at, 25 * 60);
+}
+
+/// With only `disable_idle_tasks` enabled, a chronically failing task
+/// whose grace period has expired should NOT be auto-disabled.
+async fn test_idle_flag_does_not_disable_failing_task(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "idle flag does not disable a failing task");
+
+    let mut config = (*harness.control_plane().controller_config()).clone();
+    config.disable_idle_tasks = true;
+    config.disable_failing_tasks = false;
+    harness.control_plane().set_controller_config(config);
+
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Trigger ShardFailed > 30 days, fire TaskChronicallyFailing.
+    trigger_shard_failed_alert(catalog_name, chrono::Duration::days(35), harness).await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    harness.run_pending_controller(catalog_name).await;
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskChronicallyFailing)
+        .await;
+
+    // Expire the grace period.
+    set_alert_disable_at(
+        catalog_name,
+        AlertType::TaskChronicallyFailing,
+        (chrono::Utc::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+        harness,
+    )
+    .await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+
+    harness.run_pending_controller(catalog_name).await;
+
+    let state = harness.get_controller_state(catalog_name).await;
+    let spec = state.live_spec.as_ref().expect("spec should exist");
+    let is_disabled = match spec {
+        models::AnySpec::Capture(c) => c.shards.disable,
+        models::AnySpec::Collection(c) => c.derive.as_ref().map_or(false, |d| d.shards.disable),
+        models::AnySpec::Materialization(m) => m.shards.disable,
+        models::AnySpec::Test(_) => unreachable!(),
+    };
+    assert!(
+        !is_disabled,
+        "expected {catalog_name} to remain enabled when only disable_idle_tasks is set"
+    );
+
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskChronicallyFailing)
+        .await;
+    // evaluate_alerts fires TaskAutoDisabledFailing when the grace period
+    // expires regardless of the config flag. This is intentional: the alert
+    // populates alert_history for observability, and emails only go out once
+    // alert subscriptions are explicitly updated (separate rollout step).
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskAutoDisabledFailing)
+        .await;
+
+    clear_abandon_alerts(catalog_name, harness).await;
+}
+
+/// With only `disable_failing_tasks` enabled, an idle task whose grace
+/// period has expired should NOT be auto-disabled.
+async fn test_failing_flag_does_not_disable_idle_task(
+    harness: &mut TestHarness,
+    task_type: CatalogType,
+    catalog_name: &str,
+) {
+    tracing::info!(%catalog_name, "failing flag does not disable an idle task");
+
+    let mut config = (*harness.control_plane().controller_config()).clone();
+    config.disable_failing_tasks = true;
+    config.disable_idle_tasks = false;
+    harness.control_plane().set_controller_config(config);
+
+    publish_and_await_ready(harness, task_type, catalog_name).await;
+
+    // Make the task old enough and trigger TaskIdle.
+    push_back_created_at(catalog_name, chrono::Duration::days(45), harness).await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+    harness.run_pending_controller(catalog_name).await;
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskIdle)
+        .await;
+
+    // Expire the grace period.
+    set_alert_disable_at(
+        catalog_name,
+        AlertType::TaskIdle,
+        (chrono::Utc::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+        harness,
+    )
+    .await;
+    override_shard_status_last_ts(catalog_name, chrono::Duration::minutes(5), harness).await;
+
+    harness.run_pending_controller(catalog_name).await;
+
+    let state = harness.get_controller_state(catalog_name).await;
+    let spec = state.live_spec.as_ref().expect("spec should exist");
+    let is_disabled = match spec {
+        models::AnySpec::Capture(c) => c.shards.disable,
+        models::AnySpec::Collection(c) => c.derive.as_ref().map_or(false, |d| d.shards.disable),
+        models::AnySpec::Materialization(m) => m.shards.disable,
+        models::AnySpec::Test(_) => unreachable!(),
+    };
+    assert!(
+        !is_disabled,
+        "expected {catalog_name} to remain enabled when only disable_failing_tasks is set"
+    );
+
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskIdle)
+        .await;
+    // Same as above: auto-disabled alert fires for observability regardless
+    // of the config flag.
+    harness
+        .assert_alert_firing(catalog_name, AlertType::TaskAutoDisabledIdle)
+        .await;
+
+    clear_abandon_alerts(catalog_name, harness).await;
 }
 
 /// With `disable_idle_tasks` enabled, the controller publishes
@@ -454,4 +596,24 @@ async fn set_alert_disable_at(
         result.rows_affected() > 0,
         "set_alert_disable_at for {catalog_name}/{alert_key} updated 0 rows"
     );
+}
+
+/// Removes all abandon-related alerts from controller status so subsequent
+/// tests on the same task start with a clean slate.
+async fn clear_abandon_alerts(catalog_name: &str, harness: &mut TestHarness) {
+    sqlx::query(
+        "UPDATE controller_jobs SET status = (
+            status::jsonb
+            #- '{alerts,shard_failed}'
+            #- '{alerts,task_chronically_failing}'
+            #- '{alerts,task_auto_disabled_failing}'
+            #- '{alerts,task_idle}'
+            #- '{alerts,task_auto_disabled_idle}'
+        )::json
+        WHERE live_spec_id = (SELECT id FROM live_specs WHERE catalog_name = $1)",
+    )
+    .bind(catalog_name)
+    .execute(&harness.pool)
+    .await
+    .expect("failed to clear abandon alerts");
 }


### PR DESCRIPTION
## Summary

- Replaces `DISABLE_ABANDONED_TASKS` with two independent env vars: `DISABLE_IDLE_TASKS` and `DISABLE_FAILING_TASKS`, both defaulting to `false`
- Allows enabling auto-disable for idle tasks (30d no data movement) without also auto-disabling chronically failing tasks, and vice versa

## Context

Discussion about abandoned task tracking surfaced that many chronically failing tasks are still actively moving data, and the upshot is that we should be able to enable idle-task disablement independently while we work on improving shard failure alerting before acting on chronically failing tasks.