### PR TITLE
docs: path can contain date patterns for filesink

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
@@ -56,9 +56,9 @@ Estuary collections to your bucket.
 
 #### Bindings
 
-| Property    | Title | Description                                    | Type   | Required/Default |
-|-------------|-------|------------------------------------------------|--------|------------------|
-| **`/path`** | Path  | The path that objects will be materialized to. | string | Required         |
+| Property    | Title | Description                                                                                  | Type   | Required/Default |
+|-------------|-------|----------------------------------------------------------------------------------------------|--------|------------------|
+| **`/path`** | Path  | The path that objects will be materialized to.  May contain [date patterns](#date-patterns). | string | Required         |
 
 ### Sample
 
@@ -99,8 +99,9 @@ starting back over from 0.
 
 ### Date Patterns
 
-The **prefix** option of the endpoint configuration can contain patterns that
-are expanded using the time of the start of the transaction.
+The **prefix** option of the endpoint configuration and the **path** of the
+binding configuration can contain patterns that are expanded using the time of
+the start of the transaction.
 
 :::note The transaction time is always represented as UTC.
 :::

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-parquet.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-parquet.md
@@ -55,9 +55,9 @@ Estuary collections to your bucket.
 
 #### Bindings
 
-| Property    | Title | Description                                    | Type   | Required/Default |
-|-------------|-------|------------------------------------------------|--------|------------------|
-| **`/path`** | Path  | The path that objects will be materialized to. | string | Required         |
+| Property    | Title | Description                                                                                  | Type   | Required/Default |
+|-------------|-------|----------------------------------------------------------------------------------------------|--------|------------------|
+| **`/path`** | Path  | The path that objects will be materialized to.  May contain [date patterns](#date-patterns). | string | Required         |
 
 ### Sample
 
@@ -122,8 +122,9 @@ starting back over from 0.
 
 ### Date Patterns
 
-The **prefix** option of the endpoint configuration can contain patterns that
-are expanded using the time of the start of the transaction.
+The **prefix** option of the endpoint configuration and the **path** of the
+binding configuration can contain patterns that are expanded using the time of
+the start of the transaction.
 
 :::note The transaction time is always represented as UTC.
 :::


### PR DESCRIPTION
This was added as a review comment to the original change and wasn't included in the documentation.  Both the prefix and the path can use the date patterns.

see https://github.com/estuary/connectors/pull/3988

**Workflow steps:**

None

**Documentation links affected:**

- https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-parquet
- https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-csv

**Notes for reviewers:**

(anything that might help someone review this PR)

