### PR TITLE
docs: instruct users to clear min/max_backfill_xid after backfill

### DIFF
--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -379,4 +379,6 @@ To configure this option:
 
 6. Save and publish your changes.
 
+7. After the backfill completes, edit the capture again and clear the "Minimum Backfill XID" / "Maximum Backfill XID" field, then save and publish. The XID is only applied when a backfill is triggered, so it has no effect during normal CDC operation — but leaving it in place means that any future backfill (intentional or otherwise) will be silently limited to rows above/below the old transaction ID, potentially missing data. Clearing it ensures future backfills start from a clean state.
+
 In rare cases, this method may not work as expected, as in situations where a database has already filled up its entire `xmin` space. In such cases of `xmin` wrapping, using both Minimum and Maximum Backfill XID fields can help narrow down a specific range to backfill.


### PR DESCRIPTION
## Summary
- Adds a step 7 to the PostgreSQL Capture backfill procedure in `backfilling-data.md` telling users to clear the Minimum/Maximum Backfill XID field after the backfill completes
- Explains the failure mode: the XID is only applied when a backfill is triggered, so it has no effect during normal CDC, but leaving it in place silently limits any future backfill (intentional or otherwise) to rows above/below the stale transaction ID — potentially missing data

## Context
Two customers in one day forgot about an old `min_backfill_xid` and triggered a dataflow reset backfill, only capturing a fraction of their data. The dedicated troubleshooting page (`postgres-replication-slot-recovery.md`) already has a "Clear the XMIN value" step, but the main `backfilling-data.md` guide stopped at "save and publish" with no removal instruction. This closes that gap.

## Test plan
- [ ] Docs preview renders the new step 7 correctly