### PR TITLE
go.mod: bump gazette to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
-	go.gazette.dev/core v0.103.0
+	go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d
 	golang.org/x/net v0.44.0
 	google.golang.org/api v0.251.0
 	google.golang.org/grpc v1.76.0

--- a/go.sum
+++ b/go.sum
@@ -278,10 +278,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.102.0 h1:S1FFQn4Ws4qThrnwQhZ75jghg++Tfev++fPdq6PVlGw=
-go.gazette.dev/core v0.102.0/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
-go.gazette.dev/core v0.103.0 h1:VkmnsWBbRp8Irwg3RHZ2IlC7bxlK+WQhzODo2w8pLZs=
-go.gazette.dev/core v0.103.0/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d h1:JtAaXogSI+53ssxxID4pIxeRDX76zaXUMkU5jED3Xks=
+go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=


### PR DESCRIPTION
**Description:**

Bump to the latest gazette commit, which includes a couple of improvements to `flowctl-go`.

Namely:
- [cff796b](https://github.com/gazette/core/commit/cff796b91dfe9bcc4a1e156278c22b1bc93bec2e): gazctl: relax reset-head errors from fatal => error
- [1a26589](https://github.com/gazette/core/commit/1a265897275b1d24d4be7515d2caa65e63ff9947): gazctl shards prune: skip suspended recovery logs
- [d4c94c4](https://github.com/gazette/core/commit/d4c94c44d62d48a8cd57762e2cfcba98b2aad063): gazctl shards prune: parallelize per-journal fragment removal

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

