### PR TITLE
Docs: Basic reference for SNS, Spanner materializations

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/README.md
+++ b/site/docs/reference/Connectors/materialization-connectors/README.md
@@ -29,6 +29,9 @@ In the future, other open-source materialization connectors from third parties c
 * Amazon Redshift
   * [Configuration](./amazon-redshift.md)
   * Package - ghcr.io/estuary/materialize-redshift:v2
+* Amazon SNS
+  * [Configuration](./amazon-sns.md)
+  * Package - ghcr.io/estuary/materialize-sns:v1
 * Amazon SQL Server
   * [Configuration](./SQLServer/amazon-rds-sqlserver.md)
   * Package - ghcr.io/estuary/materialize-amazon-rds-sqlserver:v2
@@ -101,6 +104,9 @@ In the future, other open-source materialization connectors from third parties c
 * Google Sheets
   * [Configuration](./Google-sheets.md)
   * Package - ghcr.io/estuary/materialize-google-sheets:v2
+* Google Spanner
+  * [Configuration](./google-spanner.md)
+  * Package - ghcr.io/estuary/materialize-spanner:v1
 * HTTP Webhook
   * [Configuration](./http-webhook.md)
   * Package - ghcr.io/estuary/materialize-webhook:v1

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-sns.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-sns.md
@@ -1,0 +1,80 @@
+
+# Amazon SNS
+
+This connector materializes Estuary collections into topics in Amazon Simple Notification Service, or SNS.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* AWS credentials. One of the following types:
+   * The AWS **access key** and **secret access key** for the user. See the [AWS blog](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/) for help finding these credentials.
+   * To authenticate using an AWS Role, you'll need the **region** and the **role arn**. Follow the steps in the [AWS IAM guide](/guides/iam-auth/aws.md) to set up the role.
+* At least one Estuary collection to materialize.
+
+## Configuration
+
+To use this connector, begin with data in one or more Estuary collections.
+Use the properties below to configure an Amazon SNS materialization.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/region`** | AWS Region | Region of the SNS service. | string | Required |
+| **`/credentials`** | Authentication | Credentials for authentication. | [Credentials](#credentials) | Required |
+| `/advanced/endpoint` | AWS Endpoint | Override the AWS endpoint URL. Used to direct requests at a compatible API such as LocalStack. | string |  |
+
+#### Credentials
+
+Credentials for authenticating with AWS. Use one of the following sets of options:
+
+**Access Key**
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials/auth_type`** | Auth Type | Method to use for authentication. | string | Required: `AWSAccessKey` |
+| **`/credentials/aws_access_key_id`** | AWS Access Key ID | AWS Access Key ID for publishing to SNS. | string | Required |
+| **`/credentials/aws_secret_access_key`** | AWS Secret Access Key | AWS Secret Access Key for publishing to SNS. | string | Required |
+
+**AWS IAM**
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/credentials/auth_type`** | Auth Type | Method to use for authentication. | string | Required: `AWSIAM` |
+| **`/credentials/aws_role_arn`** | AWS Role ARN | IAM Role to assume. | string | Required |
+| **`/credentials/aws_region`** | AWS Region | AWS Region to authenticate in. | string | Required |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/topic_name`** | Topic Name | Name of the SNS topic to publish to (without the ARN prefix). FIFO topics must end in `.fifo`. | string | Required |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${MATERIALIZATION_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-sns:v1
+        config:
+          region: us-east-1
+          credentials:
+            auth_type: AWSAccessKey
+            aws_access_key_id: example-aws-access-key-id
+            aws_secret_access_key: example-aws-secret-access-key
+    bindings:
+      - resource:
+          topic_name: orders
+        source: ${PREFIX}/${COLLECTION_NAME}
+```
+
+## Delta updates
+
+Because SNS is a write-only event-streaming system, it has no concept of stored rows or keys.
+This connector only uses [delta updates](/concepts/materialization/#delta-updates) rather than merge updates.
+Every document in the source collection results in one event published to the topic.

--- a/site/docs/reference/Connectors/materialization-connectors/google-spanner.md
+++ b/site/docs/reference/Connectors/materialization-connectors/google-spanner.md
@@ -1,0 +1,62 @@
+
+# Google Spanner
+
+This connector materializes Estuary collections into tables in Google Spanner.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+* A [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project) with the Spanner API enabled.
+* A Google Cloud Spanner instance and database.
+* Credentials for a service account that can manage your Spanner instance.
+* At least one Estuary collection to materialize.
+
+## Configuration
+
+To use this connector, begin with data in one or more Estuary collections.
+Use the properties below to configure a Google Spanner materialization.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/project_id`** | Project ID | Name of the Google Cloud project containing your Spanner instance for this materialization. | string | Required |
+| **`/instance_id`** | Instance ID | Cloud Spanner instance ID. | string | Required |
+| **`/database`** | Database | Name of the Spanner database to use for the materialization. | string | Required |
+| `/hardDelete` | Hard Delete | If this option is enabled, items deleted in the source will also be deleted from the destination. Otherwise, `_meta/op` will indicate soft deletes. | boolean | `false` |
+| **`/credentials`** | Credentials | Credentials used to authenticate with Google. | object | Required |
+| **`/credentials/service_account_json`** | Service Account JSON | The JSON key of the service account to use for authorization. | string | Required |
+| `/advanced` | Advanced Options | Options for advanced users. | object |  |
+| `/advanced/no_flow_document` | Exclude Flow Document | When enabled, the root document will not be required for standard updates. | boolean | `false` |
+| `/advanced/disable_key_distribution_optimization` | Disable Key Distribution Optimization | When enabled, the hash prefix normally added to table keys will be omitted. The hash prefix distributes writes across Spanner splits and avoids hotspots. | boolean | `false` |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+|---|---|---|---|---|
+| **`/table`** | Table Name | Name of the table to publish materialized results to. | string | Required |
+| `/schema` | Alternative Schema | Optional alternative schema for this table. Overrides the default namespace. | string |  |
+| `/additional_table_create_sql` | Additional Table Create SQL | Additional SQL statement(s) to be run in the same transaction that creates the table. | string |  |
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-spanner:v1
+        config:
+          project_id: my_google_cloud_project
+          instance_id: my_spanner_instance
+          database: my_db
+          credentials:
+            service_account_json: {secret}
+    bindings:
+      - resource:
+          table: table_name
+        source: ${PREFIX}/${source_collection}
+```


### PR DESCRIPTION
**Description:**

Amazon SNS and Google Spanner materializations do not have corresponding docs. I put together a basic reference doc for each so the dashboard and content resources have something to link to.

**Documentation links affected:**

New pages for SNS and Spanner

**Notes for reviewers:**

These basic reference pages mainly consist of connector properties. If the materialization team knows offhand the specific permissions these connectors require or has other usage notes, it'd be helpful to add those; otherwise, I can research further in the future. Thanks!
