### PR TITLE
docs: distinguish truncate from drop+recreate in backfill behavior

### DIFF
--- a/site/docs/concepts/advanced/evolutions.md
+++ b/site/docs/concepts/advanced/evolutions.md
@@ -67,7 +67,7 @@ Alternatively, you could manually update all the specs to agree to your edit, bu
 
 Evolutions can prevent errors resulting from mismatched specs in two ways:
 
-* **Materialize data to a new resource in the endpoint system**: The evolution updates the affected materialization bindings to increment their `backfill` counter, which causes the materialization to re-create the resource (database table, for example) and backfill it from the beginning.
+* **Materialize data to a new resource in the endpoint system**: The evolution updates the affected materialization bindings to increment their `backfill` counter, which causes the materialization to refresh the resource (database table, for example) and backfill it from the beginning. If the schema change requires a different table structure (such as an incompatible column type change or a primary key change), the resource is dropped and recreated; otherwise it is truncated, preserving table-level metadata such as partitioning and clustering.
 
    This is a simpler change, and how evolutions work in most cases.
 
@@ -75,7 +75,7 @@ Evolutions can prevent errors resulting from mismatched specs in two ways:
 
    This is a more complicated change, and evolutions only work this way when necessary: when the collection key or logical partitioning changes.
 
-In either case, the names of the destination resources will remain the same. For example, a materialization to Postgres would drop and re-create the affected tables with the same names they had previously.
+In either case, the names of the destination resources will remain the same. For example, a materialization to Postgres refreshes the affected tables with the same names they had previously — typically by truncating, or by dropping and recreating when the schema change requires a different table structure.
 
 Also in either case, only the specific bindings that had incompatible changes will be affected. Other bindings will remain untouched, and will not re-backfill.
 
@@ -84,7 +84,7 @@ This field can be set at the top level of a materialization spec or within each 
 If not specified at the binding level, the top-level setting applies by default.
 The `onIncompatibleSchemaChange` field offers four options:
 
-- backfill (default if unspecified): Increments the backfill counter for affected bindings, recreating the destination resources to fit the new schema and backfilling them.
+- backfill (default if unspecified): Increments the backfill counter for affected bindings, refreshing the destination resources (truncating, or dropping and recreating when the schema change requires it) and backfilling them.
 - disableBinding: Disables the affected bindings, requiring manual intervention to re-enable and resolve the incompatible fields.
 - disableTask: Disables the entire materialization, necessitating human action to re-enable and address the incompatible fields.
 - abort: Halts any automated action, leaving the resolution decision to a human.

--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -132,6 +132,17 @@ Skips truncating destination tables when a backfill is triggered.
   - If collection keys or the destination table schema change in incompatible ways, the connector will still drop and recreate the table even with this flag enabled.
 - **Applies to:** Most SQL and warehouse materialization connectors.
 
