### PR TITLE
fix CI: add missing `build:gazette` step

### DIFF
--- a/.github/workflows/platform-build.yaml
+++ b/.github/workflows/platform-build.yaml
@@ -65,6 +65,7 @@ jobs:
       - run: mise run ci:musl-opt
       - run: mise run ci:gnu-opt
       - run: mise run build:flowctl-go --release
+      - run: mise run build:gazette
       - run: mise run ci:wasm-opt
       - run: mise run ci:package
 


### PR DESCRIPTION
0c3f388254 added `mise run build:gazette` to `mise/tasks/ci/platform-build` and `ln ${HOME}/go/bin/gazette` to `ci:package`, but didn't update `platform-build.yaml` to match. The `ci:package` step fails trying to hard-link a gazette binary that was never built.
