### PR TITLE
doc: add ExtractorPlan with merge-join field extraction

### DIFF
--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -80,48 +80,7 @@ impl Extractor {
         &'s self,
         doc: &'n N,
     ) -> Result<&'n N, Cow<'s, serde_json::Value>> {
-        let Some(node) = self.ptr.query(doc) else {
-            return Err(Cow::Borrowed(&self.default));
-        };
-
-        match self.magic {
-            None => { /* sorry, kid, I guess your parents aren't coming back */ }
-            Some(Magic::UuidV1DateTime) => {
-                if let Some(date_time) = match node.as_node() {
-                    json::Node::String(s) => Some(s),
-                    _ => None,
-                }
-                .and_then(|s| proto_gazette::uuid::parse_str(s).ok())
-                .and_then(|(_producer, clock, _flags)| {
-                    let (seconds, nanos) = clock.to_unix();
-                    time::OffsetDateTime::from_unix_timestamp_nanos(
-                        seconds as i128 * 1_000_000_000 + nanos as i128,
-                    )
-                    .ok()
-                }) {
-                    // Use a custom format and not time::format_description::well_known::Rfc3339,
-                    // because date-times must be right-padded out to the nanosecond to ensure
-                    // that lexicographic ordering matches temporal ordering.
-                    let format = time::macros::format_description!(
-                        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
-                    );
-                    return Err(Cow::Owned(serde_json::Value::String(
-                        date_time
-                            .format(format)
-                            .expect("rfc3339 format always succeeds"),
-                    )));
-                }
-            }
-            Some(Magic::TruncationIndicator) => {
-                // The real magic is behind some _other_ curtain.
-                // We just set a constant false value here.
-                // If we end up pruning some part of the document, we'll go back and change this
-                // value retroactively as part of `extract_all_indicate_truncation`.
-                return Err(Cow::Owned(serde_json::Value::Bool(false)));
-            }
-        }
-
-        Ok(node)
+        self.value_from_resolved(self.ptr.query(doc))
     }
 
     /// Extract a packed tuple representation from an instance of json::AsNode.
@@ -137,30 +96,15 @@ impl Extractor {
         out: &mut bytes::BytesMut,
         indicator: &AtomicBool,
     ) {
-        let mut w = out.writer();
-
-        // Truncation indicators are handled by having the extractor always write
-        // a `false` value (0x26). We remember the byte offset of this value in the
-        // encoded tuple, and will change it to `true` at the end if any value was
-        // truncated.
         let mut projected_indicator_pos: Option<usize> = None;
-        for ex in extractors {
-            if ex.magic == Some(Magic::TruncationIndicator) {
-                debug_assert!(
-                    projected_indicator_pos.is_none(),
-                    "extractors have multiple projections of truncation indicator"
-                );
-                projected_indicator_pos = Some(w.get_ref().len());
-            }
-            // Unwrap because Write is infallible for BytesMut.
-            ex.extract_indicate_truncation(doc, &mut w, indicator)
-                .unwrap();
-        }
-
-        let write_indicator = projected_indicator_pos.filter(|_| indicator.load(Ordering::SeqCst));
-        if let Some(pos) = write_indicator {
-            out[pos] = 0x27; // this is the Foundation tuple byte value of `true`
-        }
+        write_extracted(
+            doc,
+            extractors,
+            out,
+            indicator,
+            &mut projected_indicator_pos,
+        );
+        finalize_truncation_indicator(out, projected_indicator_pos, indicator);
     }
 
     pub fn extract_all_owned<'alloc>(
@@ -204,17 +148,7 @@ impl Extractor {
         w: &mut W,
         indicator: &AtomicBool,
     ) -> std::io::Result<()> {
-        match self.query(doc) {
-            Ok(v) => self
-                .policy
-                .with_truncation_indicator(v, indicator)
-                .pack(w, tuple::TupleDepth::new().increment())?,
-            Err(v) => self
-                .policy
-                .with_truncation_indicator(v.as_ref(), indicator)
-                .pack(w, tuple::TupleDepth::new().increment())?,
-        };
-        Ok(())
+        self.extract_from_resolved_indicate_truncation(self.ptr.query(doc), w, indicator)
     }
 
     /// Extract from an instance of json::AsNode, writing a packed encoding into the writer.
@@ -259,6 +193,120 @@ impl Extractor {
         let mut hasher = highway::HighwayHasher::new(HIGHWAY_KEY);
         hasher.append(packed_key);
         (hasher.finalize64() >> 32) as u32
+    }
+
+    pub(crate) fn is_truncation_indicator(&self) -> bool {
+        matches!(self.magic, Some(Magic::TruncationIndicator))
+    }
+
+    fn value_from_resolved<'s, 'n, N: json::AsNode>(
+        &'s self,
+        resolved: Option<&'n N>,
+    ) -> Result<&'n N, Cow<'s, serde_json::Value>> {
+        let Some(node) = resolved else {
+            return Err(Cow::Borrowed(&self.default));
+        };
+
+        match self.magic {
+            None => { /* sorry, kid, I guess your parents aren't coming back */ }
+            Some(Magic::UuidV1DateTime) => {
+                if let Some(date_time) = match node.as_node() {
+                    json::Node::String(s) => Some(s),
+                    _ => None,
+                }
+                .and_then(|s| proto_gazette::uuid::parse_str(s).ok())
+                .and_then(|(_producer, clock, _flags)| {
+                    let (seconds, nanos) = clock.to_unix();
+                    time::OffsetDateTime::from_unix_timestamp_nanos(
+                        seconds as i128 * 1_000_000_000 + nanos as i128,
+                    )
+                    .ok()
+                }) {
+                    // Use a custom format and not time::format_description::well_known::Rfc3339,
+                    // because date-times must be right-padded out to the nanosecond to ensure
+                    // that lexicographic ordering matches temporal ordering.
+                    let format = time::macros::format_description!(
+                        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
+                    );
+                    return Err(Cow::Owned(serde_json::Value::String(
+                        date_time
+                            .format(format)
+                            .expect("rfc3339 format always succeeds"),
+                    )));
+                }
+            }
+            Some(Magic::TruncationIndicator) => {
+                // The real magic is behind some _other_ curtain.
+                // We just set a constant false value here.
+                // If we end up pruning some part of the document, we'll go back and change this
+                // value retroactively as part of `extract_all_indicate_truncation`.
+                return Err(Cow::Owned(serde_json::Value::Bool(false)));
+            }
+        }
+
+        Ok(node)
+    }
+
+    /// Pre-resolved variant of `extract_indicate_truncation`. Used when a leaf
+    /// node has already been found, skipping the per-extractor
+    /// `Pointer::query`.
+    pub(crate) fn extract_from_resolved_indicate_truncation<N: json::AsNode, W: std::io::Write>(
+        &self,
+        resolved: Option<&N>,
+        w: &mut W,
+        indicator: &AtomicBool,
+    ) -> std::io::Result<()> {
+        match self.value_from_resolved(resolved) {
+            Ok(v) => self
+                .policy
+                .with_truncation_indicator(v, indicator)
+                .pack(w, tuple::TupleDepth::new().increment())?,
+            Err(v) => self
+                .policy
+                .with_truncation_indicator(v.as_ref(), indicator)
+                .pack(w, tuple::TupleDepth::new().increment())?,
+        };
+        Ok(())
+    }
+}
+
+pub(crate) fn write_extracted<N: json::AsNode>(
+    doc: &N,
+    extractors: &[Extractor],
+    out: &mut bytes::BytesMut,
+    indicator: &AtomicBool,
+    projected_indicator_pos: &mut Option<usize>,
+) {
+    let mut w = out.writer();
+
+    // Truncation indicators are handled by having the extractor always write
+    // a `false` value (0x26). We remember the byte offset of this value in the
+    // encoded tuple, and will change it to `true` at the end if any value was
+    // truncated.
+    for ex in extractors {
+        if ex.is_truncation_indicator() {
+            debug_assert!(
+                projected_indicator_pos.is_none(),
+                "extractors have multiple projections of truncation indicator"
+            );
+            *projected_indicator_pos = Some(w.get_ref().len());
+        }
+        // Unwrap because Write is infallible for BytesMut.
+        ex.extract_indicate_truncation(doc, &mut w, indicator)
+            .unwrap();
+    }
+}
+
+/// Retroactively flip the truncation-indicator placeholder to `true` if
+/// anything was truncated during the enclosing extract.
+pub(crate) fn finalize_truncation_indicator(
+    out: &mut bytes::BytesMut,
+    position: Option<usize>,
+    indicator: &AtomicBool,
+) {
+    let write_indicator = position.filter(|_| indicator.load(Ordering::SeqCst));
+    if let Some(pos) = write_indicator {
+        out[pos] = 0x27; // this is the Foundation tuple byte value of `true`
     }
 }
 

