### PR TITLE
runtime: cap RocksDB MANIFEST size to roll over

### DIFF
--- a/crates/runtime/src/rocksdb.rs
+++ b/crates/runtime/src/rocksdb.rs
@@ -61,6 +61,15 @@ impl RocksDB {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
+        // The MANIFEST file is a WAL of database file state, including current live
+        // SST files and their begin & ending key ranges. A new MANIFEST-00XYZ is
+        // created at database start, where XYZ is the next available sequence number,
+        // and CURRENT is updated to point at the live MANIFEST. By default MANIFEST
+        // files may grow to 4GB, but they are typically written very slowly and thus
+        // artificially inflate the recovery log horizon. We use a much smaller limit
+        // to encourage more frequent compactions into new files.
+        opts.set_max_manifest_file_size(1 << 17); // 131072 bytes
+
         let db = rocksdb::DB::open_cf_descriptors(&opts, &path, cf_descriptors)
             .context("failed to open RocksDB")?;
 


### PR DESCRIPTION
**Description:**

Mirrors Gazette's store-rocksdb / store-sqlite setting so tasks roll their MANIFEST files instead of growing ~indefinitely and inflating the recovery log horizon.

I'm about 80% sure this on its own will be sufficient to fix an issue we've seen, where long running tasks with high rates of recovery log writes take a very long time to restart, because they must read an enormous amount of recovery log data.

From these long running tasks, I've observed:
- A single MANIFEST file, growing quite large (>100 MB), created at the very beginning of the session's recovery log, and appended to continuously
- A few other small files, written once, also at the very beginning of the session
- As the session runs, lots of churn of SST and WAL files as rocksdb does its compactions

The continuously appended, never deleted MANIFEST file creates a range in the recovery log that must be fully re-read by a new shard assignment, and that range spans from the very beginning to the end of that assignment. The MANIFEST's SeqNo range covers the entire log while the shard was running, and so it is all merged into a single segment that the new shard must read. When a shard is re-assigned, RocksDB rolls the MANIFEST on each open as a matter of course, which gets rid of the old one. So, as long as shards are re-assigned fairly often, their MANIFEST file doesn't grow too large.

A re-assigned shard also assigns precise LastOffset values for its hints as it reads the recovery log journal, although this does not appear to be the load-bearing mechanism for making subsequent restarts faster. The subsequent restarts are faster proportional only to how long the shard had previously been running.

Adding this configuration will cause the MANIFEST files to actually be cycled out on some practical frequency within a single session — piggybacking on the same RocksDB-internal rotation behavior that fires on re-open. The unlinked MANIFEST files (along with the other churned files from compaction) create sequence gaps that prevent a single huge segment, and allow the playback to read multiple disjoint targets, typically just two: the initial surviving small metadata files and the more recent "actual data" files, with a seek between them.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

