### PR TITLE
flowctl: fix false "outdated version" warning

### DIFF
--- a/crates/flowctl/build.rs
+++ b/crates/flowctl/build.rs
@@ -2,7 +2,6 @@ fn main() {
     // If we set CARGO_PKG_VERSION this way, then it will override the default value, which is
     // taken from the `version` in Cargo.toml.
     if let Ok(val) = std::env::var("FLOW_VERSION") {
-        let val = val.strip_prefix('v').unwrap_or(&val);
         println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
         eprintln!("using FLOW_VERSION: {}", val);
     }

--- a/crates/flowctl/build.rs
+++ b/crates/flowctl/build.rs
@@ -2,6 +2,7 @@ fn main() {
     // If we set CARGO_PKG_VERSION this way, then it will override the default value, which is
     // taken from the `version` in Cargo.toml.
     if let Ok(val) = std::env::var("FLOW_VERSION") {
+        let val = val.strip_prefix('v').unwrap_or(&val);
         println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
         eprintln!("using FLOW_VERSION: {}", val);
     }

--- a/crates/flowctl/src/version.rs
+++ b/crates/flowctl/src/version.rs
@@ -31,10 +31,5 @@ async fn fetch_latest_tag() -> anyhow::Result<String> {
         .json()
         .await?;
 
-    let tag = release
-        .tag_name
-        .strip_prefix('v')
-        .unwrap_or(&release.tag_name);
-
-    Ok(tag.to_owned())
+    Ok(release.tag_name)
 }


### PR DESCRIPTION
## Summary

- The release workflow sets `FLOW_VERSION` from the git tag (e.g. `v0.6.7`), which gets baked into `CARGO_PKG_VERSION` verbatim. The version check strips the `v` prefix from the GitHub API response before comparing, so `"0.6.7" != "v0.6.7"` always triggers the warning — even when the user is on the latest version.
- Fix: strip the `v` prefix in `build.rs` before setting `CARGO_PKG_VERSION`.

## Test plan

- [ ] Build flowctl with `FLOW_VERSION=v0.6.7` and verify `--version` prints `0.6.7`
- [ ] Confirm the "outdated version" warning no longer appears when running the latest release