### PR TITLE
shuffle(slice): require broker observation of journal create_revision

### DIFF
--- a/crates/proto-gazette/src/protocol.rs
+++ b/crates/proto-gazette/src/protocol.rs
@@ -375,6 +375,11 @@ pub struct ReadRequest {
     /// to skip persisted Fragments having a modication time before the bound.
     #[prost(int64, tag = "8")]
     pub begin_mod_time: i64,
+    /// Minimum Etcd revision the broker must have read through before resolving
+    /// the request. If the broker is behind, it waits for its KeySpace to catch
+    /// up.
+    #[prost(int64, tag = "9")]
+    pub min_etcd_revision: i64,
 }
 /// ReadResponse is the streamed response message of the broker Read RPC.
 /// Responses messages are of two types:
@@ -493,6 +498,11 @@ pub struct AppendRequest {
     pub subtract_registers: ::core::option::Option<LabelSet>,
     #[prost(enumeration = "append_request::Suspend", tag = "9")]
     pub suspend: i32,
+    /// Minimum Etcd revision the broker must have read through before resolving
+    /// the request. If the broker is behind, it waits for its KeySpace to catch
+    /// up.
+    #[prost(int64, tag = "10")]
+    pub min_etcd_revision: i64,
     /// Content chunks to be appended. Immediately prior to closing the stream,
     /// the client must send an empty chunk (eg, zero-valued AppendRequest) to
     /// indicate the Append should be committed. Absence of this empty chunk

--- a/crates/proto-gazette/src/protocol.serde.rs
+++ b/crates/proto-gazette/src/protocol.serde.rs
@@ -30,6 +30,9 @@ impl serde::Serialize for AppendRequest {
         if self.suspend != 0 {
             len += 1;
         }
+        if self.min_etcd_revision != 0 {
+            len += 1;
+        }
         if !self.content.is_empty() {
             len += 1;
         }
@@ -62,6 +65,11 @@ impl serde::Serialize for AppendRequest {
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.suspend)))?;
             struct_ser.serialize_field("suspend", &v)?;
         }
+        if self.min_etcd_revision != 0 {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("minEtcdRevision", ToString::to_string(&self.min_etcd_revision).as_str())?;
+        }
         if !self.content.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
@@ -89,6 +97,8 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
             "subtract_registers",
             "subtractRegisters",
             "suspend",
+            "min_etcd_revision",
+            "minEtcdRevision",
             "content",
         ];
 
@@ -102,6 +112,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
             UnionRegisters,
             SubtractRegisters,
             Suspend,
+            MinEtcdRevision,
             Content,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -132,6 +143,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                             "unionRegisters" | "union_registers" => Ok(GeneratedField::UnionRegisters),
                             "subtractRegisters" | "subtract_registers" => Ok(GeneratedField::SubtractRegisters),
                             "suspend" => Ok(GeneratedField::Suspend),
+                            "minEtcdRevision" | "min_etcd_revision" => Ok(GeneratedField::MinEtcdRevision),
                             "content" => Ok(GeneratedField::Content),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -160,6 +172,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                 let mut union_registers__ = None;
                 let mut subtract_registers__ = None;
                 let mut suspend__ = None;
+                let mut min_etcd_revision__ = None;
                 let mut content__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
@@ -213,6 +226,14 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                             }
                             suspend__ = Some(map_.next_value::<append_request::Suspend>()? as i32);
                         }
+                        GeneratedField::MinEtcdRevision => {
+                            if min_etcd_revision__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("minEtcdRevision"));
+                            }
+                            min_etcd_revision__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                         GeneratedField::Content => {
                             if content__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("content"));
@@ -232,6 +253,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                     union_registers: union_registers__,
                     subtract_registers: subtract_registers__,
                     suspend: suspend__.unwrap_or_default(),
+                    min_etcd_revision: min_etcd_revision__.unwrap_or_default(),
                     content: content__.unwrap_or_default(),
                 })
             }
@@ -3934,6 +3956,9 @@ impl serde::Serialize for ReadRequest {
         if self.begin_mod_time != 0 {
             len += 1;
         }
+        if self.min_etcd_revision != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("protocol.ReadRequest", len)?;
         if let Some(v) = self.header.as_ref() {
             struct_ser.serialize_field("header", v)?;
@@ -3965,6 +3990,11 @@ impl serde::Serialize for ReadRequest {
             #[allow(clippy::needless_borrows_for_generic_args)]
             struct_ser.serialize_field("beginModTime", ToString::to_string(&self.begin_mod_time).as_str())?;
         }
+        if self.min_etcd_revision != 0 {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("minEtcdRevision", ToString::to_string(&self.min_etcd_revision).as_str())?;
+        }
         struct_ser.end()
     }
 }
@@ -3987,6 +4017,8 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
             "endOffset",
             "begin_mod_time",
             "beginModTime",
