### PR TITLE
docs(byoc): note tenant-id workaround for Azure consent link

### DIFF
--- a/site/docs/private-byoc/byoc-deployments/azure-byoc.md
+++ b/site/docs/private-byoc/byoc-deployments/azure-byoc.md
@@ -13,6 +13,8 @@ Your account will need Azure admin access to add the application to your Azure t
 If the application subscription process is successful, you will be redirected back to Estuary's homepage. You can confirm that the OAuth flow succeeded if there is a `code` query parameter attached to the URL (e.g. `https://estuary.dev/?code=123`).
 :::
 
+If your Azure admin is signed into multiple tenants, the `common` endpoint defaults to whichever they're currently signed into, which may be the wrong one. To force a specific tenant, replace `common` with your tenant ID: `https://login.microsoftonline.com/{TENANT_ID}/oauth2/authorize?client_id=76f09062-041b-476e-9c79-1cf8d26fe213&response_type=code&redirect_uri=https%3A%2F%2Feyrcnmuzzyriypdajwdk.supabase.co%2Ffunctions%2Fv1%2Fazure-dpc-oauth`
+
 2. In Azure Portal, search for "Subscriptions" and find your subscription, then click on "Access control (IAM)"
 
 ![Subscriptions -> Access control IAM](../images/azure/step-1.png)

--- a/site/docs/private-byoc/byoc-deployments/azure-byoc.md
+++ b/site/docs/private-byoc/byoc-deployments/azure-byoc.md
@@ -13,7 +13,10 @@ Your account will need Azure admin access to add the application to your Azure t
 If the application subscription process is successful, you will be redirected back to Estuary's homepage. You can confirm that the OAuth flow succeeded if there is a `code` query parameter attached to the URL (e.g. `https://estuary.dev/?code=123`).
 :::
 
-If your Azure admin is signed into multiple tenants, the `common` endpoint defaults to whichever they're currently signed into, which may be the wrong one. To force a specific tenant, replace `common` with your tenant ID: `https://login.microsoftonline.com/{TENANT_ID}/oauth2/authorize?client_id=76f09062-041b-476e-9c79-1cf8d26fe213&response_type=code&redirect_uri=https%3A%2F%2Feyrcnmuzzyriypdajwdk.supabase.co%2Ffunctions%2Fv1%2Fazure-dpc-oauth`
+If your Azure admin is signed into multiple tenants, the `common` endpoint defaults to whichever they're currently signed into, which may be the wrong one. To force a specific tenant, replace `common` in the `data-plane-controller` link with your tenant ID:
+```
+https://login.microsoftonline.com/{TENANT_ID}/oauth2/authorize?client_id=76f09062-041b-476e-9c79-1cf8d26fe213&response_type=code&redirect_uri=https%3A%2F%2Feyrcnmuzzyriypdajwdk.supabase.co%2Ffunctions%2Fv1%2Fazure-dpc-oauth
+```
 
 2. In Azure Portal, search for "Subscriptions" and find your subscription, then click on "Access control (IAM)"
 


### PR DESCRIPTION
## Summary
- Customer feedback (Azure BYOC onboarding) flagged that `https://login.microsoftonline.com/common/oauth2/authorize?...` silently consents the `data-plane-controller` app to whichever tenant the admin is currently signed into. Admins managing multiple Azure tenants ended up adding the app to the wrong tenant, blocking their data plane provisioning.
- Adds a brief inline note after the existing tip explaining how to swap `common` for `{TENANT_ID}` to force a specific tenant.

## Test plan
- [x] Plain paragraph rendering — no callout box, kept subtle
- [ ] Visually verify in docs preview build before merge