### PR TITLE
discovers: replace invalid collection keys with discovered fallback keys

### DIFF
--- a/crates/agent/src/controllers/capture/auto_discover.rs
+++ b/crates/agent/src/controllers/capture/auto_discover.rs
@@ -337,6 +337,13 @@ fn summarize_discover(outcome: &DiscoverOutput) -> String {
         write!(&mut publish_detail, ", {added_disabled} added (disabled)").unwrap();
     }
     publish_detail.push(')');
+
+    for changed in outcome.modified.values() {
+        if let Some(reason) = &changed.reason {
+            write!(&mut publish_detail, "\n- {}: {reason}", changed.target).unwrap();
+        }
+    }
+
     publish_detail
 }
 
@@ -359,4 +366,61 @@ fn record_outcome(status: &mut AutoDiscoverStatus, outcome: AutoDiscoverOutcome)
             last_outcome: outcome,
         });
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use models::discovers::Changed;
+
+    #[test]
+    fn test_summarize_discover_includes_reasons() {
+        let mut modified = models::discovers::Changes::new();
+        modified.insert(
+            vec!["some_table".to_string()],
+            Changed {
+                target: models::Collection::new("acmeCo/some_table"),
+                disable: false,
+                reason: Some(
+                    r#"replaced collection key ["/id"] with fallback ["/foo_id", "/bar_id"] because the existing key no longer exists in the discovered schema"#.to_string(),
+                ),
+            },
+        );
+
+        let output = DiscoverOutput {
+            capture_name: models::Capture::new("acmeCo/source-postgres"),
+            draft: Default::default(),
+            added: Default::default(),
+            modified,
+            removed: Default::default(),
+        };
+
+        let summary = summarize_discover(&output);
+        insta::assert_snapshot!(summary, @r#"auto-discover changes (0 added, 1 modified, 0 removed)
+- acmeCo/some_table: replaced collection key ["/id"] with fallback ["/foo_id", "/bar_id"] because the existing key no longer exists in the discovered schema"#);
+    }
+
+    #[test]
+    fn test_summarize_discover_no_reasons() {
+        let mut modified = models::discovers::Changes::new();
+        modified.insert(
+            vec!["some_table".to_string()],
+            Changed {
+                target: models::Collection::new("acmeCo/some_table"),
+                disable: false,
+                reason: None,
+            },
+        );
+
+        let output = DiscoverOutput {
+            capture_name: models::Capture::new("acmeCo/source-postgres"),
+            draft: Default::default(),
+            added: Default::default(),
+            modified,
+            removed: Default::default(),
+        };
+
+        let summary = summarize_discover(&output);
+        insta::assert_snapshot!(summary, @"auto-discover changes (0 added, 1 modified, 0 removed)");
+    }
 }

--- a/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_create.snap
+++ b/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_create.snap
@@ -49,6 +49,7 @@ expression: path_merge_out
                 "acmeCo/my/bar",
             ),
             disable: true,
+            reason: None,
         },
         [
             "foo",
@@ -57,6 +58,7 @@ expression: path_merge_out
                 "acmeCo/my/foo",
             ),
             disable: false,
+            reason: None,
         },
     },
     {},

--- a/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_resource_paths_update-2.snap
+++ b/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_resource_paths_update-2.snap
@@ -78,6 +78,7 @@ expression: out
                 "acmeCo/other",
             ),
             disable: true,
+            reason: None,
         },
     },
     {
@@ -88,6 +89,7 @@ expression: out
                 "acmeCo/discarded",
             ),
             disable: false,
+            reason: None,
         },
     },
 )

--- a/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_update.snap
+++ b/crates/control-plane-api/src/discovers/snapshots/control_plane_api__discovers__specs__tests__capture_merge_update.snap
@@ -61,6 +61,7 @@ expression: out
                 "acmeCo/barName",
             ),
             disable: true,