+### always_drop_tables_on_backfill
+
+Forces destination tables to be dropped and recreated on every backfill instead of truncated.
+
+- **Default:** Disabled. Routine backfills run `TRUNCATE TABLE`, preserving partitioning, clustering, and other table-level DDL applied outside of Estuary.
+- **Use case:** Forcing a clean rebuild of the destination table — for example, to drop columns no longer in the selected fields or to reset table-level configuration.
+- **Caveats:**
+  - Removes any custom partitioning, clustering, indexes, or other DDL applied to the destination table outside of Estuary. You will need to re-apply that DDL after the backfill.
+  - See [Schema changes during backfill](/reference/backfilling-data/#schema-changes-during-backfill) for the full picture of when tables are dropped versus truncated.
+- **Applies to:** Relational SQL and warehouse materialization connectors (for example, PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, Databricks). Connectors whose destinations don't support an in-place truncate — such as MongoDB, DynamoDB, Elasticsearch, and Iceberg — always drop and recreate on backfill regardless of this flag.
+
 ### datetime_keys_as_string
 
 Converts datetime columns used as collection keys to string representation instead of native datetime types.

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -83,16 +83,20 @@ result in duplicate records in your destination.
 
 ### Materialization backfill
 
-A materialization backfill drops and recreates your destination tables using the data currently stored
-in your Estuary collections. This is useful when you need to refresh destination tables without
-rereading from the source.
+A materialization backfill empties your destination tables and repopulates them using the data
+currently stored in your Estuary collections. This is useful when you need to refresh destination
+tables without rereading from the source.
 
 When you perform a materialization backfill:
 
-* Destination tables are dropped and recreated
+* Destination tables are truncated, preserving table-level metadata such as partitioning, clustering, and other DDL applied outside of Estuary
 * Data is read from existing Estuary collections
 * No new data is pulled from the source
 * Tables are repopulated with data from collections
+
+If the backfill is published alongside an incompatible schema change — such as a column type
+change or a change to the collection's primary key — the destination tables are dropped and
+recreated instead, losing any custom DDL.
 
 To perform a materialization backfill:
 
@@ -137,7 +141,7 @@ Or you can select individual collections to backfill:
 </Tabs>
 
 :::tip
-Dropping destination tables may create downtime for your destination table consumers while data is backfilled.
+Refreshing destination tables may create downtime for your destination table consumers while data is backfilled.
 :::
 
 This option is best when you need to refresh destination tables but are confident your collections
@@ -146,17 +150,21 @@ contain all the necessary historical data.
 ### Dataflow reset
 
 A dataflow reset is the most comprehensive option, refreshing the entire pipeline from source to
-destination. This option drops destination tables, rereads data from the source into collections, and
+destination. This option empties destination tables, rereads data from the source into collections, and
 then materializes that data to the destination.
 
 When you perform a dataflow reset:
 
 * Data is reread from the source system
 * Inferred schemas are reset
-* Destination tables are dropped and recreated
+* Destination tables are truncated, preserving table-level metadata such as partitioning and clustering
 * Collections are replaced with fresh source data
 * Derivations are dropped and recreated
 * Destination tables are repopulated with the refreshed data
+
+As with a materialization backfill, if the reset is published alongside an incompatible schema
+change, destination tables are dropped and recreated rather than truncated, losing any custom DDL
+applied outside of Estuary.
 
 To perform a dataflow reset:
 
@@ -210,9 +218,9 @@ When deciding which backfill type to use, consider:
 * **Data retention:** If using Estuary's trial buckets, data expires after approximately 20
 days. For full historical data, [configure your own storage bucket](/getting-started/installation).
 * **Table size:** For very large tables (TBs of data), consider the impact (time, data, cost) of
-dropping and recreating tables.
-* **Downtime tolerance:** Materialization and dataflow resets involve dropping destination
-tables, which creates downtime.
+emptying and repopulating tables.
+* **Downtime tolerance:** Materialization and dataflow resets refresh destination tables, which
+creates a window of incomplete data for downstream consumers.
 * **Update strategy:** Consider whether your materializations use standard (merge) or delta
 updates, as this affects how backfilled data is handled at the destination. Using incremental
 backfills (not dropping the destination tables) when you have materializations that use
@@ -224,8 +232,8 @@ consistency across your Estuary pipelines while minimizing disruption to your da
 | **If I want to...** | **Then I should...** |
 | --- | --- |
 | Refresh my collections with source data, without dropping destination tables | Use an **Incremental Backfill** to pull all source data into Estuary collections |
-| Rebuild destination tables using existing collection data | Use a **Materialization Backfill** to drop and recreate destination tables from collections |
-| Completely refresh my entire data pipeline from source to destination | Use a **Dataflow Reset** to drop destination tables and backfill from source |
+| Rebuild destination tables using existing collection data | Use a **Materialization Backfill** to empty and repopulate destination tables from collections |
+| Completely refresh my entire data pipeline from source to destination | Use a **Dataflow Reset** to empty destination tables and backfill from source |
 | Recover from a replication slot failure in PostgreSQL | Use an **Incremental Backfill** to re-establish consistency |
 | Add a new table to my existing data flow | Use an **Incremental Backfill** for just the new binding |
 | Ensure my own storage bucket contains complete historical data | Use an **Incremental Backfill** after setting up the new storage mapping |

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -209,6 +209,39 @@ You do not need to modify other specifications: resetting from the collection up
 This option is ideal when you need a complete refresh of your entire data pipeline, especially when
 you suspect data inconsistencies between source, collections, and destinations.
 
+### Schema changes during backfill
+
+Materialization backfills and dataflow resets refresh destination tables in one of two ways, depending on whether the publication also contains incompatible schema changes:
+
+- **Truncate and repopulate** (default for routine backfills) — the connector runs `TRUNCATE TABLE`, preserving partitioning, clustering, and any other table-level DDL applied outside of Estuary.
+- **Drop and recreate** — the connector drops the existing table and recreates it from the current selected fields, losing any custom DDL.
+
+A backfill drops and recreates the table when any of the following is true:
+
+- A selected field's type changes incompatibly (for example, string → integer).
+- The source collection's primary key changes.
+- The materialization has the [`always_drop_tables_on_backfill`](/guides/advanced-usage/feature-flags) feature flag set.
+
+Truncate-and-repopulate is the default for relational SQL and warehouse destinations (for example, PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, and Databricks). Some materialization connectors — including those targeting MongoDB, DynamoDB, Elasticsearch, and Iceberg — always drop and recreate on backfill, because the underlying system doesn't support an in-place truncate.
+
+#### Controlling behavior with onIncompatibleSchemaChange
+
+When an incompatible schema change is detected, you can override the default drop-and-recreate behavior by configuring [`onIncompatibleSchemaChange`](/concepts/advanced/evolutions/) on the materialization or per binding:
+
+- `backfill` (default) — drop and recreate the table, then backfill.
+- `abort` — fail the publication so the change is never applied.
+- `disableBinding` — disable the affected binding instead of backfilling it.
+- `disableTask` — disable the entire materialization.
+
+#### Preserving existing data during a backfill
+
+To keep existing rows when a backfill is triggered, either:
+
+- Use an [incremental backfill](#incremental-backfill), or
+- Set the [`retain_existing_data_on_backfill`](/guides/advanced-usage/feature-flags) feature flag on the materialization.
+
+Both options skip the truncate step, but neither prevents the drop-and-recreate path: if the schema change requires a different table structure, the table is still dropped.
+
 ### Backfill Selection
 
 Backfills can be a powerful tool to recover data, but can also result in unnecessary data costs if used incorrectly. This section will help you choose when to backfill and which backfill option to use.

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -199,6 +199,20 @@ drop table <your_dataset>.<your_schema>.<your_table>_copy;
 ```
 6. Re-enable the materialization to continue materializing data to the now partitioned table.
 
-:::caution
-A [dataflow reset capture backfill](/reference/backfilling-data/#dataflow-reset) or [materialization backfill](/reference/backfilling-data/#materialization-backfill) will drop and recreate the table, removing any custom partitioning. If you need to backfill but don't need to drop the table, use an [incremental capture backfill](/reference/backfilling-data/#incremental-backfill) instead. Otherwise, you will need to re-apply the partitioning conversion steps above after the backfill.
+:::info
+A routine [dataflow reset](/reference/backfilling-data/#dataflow-reset) or [materialization backfill](/reference/backfilling-data/#materialization-backfill) with no schema changes runs `TRUNCATE TABLE`, which preserves partitioning, clustering, and all other table-level metadata. In that case you do **not** need to re-apply table partitioning.
+
+The table is dropped and recreated — losing custom partitioning and any other DDL applied outside of Estuary — only when the backfill is coupled with an incompatible schema change in the same publication. Cases that trigger drop + recreate:
+
+- A selected field's type changes incompatibly (e.g., string → integer)
+- The source collection's primary key changes
+- The materialization has the `always_drop_tables_on_backfill` feature flag set
+
+To protect custom partitioning when an incompatible schema change is detected, configure [`onIncompatibleSchemaChange`](/concepts/advanced/evolutions/) on the binding (or the materialization). The default is `backfill`, which is what triggers the drop + recreate above. Other options:
+
+- `abort` — fail the publication so the change is never applied
+- `disableBinding` — disable the affected binding instead of backfilling it
+- `disableTask` — disable the entire materialization
+
+If you need to keep existing rows during a backfill, use an [incremental capture backfill](/reference/backfilling-data/#incremental-backfill), or set the `retain_existing_data_on_backfill` feature flag on the materialization.
 :::

--- a/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/site/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -200,19 +200,7 @@ drop table <your_dataset>.<your_schema>.<your_table>_copy;
 6. Re-enable the materialization to continue materializing data to the now partitioned table.
 
 :::info
-A routine [dataflow reset](/reference/backfilling-data/#dataflow-reset) or [materialization backfill](/reference/backfilling-data/#materialization-backfill) with no schema changes runs `TRUNCATE TABLE`, which preserves partitioning, clustering, and all other table-level metadata. In that case you do **not** need to re-apply table partitioning.
+A routine [dataflow reset](/reference/backfilling-data/#dataflow-reset) or [materialization backfill](/reference/backfilling-data/#materialization-backfill) preserves your custom partitioning — the connector runs `TRUNCATE TABLE` and keeps all table-level DDL.
 
-The table is dropped and recreated — losing custom partitioning and any other DDL applied outside of Estuary — only when the backfill is coupled with an incompatible schema change in the same publication. Cases that trigger drop + recreate:
-
-- A selected field's type changes incompatibly (e.g., string → integer)
-- The source collection's primary key changes
-- The materialization has the `always_drop_tables_on_backfill` feature flag set
-
-To protect custom partitioning when an incompatible schema change is detected, configure [`onIncompatibleSchemaChange`](/concepts/advanced/evolutions/) on the binding (or the materialization). The default is `backfill`, which is what triggers the drop + recreate above. Other options:
-
-- `abort` — fail the publication so the change is never applied
-- `disableBinding` — disable the affected binding instead of backfilling it
-- `disableTask` — disable the entire materialization
-
-If you need to keep existing rows during a backfill, use an [incremental capture backfill](/reference/backfilling-data/#incremental-backfill), or set the `retain_existing_data_on_backfill` feature flag on the materialization.
+The table is only dropped and recreated — losing custom partitioning — when the backfill is paired with an incompatible schema change in the same publication. See [Schema changes during backfill](/reference/backfilling-data/#schema-changes-during-backfill) for the full list of triggers and the [`onIncompatibleSchemaChange`](/concepts/advanced/evolutions/) options that can prevent it.
 :::


### PR DESCRIPTION
## Summary

A routine materialization backfill or dataflow reset runs `TRUNCATE` against destination tables, preserving table-level DDL (partitioning, clustering, etc.). The drop-and-recreate path only fires when the backfill is coupled with an incompatible schema change in the same publication — an incompatible field type change, a primary key change, or the `always_drop_tables_on_backfill` feature flag.

Existing docs presented drop+recreate as the default behavior, which is wrong and pushes customers (especially BigQuery users with custom partitioning) toward unnecessary workarounds.

The decision logic lives in [materialize-boilerplate/materializer.go](https://github.com/estuary/connectors/blob/main/materialize-boilerplate/materializer.go#L520-L600) — same code path for every SQL/warehouse materialization.

## Files updated

- **`guides/backfilling-data.md`** — the highest-impact file. Rewrote the Materialization backfill and Dataflow reset sections to lead with the truncate behavior, with drop+recreate framed as the schema-change exception. Updated the consideration list and the summary table accordingly.
- **`concepts/advanced/evolutions.md`** — three lines that conflated truncate with recreate. Clarified that the `backfill` option truncates when possible and only drops+recreates when the schema change requires it.
- **`reference/Connectors/materialization-connectors/BigQuery.md`** — replaced the partitioning caution box with a corrected info block. Leads with the safe path, lists the three drop+recreate triggers, and adds `onIncompatibleSchemaChange` as a protection mechanism for customers with custom DDL.

## Test plan

- [ ] Render docs preview and verify all three pages read cleanly
- [ ] Confirm `[onIncompatibleSchemaChange](/concepts/advanced/evolutions/)` link resolves (no specific anchor exists for that field name on the evolutions page; landing on the page is acceptable)
- [ ] Confirm the existing intra-doc links in `BigQuery.md` (`#dataflow-reset`, `#materialization-backfill`, `#incremental-backfill`) still resolve after `backfilling-data.md` edits