### PR TITLE
docs: add `event_type` to list of required fields in `appsflyer.md`

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/appsflyer.md
+++ b/site/docs/reference/Connectors/capture-connectors/appsflyer.md
@@ -56,13 +56,14 @@ To receive real-time events from AppsFlyer, you need to configure AppsFlyer to s
 3. In the [AppsFlyer dashboard](https://hq1.appsflyer.com/), navigate to **Integration > API Access** and configure your [Push API postback URLs](https://support.appsflyer.com/hc/en-us/articles/207034356-Push-API-streaming-raw-data) to point to the Estuary endpoint URL.
 4. Configure your Push API export to include the following required fields, which Estuary uses to construct each document's unique identifier:
    - `app_id`
-   - `app_type`
+   - `app_type` (only on Apple platforms)
    - `appsflyer_id`
    - `campaign_type`
    - `conversion_type`
    - `event_name`
    - `event_time`
    - `event_value`
+   - `event_type`
 
 Once configured, AppsFlyer will stream events to Estuary in real time.
 


### PR DESCRIPTION
**Description:**

Adds `event_type` to the list of required API export fields. Also notes that `app_type` is only available on iOS/macOS/tvOS app messages.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