+            reason: None,
         },
     },
     {
@@ -71,6 +72,7 @@ expression: out
                 "acmeCo/discarded",
             ),
             disable: false,
+            reason: None,
         },
     },
 )

--- a/crates/control-plane-api/src/discovers/specs.rs
+++ b/crates/control-plane-api/src/discovers/specs.rs
@@ -184,6 +184,7 @@ pub fn update_capture_bindings(
                 Changed {
                     target: target.clone(),
                     disable,
+                    reason: None,
                 },
             );
             let resource = serde_json::from_slice::<models::RawValue>(&resource_config_json)?;
@@ -218,6 +219,7 @@ pub fn update_capture_bindings(
                 Changed {
                     target: binding.target.clone(),
                     disable: binding.disable,
+                    reason: None,
                 },
             )
         })
@@ -307,11 +309,37 @@ pub fn merge_collections(
         };
 
         let mut modified = false;
+        let mut reason: Option<String> = None;
 
-        if !is_fallback_key && !discovered_key.is_empty() && discovered_key != draft_model.key {
+        // Determine whether the collection key should be updated.
+        // Non-fallback keys always replace the draft key. Fallback keys
+        // only replace it when the existing key is provably invalid in
+        // the discovered schema and the fallback key itself resolves,
+        // to avoid replacing one broken key with another.
+        let update_key = if !discovered_key.is_empty() && discovered_key != draft_model.key {
+            if !is_fallback_key {
+                true
+            } else if !key_resolves_in_schema(&draft_model.key, &connector_schema)
+                && key_resolves_in_schema(&discovered_key, &connector_schema)
+            {
+                let old_ptrs: Vec<&str> = draft_model.key.iter().map(|p| p.as_str()).collect();
+                let new_ptrs: Vec<&str> = discovered_key.iter().map(|p| p.as_str()).collect();
+                reason = Some(format!(
+                    "replaced collection key {old_ptrs:?} with fallback {new_ptrs:?} because the existing key no longer exists in the discovered schema",
+                ));
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if update_key {
             tracing::debug!(
                 %collection,
                 ?discovered_key,
+                %is_fallback_key,
                 model_key = ?draft_model.key,
                 "discovered key change"
             );
@@ -378,11 +406,32 @@ pub fn merge_collections(
                 Changed {
                     target: collection.clone(),
                     disable,
+                    reason,
                 },
             );
         }
     }
     Ok(modified_collections)
+}
+
+/// Returns whether every pointer in `key` resolves (Must or May) in `schema`.
+/// Returns false on schema parse errors (conservative: don't change the key).
+fn key_resolves_in_schema(key: &models::CompositeKey, schema: &models::Schema) -> bool {
+    let Ok(built) = doc::validation::build_bundle(schema.get().as_bytes()) else {
+        return false;
+    };
+    let Ok(validator) = doc::Validator::new(built) else {
+        return false;
+    };
+    let shape = doc::Shape::infer(validator.schema(), validator.schema_index());
+
+    key.iter().all(|ptr| {
+        let (_, exists) = shape.locate(&json::Pointer::from_str(ptr.as_str()));
+        matches!(
+            exists,
+            doc::shape::location::Exists::Must | doc::shape::location::Exists::May
+        )
+    })
 }
 
 fn initializes_read_schema(schema: &models::Schema) -> Option<serde_json::Value> {
@@ -621,6 +670,38 @@ mod tests {
                 resource_path: string_vec(&["8"]),
                 disable: false,
             },
+            // case/9: Fallback key replaces existing key when old key is no
+            // longer present in the discovered schema, as when a user removes
+            // the primary key column from a postgres table.
+            Binding {
+                target: models::Collection::new("case/9"),
+                document_schema: models::Schema::new(
+                    models::RawValue::from_str(
+                        r#"{"type": "object", "properties": {"foo_id": {"type": "integer"}, "bar_id": {"type": "integer"}}, "required": ["foo_id", "bar_id"]}"#,
+                    )
+                    .unwrap(),
+                ),
+                collection_key: string_vec(&["/foo_id", "/bar_id"]),
+                is_fallback_key: true,
+                resource_path: string_vec(&["9"]),
+                disable: false,
+            },
+            // case/10: Fallback key does NOT replace existing key when old key
+            // fields still exist in the discovered schema (column exists but
+            // is no longer the primary key).
+            Binding {
+                target: models::Collection::new("case/10"),
+                document_schema: models::Schema::new(
+                    models::RawValue::from_str(
+                        r#"{"type": "object", "properties": {"id": {"type": "integer"}, "foo_id": {"type": "integer"}, "bar_id": {"type": "integer"}}, "required": ["id", "foo_id", "bar_id"]}"#,
+                    )
+                    .unwrap(),
+                ),
+                collection_key: string_vec(&["/foo_id", "/bar_id"]),
+                is_fallback_key: true,
+                resource_path: string_vec(&["10"]),
+                disable: false,
+            },
         ];
 
         let old_schema = json!({
@@ -653,6 +734,14 @@ mod tests {
                 "case/7": {
                     "schema": old_schema,
                     "key": ["/chosen", "/key"],
+                },
+                "case/9": {
+                    "schema": old_schema,
+                    "key": ["/id"],
+                },
+                "case/10": {
+                    "schema": old_schema,
+                    "key": ["/id"],
                 },
             }
         }))
