### PR TITLE
dpc: add service_region to AWSPrivateLink struct

### DIFF
--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -158,6 +158,8 @@ pub struct AWSPrivateLink {
     pub region: String,
     pub az_ids: Vec<String>,
     pub service_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_region: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -587,6 +589,7 @@ mod test {
                 az_ids: vec!["a".to_string(), "b".to_string()],
                 region: "us-west-2".to_string(),
                 service_name: "service".to_string(),
+                service_region: None,
             }),
         );
 


### PR DESCRIPTION
**Description:**

Adds optional `service_region` to `AWSPrivateLink` for cross-region PrivateLinks.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

