### PR TITLE
Don't ban social users when migrating grants

### DIFF
--- a/supabase/migrations/20260324120000_sso_grant_no_ban.sql
+++ b/supabase/migrations/20260324120000_sso_grant_no_ban.sql
@@ -1,0 +1,88 @@
+-- Remove the ban on old social-auth accounts during SSO grant migration.
+-- Users should be able to continue signing in via social auth after their
+-- grants have been transferred to a new SSO identity.
+
+begin;
+
+-- Replace the trigger function without the ban step.
+create or replace function internal.on_sso_identity_insert()
+returns trigger
+language plpgsql
+security definer
+-- https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY
+set search_path to ''
+as $$
+declare
+  new_user_email  text;
+  old_user_id     uuid;
+  grant_row       record;
+begin
+  -- Look up the new SSO user's email.
+  select email into new_user_email
+    from auth.users
+    where id = NEW.user_id;
+
+  if new_user_email is null then
+    return null;
+  end if;
+
+  -- Find the prior social-auth user with a matching email. OAuth auto-linking
+  -- means there's typically one social account per email, but limit 1 guards
+  -- against edge cases (e.g. duplicates from disabled linking or data fixes).
+  select id into old_user_id
+    from auth.users
+    where email = new_user_email
+      and id <> NEW.user_id
+      and (is_sso_user = false or is_sso_user is null)
+    order by created_at desc
+    limit 1;
+
+  if old_user_id is null then
+    return null;
+  end if;
+
+  -- Process each grant on the old user. Use a lateral join to find
+  -- the most specific tenant governing each grant's prefix.
+  for grant_row in
+    select ug.object_role, ug.capability, ug.detail,
+           t.sso_provider_id as tenant_sso_provider_id
+    from public.user_grants ug
+    left join public.tenants t
+      on t.tenant = split_part(ug.object_role::text, '/', 1) || '/'
+    where ug.user_id = old_user_id
+  loop
+    if grant_row.tenant_sso_provider_id is not null
+       and grant_row.tenant_sso_provider_id is distinct from substring(NEW.provider from 5)::uuid
+    then
+      -- Tenant has a different SSO provider: skip.
+      null;
+    else
+      -- Transfer: upsert into new user's grants (capability only upgrades).
+      insert into public.user_grants (user_id, object_role, capability, detail)
+      values (
+        NEW.user_id,
+        grant_row.object_role,
+        grant_row.capability,
+        coalesce(grant_row.detail, 'migrated from social auth')
+      )
+      -- defensive on conflict here in case the user account somehow already has grants
+      -- before the user logs in and creates the identity (maybe possible with SCIM provisioning)
+      on conflict (user_id, object_role) do update
+        set capability = greatest(
+              public.user_grants.capability,
+              excluded.capability
+            ),
+            updated_at = now(),
+            detail = case
+              when excluded.capability > public.user_grants.capability
+              then excluded.detail
+              else public.user_grants.detail
+            end;
+    end if;
+  end loop;
+
+  return null;
+end;
+$$;
+
+commit;

--- a/supabase/tests/sso_grant_migration.test.sql
+++ b/supabase/tests/sso_grant_migration.test.sql
@@ -4,11 +4,7 @@
 create or replace function tests._clean_sso_migration()
 returns void as $$
 begin
-  delete from public.refresh_tokens;
   delete from public.user_grants;
-  delete from auth.sessions where user_id in (
-    select id from auth.users where email like '%@sso-migration-test.example'
-  );
   delete from auth.identities where user_id in (
     select id from auth.users where email like '%@sso-migration-test.example'
   );
@@ -37,7 +33,6 @@ begin
 
   insert into auth.sso_providers (id) values (provider_acme), (provider_bigcorp);
 
-  delete from tenants;
   insert into tenants (tenant, sso_provider_id) values
     ('acmeCo/', provider_acme),
     ('bigcorpCo/', provider_bigcorp),
@@ -51,11 +46,6 @@ begin
     (old_alice, 'acmeCo/', 'admin'),
     (old_alice, 'bigcorpCo/', 'read'),
     (old_alice, 'openCo/', 'write');
-
-  -- Give old Alice a session and a refresh token.
-  insert into auth.sessions (id, user_id) values (gen_random_uuid(), old_alice);
-  insert into refresh_tokens (user_id, hash, valid_for) values
-    (old_alice, 'fakehash', '30 days');
 
   -- New Alice: SSO user with same email.
   insert into auth.users (id, email, is_sso_user) values
@@ -75,42 +65,12 @@ begin
     'matching SSO + non-SSO grants transferred to new user'
   );
 
-  -- Old user's grants are preserved (account is banned but grants kept for potential reactivation).
+  -- Old user's grants are preserved for the old account.
   return next results_eq(
     $i$ select count(*)::int from user_grants
         where user_id = 'a1111111-1111-1111-1111-111111111111' $i$,
     $i$ values (3) $i$,
     'old user grants preserved'
-  );
-
-  -- Old user is banned in GoTrue.
-  return next results_eq(
-    $i$ select (banned_until > now())::boolean from auth.users
-        where id = 'a1111111-1111-1111-1111-111111111111' $i$,
-    $i$ values (true) $i$,
-    'old user banned in GoTrue'
-  );
-
-  -- Old user sessions cleaned up.
-  return next is_empty(
-    $i$ select 1 from auth.sessions
-        where user_id = 'a1111111-1111-1111-1111-111111111111' $i$,
-    'old user sessions deleted'
-  );
-
-  -- Old user refresh tokens cleaned up.
-  return next is_empty(
-    $i$ select 1 from refresh_tokens
-        where user_id = 'a1111111-1111-1111-1111-111111111111' $i$,
-    'old user refresh tokens deleted'
-  );
-
-  -- bigcorpCo/ grant (different SSO provider) was NOT transferred.
-  return next is_empty(
-    $i$ select 1 from user_grants
-        where user_id = 'a5555555-5555-5555-5555-555555555555'
-          and object_role = 'bigcorpCo/' $i$,
-    'grant on tenant with different SSO provider not transferred'
   );
 
   return;
@@ -129,7 +89,6 @@ begin
 
   insert into auth.sso_providers (id) values (provider_acme);
 
-  delete from tenants;
   insert into tenants (tenant) values ('openCo/');
 
   insert into auth.users (id, email, is_sso_user) values
@@ -173,7 +132,6 @@ begin
 
   insert into auth.sso_providers (id) values (provider_acme);
 
-  delete from tenants;
   insert into tenants (tenant) values ('openCo/');
 
   insert into auth.users (id, email, is_sso_user) values
@@ -247,7 +205,6 @@ begin
 
   insert into auth.sso_providers (id) values (provider_acme), (provider_bigcorp);
 
-  delete from tenants;
   insert into tenants (tenant, sso_provider_id) values
     ('acmeCo/', provider_acme),
     ('bigcorpCo/', provider_bigcorp);
@@ -297,7 +254,6 @@ declare
 begin
   perform tests._clean_sso_migration();
 
-  delete from tenants;
   insert into tenants (tenant) values ('openCo/');
 
   insert into auth.users (id, email, is_sso_user) values


### PR DESCRIPTION
Revising the grant migration trigger I merged yesterday because the "this user is banned" error message is confusing.

We'll lock users out in phase 4c using a supabase auth hook where we can give a better error message. 