@@ -688,6 +777,34 @@ mod tests {
             spec: Default::default(),
             dependency_hash: None,
         });
+        live.collections.insert(tables::LiveCollection {
+            collection: models::Collection::new("case/9"),
+            control_id: models::Id::zero(),
+            data_plane_id: models::Id::zero(),
+            last_pub_id: models::Id::zero(),
+            last_build_id: models::Id::zero(),
+            model: serde_json::from_value(json!({
+                "schema": old_schema,
+                "key": ["/id"],
+            }))
+            .unwrap(),
+            spec: Default::default(),
+            dependency_hash: None,
+        });
+        live.collections.insert(tables::LiveCollection {
+            collection: models::Collection::new("case/10"),
+            control_id: models::Id::zero(),
+            data_plane_id: models::Id::zero(),
+            last_pub_id: models::Id::zero(),
+            last_build_id: models::Id::zero(),
+            model: serde_json::from_value(json!({
+                "schema": old_schema,
+                "key": ["/id"],
+            }))
+            .unwrap(),
+            spec: Default::default(),
+            dependency_hash: None,
+        });
 
         let modified = super::merge_collections(
             discovered_bindings,
@@ -707,6 +824,18 @@ mod tests {
                   "key": [
                     "/foo",
                     "/bar"
+                  ]
+                },
+                is_touch: 0,
+            },
+            DraftCollection {
+                collection: case/10,
+                scope: flow://collection/case/10,
+                expect_pub_id: NULL,
+                model: {
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"id": {"type": "integer"}, "foo_id": {"type": "integer"}, "bar_id": {"type": "integer"}},"required":["id", "foo_id", "bar_id"],"type":"object"}},"$ref":"flow://connector-schema"},
+                  "key": [
+                    "/id"
                   ]
                 },
                 is_touch: 0,
@@ -818,6 +947,20 @@ mod tests {
                 },
                 is_touch: 0,
             },
+            DraftCollection {
+                collection: case/9,
+                scope: flow://collection/case/9,
+                expect_pub_id: NULL,
+                model: {
+                  "schema": {"$defs":{"flow://connector-schema":{"$id":"flow://connector-schema","properties":{"foo_id": {"type": "integer"}, "bar_id": {"type": "integer"}},"required":["foo_id", "bar_id"],"type":"object"}},"$ref":"flow://connector-schema"},
+                  "key": [
+                    "/foo_id",
+                    "/bar_id"
+                  ],
+                  "reset": true
+                },
+                is_touch: 0,
+            },
         ]
         "###);
 