--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -25,6 +25,22 @@ enum Magic {
     TruncationIndicator,
 }
 
+/// Planner-facing classification of an extractor.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum PlanKind<'a> {
+    /// Sibling-leaf extractor. A candidate for inclusion in a planner block.
+    MergeJoinLeaf {
+        parent: &'a [json::ptr::Token],
+        name: &'a str,
+    },
+    /// Truncation indicator. Must run in place through the reference path so
+    /// its placeholder byte lands at the right tuple position.
+    TruncationIndicator,
+    /// Root document (empty pointer) or array-index terminal. Cannot be
+    /// included in a planner block.
+    Other,
+}
+
 impl Extractor {
     /// Build an Extractor for the JSON pointer.
     /// If the location doesn't exist, then `null` is extracted.
@@ -197,6 +213,22 @@ impl Extractor {
 
     pub(crate) fn is_truncation_indicator(&self) -> bool {
         matches!(self.magic, Some(Magic::TruncationIndicator))
+    }
+
+    pub(crate) fn plan_kind(&self) -> PlanKind<'_> {
+        if self.is_truncation_indicator() {
+            return PlanKind::TruncationIndicator;
+        }
+
+        match self.ptr.0.split_last() {
+            Some((json::ptr::Token::Property(name), parent)) => {
+                PlanKind::MergeJoinLeaf { parent, name }
+            }
+            // Root document (empty pointer) or array-index terminal (e.g.
+            // /arr/0) — neither can merge-join against an object's fields,
+            // so the plan runs them as singles through the reference path.
+            _ => PlanKind::Other,
+        }
     }
 
     fn value_from_resolved<'s, 'n, N: json::AsNode>(

--- a/crates/doc/src/extractor_plan.rs
+++ b/crates/doc/src/extractor_plan.rs
@@ -1,0 +1,511 @@
+use crate::{Extractor, OwnedNode, extractor::PlanKind};
+use bytes::BufMut;
+use json::Field as _;
+use std::sync::atomic::AtomicBool;
+
+/// Pre-compiled extraction plan that collapses repeated `Fields::get` calls
+/// into a single linear merge-join when a list of extractors picks many
+/// sibling leaves off a common parent object.
+///
+/// At plan-compile time we detect *blocks*: maximal runs of consecutive
+/// sibling-leaf extractors under a common parent with monotonically ascending
+/// field names. The plan stores only blocks; the gaps between them (and
+/// head/tail of the list) are singles that run through the reference-path
+/// unchanged.
+#[derive(Debug)]
+pub struct ExtractorPlan {
+    // Complete list of extractors, with ordering preserved.
+    extractors: Box<[Extractor]>,
+    // Computed blocks of eligible extractors.
+    blocks: Box<[Block]>,
+}
+
+#[derive(Debug)]
+struct Block {
+    // Half-open range `start..start + len` into `ExtractorPlan::extractors`.
+    start: usize,
+    len: usize,
+    // Common parent pointer for the block.
+    parent_ptr: json::Pointer,
+}
+
+impl ExtractorPlan {
+    pub fn new(extractors: &[Extractor]) -> Self {
+        let extractors = extractors.to_vec();
+        let mut blocks: Vec<Block> = Vec::new();
+
+        let mut i = 0;
+        while i < extractors.len() {
+            if let Some(block) = eligible_block(&extractors, i) {
+                i += block.len;
+                blocks.push(block);
+            } else {
+                i += 1;
+            }
+        }
+
+        Self {
+            extractors: extractors.into_boxed_slice(),
+            blocks: blocks.into_boxed_slice(),
+        }
+    }
+
+    /// Extract a packed tuple representation from an instance of
+    /// doc::OwnedNode.
+    pub fn extract_all_owned_indicate_truncation(
+        &self,
+        doc: &OwnedNode,
+        out: &mut bytes::BytesMut,
+        indicator: &AtomicBool,
+    ) {
+        match doc {
+            OwnedNode::Heap(n) => match n.access() {
+                Ok(heap_node) => self.extract_all_indicate_truncation(&heap_node, out, indicator),
+                Err(embedded) => {
+                    self.extract_all_indicate_truncation(embedded.get(), out, indicator)
+                }
+            },
+            OwnedNode::Archived(n) => self.extract_all_indicate_truncation(n.get(), out, indicator),
+        }
+    }
+
+    /// Extract a packed tuple representation from an instance of json::AsNode.
+    pub fn extract_all_indicate_truncation<N: json::AsNode>(
+        &self,
+        doc: &N,
+        out: &mut bytes::BytesMut,
+        indicator: &AtomicBool,
+    ) {
+        let mut projected_indicator_pos: Option<usize> = None;
+        let mut cursor: usize = 0;
+
+        for block in self.blocks.iter() {
+            // Write values for non-block extractors in the midst of blocks, or
+            // prior to the first block.
+            crate::extractor::write_extracted(
+                doc,
+                &self.extractors[cursor..block.start],
+                out,
+                indicator,
+                &mut projected_indicator_pos,
+            );
+            // Write values for combined extractors, forming a contiguous block.
+            emit_block(
+                doc,
+                &self.extractors[block.start..block.start + block.len],
+                &block.parent_ptr,
+                out,
+                indicator,
+            );
+            cursor = block.start + block.len;
+        }
+        // Trailing non-block extractors. When `blocks` is empty, this is the
+        // entire set of extractors.
+        crate::extractor::write_extracted(
+            doc,
+            &self.extractors[cursor..],
+            out,
+            indicator,
+            &mut projected_indicator_pos,
+        );
+
+        crate::extractor::finalize_truncation_indicator(out, projected_indicator_pos, indicator);
+    }
+}
+
+fn emit_block<N: json::AsNode>(
+    doc: &N,
+    extractors: &[Extractor],
+    parent_ptr: &json::Pointer,
+    out: &mut bytes::BytesMut,
+    indicator: &AtomicBool,
+) {
+    let parent_fields = parent_ptr.query(doc).and_then(|p| match p.as_node() {
+        json::Node::Object(fields) => Some(fields),
+        _ => None,
+    });
+
+    let mut w = out.writer();
+    if let Some(fields) = parent_fields {
+        // Parent object is present and not null.
+        merge_write_block_extractors::<N, _>(extractors, fields, &mut w, indicator);
+    } else {
+        // No non-null parent object present, or the parent is not an object at
+        // all. Emit each extractor individually, as appropriate for its `None`
+        // value.
+        for ex in extractors {
+            ex.extract_from_resolved_indicate_truncation(None::<&N>, &mut w, indicator)
+                .unwrap();
+        }
+    }
+}
+
+/// Two-pointer merge of extractors against a parent object's fields.
+fn merge_write_block_extractors<N: json::AsNode, W: std::io::Write>(
+    extractors: &[Extractor],
+    fields: &(impl json::Fields<N> + ?Sized),
+    w: &mut W,
+    indicator: &AtomicBool,
+) {
+    let mut fields_iter = fields.iter();
+    let mut field = fields_iter.next();
+
+    for ex in extractors {
+        let PlanKind::MergeJoinLeaf { name, .. } = ex.plan_kind() else {
+            unreachable!("block eligibility guarantees field name");
+        };
+
+        let resolved = loop {
+            let Some(f) = field.as_ref() else {
+                break None;
+            };
+            match f.property().cmp(name) {
+                std::cmp::Ordering::Less => {
+                    field = fields_iter.next();
+                }
+                std::cmp::Ordering::Equal => break Some(f.value()),
+                std::cmp::Ordering::Greater => break None,
+            }
+        };
+
+        // Writing to BytesMut is infallible.
+        ex.extract_from_resolved_indicate_truncation(resolved, w, indicator)
+            .unwrap();
+    }
+}
+
+/// Returns `Some(Block)` if the run at `start` is two or more sibling-leaf
+/// extractors under a common parent with monotonically ascending field
+/// names; `None` otherwise. Singletons don't form a block: they'd pay the
+/// block's setup cost (parent walk, object check, iterator construction)
+/// with no sharing benefit, and degrade the field lookup from `Fields::get`
+/// to a linear merge advance.
+fn eligible_block(extractors: &[Extractor], start: usize) -> Option<Block> {
+    let PlanKind::MergeJoinLeaf {
+        parent: parent_tokens,
+        name: mut prev_name,
+    } = extractors.get(start)?.plan_kind()
+    else {
+        return None;
+    };
+
+    let mut len = 1;
+    for ex in &extractors[start + 1..] {
+        match ex.plan_kind() {
+            PlanKind::MergeJoinLeaf { parent, name }
+                if parent == parent_tokens && name >= prev_name =>
+            {
+                prev_name = name;
+                len += 1;
+            }
+            _ => break,
+        }
+    }
+
+    (len > 1).then(|| Block {
+        start,
+        len,
+        parent_ptr: json::Pointer(parent_tokens.to_vec()),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::SerPolicy;
+    use serde_json::json;
+
+    fn pack_reference(doc: &serde_json::Value, extractors: &[Extractor]) -> bytes::Bytes {
+        let mut buf = bytes::BytesMut::new();
+        let indicator = AtomicBool::new(false);
+        Extractor::extract_all_indicate_truncation(doc, extractors, &mut buf, &indicator);
+        buf.freeze()
+    }
+
+    fn pack_plan(doc: &serde_json::Value, extractors: &[Extractor]) -> bytes::Bytes {
+        let plan = ExtractorPlan::new(extractors);
+        let mut buf = bytes::BytesMut::new();
+        let indicator = AtomicBool::new(false);
+        plan.extract_all_indicate_truncation(doc, &mut buf, &indicator);
+        buf.freeze()
+    }
+
+    fn assert_plan_matches(doc: &serde_json::Value, extractors: &[Extractor]) {
+        let reference = pack_reference(doc, extractors);
+        let plan_bytes = pack_plan(doc, extractors);
+        assert_eq!(reference, plan_bytes, "plan diverged from reference");
+    }
+
+    fn merge_joined_extractor_count(plan: &ExtractorPlan) -> usize {
+        plan.blocks.iter().map(|b| b.len).sum()
+    }
+
+    fn build_block_doc(field_count: usize) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        for i in 0..field_count {
+            obj.insert(format!("f_{i:03}"), json!(i as i64));
+        }
+        serde_json::Value::Object(obj)
+    }
+
+    #[test]
+    fn singleton_not_a_block() {
+        let doc = build_block_doc(2);
+        let policy = SerPolicy::noop();
+        for (n, expected) in [(1, 0), (2, 2)] {
+            let extractors: Vec<Extractor> = (0..n)
+                .map(|i| Extractor::new(&format!("/f_{i:03}"), &policy))
+                .collect();
+            let plan = ExtractorPlan::new(&extractors);
+            assert_eq!(merge_joined_extractor_count(&plan), expected, "n={n}");
+            assert_plan_matches(&doc, &extractors);
+        }
+    }
+
+    #[test]
+    fn empty_extractor_slice() {
+        let doc = json!({"a": 1});
+        let plan = ExtractorPlan::new(&[]);
+        let mut buf = bytes::BytesMut::new();
+        let indicator = AtomicBool::new(false);
+        plan.extract_all_indicate_truncation(&doc, &mut buf, &indicator);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn no_blocks_with_truncation() {
+        let policy = SerPolicy {
+            str_truncate_after: 3,
+            ..SerPolicy::noop()
+        };
+        let doc = json!({"a": "xxxxxx", "b": "short", "c": "yyyyyy"});
+        let extractors = vec![
+            Extractor::new("/a", &policy),
+            Extractor::for_truncation_indicator(),
+            Extractor::new("/b", &policy),
+            Extractor::new("/c", &policy),
+        ];
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn one_block_with_truncation() {
+        const N: usize = 4;
+        let policy = SerPolicy {
+            str_truncate_after: 3,
+            ..SerPolicy::noop()
+        };
+        let mut obj = serde_json::Map::new();
+        for i in 0..N {
+            obj.insert(format!("f_{i:03}"), json!("xxxxxx"));
+        }
+        let doc = json!({"inner": serde_json::Value::Object(obj)});
+        let mut extractors = vec![Extractor::for_truncation_indicator()];
+        for i in 0..N {
+            extractors.push(Extractor::new(&format!("/inner/f_{i:03}"), &policy));
+        }
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(merge_joined_extractor_count(&plan), N);
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn indicator_between_siblings() {
+        let policy = SerPolicy::noop();
+        for (half, expected_joined) in [(1, 0), (4, 8)] {
+            let doc = build_block_doc(2 * half);
+            let mut extractors: Vec<Extractor> = (0..half)
+                .map(|i| Extractor::new(&format!("/f_{i:03}"), &policy))
+                .collect();
+            extractors.push(Extractor::for_truncation_indicator());
+            for i in half..(2 * half) {
+                extractors.push(Extractor::new(&format!("/f_{i:03}"), &policy));
+            }
+            let plan = ExtractorPlan::new(&extractors);
+            assert_eq!(
+                merge_joined_extractor_count(&plan),
+                expected_joined,
+                "half={half}"
+            );
+            assert_plan_matches(&doc, &extractors);
+        }
+    }
+
+    #[test]
+    fn block_with_missing_fields_uses_defaults() {
+        const N: usize = 4;
+        let doc = build_block_doc(N);
+        let policy = SerPolicy::noop();
+        let mut extractors: Vec<Extractor> = (0..N)
+            .map(|i| Extractor::new(&format!("/f_{i:03}"), &policy))
+            .collect();
+        for i in 0..N {
+            let ptr = format!("/absent_{i}");
+            if i < N / 2 {
+                extractors.push(Extractor::with_default(
+                    &ptr,
+                    &policy,
+                    json!(format!("d_{i}")),
+                ));
+            } else {
+                // No default.
+                extractors.push(Extractor::new(&ptr, &policy));
+            }
+        }
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(plan.blocks.len(), 2);
+        assert_eq!(merge_joined_extractor_count(&plan), 2 * N);
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn block_with_unusable_parent_uses_defaults() {
+        let policy = SerPolicy::noop();
+        for (doc, parent) in [
+            // Nested parent is not an object.
+            (json!({"present": 1}), "/absent_parent"),
+            (json!({"arr": [1, 2, 3]}), "/arr"),
+            (json!({"p": null}), "/p"),
+            (json!({"p": "hi"}), "/p"),
+            (json!({"p": 42}), "/p"),
+            (json!({"p": true}), "/p"),
+            // Root document is not an object.
+            (json!([1, 2, 3]), ""),
+            (json!(null), ""),
+            (json!("hi"), ""),
+            (json!(42), ""),
+            (json!(true), ""),
+        ] {
+            const N: usize = 4;
+            let extractors: Vec<Extractor> = (0..N)
+                .map(|i| {
+                    Extractor::with_default(
+                        &format!("{parent}/f_{i:03}"),
+                        &policy,
+                        json!(format!("d_{i}")),
+                    )
+                })
+                .collect();
+            let plan = ExtractorPlan::new(&extractors);
+            assert_eq!(merge_joined_extractor_count(&plan), N, "parent={parent}");
+            assert_plan_matches(&doc, &extractors);
+        }
+    }
+
+    #[test]
+    fn block_with_duplicate_target_names() {
+        let doc = json!({
+            "a": "A", "b": "B", "c": "C", "d": "D",
+            "e": "E", "f": "F", "g": "G", "h": "H",
+        });
+        let policy = SerPolicy::noop();
+        let extractors = vec![
+            Extractor::new("/a", &policy),
+            Extractor::new("/b", &policy),
+            Extractor::new("/b", &policy), // duplicate
+            Extractor::new("/c", &policy),
+            Extractor::new("/d", &policy),
+            Extractor::new("/e", &policy),
+            Extractor::new("/f", &policy),
+            Extractor::new("/g", &policy),
+            Extractor::new("/h", &policy),
+        ];
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(merge_joined_extractor_count(&plan), extractors.len());
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn block_with_uuid_magic_inside() {
+        let doc = json!({
+            "a": "85bad119-15f2-11ee-8401-43f05f562888",
+            "b": "not-a-uuid",
+            "c": 42,
+            "d": "1878923d-162a-11ee-8401-43f05f562888",
+            "e": "extra",
+            "f": "1878923d-162a-11ee-8401-43f05f562888",
+            "g": "extra",
+            "h": "extra",
+        });
+        let extractors = vec![
+            Extractor::for_uuid_v1_date_time("/a"),
+            Extractor::for_uuid_v1_date_time("/b"),
+            Extractor::for_uuid_v1_date_time("/c"),
+            Extractor::for_uuid_v1_date_time("/d"),
+            Extractor::new("/e", &SerPolicy::noop()),
+            Extractor::for_uuid_v1_date_time("/f"),
+            Extractor::new("/g", &SerPolicy::noop()),
+            Extractor::new("/h", &SerPolicy::noop()),
+        ];
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(merge_joined_extractor_count(&plan), extractors.len());
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn array_index_suffix_not_eligible() {
+        let doc = json!({"arr": ["v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7"]});
+        let policy = SerPolicy::noop();
+        let extractors: Vec<Extractor> = (0..8)
+            .map(|i| Extractor::new(&format!("/arr/{i}"), &policy))
+            .collect();
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(merge_joined_extractor_count(&plan), 0);
+        assert_plan_matches(&doc, &extractors);
+    }
+
+    #[test]
+    fn sort_violations_split_runs() {
+        let policy = SerPolicy::noop();
+        for (doc, pointers, expected) in [
+            (
+                // Trailing violation leaves a singleton that doesn't form a block.
+                json!({"a":"a","b":"b","c":"c","d":"d","e":"e","f":"f","g":"g","h":"h","A":"A"}),
+                &["/a", "/b", "/c", "/d", "/e", "/f", "/g", "/h", "/A"][..],
+                8,
+            ),
+            (
+                // All-descending: every run has length 1, no blocks form.
+                json!({"a": 1, "b": 2, "c": 3}),
+                &["/c", "/b", "/a"][..],
+                0,
+            ),
+        ] {
+            let extractors: Vec<Extractor> = pointers
+                .iter()
+                .map(|p| Extractor::new(*p, &policy))
+                .collect();
+            let plan = ExtractorPlan::new(&extractors);
+            assert_eq!(
+                merge_joined_extractor_count(&plan),
+                expected,
+                "pointers={pointers:?}"
+            );
+            assert_plan_matches(&doc, &extractors);
+        }
+    }
+
+    #[test]
+    fn adjacent_runs_under_different_parents_dont_fuse() {
+        const N: usize = 4;
+        let mut obj_a = serde_json::Map::new();
+        let mut obj_b = serde_json::Map::new();
+        for i in 0..N {
+            obj_a.insert(format!("col_{i:03}"), json!(i as i64));
+            obj_b.insert(format!("col_{i:03}"), json!(format!("b_{i}")));
+        }
+        let doc =
+            json!({"a": serde_json::Value::Object(obj_a), "b": serde_json::Value::Object(obj_b)});
+        let policy = SerPolicy::noop();
+        let mut extractors: Vec<Extractor> = (0..N)
+            .map(|i| Extractor::new(&format!("/a/col_{i:03}"), &policy))
+            .collect();
+        for i in 0..N {
+            extractors.push(Extractor::new(&format!("/b/col_{i:03}"), &policy));
+        }
+        let plan = ExtractorPlan::new(&extractors);
+        assert_eq!(plan.blocks.len(), 2);
+        assert_eq!(merge_joined_extractor_count(&plan), 2 * N);
+        assert_plan_matches(&doc, &extractors);
+    }
+}

--- a/crates/doc/src/extractor_plan.rs
+++ b/crates/doc/src/extractor_plan.rs
@@ -508,4 +508,71 @@ mod test {
         assert_eq!(merge_joined_extractor_count(&plan), 2 * N);
         assert_plan_matches(&doc, &extractors);
     }
+
+    // HeapNode preserves duplicate JSON object properties. The reference path's
+    // Fields::get uses a linear `find` (first match) below 16 fields and
+    // `binary_search_by` (arbitrary match) at or above. The plan's merge-join
+    // always returns the first match, so the two paths agree below the
+    // threshold and can disagree at or above it.
+    #[test]
+    fn duplicate_keys_diverge_at_fields_get_threshold() {
+        let policy = SerPolicy::noop();
+        let extractors = vec![
+            Extractor::new("/parent/a", &policy),
+            Extractor::new("/parent/z", &policy),
+        ];
+
+        fn pack(extractors: &[Extractor], raw: &str) -> (bytes::Bytes, bytes::Bytes) {
+            // Raw JSON bytes through a Deserializer preserve duplicate keys;
+            // going via serde_json::Value would coalesce them through
+            // BTreeMap before HeapNode ever sees them.
+            let alloc = crate::HeapNode::new_allocator();
+            let mut de = serde_json::Deserializer::from_str(raw);
+            let heap = crate::HeapNode::from_serde(&mut de, &alloc).unwrap();
+
+            let mut ref_buf = bytes::BytesMut::new();
+            Extractor::extract_all_indicate_truncation(
+                &heap,
+                extractors,
+                &mut ref_buf,
+                &AtomicBool::new(false),
+            );
+
+            let mut plan_buf = bytes::BytesMut::new();
+            ExtractorPlan::new(extractors).extract_all_indicate_truncation(
+                &heap,
+                &mut plan_buf,
+                &AtomicBool::new(false),
+            );
+
+            (ref_buf.freeze(), plan_buf.freeze())
+        }
+
+        // Parent has 3 fields — Fields::get takes the linear branch and
+        // returns the first "a" (value 1), matching the plan.
+        let small = r#"{"parent":{"a":1,"a":2,"z":9}}"#;
+        let (reference_small, plan_small) = pack(&extractors, small);
+        assert_eq!(reference_small, plan_small, "below threshold, paths agree");
+
+        // Parent has 16 fields — Fields::get switches to binary_search_by,
+        // which lands on the second "a" (value 2) for this construction,
+        // while the plan still returns the first (value 1).
+        let large = concat!(
+            r#"{"parent":{"a":1,"a":2,"#,
+            r#""c01":0,"c02":0,"c03":0,"c04":0,"c05":0,"c06":0,"c07":0,"#,
+            r#""c08":0,"c09":0,"c10":0,"c11":0,"c12":0,"c13":0,"z":9}}"#,
+        );
+        let (reference_large, plan_large) = pack(&extractors, large);
+        assert_ne!(
+            reference_large, plan_large,
+            "at the 16-field threshold, paths diverge on duplicates",
+        );
+
+        // The plan's output is independent of parent size: it always
+        // resolves to the first occurrence.
+        assert_eq!(
+            plan_small, plan_large,
+            "plan resolves to the first duplicate regardless of parent size",
+        );
+    }
 }

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -35,6 +35,11 @@ pub use ser::SerPolicy;
 mod extractor;
 pub use extractor::{Extractor, TRUNCATION_INDICATOR_PTR};
 
+// ExtractorPlan is a pre-compiled Vec<Extractor> that shares pointer
+// traversals.
+mod extractor_plan;
+pub use extractor_plan::ExtractorPlan;
+
 // Optimized conversions from AsNode implementations into HeapNode.
 pub mod lazy;
 pub use lazy::LazyNode;

--- a/crates/doc/tests/extractor_perf.rs
+++ b/crates/doc/tests/extractor_perf.rs
@@ -1,0 +1,296 @@
+use doc::{ArchivedNode, Extractor, ExtractorPlan, HeapNode, SerPolicy};
+use serde_json::{Map, Value, json};
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+// This benchmark compares `Extractor::extract_all_indicate_truncation`
+// against `ExtractorPlan::extract_all_indicate_truncation` across the
+// essential planner performance cases.
+//
+// Run in CI to keep it functional; for manual investigation:
+//
+//   cargo test --release -p doc --test extractor_perf -- --nocapture
+
+// How many total rounds to run?
+const TOTAL_ROUNDS: usize = 100;
+
+#[derive(Debug)]
+struct CaseReport {
+    name: &'static str,
+    extractor_count: usize,
+    heap_extractor_ns_per_doc: f64,
+    heap_plan_ns_per_doc: f64,
+    archived_extractor_ns_per_doc: f64,
+    archived_plan_ns_per_doc: f64,
+}
+
+#[test]
+fn extractor_perf() {
+    let policy = SerPolicy::noop();
+    let begin = Instant::now();
+
+    let mut reports: Vec<CaseReport> = Vec::new();
+    for (name, doc, extractors) in [
+        build_single_wide_block(&policy),
+        build_nested_blocks_with_singles(&policy),
+        build_no_blocks(&policy),
+        build_sparse_block_large_parent(&policy),
+        build_many_small_blocks(&policy),
+        build_deeply_nested_blocks(&policy),
+    ] {
+        reports.push(run_case(name, &doc, &extractors));
+    }
+
+    let duration = begin.elapsed();
+
+    eprintln!("\n=== extractor_perf ({TOTAL_ROUNDS} rounds/case) ===");
+    for r in &reports {
+        eprintln!(
+            "\n{name}:\n  extractors={extractors}\n  HeapNode     Extractor={h_ex:.0}ns   ExtractorPlan={h_pl:.0}ns   ({speed_h:.2}x)\n  ArchivedNode Extractor={a_ex:.0}ns   ExtractorPlan={a_pl:.0}ns   ({speed_a:.2}x)",
+            name = r.name,
+            extractors = r.extractor_count,
+            h_ex = r.heap_extractor_ns_per_doc,
+            h_pl = r.heap_plan_ns_per_doc,
+            speed_h = r.heap_extractor_ns_per_doc / r.heap_plan_ns_per_doc.max(1.0),
+            a_ex = r.archived_extractor_ns_per_doc,
+            a_pl = r.archived_plan_ns_per_doc,
+            speed_a = r.archived_extractor_ns_per_doc / r.archived_plan_ns_per_doc.max(1.0),
+        );
+    }
+    eprintln!(
+        "\nRounds: {}\nCases: {}\nElapsed: {}s",
+        TOTAL_ROUNDS,
+        reports.len(),
+        duration.as_secs_f64(),
+    );
+}
+
+fn run_case(name: &'static str, doc: &Value, extractors: &[Extractor]) -> CaseReport {
+    let alloc = HeapNode::new_allocator();
+    let heap = HeapNode::from_serde(doc, &alloc).unwrap();
+    let archive = heap.to_archive();
+    let archived = ArchivedNode::from_archive(&archive);
+
+    let plan = ExtractorPlan::new(extractors);
+
+    let extractor_count = extractors.len();
+
+    let heap_ex = time_extractor(extractors, &heap);
+    let heap_pl = time_plan(&plan, &heap);
+    let arch_ex = time_extractor(extractors, archived);
+    let arch_pl = time_plan(&plan, archived);
+
+    CaseReport {
+        name,
+        extractor_count,
+        heap_extractor_ns_per_doc: heap_ex,
+        heap_plan_ns_per_doc: heap_pl,
+        archived_extractor_ns_per_doc: arch_ex,
+        archived_plan_ns_per_doc: arch_pl,
+    }
+}
+
+fn time_extractor<N: json::AsNode>(extractors: &[Extractor], doc: &N) -> f64 {
+    let mut buf = bytes::BytesMut::with_capacity(4096);
+    // Warm up.
+    for _ in 0..(TOTAL_ROUNDS / 10).max(1) {
+        buf.clear();
+        let indicator = AtomicBool::new(false);
+        Extractor::extract_all_indicate_truncation(doc, extractors, &mut buf, &indicator);
+    }
+
+    let start = Instant::now();
+    for _ in 0..TOTAL_ROUNDS {
+        buf.clear();
+        let indicator = AtomicBool::new(false);
+        Extractor::extract_all_indicate_truncation(doc, extractors, &mut buf, &indicator);
+    }
+    let elapsed = start.elapsed().as_nanos() as f64;
+    elapsed / TOTAL_ROUNDS as f64
+}
+
+fn time_plan<N: json::AsNode>(plan: &ExtractorPlan, doc: &N) -> f64 {
+    let mut buf = bytes::BytesMut::with_capacity(4096);
+    for _ in 0..(TOTAL_ROUNDS / 10).max(1) {
+        buf.clear();
+        let indicator = AtomicBool::new(false);
+        plan.extract_all_indicate_truncation(doc, &mut buf, &indicator);
+    }
+
+    let start = Instant::now();
+    for _ in 0..TOTAL_ROUNDS {
+        buf.clear();
+        let indicator = AtomicBool::new(false);
+        plan.extract_all_indicate_truncation(doc, &mut buf, &indicator);
+    }
+    let elapsed = start.elapsed().as_nanos() as f64;
+    elapsed / TOTAL_ROUNDS as f64
+}
+
+fn build_single_wide_block(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // One top-level merge-join block. This is the primary happy path.
+    const N: usize = 64;
+
+    let doc = Value::Object(numbered_fields("f", N));
+    let extractors = (0..N)
+        .map(|i| Extractor::new(&format!("/f_{i:03}"), policy))
+        .collect();
+
+    ("single wide block", doc, extractors)
+}
+
+fn build_nested_blocks_with_singles(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // Realistic materialization shape: two wide nested blocks plus metadata,
+    // UUID magic, and truncation indicator singles.
+    const PER_SECTION: usize = 32;
+
+    let doc = json!({
+        "_meta": {
+            "uuid": "85bad119-15f2-11ee-8401-43f05f562888",
+            "op": "u",
+            "source": {"ts_ms": 1_696_000_000_000u64, "table": "orders"},
+        },
+        "after": Value::Object(numbered_fields("col", PER_SECTION)),
+        "before": Value::Object(numbered_fields("col", PER_SECTION)),
+    });
+
+    let mut extractors = Vec::new();
+    extractors.push(Extractor::for_uuid_v1_date_time("/_meta/uuid"));
+    extractors.push(Extractor::new("/_meta/op", policy));
+    extractors.push(Extractor::new("/_meta/source/table", policy));
+    extractors.push(Extractor::new("/_meta/source/ts_ms", policy));
+    for i in 0..PER_SECTION {
+        extractors.push(Extractor::new(&format!("/after/col_{i:03}"), policy));
+    }
+    for i in 0..PER_SECTION {
+        extractors.push(Extractor::new(&format!("/before/col_{i:03}"), policy));
+    }
+    extractors.push(Extractor::for_truncation_indicator());
+
+    ("cdc blocks with singles", doc, extractors)
+}
+
+fn build_no_blocks(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // Every consecutive pair of extractors targets a different parent, so each
+    // run is a singleton and no blocks form. Measures plan-overhead parity
+    // against the reference path's pure `Fields::get` walk.
+    let doc = json!({
+        "_meta": {
+            "timestamp": "2024-06-01T12:34:56Z",
+            "uuid": "85bad119-15f2-11ee-8401-43f05f562888",
+            "version": "v2",
+        },
+        "client": {"ip": "10.0.0.5", "platform": "macos", "user_agent": "example/1.0"},
+        "request": {
+            "duration_ms": 37,
+            "headers": {"content_type": "application/json"},
+            "method": "POST",
+            "path": "/api/v1/orders",
+        },
+        "response": {"size_bytes": 4096, "status": 200},
+        "trace": {"span_id": "abc123", "trace_id": "def456"},
+        "user": {"id": 42, "org_id": "acme", "role": "admin"},
+    });
+
+    let extractors = vec![
+        Extractor::new("/_meta/timestamp", policy),
+        Extractor::new("/client/ip", policy),
+        Extractor::new("/request/duration_ms", policy),
+        Extractor::new("/request/headers/content_type", policy),
+        Extractor::new("/response/size_bytes", policy),
+        Extractor::new("/trace/span_id", policy),
+        Extractor::new("/user/id", policy),
+        Extractor::for_uuid_v1_date_time("/_meta/uuid"),
+        Extractor::new("/client/platform", policy),
+        Extractor::new("/request/method", policy),
+        Extractor::new("/response/status", policy),
+        Extractor::new("/trace/trace_id", policy),
+        Extractor::new("/user/org_id", policy),
+        Extractor::new("/_meta/version", policy),
+        Extractor::new("/client/user_agent", policy),
+        Extractor::new("/request/path", policy),
+        Extractor::new("/user/role", policy),
+    ];
+
+    ("no blocks", doc, extractors)
+}
+
+fn build_sparse_block_large_parent(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // Risk case: the block is much smaller than the parent object, so the
+    // merge path scans many fields that are not projected.
+    const PARENT_FIELDS: usize = 512;
+    const BLOCK: usize = 32;
+
+    let doc = Value::Object(numbered_fields("f", PARENT_FIELDS));
+    let extractors = (0..BLOCK)
+        .map(|i| {
+            let target = (i * (PARENT_FIELDS / BLOCK) + 7) % PARENT_FIELDS;
+            Extractor::new(&format!("/f_{target:03}"), policy)
+        })
+        .collect();
+
+    ("sparse block, large parent", doc, extractors)
+}
+
+fn build_many_small_blocks(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // Per-block overhead case: many parents, each just large enough to form
+    // a block.
+    const SECTIONS: [&str; 8] = [
+        "client", "context", "env", "request", "response", "server", "trace", "user",
+    ];
+    const FIELDS_PER_SECTION: usize = 10;
+
+    let mut doc_map = Map::new();
+    for section in SECTIONS {
+        doc_map.insert(
+            section.to_string(),
+            Value::Object(numbered_fields("f", FIELDS_PER_SECTION)),
+        );
+    }
+    let doc = Value::Object(doc_map);
+
+    let mut extractors = Vec::with_capacity(SECTIONS.len() * FIELDS_PER_SECTION);
+    for section in SECTIONS {
+        for i in 0..FIELDS_PER_SECTION {
+            extractors.push(Extractor::new(&format!("/{section}/f_{i:03}"), policy));
+        }
+    }
+
+    ("many small blocks", doc, extractors)
+}
+
+fn build_deeply_nested_blocks(policy: &SerPolicy) -> (&'static str, Value, Vec<Extractor>) {
+    // 500 fields across five nesting levels: 100 at root, plus 100 more at each
+    // of /a, /a/b, /a/b/c, /a/b/c/d. Each level forms its own wide block.
+    const PER_LEVEL: usize = 100;
+
+    // Build deepest-first, wrap outward.
+    let d = numbered_fields("f", PER_LEVEL);
+    let mut c = numbered_fields("f", PER_LEVEL);
+    c.insert("d".into(), Value::Object(d));
+    let mut b = numbered_fields("f", PER_LEVEL);
+    b.insert("c".into(), Value::Object(c));
+    let mut a = numbered_fields("f", PER_LEVEL);
+    a.insert("b".into(), Value::Object(b));
+    let mut root = numbered_fields("f", PER_LEVEL);
+    root.insert("a".into(), Value::Object(a));
+
+    let doc = Value::Object(root);
+
+    let mut extractors = Vec::with_capacity(PER_LEVEL * 5);
+    for prefix in ["", "/a", "/a/b", "/a/b/c", "/a/b/c/d"] {
+        for i in 0..PER_LEVEL {
+            extractors.push(Extractor::new(&format!("{prefix}/f_{i:03}"), policy));
+        }
+    }
+
+    ("deeply nested blocks", doc, extractors)
+}
+
+fn numbered_fields(prefix: &str, n: usize) -> Map<String, Value> {
+    let mut fields = Map::new();
+    for i in 0..n {
+        fields.insert(format!("{prefix}_{i:03}"), json!(format!("v_{i}")));
+    }
+    fields
+}

--- a/crates/doc/tests/extractor_plan_fuzz.rs
+++ b/crates/doc/tests/extractor_plan_fuzz.rs
@@ -1,0 +1,276 @@
+use doc::{ArchivedNode, Extractor, ExtractorPlan, HeapNode, SerPolicy};
+use quickcheck::{Arbitrary, Gen, QuickCheck};
+use serde_json::{Value, json};
+use std::sync::LazyLock;
+use std::sync::atomic::AtomicBool;
+
+// Differential fuzz test: `ExtractorPlan` must produce byte-for-byte identical
+// output to the reference `Extractor` path for the same extractor list.
+//
+// The planner has one optimized behavior: runs of two or more ordered sibling
+// leaves under a common parent are emitted by walking to the parent once and
+// merge-joining the parent's fields. Singletons fall through to the reference
+// path. This test keeps the document fixed and fuzzes extractor plans that
+// mix runs of varying length (including 1) with fallback singles, so both
+// sides of the block/no-block boundary are exercised.
+//
+// Each generated plan includes three runs (under `/wide`, `/nested/inner`,
+// and a randomly-chosen *unusable* parent) of randomized length in
+// `[1, MAX_RUN_LEN]`, plus interspersed singles and optional
+// truncation-indicator / UUID extractors.
+
+const UUID_STR: &str = "85bad119-15f2-11ee-8401-43f05f562888";
+const UUID_PTR: &str = "/_meta/uuid";
+
+const FIELD_COUNT: usize = 24;
+const MAX_RUN_LEN: usize = 12;
+
+#[derive(Clone, Copy, Debug)]
+enum ExtractorDefault {
+    None,
+    Number,
+    String,
+    Object,
+}
+
+impl ExtractorDefault {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match u8::arbitrary(g) % 4 {
+            0 => ExtractorDefault::Number,
+            1 => ExtractorDefault::String,
+            2 => ExtractorDefault::Object,
+            _ => ExtractorDefault::None,
+        }
+    }
+
+    fn value(self) -> Option<Value> {
+        match self {
+            ExtractorDefault::None => None,
+            ExtractorDefault::Number => Some(json!(42)),
+            ExtractorDefault::String => Some(json!("default")),
+            ExtractorDefault::Object => Some(json!({"default": true})),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ExtractorSpec {
+    Regular {
+        ptr: String,
+        default: ExtractorDefault,
+    },
+    Uuid,
+    Indicator,
+}
+
+impl ExtractorSpec {
+    fn regular(ptr: impl Into<String>, default: ExtractorDefault) -> Self {
+        Self::Regular {
+            ptr: ptr.into(),
+            default,
+        }
+    }
+
+    fn build(&self, policy: &SerPolicy) -> Extractor {
+        match self {
+            Self::Regular { ptr, default } => match default.value() {
+                None => Extractor::new(ptr.as_str(), policy),
+                Some(v) => Extractor::with_default(ptr, policy, v),
+            },
+            Self::Uuid => Extractor::for_uuid_v1_date_time(UUID_PTR),
+            Self::Indicator => Extractor::for_truncation_indicator(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PlanSpec {
+    entries: Vec<ExtractorSpec>,
+    policy_kind: u8,
+}
+
+impl Arbitrary for PlanSpec {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut entries = Vec::new();
+        let indicator_slot = usize::arbitrary(g) % 7;
+        let uuid_slot = usize::arbitrary(g) % 7;
+        let unusable_parent = match u8::arbitrary(g) % 4 {
+            0 => "/missing_parent",
+            1 => "/null_parent",
+            2 => "/str_parent",
+            _ => "/arr",
+        };
+
+        for slot in 0..=6 {
+            if uuid_slot == slot {
+                entries.push(ExtractorSpec::Uuid);
+            }
+            if indicator_slot == slot {
+                entries.push(ExtractorSpec::Indicator);
+            }
+
+            match slot {
+                0 | 2 | 5 => push_random_singles(&mut entries, g),
+                1 => push_run(&mut entries, "/wide", g),
+                3 => push_run(&mut entries, "/nested/inner", g),
+                4 => push_run(&mut entries, unusable_parent, g),
+                6 => {}
+                _ => unreachable!(),
+            }
+        }
+
+        Self {
+            entries,
+            policy_kind: u8::arbitrary(g) % 3,
+        }
+    }
+}
+
+impl PlanSpec {
+    fn build_extractors(&self) -> Vec<Extractor> {
+        let policy = match self.policy_kind {
+            0 => SerPolicy::noop(),
+            1 => SerPolicy::truncate_strings(4),
+            _ => SerPolicy {
+                str_truncate_after: 8,
+                array_truncate_after: 2,
+                nested_obj_truncate_after: 2,
+            },
+        };
+
+        self.entries.iter().map(|e| e.build(&policy)).collect()
+    }
+}
+
+fn push_run(entries: &mut Vec<ExtractorSpec>, parent: &str, g: &mut Gen) {
+    let len = 1 + usize::arbitrary(g) % MAX_RUN_LEN;
+    let offset = usize::arbitrary(g) % (FIELD_COUNT - len + 1);
+
+    for i in 0..len {
+        let field = if i > 0 && u8::arbitrary(g) % 12 == 0 {
+            i - 1 // duplicate the prior target; duplicate names are block-eligible.
+        } else {
+            i
+        };
+        entries.push(ExtractorSpec::regular(
+            format!("{parent}/f_{:02}", offset + field),
+            ExtractorDefault::arbitrary(g),
+        ));
+    }
+}
+
+fn push_random_singles(entries: &mut Vec<ExtractorSpec>, g: &mut Gen) {
+    let count = usize::arbitrary(g) % 4;
+    for _ in 0..count {
+        let ptr = match u8::arbitrary(g) % 12 {
+            0 => "",
+            1 => "/arr",
+            2 => "/arr/0",
+            3 => "/arr/9",
+            4 => "/wide/f_00",
+            5 => "/wide/f_01",
+            6 => "/nested/inner/f_02",
+            7 => "/missing",
+            8 => "/missing/child",
+            9 => "/null_parent/child",
+            10 => "/str_parent/child",
+            _ => "/long",
+        };
+        entries.push(ExtractorSpec::regular(ptr, ExtractorDefault::arbitrary(g)));
+    }
+}
+
+fn build_doc() -> Value {
+    json!({
+        "_meta": {"uuid": UUID_STR},
+        "wide": field_map(),
+        "nested": {"inner": field_map()},
+        "arr": ["v0", "v1", "v2", "v3"],
+        "null_parent": null,
+        "str_parent": "not-an-object",
+        "long": "this string is intentionally long enough to truncate",
+    })
+}
+
+fn field_map() -> Value {
+    let mut fields = serde_json::Map::new();
+    for i in 0..FIELD_COUNT {
+        if i % 2 == 0 {
+            fields.insert(format!("f_{i:02}"), field_value(i));
+        }
+    }
+    Value::Object(fields)
+}
+
+fn field_value(i: usize) -> Value {
+    match i % 8 {
+        0 => json!(i as i64),
+        2 => json!(format!("value-{i}-with-tail")),
+        4 => json!(true),
+        _ => json!({"nested": i, "values": [1, 2, 3, 4]}),
+    }
+}
+
+fn pack_reference<N: json::AsNode>(doc: &N, extractors: &[Extractor]) -> bytes::Bytes {
+    let mut buf = bytes::BytesMut::new();
+    let indicator = AtomicBool::new(false);
+    Extractor::extract_all_indicate_truncation(doc, extractors, &mut buf, &indicator);
+    buf.freeze()
+}
+
+fn pack_plan<N: json::AsNode>(plan: &ExtractorPlan, doc: &N) -> bytes::Bytes {
+    let mut buf = bytes::BytesMut::new();
+    let indicator = AtomicBool::new(false);
+    plan.extract_all_indicate_truncation(doc, &mut buf, &indicator);
+    buf.freeze()
+}
+
+fn check_representation<N: json::AsNode>(
+    name: &str,
+    doc: &Value,
+    node: &N,
+    plan: &ExtractorPlan,
+    extractors: &[Extractor],
+) -> bool {
+    let ref_bytes = pack_reference(node, extractors);
+    let plan_bytes = pack_plan(plan, node);
+
+    if ref_bytes == plan_bytes {
+        true
+    } else {
+        eprintln!(
+            "{name} divergence\ndoc={doc}\nextractors={extractors:#?}\nref={ref_bytes:02x?}\nplan={plan_bytes:02x?}",
+        );
+        false
+    }
+}
+
+static DOC: LazyLock<Value> = LazyLock::new(build_doc);
+
+fn assert_equivalent(plan_spec: PlanSpec) -> bool {
+    let doc: &Value = &DOC;
+    let extractors = plan_spec.build_extractors();
+    let plan = ExtractorPlan::new(&extractors);
+
+    if !check_representation("serde_json::Value", doc, doc, &plan, &extractors) {
+        return false;
+    }
+
+    let alloc = HeapNode::new_allocator();
+    let heap = HeapNode::from_serde(doc, &alloc).expect("build_doc produces valid HeapNode input");
+    if !check_representation("HeapNode", doc, &heap, &plan, &extractors) {
+        return false;
+    }
+
+    let archive = heap.to_archive();
+    let archived = ArchivedNode::from_archive(&archive);
+    check_representation("ArchivedNode", doc, archived, &plan, &extractors)
+}
+
+#[test]
+fn fuzz_plan_matches_extractor() {
+    QuickCheck::new()
+        .r#gen(Gen::new(50))
+        .tests(1_000)
+        .quickcheck(assert_equivalent as fn(PlanSpec) -> bool);
+}

--- a/crates/runtime/src/materialize/mod.rs
+++ b/crates/runtime/src/materialize/mod.rs
@@ -27,15 +27,15 @@ pub struct Task {
 
 #[derive(Debug)]
 struct Binding {
-    collection_name: String,               // Source collection.
-    delta_updates: bool,                   // Delta updates, or standard?
-    journal_read_suffix: String, // Suffix attached to journal checkpoints for this binding.
+    collection_name: String,             // Source collection.
+    delta_updates: bool,                 // Delta updates, or standard?
+    journal_read_suffix: String,         // Suffix attached to journal checkpoints for this binding.
     key_extractors: Vec<doc::Extractor>, // Key extractors for this collection.
-    read_schema_json: bytes::Bytes, // Read JSON-Schema of collection documents.
-    ser_policy: doc::SerPolicy,  // Serialization policy for this source.
-    state_key: String,           // State key for this binding.
-    store_document: bool,        // Are we storing the root document (often `flow_document`)?
-    value_extractors: Vec<doc::Extractor>, // Field extractors for this collection.
+    read_schema_json: bytes::Bytes,      // Read JSON-Schema of collection documents.
+    ser_policy: doc::SerPolicy,          // Serialization policy for this source.
+    state_key: String,                   // State key for this binding.
+    store_document: bool, // Are we storing the root document (often `flow_document`)?
+    value_plan: doc::ExtractorPlan,
     /// Pointer to extract the document UUID.
     uuid_ptr: json::Pointer,
 }

--- a/crates/runtime/src/materialize/protocol.rs
+++ b/crates/runtime/src/materialize/protocol.rs
@@ -453,12 +453,9 @@ pub fn send_connector_store(
     .expect("document serialization cannot fail");
     let mut doc_json = buf.split().freeze();
 
-    doc::Extractor::extract_all_owned_indicate_truncation(
-        &root,
-        &binding.value_extractors,
-        buf,
-        &truncation_indicator,
-    );
+    binding
+        .value_plan
+        .extract_all_owned_indicate_truncation(&root, buf, &truncation_indicator);
     let values_packed = buf.split().freeze();
 
     // Accumulate metrics over reads for our transforms.

--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -165,7 +165,11 @@ impl Binding {
         };
 
         let key_extractors = extractors::for_fields(selected_key, projections, &ser_policy)?;
-        let value_extractors = extractors::for_fields(selected_values, projections, &ser_policy)?;
+        let value_plan = doc::ExtractorPlan::new(&extractors::for_fields(
+            selected_values,
+            projections,
+            &ser_policy,
+        )?);
 
         let read_schema_json = if read_schema_json.is_empty() {
             write_schema_json
@@ -185,7 +189,7 @@ impl Binding {
             ser_policy,
             state_key: state_key.clone(),
             store_document: !selected_root.is_empty(),
-            value_extractors,
+            value_plan,
             uuid_ptr,
         })
     }

--- a/crates/runtime/src/materialize/triggers.rs
+++ b/crates/runtime/src/materialize/triggers.rs
@@ -341,7 +341,7 @@ mod test {
                     ser_policy: doc::SerPolicy::noop(),
                     state_key: String::new(),
                     store_document: false,
-                    value_extractors: Vec::new(),
+                    value_plan: doc::ExtractorPlan::new(&[]),
                     uuid_ptr: json::Pointer::empty(),
                 })
                 .collect(),

--- a/plans/optimized-extractor.md
+++ b/plans/optimized-extractor.md
@@ -1,0 +1,224 @@
+# ExtractorPlan: Merge-Join Optimization for Field Extraction
+
+## Motivation
+
+Materializations project each output field by invoking
+`doc::Extractor::extract_all_indicate_truncation`, which calls
+`Pointer::query` once per extractor. For a binding with N projected fields on
+a common parent object, that's N independent walks from the document root
+down through the shared parent, plus N lookups against the parent's fields.
+
+Real bindings commonly have many sibling-leaf fields under one parent
+(`/after/col_*`, `/before/col_*`, etc.), so this is N walks of nearly
+identical work followed by N `Fields::get` calls on the same parent. Each
+`Fields::get` is `O(log F)` against the parent's sorted field list.
+
+If the extractor list is sorted by field name, that sequence collapses to a
+single merge-join: walk to the parent once, then step through the parent's
+fields and the extractor list in tandem in `O(F + N)`. The win compounds
+with parent depth and section width.
+
+## Work to do
+
+1. Add `crates/doc/src/extractor_plan.rs` defining `ExtractorPlan`, a
+   pre-compiled plan over a `Vec<Extractor>`.
+2. Refactor `crates/doc/src/extractor.rs` to expose the building blocks
+   the plan needs (see dedicated section below).
+3. Wire the plan into the materialize runtime: replace
+   `Binding.value_extractors` with `Binding.value_plan: doc::ExtractorPlan`.
+4. Add tests: a differential fuzz test (`extractor_plan_fuzz.rs`) and a
+   performance benchmark harness (`extractor_perf.rs`).
+
+## `ExtractorPlan`: design
+
+`ExtractorPlan::new` should scan the extractor list for **blocks**:
+maximal runs of two or more consecutive extractors that are all
+sibling-leaves (`parent_ptr + /property`) under a single common parent
+with field names in monotonically ascending order. Singletons don't
+form a block — they'd pay the block's setup cost (parent walk, object
+check, iterator construction) with no sharing benefit, and degrade the
+field lookup from `Fields::get` (binary search) to a linear merge
+advance.
+
+At extract time:
+- Extractors outside any block should flow through the reference path
+  (`write_extracted`), which does a per-extractor `Pointer::query`.
+- For each block, walk once to the parent pointer (`emit_block`). If
+  the parent resolves to an object, do a two-pointer walk of the
+  parent's fields and the block's field names
+  (`merge_write_block_extractors`). If the parent is missing, null, or
+  a non-object, every block extractor receives `None` and uses its
+  default.
+
+The plan must preserve the exact output bytes of the reference path,
+including truncation-indicator bookkeeping and the ordering of defaults
+when fields are missing. Enforce that invariant with the differential
+fuzz test.
+
+### Ineligibility rules (keep deliberately simple)
+
+- Root-document extractor (`Pointer` empty) — no parent to merge against.
+- Array-index terminal (`/arr/0`) — merge-join is over object field
+  names, not positional indices.
+- Truncation indicator — must write its placeholder at its own tuple
+  position, so it breaks a run even if it sits between otherwise-eligible
+  siblings.
+- Non-ascending field names — the merge-join relies on monotonic
+  ordering; a back-step splits the run.
+- Different parents — different parent pointers never fuse.
+
+Note on sort violations: splitting a run when field names aren't in
+ascending order is intentionally all-or-nothing. We deliberately skip
+the obvious next step — reorder the block into sorted form, merge-join,
+then scatter values back into their original output positions — because
+field selection for materializations almost always emits fields in
+field-name order already. Treating reordering as a non-goal keeps both
+the planner and the runtime straightforward.
+
+## Refactor of `extractor.rs` to support the plan
+
+`ExtractorPlan` needs almost all of `Extractor`'s internals — policy
+application, UUID magic, truncation-indicator accounting, default
+substitution, tuple packing. Duplicating any of that would be fragile,
+so the job here is to lift the right seams out of `Extractor` and make
+them reachable from the plan module without changing observable
+behavior.
+
+The refactor should be structural only. Every reshuffle needs a
+corresponding inlined call at the old site so the pre-refactor
+`extract_all_indicate_truncation` and `extract_indicate_truncation`
+still work byte-for-byte the same.
+
+### New `PlanKind` classifier (crate-visible)
+
+Add a small enum (`PlanKind<'a>`) returned by a new
+`Extractor::plan_kind()` method, which inspects `self.ptr`'s terminal
+token and `self.magic`. The plan-compile scan uses this to decide
+eligibility without reaching into `Extractor`'s private fields. Three
+variants:
+
+- `MergeJoinLeaf { parent, name }` — an extractor whose pointer ends in
+  an object-property token. `parent` is the shared prefix slice;
+  `name` is the property name. These are the candidates for blocks.
+- `TruncationIndicator` — must run in place through the reference path.
+- `Other` — root or array-index terminal; not block-eligible.
+
+### Split `query` into resolved/unresolved halves
+
+`Extractor::query` currently does two things: resolve `self.ptr`
+against the doc, then apply magic and defaults to the resolved node.
+Split those steps:
+
+- `fn query(...)` — keep the signature; have it delegate to
+  `value_from_resolved(self.ptr.query(doc))`.
+- `fn value_from_resolved(...)` — new; takes an `Option<&N>` that has
+  already been resolved by some other means (in the plan's case, by
+  the merge-join). Contains the magic / default logic previously
+  embedded in `query`.
+
+This split is what lets the plan skip the per-extractor
+`Pointer::query` while still routing the resolved node through the
+exact same magic / default / truncation pipeline.
+
+### New `extract_from_resolved_indicate_truncation`
+
+Add a sibling of `extract_indicate_truncation` that takes a
+pre-resolved `Option<&N>` instead of walking `self.ptr` itself. This
+is the method `merge_write_block_extractors` and `emit_block` will
+call on a per-extractor basis after the merge-join has already
+resolved (or failed to resolve) the leaf. Make it crate-visible only.
+
+Have the existing `extract_indicate_truncation` trivially delegate to
+it.
+
+### Lift shared helpers out of `extract_all_indicate_truncation`
+
+`Extractor::extract_all_indicate_truncation` currently inlines two
+pieces of logic the plan also needs:
+
+- The per-slice write loop, including the debug-assert that catches
+  multiple truncation-indicator projections and the
+  `projected_indicator_pos` bookkeeping.
+- The retroactive flip of the indicator placeholder byte
+  (`0x26` → `0x27`) once the full extract is done.
+
+Lift those into two crate-visible free functions:
+
+- `write_extracted(doc, extractors, out, indicator, &mut projected_indicator_pos)`
+- `finalize_truncation_indicator(out, projected_indicator_pos, indicator)`
+
+Have `Extractor::extract_all_indicate_truncation` thread a local
+`projected_indicator_pos` through both, and have
+`ExtractorPlan::extract_all_indicate_truncation` do the same — calling
+`write_extracted` for the gap ranges between blocks and once more at
+the tail, with a single `finalize_truncation_indicator` at the end.
+Keeping the bookkeeping in one place is what makes it safe for the
+plan to interleave merge-join blocks with reference-path gaps without
+losing the single-indicator invariant.
+
+### Small helper: `is_truncation_indicator`
+
+Add a crate-visible `Extractor::is_truncation_indicator()` that
+replaces the direct `self.magic == Some(Magic::TruncationIndicator)`
+check inside the old `extract_all_indicate_truncation`. Both
+`write_extracted` and `plan_kind` will use it, and it avoids leaking
+the private `Magic` enum to the plan module.
+
+## Materialize runtime integration
+
+In `crates/runtime/src/materialize/`:
+
+- `mod.rs` — replace `Binding.value_extractors: Vec<doc::Extractor>`
+  with `Binding.value_plan: doc::ExtractorPlan`. Build the plan once
+  per binding at task-load time and reuse it for every document.
+- `task.rs` — in `Binding::build`, call `doc::ExtractorPlan::new(...)`
+  on the result of `extractors::for_fields(selected_values, ...)`.
+  Leave key extractors unchanged (keys are a small, fixed set where
+  merge-join wouldn't pay off).
+- `protocol.rs` — have `send_connector_store` call
+  `binding.value_plan.extract_all_owned_indicate_truncation(...)`
+  instead of `doc::Extractor::extract_all_owned_indicate_truncation`.
+- `triggers.rs` — update the test fixture to construct
+  `doc::ExtractorPlan::new(&[])`.
+
+Wire up only value extraction in this change. Key extraction should
+stay on the reference path.
+
+## Tests
+
+### `crates/doc/tests/extractor_plan_fuzz.rs` — differential fuzz
+
+QuickCheck-driven. For each generated `PlanSpec`, build both an
+`Extractor`-only reference pack and an `ExtractorPlan` pack over the
+same doc and assert byte equality. Run over `serde_json::Value`,
+`HeapNode`, and `ArchivedNode` so all three `AsNode` implementations
+are covered.
+
+Construct the generator to stress the planner, not to be uniformly
+random: every `PlanSpec` should contain three blocks (`/wide`,
+`/nested/inner`, and an intentionally-unusable parent like
+`/missing_parent` or `/arr`), interleaved with random singles,
+truncation indicator, UUID magic, and three policy variants (noop,
+string truncation, aggressive truncation).
+
+### `crates/doc/tests/extractor_perf.rs` — benchmark harness
+
+Not a correctness test; a performance harness that reports ns/doc for
+`Extractor` vs `ExtractorPlan` over six representative shapes:
+
+- `single wide block` — happy path: one 64-field top-level block.
+- `nested blocks with singles` — two nested 32-field blocks + metadata /
+  UUID / truncation-indicator singles. Closest to production shape.
+- `no blocks` — many singles under parents that never reach the
+  merge-join threshold. Verifies the plan doesn't regress here.
+- `sparse block, large parent` — 32 extractors over a 512-field parent.
+  The risk case: the merge scan visits many unprojected fields.
+- `many small blocks` — 8 parents of 10 fields each. Per-block fixed
+  overhead case.
+- `deeply nested blocks` — 5 parents at increasing depth, 100 fields
+  each. Demonstrates how parent-walk reuse compounds with depth.
+
+Run `TOTAL_ROUNDS = 100` per case against both `HeapNode` and
+`ArchivedNode`. Include it in CI so it keeps compiling, but note that
+meaningful numbers require `cargo test --release -p doc --test
+extractor_perf -- --nocapture`.


### PR DESCRIPTION
**Description:**

This PR optimizes field extraction by pre-compiling a `Vec<Extractor>` into **blocks** (runs of consecutive sibling-leaf extractors under a common parent). Each block navigates to the parent once and merge-joins the parent's fields against the block's leaf names. This replaces `N` root-to-leaf `Pointer::query` calls and `N` `Fields::get` calls with a single walk and a linear sweep.

On its own, the merge-join of many sorted extractor fields is a significant win. Avoiding repeated `Pointer::query` calls for common prefixes naturally extends this mechanism for further optimization.

### Output Equivalence

The plan produces byte-for-byte identical output to the reference Extractor path in the common case.

**Known edge case: duplicate property names at 16+ fields**. `Fields::get` uses a linear find below 16 fields (first match) and `binary_search_by` at or above (arbitrary match per Rust's documented semantics). The plan's merge-join always returns the first match, so the two paths agree below the threshold and can disagree at or above.  The plan's defined tiebreak is "first occurrence wins". See the `duplicate_keys_diverge_at_fields_get_threshold` unit test for the concrete construction.

### Performance Impact
The included benchmarks demonstrate a 2x to 5x+ improvement in typical cases:
* **Flat, wide objects:** See ~2x improvement, primarily benefiting from the linear merge-join.
* **Wide, deeply nested structures:** See 5x+ improvement, compounding the benefits of the linear sweep and the reduction in tree-walking.

### Edge Cases & Degradation
* **Parity:** If the selected fields are completely scattered throughout the object and form no blocks, the compiled plan essentially degrades gracefully to using single `Fields::get` calls, performing at parity with the unoptimized approach.
* **Worst-case scenario:** Performance can theoretically be worse than pure `Fields::get` in a wide object containing small clusters of fields that form isolated blocks scattered throughout it. This forces multiple linear scans instead of multiple binary searches. This is an adversarial and highly uncommon construction, but it serves as the primary motivator for not allowing *single* fields to form a block.

### Design Notes
In a preliminary implementation, I included a tuning parameter for the minimum number of eligible fields needed to form a block. It turned out that a threshold of just 2 was beneficial in plausible cases, making it easier to simply define a block as "any number of consecutive fields" (greater than one). The only role a tuning parameter would play is protecting against the adversarial case described above, which seems too rare in practice to justify the added complexity.

Closes https://github.com/estuary/flow/issues/2872

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

