### PR TITLE
data-plane-controller: periodic converge

### DIFF
--- a/crates/data-plane-controller/src/job/executor.rs
+++ b/crates/data-plane-controller/src/job/executor.rs
@@ -281,6 +281,11 @@ impl Executor {
         if state.last_refresh + REFRESH_INTERVAL < chrono::Utc::now() {
             state.pending_refresh = true;
         }
+        // Periodically force a convergence pass even when nothing has changed,
+        // to catch silent infrastructure drift or missed triggers.
+        if state.last_pulumi_up + CONVERGE_INTERVAL < chrono::Utc::now() {
+            state.pending_converge = true;
+        }
         // Changes to branch or stack configuration require a convergence pass.
         if state.deploy_branch != next.deploy_branch {
             state.deploy_branch = next.deploy_branch;
@@ -622,3 +627,4 @@ impl automations::Outcome for Outcome {
 const IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 const POLL_AGAIN: std::time::Duration = std::time::Duration::ZERO;
 const REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2 * 60 * 60);
+const CONVERGE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(4 * 60 * 60);


### PR DESCRIPTION
**Description:**

Historically, we've relied on `PulumiRefresh` to detect drift and trigger a convergence. This holds for AWS and GCP, but not Azure. Because of that, we need some way to ensure that converges are still happening regularly. This is a small change to allow that to happen. 4 hours was chosen because that seems to be the average amount of time the other providers go before some remote drift triggers a converge.

**Workflow steps:**

Automatic. Detects time since last successful converge for a plane and if greater than 4 hours, "signals" for the DPC to run a convergence on it.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

