### PR TITLE
docs: fix token usage instructions with `FLOW_AUTH_TOKEN`

### DIFF
--- a/site/docs/guides/flowctl/ci-cd.md
+++ b/site/docs/guides/flowctl/ci-cd.md
@@ -19,11 +19,11 @@ During development, you can locally create, manage, and test your resources befo
 Before creating these resources, you will need:
 * An [Estuary account](https://dashboard.estuary.dev/register)
 * `flowctl` [installed](../get-started-with-flowctl.md) on your machine
-* An Estuary [access token](../how_to_generate_refresh_token.md)
+* An Estuary [refresh token](../how_to_generate_refresh_token.md)
 
 You can authenticate your `flowctl` session in one of two ways:
 
-* Set the `FLOW_AUTH_TOKEN` environment variable to your Estuary access token. This is the recommended way to handle a CI or automation setup.
+* Set the `FLOW_AUTH_TOKEN` environment variable to your Estuary refresh token. This is the recommended way to handle a CI or automation setup.
 
 * Or run the `flowctl auth login` command and paste in your token. This is handy for local development.
 


### PR DESCRIPTION
**Description:**

Fixes incorrect terminology in the CI/CD docs page. `FLOW_AUTH_TOKEN` requires a refresh token (long-lived, 90-day expiry), not an access token (short-lived, ~1 hour).

**Workflow steps:**

N/A

**Documentation links affected:**

- `guides/flowctl/ci-cd.md` - https://docs.estuary.dev/guides/flowctl/ci-cd/

**Notes for reviewers:**

N/A

