### PR TITLE
docs: source-sage-intacct permission required for deletions

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/sage-intacct.md
+++ b/site/docs/reference/Connectors/capture-connectors/sage-intacct.md
@@ -21,6 +21,12 @@ updated documents:
 * ITEM
 * TASK
 
+:::info
+The incremental strategy for the above objects captures deletions by querying the AUDITHISTORY object.
+If the credentials provided to the connector do not have permission to query the AUDITHISTORY object,
+deletions will not be captured.
+:::
+
 These objects support capturing via periodic snapshotting:
 * COMPANYPREF
 


### PR DESCRIPTION
**Description:**

Documentation updates for https://github.com/estuary/connectors/pull/4465. Mainly just specifying that the connector only captures deletions if it can query the `AUDITHISTORY` object.
