### PR TITLE
Reject footguns in `redact` annotation placement

### DIFF
--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -191,6 +191,48 @@ fn walk_collection(
         check_uuid_ptr_not_redacted(scope.push_prop("schema"), &write_spec.spec, errors);
     }
 
+    // Redaction runs at capture time using the write schema. Annotations
+    // placed only in the read schema do not protect stored documents.
+    if let Some(read) = &read_spec {
+        check_read_schema_redact_in_write_schema(
+            scope.push_prop("readSchema"),
+            &read.spec,
+            &write_spec.spec,
+            errors,
+        );
+    }
+
+    // Annotations placed inside `$defs` entries whose `$id` is a system-managed
+    // schema URI are silently overwritten by discover or validation-time
+    // inlining. Scan the user-authored models (not the post-inlining
+    // `read_spec.model`, which carries a verbatim copy of the write schema).
+    if let Some(read) = read_model.as_ref() {
+        let write = write_model
+            .as_ref()
+            .expect("split schemas have write_model");
+        check_redact_in_managed_defs(
+            scope.push_prop("writeSchema"),
+            write,
+            &write_spec.spec.curi,
+            errors,
+        );
+        if let Some(read_spec) = &read_spec {
+            check_redact_in_managed_defs(
+                scope.push_prop("readSchema"),
+                read,
+                &read_spec.spec.curi,
+                errors,
+            );
+        }
+    } else if let Some(schema) = schema_model.as_ref() {
+        check_redact_in_managed_defs(
+            scope.push_prop("schema"),
+            schema,
+            &write_spec.spec.curi,
+            errors,
+        );
+    }
+
     let effective_read_spec = read_spec
         .as_ref()
         .map(|Schema { spec, .. }| spec)
@@ -800,6 +842,109 @@ fn check_uuid_ptr_not_redacted(scope: Scope, spec: &schema::Schema, errors: &mut
             Error::UuidPtrHasRedact {
                 ptr: ptr_str.to_string(),
                 schema: spec.curi.clone(),
+                strategy: shape.redact.clone(),
+            }
+            .push(scope, errors);
+        }
+    }
+}
+
+// For each location in `read_spec` that has a `redact` strategy, emit an
+// error if the same location in `write_spec` does not also have a `redact`
+// strategy. Locations introduced through patternProperties are skipped,
+// because they cannot be matched precisely against the write shape.
+fn check_read_schema_redact_in_write_schema(
+    scope: Scope,
+    read_schema: &schema::Schema,
+    write_schema: &schema::Schema,
+    errors: &mut tables::Errors,
+) {
+    for (ptr, is_pattern, shape, _exists) in read_schema.shape.locations() {
+        if is_pattern {
+            continue;
+        }
+        if matches!(shape.redact, doc::shape::Redact::Unset) {
+            continue;
+        }
+        let (write_shape, write_exists) = write_schema.shape.locate(&ptr);
+        if matches!(write_exists, doc::shape::location::Exists::Cannot) {
+            continue;
+        }
+        if matches!(write_shape.redact, doc::shape::Redact::Unset) {
+            let ptr_str = ptr.to_string();
+            let location = if ptr_str.is_empty() {
+                "the document root".to_string()
+            } else {
+                format!("location {ptr_str}")
+            };
+            Error::ReadSchemaRedactNotInWriteSchema {
+                location,
+                ptr: ptr_str,
+                schema: read_schema.curi.clone(),
+                strategy: shape.redact.clone(),
+            }
+            .push(scope, errors);
+        }
+    }
+}
+
+// Scan `$defs` entries whose `$id` is one of the system-managed schema URIs
+// for any nested `redact` annotation. These subtrees are owned by the system:
+// discover overwrites `flow://connector-schema`, and validation-time inlining
+// replaces `flow://inferred-schema`, `flow://write-schema`, and
+// `flow://relaxed-write-schema`. Annotations placed inside them are silently
+// lost on the next publication. We discriminate by `$id` (the canonical URI
+// that drives `$ref` resolution), not by the `$defs` key (which is convention
+// only and can be renamed).
+fn check_redact_in_managed_defs(
+    scope: Scope,
+    model: &models::Schema,
+    curi: &url::Url,
+    errors: &mut tables::Errors,
+) {
+    const MANAGED_IDS: &[&str] = &[
+        models::Schema::REF_INFERRED_SCHEMA_URL,
+        models::Schema::REF_WRITE_SCHEMA_URL,
+        models::Schema::REF_RELAXED_WRITE_SCHEMA_URL,
+        models::Schema::REF_CONNECTOR_SCHEMA_URL,
+    ];
+
+    let raw: serde_json::Value = match serde_json::from_str(model.get()) {
+        Ok(v) => v,
+        Err(_) => return, // Parse errors are reported elsewhere.
+    };
+    let Some(defs) = raw.get("$defs").and_then(|v| v.as_object()) else {
+        return;
+    };
+    for (_def_key, def_value) in defs {
+        let Some(def_id) = def_value.get("$id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !MANAGED_IDS.contains(&def_id) {
+            continue;
+        }
+        let bundle = serde_json::to_vec(def_value).expect("def_value re-serializes");
+        let Ok(def_schema) = schema::Schema::new(&bundle) else {
+            continue; // Schema build errors are reported elsewhere.
+        };
+        for (ptr, is_pattern, shape, _exists) in def_schema.shape.locations() {
+            if is_pattern {
+                continue;
+            }
+            if matches!(shape.redact, doc::shape::Redact::Unset) {
+                continue;
+            }
+            let ptr_str = ptr.to_string();
+            let location = if ptr_str.is_empty() {
+                "the document root".to_string()
+            } else {
+                format!("location {ptr_str}")
+            };
+            Error::RedactInsideManagedDefs {
+                location,
+                ptr: ptr_str,
+                def_id: def_id.to_string(),
+                schema: curi.clone(),
                 strategy: shape.redact.clone(),
             }
             .push(scope, errors);

--- a/crates/validation/src/errors.rs
+++ b/crates/validation/src/errors.rs
@@ -154,6 +154,30 @@ pub enum Error {
         schema: Url,
         strategy: doc::shape::Redact,
     },
+    #[error(
+        "{location} has a `redact` strategy in the read schema but the write schema has \
+         no `redact` at this location; redaction is applied at capture time using the write \
+         schema, so this annotation does not protect stored data. Move the annotation to the \
+         write schema."
+    )]
+    ReadSchemaRedactNotInWriteSchema {
+        location: String,
+        ptr: String,
+        schema: Url,
+        strategy: doc::shape::Redact,
+    },
+    #[error(
+        "{location} inside `$defs/{def_id}` has a `redact` strategy, but `$defs/{def_id}` is a \
+         system-managed schema subtree that is overwritten by discover or validation-time \
+         inlining. Move the annotation to the top level of the schema."
+    )]
+    RedactInsideManagedDefs {
+        location: String,
+        ptr: String,
+        def_id: String,
+        schema: Url,
+        strategy: doc::shape::Redact,
+    },
     #[error("{category} projection {field} does not exist in collection {collection}")]
     NoSuchProjection {
         category: String,

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -1925,6 +1925,118 @@ test://example/int-string.schema:
 }
 
 #[test]