@@ -825,12 +968,22 @@ mod tests {
         Ok(
             {
                 [
+                    "10",
+                ]: Changed {
+                    target: Collection(
+                        "case/10",
+                    ),
+                    disable: false,
+                    reason: None,
+                },
+                [
                     "3",
                 ]: Changed {
                     target: Collection(
                         "case/3",
                     ),
                     disable: false,
+                    reason: None,
                 },
                 [
                     "6",
@@ -839,6 +992,18 @@ mod tests {
                         "case/6",
                     ),
                     disable: true,
+                    reason: None,
+                },
+                [
+                    "9",
+                ]: Changed {
+                    target: Collection(
+                        "case/9",
+                    ),
+                    disable: false,
+                    reason: Some(
+                        "replaced collection key [\"/id\"] with fallback [\"/foo_id\", \"/bar_id\"] because the existing key no longer exists in the discovered schema",
+                    ),
                 },
             },
         )

--- a/crates/models/src/discovers.rs
+++ b/crates/models/src/discovers.rs
@@ -10,6 +10,8 @@ pub struct Changed {
     pub target: crate::Collection,
     /// Whether the binding is disabled.
     pub disable: bool,
+    /// Optional reason describing a non-obvious change that was made.
+    pub reason: Option<String>,
 }
 /// Represents a set of changes resulting from a discover.
 pub type Changes = BTreeMap<ResourcePath, Changed>;

--- a/crates/models/src/status/capture.rs
+++ b/crates/models/src/status/capture.rs
@@ -42,7 +42,12 @@ pub struct DiscoverChange {
 }
 
 impl DiscoverChange {
-    pub fn new(resource_path: ResourcePath, Changed { target, disable }: Changed) -> Self {
+    pub fn new(
+        resource_path: ResourcePath,
+        Changed {
+            target, disable, ..
+        }: Changed,
+    ) -> Self {
         Self {
             resource_path,
             target,


### PR DESCRIPTION
#### Context

When a user removes a primary key column from a captured table, the connector's discover response returns the updated schema (without that column) and optionally a set of fields which together uniquely identify a row, marked as a fallback key. The discover merge logic is designed to skip key updates for fallback keys, preserving any user-customized key, but it still updates the schema of the collection. The result is a collection whose key references field(s) in the schema that no longer exist, which causes newly captured documents to fail validation due to:

```
location /key is unknown in schema schema://bundle
```

The connector behavior is correct: a secondary unique index is not the primary key, so marking it as a fallback is accurate. The merge logic just didn't account for the case where the existing key becomes invalid after a schema update, and we have a viable alternative in the form of the fallback key.

#### What changed

`merge_collections` now validates the existing key against the discovered schema. When a fallback key is discovered and the existing key no longer resolves (its fields aren't in the schema), the fallback replaces it. Two guards prevent over-application:

1. The existing key must actually be invalid in the discovered schema. If the old column still exists but just isn't the primary key anymore, the existing key is preserved.
2. The discovered fallback key must itself resolve. This prevents replacing one broken key with another.

The key validity check uses `doc::Shape::infer` + `shape.locate()` to determine whether each pointer resolves to an explicit schema location (`Exists::Must` or `Exists::May`) vs an implicit or impossible one.

When a fallback key replacement occurs, a `reason` string is attached to the `Changed` struct and included in the publication detail, producing output like:

```
auto-discover changes (0 added, 1 modified, 0 removed)
- acmeCo/some_table: replaced collection key ["/id"] with fallback ["/foo_id", "/bar_id"] because the existing key no longer exists in the discovered schema
```

---

**Question:** Should this be further constrained to `Exists::Must`? I imagine that we don't currently have any constraint that fields included in a fallback key be required fields, so many of them likely are `Exists::May`. What... happens when a key is optional? Would that even work?