### PR TITLE
protocols/catalog: skip NULL-spec rows in LoadAll* queries

### DIFF
--- a/go/protocols/catalog/build_load.go
+++ b/go/protocols/catalog/build_load.go
@@ -64,11 +64,13 @@ func LoadAllErrors(db *sql.DB) ([]Error, error) {
 	return out, err
 }
 
-// LoadAllCollections loads all collections.
+// LoadAllCollections loads all collections, excluding tombstone rows
+// whose spec is NULL because the collection is being deleted by the
+// current publication.
 func LoadAllCollections(db *sql.DB) ([]*pf.CollectionSpec, error) {
 	var out []*pf.CollectionSpec
 	var err = loadSpecs(db,
-		`SELECT spec FROM built_collections ORDER BY collection ASC;`,
+		`SELECT spec FROM built_collections WHERE spec IS NOT NULL ORDER BY collection ASC;`,
 		func() loadableSpec { return new(pf.CollectionSpec) },
 		func(l loadableSpec) { out = append(out, l.(*pf.CollectionSpec)) },
 	)
@@ -81,11 +83,13 @@ func LoadCollection(db *sql.DB, name string) (*pf.CollectionSpec, error) {
 	return out, loadOneSpec(db, `SELECT spec FROM built_collections WHERE collection = ?;`, out, name)
 }
 
-// LoadAllCaptures loads all captures.
+// LoadAllCaptures loads all captures, excluding tombstone rows whose
+// spec is NULL because the capture is being deleted by the current
+// publication.
 func LoadAllCaptures(db *sql.DB) ([]*pf.CaptureSpec, error) {
 	var out []*pf.CaptureSpec
 	var err = loadSpecs(db,
-		`SELECT spec FROM built_captures ORDER BY capture ASC;`,
+		`SELECT spec FROM built_captures WHERE spec IS NOT NULL ORDER BY capture ASC;`,
 		func() loadableSpec { return new(pf.CaptureSpec) },
 		func(l loadableSpec) { out = append(out, l.(*pf.CaptureSpec)) },
 	)
@@ -98,11 +102,13 @@ func LoadCapture(db *sql.DB, name string) (*pf.CaptureSpec, error) {
 	return out, loadOneSpec(db, `SELECT spec FROM built_captures WHERE capture = ?;`, out, name)
 }
 
-// LoadAllMaterializations loads all materializations.
+// LoadAllMaterializations loads all materializations, excluding
+// tombstone rows whose spec is NULL because the materialization is
+// being deleted by the current publication.
 func LoadAllMaterializations(db *sql.DB) ([]*pf.MaterializationSpec, error) {
 	var out []*pf.MaterializationSpec
 	var err = loadSpecs(db,
-		`SELECT spec FROM built_materializations ORDER BY materialization ASC;`,
+		`SELECT spec FROM built_materializations WHERE spec IS NOT NULL ORDER BY materialization ASC;`,
 		func() loadableSpec { return new(pf.MaterializationSpec) },
 		func(l loadableSpec) { out = append(out, l.(*pf.MaterializationSpec)) },
 	)
@@ -115,11 +121,22 @@ func LoadMaterialization(db *sql.DB, name string) (*pf.MaterializationSpec, erro
 	return out, loadOneSpec(db, `SELECT spec FROM built_materializations WHERE materialization = ?;`, out, name)
 }
 
-// LoadAllTests loads all tests.
+// LoadAllTests loads all tests, excluding tombstone rows whose spec
+// is NULL because the test is being deleted by the current publication.
+//
+// Without this filter, a publication that deletes a test (which the
+// Rust build layer represents as a row with model=None / spec=NULL,
+// per BuiltRow::is_delete in crates/tables/src/built.rs) would cause
+// the test runner to load an empty TestSpec and fail TestSpec.Validate
+// with "missing Name", e.g.
+//
+//   extracting from build: validating spec : missing Name
+//
+// This blocks `flowctl catalog delete` for any test spec.
 func LoadAllTests(db *sql.DB) ([]*pf.TestSpec, error) {
 	var out []*pf.TestSpec
 	var err = loadSpecs(db,
-		`SELECT spec FROM built_tests ORDER BY test ASC;`,
+		`SELECT spec FROM built_tests WHERE spec IS NOT NULL ORDER BY test ASC;`,
 		func() loadableSpec { return new(pf.TestSpec) },
 		func(l loadableSpec) {
 			out = append(out, l.(*pf.TestSpec))

--- a/go/protocols/catalog/build_load.go
+++ b/go/protocols/catalog/build_load.go
@@ -64,9 +64,7 @@ func LoadAllErrors(db *sql.DB) ([]Error, error) {
 	return out, err
 }
 
-// LoadAllCollections loads all collections, excluding tombstone rows
-// whose spec is NULL because the collection is being deleted by the
-// current publication.
+// LoadAllCollections loads all collections.
 func LoadAllCollections(db *sql.DB) ([]*pf.CollectionSpec, error) {
 	var out []*pf.CollectionSpec
 	var err = loadSpecs(db,
@@ -83,9 +81,7 @@ func LoadCollection(db *sql.DB, name string) (*pf.CollectionSpec, error) {
 	return out, loadOneSpec(db, `SELECT spec FROM built_collections WHERE collection = ?;`, out, name)
 }
 
-// LoadAllCaptures loads all captures, excluding tombstone rows whose
-// spec is NULL because the capture is being deleted by the current
-// publication.
+// LoadAllCaptures loads all captures.
 func LoadAllCaptures(db *sql.DB) ([]*pf.CaptureSpec, error) {
 	var out []*pf.CaptureSpec
 	var err = loadSpecs(db,
@@ -102,9 +98,7 @@ func LoadCapture(db *sql.DB, name string) (*pf.CaptureSpec, error) {
 	return out, loadOneSpec(db, `SELECT spec FROM built_captures WHERE capture = ?;`, out, name)
 }
 
-// LoadAllMaterializations loads all materializations, excluding
-// tombstone rows whose spec is NULL because the materialization is
-// being deleted by the current publication.
+// LoadAllMaterializations loads all materializations.
 func LoadAllMaterializations(db *sql.DB) ([]*pf.MaterializationSpec, error) {
 	var out []*pf.MaterializationSpec
 	var err = loadSpecs(db,
@@ -121,18 +115,7 @@ func LoadMaterialization(db *sql.DB, name string) (*pf.MaterializationSpec, erro
 	return out, loadOneSpec(db, `SELECT spec FROM built_materializations WHERE materialization = ?;`, out, name)
 }
 
-// LoadAllTests loads all tests, excluding tombstone rows whose spec
-// is NULL because the test is being deleted by the current publication.
-//
-// Without this filter, a publication that deletes a test (which the
-// Rust build layer represents as a row with model=None / spec=NULL,
-// per BuiltRow::is_delete in crates/tables/src/built.rs) would cause
-// the test runner to load an empty TestSpec and fail TestSpec.Validate
-// with "missing Name", e.g.
-//
-//   extracting from build: validating spec : missing Name
-//
-// This blocks `flowctl catalog delete` for any test spec.
+// LoadAllTests loads all tests.
 func LoadAllTests(db *sql.DB) ([]*pf.TestSpec, error) {
 	var out []*pf.TestSpec
 	var err = loadSpecs(db,


### PR DESCRIPTION
**Description:**

`flowctl catalog delete --name <test>` (and any publication that deletes a test) currently fails with:
```
test:N> FATA fatal error err="extracting from build: validating spec : missing Name"
Error: failed with status: testFailed
```

The Rust build layer represents a deletion as a `built_*` row with `spec` NULL (per `BuiltRow::is_delete` in [built.rs](https://github.com/estuary/flow/blob/8553fa84846058d449726012842cacb707209eec/crates/tables/src/built.rs#L64-L66)). The Go-side `LoadAll*` queries in [build_load.go](https://github.com/estuary/flow/blob/8553fa84846058d449726012842cacb707209eec/go/protocols/catalog/build_load.go) did not filter those rows, so `flowctl-go api test` would `Scan` a NULL `spec` into an empty byte slice, `Unmarshal` it into a zero-value `TestSpec`, and trip `TestSpec.Validate()` with `missing Name`.

Fix: add `WHERE spec IS NOT NULL` to all four LoadAll* queries (collections, captures, materializations, tests). The same defect was latent in the other three loaders even though the visible failure was only in tests, since the test phase is the one that per-row-validates inside loadSpecs.

**Workflow steps:**

Repo before fix:
```
cat > flow.yaml <<'YAML'
collections:
  acmeCo/widgets:
    schema: { type: object, properties: { id: { type: string } }, required: [id] }
    key: [/id]
tests:
  acmeCo/widget-test:
    - ingest: { collection: acmeCo/widgets, documents: [{ id: "w1" }] }
    - verify: { collection: acmeCo/widgets, documents: [{ id: "w1" }] }
YAML
flowctl catalog publish --source flow.yaml --auto-approve
flowctl catalog delete --name acmeCo/widget-test
# → testFailed: validating spec : missing Name
```

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

