### PR TITLE
Inject controller defaults into `effectiveAlertConfig` resolution

### DIFF
--- a/crates/agent/src/controllers/abandon.rs
+++ b/crates/agent/src/controllers/abandon.rs
@@ -1,4 +1,7 @@
-use super::{ControllerConfig, ControllerState, NextRun, alerts};
+use super::{
+    ControllerConfig, ControllerState, NextRun, ResolvedAlertConfig,
+    ResolvedTaskChronicallyFailingConfig, ResolvedTaskIdleConfig, alerts,
+};
 use crate::controllers::activation::has_task_shards;
 use crate::controllers::publication_status::PendingPublication;
 use crate::controlplane::ControlPlane;
@@ -33,16 +36,22 @@ impl std::fmt::Display for DisableReason {
     }
 }
 
-fn auto_disable_enabled(alert_config: Option<&models::AlertConfig>, reason: DisableReason) -> bool {
+fn auto_disable_enabled(alert_config: &ResolvedAlertConfig, reason: DisableReason) -> bool {
     match reason {
-        DisableReason::Idle => alert_config
-            .and_then(|a| a.task_idle.as_ref())
-            .and_then(|t| t.auto_disable)
-            .unwrap_or(false),
-        DisableReason::ChronicallyFailing => alert_config
-            .and_then(|a| a.task_chronically_failing.as_ref())
-            .and_then(|c| c.auto_disable)
-            .unwrap_or(false),
+        DisableReason::Idle => matches!(
+            &alert_config.task_idle,
+            ResolvedTaskIdleConfig::Enabled {
+                auto_disable: true,
+                ..
+            }
+        ),
+        DisableReason::ChronicallyFailing => matches!(
+            &alert_config.task_chronically_failing,
+            ResolvedTaskChronicallyFailingConfig::Enabled {
+                auto_disable: true,
+                ..
+            }
+        ),
     }
 }
 
@@ -52,7 +61,7 @@ pub async fn evaluate_abandoned<C: ControlPlane>(
     abandon_status: &mut AbandonStatus,
     state: &ControllerState,
     control_plane: &C,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     // Tasks without shards (disabled, Dekaf, etc.) don't need abandon monitoring.
     if !has_task_shards(state) {
@@ -124,16 +133,16 @@ async fn fetch_abandonment_timestamps<C: ControlPlane>(
 /// be disabled, or `None` if no disable is needed.
 ///
 /// `config` supplies grace periods and `abandon_user_pub_recency`, which are
-/// system-level policies and remain global. `alert_config` may supply
-/// per-task threshold overrides for `taskIdle` and `taskChronicallyFailing`;
-/// absent fields fall through to `config`.
+/// system-level policies and remain global. `alert_config` supplies
+/// per-task threshold overrides for `taskIdle` and `taskChronicallyFailing`,
+/// with global defaults already merged as the lowest-priority layer.
 fn evaluate_alerts(
     alerts_status: &mut Alerts,
     state: &ControllerState,
     now: DateTime<Utc>,
     timestamps: AbandonmentTimestamps,
     config: &ControllerConfig,
-    alert_config: Option<&models::AlertConfig>,
+    alert_config: &ResolvedAlertConfig,
 ) -> Option<DisableReason> {
     // Tasks that are disabled, Dekaf, or lack shards don't get abandonment checks.
     // Silently resolve any alerts that may have been firing so re-enablement starts clean.
@@ -155,20 +164,13 @@ fn evaluate_alerts(
         .get(&AlertType::ShardFailed)
         .map(|a| a.first_ts);
 
-    let chronically_failing_threshold = alert_config
-        .and_then(|a| a.task_chronically_failing.as_ref())
-        .and_then(|c| c.condition.as_ref())
-        .and_then(|c| c.failing_for)
-        .and_then(|d| chrono::Duration::from_std(d).ok())
-        .unwrap_or(config.chronically_failing_threshold);
-    let chronic_silenced = alert_config
-        .and_then(|a| a.task_chronically_failing.as_ref())
-        .and_then(|c| c.enabled)
-        == Some(false);
-    let is_chronically_failing = !chronic_silenced
-        && shard_failed_since
-            .is_some_and(|first_ts| (now - first_ts) >= chronically_failing_threshold)
-        && user_pub_stale;
+    let is_chronically_failing = match &alert_config.task_chronically_failing {
+        ResolvedTaskChronicallyFailingConfig::Enabled { failing_for, .. } => {
+            shard_failed_since.is_some_and(|first_ts| (now - first_ts) >= *failing_for)
+                && user_pub_stale
+        }
+        ResolvedTaskChronicallyFailingConfig::Disabled => false,
+    };
 
     let mut disable_reason = None;
 
@@ -223,11 +225,9 @@ fn evaluate_alerts(
         let disable_at = chrono::NaiveDate::parse_from_str(&disable_at, "%Y-%m-%d")
             .expect("disable_at was set from a valid date");
 
-        let should_auto_disable_failing = alert_config
-            .map(|cfg| auto_disable_enabled(Some(cfg), DisableReason::ChronicallyFailing))
-            .unwrap_or(false);
-
-        if now.date_naive() >= disable_at && should_auto_disable_failing {
+        if now.date_naive() >= disable_at
+            && auto_disable_enabled(alert_config, DisableReason::ChronicallyFailing)
+        {
             if !alerts_status.contains_key(&AlertType::TaskAutoDisabledFailing) {
                 alerts::set_alert_firing(
                     alerts_status,
@@ -262,21 +262,15 @@ fn evaluate_alerts(
     let has_failure_alerts = alerts_status.contains_key(&AlertType::ShardFailed)
         || alerts_status.contains_key(&AlertType::TaskChronicallyFailing);
 
-    let idle_threshold = alert_config
-        .and_then(|a| a.task_idle.as_ref())
-        .and_then(|t| t.condition.as_ref())
-        .and_then(|c| c.idle_for)
-        .and_then(|d| chrono::Duration::from_std(d).ok())
-        .unwrap_or(config.abandon_idle_threshold);
-    let idle_silenced = alert_config
-        .and_then(|a| a.task_idle.as_ref())
-        .and_then(|t| t.enabled)
-        == Some(false);
-    let data_stale = timestamps
-        .last_data_movement_ts
-        .map_or(true, |ts| (now - ts) >= idle_threshold);
-
-    let is_idle = !idle_silenced && !has_failure_alerts && data_stale && user_pub_stale;
+    let is_idle = match &alert_config.task_idle {
+        ResolvedTaskIdleConfig::Enabled { idle_for, .. } => {
+            let data_stale = timestamps
+                .last_data_movement_ts
+                .map_or(true, |ts| (now - ts) >= *idle_for);
+            !has_failure_alerts && data_stale && user_pub_stale
+        }
+        ResolvedTaskIdleConfig::Disabled => false,
+    };
 
     if is_idle {
         if !alerts_status.contains_key(&AlertType::TaskIdle) {
@@ -316,11 +310,8 @@ fn evaluate_alerts(
         let disable_at = chrono::NaiveDate::parse_from_str(disable_at, "%Y-%m-%d")
             .expect("disable_at was set from a valid date");
 
-        let should_auto_disable_idle = alert_config
-            .map(|cfg| auto_disable_enabled(Some(cfg), DisableReason::Idle))
-            .unwrap_or(false);
-
-        if now.date_naive() >= disable_at && should_auto_disable_idle {
+        if now.date_naive() >= disable_at && auto_disable_enabled(alert_config, DisableReason::Idle)
+        {
             if !alerts_status.contains_key(&AlertType::TaskAutoDisabledIdle) {
                 alerts::set_alert_firing(
                     alerts_status,
@@ -404,6 +395,10 @@ mod test {
     use chrono::{Duration, TimeZone};
     use models::status::{AlertState, ControllerAlert, ControllerStatus};
     use models::{AnySpec, Id};
+
+    fn resolve(cfg: models::AlertConfig) -> ResolvedAlertConfig {
+        ResolvedAlertConfig::from_effective(cfg).expect("test config should include defaults")
+    }
 
     fn fixed_now() -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap()
@@ -505,7 +500,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -542,7 +537,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -581,7 +576,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -623,7 +618,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -658,14 +653,9 @@ mod test {
     #[test]
     fn chronically_failing_lifecycle() {
         let config = ControllerConfig::default();
-        let alert_cfg = models::AlertConfig {
-            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
-                enabled: None,
-                auto_disable: Some(true),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut cfg = config.alert_config_defaults();
+        cfg.task_chronically_failing.as_mut().unwrap().auto_disable = Some(true);
+        let alert_cfg = resolve(cfg);
         let shard_failed_at = fixed_now();
         let created_at = shard_failed_at - Duration::days(90);
         let state = mock_state(Some(enabled_capture()), created_at);
@@ -679,7 +669,7 @@ mod test {
 
         // Tick 1: 29 days of failure, below the 30-day chronically-failing threshold.
         let now = shard_failed_at + config.chronically_failing_threshold - Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, &alert_cfg);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -698,7 +688,7 @@ mod test {
         // Tick 2: 31 days of failure, over threshold. TaskChronicallyFailing fires
         // with a 7-day grace period before auto-disable.
         let now = shard_failed_at + config.chronically_failing_threshold + Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, &alert_cfg);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -727,7 +717,7 @@ mod test {
 
         // Tick 3: 4 days into grace period, still within the window.
         let now = shard_failed_at + config.chronically_failing_threshold + Duration::days(5);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, &alert_cfg);
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -759,14 +749,7 @@ mod test {
         let chronically_fired_at =
             shard_failed_at + config.chronically_failing_threshold + Duration::days(1);
         let now = chronically_fired_at + config.chronically_failing_disable_after;
-        let reason = evaluate_alerts(
-            &mut alerts,
-            &state,
-            now,
-            timestamps,
-            &config,
-            Some(&alert_cfg),
-        );
+        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, &alert_cfg);
         assert_eq!(reason, Some(DisableReason::ChronicallyFailing));
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -817,7 +800,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &alert_cfg,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -844,7 +827,14 @@ mod test {
 
         // Tick 1: Grace period is 7 days. TaskChronicallyFailing fires with
         // disable_at = base + 7d.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            base,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
 
         let original_disable_at = alerts
@@ -865,7 +855,14 @@ mod test {
         // Tick 2: 3 days later. Past the new 1-day grace period, but still
         // before the original 7-day disable_at. The stored date wins.
         let now = base + Duration::days(3);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
 
         // Verify the stored disable_at hasn't changed.
@@ -901,7 +898,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -924,7 +921,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -947,7 +944,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -972,7 +969,7 @@ mod test {
                 last_user_pub_at: Some(now - Duration::days(3)),
             },
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -996,7 +993,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -1032,7 +1029,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            None,
+            &resolve(config.alert_config_defaults()),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -1067,14 +1064,9 @@ mod test {
     #[test]
     fn idle_lifecycle() {
         let config = ControllerConfig::default();
-        let alert_cfg = models::AlertConfig {
-            task_idle: Some(models::TaskIdleConfig {
-                enabled: None,
-                auto_disable: Some(true),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut cfg = config.alert_config_defaults();
+        cfg.task_idle.as_mut().unwrap().auto_disable = Some(true);
+        let alert_cfg = resolve(cfg);
         let base = fixed_now();
         let created_at = base - Duration::days(90);
         let state = mock_state(Some(enabled_materialization()), created_at);
@@ -1090,7 +1082,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &alert_cfg,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -1104,7 +1096,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            None,
+            &alert_cfg,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -1130,7 +1122,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            Some(&alert_cfg),
+            &alert_cfg,
         );
         assert_eq!(reason, Some(DisableReason::Idle));
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -1168,7 +1160,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            None,
+            &alert_cfg,
         );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -1186,7 +1178,14 @@ mod test {
         let mut alerts: Alerts = Default::default();
 
         // Tick 1: Grace period is 7 days. TaskIdle fires with disable_at = base + 7d.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            base,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
 
         let original_disable_at = alerts
@@ -1207,7 +1206,14 @@ mod test {
         // Tick 2: 3 days later. Past the new 1-day grace period, but still
         // before the original 7-day disable_at. The stored date wins.
         let now = base + Duration::days(3);
-        let reason = evaluate_alerts(&mut alerts, &state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            now,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
 
         // Verify the stored disable_at hasn't changed.
@@ -1234,7 +1240,14 @@ mod test {
         let mut alerts: Alerts = Default::default();
 
         // Tick 1: Task is idle, no data, no user pub.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            base,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
         {
@@ -1254,7 +1267,14 @@ mod test {
         // Tick 2: Task is now disabled. All abandonment alerts resolve.
         let disabled_state = mock_state(Some(disabled_capture()), created_at);
         let now = base + Duration::days(1);
-        let reason = evaluate_alerts(&mut alerts, &disabled_state, now, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &disabled_state,
+            now,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
     }
@@ -1265,14 +1285,8 @@ mod test {
         let now = fixed_now();
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
         let mut alerts: Alerts = Default::default();
-        let alert_cfg = models::AlertConfig {
-            task_idle: Some(models::TaskIdleConfig {
-                enabled: Some(false),
-                auto_disable: None,
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut cfg = config.alert_config_defaults();
+        cfg.task_idle.as_mut().unwrap().enabled = Some(false);
 
         evaluate_alerts(
             &mut alerts,
@@ -1280,7 +1294,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            Some(&alert_cfg),
+            &resolve(cfg),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -1296,14 +1310,8 @@ mod test {
             AlertType::ShardFailed,
             shard_failed_alert(now - Duration::days(40), now),
         );
-        let alert_cfg = models::AlertConfig {
-            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
-                enabled: Some(false),
-                auto_disable: None,
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut cfg = config.alert_config_defaults();
+        cfg.task_chronically_failing.as_mut().unwrap().enabled = Some(false);
 
         evaluate_alerts(
             &mut alerts,
@@ -1311,7 +1319,7 @@ mod test {
             now,
             AbandonmentTimestamps::default(),
             &config,
-            Some(&alert_cfg),
+            &resolve(cfg),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @r#"
@@ -1335,16 +1343,14 @@ mod test {
         let now = fixed_now();
         let state = mock_state(Some(enabled_capture()), now - Duration::days(60));
         let mut alerts: Alerts = Default::default();
-        let alert_cfg = models::AlertConfig {
-            task_idle: Some(models::TaskIdleConfig {
-                enabled: None,
-                auto_disable: None,
-                condition: Some(models::TaskIdleCondition {
-                    idle_for: Some(std::time::Duration::from_secs(60 * 60 * 24 * 90)),
-                }),
-            }),
-            ..Default::default()
-        };
+        let mut cfg = config.alert_config_defaults();
+        cfg.task_idle
+            .as_mut()
+            .unwrap()
+            .condition
+            .as_mut()
+            .unwrap()
+            .idle_for = Some(std::time::Duration::from_secs(60 * 60 * 24 * 90));
 
         // 45 days of no data: stale at the default 30d threshold, but not
         // at the custom 90d threshold.
@@ -1357,7 +1363,7 @@ mod test {
                 ..Default::default()
             },
             &config,
-            Some(&alert_cfg),
+            &resolve(cfg),
         );
 
         insta::assert_json_snapshot!(serde_json::to_value(&alerts).unwrap(), @"{}");
@@ -1366,14 +1372,13 @@ mod test {
     #[test]
     fn alert_config_auto_disable_false_resolves_existing_failing_auto_disabled_alert() {
         let config = ControllerConfig::default();
-        let auto_disable_on = models::AlertConfig {
-            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
-                enabled: None,
-                auto_disable: Some(true),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut on_cfg = config.alert_config_defaults();
+        on_cfg
+            .task_chronically_failing
+            .as_mut()
+            .unwrap()
+            .auto_disable = Some(true);
+        let auto_disable_on = resolve(on_cfg);
         let base = fixed_now();
         let shard_failed_at = base - config.chronically_failing_threshold - Duration::days(15);
         let created_at = shard_failed_at - Duration::days(30);
@@ -1393,7 +1398,7 @@ mod test {
             base,
             timestamps,
             &config,
-            Some(&auto_disable_on),
+            &auto_disable_on,
         );
         assert!(reason.is_none());
         assert!(alerts.contains_key(&AlertType::TaskChronicallyFailing));
@@ -1406,7 +1411,7 @@ mod test {
             now,
             timestamps,
             &config,
-            Some(&auto_disable_on),
+            &auto_disable_on,
         );
         assert_eq!(reason, Some(DisableReason::ChronicallyFailing));
         assert!(alerts.contains_key(&AlertType::TaskAutoDisabledFailing));
@@ -1414,21 +1419,20 @@ mod test {
         // Flip per-task auto_disable to false while the task is still
         // chronically failing. The warning should remain, but the
         // auto-disabled alert should resolve.
-        let auto_disable_off = models::AlertConfig {
-            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
-                enabled: None,
-                auto_disable: Some(false),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut off_cfg = config.alert_config_defaults();
+        off_cfg
+            .task_chronically_failing
+            .as_mut()
+            .unwrap()
+            .auto_disable = Some(false);
+        let auto_disable_off = resolve(off_cfg);
         let reason = evaluate_alerts(
             &mut alerts,
             &state,
             now,
             timestamps,
             &config,
-            Some(&auto_disable_off),
+            &auto_disable_off,
         );
         assert!(reason.is_none());
         assert!(alerts.contains_key(&AlertType::TaskChronicallyFailing));
@@ -1441,14 +1445,9 @@ mod test {
     #[test]
     fn alert_config_auto_disable_false_resolves_existing_idle_auto_disabled_alert() {
         let config = ControllerConfig::default();
-        let auto_disable_on = models::AlertConfig {
-            task_idle: Some(models::TaskIdleConfig {
-                enabled: None,
-                auto_disable: Some(true),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut on_cfg = config.alert_config_defaults();
+        on_cfg.task_idle.as_mut().unwrap().auto_disable = Some(true);
+        let auto_disable_on = resolve(on_cfg);
         let base = fixed_now();
         let created_at = base - Duration::days(90);
         let state = mock_state(Some(enabled_materialization()), created_at);
@@ -1456,7 +1455,14 @@ mod test {
         let mut alerts: Alerts = Default::default();
 
         // First fire TaskIdle.
-        let reason = evaluate_alerts(&mut alerts, &state, base, timestamps, &config, None);
+        let reason = evaluate_alerts(
+            &mut alerts,
+            &state,
+            base,
+            timestamps,
+            &config,
+            &resolve(config.alert_config_defaults()),
+        );
         assert!(reason.is_none());
         assert!(alerts.contains_key(&AlertType::TaskIdle));
 
@@ -1468,27 +1474,22 @@ mod test {
             now,
             timestamps,
             &config,
-            Some(&auto_disable_on),
+            &auto_disable_on,
         );
         assert_eq!(reason, Some(DisableReason::Idle));
         assert!(alerts.contains_key(&AlertType::TaskAutoDisabledIdle));
 
         // Flip per-task auto_disable to false while the task remains idle.
-        let auto_disable_off = models::AlertConfig {
-            task_idle: Some(models::TaskIdleConfig {
-                enabled: None,
-                auto_disable: Some(false),
-                condition: None,
-            }),
-            ..Default::default()
-        };
+        let mut off_cfg = config.alert_config_defaults();
+        off_cfg.task_idle.as_mut().unwrap().auto_disable = Some(false);
+        let auto_disable_off = resolve(off_cfg);
         let reason = evaluate_alerts(
             &mut alerts,
             &state,
             now,
             timestamps,
             &config,
-            Some(&auto_disable_off),
+            &auto_disable_off,
         );
         assert!(reason.is_none());
         assert!(alerts.contains_key(&AlertType::TaskIdle));

--- a/crates/agent/src/controllers/activation.rs
+++ b/crates/agent/src/controllers/activation.rs
@@ -1,4 +1,7 @@
-use super::{ControllerConfig, ControllerState, NextRun, alerts, backoff_data_plane_activate};
+use super::{
+    ControllerConfig, ControllerState, NextRun, ResolvedAlertConfig, ResolvedShardFailedAlert,
+    alerts, backoff_data_plane_activate,
+};
 use crate::{
     controllers::{ControllerErrorExt, Inbox},
     controlplane::ControlPlane,
@@ -24,24 +27,15 @@ pub async fn update_activation<C: ControlPlane>(
     state: &ControllerState,
     events: &Inbox,
     control_plane: &C,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     let now = control_plane.current_time();
     let config = control_plane.controller_config();
-    let shard_failed_condition = alert_cfg
-        .and_then(|a| a.shard_failed.as_ref())
-        .and_then(|s| s.condition.as_ref());
-    let failure_retention = shard_failed_condition
-        .and_then(|c| c.per)
-        .and_then(|d| chrono::Duration::from_std(d).ok())
-        .unwrap_or(config.shard_failure_retention);
-    let alert_after_shard_failures = shard_failed_condition
-        .and_then(|c| c.failures)
-        .unwrap_or(config.alert_after_shard_failures);
-    let shard_failed_enabled = alert_cfg
-        .and_then(|a| a.shard_failed.as_ref())
-        .and_then(|s| s.enabled)
-        .unwrap_or(true);
+    let failure_retention = alert_cfg.shard_failed.retention;
+    let (shard_failed_enabled, alert_after_shard_failures) = match &alert_cfg.shard_failed.alert {
+        ResolvedShardFailedAlert::Enabled { failures } => (true, *failures),
+        ResolvedShardFailedAlert::Disabled => (false, 0),
+    };
     if !shard_failed_enabled {
         alerts::resolve_alert(alerts_status, AlertType::ShardFailed);
     }

--- a/crates/agent/src/controllers/capture.rs
+++ b/crates/agent/src/controllers/capture.rs
@@ -1,7 +1,7 @@
 mod auto_discover;
 use super::{
-    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, backoff_data_plane_activate,
-    coalesce_results, dependencies::Dependencies,
+    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, ResolvedAlertConfig,
+    backoff_data_plane_activate, coalesce_results, dependencies::Dependencies,
 };
 use crate::controllers::{
     abandon, activation, config_update, data_movement, periodic, publication_status, republish,
@@ -22,7 +22,7 @@ pub async fn update<C: ControlPlane>(
     events: &Inbox,
     control_plane: &C,
     model: &models::CaptureDef,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     publication_status::clear_pending_publication_next_after(&mut status.publications);
 

--- a/crates/agent/src/controllers/collection.rs
+++ b/crates/agent/src/controllers/collection.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeSet;
 
 use super::{
-    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, abandon, activation,
-    backoff_data_plane_activate, backoff_publication_failure, coalesce_results, data_movement,
+    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, ResolvedAlertConfig,
+    abandon, activation, backoff_data_plane_activate, backoff_publication_failure,
+    coalesce_results, data_movement,
     dependencies::Dependencies,
     periodic,
     publication_status::{self, PendingPublication},
@@ -19,7 +20,7 @@ pub async fn update<C: ControlPlane>(
     events: &Inbox,
     control_plane: &C,
     model: &models::CollectionDef,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     publication_status::clear_pending_publication_next_after(&mut status.publications);
     let published = maybe_publish(events, status, state, control_plane, model).await;

--- a/crates/agent/src/controllers/data_movement.rs
+++ b/crates/agent/src/controllers/data_movement.rs
@@ -4,7 +4,9 @@
 //! (`dataMovementStalled.condition.stalledFor`). If no threshold is configured
 //! there, evaluation falls back to `alert_data_processing`.
 
-use super::{ControllerState, NextRun, alerts};
+use super::{
+    ControllerState, NextRun, ResolvedAlertConfig, ResolvedDataMovementStalledConfig, alerts,
+};
 use crate::controllers::activation::has_task_shards;
 use crate::controlplane::ControlPlane;
 use chrono::{DurationRound, TimeDelta};
@@ -20,31 +22,20 @@ pub async fn evaluate_data_movement_stalled<C: ControlPlane>(
     alerts_status: &mut Alerts,
     state: &ControllerState,
     control_plane: &C,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     let Some(spec) = state.live_spec.as_ref().filter(|_| moves_data(state)) else {
         alerts::resolve_alert(alerts_status, AlertType::DataMovementStalled);
         return Ok(None);
     };
 
-    if alert_cfg
-        .and_then(|a| a.data_movement_stalled.as_ref())
-        .and_then(|d| d.enabled)
-        == Some(false)
-    {
-        alerts::resolve_alert(alerts_status, AlertType::DataMovementStalled);
-        return Ok(Some(NextRun::after_minutes(RECHECK_MINUTES)));
-    }
-
-    let configured_threshold = alert_cfg
-        .and_then(|a| a.data_movement_stalled.as_ref())
-        .and_then(|d| d.condition.as_ref())
-        .and_then(|c| c.stalled_for)
-        .and_then(|d| chrono::Duration::from_std(d).ok());
-
-    let threshold = match configured_threshold {
-        Some(t) => t,
-        None => {
+    let threshold = match &alert_cfg.data_movement_stalled {
+        ResolvedDataMovementStalledConfig::Disabled => {
+            alerts::resolve_alert(alerts_status, AlertType::DataMovementStalled);
+            return Ok(Some(NextRun::after_minutes(RECHECK_MINUTES)));
+        }
+        ResolvedDataMovementStalledConfig::Configured { stalled_for } => *stalled_for,
+        ResolvedDataMovementStalledConfig::LegacyFallback => {
             // TODO: remove once this fallback path is no longer needed.
             // Fall back to `alert_data_processing`.
             match control_plane

--- a/crates/agent/src/controllers/materialization.rs
+++ b/crates/agent/src/controllers/materialization.rs
@@ -1,7 +1,7 @@
 use crate::controllers::{
-    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, abandon, activation,
-    backoff_data_plane_activate, backoff_publication_failure, coalesce_results, config_update,
-    data_movement,
+    ControlPlane, ControllerErrorExt, ControllerState, Inbox, NextRun, ResolvedAlertConfig,
+    abandon, activation, backoff_data_plane_activate, backoff_publication_failure,
+    coalesce_results, config_update, data_movement,
     dependencies::Dependencies,
     periodic,
     publication_status::{self, PendingPublication},
@@ -27,7 +27,7 @@ pub async fn update<C: ControlPlane>(
     events: &Inbox,
     control_plane: &C,
     model: &models::MaterializationDef,
-    alert_cfg: Option<&models::AlertConfig>,
+    alert_cfg: &ResolvedAlertConfig,
 ) -> anyhow::Result<Option<NextRun>> {
     publication_status::clear_pending_publication_next_after(&mut status.publications);
 

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -92,6 +92,46 @@ impl Default for ControllerConfig {
     }
 }
 
+impl ControllerConfig {
+    /// Builds a `models::AlertConfig` populated with the global defaults from
+    /// this config. Used as the lowest-priority layer when resolving effective
+    /// alert configs via the GraphQL API.
+    ///
+    /// `dataMovementStalled` is omitted because its threshold is inherently
+    /// per-task (different tasks have different expected data frequencies)
+    /// and there is no sensible global default.
+    pub fn alert_config_defaults(&self) -> models::AlertConfig {
+        models::AlertConfig {
+            data_movement_stalled: None,
+            shard_failed: Some(models::ShardFailedConfig {
+                enabled: Some(true),
+                condition: Some(models::ShardFailedCondition {
+                    failures: Some(self.alert_after_shard_failures),
+                    per: Some(self.shard_failure_retention.to_std().unwrap_or_default()),
+                }),
+            }),
+            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
+                enabled: Some(true),
+                auto_disable: Some(false),
+                condition: Some(models::TaskChronicallyFailingCondition {
+                    failing_for: Some(
+                        self.chronically_failing_threshold
+                            .to_std()
+                            .unwrap_or_default(),
+                    ),
+                }),
+            }),
+            task_idle: Some(models::TaskIdleConfig {
+                enabled: Some(true),
+                auto_disable: Some(false),
+                condition: Some(models::TaskIdleCondition {
+                    idle_for: Some(self.abandon_idle_threshold.to_std().unwrap_or_default()),
+                }),
+            }),
+        }
+    }
+}
+
 /// This version is used to determine if the controller state is compatible with the current
 /// code. Any controller state having a higher version than this will be ignored.
 pub const CONTROLLER_VERSION: i32 = 2;
@@ -822,5 +862,12 @@ mod test {
             format!("{PUBLICATION_COOLDOWN_ERROR} (will retry)"),
             err.to_string()
         );
+    }
+
+    #[test]
+    fn alert_config_defaults_snapshot() {
+        let config = ControllerConfig::default();
+        let defaults = config.alert_config_defaults();
+        insta::assert_json_snapshot!(serde_json::to_value(&defaults).unwrap());
     }
 }

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -132,6 +132,208 @@ impl ControllerConfig {
     }
 }
 
+/// Runtime alert policy consumed by controller evaluators.
+///
+/// `models::AlertConfig` is intentionally sparse because it represents JSON
+/// patch layers from `alert_configs`. This type is intentionally dense because
+/// it represents the policy after defaults and overrides have been resolved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedAlertConfig {
+    pub shard_failed: ResolvedShardFailedConfig,
+    pub task_chronically_failing: ResolvedTaskChronicallyFailingConfig,
+    pub task_idle: ResolvedTaskIdleConfig,
+    pub data_movement_stalled: ResolvedDataMovementStalledConfig,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedShardFailedConfig {
+    /// Failure records are retained and pruned even if the ShardFailed alert is
+    /// not emitted, because retry behavior still depends on recent failures.
+    pub retention: chrono::Duration,
+    pub alert: ResolvedShardFailedAlert,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedShardFailedAlert {
+    Disabled,
+    Enabled { failures: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedTaskChronicallyFailingConfig {
+    Disabled,
+    Enabled {
+        failing_for: chrono::Duration,
+        auto_disable: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedTaskIdleConfig {
+    Disabled,
+    Enabled {
+        idle_for: chrono::Duration,
+        auto_disable: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedDataMovementStalledConfig {
+    Disabled,
+    Configured {
+        stalled_for: chrono::Duration,
+    },
+    /// No global default exists for this threshold. Until the migration is
+    /// complete, the evaluator must look for a per-task legacy row in
+    /// `alert_data_processing`.
+    LegacyFallback,
+}
+
+impl ResolvedAlertConfig {
+    /// Convert a merged `models::AlertConfig` into evaluator-ready policy.
+    ///
+    /// This is the single place where the "defaults have been applied" invariant
+    /// is checked. The exhaustive destructuring below is deliberate: adding a
+    /// new model field should force an explicit decision about whether and how
+    /// that field participates in runtime alert evaluation.
+    pub fn from_effective(config: models::AlertConfig) -> anyhow::Result<Self> {
+        let models::AlertConfig {
+            data_movement_stalled,
+            shard_failed,
+            task_chronically_failing,
+            task_idle,
+        } = config;
+
+        Ok(Self {
+            shard_failed: resolve_shard_failed(shard_failed)?,
+            task_chronically_failing: resolve_task_chronically_failing(task_chronically_failing)?,
+            task_idle: resolve_task_idle(task_idle)?,
+            data_movement_stalled: resolve_data_movement_stalled(data_movement_stalled)?,
+        })
+    }
+}
+
+fn resolve_shard_failed(
+    config: Option<models::ShardFailedConfig>,
+) -> anyhow::Result<ResolvedShardFailedConfig> {
+    let config = required(config, "shardFailed")?;
+    let models::ShardFailedConfig { enabled, condition } = config;
+    let condition = required(condition, "shardFailed.condition")?;
+    let models::ShardFailedCondition { failures, per } = condition;
+
+    let alert = if required(enabled, "shardFailed.enabled")? {
+        ResolvedShardFailedAlert::Enabled {
+            failures: required(failures, "shardFailed.condition.failures")?,
+        }
+    } else {
+        ResolvedShardFailedAlert::Disabled
+    };
+
+    Ok(ResolvedShardFailedConfig {
+        retention: required_duration(per, "shardFailed.condition.per")?,
+        alert,
+    })
+}
+
+fn resolve_task_chronically_failing(
+    config: Option<models::TaskChronicallyFailingConfig>,
+) -> anyhow::Result<ResolvedTaskChronicallyFailingConfig> {
+    let config = required(config, "taskChronicallyFailing")?;
+    let models::TaskChronicallyFailingConfig {
+        enabled,
+        auto_disable,
+        condition,
+    } = config;
+
+    if !required(enabled, "taskChronicallyFailing.enabled")? {
+        return Ok(ResolvedTaskChronicallyFailingConfig::Disabled);
+    }
+
+    let condition = required(condition, "taskChronicallyFailing.condition")?;
+    let models::TaskChronicallyFailingCondition { failing_for } = condition;
+
+    Ok(ResolvedTaskChronicallyFailingConfig::Enabled {
+        failing_for: required_duration(failing_for, "taskChronicallyFailing.condition.failingFor")?,
+        auto_disable: required(auto_disable, "taskChronicallyFailing.autoDisable")?,
+    })
+}
+
+fn resolve_task_idle(
+    config: Option<models::TaskIdleConfig>,
+) -> anyhow::Result<ResolvedTaskIdleConfig> {
+    let config = required(config, "taskIdle")?;
+    let models::TaskIdleConfig {
+        enabled,
+        auto_disable,
+        condition,
+    } = config;
+
+    if !required(enabled, "taskIdle.enabled")? {
+        return Ok(ResolvedTaskIdleConfig::Disabled);
+    }
+
+    let condition = required(condition, "taskIdle.condition")?;
+    let models::TaskIdleCondition { idle_for } = condition;
+
+    Ok(ResolvedTaskIdleConfig::Enabled {
+        idle_for: required_duration(idle_for, "taskIdle.condition.idleFor")?,
+        auto_disable: required(auto_disable, "taskIdle.autoDisable")?,
+    })
+}
+
+fn resolve_data_movement_stalled(
+    config: Option<models::DataMovementStalledConfig>,
+) -> anyhow::Result<ResolvedDataMovementStalledConfig> {
+    let Some(config) = config else {
+        return Ok(ResolvedDataMovementStalledConfig::LegacyFallback);
+    };
+
+    let models::DataMovementStalledConfig { enabled, condition } = config;
+    if enabled == Some(false) {
+        return Ok(ResolvedDataMovementStalledConfig::Disabled);
+    }
+
+    let stalled_for = match condition {
+        Some(condition) => {
+            let models::DataMovementStalledCondition { stalled_for } = condition;
+            optional_duration(stalled_for, "dataMovementStalled.condition.stalledFor")?
+        }
+        None => None,
+    };
+
+    Ok(match stalled_for {
+        Some(stalled_for) => ResolvedDataMovementStalledConfig::Configured { stalled_for },
+        None => ResolvedDataMovementStalledConfig::LegacyFallback,
+    })
+}
+
+fn required<T>(value: Option<T>, path: &'static str) -> anyhow::Result<T> {
+    value.ok_or_else(|| anyhow::anyhow!("missing resolved alert config field {path}"))
+}
+
+fn required_duration(
+    value: Option<std::time::Duration>,
+    path: &'static str,
+) -> anyhow::Result<chrono::Duration> {
+    let value = required(value, path)?;
+    chrono_duration(value, path)
+}
+
+fn optional_duration(
+    value: Option<std::time::Duration>,
+    path: &'static str,
+) -> anyhow::Result<Option<chrono::Duration>> {
+    value.map(|value| chrono_duration(value, path)).transpose()
+}
+
+fn chrono_duration(
+    value: std::time::Duration,
+    path: &'static str,
+) -> anyhow::Result<chrono::Duration> {
+    chrono::Duration::from_std(value)
+        .with_context(|| format!("resolved alert config field {path} is out of range"))
+}
+
 /// This version is used to determine if the controller state is compatible with the current
 /// code. Any controller state having a higher version than this will be ignored.
 pub const CONTROLLER_VERSION: i32 = 2;
@@ -640,14 +842,11 @@ async fn controller_update<C: ControlPlane>(
         return Ok(None);
     };
 
-    // Fetch the effective alert config once per run so all evaluators
-    // observe a consistent snapshot; absent fields fall through to
-    // `ControllerConfig` globals at the evaluator call site.
     let alert_cfg = control_plane
-        .fetch_alert_config(state.catalog_name.clone())
+        .resolved_alert_config(state.catalog_name.clone())
         .await
-        .context("fetching alert config")?;
-    let alert_cfg = alert_cfg.as_ref();
+        .context("resolving alert config")?;
+    let alert_cfg = &alert_cfg;
 
     let next_run = match live_spec {
         AnySpec::Capture(c) => {
@@ -869,5 +1068,93 @@ mod test {
         let config = ControllerConfig::default();
         let defaults = config.alert_config_defaults();
         insta::assert_json_snapshot!(serde_json::to_value(&defaults).unwrap());
+    }
+
+    #[test]
+    fn resolved_alert_config_rejects_unresolved_defaults() {
+        let err = ResolvedAlertConfig::from_effective(models::AlertConfig::default())
+            .expect_err("missing defaults should be rejected at the boundary");
+        assert!(
+            err.to_string()
+                .contains("missing resolved alert config field shardFailed"),
+            "{err}",
+        );
+    }
+
+    #[test]
+    fn resolved_alert_config_leaves_data_movement_threshold_unresolved() {
+        let resolved = ResolvedAlertConfig::from_effective(
+            ControllerConfig::default().alert_config_defaults(),
+        )
+        .expect("controller defaults should resolve");
+
+        assert_eq!(
+            resolved.data_movement_stalled,
+            ResolvedDataMovementStalledConfig::LegacyFallback,
+        );
+    }
+
+    #[test]
+    fn resolved_alert_config_models_disabled_branches_without_irrelevant_fields() {
+        let mut cfg = ControllerConfig::default().alert_config_defaults();
+        let idle = cfg.task_idle.as_mut().unwrap();
+        idle.enabled = Some(false);
+        idle.auto_disable = None;
+        idle.condition = None;
+
+        let chronic = cfg.task_chronically_failing.as_mut().unwrap();
+        chronic.enabled = Some(false);
+        chronic.auto_disable = None;
+        chronic.condition = None;
+
+        let shard_failed = cfg.shard_failed.as_mut().unwrap();
+        shard_failed.enabled = Some(false);
+        shard_failed.condition.as_mut().unwrap().failures = None;
+
+        let resolved = ResolvedAlertConfig::from_effective(cfg)
+            .expect("disabled alert branches should not require irrelevant fields");
+
+        assert_eq!(resolved.task_idle, ResolvedTaskIdleConfig::Disabled);
+        assert_eq!(
+            resolved.task_chronically_failing,
+            ResolvedTaskChronicallyFailingConfig::Disabled,
+        );
+        assert_eq!(
+            resolved.shard_failed.alert,
+            ResolvedShardFailedAlert::Disabled,
+        );
+    }
+
+    #[test]
+    fn resolved_alert_config_models_data_movement_states() {
+        let disabled = ResolvedAlertConfig::from_effective(models::AlertConfig {
+            data_movement_stalled: Some(models::DataMovementStalledConfig {
+                enabled: Some(false),
+                condition: None,
+            }),
+            ..ControllerConfig::default().alert_config_defaults()
+        })
+        .expect("disabled DataMovementStalled should resolve");
+        assert_eq!(
+            disabled.data_movement_stalled,
+            ResolvedDataMovementStalledConfig::Disabled,
+        );
+
+        let configured = ResolvedAlertConfig::from_effective(models::AlertConfig {
+            data_movement_stalled: Some(models::DataMovementStalledConfig {
+                enabled: None,
+                condition: Some(models::DataMovementStalledCondition {
+                    stalled_for: Some(std::time::Duration::from_secs(3600)),
+                }),
+            }),
+            ..ControllerConfig::default().alert_config_defaults()
+        })
+        .expect("configured DataMovementStalled should resolve");
+        assert_eq!(
+            configured.data_movement_stalled,
+            ResolvedDataMovementStalledConfig::Configured {
+                stalled_for: chrono::Duration::hours(1),
+            },
+        );
     }
 }

--- a/crates/agent/src/controllers/mod.rs
+++ b/crates/agent/src/controllers/mod.rs
@@ -183,9 +183,13 @@ pub enum ResolvedDataMovementStalledConfig {
     Configured {
         stalled_for: chrono::Duration,
     },
-    /// No global default exists for this threshold. Until the migration is
-    /// complete, the evaluator must look for a per-task legacy row in
-    /// `alert_data_processing`.
+    /// No `dataMovementStalled` config exists anywhere in the alert_configs
+    /// hierarchy. The evaluator falls back to a per-task
+    /// `alert_data_processing.evaluation_interval` row if one exists;
+    /// otherwise the alert is inactive. This is a deferred-resolution
+    /// sentinel: the threshold is not yet known at the type level, so the
+    /// evaluator must still hit the DB. Compatibility behavior, retired
+    /// once the migration off `alert_data_processing` is complete.
     LegacyFallback,
 }
 
@@ -293,16 +297,15 @@ fn resolve_data_movement_stalled(
         return Ok(ResolvedDataMovementStalledConfig::Disabled);
     }
 
-    let stalled_for = match condition {
-        Some(condition) => {
-            let models::DataMovementStalledCondition { stalled_for } = condition;
-            optional_duration(stalled_for, "dataMovementStalled.condition.stalledFor")?
+    Ok(match condition {
+        Some(models::DataMovementStalledCondition { stalled_for }) => {
+            ResolvedDataMovementStalledConfig::Configured {
+                stalled_for: chrono_duration(
+                    stalled_for,
+                    "dataMovementStalled.condition.stalledFor",
+                )?,
+            }
         }
-        None => None,
-    };
-
-    Ok(match stalled_for {
-        Some(stalled_for) => ResolvedDataMovementStalledConfig::Configured { stalled_for },
         None => ResolvedDataMovementStalledConfig::LegacyFallback,
     })
 }
@@ -317,13 +320,6 @@ fn required_duration(
 ) -> anyhow::Result<chrono::Duration> {
     let value = required(value, path)?;
     chrono_duration(value, path)
-}
-
-fn optional_duration(
-    value: Option<std::time::Duration>,
-    path: &'static str,
-) -> anyhow::Result<Option<chrono::Duration>> {
-    value.map(|value| chrono_duration(value, path)).transpose()
 }
 
 fn chrono_duration(
@@ -1144,7 +1140,7 @@ mod test {
             data_movement_stalled: Some(models::DataMovementStalledConfig {
                 enabled: None,
                 condition: Some(models::DataMovementStalledCondition {
-                    stalled_for: Some(std::time::Duration::from_secs(3600)),
+                    stalled_for: std::time::Duration::from_secs(3600),
                 }),
             }),
             ..ControllerConfig::default().alert_config_defaults()
@@ -1155,6 +1151,19 @@ mod test {
             ResolvedDataMovementStalledConfig::Configured {
                 stalled_for: chrono::Duration::hours(1),
             },
+        );
+
+        let unconfigured = ResolvedAlertConfig::from_effective(models::AlertConfig {
+            data_movement_stalled: Some(models::DataMovementStalledConfig {
+                enabled: None,
+                condition: None,
+            }),
+            ..ControllerConfig::default().alert_config_defaults()
+        })
+        .expect("DataMovementStalled without a condition should resolve");
+        assert_eq!(
+            unconfigured.data_movement_stalled,
+            ResolvedDataMovementStalledConfig::LegacyFallback,
         );
     }
 }

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__alert_config_defaults_snapshot.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__alert_config_defaults_snapshot.snap
@@ -1,0 +1,28 @@
+---
+source: crates/agent/src/controllers/mod.rs
+assertion_line: 870
+expression: "serde_json::to_value(&defaults).unwrap()"
+---
+{
+  "shardFailed": {
+    "condition": {
+      "failures": 3,
+      "per": "8h"
+    },
+    "enabled": true
+  },
+  "taskChronicallyFailing": {
+    "autoDisable": false,
+    "condition": {
+      "failingFor": "30days"
+    },
+    "enabled": true
+  },
+  "taskIdle": {
+    "autoDisable": false,
+    "condition": {
+      "idleFor": "30days"
+    },
+    "enabled": true
+  }
+}

--- a/crates/agent/src/controllers/snapshots/agent__controllers__test__alert_config_defaults_snapshot.snap
+++ b/crates/agent/src/controllers/snapshots/agent__controllers__test__alert_config_defaults_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/agent/src/controllers/mod.rs
-assertion_line: 870
 expression: "serde_json::to_value(&defaults).unwrap()"
 ---
 {

--- a/crates/agent/src/controlplane.rs
+++ b/crates/agent/src/controlplane.rs
@@ -96,13 +96,13 @@ pub trait ControlPlane: Send + Sync {
         catalog_name: String,
     ) -> anyhow::Result<Option<DateTime<Utc>>>;
 
-    /// Returns the effective alert config for `catalog_name`, or `None` if no
-    /// row applies. Exact-name rows override prefix rows; among prefixes, the
-    /// longest match wins.
-    async fn fetch_alert_config(
+    /// Returns the effective alert config for `catalog_name`, after merging
+    /// global defaults from `ControllerConfig` as the lowest-priority layer.
+    /// DB rows override defaults; among prefixes, the longest match wins.
+    async fn resolved_alert_config(
         &self,
         catalog_name: String,
-    ) -> anyhow::Result<Option<models::AlertConfig>>;
+    ) -> anyhow::Result<crate::controllers::ResolvedAlertConfig>;
 
     /// Returns `alert_data_processing.evaluation_interval` for `catalog_name`,
     /// used as the fallback `DataMovementStalled` threshold when
@@ -463,13 +463,16 @@ impl<C: DiscoverConnectors + MakeConnectors> ControlPlane for PGControlPlane<C> 
             .context("fetching last data movement")
     }
 
-    async fn fetch_alert_config(
+    async fn resolved_alert_config(
         &self,
         catalog_name: String,
-    ) -> anyhow::Result<Option<models::AlertConfig>> {
-        controllers::fetch_alert_config(&catalog_name, &self.pool)
+    ) -> anyhow::Result<crate::controllers::ResolvedAlertConfig> {
+        let defaults = self.controller_config.alert_config_defaults();
+        let cfg = controllers::fetch_alert_config(&catalog_name, &self.pool, &defaults)
             .await
-            .context("fetching alert config")
+            .context("fetching alert config")?;
+        crate::controllers::ResolvedAlertConfig::from_effective(cfg)
+            .context("resolving effective alert config")
     }
 
     async fn fetch_legacy_data_movement_stalled_threshold(

--- a/crates/agent/src/integration_tests/alerts.rs
+++ b/crates/agent/src/integration_tests/alerts.rs
@@ -478,6 +478,12 @@ async fn test_data_movement_stalled_end_to_end() {
         chrono::Duration::hours(3),
     )
     .await;
+    insert_capture_for_controller(
+        &pool,
+        "acme/team-a/alert-disabled",
+        chrono::Duration::hours(3),
+    )
+    .await;
 
     // A subscriber so that the fired alert produces recipient rows in the
     // `arguments` JSON (needed for the parity snapshot).
@@ -505,15 +511,25 @@ async fn test_data_movement_stalled_end_to_end() {
             serde_json::json!({ "dataMovementStalled": { "condition": { "stalledFor": "4h" } } }),
         )
         .await;
+    harness
+        .upsert_alert_config(
+            "acme/team-a/alert-disabled",
+            serde_json::json!({ "dataMovementStalled": { "enabled": false } }),
+        )
+        .await;
 
     // Fallback threshold from `alert_data_processing` for `acme/legacy`.
+    // `acme/team-a/alert-disabled` also gets a legacy row to prove that
+    // `enabled: false` suppresses the legacy fallback path too.
     sqlx::query!(
         r#"insert into alert_data_processing (catalog_name, evaluation_interval)
-           values ('acme/legacy', '2 hours'::interval)"#,
+           values
+             ('acme/legacy', '2 hours'::interval),
+             ('acme/team-a/alert-disabled', '2 hours'::interval)"#,
     )
     .execute(&pool)
     .await
-    .expect("failed to insert alert_data_processing row");
+    .expect("failed to insert alert_data_processing rows");
 
     for name in [
         "acme/team-a/stalled",
@@ -525,6 +541,7 @@ async fn test_data_movement_stalled_end_to_end() {
         "acme/team-a/dekaf-mat",
         "acme/team-a/mat-stalled",
         "acme/team-a/disabled-cap",
+        "acme/team-a/alert-disabled",
     ] {
         harness.run_pending_controller(name).await;
     }
@@ -613,6 +630,16 @@ async fn test_data_movement_stalled_end_to_end() {
     assert!(
         !current_alerts(&disabled).contains_key(&AlertType::DataMovementStalled),
         "shards.disable=true must suppress DataMovementStalled"
+    );
+
+    // `enabled: false` suppresses the alert even when a legacy
+    // `alert_data_processing` row would otherwise supply a threshold.
+    let alert_disabled = harness
+        .get_controller_state("acme/team-a/alert-disabled")
+        .await;
+    assert!(
+        !current_alerts(&alert_disabled).contains_key(&AlertType::DataMovementStalled),
+        "enabled=false must suppress, even with a legacy alert_data_processing row present",
     );
 
     // Re-running the controller when the alert is already firing must
@@ -950,95 +977,6 @@ async fn test_alert_configs_hierarchical_merge() {
       }
     }
     "#);
-}
-
-/// `dataMovementStalled.enabled: false` at a deeper layer silences the
-/// alert even when a prefix supplies a threshold.
-#[tokio::test]
-async fn test_data_movement_stalled_disabled_overrides_prefix_threshold() {
-    let mut harness =
-        TestHarness::init("test_data_movement_stalled_disabled_overrides_prefix_threshold").await;
-    harness.setup_tenant("acme").await;
-    let pool = harness.pool.clone();
-
-    insert_capture_for_controller(&pool, "acme/other", chrono::Duration::hours(3)).await;
-    insert_capture_for_controller(&pool, "acme/batch", chrono::Duration::hours(3)).await;
-    insert_capture_for_controller(&pool, "acme/cleared-no-legacy", chrono::Duration::hours(3))
-        .await;
-    insert_capture_for_controller(&pool, "acme/cleared-legacy", chrono::Duration::hours(3)).await;
-
-    // Tenant-wide DataMovementStalled opt-in with a 1h threshold.
-    harness
-        .upsert_alert_config(
-            "acme/",
-            serde_json::json!({ "dataMovementStalled": { "condition": { "stalledFor": "1h" } } }),
-        )
-        .await;
-    // …but `acme/batch` explicitly opts out.
-    harness
-        .upsert_alert_config(
-            "acme/batch",
-            serde_json::json!({ "dataMovementStalled": { "enabled": false } }),
-        )
-        .await;
-    // Explicit null clears the inherited configured threshold. With no legacy
-    // row, that means no alert; with a legacy row, it means legacy fallback.
-    for name in ["acme/cleared-no-legacy", "acme/cleared-legacy"] {
-        harness
-            .upsert_alert_config(
-                name,
-                serde_json::json!({ "dataMovementStalled": { "condition": null } }),
-            )
-            .await;
-    }
-    sqlx::query!(
-        r#"insert into alert_data_processing (catalog_name, evaluation_interval)
-           values
-             ('acme/batch', '2 hours'::interval),
-             ('acme/cleared-legacy', '2 hours'::interval)"#,
-    )
-    .execute(&pool)
-    .await
-    .expect("failed to insert legacy alert_data_processing rows");
-
-    // No catalog_stats_hourly rows means zero bytes for everyone.
-    for name in [
-        "acme/other",
-        "acme/batch",
-        "acme/cleared-no-legacy",
-        "acme/cleared-legacy",
-    ] {
-        harness.run_pending_controller(name).await;
-    }
-
-    let other = harness.get_controller_state("acme/other").await;
-    assert!(
-        current_alerts(&other).contains_key(&AlertType::DataMovementStalled),
-        "acme/other inherits tenant threshold and must fire; got: {:?}",
-        current_alerts(&other).keys().collect::<Vec<_>>(),
-    );
-    let batch = harness.get_controller_state("acme/batch").await;
-    assert!(
-        !current_alerts(&batch).contains_key(&AlertType::DataMovementStalled),
-        "acme/batch opts out via enabled=false; must NOT fire despite inherited and legacy thresholds"
-    );
-    let cleared_no_legacy = harness.get_controller_state("acme/cleared-no-legacy").await;
-    assert!(
-        !current_alerts(&cleared_no_legacy).contains_key(&AlertType::DataMovementStalled),
-        "condition=null clears the inherited threshold; without legacy fallback it must not fire"
-    );
-    let cleared_legacy = harness.get_controller_state("acme/cleared-legacy").await;
-    let cleared_legacy_alert = current_alerts(&cleared_legacy)
-        .get(&AlertType::DataMovementStalled)
-        .expect("condition=null should fall back to the legacy threshold when present");
-    assert_eq!(
-        cleared_legacy_alert
-            .extra
-            .get("evaluation_interval")
-            .unwrap(),
-        "2h",
-        "legacy fallback threshold is 2h"
-    );
 }
 
 /// Once a DataMovementStalled alert resolves because bytes were written,

--- a/crates/agent/src/integration_tests/alerts.rs
+++ b/crates/agent/src/integration_tests/alerts.rs
@@ -883,10 +883,10 @@ async fn test_abandon_per_task_thresholds() {
 /// exact-name row each contribute their fields independently. Exercised
 /// here by inserting three rows at `acme/`, `acme/prod/`, and
 /// `acme/prod/source-pg`, each setting distinct fields, and asserting the
-/// merged config resolved via `ControlPlane::fetch_alert_config`.
+/// merged sparse config before the agent projects it into runtime policy.
 #[tokio::test]
 async fn test_alert_configs_hierarchical_merge() {
-    let mut harness = TestHarness::init("test_alert_configs_hierarchical_merge").await;
+    let harness = TestHarness::init("test_alert_configs_hierarchical_merge").await;
     harness.setup_tenant("acme").await;
 
     // Tenant-wide default: explicitly enable ShardFailed with a loose
@@ -916,28 +916,37 @@ async fn test_alert_configs_hierarchical_merge() {
         )
         .await;
 
-    let merged = {
-        use crate::controlplane::ControlPlane;
-        harness
-            .control_plane()
-            .fetch_alert_config("acme/prod/source-pg".to_string())
-            .await
-            .expect("fetch_alert_config")
-            .expect("some config matches")
-    };
+    let defaults = crate::controllers::ControllerConfig::default().alert_config_defaults();
+    let merged = control_plane_api::controllers::fetch_alert_config(
+        "acme/prod/source-pg",
+        &harness.pool,
+        &defaults,
+    )
+    .await
+    .expect("fetch_alert_config");
 
     insta::assert_json_snapshot!(serde_json::to_value(&merged).unwrap(), @r#"
     {
       "shardFailed": {
         "condition": {
-          "failures": 10
+          "failures": 10,
+          "per": "8h"
+        },
+        "enabled": true
+      },
+      "taskChronicallyFailing": {
+        "autoDisable": false,
+        "condition": {
+          "failingFor": "30days"
         },
         "enabled": true
       },
       "taskIdle": {
+        "autoDisable": false,
         "condition": {
           "idleFor": "30days"
-        }
+        },
+        "enabled": true
       }
     }
     "#);
@@ -954,6 +963,9 @@ async fn test_data_movement_stalled_disabled_overrides_prefix_threshold() {
 
     insert_capture_for_controller(&pool, "acme/other", chrono::Duration::hours(3)).await;
     insert_capture_for_controller(&pool, "acme/batch", chrono::Duration::hours(3)).await;
+    insert_capture_for_controller(&pool, "acme/cleared-no-legacy", chrono::Duration::hours(3))
+        .await;
+    insert_capture_for_controller(&pool, "acme/cleared-legacy", chrono::Duration::hours(3)).await;
 
     // Tenant-wide DataMovementStalled opt-in with a 1h threshold.
     harness
@@ -969,10 +981,35 @@ async fn test_data_movement_stalled_disabled_overrides_prefix_threshold() {
             serde_json::json!({ "dataMovementStalled": { "enabled": false } }),
         )
         .await;
+    // Explicit null clears the inherited configured threshold. With no legacy
+    // row, that means no alert; with a legacy row, it means legacy fallback.
+    for name in ["acme/cleared-no-legacy", "acme/cleared-legacy"] {
+        harness
+            .upsert_alert_config(
+                name,
+                serde_json::json!({ "dataMovementStalled": { "condition": null } }),
+            )
+            .await;
+    }
+    sqlx::query!(
+        r#"insert into alert_data_processing (catalog_name, evaluation_interval)
+           values
+             ('acme/batch', '2 hours'::interval),
+             ('acme/cleared-legacy', '2 hours'::interval)"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("failed to insert legacy alert_data_processing rows");
 
     // No catalog_stats_hourly rows means zero bytes for everyone.
-    harness.run_pending_controller("acme/other").await;
-    harness.run_pending_controller("acme/batch").await;
+    for name in [
+        "acme/other",
+        "acme/batch",
+        "acme/cleared-no-legacy",
+        "acme/cleared-legacy",
+    ] {
+        harness.run_pending_controller(name).await;
+    }
 
     let other = harness.get_controller_state("acme/other").await;
     assert!(
@@ -983,7 +1020,24 @@ async fn test_data_movement_stalled_disabled_overrides_prefix_threshold() {
     let batch = harness.get_controller_state("acme/batch").await;
     assert!(
         !current_alerts(&batch).contains_key(&AlertType::DataMovementStalled),
-        "acme/batch opts out via enabled=false; must NOT fire despite inherited threshold"
+        "acme/batch opts out via enabled=false; must NOT fire despite inherited and legacy thresholds"
+    );
+    let cleared_no_legacy = harness.get_controller_state("acme/cleared-no-legacy").await;
+    assert!(
+        !current_alerts(&cleared_no_legacy).contains_key(&AlertType::DataMovementStalled),
+        "condition=null clears the inherited threshold; without legacy fallback it must not fire"
+    );
+    let cleared_legacy = harness.get_controller_state("acme/cleared-legacy").await;
+    let cleared_legacy_alert = current_alerts(&cleared_legacy)
+        .get(&AlertType::DataMovementStalled)
+        .expect("condition=null should fall back to the legacy threshold when present");
+    assert_eq!(
+        cleared_legacy_alert
+            .extra
+            .get("evaluation_interval")
+            .unwrap(),
+        "2h",
+        "legacy fallback threshold is 2h"
     );
 }
 

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1684,6 +1684,7 @@ impl TestHarness {
             self.pool.clone(),
             self.publisher.clone(),
             snapshot_watch.clone(),
+            None,
         ));
 
         self.control_plane_app = Some(app);

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -2032,11 +2032,11 @@ impl ControlPlane for TestControlPlane {
         self.inner.fetch_last_data_movement_ts(catalog_name).await
     }
 
-    async fn fetch_alert_config(
+    async fn resolved_alert_config(
         &self,
         catalog_name: String,
-    ) -> anyhow::Result<Option<models::AlertConfig>> {
-        self.inner.fetch_alert_config(catalog_name).await
+    ) -> anyhow::Result<crate::controllers::ResolvedAlertConfig> {
+        self.inner.resolved_alert_config(catalog_name).await
     }
 
     async fn fetch_legacy_data_movement_stalled_threshold(

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1610,7 +1610,9 @@ impl TestHarness {
         };
 
         // Create GraphQL schema
-        let schema = control_plane_api::server::public::graphql::create_schema();
+        let schema = control_plane_api::server::public::graphql::create_schema(
+            models::AlertConfig::default(),
+        );
 
         // Create GraphQL request
         let request = async_graphql::Request::new(query)
@@ -1684,7 +1686,6 @@ impl TestHarness {
             self.pool.clone(),
             self.publisher.clone(),
             snapshot_watch.clone(),
-            None,
         ));
 
         self.control_plane_app = Some(app);

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -299,6 +299,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
 
     let controller_publication_cooldown =
         chrono::Duration::from_std(args.controller_publication_cooldown)?;
+    let alert_config_defaults = args.controller_config.alert_config_defaults();
     let control_plane = agent::PGControlPlane::new(
         pg_pool.clone(),
         system_user_id,
@@ -318,6 +319,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         pg_pool.clone(),
         publisher.clone(),
         snapshot_watch,
+        Some(alert_config_defaults),
     ));
     let api_router = control_plane_api::build_router(api_app.clone(), &args.allow_origin)?;
     let api_server = axum::serve(api_listener, api_router).with_graceful_shutdown(shutdown.clone());

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -319,9 +319,12 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         pg_pool.clone(),
         publisher.clone(),
         snapshot_watch,
-        Some(alert_config_defaults),
     ));
-    let api_router = control_plane_api::build_router(api_app.clone(), &args.allow_origin)?;
+    let api_router = control_plane_api::build_router(
+        api_app.clone(),
+        &args.allow_origin,
+        alert_config_defaults,
+    )?;
     let api_server = axum::serve(api_listener, api_router).with_graceful_shutdown(shutdown.clone());
     let api_server = async move { anyhow::Result::Ok(api_server.await?) };
 

--- a/crates/control-plane-api/src/controllers.rs
+++ b/crates/control-plane-api/src/controllers.rs
@@ -140,13 +140,10 @@ pub async fn fetch_last_data_movement_ts(
 pub async fn fetch_alert_config(
     catalog_name: &str,
     db: impl sqlx::PgExecutor<'static>,
-) -> anyhow::Result<Option<models::AlertConfig>> {
-    let (config, _) = fetch_alert_config_with_provenance(catalog_name, db, None).await?;
-    if config == models::AlertConfig::default() {
-        Ok(None)
-    } else {
-        Ok(Some(config))
-    }
+    defaults: &models::AlertConfig,
+) -> anyhow::Result<models::AlertConfig> {
+    let (config, _) = fetch_alert_config_with_provenance(catalog_name, db, Some(defaults)).await?;
+    Ok(config)
 }
 
 /// Computes the effective `AlertConfig` for `catalog_name` by deep-merging

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -34,6 +34,7 @@ pub enum Rejection {
 /// App is the wired application state of the control-plane API.
 pub struct App {
     pub _id_generator: std::sync::Mutex<models::IdGenerator>,
+    pub alert_config_defaults: Option<models::AlertConfig>,
     pub control_plane_jwt_decode_keys: Vec<tokens::jwt::DecodingKey>,
     pub control_plane_jwt_encode_key: tokens::jwt::EncodingKey,
     pub pg_pool: sqlx::PgPool,
@@ -48,9 +49,11 @@ impl App {
         pg_pool: sqlx::PgPool,
         publisher: crate::publications::Publisher,
         snapshot: Arc<dyn tokens::Watch<Snapshot>>,
+        alert_config_defaults: Option<models::AlertConfig>,
     ) -> Self {
         Self {
             _id_generator: std::sync::Mutex::new(id_generator),
+            alert_config_defaults,
             control_plane_jwt_decode_keys: vec![tokens::jwt::DecodingKey::from_secret(jwt_secret)],
             control_plane_jwt_encode_key: tokens::jwt::EncodingKey::from_secret(jwt_secret),
             pg_pool,

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -34,7 +34,6 @@ pub enum Rejection {
 /// App is the wired application state of the control-plane API.
 pub struct App {
     pub _id_generator: std::sync::Mutex<models::IdGenerator>,
-    pub alert_config_defaults: Option<models::AlertConfig>,
     pub control_plane_jwt_decode_keys: Vec<tokens::jwt::DecodingKey>,
     pub control_plane_jwt_encode_key: tokens::jwt::EncodingKey,
     pub pg_pool: sqlx::PgPool,
@@ -49,11 +48,9 @@ impl App {
         pg_pool: sqlx::PgPool,
         publisher: crate::publications::Publisher,
         snapshot: Arc<dyn tokens::Watch<Snapshot>>,
-        alert_config_defaults: Option<models::AlertConfig>,
     ) -> Self {
         Self {
             _id_generator: std::sync::Mutex::new(id_generator),
-            alert_config_defaults,
             control_plane_jwt_decode_keys: vec![tokens::jwt::DecodingKey::from_secret(jwt_secret)],
             control_plane_jwt_encode_key: tokens::jwt::EncodingKey::from_secret(jwt_secret),
             pg_pool,
@@ -127,7 +124,11 @@ where
 }
 
 /// Build the agent's API router.
-pub fn build_router(app: Arc<App>, allow_origin: &[String]) -> anyhow::Result<axum::Router<()>> {
+pub fn build_router(
+    app: Arc<App>,
+    allow_origin: &[String],
+    alert_config_defaults: models::AlertConfig,
+) -> anyhow::Result<axum::Router<()>> {
     use axum::routing::post;
 
     let allow_origin = allow_origin
@@ -161,7 +162,7 @@ pub fn build_router(app: Arc<App>, allow_origin: &[String]) -> anyhow::Result<ax
         .allow_origin(tower_http::cors::AllowOrigin::list(allow_origin))
         .allow_headers(allow_headers);
 
-    let public_api_router = public::api_v1_router(app.clone());
+    let public_api_router = public::api_v1_router(app.clone(), alert_config_defaults);
 
     let main_router = axum::Router::new()
         .route("/authorize/task", post(authorize_task::authorize_task))

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -465,4 +465,117 @@ mod test {
             .await;
         insta::assert_json_snapshot!("rejected_nonexistent_task", response);
     }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_effective_alert_config_with_defaults(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let defaults = models::AlertConfig {
+            data_movement_stalled: None,
+            shard_failed: Some(models::ShardFailedConfig {
+                enabled: Some(true),
+                condition: Some(models::ShardFailedCondition {
+                    failures: Some(3),
+                    per: Some(std::time::Duration::from_secs(8 * 3600)),
+                }),
+            }),
+            task_chronically_failing: Some(models::TaskChronicallyFailingConfig {
+                enabled: Some(true),
+                auto_disable: Some(false),
+                condition: Some(models::TaskChronicallyFailingCondition {
+                    failing_for: Some(std::time::Duration::from_secs(30 * 86400)),
+                }),
+            }),
+            task_idle: Some(models::TaskIdleConfig {
+                enabled: Some(true),
+                auto_disable: Some(false),
+                condition: Some(models::TaskIdleCondition {
+                    idle_for: Some(std::time::Duration::from_secs(30 * 86400)),
+                }),
+            }),
+        };
+
+        let server = test_server::TestServer::start_with_defaults(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+            Some(defaults),
+        )
+        .await;
+
+        let token = server.make_access_token(
+            uuid::Uuid::from_bytes([0x11; 16]),
+            Some("alice@example.test"),
+        );
+
+        // No alert_configs rows exist: effective config should be entirely defaults.
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        liveSpecs(by: { names: ["aliceCo/in/capture-foo"] }) {
+                            edges {
+                                node {
+                                    catalogName
+                                    liveSpec {
+                                        effectiveAlertConfig {
+                                            config
+                                            provenance { path source }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("effective_defaults_only", response);
+
+        // Insert a prefix override for a single field.
+        let _: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation {
+                        updateAlertConfig(
+                            catalogPrefixOrName: "aliceCo/"
+                            config: { shardFailed: { condition: { failures: 5 } } }
+                        ) { id }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+
+        // Query effective config on the same task: defaults + prefix override merged.
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        liveSpecs(by: { names: ["aliceCo/in/capture-foo"] }) {
+                            edges {
+                                node {
+                                    catalogName
+                                    liveSpec {
+                                        effectiveAlertConfig {
+                                            config
+                                            provenance { path source }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("effective_defaults_plus_prefix_override", response);
+    }
 }

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -61,12 +61,12 @@ pub async fn resolve_effective_alert_config(
     catalog_prefix_or_name: &str,
 ) -> async_graphql::Result<EffectiveAlertConfig> {
     let env = ctx.data::<crate::Envelope>()?;
-    let defaults = ctx.data_opt::<models::AlertConfig>();
+    let defaults = ctx.data::<models::AlertConfig>()?;
 
     let (config, provenance_map) = crate::controllers::fetch_alert_config_with_provenance(
         catalog_prefix_or_name,
         &env.pg_pool,
-        defaults,
+        Some(defaults),
     )
     .await
     .map_err(|e| async_graphql::Error::new(e.to_string()))?;
@@ -498,10 +498,10 @@ mod test {
             }),
         };
 
-        let server = test_server::TestServer::start_with_defaults(
+        let server = test_server::TestServer::start_with_alert_defaults(
             pool.clone(),
             test_server::snapshot(pool.clone(), true).await,
-            Some(defaults),
+            defaults,
         )
         .await;
 

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -94,17 +94,22 @@ pub fn schema_sdl() -> String {
 #[axum::debug_handler(state=std::sync::Arc<crate::App>)]
 pub(crate) async fn graphql_handler(
     axum::Extension(schema): axum::Extension<GraphQLSchema>,
+    axum::extract::State(app): axum::extract::State<std::sync::Arc<crate::App>>,
     env: crate::Envelope,
     axum::extract::Json(req): axum::extract::Json<async_graphql::Request>,
 ) -> axum::response::Response {
     let pg_pool = env.pg_pool.clone();
 
-    let request = req
+    let mut request = req
         .data(env)
         .data(async_graphql::dataloader::DataLoader::new(
             PgDataLoader(pg_pool),
             tokio::spawn,
         ));
+
+    if let Some(defaults) = &app.alert_config_defaults {
+        request = request.data(defaults.clone());
+    }
 
     let response = schema.execute(request).await;
 

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -75,41 +75,37 @@ pub struct MutationRoot(
     invite_links::InviteLinksMutation,
 );
 
-pub fn create_schema() -> GraphQLSchema {
+pub fn create_schema(alert_config_defaults: models::AlertConfig) -> GraphQLSchema {
     Schema::build(
         QueryRoot::default(),
         MutationRoot::default(),
         EmptySubscription,
     )
+    .data(alert_config_defaults)
     .finish()
 }
 
 /// Returns the GraphQL SDL (Schema Definition Language) as a string.
 /// This is used by the flow-client build script to generate types.
 pub fn schema_sdl() -> String {
-    let schema = create_schema();
+    let schema = create_schema(models::AlertConfig::default());
     schema.sdl()
 }
 
 #[axum::debug_handler(state=std::sync::Arc<crate::App>)]
 pub(crate) async fn graphql_handler(
     axum::Extension(schema): axum::Extension<GraphQLSchema>,
-    axum::extract::State(app): axum::extract::State<std::sync::Arc<crate::App>>,
     env: crate::Envelope,
     axum::extract::Json(req): axum::extract::Json<async_graphql::Request>,
 ) -> axum::response::Response {
     let pg_pool = env.pg_pool.clone();
 
-    let mut request = req
+    let request = req
         .data(env)
         .data(async_graphql::dataloader::DataLoader::new(
             PgDataLoader(pg_pool),
             tokio::spawn,
         ));
-
-    if let Some(defaults) = &app.alert_config_defaults {
-        request = request.data(defaults.clone());
-    }
 
     let response = schema.execute(request).await;
 

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__effective_defaults_only.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__effective_defaults_only.snap
@@ -1,0 +1,83 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+assertion_line: 537
+expression: response
+---
+{
+  "data": {
+    "liveSpecs": {
+      "edges": [
+        {
+          "node": {
+            "catalogName": "aliceCo/in/capture-foo",
+            "liveSpec": {
+              "effectiveAlertConfig": {
+                "config": {
+                  "shardFailed": {
+                    "condition": {
+                      "failures": 3,
+                      "per": "8h"
+                    },
+                    "enabled": true
+                  },
+                  "taskChronicallyFailing": {
+                    "autoDisable": false,
+                    "condition": {
+                      "failingFor": "30days"
+                    },
+                    "enabled": true
+                  },
+                  "taskIdle": {
+                    "autoDisable": false,
+                    "condition": {
+                      "idleFor": "30days"
+                    },
+                    "enabled": true
+                  }
+                },
+                "provenance": [
+                  {
+                    "path": "shardFailed.condition.failures",
+                    "source": null
+                  },
+                  {
+                    "path": "shardFailed.condition.per",
+                    "source": null
+                  },
+                  {
+                    "path": "shardFailed.enabled",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.autoDisable",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.condition.failingFor",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.enabled",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.autoDisable",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.condition.idleFor",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.enabled",
+                    "source": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__effective_defaults_plus_prefix_override.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__effective_defaults_plus_prefix_override.snap
@@ -1,0 +1,83 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+assertion_line: 579
+expression: response
+---
+{
+  "data": {
+    "liveSpecs": {
+      "edges": [
+        {
+          "node": {
+            "catalogName": "aliceCo/in/capture-foo",
+            "liveSpec": {
+              "effectiveAlertConfig": {
+                "config": {
+                  "shardFailed": {
+                    "condition": {
+                      "failures": 5,
+                      "per": "8h"
+                    },
+                    "enabled": true
+                  },
+                  "taskChronicallyFailing": {
+                    "autoDisable": false,
+                    "condition": {
+                      "failingFor": "30days"
+                    },
+                    "enabled": true
+                  },
+                  "taskIdle": {
+                    "autoDisable": false,
+                    "condition": {
+                      "idleFor": "30days"
+                    },
+                    "enabled": true
+                  }
+                },
+                "provenance": [
+                  {
+                    "path": "shardFailed.condition.failures",
+                    "source": "aliceCo/"
+                  },
+                  {
+                    "path": "shardFailed.condition.per",
+                    "source": null
+                  },
+                  {
+                    "path": "shardFailed.enabled",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.autoDisable",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.condition.failingFor",
+                    "source": null
+                  },
+                  {
+                    "path": "taskChronicallyFailing.enabled",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.autoDisable",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.condition.idleFor",
+                    "source": null
+                  },
+                  {
+                    "path": "taskIdle.enabled",
+                    "source": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/mod.rs
+++ b/crates/control-plane-api/src/server/public/mod.rs
@@ -34,7 +34,10 @@ pub mod status;
 /// returns JSON, which is all of them. Just ensure that `T` implements
 /// `serde::Serialize` and `schemars::JsonSchema`. See the `crate::server::error` module
 /// docs for more information on error handling.
-pub(crate) fn api_v1_router(app: Arc<crate::App>) -> axum::Router<Arc<crate::App>> {
+pub(crate) fn api_v1_router(
+    app: Arc<crate::App>,
+    alert_config_defaults: models::AlertConfig,
+) -> axum::Router<Arc<crate::App>> {
     // When errors occur during the process of generating an openapi spec, aide
     // will call this function with the error so we can log it. They have a note
     // in their docs warning about false positives where it logs errors even
@@ -47,7 +50,7 @@ pub(crate) fn api_v1_router(app: Arc<crate::App>) -> axum::Router<Arc<crate::App
         }
     });
 
-    let graphql_schema = graphql::create_schema();
+    let graphql_schema = graphql::create_schema(alert_config_defaults);
     let router = aide::axum::ApiRouter::new()
         .api_route(
             "/api/v1/catalog/status",

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -70,6 +70,14 @@ pub struct TestServer {
 
 impl TestServer {
     pub async fn start(pg_pool: sqlx::PgPool, snapshot: Arc<dyn tokens::Watch<Snapshot>>) -> Self {
+        Self::start_with_defaults(pg_pool, snapshot, None).await
+    }
+
+    pub async fn start_with_defaults(
+        pg_pool: sqlx::PgPool,
+        snapshot: Arc<dyn tokens::Watch<Snapshot>>,
+        alert_config_defaults: Option<models::AlertConfig>,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         // TODO(johnny): Aggregate into a sink?
         let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(1);
@@ -91,6 +99,7 @@ impl TestServer {
             pg_pool.clone(),
             publisher,
             snapshot,
+            alert_config_defaults,
         ));
         let encoding_key = app.control_plane_jwt_encode_key.clone();
 

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -70,13 +70,13 @@ pub struct TestServer {
 
 impl TestServer {
     pub async fn start(pg_pool: sqlx::PgPool, snapshot: Arc<dyn tokens::Watch<Snapshot>>) -> Self {
-        Self::start_with_defaults(pg_pool, snapshot, None).await
+        Self::start_with_alert_defaults(pg_pool, snapshot, models::AlertConfig::default()).await
     }
 
-    pub async fn start_with_defaults(
+    pub async fn start_with_alert_defaults(
         pg_pool: sqlx::PgPool,
         snapshot: Arc<dyn tokens::Watch<Snapshot>>,
-        alert_config_defaults: Option<models::AlertConfig>,
+        alert_config_defaults: models::AlertConfig,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         // TODO(johnny): Aggregate into a sink?
@@ -99,7 +99,6 @@ impl TestServer {
             pg_pool.clone(),
             publisher,
             snapshot,
-            alert_config_defaults,
         ));
         let encoding_key = app.control_plane_jwt_encode_key.clone();
 
@@ -108,7 +107,8 @@ impl TestServer {
             .expect("failed to bind test server");
         let addr = listener.local_addr().expect("failed to get local addr");
 
-        let router = crate::server::build_router(app, &[addr.to_string()]).unwrap();
+        let router =
+            crate::server::build_router(app, &[addr.to_string()], alert_config_defaults).unwrap();
 
         tokio::spawn(async move {
             axum::serve(listener, router)

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -91,6 +91,11 @@ type AlertConfigEntry {
 	createdAt: DateTime!
 	updatedAt: DateTime!
 	lastModifiedBy: UUID
+	"""
+	The fully-resolved effective config at this scope, merging all
+	ancestor prefix layers and controller defaults.
+	"""
+	effective: EffectiveAlertConfig!
 }
 
 type AlertConfigEntryConnection {
@@ -696,6 +701,11 @@ type DiscoverChange {
 	disable: Boolean!
 }
 
+type EffectiveAlertConfig {
+	config: JSON!
+	provenance: [FieldProvenance!]!
+}
+
 """
 A generic error that can be associated with a particular draft spec for a given operation.
 """
@@ -703,6 +713,11 @@ type Error {
 	catalogName: String!
 	scope: String
 	detail: String!
+}
+
+type FieldProvenance {
+	path: String!
+	source: String
 }
 
 scalar Id
@@ -848,6 +863,11 @@ type LiveSpec {
 	be empty if this spec is a not a collection.
 	"""
 	readBy(after: String, before: String, first: Int, last: Int): LiveSpecRefConnection
+	"""
+	The fully-resolved effective alert config for this task, merging all
+	ancestor prefix layers and controller defaults.
+	"""
+	effectiveAlertConfig: EffectiveAlertConfig!
 }
 
 """
@@ -1011,6 +1031,12 @@ type MutationRoot {
 	testConnectionHealth(catalogPrefix: Prefix!, spec: JSON!): ConnectionHealthTestResult!
 	"""
 	Creates or replaces the alert config at `catalogPrefixOrName`.
+	
+	`catalogPrefixOrName` is either a catalog prefix ending in `/`
+	(applies to all tasks under that prefix) or an exact catalog name
+	with no trailing slash (applies to that single task). Exact catalog
+	names must refer to a task that currently exists in `live_specs`;
+	prefixes have no such constraint.
 	
 	To clear all configured overrides while keeping the row, pass an empty
 	`{}` config.

--- a/crates/models/src/alert_config.rs
+++ b/crates/models/src/alert_config.rs
@@ -32,13 +32,11 @@ pub struct DataMovementStalledConfig {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DataMovementStalledCondition {
     /// How long to wait for data movement before the alert fires.
-    #[serde(
-        default,
-        with = "humantime_serde",
-        skip_serializing_if = "Option::is_none"
-    )]
+    /// Required when `condition` is provided; opt out at the task level by
+    /// setting `enabled: false` rather than omitting the threshold.
+    #[serde(with = "humantime_serde")]
     #[schemars(schema_with = "crate::duration_schema")]
-    pub stalled_for: Option<Duration>,
+    pub stalled_for: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -124,7 +122,7 @@ mod test {
             data_movement_stalled: Some(DataMovementStalledConfig {
                 enabled: Some(true),
                 condition: Some(DataMovementStalledCondition {
-                    stalled_for: Some(Duration::from_secs(7200)),
+                    stalled_for: Duration::from_secs(7200),
                 }),
             }),
             shard_failed: Some(ShardFailedConfig {
@@ -239,6 +237,24 @@ mod test {
     }
 
     #[test]
+    fn stalled_for_must_be_present_in_condition() {
+        // Empty `condition` object: missing required `stalledFor` field.
+        let err =
+            serde_json::from_str::<AlertConfig>(r#"{"dataMovementStalled": {"condition": {}}}"#)
+                .expect_err("missing stalledFor should be rejected");
+        assert!(
+            err.to_string().contains("stalledFor"),
+            "expected error to mention stalledFor, got: {err}",
+        );
+
+        // `stalledFor: null`: humantime_serde rejects the null payload.
+        serde_json::from_str::<AlertConfig>(
+            r#"{"dataMovementStalled": {"condition": {"stalledFor": null}}}"#,
+        )
+        .expect_err("null stalledFor should be rejected");
+    }
+
+    #[test]
     fn humantime_formats_accepted() {
         let cfg: AlertConfig = serde_json::from_str(
             r#"{"dataMovementStalled": {"condition": {"stalledFor": "2h"}}, "shardFailed": {"condition": {"per": "8h"}}}"#,
@@ -250,7 +266,7 @@ mod test {
                 .condition
                 .unwrap()
                 .stalled_for,
-            Some(Duration::from_secs(7200))
+            Duration::from_secs(7200)
         );
         assert_eq!(
             cfg.shard_failed.unwrap().condition.unwrap().per,


### PR DESCRIPTION
## Summary

After merging #2868, `effectiveAlertConfig` only returned fields from explicit `alert_configs` DB rows. A task with no prefix-level overrides would return just the fields that happened to be set:

```json
"effectiveAlertConfig": {
  "config": { "dataMovementStalled": { "condition": { "stalledFor": "4h" } } },
  "provenance": [{ "path": "dataMovementStalled.condition.stalledFor", "source": "estuary/jshearer/" }]
}
```

It should include all alert types with their controller defaults (provenance `source: null`):

```json
"effectiveAlertConfig": {
  "config": {
    "shardFailed": { "enabled": true, "condition": { "failures": 3, "per": "8h" } },
    "taskChronicallyFailing": { "enabled": true, "autoDisable": false, "condition": { "failingFor": "30days" } },
    "taskIdle": { "enabled": true, "autoDisable": false, "condition": { "idleFor": "30days" } }
  },
  "provenance": [
    { "path": "shardFailed.condition.failures", "source": null },
    { "path": "shardFailed.enabled", "source": null },
    ...
  ]
}
```

This fixes it by providing the defaults from `ControllerConfig` into `App` so they can be injected into the GraphQL request context and rendered as the default layer for the effective alert config.