### PR TITLE
deps: bump aws-lc-sys and lz4_flex for security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -841,16 +841,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libloading",
 ]
 
 [[package]]
@@ -1373,8 +1371,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -2581,7 +2577,7 @@ dependencies = [
  "labels",
  "lazy_static",
  "locate-bin",
- "lz4_flex",
+ "lz4_flex 0.13.0",
  "md5",
  "metrics",
  "metrics-exporter-prometheus",
@@ -4804,7 +4800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4989,9 +4985,18 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
 ]
@@ -5665,7 +5670,7 @@ dependencies = [
  "flate2",
  "half",
  "hashbrown 0.16.0",
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "num",
  "num-bigint",
  "paste",


### PR DESCRIPTION
## Summary

Bumps two Rust crates via `Cargo.lock` only (no `Cargo.toml` or source changes) to close 6 high-severity Dependabot alerts:

- `aws-lc-sys` 0.32.2 → **0.40.0** (via `aws-lc-rs` 1.14.1 → 1.16.3)
  - Closes [#234](https://github.com/estuary/flow/security/dependabot/234), [#235](https://github.com/estuary/flow/security/dependabot/235), [#236](https://github.com/estuary/flow/security/dependabot/236), [#247](https://github.com/estuary/flow/security/dependabot/247), [#248](https://github.com/estuary/flow/security/dependabot/248) — PKCS7 bypasses, AES-CCM timing side-channel, X.509 name-constraint bypass, CRL scope check. aws-lc-sys is in the build via `rustls 0.23` + `rustls-webpki` + `jsonwebtoken 10` on the aws-lc-rs crypto provider.
- `lz4_flex` 0.11.5 → **0.11.6** (plus `0.13.0` added transitively for the workspace dep)
  - Closes [#245](https://github.com/estuary/flow/security/dependabot/245) — decompression info leak. Reachable via the `parquet` crate used by `crates/parser` to decode user-supplied parquet files.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p parser -p json -p dekaf --lib` green (covers the parquet→lz4 decode path and the dekaf lz4 encoder)
- [x] CI runs full workspace tests (local run blocked on live Supabase for `agent` sqlx queries not in the offline cache)