### PR TITLE
ci: fix docs preview link for relative frontmatter slugs

### DIFF
--- a/.github/workflows/docs-ci-previews.yaml
+++ b/.github/workflows/docs-ci-previews.yaml
@@ -82,6 +82,15 @@ jobs:
               const match = content.match(/^slug:\s*(.+)$/m);
               if (match) {
                 slug = match[1].trim().replace(/['"]/g, '');
+                // Relative slugs (no leading /) are resolved from the file's directory,
+                // matching Docusaurus behaviour. e.g. slug: installation in
+                // getting-started/installation.md → /getting-started/installation
+                if (!slug.startsWith('/')) {
+                  const parts = f.replace('site/docs/', '').split('/');
+                  parts.pop();
+                  const dir = parts.join('/');
+                  slug = dir ? `/${dir}/${slug}` : `/${slug}`;
+                }
               }
               if (!slug) {
                 slug = '/' + f
@@ -89,7 +98,6 @@ jobs:
                   .replace(/\/README\.md$/, '/')
                   .replace(/\.md$/, '/');
               }
-              if (!slug.startsWith('/')) slug = '/' + slug;
               return `- [${slug}](${base}${slug})`;
             });
 


### PR DESCRIPTION
## Summary

Fixes incorrect preview links for docs files that use a relative `slug` in their frontmatter.

Docusaurus resolves relative slugs (no leading `/`) from the file's directory. For example, `slug: installation` in `site/docs/getting-started/installation.md` produces the URL `/getting-started/installation` — not `/installation`.

The preview link script was prepending `/` directly, producing the wrong URL. Caught on #2827.

**Fix:** when the slug doesn't start with `/`, construct the full path using the file's directory.

## Test plan

- [x] Backtested against 4 real docs files with varying slug patterns (relative, absolute, root `/`, no slug) — all resolve correctly
- [x] The bug case: `getting-started/installation.md` with `slug: installation` → `/getting-started/installation` ✓
- [x] Absolute slug (`slug: /`) → unchanged ✓
- [x] No slug → falls back to file path derivation ✓