### PR TITLE
data-plane-controller: rollout "waiting" field

### DIFF
--- a/crates/data-plane-controller/src/shared/snapshots/data_plane_controller__shared__stack__test__simulate_waiting_rollout.snap
+++ b/crates/data-plane-controller/src/shared/snapshots/data_plane_controller__shared__stack__test__simulate_waiting_rollout.snap
@@ -1,0 +1,195 @@
+---
+source: crates/data-plane-controller/src/shared/stack.rs
+expression: "&simulate_rollout(&mut stack.config.model, &[])"
+---
+[
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 3,
+      "current": 3,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      },
+      "tier": 50
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 0,
+      "current": 0,
+      "rollout": {
+        "target": 3,
+        "step": 1,
+        "waiting": true
+      },
+      "tier": 50
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 2,
+      "current": 3,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      },
+      "tier": 50
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 0,
+      "current": 0,
+      "rollout": {
+        "target": 3,
+        "step": 1
+      },
+      "tier": 50
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 1,
+      "current": 2,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      },
+      "tier": 50
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 1,
+      "current": 0,
+      "rollout": {
+        "target": 3,
+        "step": 1
+      },
+      "tier": 50
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:v3.5.17",
+      "desired": 0,
+      "current": 1,
+      "rollout": {
+        "target": 0,
+        "step": 1
+      },
+      "tier": 50
+    },
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 2,
+      "current": 1,
+      "rollout": {
+        "target": 3,
+        "step": 1
+      },
+      "tier": 50
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 3,
+      "current": 2,
+      "rollout": {
+        "target": 3,
+        "step": 1
+      },
+      "tier": 50
+    }
+  ],
+  [
+    {
+      "role": "etcd",
+      "template": {
+        "ami_image_id": "ami-01a8b7cc84780badb",
+        "instance_type": "m5d.large",
+        "provider": "aws",
+        "region": "us-west-2",
+        "zone": "a"
+      },
+      "oci_image": "quay.io/coreos/etcd:next",
+      "desired": 3,
+      "current": 3,
+      "tier": 50
+    }
+  ]
+]

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -1000,6 +1000,38 @@ mod test {
         insta::assert_json_snapshot!(&outcomes);
     }
 
