### PR TITLE
mise: wasm-bindgen changed repos

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@
 go = { version = "1.25" }
 # `rust` is required, but installation via mise is incompatible with Swatim/rust-cache
 
-"github:drager/wasm-pack" = { version = "0.13.1" }
+"github:wasm-bindgen/wasm-pack" = { version = "0.13.1" }
 "github:etcd-io/etcd" = { version = "3.5.24" }
 "github:getsops/sops" = { version = "3.11.0", bin = "sops" }
 "github:jdx/usage" = { version = "2.6.0" }


### PR DESCRIPTION
**Description:**

Apparently these guys moved their repo and associated packages like an hour ago:
https://github.com/drager/wasm-pack/commit/25d02924699b4d48121d0c31247ed8e35b8d17f2

This borked out mise build tools install:
```
Error: 
     0: Failed to install github:drager/wasm-pack@0.13.1: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/drager/wasm-pack/releases/tags/drager/wasm-pack@0.13.1)
```
This should point us at their new repo?

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

