### PR TITLE
docs: add SSE-KMS instructions & add tip re: UI generated policy

### DIFF
--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -112,13 +112,36 @@ Estuary's data plane IAM user will need the following actions:
 * `s3:GetBucketPolicy`
 
 You can apply the policy through the [AWS Console](https://console.aws.amazon.com/s3/) or the `aws` CLI.
-The storage mapping dialog provides a ready-to-use policy JSON during connection testing.
+
+:::tip
+The storage mapping dialog generates a complete bucket policy with the correct IAM ARNs for all data planes mapped to this bucket. Copy and paste it directly into your bucket's policy configuration — no manual ARN lookup needed.
+:::
 
 #### S3 Bucket Encryption
 
-Estuary supports **SSE-S3** (Amazon S3 managed keys) for default bucket encryption. **SSE-KMS** (AWS Key Management Service) is **not supported** for storage mapping buckets because Estuary's data plane IAM user does not have access to your KMS keys.
+S3 buckets are encrypted with **SSE-S3** (Amazon S3 managed keys) by default, which works with Estuary out of the box.
 
-If your bucket uses SSE-KMS as the default encryption, change it to SSE-S3:
+If your bucket uses **SSE-KMS** (AWS Key Management Service) for default encryption, you must grant Estuary's data plane IAM user permissions on your KMS key. Add the following statement to your [KMS key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html):
+
+```json
+{
+  "Sid": "AllowEstuaryDataPlane",
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "<data-plane-IAM-ARN>"
+  },
+  "Action": [
+    "kms:GenerateDataKey",
+    "kms:Decrypt",
+    "kms:DescribeKey"
+  ],
+  "Resource": "*"
+}
+```
+
+Replace `<data-plane-IAM-ARN>` with your data plane's IAM ARN, found under **Admin > Settings > Data Planes** in the Estuary dashboard.
+
+Alternatively, you can switch your bucket's default encryption from SSE-KMS to SSE-S3 to avoid managing KMS permissions:
 
 1. In the [AWS Console](https://console.aws.amazon.com/s3/), navigate to your bucket.
 2. Go to **Properties** > **Default encryption**.

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -114,6 +114,17 @@ Estuary's data plane IAM user will need the following actions:
 You can apply the policy through the [AWS Console](https://console.aws.amazon.com/s3/) or the `aws` CLI.
 The storage mapping dialog provides a ready-to-use policy JSON during connection testing.
 
+#### S3 Bucket Encryption
+
+Estuary supports **SSE-S3** (Amazon S3 managed keys) for default bucket encryption. **SSE-KMS** (AWS Key Management Service) is **not supported** for storage mapping buckets because Estuary's data plane IAM user does not have access to your KMS keys.
+
+If your bucket uses SSE-KMS as the default encryption, change it to SSE-S3:
+
+1. In the [AWS Console](https://console.aws.amazon.com/s3/), navigate to your bucket.
+2. Go to **Properties** > **Default encryption**.
+3. Click **Edit** and change from **AWS Key Management Service key (SSE-KMS)** to **Amazon S3 managed key (SSE-S3)**.
+4. Save the change, then retry the connection test in Estuary.
+
 ### Azure Blob Storage
 
 For an [Azure storage account](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create)


### PR DESCRIPTION
**Description:**

Adds S3 encryption guidance for storage mapping buckets. Documents that SSE-S3 works out of the box, and that SSE-KMS is supported if the customer grants Estuary's data plane the necessary KMS permissions (`kms:GenerateDataKey`, `kms:Decrypt`, `kms:DescribeKey`). Includes a ready-to-use KMS key policy snippet and a fallback option to switch to SSE-S3. Also adds a callout that the storage mapping UI generates a complete bucket policy with the correct IAM ARNs.

**Workflow steps:**

N/A

**Documentation links affected:**

- `getting-started/installation.md` - https://docs.estuary.dev/getting-started/installation/#amazon-s3

**Notes for reviewers:**

- Tested SSE-KMS e2e via my own Estuary tenant. A bucket with SSE-KMS default encryption fails the connection test without KMS permissions and passes after granting `kms:GenerateDataKey`, `kms:Decrypt`, `kms:DescribeKey` to the data plane IAM user
- Bucket policy tip addresses a request to make the UI-generated policy more discoverable in the docs (particularly for AI/MCP).