+    #[test]
+    fn simulate_waiting_rollout() {
+        let State { mut stack, .. } =
+            serde_json::from_str(include_str!("state_fixture.json")).unwrap();
+
+        stack
+            .config
+            .model
+            .deployments
+            .retain(|d| d.role == Role::Etcd);
+
+        // Manually configure a replace-style rollout using `waiting` directly,
+        // without going through a Release.
+        let old_desired = stack.config.model.deployments[0].desired;
+        let template = stack.config.model.deployments[0].clone();
+
+        stack.config.model.deployments[0].rollout =
+            Some(Rollout { target: 0, step: 1, waiting: false });
+
+        let new_deployment = Deployment {
+            current: 0,
+            desired: 0,
+            oci_image: "quay.io/coreos/etcd:next".to_string(),
+            oci_image_override: None,
+            rollout: Some(Rollout { target: old_desired, step: 1, waiting: true }),
+            ..template
+        };
+        stack.config.model.deployments.push(new_deployment);
+
+        insta::assert_json_snapshot!(&simulate_rollout(&mut stack.config.model, &[]));
+    }
+
     fn simulate_rollout(model: &mut DataPlane, releases: &[Release]) -> Vec<Vec<Deployment>> {
         let mut outcomes = Vec::new();
         outcomes.push(model.deployments.clone());

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -200,6 +200,10 @@ pub struct Rollout {
     pub target: usize,
     /// Maximum amount to increment or decrement `desired` towards `target`.
     pub step: usize,
+    /// When true, skip the next step and flip to false.
+    /// Used to give a sibling deployment a one-cycle head start before this one begins stepping.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub waiting: bool,
 }
 
 /// A Release is matched against a current Deployment of a data-plane.
@@ -508,6 +512,7 @@ impl DataPlane {
                 rollout: Some(Rollout {
                     step: release.step.abs() as usize,
                     target: last.desired,
+                    waiting: false,
                 }),
                 template: last.template.clone(),
                 tier: last.tier,
@@ -517,6 +522,7 @@ impl DataPlane {
             last.rollout = Some(Rollout {
                 step: release.step.abs() as usize,
                 target: 0,
+                waiting: false,
             });
 
             if release.step < 0 {
@@ -549,9 +555,13 @@ impl Deployment {
     }
 
     pub fn step_rollout(&mut self) -> bool {
-        let Some(rollout) = &self.rollout else {
+        let Some(rollout) = &mut self.rollout else {
             return false;
         };
+        if rollout.waiting {
+            rollout.waiting = false;
+            return true;
+        }
         if self.desired < rollout.target {
             self.desired += rollout.step.min(rollout.target - self.desired);
         } else {
@@ -753,7 +763,7 @@ mod test {
         deployments.push(Deployment {
             current: 0,
             desired: 0,
-            rollout: Some(Rollout { step: 1, target: 1 }),
+            rollout: Some(Rollout { step: 1, target: 1, waiting: false }),
             ..deployments[0].clone()
         });
 

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -763,7 +763,11 @@ mod test {
         deployments.push(Deployment {
             current: 0,
             desired: 0,
-            rollout: Some(Rollout { step: 1, target: 1, waiting: false }),
+            rollout: Some(Rollout {
+                step: 1,
+                target: 1,
+                waiting: false,
+            }),
             ..deployments[0].clone()
         });
 
@@ -1016,15 +1020,22 @@ mod test {
         let old_desired = stack.config.model.deployments[0].desired;
         let template = stack.config.model.deployments[0].clone();
 
-        stack.config.model.deployments[0].rollout =
-            Some(Rollout { target: 0, step: 1, waiting: false });
+        stack.config.model.deployments[0].rollout = Some(Rollout {
+            target: 0,
+            step: 1,
+            waiting: false,
+        });
 
         let new_deployment = Deployment {
             current: 0,
             desired: 0,
             oci_image: "quay.io/coreos/etcd:next".to_string(),
             oci_image_override: None,
-            rollout: Some(Rollout { target: old_desired, step: 1, waiting: true }),
+            rollout: Some(Rollout {
+                target: old_desired,
+                step: 1,
+                waiting: true,
+            }),
             ..template
         };
         stack.config.model.deployments.push(new_deployment);


### PR DESCRIPTION
**Description:**

Currently, `rollout`s have some one-time special logic when they are created by an associated `release`: the sign value of the `step` field of a `release` is used to determine whether the "`last`" `release` steps first or the "`next`". This has the functional effect of offsetting the progress of `deployment`s with a `rollout` by one step. This is to ensure that either new instances come up before the old are taken down, or old instances are taken down before the new ones come up.

This is a small change to allow us to "delay" a `rollout` step by one converge without referring to a `release`, by adding a `waiting` field that causes the deployment to skip one converge cycle and then disappears. This is functionally the same thing that the release-related rollout process does:
```
if release.step < 0 {
    // Replace by stepping down the `last` deployment now,
    // and then stepping up `next` after convergence.
    last.step_rollout();
} else {
    // Surge by stepping up the `next` deployment now,
    // and then stepping down `last` after convergence.
    next.step_rollout();
};
```
but allows us to have it happen independently of a `rollout` being created by a `release`. The use this would currently have is allowing us to safely use `rollout` when we want to coordinate some data plane change in a "set-and-forget"/automated manner; this was the most surgical way I could think of to accomplish this. The alternatives were changing how `rollout` works in general, or creating some weird operator-like thing to watch deployments.

More clearly, we need some way to enforce ordering on `deployment`s coming up or down, our release-rollout path does such a thing based on the `release` that created the `rollout`, but this functionality is not exposed in the `rollout` itself. It would be useful to us for some automations to be able to use this field in such a way. This is a way to do that.

Changes no behavior otherwise. Verified on local mise plane with `data-plane-controller`.

**Workflow steps:**

Add a `rollout` field to a `deployment` with `"waiting": true`- you'll see that disappear after one converge, then the `rollout` continues the same way it usually would.

Example, spin down before spin up:

|"Frame"|"last" deploy|"next" deploy|
|---|---|---|
|Pre-run|rollout added, waiting=false|new deployment w/ rollout created, waiting=true|
|1|Desired = 3 -> 2|one time skip, waiting=false|
|2|Desired = 2 -> 1|Desired = 0 -> 1|
|3|Desired = 1 -> 0|Desired = 1 -> 2|
|4|N/A|Desired = 2 -> 3|

Adds a simple test to demonstrate this. The etcd deployment "frames" are the same as in the `simulate_etcd_rollout` test, without using a release.

**Documentation links affected:**

N/A

**Notes for reviewers:**

The most immediate use for this for me (and solutions?) is the creation of a `resize` command for the `est-dry-dock` CLI. 