### PR TITLE
docs: add marketing events stream to source-hubspot-native

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
+++ b/site/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
@@ -22,6 +22,7 @@ The connector automatically discovers bindings for the following HubSpot resourc
 * [Goals](https://developers.hubspot.com/docs/api-reference/crm-goal-targets-v3/guide)
 * [Line Items](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/line-items)
 * [Marketing Emails](https://developers.hubspot.com/docs/api-reference/marketing-marketing-emails-v3/marketing-emails/get-marketing-v3-emails-)
+* [Marketing Events](https://developers.hubspot.com/docs/api-reference/legacy/marketing/marketing-events/guide)
 * [Orders](https://developers.hubspot.com/docs/api-reference/crm-orders-v3/guide)
 * [Owners](https://developers.hubspot.com/beta-docs/reference/api/crm/owners/v2)
 * [Products](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/products)


### PR DESCRIPTION
**Description:**

Adds documentation for github.com/estuary/connectors/pull/4547

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

