### PR TITLE
ci: fix docs preview links for Docusaurus category index files

### DIFF
--- a/.github/workflows/docs-ci-previews.yaml
+++ b/.github/workflows/docs-ci-previews.yaml
@@ -93,10 +93,22 @@ jobs:
                 }
               }
               if (!slug) {
-                slug = '/' + f
-                  .replace('site/docs/', '')
-                  .replace(/\/README\.md$/, '/')
-                  .replace(/\.md$/, '/');
+                // Docusaurus category index convention: README.md, index.md, or
+                // <folder_name>.md (case-insensitive) become the category's URL,
+                // served at the folder path rather than folder/filename.
+                // e.g. PostgreSQL/PostgreSQL.md → /PostgreSQL/, not /PostgreSQL/PostgreSQL/
+                const parts = f.replace('site/docs/', '').split('/');
+                const fileName = parts[parts.length - 1].replace(/\.md$/, '');
+                const parentDir = parts.length > 1 ? parts[parts.length - 2] : '';
+                const isCategoryIndex =
+                  /^(readme|index)$/i.test(fileName) ||
+                  (parentDir && fileName.toLowerCase() === parentDir.toLowerCase());
+                if (isCategoryIndex) {
+                  parts.pop();
+                  slug = '/' + (parts.length ? parts.join('/') + '/' : '');
+                } else {
+                  slug = '/' + parts.join('/').replace(/\.md$/, '/');
+                }
               }
               return `- [${slug}](${base}${slug})`;
             });


### PR DESCRIPTION
## Summary

- The docs PR preview comment script was generating 404 links for Docusaurus category-index files (e.g. `PostgreSQL/PostgreSQL.md`, `README.md`, `index.md`) because it only stripped `/README.md`, not the general category-index convention.
- Caught on #2843, where the first link in the preview comment pointed to `/PostgreSQL/PostgreSQL/` (404) instead of `/PostgreSQL/`.
- Fix: detect files whose name matches `readme`, `index`, or the parent directory name (case-insensitive), and emit the folder URL.

## Test plan

Verified the updated resolver against all 7 files from #2843 and HTTP-checked each URL on production `docs.estuary.dev` — all 200:

- [x] `PostgreSQL/PostgreSQL.md` → `/reference/Connectors/capture-connectors/PostgreSQL/` (category index, previously broken)
- [x] `PostgreSQL/Supabase.md` → `/reference/Connectors/capture-connectors/PostgreSQL/Supabase/` (control)
- [x] `PostgreSQL/amazon-rds-postgres.md`, `google-cloud-sql-postgres.md`, `neon-postgres.md`, `shopify-native.md`, `Snowflake.md` all resolve 200
- [x] Synthetic cases: README.md, case-insensitive folder match, top-level files

End-to-end CI verification will happen organically on the next docs PR that touches a category-index file.