### PR TITLE
materialize-mysql: document 'Additional Table Create SQL'

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/MySQL/amazon-rds-mysql.md
+++ b/site/docs/reference/Connectors/materialization-connectors/MySQL/amazon-rds-mysql.md
@@ -161,10 +161,11 @@ authorize the client.
 
 #### Bindings
 
-| Property         | Title        | Description                                                                                                        | Type    | Required/Default |
-| ---------------- | ------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| **`/table`**     | Table        | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
-| `/delta_updates` | Delta Update | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| Property                       | Title                       | Description                                                                                                        | Type    | Required/Default |
+| ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after the table is created.                                                  | string  |                  |
+| `/delta_updates`               | Delta Update                | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| **`/table`**                   | Table                       | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/site/docs/reference/Connectors/materialization-connectors/MySQL/google-cloud-sql-mysql.md
@@ -141,10 +141,11 @@ authorize the client.
 
 #### Bindings
 
-| Property         | Title        | Description                                                                                                        | Type    | Required/Default |
-| ---------------- | ------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| **`/table`**     | Table        | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
-| `/delta_updates` | Delta Update | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| Property                       | Title                       | Description                                                                                                        | Type    | Required/Default |
+| ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after the table is created.                                                  | string  |                  |
+| `/delta_updates`               | Delta Update                | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| **`/table`**                   | Table                       | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/MySQL/mysql.md
+++ b/site/docs/reference/Connectors/materialization-connectors/MySQL/mysql.md
@@ -114,10 +114,11 @@ authorize the client.
 
 #### Bindings
 
-| Property         | Title        | Description                                                                                                        | Type    | Required/Default |
-| ---------------- | ------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| **`/table`**     | Table        | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
-| `/delta_updates` | Delta Update | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| Property                       | Title                       | Description                                                                                                        | Type    | Required/Default |
+| ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after the table is created.                                                  | string  |                  |
+| `/delta_updates`               | Delta Update                | Should updates to this table be done via delta updates.                                                            | boolean | `false`          |
+| **`/table`**                   | Table                       | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string  | Required         |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/MySQL/singlestore-mysql.md
+++ b/site/docs/reference/Connectors/materialization-connectors/MySQL/singlestore-mysql.md
@@ -81,8 +81,9 @@ authorize the client.
 
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
-| **`/table`** | Table | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string | Required |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after the table is created. | string | |
 | `/delta_updates` | Delta Update | Should updates to this table be done via delta updates. | boolean | `false` |
+| **`/table`** | Table | Table name to materialize to. It will be created by the connector, unless the connector has previously created it. | string | Required |
 
 ### Sample
 

--- a/site/docs/reference/Connectors/materialization-connectors/mysql-heatwave.md
+++ b/site/docs/reference/Connectors/materialization-connectors/mysql-heatwave.md
@@ -34,9 +34,10 @@ Configuring the SSL mode strengthens security when transferring data to Oracle M
 
 ### Bindings
 
-| Property                | Title              | Description                                | Type   | Required/Default       |
-|-------------------------|--------------------|--------------------------------------------|--------|------------------------|
-| **`/table`**            | Table              | The name of the table to send data to.     | string | Required               |
+| Property                       | Title                       | Description                                                       | Type   | Required/Default |
+|--------------------------------|-----------------------------|-------------------------------------------------------------------|--------|------------------|
+| **`/table`**                   | Table                       | The name of the table to send data to.                            | string | Required         |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run after the table is created. | string |                  |
 
 
 


### PR DESCRIPTION
**Description:**

Helps https://github.com/estuary/connectors/issues/4028

Document the "Additional Table Create SQL" materialize-mysql feature.

The feature is slightly different to the materialize-postgres equivalent - MySQL cannot perform SQL statements after `CREATE TABLE` in one transaction, hence "Additional SQL statement(s) to be run after the table is created."

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

https://docs.estuary.dev/reference/Connectors/materialization-connectors/MySQL/#bindings etc

**Notes for reviewers:**

See also https://github.com/estuary/connectors/pull/4263

