### PR TITLE
ci: pin `sccache` to stop tests from using a newer version and breaking

### DIFF
--- a/.github/workflows/dekaf-test.yaml
+++ b/.github/workflows/dekaf-test.yaml
@@ -12,6 +12,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+env:
+    SCCACHE_VERSION: v0.12.0
+
 jobs:
     dekaf-test:
         name: Dekaf Test
@@ -46,7 +49,10 @@ jobs:
                   key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
             - uses: mozilla-actions/sccache-action@v0.0.9
+              with:
+                  version: ${{ env.SCCACHE_VERSION }}
             - run: echo 'SCCACHE_GHA_ENABLED=true' >> $GITHUB_ENV
+            - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
             - run: mise run build:rocksdb
             - run: mise run ci:musl-dev
             - run: mise run ci:gnu-dev

--- a/.github/workflows/platform-build.yaml
+++ b/.github/workflows/platform-build.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SCCACHE_VERSION: v0.12.0
+
 jobs:
   platform-build:
     strategy:
@@ -52,7 +55,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          version: ${{ env.SCCACHE_VERSION }}
       - run: echo 'SCCACHE_GHA_ENABLED=true' >> $GITHUB_ENV
+      - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
 
       # These steps are kept in lockstep with task `ci:platform-build`
       - run: mise run build:rocksdb

--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SCCACHE_VERSION: v0.12.0
+
 jobs:
   format-check:
     name: Format Check
@@ -51,7 +54,10 @@ jobs:
             ~/rocksdb-${{ env.ROCKSDB_VERSION }}/lib/
 
       - uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          version: ${{ env.SCCACHE_VERSION }}
       - run: echo 'SCCACHE_GHA_ENABLED=true' >> $GITHUB_ENV
+      - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
 
       - name: Cache sqlx-cli
         id: cache-sqlx
@@ -101,7 +107,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          version: ${{ env.SCCACHE_VERSION }}
       - run: echo 'SCCACHE_GHA_ENABLED=true' >> $GITHUB_ENV
+      - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
 
       # These steps are kept in lockstep with task `ci:platform-test`
       # (formating and SQLx checks are run in separate jobs above to provide faster feedback).


### PR DESCRIPTION
I had been running into frequent CI failures caused by 
```
  sccache: error: failed to get stats from server
  sccache: caused by: Failed to send data to or receive data from server. Mismatch of client/server versions?
  sccache: caused by: tag for enum is not valid, found 95
```
This pins the GitHub Actions `sccache` to `v0.12.0`, which is the same version that it's pinned to in `mise`:

https://github.com/estuary/flow/blob/6bd08ca9bd2e40042083762e2161870added9cfd/mise.toml#L13

As a separate piece of work we should probably figure out whether we need to [upgrade to 0.15.0](https://github.com/mozilla/sccache), this is just about stopping tests from failing.