### PR TITLE
Guard against stale GQL schema

### DIFF
--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -28,8 +28,8 @@ jobs:
 
       - run: mise run ci:format-check
 
-  sqlx-check:
-    name: SQLx Check
+  generated-artifacts-check:
+    name: Generated Artifacts Check
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -73,6 +73,10 @@ jobs:
       - run: mise run build:rocksdb
       - run: mise run local:supabase
       - run: mise run ci:sqlx-check
+
+      # Reuses this job's compiled workspace (flow-client --all-features pulls in
+      # control-plane-api) to verify the committed GraphQL SDL hasn't drifted.
+      - run: mise run ci:graphql-schema-check
 
   platform-test:
     name: Platform Test

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -312,6 +312,11 @@ type AutoDiscoverStatus {
 	failure: AutoDiscoverFailure
 }
 
+type BillingPaymentMethodPayload {
+	paymentMethods: [PaymentMethod!]!
+	primaryPaymentMethod: PaymentMethod
+}
+
 input BoolFilter {
 	eq: Boolean
 }
@@ -341,11 +346,24 @@ enum CapabilityBit {
 	Assume
 }
 
+type CardPaymentMethodDetails {
+	brand: String
+	last4: String
+	expMonth: Int!
+	expYear: Int!
+}
+
 enum CatalogType {
 	capture
 	collection
 	materialization
 	test
+}
+
+enum ChargeStatus {
+	FAILED
+	PENDING
+	SUCCEEDED
 }
 
 scalar Collection
@@ -585,6 +603,10 @@ type Controller {
 	updatedAt: DateTime!
 }
 
+type CreateBillingSetupIntentPayload {
+	clientSecret: String!
+}
+
 """
 Result of creating a storage mapping.
 """
@@ -687,6 +709,11 @@ type DataPlaneEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+input DateFilter {
+	gt: NaiveDate
+	lt: NaiveDate
 }
 
 """
@@ -831,6 +858,72 @@ type InviteLinkEdge {
 input InviteLinksFilter {
 	singleUse: BoolFilter
 	catalogPrefix: PrefixFilter
+}
+
+type Invoice {
+	dateStart: String!
+	dateEnd: String!
+	invoiceType: InvoiceType!
+	subtotal: Int!
+	lineItems: JSON!
+	extra: JSON!
+	amountDue: Int
+	status: String
+	invoicePdf: String
+	hostedInvoiceUrl: String
+	paymentDetails: InvoicePaymentDetails
+}
+
+type InvoiceConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [InvoiceEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Invoice!]!
+}
+
+"""
+An edge in a connection.
+"""
+type InvoiceEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Invoice!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input InvoiceFilter {
+	dateStart: DateFilter
+	dateEnd: DateFilter
+	invoiceType: InvoiceTypeFilter
+}
+
+type InvoicePaymentDetails {
+	status: ChargeStatus!
+	receiptUrl: String
+	card: CardPaymentMethodDetails
+	usBankAccount: UsBankAccountPaymentMethodDetails
+}
+
+enum InvoiceType {
+	FINAL
+	PREVIEW
+	MANUAL
+}
+
+input InvoiceTypeFilter {
+	eq: InvoiceType
 }
 
 """
@@ -1010,6 +1103,9 @@ type LockFailure {
 }
 
 type MutationRoot {
+	createBillingSetupIntent(tenant: String!): CreateBillingSetupIntentPayload!
+	setBillingPaymentMethod(tenant: String!, paymentMethodId: String!): BillingPaymentMethodPayload!
+	deleteBillingPaymentMethod(tenant: String!, paymentMethodId: String!): BillingPaymentMethodPayload!
 	"""
 	Create a storage mapping for the given catalog prefix.
 	
@@ -1092,6 +1188,17 @@ type MutationRoot {
 	deleteInviteLink(token: UUID!): Boolean!
 }
 
+"""
+ISO 8601 calendar date without timezone.
+Format: %Y-%m-%d
+
+# Examples
+
+* `1994-11-13`
+* `2000-02-24`
+"""
+scalar NaiveDate
+
 scalar Name
 
 """
@@ -1114,6 +1221,18 @@ type PageInfo {
 	When paginating forwards, the cursor to continue.
 	"""
 	endCursor: String
+}
+
+type PaymentMethod {
+	id: String!
+	type: String!
+	billingDetails: PaymentMethodBillingDetails!
+	card: CardPaymentMethodDetails
+	usBankAccount: UsBankAccountPaymentMethodDetails
+}
+
+type PaymentMethodBillingDetails {
+	name: String
 }
 
 """
@@ -1361,6 +1480,7 @@ type QueryRoot {
 	Returns a paginated list of connectors, optionally filtered by protocol.
 	"""
 	connectors(filter: ConnectorsFilter, after: String, before: String, first: Int, last: Int): ConnectorConnection!
+	tenant(name: String!): Tenant
 }
 
 """
@@ -1737,6 +1857,17 @@ input StorageMappingsBy {
 	underPrefix: Prefix
 }
 
+type Tenant {
+	name: String!
+	billing: TenantBilling!
+}
+
+type TenantBilling {
+	paymentMethods: [PaymentMethod!]!
+	primaryPaymentMethod: PaymentMethod
+	invoices(filter: InvoiceFilter, after: String, before: String, first: Int, last: Int): InvoiceConnection!
+}
+
 """
 A UUID is a unique 128-bit number, stored as 16 octets. UUIDs are parsed as
 Strings within GraphQL. UUIDs are used to assign unique identifiers to
@@ -1776,6 +1907,12 @@ type UpdateStorageMappingResult {
 URL is a String implementing the [URL Standard](http://url.spec.whatwg.org/)
 """
 scalar Url
+
+type UsBankAccountPaymentMethodDetails {
+	bankName: String
+	last4: String
+	accountHolderType: String
+}
 
 """
 Marks an element of a GraphQL schema as no longer supported.

--- a/mise/tasks/ci/graphql-schema-check
+++ b/mise/tasks/ci/graphql-schema-check
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#MISE description="Verify the committed flow-client GraphQL SDL is up-to-date"
+
+set -euo pipefail
+
+# Regenerate the SDL from the current schema. flow-client's build script writes
+# crates/flow-client/control-plane-api.graphql when the `generate` feature is
+# enabled (pulled in by --all-features); see `build:graphql-schema`.
+cargo build -p flow-client --all-features
+
+# Fail if the committed copy drifted from what the schema now produces.
+if ! git diff --exit-code -- crates/flow-client/control-plane-api.graphql; then
+  echo >&2 "error: committed GraphQL SDL is out of date."
+  echo >&2 "run 'mise run build:graphql-schema' and commit crates/flow-client/control-plane-api.graphql"
+  exit 1
+fi


### PR DESCRIPTION
## Guard against committed GraphQL SDL drift

`crates/flow-client/control-plane-api.graphql` is generated from the control-plane schema and committed to the repo.
Nothing currently verifies it stays in sync, so a schema change that lands without regenerating leaves the checked-in SDL stale until someone notices.