### PR TITLE
Prevent tenants from enabling enforce_sso without an sso_provider_id

### DIFF
--- a/supabase/migrations/20260424120000_require_sso_provider_for_enforce_sso.sql
+++ b/supabase/migrations/20260424120000_require_sso_provider_for_enforce_sso.sql
@@ -1,0 +1,6 @@
+-- Prevent tenants from enabling enforce_sso without an sso_provider_id.
+
+alter table public.tenants
+  add constraint tenants_enforce_sso_requires_provider
+  check (not (enforce_sso and sso_provider_id is null));
+


### PR DESCRIPTION
Adds a CHECK constraint on `public.tenants` preventing `enforce_sso = true` when `sso_provider_id is null` — a combination that locks matching-domain users out with no SSO path in. Caught after a tenant was set to `enforce_sso` without a provider.
