### PR TITLE
Update default agent API URL to api.estuary.dev

### DIFF
--- a/crates/flow-client-next/src/lib.rs
+++ b/crates/flow-client-next/src/lib.rs
@@ -45,7 +45,7 @@ where
 }
 
 lazy_static::lazy_static! {
-    pub static ref DEFAULT_AGENT_URL:  url::Url = url::Url::parse("https://agent-api-1084703453822.us-central1.run.app").unwrap();
+    pub static ref DEFAULT_AGENT_URL:  url::Url = url::Url::parse("https://api.estuary.dev").unwrap();
     pub static ref DEFAULT_DASHBOARD_URL: url::Url = url::Url::parse("https://dashboard.estuary.dev/").unwrap();
     pub static ref DEFAULT_PG_URL: url::Url = url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap();
     pub static ref DEFAULT_CONFIG_ENCRYPTION_URL: url::Url = url::Url::parse("https://config-encryption.estuary.dev/").unwrap();

--- a/crates/flow-client/src/lib.rs
+++ b/crates/flow-client/src/lib.rs
@@ -57,7 +57,7 @@ pub fn parse_jwt_claims<T: serde::de::DeserializeOwned>(token: &str) -> anyhow::
 }
 
 lazy_static::lazy_static! {
-    pub static ref DEFAULT_AGENT_URL:  url::Url = url::Url::parse("https://agent-api-1084703453822.us-central1.run.app").unwrap();
+    pub static ref DEFAULT_AGENT_URL:  url::Url = url::Url::parse("https://api.estuary.dev").unwrap();
     pub static ref DEFAULT_DASHBOARD_URL: url::Url = url::Url::parse("https://dashboard.estuary.dev/").unwrap();
     pub static ref DEFAULT_PG_URL: url::Url = url::Url::parse("https://eyrcnmuzzyriypdajwdk.supabase.co/rest/v1").unwrap();
     pub static ref DEFAULT_CONFIG_ENCRYPTION_URL: url::Url = url::Url::parse("https://config-encryption.estuary.dev/").unwrap();


### PR DESCRIPTION
## Summary
- Updates the hardcoded default agent API URL from the Cloud Run hostname (`agent-api-1084703453822.us-central1.run.app`) to the custom domain (`api.estuary.dev`) in both `flow-client` and `flow-client-next`.
- The Cloud Run deployment workflow is unchanged — this only affects the client-side default URL.
- DNS and routing for `api.estuary.dev` is already verified (estuary/security#641).

## Help needed
- Could someone with testing/deployment context advise on any additional validation needed before merging?

## Test plan
- [ ] Confirm `flowctl` commands work against the new default URL