### PR TITLE
Target naming phase 1

### DIFF
--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -414,6 +414,7 @@ mod test {
             bindings: vec![],
             shards: Default::default(),
             source: None,
+            target_naming: None,
             on_incompatible_schema_change: Default::default(),
             expect_pub_id: None,
             delete: false,

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -309,6 +309,7 @@ pub async fn update_source_capture<C: ControlPlane>(
 
     let mut new_model = model.clone();
     update_linked_materialization(
+        model.target_naming.as_ref(),
         model.source.as_ref().unwrap(),
         resource_spec_pointers,
         &status.add_bindings,
@@ -364,6 +365,7 @@ fn get_bindings_to_add(
 }
 
 fn update_linked_materialization(
+    target_naming: Option<&models::TargetNamingStrategy>,
     source_capture: &SourceType,
     resource_spec_pointers: tables::utils::ResourceSpecPointers,
     bindings_to_add: &BTreeSet<models::Collection>,
@@ -372,7 +374,8 @@ fn update_linked_materialization(
     for collection_name in bindings_to_add {
         let mut resource_spec = serde_json::json!({});
         tables::utils::update_materialization_resource_spec(
-            source_capture,
+            target_naming,
+            Some(source_capture),
             &mut resource_spec,
             &resource_spec_pointers,
             &collection_name,

--- a/crates/control-plane-api/src/publications/mod.rs
+++ b/crates/control-plane-api/src/publications/mod.rs
@@ -376,13 +376,13 @@ impl Publisher {
                 .await
                 .context("checking connector images")?
         };
-        let forbidden_source_capture = specs::check_source_capture_annotations(&draft, &self.db)
+        let forbidden_annotations = specs::check_connector_annotations(&draft, &self.db)
             .await
-            .context("checking source capture")?;
-        if !forbidden_images.is_empty() || !forbidden_source_capture.is_empty() {
+            .context("checking connector annotations")?;
+        if !forbidden_images.is_empty() || !forbidden_annotations.is_empty() {
             let mut built = tables::Validations::default();
             built.errors = forbidden_images;
-            built.errors.extend(forbidden_source_capture.into_iter());
+            built.errors.extend(forbidden_annotations.into_iter());
             let output = build::Output {
                 draft,
                 built,

--- a/crates/control-plane-api/src/publications/specs.rs
+++ b/crates/control-plane-api/src/publications/specs.rs
@@ -282,7 +282,7 @@ async fn update_live_specs(
     Ok(lock_failures)
 }
 
-pub async fn check_source_capture_annotations(
+pub async fn check_connector_annotations(
     draft: &tables::DraftCatalog,
     pool: &sqlx::PgPool,
 ) -> anyhow::Result<tables::Errors> {
@@ -297,26 +297,35 @@ pub async fn check_source_capture_annotations(
         };
         let (image_name, image_tag) = split_image_tag(&image);
 
-        let Some(source_capture) = &model.source else {
+        // Skip materializations that have neither sourceCapture nor targetNaming.
+        if model.source.is_none() && model.target_naming.is_none() {
             continue;
-        };
+        }
 
-        // SourceCaptures require a connector_tags row in any case. To avoid an error down the line
-        // in the controller we validate that here. This should only happen for test connector
-        // tags, hence the technical error message
+        // We need the connector's resource config schema to validate x-schema-name support.
+        // This requires a connector_tags row. Missing rows should only occur for test
+        // connector tags, hence the technical error message.
         let Some(connector_spec) =
             crate::connector_tags::fetch_connector_spec(&image_name, &image_tag, pool).await?
         else {
             errors.insert(tables::Error {
                 scope: tables::synthetic_scope(model.catalog_type(), materialization.catalog_name()),
-                error: anyhow::anyhow!("materializations with a sourceCapture only work for known connector tags. {image} is not known to the control plane"),
+                error: anyhow::anyhow!("materializations with a sourceCapture or targetNaming only work for known connector tags. {image} is not known to the control plane"),
             });
             continue;
         };
-        if let SourceType::Configured(source_capture_def) = source_capture {
-            let resource_config_schema = connector_spec.resource_config_schema;
-            let resource_spec_pointers = utils::pointer_for_schema(resource_config_schema.0.get())?;
+        let resource_config_schema = connector_spec.resource_config_schema;
+        let resource_spec_pointers = utils::pointer_for_schema(resource_config_schema.0.get())?;
 
+        // Blanket check: TargetNamingStrategy requires x-schema-name support.
+        if model.target_naming.is_some() && resource_spec_pointers.x_schema_name.is_none() {
+            errors.insert(tables::Error {
+                scope: tables::synthetic_scope(model.catalog_type(), materialization.catalog_name()),
+                error: anyhow::anyhow!("targetNaming requires the connector '{image_name}' to support x-schema-name in its resource config"),
+            });
+        }
+
+        if let Some(SourceType::Configured(source_capture_def)) = &model.source {
             if source_capture_def.delta_updates && resource_spec_pointers.x_delta_updates.is_none()
             {
                 errors.insert(tables::Error {
@@ -325,6 +334,7 @@ pub async fn check_source_capture_annotations(
                 });
             }
 
+            // TODO(js): Remove this check once we finish the target naming migration
             if source_capture_def.target_naming == TargetNaming::WithSchema
                 && resource_spec_pointers.x_schema_name.is_none()
             {

--- a/crates/flow-web/src/lib.rs
+++ b/crates/flow-web/src/lib.rs
@@ -112,7 +112,10 @@ pub fn update_materialization_resource_spec(input: JsValue) -> Result<JsValue, J
     #[derive(serde::Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     struct Input {
-        source_capture: SourceType,
+        #[serde(default)]
+        source_capture: Option<SourceType>,
+        #[serde(default)]
+        target_naming: Option<models::TargetNamingStrategy>,
         resource_spec: serde_json::Value,
         resource_spec_pointers: ResourceSpecPointers,
         collection_name: String,
@@ -120,6 +123,7 @@ pub fn update_materialization_resource_spec(input: JsValue) -> Result<JsValue, J
 
     let Input {
         source_capture,
+        target_naming,
         resource_spec,
         resource_spec_pointers,
         collection_name,
@@ -128,7 +132,8 @@ pub fn update_materialization_resource_spec(input: JsValue) -> Result<JsValue, J
 
     let mut resource_spec = resource_spec.clone();
     tables::utils::update_materialization_resource_spec(
-        &source_capture,
+        target_naming.as_ref(),
+        source_capture.as_ref(),
         &mut resource_spec,
         &resource_spec_pointers,
         collection_name.as_ref(),

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -49,7 +49,7 @@ pub use journals::{
 };
 pub use materializations::{
     MaterializationBinding, MaterializationDef, MaterializationEndpoint, MaterializationFields,
-    RecommendedDepth,
+    RecommendedDepth, TargetNamingStrategy,
 };
 pub use raw_value::RawValue;
 pub use references::{

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -9,6 +9,35 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::BTreeMap;
 
+/// Naming strategy for materialization binding resource names.
+///
+/// Controls how collection names are mapped to destination table and schema
+/// names when bindings are added. Only applies to connectors whose
+/// destination system supports schemas.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(tag = "strategy", rename_all = "camelCase")]
+pub enum TargetNamingStrategy {
+    /// Mirror the source collection's schema structure in the destination.
+    /// The schema component of the collection name becomes the destination schema,
+    /// and the final component becomes the table name.
+    MatchSourceStructure,
+    /// Place all tables in a single named schema, using only the collection's
+    /// final name component as the table name.
+    SingleSchema {
+        /// The destination schema name.
+        schema: String,
+    },
+    /// Prefix table names with the schema component and place them in a named schema.
+    #[serde(rename_all = "camelCase")]
+    PrefixTableNames {
+        /// The destination schema name.
+        schema: String,
+        /// When true, omit the prefix for common default schema names like "public" or "dbo".
+        #[serde(default)]
+        skip_common_defaults: bool,
+    },
+}
+
 /// A Materialization binds a Flow collection with an external system & target
 /// (e.x, a SQL table) into which the collection is to be continuously materialized.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
@@ -19,6 +48,12 @@ pub struct MaterializationDef {
     #[serde(alias = "sourceCapture")]
     #[schemars(with = "SourceType")]
     pub source: Option<SourceType>,
+    /// # Naming strategy for destination resources.
+    /// Controls how collection names are mapped to destination table and schema
+    /// names when bindings are added. Only applies to connectors whose
+    /// destination system supports schemas.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_naming: Option<TargetNamingStrategy>,
     /// # Default handling of schema changes that are incompatible with the target resource.
     /// This can be overridden on a per-binding basis.
     #[serde(
@@ -172,6 +207,7 @@ impl MaterializationDef {
     pub fn example() -> Self {
         Self {
             source: None,
+            target_naming: None,
             endpoint: MaterializationEndpoint::Connector(ConnectorConfig::example()),
             bindings: vec![MaterializationBinding::example()],
             shards: ShardTemplate::default(),

--- a/crates/models/src/materializations.rs
+++ b/crates/models/src/materializations.rs
@@ -14,27 +14,70 @@ use std::collections::BTreeMap;
 /// Controls how collection names are mapped to destination table and schema
 /// names when bindings are added. Only applies to connectors whose
 /// destination system supports schemas.
+///
+/// Given a collection like `acmeCo/marketing/mySchema/myTable`, all
+/// strategies use the last two path segments: `mySchema` and `myTable`.
+///
+/// Template fields use mustache-style substitution to wrap computed names
+/// (e.g. `"staging_{{table}}"` produces `"staging_myTable"`).
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(tag = "strategy", rename_all = "camelCase")]
 pub enum TargetNamingStrategy {
-    /// Mirror the source collection's schema structure in the destination.
-    /// The schema component of the collection name becomes the destination schema,
-    /// and the final component becomes the table name.
-    MatchSourceStructure,
-    /// Place all tables in a single named schema, using only the collection's
-    /// final name component as the table name.
+    /// Use the collection's path segments directly as the destination
+    /// schema and table names.
+    ///
+    /// `acmeCo/mySchema/myTable` -> schema `mySchema`, table `myTable`.
+    #[serde(rename_all = "camelCase")]
+    MatchSourceStructure {
+        /// Template for the table name. `{{table}}` is replaced with
+        /// the last path segment (e.g. `myTable`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(with = "String")]
+        table_template: Option<String>,
+        /// Template for the schema name. `{{schema}}` is replaced with
+        /// the second-to-last path segment (e.g. `mySchema`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(with = "String")]
+        schema_template: Option<String>,
+    },
+    /// Place all tables in a single, explicitly named schema, using only
+    /// the last path segment as the table name.
+    ///
+    /// With `schema: "prod"`: `acmeCo/mySchema/myTable` -> schema `prod`,
+    /// table `myTable`.
+    #[serde(rename_all = "camelCase")]
     SingleSchema {
         /// The destination schema name.
         schema: String,
+        /// Template for the table name. `{{table}}` is replaced with
+        /// the last path segment (e.g. `myTable`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(with = "String")]
+        table_template: Option<String>,
     },
-    /// Prefix table names with the schema component and place them in a named schema.
+    /// Like `singleSchema`, but prefixes each table name with the
+    /// second-to-last path segment and `_` to avoid collisions when
+    /// multiple source schemas contain identically named tables.
+    ///
+    /// With `schema: "prod"`: `acmeCo/mySchema/myTable` -> schema `prod`,
+    /// table `mySchema_myTable`.
+    ///
+    /// With `skipCommonDefaults: true`, the prefix is omitted for common
+    /// defaults (`public`, `dbo`): `acmeCo/public/myTable` -> table
+    /// `myTable` instead of `public_myTable`.
     #[serde(rename_all = "camelCase")]
     PrefixTableNames {
         /// The destination schema name.
         schema: String,
-        /// When true, omit the prefix for common default schema names like "public" or "dbo".
+        /// When true, omit the prefix for common default schema names
+        /// like "public" or "dbo".
         #[serde(default)]
         skip_common_defaults: bool,
+        /// Template for the table name. `{{table}}` is replaced with
+        /// the already-prefixed name (e.g. `mySchema_myTable`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(with = "String")]
+        table_template: Option<String>,
     },
 }
 

--- a/crates/sources/src/inline.rs
+++ b/crates/sources/src/inline.rs
@@ -249,6 +249,7 @@ fn inline_materialization(
 ) {
     let models::MaterializationDef {
         source: _,
+        target_naming: _,
         endpoint,
         bindings,
         shards: _,

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -980,6 +980,18 @@ expression: "&schema"
           "title": "Automatically materialize new bindings from a named capture",
           "$ref": "#/$defs/SourceType"
         },
+        "targetNaming": {
+          "title": "Naming strategy for destination resources.",
+          "description": "Controls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TargetNamingStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "triggers": {
           "title": "Triggers to fire upon transaction completion.",
           "anyOf": [
@@ -1421,6 +1433,65 @@ expression: "&schema"
           "description": "Like `prefixSchema`, except that it will omit the prefix for the\nfollowing common default schema names:\n- public\n- dbo",
           "type": "string",
           "const": "prefixNonDefaultSchema"
+        }
+      ]
+    },
+    "TargetNamingStrategy": {
+      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+      "oneOf": [
+        {
+          "description": "Mirror the source collection's schema structure in the destination.\nThe schema component of the collection name becomes the destination schema,\nand the final component becomes the table name.",
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "string",
+              "const": "matchSourceStructure"
+            }
+          },
+          "required": [
+            "strategy"
+          ]
+        },
+        {
+          "description": "Place all tables in a single named schema, using only the collection's\nfinal name component as the table name.",
+          "type": "object",
+          "properties": {
+            "schema": {
+              "description": "The destination schema name.",
+              "type": "string"
+            },
+            "strategy": {
+              "type": "string",
+              "const": "singleSchema"
+            }
+          },
+          "required": [
+            "strategy",
+            "schema"
+          ]
+        },
+        {
+          "description": "Prefix table names with the schema component and place them in a named schema.",
+          "type": "object",
+          "properties": {
+            "schema": {
+              "description": "The destination schema name.",
+              "type": "string"
+            },
+            "skipCommonDefaults": {
+              "description": "When true, omit the prefix for common default schema names like \"public\" or \"dbo\".",
+              "type": "boolean",
+              "default": false
+            },
+            "strategy": {
+              "type": "string",
+              "const": "prefixTableNames"
+            }
+          },
+          "required": [
+            "strategy",
+            "schema"
+          ]
         }
       ]
     },

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -1437,15 +1437,23 @@ expression: "&schema"
       ]
     },
     "TargetNamingStrategy": {
-      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.\n\nGiven a collection like `acmeCo/marketing/mySchema/myTable`, all\nstrategies use the last two path segments: `mySchema` and `myTable`.\n\nTemplate fields use mustache-style substitution to wrap computed names\n(e.g. `\"staging_{{table}}\"` produces `\"staging_myTable\"`).",
       "oneOf": [
         {
-          "description": "Mirror the source collection's schema structure in the destination.\nThe schema component of the collection name becomes the destination schema,\nand the final component becomes the table name.",
+          "description": "Use the collection's path segments directly as the destination\nschema and table names.\n\n`acmeCo/mySchema/myTable` -> schema `mySchema`, table `myTable`.",
           "type": "object",
           "properties": {
+            "schemaTemplate": {
+              "description": "Template for the schema name. `{{schema}}` is replaced with\nthe second-to-last path segment (e.g. `mySchema`).",
+              "type": "string"
+            },
             "strategy": {
               "type": "string",
               "const": "matchSourceStructure"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe last path segment (e.g. `myTable`).",
+              "type": "string"
             }
           },
           "required": [
@@ -1453,7 +1461,7 @@ expression: "&schema"
           ]
         },
         {
-          "description": "Place all tables in a single named schema, using only the collection's\nfinal name component as the table name.",
+          "description": "Place all tables in a single, explicitly named schema, using only\nthe last path segment as the table name.\n\nWith `schema: \"prod\"`: `acmeCo/mySchema/myTable` -> schema `prod`,\ntable `myTable`.",
           "type": "object",
           "properties": {
             "schema": {
@@ -1463,6 +1471,10 @@ expression: "&schema"
             "strategy": {
               "type": "string",
               "const": "singleSchema"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe last path segment (e.g. `myTable`).",
+              "type": "string"
             }
           },
           "required": [
@@ -1471,7 +1483,7 @@ expression: "&schema"
           ]
         },
         {
-          "description": "Prefix table names with the schema component and place them in a named schema.",
+          "description": "Like `singleSchema`, but prefixes each table name with the\nsecond-to-last path segment and `_` to avoid collisions when\nmultiple source schemas contain identically named tables.\n\nWith `schema: \"prod\"`: `acmeCo/mySchema/myTable` -> schema `prod`,\ntable `mySchema_myTable`.\n\nWith `skipCommonDefaults: true`, the prefix is omitted for common\ndefaults (`public`, `dbo`): `acmeCo/public/myTable` -> table\n`myTable` instead of `public_myTable`.",
           "type": "object",
           "properties": {
             "schema": {
@@ -1479,13 +1491,17 @@ expression: "&schema"
               "type": "string"
             },
             "skipCommonDefaults": {
-              "description": "When true, omit the prefix for common default schema names like \"public\" or \"dbo\".",
+              "description": "When true, omit the prefix for common default schema names\nlike \"public\" or \"dbo\".",
               "type": "boolean",
               "default": false
             },
             "strategy": {
               "type": "string",
               "const": "prefixTableNames"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe already-prefixed name (e.g. `mySchema_myTable`).",
+              "type": "string"
             }
           },
           "required": [

--- a/crates/tables/src/utils.rs
+++ b/crates/tables/src/utils.rs
@@ -34,22 +34,38 @@ pub fn update_materialization_resource_spec(
 
     let (x_collection_name, maybe_x_schema_name) = if let Some(strategy) = target_naming {
         match strategy {
-            TargetNamingStrategy::MatchSourceStructure => {
-                (split[0].to_string(), Some(split[1].to_string()))
-            }
-            TargetNamingStrategy::SingleSchema { schema } => {
-                (split[0].to_string(), Some(schema.clone()))
-            }
+            TargetNamingStrategy::MatchSourceStructure {
+                table_template,
+                schema_template,
+            } => (
+                apply_template(table_template.as_deref(), "{{table}}", split[0]),
+                Some(apply_template(
+                    schema_template.as_deref(),
+                    "{{schema}}",
+                    split[1],
+                )),
+            ),
+            TargetNamingStrategy::SingleSchema {
+                schema,
+                table_template,
+            } => (
+                apply_template(table_template.as_deref(), "{{table}}", split[0]),
+                Some(schema.clone()),
+            ),
             TargetNamingStrategy::PrefixTableNames {
                 schema,
                 skip_common_defaults,
+                table_template,
             } => {
-                let name = if *skip_common_defaults && is_default_schema_name(split[1]) {
+                let base = if *skip_common_defaults && is_default_schema_name(split[1]) {
                     split[0].to_string()
                 } else {
                     format!("{}_{}", split[1], split[0])
                 };
-                (name, Some(schema.clone()))
+                (
+                    apply_template(table_template.as_deref(), "{{table}}", &base),
+                    Some(schema.clone()),
+                )
             }
         }
     } else if let Some(source) = source_capture {
@@ -167,6 +183,13 @@ pub fn pointer_for_schema(schema: &str) -> anyhow::Result<ResourceSpecPointers> 
         Err(anyhow::anyhow!(
             "resource spec schema does not contain any location annotated with x-collection-name"
         ))
+    }
+}
+
+fn apply_template(template: Option<&str>, placeholder: &str, value: &str) -> String {
+    match template {
+        Some(t) => t.replacen(placeholder, value, 1),
+        None => value.to_string(),
     }
 }
 
@@ -353,7 +376,10 @@ mod test {
 
     #[test]
     fn test_target_naming_strategy_match_source_structure() {
-        let strategy = models::TargetNamingStrategy::MatchSourceStructure;
+        let strategy = models::TargetNamingStrategy::MatchSourceStructure {
+            table_template: None,
+            schema_template: None,
+        };
 
         let result = test_update_strategy(
             json!({}),
@@ -373,6 +399,7 @@ mod test {
     fn test_target_naming_strategy_single_schema() {
         let strategy = models::TargetNamingStrategy::SingleSchema {
             schema: "prod".to_string(),
+            table_template: None,
         };
 
         let result = test_update_strategy(
@@ -394,6 +421,7 @@ mod test {
         let strategy = models::TargetNamingStrategy::PrefixTableNames {
             schema: "prod".to_string(),
             skip_common_defaults: false,
+            table_template: None,
         };
 
         let result = test_update_strategy(
@@ -413,6 +441,7 @@ mod test {
         let strategy_skip = models::TargetNamingStrategy::PrefixTableNames {
             schema: "prod".to_string(),
             skip_common_defaults: true,
+            table_template: None,
         };
 
         let result = test_update_strategy(
@@ -449,6 +478,7 @@ mod test {
         // delta_updates defaults to false when source_capture is absent.
         let strategy = models::TargetNamingStrategy::SingleSchema {
             schema: "prod".to_string(),
+            table_template: None,
         };
         let mut existing = json!({});
         update_materialization_resource_spec(
@@ -469,6 +499,7 @@ mod test {
     fn test_target_naming_strategy_with_delta_updates() {
         let strategy = models::TargetNamingStrategy::SingleSchema {
             schema: "prod".to_string(),
+            table_template: None,
         };
 
         // delta_updates from source_capture is honored
@@ -490,13 +521,18 @@ mod test {
     fn test_target_naming_strategy_requires_x_schema_name() {
         // All strategy variants error when x-schema-name is absent.
         for strategy in &[
-            models::TargetNamingStrategy::MatchSourceStructure,
+            models::TargetNamingStrategy::MatchSourceStructure {
+                table_template: None,
+                schema_template: None,
+            },
             models::TargetNamingStrategy::SingleSchema {
                 schema: "prod".to_string(),
+                table_template: None,
             },
             models::TargetNamingStrategy::PrefixTableNames {
                 schema: "prod".to_string(),
                 skip_common_defaults: false,
+                table_template: None,
             },
         ] {
             let mut existing = json!({});
@@ -530,5 +566,115 @@ mod test {
             "no naming strategy available: both targetNaming and sourceCapture are absent",
             err.to_string()
         );
+    }
+
+    #[test]
+    fn test_match_source_structure_with_templates() {
+        let strategy = models::TargetNamingStrategy::MatchSourceStructure {
+            table_template: Some("staging_{{table}}".to_string()),
+            schema_template: Some("analytics_{{schema}}".to_string()),
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "staging_myTable", "schemaName": "analytics_mySchema"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_single_schema_with_table_template() {
+        let strategy = models::TargetNamingStrategy::SingleSchema {
+            schema: "prod".to_string(),
+            table_template: Some("v2_{{table}}".to_string()),
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "v2_myTable", "schemaName": "prod"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_prefix_table_names_with_table_template() {
+        let strategy = models::TargetNamingStrategy::PrefixTableNames {
+            schema: "prod".to_string(),
+            skip_common_defaults: false,
+            table_template: Some("v_{{table}}".to_string()),
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "v_mySchema_myTable", "schemaName": "prod"}),
+            result,
+        );
+
+        // With skip_common_defaults + template
+        let strategy_skip = models::TargetNamingStrategy::PrefixTableNames {
+            schema: "prod".to_string(),
+            skip_common_defaults: true,
+            table_template: Some("v_{{table}}".to_string()),
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/public/myTable",
+            &strategy_skip,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "v_myTable", "schemaName": "prod"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_template_serde_round_trip() {
+        // None templates are omitted from serialization.
+        let strategy = models::TargetNamingStrategy::MatchSourceStructure {
+            table_template: None,
+            schema_template: None,
+        };
+        let json = serde_json::to_value(&strategy).unwrap();
+        assert_eq!(json, json!({"strategy": "matchSourceStructure"}));
+        let round_tripped: models::TargetNamingStrategy = serde_json::from_value(json).unwrap();
+        assert_eq!(round_tripped, strategy);
+
+        // Present templates are preserved.
+        let strategy = models::TargetNamingStrategy::MatchSourceStructure {
+            table_template: Some("staging_{{table}}".to_string()),
+            schema_template: Some("analytics_{{schema}}".to_string()),
+        };
+        let json = serde_json::to_value(&strategy).unwrap();
+        assert_eq!(
+            json,
+            json!({"strategy": "matchSourceStructure", "tableTemplate": "staging_{{table}}", "schemaTemplate": "analytics_{{schema}}"})
+        );
+        let round_tripped: models::TargetNamingStrategy = serde_json::from_value(json).unwrap();
+        assert_eq!(round_tripped, strategy);
     }
 }

--- a/crates/tables/src/utils.rs
+++ b/crates/tables/src/utils.rs
@@ -1,4 +1,4 @@
-use models::{SourceType, TargetNaming};
+use models::{SourceType, TargetNaming, TargetNamingStrategy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -9,16 +9,21 @@ pub struct ResourceSpecPointers {
     pub x_delta_updates: Option<json::Pointer>,
 }
 
-///
 /// # Panics
 /// If the `full_collection_name` doesn't contain any `/` characters, which should never
 /// be the case since we should have already validated the collection name.
 pub fn update_materialization_resource_spec(
-    source_capture: &SourceType,
+    target_naming: Option<&TargetNamingStrategy>,
+    source_capture: Option<&SourceType>,
     resource_spec: &mut Value,
     resource_spec_pointers: &ResourceSpecPointers,
     full_collection_name: &str,
 ) -> anyhow::Result<()> {
+    // TargetNamingStrategy requires x-schema-name support from the connector.
+    if target_naming.is_some() && resource_spec_pointers.x_schema_name.is_none() {
+        anyhow::bail!("targetNaming requires a connector that supports x-schema-name");
+    }
+
     let split: Vec<&str> = full_collection_name.rsplit('/').take(2).collect();
 
     if split.len() < 2 {
@@ -27,25 +32,55 @@ pub fn update_materialization_resource_spec(
         ));
     }
 
-    let source_capture_def = source_capture.to_normalized_def();
+    let (x_collection_name, maybe_x_schema_name) = if let Some(strategy) = target_naming {
+        match strategy {
+            TargetNamingStrategy::MatchSourceStructure => {
+                (split[0].to_string(), Some(split[1].to_string()))
+            }
+            TargetNamingStrategy::SingleSchema { schema } => {
+                (split[0].to_string(), Some(schema.clone()))
+            }
+            TargetNamingStrategy::PrefixTableNames {
+                schema,
+                skip_common_defaults,
+            } => {
+                let name = if *skip_common_defaults && is_default_schema_name(split[1]) {
+                    split[0].to_string()
+                } else {
+                    format!("{}_{}", split[1], split[0])
+                };
+                (name, Some(schema.clone()))
+            }
+        }
+    } else if let Some(source) = source_capture {
+        let source_def = source.to_normalized_def();
 
-    let maybe_x_schema_name = match source_capture_def.target_naming {
-        TargetNaming::WithSchema => Some(split[1].to_string()),
-        TargetNaming::NoSchema
-        | TargetNaming::PrefixSchema
-        | TargetNaming::PrefixNonDefaultSchema => None,
+        // TODO(js): Remove this legacy path once we finish the target naming migration.
+        let schema = match source_def.target_naming {
+            TargetNaming::WithSchema => Some(split[1].to_string()),
+            TargetNaming::NoSchema
+            | TargetNaming::PrefixSchema
+            | TargetNaming::PrefixNonDefaultSchema => None,
+        };
+
+        let name = match source_def.target_naming {
+            TargetNaming::NoSchema | TargetNaming::WithSchema => split[0].to_string(),
+            TargetNaming::PrefixNonDefaultSchema if is_default_schema_name(split[1]) => {
+                split[0].to_string()
+            }
+            TargetNaming::PrefixNonDefaultSchema | TargetNaming::PrefixSchema => {
+                format!("{}_{}", split[1], split[0])
+            }
+        };
+
+        (name, schema)
+    } else {
+        anyhow::bail!(
+            "no naming strategy available: both targetNaming and sourceCapture are absent"
+        );
     };
 
-    let x_collection_name = match source_capture_def.target_naming {
-        TargetNaming::NoSchema | TargetNaming::WithSchema => split[0].to_string(),
-        TargetNaming::PrefixNonDefaultSchema if is_default_schema_name(&split[1]) => {
-            split[0].to_string()
-        }
-        TargetNaming::PrefixNonDefaultSchema | TargetNaming::PrefixSchema => {
-            format!("{}_{}", split[1], split[0])
-        }
-    };
-
+    // Write x-collection-name.
     let x_collection_name_ptr = &resource_spec_pointers.x_collection_name;
     let Some(x_collection_name_prev) =
         json::ptr::create_value(x_collection_name_ptr, resource_spec)
@@ -56,6 +91,7 @@ pub fn update_materialization_resource_spec(
     };
     let _ = std::mem::replace(x_collection_name_prev, x_collection_name.into());
 
+    // Write x-schema-name when resolved.
     if let Some(x_schema_name) = maybe_x_schema_name {
         let Some(x_schema_name_ptr) = &resource_spec_pointers.x_schema_name else {
             anyhow::bail!(
@@ -71,7 +107,12 @@ pub fn update_materialization_resource_spec(
         let _ = std::mem::replace(x_schema_name_prev, x_schema_name.into());
     }
 
-    if source_capture_def.delta_updates {
+    // Write x-delta-updates from source_capture.
+    let delta_updates = source_capture
+        .map(|s| s.to_normalized_def().delta_updates)
+        .unwrap_or(false);
+
+    if delta_updates {
         let Some(x_delta_updates_ptr) = &resource_spec_pointers.x_delta_updates else {
             anyhow::bail!(
                 "sources.deltaUpdates is true, but the materialization connector does not support it"
@@ -138,31 +179,89 @@ mod test {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn test_updating_materialization_resource_spec() {
-        let pointers_full = ResourceSpecPointers {
+    fn pointers_full() -> ResourceSpecPointers {
+        ResourceSpecPointers {
             x_collection_name: json::Pointer::from("/collectionName"),
             x_schema_name: Some(json::Pointer::from("/schemaName")),
             x_delta_updates: Some(json::Pointer::from("/deltaUpdates")),
-        };
-        let pointers_no_schema = ResourceSpecPointers {
+        }
+    }
+
+    fn pointers_no_schema() -> ResourceSpecPointers {
+        ResourceSpecPointers {
             x_collection_name: json::Pointer::from("/collectionName"),
             x_schema_name: None,
             x_delta_updates: Some(json::Pointer::from("/deltaUpdates")),
-        };
-        let pointers_sparse = ResourceSpecPointers {
+        }
+    }
+
+    fn pointers_sparse() -> ResourceSpecPointers {
+        ResourceSpecPointers {
             x_collection_name: json::Pointer::from("/collectionName"),
             x_schema_name: None,
             x_delta_updates: None,
-        };
+        }
+    }
 
-        // A non-default schema name gets added as a prefix
-        let result = test_update(
+    /// Helper for the legacy path (source_capture only, no top-level target_naming).
+    fn test_update_legacy(
+        mut existing: serde_json::Value,
+        collection_name: &str,
+        target_naming: models::TargetNaming,
+        delta_updates: bool,
+        pointers: &ResourceSpecPointers,
+    ) -> anyhow::Result<serde_json::Value> {
+        let source = models::SourceType::Configured(models::SourceDef {
+            capture: None,
+            target_naming,
+            delta_updates,
+            fields_recommended: Default::default(),
+        });
+        update_materialization_resource_spec(
+            None,
+            Some(&source),
+            &mut existing,
+            pointers,
+            collection_name,
+        )?;
+        Ok(existing)
+    }
+
+    /// Helper for the new path (top-level target_naming, optional source_capture for delta_updates).
+    fn test_update_strategy(
+        mut existing: serde_json::Value,
+        collection_name: &str,
+        strategy: &models::TargetNamingStrategy,
+        delta_updates: bool,
+        pointers: &ResourceSpecPointers,
+    ) -> anyhow::Result<serde_json::Value> {
+        let source = models::SourceType::Configured(models::SourceDef {
+            capture: None,
+            target_naming: models::TargetNaming::NoSchema,
+            delta_updates,
+            fields_recommended: Default::default(),
+        });
+        update_materialization_resource_spec(
+            Some(strategy),
+            Some(&source),
+            &mut existing,
+            pointers,
+            collection_name,
+        )?;
+        Ok(existing)
+    }
+
+    #[test]
+    fn test_legacy_naming_unchanged() {
+        // Legacy tests: behavior is identical to the old function signature.
+
+        // PrefixNonDefaultSchema: non-default schema gets prefixed
+        let result = test_update_legacy(
             json!({}),
             "test/skeema/kollection",
             models::TargetNaming::PrefixNonDefaultSchema,
             true,
-            &pointers_no_schema,
+            &pointers_no_schema(),
         )
         .expect("failed to update");
         assert_eq!(
@@ -170,36 +269,38 @@ mod test {
             result
         );
 
-        // Update the existing resource and expect that it no longer has the schema prefix
-        let result = test_update(
+        // PrefixNonDefaultSchema: default "public" schema is NOT prefixed
+        let result = test_update_legacy(
             result,
             "test/public/differentCollection",
             models::TargetNaming::PrefixNonDefaultSchema,
             true,
-            &pointers_no_schema,
+            &pointers_no_schema(),
         )
         .expect("failed to update");
         assert_eq!(
             json!({"collectionName": "differentCollection", "deltaUpdates": true}),
             result,
         );
-        // The default dbo schema also doesn't get added as a prefix
-        let result = test_update(
+
+        // PrefixNonDefaultSchema: default "dbo" schema is NOT prefixed
+        let result = test_update_legacy(
             json!({}),
             "test/dbo/kollection",
             models::TargetNaming::PrefixNonDefaultSchema,
             false,
-            &pointers_sparse,
+            &pointers_sparse(),
         )
         .expect("failed to update");
-        assert_eq!(json!({"collectionName": "kollection"}), result,);
+        assert_eq!(json!({"collectionName": "kollection"}), result);
 
-        let result = test_update(
+        // WithSchema: schema from collection name
+        let result = test_update_legacy(
             json!({}),
             "test/dbo/kollection",
             models::TargetNaming::WithSchema,
             false,
-            &pointers_full,
+            &pointers_full(),
         )
         .expect("failed to update");
         assert_eq!(
@@ -207,12 +308,13 @@ mod test {
             result,
         );
 
-        let result = test_update(
+        // PrefixSchema: always prefixes
+        let result = test_update_legacy(
             json!({}),
             "test/public/kollection",
             models::TargetNaming::PrefixSchema,
             true,
-            &pointers_no_schema,
+            &pointers_no_schema(),
         )
         .expect("failed to update");
         assert_eq!(
@@ -220,14 +322,13 @@ mod test {
             result,
         );
 
-        // Error cases:
-        // ResourceSpecPointers are missing x-schema-name
-        let err = test_update(
+        // Error: WithSchema without x-schema-name support
+        let err = test_update_legacy(
             json!({}),
             "test/public/kollection",
             models::TargetNaming::WithSchema,
             true,
-            &pointers_no_schema,
+            &pointers_no_schema(),
         )
         .expect_err("should fail");
         assert_eq!(
@@ -235,13 +336,13 @@ mod test {
             err.to_string()
         );
 
-        // ResourceSpecPointers are missing x-delta-updates
-        let err = test_update(
+        // Error: delta_updates without x-delta-updates support
+        let err = test_update_legacy(
             json!({}),
             "test/public/kollection",
             models::TargetNaming::NoSchema,
             true,
-            &pointers_sparse,
+            &pointers_sparse(),
         )
         .expect_err("should fail");
         assert_eq!(
@@ -250,20 +351,184 @@ mod test {
         );
     }
 
-    fn test_update(
-        mut existing: serde_json::Value,
-        collection_name: &str,
-        target_naming: models::TargetNaming,
-        delta_updates: bool,
-        pointers: &ResourceSpecPointers,
-    ) -> anyhow::Result<serde_json::Value> {
-        let sources = models::SourceType::Configured(models::SourceDef {
-            capture: None,
-            target_naming,
-            delta_updates,
-            fields_recommended: Default::default(),
-        });
-        update_materialization_resource_spec(&sources, &mut existing, pointers, collection_name)?;
-        Ok(existing)
+    #[test]
+    fn test_target_naming_strategy_match_source_structure() {
+        let strategy = models::TargetNamingStrategy::MatchSourceStructure;
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "myTable", "schemaName": "mySchema"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_target_naming_strategy_single_schema() {
+        let strategy = models::TargetNamingStrategy::SingleSchema {
+            schema: "prod".to_string(),
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "myTable", "schemaName": "prod"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_target_naming_strategy_prefix_table_names() {
+        let strategy = models::TargetNamingStrategy::PrefixTableNames {
+            schema: "prod".to_string(),
+            skip_common_defaults: false,
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "mySchema_myTable", "schemaName": "prod"}),
+            result,
+        );
+
+        // With skip_common_defaults: "public" is skipped
+        let strategy_skip = models::TargetNamingStrategy::PrefixTableNames {
+            schema: "prod".to_string(),
+            skip_common_defaults: true,
+        };
+
+        let result = test_update_strategy(
+            json!({}),
+            "test/public/myTable",
+            &strategy_skip,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "myTable", "schemaName": "prod"}),
+            result,
+        );
+
+        // Without skip_common_defaults: "public" IS prefixed
+        let result = test_update_strategy(
+            json!({}),
+            "test/public/myTable",
+            &strategy,
+            false,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "public_myTable", "schemaName": "prod"}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_target_naming_strategy_without_source_capture() {
+        // Materializations without sourceCapture can use targetNaming.
+        // delta_updates defaults to false when source_capture is absent.
+        let strategy = models::TargetNamingStrategy::SingleSchema {
+            schema: "prod".to_string(),
+        };
+        let mut existing = json!({});
+        update_materialization_resource_spec(
+            Some(&strategy),
+            None,
+            &mut existing,
+            &pointers_full(),
+            "test/mySchema/myTable",
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "myTable", "schemaName": "prod"}),
+            existing,
+        );
+    }
+
+    #[test]
+    fn test_target_naming_strategy_with_delta_updates() {
+        let strategy = models::TargetNamingStrategy::SingleSchema {
+            schema: "prod".to_string(),
+        };
+
+        // delta_updates from source_capture is honored
+        let result = test_update_strategy(
+            json!({}),
+            "test/mySchema/myTable",
+            &strategy,
+            true,
+            &pointers_full(),
+        )
+        .expect("failed to update");
+        assert_eq!(
+            json!({"collectionName": "myTable", "schemaName": "prod", "deltaUpdates": true}),
+            result,
+        );
+    }
+
+    #[test]
+    fn test_target_naming_strategy_requires_x_schema_name() {
+        // All strategy variants error when x-schema-name is absent.
+        for strategy in &[
+            models::TargetNamingStrategy::MatchSourceStructure,
+            models::TargetNamingStrategy::SingleSchema {
+                schema: "prod".to_string(),
+            },
+            models::TargetNamingStrategy::PrefixTableNames {
+                schema: "prod".to_string(),
+                skip_common_defaults: false,
+            },
+        ] {
+            let mut existing = json!({});
+            let err = update_materialization_resource_spec(
+                Some(strategy),
+                None,
+                &mut existing,
+                &pointers_no_schema(),
+                "test/public/kollection",
+            )
+            .expect_err("should fail");
+            assert_eq!(
+                "targetNaming requires a connector that supports x-schema-name",
+                err.to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_naming_no_source_errors() {
+        let mut existing = json!({});
+        let err = update_materialization_resource_spec(
+            None,
+            None,
+            &mut existing,
+            &pointers_full(),
+            "test/public/kollection",
+        )
+        .expect_err("should fail");
+        assert_eq!(
+            "no naming strategy available: both targetNaming and sourceCapture are absent",
+            err.to_string()
+        );
     }
 }

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -114,6 +114,7 @@ async fn walk_materialization<C: Connectors>(
     let models::MaterializationDef {
         on_incompatible_schema_change,
         source: sources,
+        mut target_naming,
         endpoint,
         bindings: bindings_model,
         mut shards,
@@ -122,6 +123,20 @@ async fn walk_materialization<C: Connectors>(
         delete: _,
         reset,
     } = model;
+
+    // Model fix #1: Promote source.target_naming == WithSchema to top-level
+    // MatchSourceStructure. This is safe because MatchSourceStructure and WithSchema
+    // represent identical behavior.
+    if target_naming.is_none() {
+        if let Some(source) = &sources {
+            if source.to_normalized_def().target_naming == models::TargetNaming::WithSchema {
+                target_naming = Some(models::TargetNamingStrategy::MatchSourceStructure);
+                model_fixes.push(
+                    "promoted source.targetNaming 'withSchema' to top-level targetNaming 'matchSourceStructure'".to_string(),
+                );
+            }
+        }
+    }
 
     indexed::walk_name(
         scope,
@@ -624,6 +639,7 @@ async fn walk_materialization<C: Connectors>(
     };
     let model = models::MaterializationDef {
         source: sources,
+        target_naming,
         on_incompatible_schema_change,
         endpoint,
         bindings: bindings_model,

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -114,7 +114,7 @@ async fn walk_materialization<C: Connectors>(
     let models::MaterializationDef {
         on_incompatible_schema_change,
         source: sources,
-        mut target_naming,
+        target_naming,
         endpoint,
         bindings: bindings_model,
         mut shards,
@@ -123,20 +123,6 @@ async fn walk_materialization<C: Connectors>(
         delete: _,
         reset,
     } = model;
-
-    // Model fix #1: Promote source.target_naming == WithSchema to top-level
-    // MatchSourceStructure. This is safe because MatchSourceStructure and WithSchema
-    // represent identical behavior.
-    if target_naming.is_none() {
-        if let Some(source) = &sources {
-            if source.to_normalized_def().target_naming == models::TargetNaming::WithSchema {
-                target_naming = Some(models::TargetNamingStrategy::MatchSourceStructure);
-                model_fixes.push(
-                    "promoted source.targetNaming 'withSchema' to top-level targetNaming 'matchSourceStructure'".to_string(),
-                );
-            }
-        }
-    }
 
     indexed::walk_name(
         scope,

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -296,6 +296,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
             expect_pub_id: None,
             shards: models::ShardTemplate::default(),
             source: None,
+            target_naming: None,
             triggers: None,
             delete: false,
             reset: false,

--- a/crates/validation/tests/snapshots/field_selection_conflicts__abort.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__abort.snap
@@ -22,6 +22,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Abort,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/field_selection_conflicts__backfill_binding.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__backfill_binding.snap
@@ -22,6 +22,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Backfill,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/field_selection_conflicts__disable_binding.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__disable_binding.snap
@@ -9,6 +9,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: DisableBinding,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/field_selection_conflicts__disable_task.snap
+++ b/crates/validation/tests/snapshots/field_selection_conflicts__disable_task.snap
@@ -9,6 +9,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: DisableTask,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding.snap
@@ -19,6 +19,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Backfill,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding_with_reset.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__backfill_binding_with_reset.snap
@@ -19,6 +19,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Backfill,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__disable_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__disable_binding.snap
@@ -9,6 +9,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: DisableBinding,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__disable_task.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__disable_task.snap
@@ -9,6 +9,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: DisableTask,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__noop_with_delta_binding.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__noop_with_delta_binding.snap
@@ -19,6 +19,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Backfill,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/group_by_conflicts__noop_with_manual_group_by.snap
+++ b/crates/validation/tests/snapshots/group_by_conflicts__noop_with_manual_group_by.snap
@@ -20,6 +20,7 @@ expression: "(selections, errors)"
             Some(
                 MaterializationDef {
                     source: None,
+                    target_naming: None,
                     on_incompatible_schema_change: Abort,
                     endpoint: Connector(
                         ConnectorConfig {

--- a/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
+++ b/crates/validation/tests/snapshots/transition_tests__group_by_migration.snap
@@ -6,6 +6,7 @@ expression: "(&outcome.built_materializations[0].model,\n&outcome.built_material
     Some(
         MaterializationDef {
             source: None,
+            target_naming: None,
             on_incompatible_schema_change: Backfill,
             endpoint: Connector(
                 ConnectorConfig {

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -1433,15 +1433,23 @@
       ]
     },
     "TargetNamingStrategy": {
-      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.\n\nGiven a collection like `acmeCo/marketing/mySchema/myTable`, all\nstrategies use the last two path segments: `mySchema` and `myTable`.\n\nTemplate fields use mustache-style substitution to wrap computed names\n(e.g. `\"staging_{{table}}\"` produces `\"staging_myTable\"`).",
       "oneOf": [
         {
-          "description": "Mirror the source collection's schema structure in the destination.\nThe schema component of the collection name becomes the destination schema,\nand the final component becomes the table name.",
+          "description": "Use the collection's path segments directly as the destination\nschema and table names.\n\n`acmeCo/mySchema/myTable` -> schema `mySchema`, table `myTable`.",
           "type": "object",
           "properties": {
+            "schemaTemplate": {
+              "description": "Template for the schema name. `{{schema}}` is replaced with\nthe second-to-last path segment (e.g. `mySchema`).",
+              "type": "string"
+            },
             "strategy": {
               "type": "string",
               "const": "matchSourceStructure"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe last path segment (e.g. `myTable`).",
+              "type": "string"
             }
           },
           "required": [
@@ -1449,7 +1457,7 @@
           ]
         },
         {
-          "description": "Place all tables in a single named schema, using only the collection's\nfinal name component as the table name.",
+          "description": "Place all tables in a single, explicitly named schema, using only\nthe last path segment as the table name.\n\nWith `schema: \"prod\"`: `acmeCo/mySchema/myTable` -> schema `prod`,\ntable `myTable`.",
           "type": "object",
           "properties": {
             "schema": {
@@ -1459,6 +1467,10 @@
             "strategy": {
               "type": "string",
               "const": "singleSchema"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe last path segment (e.g. `myTable`).",
+              "type": "string"
             }
           },
           "required": [
@@ -1467,7 +1479,7 @@
           ]
         },
         {
-          "description": "Prefix table names with the schema component and place them in a named schema.",
+          "description": "Like `singleSchema`, but prefixes each table name with the\nsecond-to-last path segment and `_` to avoid collisions when\nmultiple source schemas contain identically named tables.\n\nWith `schema: \"prod\"`: `acmeCo/mySchema/myTable` -> schema `prod`,\ntable `mySchema_myTable`.\n\nWith `skipCommonDefaults: true`, the prefix is omitted for common\ndefaults (`public`, `dbo`): `acmeCo/public/myTable` -> table\n`myTable` instead of `public_myTable`.",
           "type": "object",
           "properties": {
             "schema": {
@@ -1475,13 +1487,17 @@
               "type": "string"
             },
             "skipCommonDefaults": {
-              "description": "When true, omit the prefix for common default schema names like \"public\" or \"dbo\".",
+              "description": "When true, omit the prefix for common default schema names\nlike \"public\" or \"dbo\".",
               "type": "boolean",
               "default": false
             },
             "strategy": {
               "type": "string",
               "const": "prefixTableNames"
+            },
+            "tableTemplate": {
+              "description": "Template for the table name. `{{table}}` is replaced with\nthe already-prefixed name (e.g. `mySchema_myTable`).",
+              "type": "string"
             }
           },
           "required": [

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -799,6 +799,15 @@
         "name"
       ]
     },
+    "HttpMethod": {
+      "description": "HTTP method for the webhook request.",
+      "type": "string",
+      "enum": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ]
+    },
     "Id": {
       "type": "string"
     },
@@ -966,6 +975,29 @@
         "source": {
           "title": "Automatically materialize new bindings from a named capture",
           "$ref": "#/$defs/SourceType"
+        },
+        "targetNaming": {
+          "title": "Naming strategy for destination resources.",
+          "description": "Controls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TargetNamingStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "triggers": {
+          "title": "Triggers to fire upon transaction completion.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Triggers"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -1400,6 +1432,65 @@
         }
       ]
     },
+    "TargetNamingStrategy": {
+      "description": "Naming strategy for materialization binding resource names.\n\nControls how collection names are mapped to destination table and schema\nnames when bindings are added. Only applies to connectors whose\ndestination system supports schemas.",
+      "oneOf": [
+        {
+          "description": "Mirror the source collection's schema structure in the destination.\nThe schema component of the collection name becomes the destination schema,\nand the final component becomes the table name.",
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "string",
+              "const": "matchSourceStructure"
+            }
+          },
+          "required": [
+            "strategy"
+          ]
+        },
+        {
+          "description": "Place all tables in a single named schema, using only the collection's\nfinal name component as the table name.",
+          "type": "object",
+          "properties": {
+            "schema": {
+              "description": "The destination schema name.",
+              "type": "string"
+            },
+            "strategy": {
+              "type": "string",
+              "const": "singleSchema"
+            }
+          },
+          "required": [
+            "strategy",
+            "schema"
+          ]
+        },
+        {
+          "description": "Prefix table names with the schema component and place them in a named schema.",
+          "type": "object",
+          "properties": {
+            "schema": {
+              "description": "The destination schema name.",
+              "type": "string"
+            },
+            "skipCommonDefaults": {
+              "description": "When true, omit the prefix for common default schema names like \"public\" or \"dbo\".",
+              "type": "boolean",
+              "default": false
+            },
+            "strategy": {
+              "type": "string",
+              "const": "prefixTableNames"
+            }
+          },
+          "required": [
+            "strategy",
+            "schema"
+          ]
+        }
+      ]
+    },
     "TestDef": {
       "description": "Test the behavior of reductions and derivations, through a sequence of test steps.",
       "type": "object",
@@ -1689,6 +1780,75 @@
         "name",
         "source",
         "shuffle"
+      ]
+    },
+    "TriggerConfig": {
+      "description": "Configuration for a webhook trigger that fires when new data is\nmaterialized to the endpoint.",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "title": "HTTP headers to include in the webhook request.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "secret": true
+          }
+        },
+        "maxAttempts": {
+          "title": "Maximum number of delivery attempts (including the initial attempt).",
+          "description": "The task is failed if all attempts are exhausted without a successful delivery.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 3,
+          "minimum": 0
+        },
+        "method": {
+          "title": "HTTP method to use for the webhook request.",
+          "$ref": "#/$defs/HttpMethod",
+          "default": "POST"
+        },
+        "payloadTemplate": {
+          "title": "Handlebars template for the JSON payload body.",
+          "type": "string"
+        },
+        "timeout": {
+          "title": "Request timeout for each delivery attempt.",
+          "description": "The task is failed if all attempts are exhausted without a successful delivery.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "30s",
+          "pattern": "^\\d+(s|m|h|d)$"
+        },
+        "url": {
+          "title": "URL of the webhook endpoint.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "payloadTemplate"
+      ]
+    },
+    "Triggers": {
+      "title": "Triggers",
+      "description": "Webhook triggers that fire upon materialization transaction completion.",
+      "type": "object",
+      "properties": {
+        "config": {
+          "title": "Trigger Configurations",
+          "description": "List of webhook triggers to fire when new data is materialized.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TriggerConfig"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "config"
       ]
     },
     "Value": true


### PR DESCRIPTION
## Summary

Phase 1 of the target naming redesign ([#2780](https://github.com/estuary/flow/issues/2780)). This PR adds `TargetNamingStrategy` as a new top-level field on `MaterializationDef`, decoupling naming behavior from `SourceDef` so that materializations without a sourceCapture can express a naming preference. It also adds optional template fields for decorating generated table and schema names.

### What changed

`TargetNamingStrategy` is an enum with three variants:
- `matchSourceStructure { tableTemplate, schemaTemplate }`: schema from collection name, table is the final component. Both names are derived, so both support templates.
- `singleSchema { schema, tableTemplate }`: all tables in one named schema. Schema is user-provided, so only the table name supports a template.
- `prefixTableNames { schema, skipCommonDefaults, tableTemplate }`: schema component prefixed to table name. Schema is user-provided, so only the table name supports a template.

Template fields use mustache-style substitution (e.g. "staging_{{table}}" produces staging_myTable). tableTemplate uses {{table}} as the placeholder, schemaTemplate uses {{schema}}. When absent, names are used as-is.`singleSchema` and `prefixTableNames` have no schema template because their schema is already a user-provided string.

The existing `SourceDef.target_naming` enum is preserved as a fallback. When both `MaterializationDef.target_naming` and `source.target_naming` are present, the top-level field wins for naming; `delta_updates` is always read from `source`.

### Rollout strategy

This PR ships only the model and naming logic. There is no auto-promotion of existing specs in the validation layer. Clients (the UI) can adopt the new field progressively: present and edit `targetNaming` if present, otherwise fall back to the existing `source.targetNaming` field. A later phase will populate the remaining materializations' root `target_naming` based on knowledge of each connector's endpoint-config `schema` location and default.

### WASM API

The `update_materialization_resource_spec` WASM function now accepts `targetNaming` alongside `sourceCapture`, both optional. `sourceCapture` is optional because not all materializations have one, not because it's being replaced. Existing UI code that sends `sourceCapture` continues to work unchanged.

### Note on `flow.schema.json`

The regenerated schema includes `Triggers`, `TriggerConfig`, and `HttpMethod` types that were already in the models but missing from the previously-stale `flow.schema.json`. These are unrelated to this PR.

Closes https://github.com/estuary/flow/issues/2234