### PR TITLE
Fix missing User-Agent on postgrest client, encourage users to update flowctl if a new version is available

### DIFF
--- a/crates/flow-client/src/client.rs
+++ b/crates/flow-client/src/client.rs
@@ -54,14 +54,15 @@ impl Client {
         );
 
         let http_client = reqwest::ClientBuilder::new()
-            .user_agent(user_agent)
+            .user_agent(user_agent.clone())
             .build()
             .expect("failed to build http client");
         Self {
             agent_endpoint,
             http_client,
             pg_parent: postgrest::Postgrest::new(pg_url.as_str())
-                .insert_header("apikey", pg_api_token.as_str()),
+                .insert_header("apikey", pg_api_token.as_str())
+                .insert_header("user-agent", user_agent),
             journal_client,
             shard_client,
             user_access_token,

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -17,6 +17,7 @@ mod output;
 mod poll;
 mod preview;
 mod raw;
+mod version;
 
 pub(crate) use flow_client::client::Client;
 use flow_client::client::refresh_authorizations;
@@ -186,7 +187,10 @@ impl Cli {
             output,
         };
 
-        match &self.cmd {
+        // Version check runs concurrently with the command
+        let version_check = tokio::spawn(version::check_latest());
+
+        let result = match &self.cmd {
             Command::AlertSubscriptions(alerts) => alerts.run(&mut context).await,
             Command::Auth(auth) => auth.run(&mut context).await,
             Command::Catalog(catalog) => catalog.run(&mut context).await,
@@ -197,8 +201,16 @@ impl Cli {
             Command::Draft(draft) => draft.run(&mut context).await,
             Command::Logs(logs) => logs.run(&mut context).await,
             Command::Raw(advanced) => advanced.run(&mut context).await,
-        }?;
+        };
 
+        // Print before `result?` so the warning is visible even when the command fails
+        if let Ok(Some(latest)) = version_check.await {
+            tracing::warn!(
+                "You're running an outdated version of flowctl — please update to {latest}",
+            );
+        }
+
+        result?;
         context.config.write(&self.profile)?;
 
         Ok(())

--- a/crates/flowctl/src/version.rs
+++ b/crates/flowctl/src/version.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+
+pub async fn check_latest() -> Option<String> {
+    match fetch_latest_tag().await {
+        Ok(latest) if latest != env!("CARGO_PKG_VERSION") => Some(latest),
+        Ok(_) => None,
+        Err(err) => {
+            tracing::debug!(%err, "version check failed");
+            None
+        }
+    }
+}
+
+async fn fetch_latest_tag() -> anyhow::Result<String> {
+    #[derive(serde::Deserialize)]
+    struct Release {
+        tag_name: String,
+    }
+
+    let current = env!("CARGO_PKG_VERSION");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()?;
+
+    let release: Release = client
+        .get("https://api.github.com/repos/estuary/flow/releases/latest")
+        .header("User-Agent", format!("flowctl/{current}"))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let tag = release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name);
+
+    Ok(tag.to_owned())
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where the `flowctl-<version>` User-Agent was set on the agent-API HTTP client but never on the PostgREST client, so all PostgREST calls arrived with an empty UA
- flowctl checks github for newer versions, prompts user to upgrade

```
$ flowctl some_command
WARN You're running an outdated version of flowctl — please update to 0.6.6
```