+            "min_etcd_revision",
+            "minEtcdRevision",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -3999,6 +4031,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
             MetadataOnly,
             EndOffset,
             BeginModTime,
+            MinEtcdRevision,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4028,6 +4061,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                             "metadataOnly" | "metadata_only" => Ok(GeneratedField::MetadataOnly),
                             "endOffset" | "end_offset" => Ok(GeneratedField::EndOffset),
                             "beginModTime" | "begin_mod_time" => Ok(GeneratedField::BeginModTime),
+                            "minEtcdRevision" | "min_etcd_revision" => Ok(GeneratedField::MinEtcdRevision),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4055,6 +4089,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                 let mut metadata_only__ = None;
                 let mut end_offset__ = None;
                 let mut begin_mod_time__ = None;
+                let mut min_etcd_revision__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Header => {
@@ -4111,6 +4146,14 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::MinEtcdRevision => {
+                            if min_etcd_revision__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("minEtcdRevision"));
+                            }
+                            min_etcd_revision__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(ReadRequest {
@@ -4122,6 +4165,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                     metadata_only: metadata_only__.unwrap_or_default(),
                     end_offset: end_offset__.unwrap_or_default(),
                     begin_mod_time: begin_mod_time__.unwrap_or_default(),
+                    min_etcd_revision: min_etcd_revision__.unwrap_or_default(),
                 })
             }
         }

--- a/crates/shuffle/src/slice/actor.rs
+++ b/crates/shuffle/src/slice/actor.rs
@@ -270,7 +270,7 @@ impl SliceActor {
         let shuffle::slice_request::StartRead {
             binding: binding_index,
             spec,
-            create_revision: _,
+            create_revision,
             mod_revision: _,
             route,
             checkpoint,
@@ -293,6 +293,7 @@ impl SliceActor {
             binding = binding.state_key(),
             %journal,
             offset,
+            create_revision,
             ?producers,
             "starting journal read"
         );
@@ -308,6 +309,7 @@ impl SliceActor {
             end_offset: 0, // No end offset.
             metadata_only: false,
             offset,
+            min_etcd_revision: create_revision,
 
             // `route` is a hint which directs us to the right broker.
             // This is an optimization and isn't required for correctness.
@@ -337,6 +339,7 @@ impl SliceActor {
                 &request.journal,
                 &binding_state_key,
                 request.header.take(),
+                create_revision,
             )
             .await?;
 

--- a/crates/shuffle/src/slice/read.rs
+++ b/crates/shuffle/src/slice/read.rs
@@ -116,6 +116,7 @@ pub async fn probe_write_head(
     journal: &str,
     binding_state_key: &str,
     header: Option<broker::Header>,
+    journal_create_revision: i64,
 ) -> anyhow::Result<(i64, Option<broker::Header>)> {
     use futures::StreamExt;
 
@@ -127,6 +128,7 @@ pub async fn probe_write_head(
         block: false,
         do_not_proxy: true,
         header,
+        min_etcd_revision: journal_create_revision,
         ..Default::default()
     });
     tokio::pin!(stream);

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
-	go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d
+	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
 	golang.org/x/net v0.44.0
 	google.golang.org/api v0.251.0
 	google.golang.org/grpc v1.76.0

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d h1:JtAaXogSI+53ssxxID4pIxeRDX76zaXUMkU5jED3Xks=
-go.gazette.dev/core v0.103.1-0.20260501144951-d4c94c44d62d/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee h1:yceN2m1184/i4YSN4tlfMSdpnV+xnePgnUf4KFa00oE=
+go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=


### PR DESCRIPTION
**Description:**

Set `ReadRequest.min_etcd_revision` to the journal's `CreateRevision` on the slice's metadata probe and streaming read. The broker's resolver treats this as a floor and waits for its KeySpace to catch up before answering, avoiding a spurious `JOURNAL_NOT_FOUND` when the read RPC reaches a broker whose Etcd watch hasn't yet observed the journal.

A couple of other options were considered, but this is ultimately a more principled approach:
- **Client-side retries based on known required revs vs. broker return revs** ❌: Self-contained in the client code and generally "do-able", but  bakes a new "is the broker caught up?" predicate into every retry path that cares, and adds additional network round-trips on retries.
- **Have the client thread through a complete `broker::Header` ❌**: The broker honors `proxyHeader.Etcd.Revision` as a min-revision floor, so we could repurpose it. But that field is server-to-server proxy machinery; using it from a client means manufacturing a credential (`cluster_id` sourced from a real `ListResponse`, route that passes validation, etc.) and threading it through every layer that produces a read request, all to communicate a single `int64`. A dedicated request field says what we mean.

See also: https://github.com/gazette/core/pull/469

Closes https://github.com/estuary/flow/issues/2911

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

