### PR TITLE
data-plane-controller: let vpc exist

### DIFF
--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -286,6 +286,8 @@ pub struct AnsibleHost {
     pub zone: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub geo_region: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vpc: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
**Description:**

Extremely small PR to let the `vpc` field be passed from Pulumi to Ansible.

**Workflow steps:**

Automatic. VPC populated from Pulumi.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