+fn test_read_schema_redact_not_in_write_schema() {
+    // A redact annotation in the read schema with no corresponding annotation
+    // in the write schema is non-functional: redaction runs at capture time
+    // against the write schema, so stored data is not protected.
+    let errors = common::run_errors(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  collections:
+    testing/redact-read-only:
+      key: [/id]
+      writeSchema:
+        type: object
+        properties:
+          id: { type: string }
+          email: { type: string }
+        required: [id]
+      readSchema:
+        type: object
+        properties:
+          id: { type: string }
+          email:
+            type: string
+            redact: { strategy: sha256 }
+        required: [id]
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_redact_inside_managed_defs_connector_schema() {
+    // A redact annotation placed inside a `$defs` entry whose `$id` is
+    // `flow://connector-schema` is silently overwritten on the next discover.
+    // The `$defs` key here is intentionally a user-chosen name (not the
+    // canonical URI), so this test also covers the discriminator: the check
+    // matches on `$id`, not the `$defs` key.
+    let errors = common::run_errors(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  collections:
+    testing/redact-in-defs:
+      key: [/id]
+      writeSchema:
+        $defs:
+          connector:
+            $id: "flow://connector-schema"
+            type: object
+            properties:
+              id: { type: string }
+              email:
+                type: string
+                redact: { strategy: sha256 }
+            required: [id]
+        $ref: "flow://connector-schema"
+      readSchema:
+        $defs:
+          flow://inferred-schema:
+            $id: flow://inferred-schema
+            type: object
+            properties:
+              id: { type: string }
+              _meta:
+                type: object
+                properties:
+                  uuid: { type: string }
+                required: [uuid]
+            required: [id, _meta]
+            x-collection-generation-id: 0000000000000001
+        allOf:
+          - $ref: flow://relaxed-write-schema
+          - $ref: flow://inferred-schema
+"#,
+    );
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn test_redact_at_top_level_passes() {
+    // A redact annotation at the top level of writeSchema (outside $defs),
+    // also present in readSchema, is the supported placement and produces
+    // no errors.
+    let errors = common::run_errors(
+        MODEL_YAML,
+        r#"
+test://example/catalog.yaml:
+  collections:
+    testing/redact-supported:
+      key: [/id]
+      writeSchema:
+        type: object
+        properties:
+          id: { type: string }
+          email:
+            type: string
+            redact: { strategy: sha256 }
+        required: [id]
+      readSchema:
+        type: object
+        properties:
+          id: { type: string }
+          email:
+            type: string
+            redact: { strategy: sha256 }
+        required: [id]
+"#,
+    );
+    insta::assert_debug_snapshot!(errors, @"[]");
+}
+
+#[test]
 fn test_materialization_too_many_bindings() {
     let bindings_count = validation::MAX_BINDINGS + 1;
 

--- a/crates/validation/tests/snapshots/scenario_tests__read_schema_redact_not_in_write_schema.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__read_schema_redact_not_in_write_schema.snap
@@ -1,0 +1,10 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/catalog.yaml#/collections/testing~1redact-read-only/readSchema,
+        error: location /email has a `redact` strategy in the read schema but the write schema has no `redact` at this location; redaction is applied at capture time using the write schema, so this annotation does not protect stored data. Move the annotation to the write schema.,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__redact_inside_managed_defs_connector_schema.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__redact_inside_managed_defs_connector_schema.snap
@@ -1,0 +1,10 @@
+---
+source: crates/validation/tests/scenario_tests.rs
+expression: errors
+---
+[
+    Error {
+        scope: test://example/catalog.yaml#/collections/testing~1redact-in-defs/writeSchema,
+        error: location /email inside `$defs/flow://connector-schema` has a `redact` strategy, but `$defs/flow://connector-schema` is a system-managed schema subtree that is overwritten by discover or validation-time inlining. Move the annotation to the top level of the schema.,
+    },
+]

--- a/crates/validation/tests/snapshots/scenario_tests__shape_inspections-2.snap
+++ b/crates/validation/tests/snapshots/scenario_tests__shape_inspections-2.snap
@@ -24,6 +24,18 @@ expression: errors
         error: `block` redact strategy cannot be applied at '/int' because it must exist,
     },
     Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/readSchema,
+        error: the document root has a `redact` strategy in the read schema but the write schema has no `redact` at this location; redaction is applied at capture time using the write schema, so this annotation does not protect stored data. Move the annotation to the write schema.,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/readSchema,
+        error: location /int has a `redact` strategy in the read schema but the write schema has no `redact` at this location; redaction is applied at capture time using the write schema, so this annotation does not protect stored data. Move the annotation to the write schema.,
+    },
+    Error {
+        scope: test://example/int-string#/collections/testing~1int-string-rw/readSchema,
+        error: location /str has a `redact` strategy in the read schema but the write schema has no `redact` at this location; redaction is applied at capture time using the write schema, so this annotation does not protect stored data. Move the annotation to the write schema.,
+    },
+    Error {
         scope: test://example/int-string#/collections/testing~1int-string-rw/key/0,
         error: location /int has a `redact` strategy, which is disallowed because the location is used as a key,
     },


### PR DESCRIPTION
## Background

Redaction runs at capture time (or pedantically, at any time that data is written to a collection, which also includes derivations), at the moment documents enter the system. The runtime applies it according to the `redact` annotations present in the collection's write schema. For the annotation to take effect, it has to survive the publication pipeline and end up in the write schema. The platform currently _accepts_ `redact` in several locations where one or both of those conditions fail silently: in `readSchema`, which only materializations consult, and anywhere inside a `flow://...` subtree (`flow://write-schema`, `flow://inferred-schema`, `flow://relaxed-write-schema`, `flow://connector-schema`), each of which the publication pipeline overwrites on every build.

Two categories of misplacement are accepted today with no signal to the user:

* **`redact` only in the read schema.** The read schema is used at materialization time, not at capture time. A redaction annotation in this location _will_ prevent sensitive data from being written to the destination system, but it _won't_ prevent it from being stored in the customer's collection in the first place. 
* **`redact` inside `$defs/flow://*`.** These are virtual schemas that get replaced before publication completes. Discover overwrites `$defs/flow://connector-schema` with `overwrite: true` on every run, and validation inlines `flow://write-schema`, `flow://relaxed-write-schema`, and `flow://inferred-schema` from other sources. Annotations placed inside any of them are erased before they ever reach the runtime.
  * **Concept:** would a better solution be to error if a publication contains _any_ changes to a `flow://` schema? Not actually sure if that's a trivial thing to check though..

This PR adds validation checks that block these misplacements at publication time.

## Changes

Two new errors, modeled on the existing `KeyHasRedact` and `UuidPtrHasRedact`:

* `ReadSchemaRedactNotInWriteSchema`: walks the read schema's locations and errors if any `redact` annotation has no corresponding `redact` at the same pointer in the write schema.
  * **Note:** I suppose technically this doesn't have to be an error... but it feels like we should err on the side of caution and forbid the narrow use-case of writing unredacted data to the collection, and only redacting at materialize time. Any objections?
* `RedactInsideManagedDefs`: scans the user-authored schema model for `redact` annotations inside any `$defs/flow://...` entry and reports the offending JSON pointer. The scan reads the pre-inlining model, so the verbatim copy of the write schema that validation places into `$defs/flow://write-schema` is not misreported.

Closes #2914.