### PR TITLE
control-plane: fix silent success of `flowctl catalog test` when tests fail

### DIFF
--- a/crates/control-plane-api/src/publications/builds.rs
+++ b/crates/control-plane-api/src/publications/builds.rs
@@ -211,6 +211,11 @@ pub async fn test_catalog(
     let consumer_socket_path = tmpdir.join("consumer.sock");
     let consumer_sock = format!("unix://localhost{}", consumer_socket_path.display());
 
+    // The temp-data-plane is started concurrently and the unix sockets do not
+    // exist until gazette and the consumer have begun listening. Waiting for
+    // the socket files prevents an immediate ENOENT on the first gRPC dial.
+    wait_for_sockets(&[&broker_socket_path, &consumer_socket_path]).await?;
+
     let build_id = format!("{build_id}");
 
     // Activate all derivations.
@@ -331,6 +336,16 @@ pub async fn test_catalog(
     }
 
     Ok(errors)
+}
+
+async fn wait_for_sockets(paths: &[&path::Path]) -> anyhow::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        while !paths.iter().all(|p| p.exists()) {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .with_context(|| format!("timed out waiting for temp-data-plane sockets {paths:?}"))
 }
 
 /*

--- a/crates/control-plane-api/src/publications/mod.rs
+++ b/crates/control-plane-api/src/publications/mod.rs
@@ -174,7 +174,7 @@ impl UncommittedBuild {
     }
 
     pub fn errors(&self) -> impl Iterator<Item = &tables::Error> {
-        self.output.errors()
+        self.output.errors().chain(self.test_errors.iter())
     }
 
     pub fn build_failed(self) -> PublicationResult {
@@ -757,7 +757,12 @@ mod test {
             .collect(),
             retry_count: 0,
         };
+
+        assert_eq!(1, build.errors().count());
+        assert!(build.has_errors());
+
         let result = build.build_failed();
         assert_eq!(StatusType::TestFailed, result.status.r#type);
+        assert_eq!(1, result.test_errors.len());
     }
 }

--- a/docker/control-plane-agent.Dockerfile
+++ b/docker/control-plane-agent.Dockerfile
@@ -35,7 +35,12 @@ ARG TARGETARCH
 COPY ${TARGETARCH}/agent /usr/local/bin/
 COPY ${TARGETARCH}/sops /usr/local/bin/
 COPY ${TARGETARCH}/flowctl-go /usr/local/bin/
+COPY ${TARGETARCH}/gazette /usr/local/bin/
+COPY ${TARGETARCH}/etcd /usr/local/bin/
 COPY ${TARGETARCH}/agent-api-entrypoint.sh /usr/local/bin/
+RUN command -v flowctl-go \
+    && command -v gazette \
+    && command -v etcd
 
 CMD [ "/usr/local/bin/agent-api-entrypoint.sh" ]
 WORKDIR /tmp

--- a/mise/tasks/ci/package
+++ b/mise/tasks/ci/package
@@ -32,7 +32,9 @@ ln ${CARGO_TARGET_DIR}/release/data-plane-controller ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/dekaf ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/flowctl ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/oidc-discovery-server ${PACKAGE_DIR}/
+ln ${HOME}/go/bin/gazette ${PACKAGE_DIR}/
 ln ${HOME}/go/bin/flowctl-go ${PACKAGE_DIR}/
+ln $(which etcd) ${PACKAGE_DIR}/
 
 cp crates/flow-web/pkg/estuary-flow-web-*.tgz ${HOME}/flow-package/estuary-flow-web.tgz
 cp crates/data-plane-controller/entrypoint.sh ${PACKAGE_DIR}/data-plane-controller-entrypoint.sh

--- a/mise/tasks/ci/platform-build
+++ b/mise/tasks/ci/platform-build
@@ -5,6 +5,7 @@ mise run build:rocksdb
 mise run ci:musl-opt
 mise run ci:gnu-opt
 mise run build:flowctl-go --release
+mise run build:gazette
 mise run ci:wasm-opt
 mise run ci:package
 mise run ci:docker-images


### PR DESCRIPTION
### Bug

`flowctl catalog test` printed `Tests successful` and exited 0 even when derivation tests failed. Three bugs combine: publication status semantics drop test errors, the agent image is missing the binaries needed to run tests, and the agent races its own data plane during activation.

Given a derivation with a deliberately wrong `verify`:

```yaml
collections:
  test/source/customers:
    schema: { type: object, properties: { id: {type: string}, status: {type: string} }, required: [id, status] }
    key: [/id]
  test/derived/active-customers:
    schema: { type: object, properties: { customer_id: {type: string} }, required: [customer_id] }
    key: [/customer_id]
    derive:
      using: { sqlite: {} }
      transforms:
        - name: filter
          source: test/source/customers
          shuffle: any
          lambda: SELECT $id AS customer_id WHERE $status = 'active';
tests:
  test/tests/filter:
    steps:
      - ingest: { collection: test/source/customers, documents: [{id: c1, status: active}] }
      - verify: { collection: test/derived/active-customers, documents: [{customer_id: zzz}] }
```

Running `flowctl catalog test`:

```
$ flowctl --profile local catalog test --source catalog-test-fail.flow.yaml
Created draft: 14acb38b4c81a800
Running tests for catalog items:
catalog_name: test/derived/active-customers
spec_type: collection

catalog_name: test/source/customers
spec_type: collection

catalog_name: test/tests/filter
spec_type: test

Starting tests...
ERROR scope=flow://publication/test/activate detail=Test setup failed. View logs for details and reach out to support@estuary.dev
Tests successful
EXIT=0
```

The agent reports `Test setup failed` and the publication completes, then `Tests successful` is printed and the process exits 0.

### Analysis

Three independent bugs:

1. `UncommittedBuild::errors()` only chained draft, live, and built errors from `build::Output`, not `test_errors`. So a dry-run publication with a non-empty draft, no build errors, and only `test_errors` fell through to `StatusType::Success` in `try_publish`. `commit()` had the same gap via `!has_errors()`. `flowctl` polls `job_status->>'type'` and bails only if the value is not `success`, so the CLI exits 0.

2. The control-plane agent image only copies `agent`, `sops`, and `flowctl-go`. `flowctl-go temp-data-plane` calls `pkgbin.MustLocate("etcd")` and `pkgbin.MustLocate("gazette")`, which `logrus.Fatal` if the binaries are not on PATH or beside the executable, so the temp data plane could not start in production.

3. With `etcd` and `gazette` available, the temp data plane spawns, but `test_catalog` calls `activate_collection` against `unix://.../gazette.sock` ~1ms later in a `tokio::select!`, before the sockets exist. The gRPC dial returns `Unavailable: No such file or directory (os error 2)` and `Test setup failed` lands in `test_errors`, which bug 1 then masks. Bug 2 hides bug 3 today since the data plane never starts. The `before` output above is from a local stack, where `etcd` and `gazette` are on `PATH` via `mise`, so bug 3 is the immediate cause of `Test setup failed` rather than bug 2; either way the user-visible output is identical.

### Fixes

- `crates/control-plane-api/src/publications/mod.rs`: include `test_errors` in `UncommittedBuild::errors()` so dry-run status selection and commit guards consider test failures.
- `crates/control-plane-api/src/publications/builds.rs`: poll for the `gazette.sock` and `consumer.sock` files before activating derivations, with a 30s deadline.
- `docker/control-plane-agent.Dockerfile`, `mise/tasks/ci/package`, `mise/tasks/ci/platform-build`: stage `gazette` and `etcd` into the package directory and copy them into the agent image, with `command -v` checks at image build time.

### Verification

Same spec, same command, after the fix:

```
$ flowctl --profile local catalog test --source catalog-test-fail.flow.yaml
Created draft: 14acb0fe9f818c00
...
Starting tests...
2026-05-01T00:00:52Z temp-data-plane:1> export BROKER_ADDRESS=unix://localhost/tmp/.tmpuaecle/gazette.sock
2026-05-01T00:00:52Z temp-data-plane:1> export CONSUMER_ADDRESS=unix://localhost/tmp/.tmpuaecle/consumer.sock
2026-05-01T00:00:52Z test:1> Running  1  tests...
2026-05-01T00:00:52Z test:1> ❌ flow://test/test/tests/filter failure at step /1/verify :
2026-05-01T00:00:52Z test:1> verify: actual and expected document(s) did not match:
2026-05-01T00:00:52Z test:1> mismatched document at index 0:
2026-05-01T00:00:52Z test:1> {
2026-05-01T00:00:52Z test:1>     "_meta": { "uuid": "flow-uuid" },
2026-05-01T00:00:52Z test:1>     "customer_id": "c1" => "zzz"
2026-05-01T00:00:52Z test:1> }
2026-05-01T00:00:52Z test:1> Ran 1 tests, 0 passed, 1 failed
2026-05-01T00:00:52Z test:2> FATA[0001] fatal error  err="failed tests: [test/tests/filter]"
ERROR scope=flow://publication/test/api/test detail=One or more test cases failed. View logs for details.
Error: Tests failed

Caused by:
    failed with status: testFailed
EXIT=1
```

A passing test still resolves to `success` with exit 0.

**Notes for reviewers:**

- The existing `test_errors_result_in_test_failed_status` is extended to assert that `errors()` and `has_errors()` both surface `test_errors`, and that `build_failed()` carries the test errors through to the result.
- The race fix in `builds.rs` polls socket file existence rather than retrying gRPC dials. Without it, `connect()` fails with `ENOENT` because tokio polls the test_catalog future and dials the unix socket before the temp-data-plane subprocess has even `fork`/`exec`'d and bound its sockets, without a retry.
- The packaging change adds `mise run build:gazette` to `ci:platform-build` because `ci:package` previously assumed `~/go/bin/gazette` was already built.
- Closes #2871.