### PR TITLE
docs: note QUOTED_IDENTIFIERS_IGNORE_CASE incompatibility for Snowflake materialization

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -21,6 +21,7 @@ To use this connector, you'll need:
     * A virtual warehouse
     * A user with a role assigned that grants the appropriate access levels to these resources.
     * The correct timezone setting (see [Timestamp Data Type Mapping](#timestamp-data-type-mapping))
+    * The `QUOTED_IDENTIFIERS_IGNORE_CASE` parameter must not be enabled for the Estuary user.
 
     See the [script below](#setup) for details.
 * Know your Snowflake account's host URL. This is formatted using your [Snowflake account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used),
@@ -59,6 +60,8 @@ create user if not exists identifier($estuary_user)
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);
+-- Estuary requires case-sensitive quoted identifiers (e.g. "_meta/op").
+alter user identifier($estuary_user) set QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;
 grant all on schema identifier($estuary_schema) to identifier($estuary_role);
 -- create a warehouse for estuary
 create warehouse if not exists identifier($warehouse_name)


### PR DESCRIPTION
Adds a one-line prerequisite note that `QUOTED_IDENTIFIERS_IGNORE_CASE` must not be enabled for the Estuary user when using the Snowflake materialization connector.

Related connector fix: estuary/connectors#4243