### PR TITLE
models: strip `minLength` and `maxLength` from relaxed write schema

### DIFF
--- a/crates/models/src/fixture.schema.json
+++ b/crates/models/src/fixture.schema.json
@@ -31,7 +31,8 @@
             "string",
             "null"
           ],
-          "minLength": 16
+          "minLength": 16,
+          "maxLength": 128
         },
         "an_array_of_timestamps": {
           "type": "array",

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -211,6 +211,10 @@ struct RelaxedSchemaObj {
     _const: String,
     #[serde(rename = "enum", default, skip_serializing)]
     _enum: Vec<serde_json::Value>,
+    #[serde(rename = "minLength", default, skip_serializing)]
+    _min_length: Option<serde_json::Value>,
+    #[serde(rename = "maxLength", default, skip_serializing)]
+    _max_length: Option<serde_json::Value>,
 
     // Other keywords are passed-through.
     #[serde(flatten)]
@@ -382,6 +386,34 @@ mod test {
     fn test_relaxation() {
         let fixture = Schema::new(RawValue::from_str(include_str!("fixture.schema.json")).unwrap());
         insta::assert_json_snapshot!(fixture.to_relaxed_schema().unwrap().to_value())
+    }
+
+    #[test]
+    fn test_relaxation_drops_min_max_length() {
+        let schema = schema!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "A name field"
+                }
+            }
+        });
+
+        let relaxed = schema.to_relaxed_schema().unwrap().to_value();
+
+        assert_eq!(
+            relaxed,
+            json!({
+                "properties": {
+                    "name": {
+                        "description": "A name field"
+                    }
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/models/src/snapshots/models__schemas__test__relaxation.snap
+++ b/crates/models/src/snapshots/models__schemas__test__relaxation.snap
@@ -11,8 +11,7 @@ expression: fixture.to_relaxed_schema().unwrap().to_value()
           "title": "A constant property"
         },
         "a_string": {
-          "description": "(source type: varchar)",
-          "minLength": 16
+          "description": "(source type: varchar)"
         },
         "an_array_of_timestamps": {
           "items": {},


### PR DESCRIPTION
Connectors emit `maxLength` constraints reflecting source column sizes. When these constraints pass through to `flow://relaxed-write-schema` and intersect with the inferred schema via `allOf`, the most restrictive bound wins. This causes materialization validation failures when transformations like SHA-256 redaction produce values longer than the original column limit.

* Add `minLength` and `maxLength` to `RelaxedSchemaObj`'s stripped keyword set, matching the existing pattern for `type`, `required`, `format`, `const`, and `enum`

Part of https://github.com/estuary/flow/issues/2818