### PR TITLE
Docs: Refresh data flow tutorials

### DIFF
--- a/site/docs/concepts/materialization/materialization.md
+++ b/site/docs/concepts/materialization/materialization.md
@@ -376,7 +376,7 @@ these are:
 
 2. **Naming Convention**
 
-   The [target resource naming convention](#target-resource-naming-convention-options) can be set in a materialization's Source Collections section.
+   The [target resource naming convention](#target-resource-naming-conventions) can be set in a materialization's Source Collections section.
    This option provides general rules for schema and table names for all newly-added bindings.
 
 3. **Manual Overrides**

--- a/site/docs/getting-started/tutorials/continuous-materialized-view.md
+++ b/site/docs/getting-started/tutorials/continuous-materialized-view.md
@@ -214,11 +214,11 @@ Your transformation will continue in real time based on the raw dataset, which i
 
 Now, you'll materialize your new fact table to Postgres. You'll also materialize the source dataset to compare performance.
 
-1. Go to the [Destinations page](https://dashboard.estuary.dev/materializations) in Estuary's web app.
+1. Go to the [Destinations page](https://dashboard.estuary.dev/materializations) in Estuary's dashboard.
 
 2. Click **New Materialization**.
 
-3. Find the **PostgreSQL** and click **Materialization**.
+3. Find the **PostgreSQL** tile and click **Materialization**.
 
 3. Add a unique name for the materialization, for example, `yourprefix/yourname-materialized-views-demo`.
 
@@ -232,7 +232,13 @@ Now, you'll materialize your new fact table to Postgres. You'll also materialize
 
    See the [connector documentation](https://docs.estuary.dev/reference/Connectors/materialization-connectors/PostgreSQL/) if you need help finding these properties.
 
-5. In the **Source Collections** browser, search for and add the collection `demo/wikipedia/recentchange` and name the corresponding Postgres Table `wikipedia_raw`.
+5. In the **Source Collections** browser, search for and add the collection `demo/wikipedia/recentchange`.
+
+   When you first add a capture or collection to your materialization, you will be prompted to select a **target naming strategy**.
+   This sets defaults for your table and schema names in your destination.
+   We'll be updating our table names manually for clarity, so simply stick with "Match source structure" and continue.
+
+   In the collection's **Resource Configuration**, you can then name the corresponding Postgres table `wikipedia_raw`.
 
 6. Also search for and add the collection you just derived, (for example, `yourprefix/wikipedia/user-fact-table`).
 Name the corresponding Postgres table `wikipedia_data_by_user`.

--- a/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
+++ b/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
@@ -11,7 +11,7 @@ The dataset you'll use is composed of zipped CSV files in an Amazon S3 cloud sto
 
 You'll need:
 
-* An Estuary account. If you don't have one, visit the [Estuary web app](https://dashboard.estuary.dev) to register for free.
+* An Estuary account. If you don't have one, visit [Estuary's dashboard](https://dashboard.estuary.dev) to register for free.
 
 * A [Snowflake free trial account](https://signup.snowflake.com/) (or a full account).
   Snowflake trials are valid for 30 days.
@@ -37,7 +37,7 @@ The simplest Data Flow comprises three types of entities:
 
 * A data **capture**, which ingests data from the source. In this case, you'll capture from Amazon S3.
 
-* One or more **collections**, which Estuary uses to store that data inside a cloud-backed data lake
+* One or more **collections**, which Estuary uses to store that data inside a cloud-backed data lake.
 
 * A **materialization**, to push the data to an external destination. In this case, you'll materialize to a Snowflake data warehouse.
 
@@ -82,38 +82,42 @@ You'll start by creating your capture.
 
 6. Next, fill out the required properties for S3.
 
-   * **AWS Access Key ID** and **AWS Secret Access Key**: The bucket is public, so you can leave these fields blank.
-
    * **AWS Region**: `us-east-1`
 
    * **Bucket**: `tripdata`
 
    * **Prefix**: The storage bucket isn't organized by prefixes, so leave this blank.
 
-   * **Match Keys**: `2022`
+   * **Match Keys**: `2025.*`
 
-   The Citi Bike storage bucket has been around for a while. Some of the older datasets have incorrect file extensions or contain data in different formats. By selecting a subset of files from the year 2022, you'll make things easier to manage for the purposes of this tutorial.
-   (In a real-world use case, you'd likely reconcile the different schemas of the various data formats using a **derivation**.
-   [Derivations](../../concepts/README.md#derivations) are a more advanced Estuary skill.)
+      The Citi Bike storage bucket has been around for a while. Some of the older datasets have incorrect file extensions or contain data in different formats. By selecting a subset of files from the year 2025, you'll make things easier to manage for the purposes of this tutorial.
+      (In a real-world use case, you'd likely reconcile the different schemas of the various data formats using a **derivation**.
+      [Derivations](../../concepts/README.md#derivations) are a more advanced Estuary skill.)
+
+   * **Authentication**: The bucket is public, so select **Anonymous** authentication.
+
+   * **Parser Configuration**: Estuary is often able to automatically determine how to parse incoming data.
+   For this capture, however, you can specify **Zip Archive** as the compression type and **CSV** as the file type.
 
 7. Click **Next**.
 
    Estuary uses the configuration you provided to initiate a connection with S3. It generates a list of **collections** that will store the data inside Estuary. In this case, there's just one collection from the bucket.
 
-     Once this process completes, you can move on to the next step. If there's an error, go back and check your configuration.
+   Once this process completes, you can move on to the next step. If there's an error, go back and check your configuration.
+
 8. Click **Save and Publish**.
 
-   Estuary deploys, or **publishes**, your capture, including your change to the schema. You'll see a notification when the this is complete.
+   Estuary deploys, or **publishes**, your capture. You'll see a notification when the this is complete.
 
    A subset of data from the Citi Bike tripdata bucket has been captured to a collection. Now, you can materialize that data to Snowflake.
 
-9. Click **Materialize Collections**.
+9. Click **Materialize**.
 
 ## Prepare Snowflake to use with Estuary
 
 Before you can materialize from Estuary to Snowflake, you need to complete some setup steps.
 
-1. Leave the Estuary web app open. In a new window or tab, go to your Snowflake console.
+1. Leave the Estuary dashboard open. In a new window or tab, go to your Snowflake console.
 
    If you're a new trial user, you should have received instructions by email. For additional help in this section, see the [Snowflake documentation](https://docs.snowflake.com/en/user-guide-getting-started.html).
 
@@ -121,14 +125,13 @@ Before you can materialize from Estuary to Snowflake, you need to complete some 
 
    This provides an interface where you can run queries.
 
-3. Paste the following script into the console, changing the value for `estuary_password` from `secret` to a strong password:
+3. Paste the following script into the console:
 
 ```sql
 set database_name = 'ESTUARY_DB';
 set warehouse_name = 'ESTUARY_WH';
 set estuary_role = 'ESTUARY_ROLE';
 set estuary_user = 'ESTUARY_USER';
-set estuary_password = 'secret';
 set estuary_schema = 'ESTUARY_SCHEMA';
 -- create role and schema for Estuary
 create role if not exists identifier($estuary_role);
@@ -139,10 +142,11 @@ use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
-password = $estuary_password
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);
+-- Estuary requires case-sensitive quoted identifiers (e.g. "_meta/op").
+alter user identifier($estuary_user) set QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;
 grant all on schema identifier($estuary_schema) to identifier($estuary_role);
 -- create a warehouse for estuary
 create warehouse if not exists identifier($warehouse_name)
@@ -166,34 +170,46 @@ COMMIT;
 
 4. Click the drop-down arrow next to the **Run** button and click **Run All**.
 
-  Snowflake runs all the queries and is ready to use with Estuary.
+5. Set up JWT authentication for the `estuary_user`.
 
-5. Return to the Estuary web application.
+   You can generate a public/private key-pair in your terminal using:
+
+   ```shell
+   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+   openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+   ```
+
+   Assign the _public_ key to `estuary_user` in Snowflake:
+
+   ```sql
+   ALTER USER identifier($estuary_user) SET RSA_PUBLIC_KEY='MIIBIjANBgkqh...'
+   ```
+
+6. Return to the Estuary dashboard.
 
 ## Materialize your Estuary collection to Snowflake
 
-You were directed to the **Materializations** page.
+When you clicked **Materialize** from your S3 capture, you were directed to the **Materializations** page.
 All of the available materialization connectors — representing the possible data destinations — are shown as tiles.
 
 1. Find the **Snowflake** tile and click **Materialization**.
 
    A new form appears with the properties required to materialize to Snowflake.
 
-2. Click inside the **Name** box.
+2. You will be prompted to select a [default naming strategy](/concepts/materialization/#target-resource-naming-conventions) for your materialization.
 
-3. Click your prefix from the dropdown and append a unique name after it. For example, `myOrg/yourname/citibiketutorial`.
+   For this demo, select **Set a default schema** and enter the schema name you created using the SQL script in Snowflake.
+   By default, this will be `ESTUARY_SCHEMA`.
+
+   Click **Continue** to set your selection.
+
+3. In the **Name** box, select your prefix from the dropdown and append a unique name after it. For example, `myOrg/yourname/citibiketutorial`.
 
 4. Next, fill out the required properties for Snowflake (most of these come from the script you just ran).
 
    * **Host URL**: This is the URL you use to log into Snowflake. If you recently signed up for a trial, it should be in your email. Omit the protocol from the beginning. For example, `ACCOUNTID.region.cloudprovider.snowflakecomputing.com` or `orgname-accountname.snowflakecomputing.com`.
 
       [Learn more about account identifiers and host URLs.](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used)
-
-   * **Account**: Your account identifier. This is part of the Host URL. Using the previous examples, it would be `ACCOUNTID` or `accountname`.
-
-   * **User**: `ESTUARY_USER`
-
-   * **Password**: `secret` (Substitute the password you set in the script.)
 
    * **Database**: `ESTUARY_DB`
 
@@ -203,18 +219,18 @@ All of the available materialization connectors — representing the possible da
 
    * **Role**: `ESTUARY_ROLE`
 
-4. Scroll down to view the **Source Collections** section and change the default name in the **Table** field to `CitiBikeData` or another name of your choosing.
+   * **Timestamp Type**: Choose how timestamp columns should be stored in Snowflake.
+   Unless you have already explicitly set your `TIMESTAMP_TYPE_MAPPING` in Snowflake, you can default to `TIMESTAMP_LTZ` for this field.
 
-   Every Estuary collection is defined by one or more **schemas**.
-   Because S3 is a cloud storage bucket, the schema used to ingest the data is quite permissive.
+   * **Authentication**: Using Private Key (JWT) auth, enter your user (`ESTUARY_USER`) and the _private_ key you generated.
 
-   You'll add a more detailed schema for Estuary to use to materialize the data to Snowflake. This will ensure that each field from the source CSV is mapped to a column in the Snowflake table.
+4. Scroll down to view the **Source Collections** section.
 
-5. With the collection still selected, click its **Collection** tab. Then, click **Schema Inference**.
+   Estuary automatically infers the schema of incoming data.
+   To check how your data will materialize in Snowflake, select your `tripdata` collection and view its **Collection** tab.
+   You should see fields related to the start and end of bike trips and their inferred data types.
 
-   Estuary examines the data and automatically generates a new `readSchema`. Scroll through and note the differences between this and the original schema, renamed `writeSchema`.
-
-6. Click **Apply Inferred Schema**.
+   You can also control which fields get materialized in the **Resource Configuration** tab under **Field Selection**.
 
 7. Click **Next**.
 

--- a/site/docs/getting-started/tutorials/firestore-to-dwh.md
+++ b/site/docs/getting-started/tutorials/firestore-to-dwh.md
@@ -13,7 +13,7 @@ You'll need:
 
 * (Recommended) understanding of Estuary's [basic concepts](/concepts/#essential-concepts).
 
-* Access to the [**Estuary web application**](http://dashboard.estuary.dev) through an Estuary account.
+* Access to the [**Estuary dashboard**](http://dashboard.estuary.dev) through an Estuary account.
 If you don't have one, visit the web app to register for free.
 
 * A **Firestore database** that contains the data you'd like to move to Snowflake. You [create this as part of a Google Firebase project](https://cloud.google.com/firestore/docs/create-database-web-mobile-client-library).
@@ -27,10 +27,12 @@ If you don't have one, visit the web app to register for free.
 
 * A Snowflake account with:
 
-  * A target **database**, **schema**, and virtual **warehouse**; and a **user** with a **role** assigned that grants the appropriate access levels to these resources.
+  * A target **database**, **schema**, and virtual **warehouse**.
+
+  * A **user** with a **role** assigned that grants the appropriate access levels to these resources and a **public key** assigned for JWT auth.
   [You can use a script to quickly create all of these items.](/reference/Connectors/materialization-connectors/Snowflake/#setup) Have these details on hand for setup with Estuary.
 
-  * The account identifier and host URL noted. [The URL is formatted using the account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used). For example, you might have the account identifier `orgname-accountname.snowflakecomputing.com`.
+  * The host URL noted. [The URL is formatted using the account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used). For example, you might have the account identifier `orgname-accountname.snowflakecomputing.com`.
 
 ## Introduction
 
@@ -50,8 +52,7 @@ We'll walk through how to configure the [Firestore](/reference/Connectors/captur
 
 You'll first create a capture to connect to your Firestore database, which will yield one Estuary collection for each [Firestore collection](https://cloud.google.com/firestore/docs/data-model) in your database.
 
-1. Go to Estuary's web application at [dashboard.estuary.dev](https://dashboard.estuary.dev/) and sign in using the
-credentials provided by your Estuary account manager.
+1. Go to Estuary's dashboard at [dashboard.estuary.dev](https://dashboard.estuary.dev/) and sign in.
 
 2. Click the **Sources** tab and choose **New Capture**.
 
@@ -76,9 +77,9 @@ credentials provided by your Estuary account manager.
 
    Estuary uses the provided configuration to initiate a connection with Firestore.
 
-   It maps each available Firestore collection to a possible Estuary collection. It also generates minimal schemas for each collection.
+   It maps each available Firestore collection to a possible Estuary collection. It also infers schemas for each collection.
 
-   You can use the **Source Collections** browser to remove or modify collections. You'll have the chance to tighten up each collection's JSON schema later, when you materialize to Snowflake.
+   You can remove or modify collections in the **Source Collections** section. For each collection, you can rename or [redact](/features/redaction) fields from its **Collection** tab.
 
   :::tip
   If you make any changes to collections, click **Next** again.
@@ -90,7 +91,7 @@ credentials provided by your Estuary account manager.
 
    The data currently in your Firestore database has been captured, and future updates to it will be captured continuously.
 
-8. Click **Materialize Collections** to continue.
+8. Click **Materialize** to continue.
 
 ## Materialize to Snowflake
 
@@ -100,48 +101,40 @@ Next, you'll add a Snowflake materialization to connect the captured data to its
 
    A form appears with the properties required for a Snowflake materialization.
 
-2.  Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/mySnowflakeMaterialization`.
+2. You will be prompted to select a [default naming strategy](/concepts/materialization/#target-resource-naming-conventions) for your materialization.
 
-3. Fill out the required properties for Snowflake (you should have most of these handy from the [prerequisites](#prerequisites)).
+   For this demo, select **Set a default schema** and enter the schema name you created as per the [prerequisites](#prerequisites).
+
+   Click **Continue** to set your selection.
+
+3.  Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/mySnowflakeMaterialization`.
+
+4. Fill out the required properties for Snowflake (you should have most of these handy from the [prerequisites](#prerequisites)).
 
    * **Host URL**
-   * **Account**
-   * **User**
-   * **Password**
    * **Database**
    * **Schema**
    * **Warehouse**: optional
    * **Role**: optional
+   * **Timestamp type**
+   * **User**
+   * **Private key**
 
-4. Click **Next**.
+5. Click **Next**.
 
    Estuary uses the provided configuration to initiate a connection to Snowflake.
 
    You'll be notified if there's an error. In that case, fix the configuration form or Snowflake setup as needed and click **Next** to try again.
 
-   Once the connection is successful, the Endpoint Config collapses and the **Source Collections** browser becomes prominent.
+   Once the connection is successful, the Endpoint Config collapses and the **Source Collections** section becomes prominent.
    It shows the collections you captured previously.
    Each of them will be mapped to a Snowflake table.
 
-5. In the **Source Collections** browser, optionally change the name in the **Table** field for each collection.
+6. In the **Source Collections** section, optionally modify the **Resource Configuration** for each collection.
 
-   These will be the names of the output tables in Snowflake.
+   This includes table name, an alternative schema name, and field selection options.
 
-6. For each table, choose whether to [enable delta updates](/reference/Connectors/materialization-connectors/Snowflake/#delta-updates).
-
-7. For each collection, apply a stricter schema to be used for the materialization.
-
-   Firestore has a flat data structure.
-   To materialize data effectively from Firestore to Snowflake, you should apply a schema that can translate to a table structure.
-   Estuary's **Schema Inference** tool can help.
-
-   1. In the Source Collections browser, choose a collection and click its **Collection** tab.
-
-   2. Click **Schema Inference**
-
-      The Schema Inference window appears. Estuary scans the data in your collection and infers a new schema, called the `readSchema`, to use for the materialization.
-
-   3. Review the new schema and click **Apply Inferred Schema**.
+7. For each table, choose whether to [enable delta updates](/reference/Connectors/materialization-connectors/Snowflake/#delta-updates).
 
 8. Click **Next** to apply the changes you made to collections.
 
@@ -149,7 +142,7 @@ Next, you'll add a Snowflake materialization to connect the captured data to its
 
 ## What's next?
 
-Your Data Flow has been deployed, and will run continuously until it's stopped. Updates in your Firestore database will be reflected in your Snowflake table as they occur.
+Your Data Flow has been deployed, and will run continuously until it's stopped. Updates in your Firestore database will be reflected in your Snowflake table based on your defined sync schedule.
 
 You can advance your Data Flow by adding a **derivation**. Derivations are real-time data transformations.
 See the [guide to create a derivation](/guides/flowctl/create-derivation).

--- a/site/docs/getting-started/tutorials/postgresql_cdc_to_snowflake.md
+++ b/site/docs/getting-started/tutorials/postgresql_cdc_to_snowflake.md
@@ -326,18 +326,17 @@ Similarly to the source side, we’ll need to set up some initial configuration 
 
 Preparing Snowflake for use with Estuary involves the following steps:
 
-1\. Keep Estuary's web app open and open a new tab or window to access your Snowflake console.
+1\. Keep Estuary's dashboard open and open a new tab or window to access your Snowflake console.
 
 2\. Create a new SQL worksheet. This provides a platform to execute queries.
 
-3\. Paste the provided script into the SQL console, adjusting the value for `estuary_password` to a strong password.
+3\. Paste the provided script into the SQL console.
 
 ```sql
 set database_name = 'ESTUARY_DB';
 set warehouse_name = 'ESTUARY_WH';
 set estuary_role = 'ESTUARY_ROLE';
 set estuary_user = 'ESTUARY_USER';
-set estuary_password = 'secret';
 set estuary_schema = 'ESTUARY_SCHEMA';
 -- create role and schema for Estuary
 create role if not exists identifier($estuary_role);
@@ -348,10 +347,11 @@ use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
-password = $estuary_password
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);
+-- Estuary requires case-sensitive quoted identifiers (e.g. "_meta/op").
+alter user identifier($estuary_user) set QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;
 grant all on schema identifier($estuary_schema) to identifier($estuary_role);
 -- create a warehouse for estuary
 create warehouse if not exists identifier($warehouse_name)
@@ -377,7 +377,22 @@ COMMIT;
 
 5\. Snowflake will process the queries, setting up the necessary roles, databases, schemas, users, and warehouses for Estuary.
 
-6\. Once the setup is complete, return to Estuary's web application to continue with the integration process.
+6\. Associate a _public key_ from a JWT key-pair to the new Snowflake user.
+
+   You can generate a public/private key-pair in your terminal using:
+
+   ```shell
+   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+   openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+   ```
+
+   Assign the public key to `estuary_user` in Snowflake:
+
+   ```sql
+   ALTER USER identifier($estuary_user) SET RSA_PUBLIC_KEY='MIIBIjANBgkqh...'
+   ```
+
+7\. Once the setup is complete, return to Estuary's dashboard to continue with the integration process.
 
 Back in Estuary, head over to the **Destinations** page, where you can [create a new Materialization](https://dashboard.estuary.dev/materializations/create).
 
@@ -391,13 +406,11 @@ You can grab your Snowflake host URL and account identifier by navigating to the
 
 ![Grab your Snowflake account id](https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//snowflake_account_id_af1cc78df8/snowflake_account_id_af1cc78df8.png)
 
-If you scroll down to the Advanced Options section, you will be able to configure the "Update Delay" parameter. If you leave this parameter unset, the default value of 30 minutes will be used.
+If you scroll down to the **Sync Schedule** section, you will be able to configure the update cadence for the connector. If you leave these parameters unset, the default value of 30 minutes will be used.
 
-![Update Delay](https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//snowflake_update_delay_dark_f26179d3fc/snowflake_update_delay_dark_f26179d3fc.png)
+The Sync Frequency parameter in Estuary materializations offers a flexible approach to data ingestion scheduling. It represents the amount of time the system will wait before it begins materializing the latest data.
 
-The Update Delay parameter in Estuary materializations offers a flexible approach to data ingestion scheduling. It represents the amount of time the system will wait before it begins materializing the latest data.
-
-For example, if an update delay is set to 2 hours, the materialization task will pause for 2 hours before processing the latest available data. This delay ensures that data is not pulled in immediately after it becomes available, allowing your Snowflake warehouse to go idle and be suspended in between updates, which can significantly reduce the number of credits consumed.
+For example, if the sync frequency is set to 2 hours, the materialization task will pause for 2 hours before processing the latest available data. This delay ensures that data is not pulled in immediately after it becomes available, allowing your Snowflake warehouse to go idle and be suspended in between updates, which can significantly reduce the number of credits consumed.
 
 After the connection details are in place, the next step is to link the capture we just created to Snowflake.
 
@@ -405,7 +418,13 @@ You can achieve this by clicking on the “Source from Capture” button, and se
 
 ![Link Capture](https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//link_source_to_capture_b0d37a738f/link_source_to_capture_b0d37a738f.png)
 
-After pressing continue, you are met with a few configuration options, but for now, feel free to press **Next,** then **Save and Publish** in the top right corner, the defaults will work perfectly fine for this tutorial.
+After pressing continue, you are prompted to select a default naming strategy.
+This controls what your table and schema names look like in your destination.
+
+For this tutorial, select **Set a default schema** and enter the Snowflake schema you created (`ESTUARY_SCHEMA` by default).
+Click **Set Source Capture** to finish.
+
+You can further configure each collection and the fields you want to materialize, but for now, feel free to press **Next,** then **Save and Publish** in the top right corner. The defaults will work perfectly fine for this tutorial.
 
 A successful deployment will look something like this:
 
@@ -417,10 +436,10 @@ And that’s pretty much it, you’ve successfully published a real-time CDC pip
 
 Looks like the data is arriving as expected, and the schema of the table is properly configured by the connector based on the types of the original table in Postgres.
 
-To get a feel for how the data flow works, head over to the collection details page on Estuary's web UI to see your changes immediately. On the Snowflake end, they will be materialized after the next update.
+To get a feel for how the data flow works, head over to the collection details page on Estuary's dashboard to see your changes immediately. On the Snowflake end, they will be materialized after the next update.
 
 :::note
-Based on your configuration of the "Update Delay" parameter when setting up the Snowflake Materialization, you might have to wait until the configured amount of time passes for your changes to make it to the destination.
+Based on your configuration of the "Sync Schedule" parameters when setting up the Snowflake materialization, you might have to wait until the configured amount of time passes for new changes to make it to the destination.
 :::
 
 
@@ -475,6 +494,6 @@ Now try it out on your own PostgreSQL database or other sources.
 
 If you want to learn more, make sure you read through the [Estuary documentation](https://docs.estuary.dev/).
 
-You’ll find instructions on how to use other connectors [here](https://docs.estuary.dev/). There are more tutorials [here](https://docs.estuary.dev/guides/). 
+You’ll find instructions on how to use other connectors [here](/reference/Connectors). There are more tutorials [here](https://docs.estuary.dev/guides/). 
 
 Also, don’t forget to join the [Estuary Slack Community](https://estuary-dev.slack.com/ssb/redirect#/shared-invite/email)!

--- a/site/docs/guides/create-dataflow.md
+++ b/site/docs/guides/create-dataflow.md
@@ -30,8 +30,7 @@ Here, we'll walk through how to leverage various connectors, configure them, and
 You'll first create a **capture** to connect to your data source system.
 This process will create one or more **collections** in Estuary, which you can then materialize to another system.
 
-1. Go to the Estuary web application at [dashboard.estuary.dev](https://dashboard.estuary.dev/) and sign in using the
-credentials provided by your Estuary account manager.
+1. Go to the Estuary dashboard at [dashboard.estuary.dev](https://dashboard.estuary.dev/) and sign in.
 
 2. Click the **Sources** tab and choose **New Capture**.
 
@@ -53,29 +52,26 @@ credentials provided by your Estuary account manager.
    Estuary uses the provided information to initiate a connection to the source system.
    It identifies one or more data **resources** — these may be tables, data streams, or something else, depending on the connector. These are each mapped to a **collection**.
 
-   The **Output Collections** browser appears, showing this list of available collections.
+   The **Target Collections** section shows this list of available collections.
    You can decide which ones you want to capture.
 
 6. Look over the list of available collections. All are selected by default.
 You can remove collections you don't want to capture, change collection names, and for some connectors, modify other properties.
 
 :::tip
-Narrow down a large list of available collections by typing in the **Search Bindings** box.
-
+Narrow down a large list of available collections by typing in the **Filter Bindings** box.
 :::
 
-   If you're unsure which collections you want to keep or remove, you can look at their [schemas](../concepts/README.md#schemas).
+7. Select a collection and click the **Collection** tab to view its [schema](/concepts/#schemas) and collection key.
 
-7. In the **Output Collections** browser, select a collection and click the **Collection** tab to view its schema and collection key.
-
-    For many source systems, you'll notice that the collection schemas are quite permissive.
-    You'll have the option to apply more restrictive schemas later, when you materialize the collections.
+   You can **rename** or [**redact**](/features/redaction) fields in the schema table.
+   If you don't want to keep all the discovered fields, you'll have the option to select or remove fields when you materialize the collections.
 
 8. If you made any changes to output collections, click **Next** again.
 
 8. Once you're satisfied with the configuration, click **Save and Publish**. You'll see a notification when the capture publishes successfully.
 
-9. Click **Materialize collections** to continue.
+9. Click **Materialize** to continue.
 
 ## Create a materialization
 
@@ -86,11 +82,15 @@ Now that you've captured data into one or more collections, you can materialize 
    The page populates with the properties required for that connector.
    More details on each connector are provided in the [connectors reference](../reference/Connectors/materialization-connectors/README.md).
 
-2. Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/myFirstMaterialization`.
+2. If your destination supports the concept of a schema, you will be prompted to choose a [default naming convention](/concepts/materialization/#target-resource-naming-conventions) for your materialization.
 
-3. Fill out the required properties in the **Endpoint Configuration**.
+   This lets you define rules about how table and schema names should appear in your destination.
 
-4. Click **Next**.
+3. Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/myFirstMaterialization`.
+
+4. Fill out the required properties in the **Endpoint Configuration**.
+
+5. Click **Next**.
 
    Estuary initiates a connection with the destination system.
 
@@ -102,32 +102,18 @@ Now that you've captured data into one or more collections, you can materialize 
 
    Now's your chance to make changes to the collections before you materialize them.
 
-5. Optionally remove some collections or add additional collections.
+6. Optionally remove some collections or add additional collections.
 
    * Type in the **Search Collections** box to find a collection.
 
    * To remove a collection, click the **x** in its table row. You can also click the **Remove All** button.
 
-6. Optionally apply a stricter schema to each collection to use for the materialization.
+7. Optionally modify fields to materialize from the binding's **Resource Configuration**.
 
-   Depending on the data source, you may have captured data with a fairly permissive schema.
-   You can tighten up the schema so it'll materialize to your destination in the correct shape.
-   (This isn't necessary for database and SaaS data sources, so the option won't be available.)
+   [Field selection](/guides/customize-materialization-fields/#field-selection-for-materializations) lets you require or exclude fields,
+   select a default field depth to materialize, and choose a group-by key independent of the collection key.
 
-   1. Choose a collection from the list and click its **Collection** tab.
-
-   2. Click **Schema Inference**.
-
-      The Schema Inference window appears. Estuary scans the data in your collection and infers a new schema, called the `readSchema`, to use for the materialization.
-
-   3. Review the new schema and click **Apply Inferred Schema**.
-
-   You can exert even more control over the output data structure using the **Field Selector** on the **Config tab**.
-   [Learn how.](/guides/customize-materialization-fields)
-
-7. If you've made any changes to source fields, click **Next** again.
-
-7. Click **Save and publish**. You'll see a notification when the full Data Flow publishes successfully.
+8. Click **Save and publish**. You'll see a notification when the full Data Flow publishes successfully.
 
 ## What's next?
 

--- a/site/docs/guides/dashboard/edit-data-flows.md
+++ b/site/docs/guides/dashboard/edit-data-flows.md
@@ -36,23 +36,9 @@ You may have to re-authenticate with the source system. Be sure to have current 
    To refresh your connection with the source and see an updated list of possible collections, click the **Refresh** button,
    but be aware that it will overwrite all existing collection selections.
 
-5. Use the **Schema Inference** tool, if desired.
+5. When you're done making changes, click **Next.**
 
-   This option is available for source systems with permissive schemas, such as NoSQL databases and cloud storage.
-   Estuary can help you tighten up the schema to be used for downstream tasks in your Data Flow.
-
-   1. In the Output Collections browser, choose a collection and click its **Collection** tab.
-
-   2. Click **Schema Inference**
-
-      The Schema Inference window appears. Estuary scans the data in your collection and infers a new schema, called the [`readSchema`](/concepts/schemas/#write-and-read-schemas), to use for
-      downstream tasks like materializations and derivations.
-
-   3. Review the new schema and click **Apply Inferred Schema**.
-
-6. When you're done making changes, click **Next.**
-
-8. Click **Save and Publish**.
+6. Click **Save and Publish**.
 
 Editing a capture only affects how it will work going forward.
 Data that was captured before editing will reflect the original configuration.
@@ -74,19 +60,6 @@ You may have to re-authenticate with the destination system. Be sure to have cur
 :::
 
 4. Use the **Source Collections** browser to add or remove collections from the materialization, if desired.
-
-6. Optionally apply a stricter schema to each collection to use for the materialization.
-
-   This option is available for collections captured from source systems with permissive schemas, such as NoSQL databases and cloud storage.
-   Estuary can help you tighten up the schema to be used for downstream tasks in your Data Flow.
-
-   1. In the Source Collections browser, choose a collection and click its **Collection** tab.
-
-   2. Click **Schema Inference**
-
-      The Schema Inference window appears. Estuary scans the data in your collection and infers a new schema, called the [`readSchema`](/concepts/schemas/#write-and-read-schemas), to use for the materialization.
-
-   3. Review the new schema and click **Apply Inferred Schema**.
 
 5. When you're done making changes, click **Next.**
 


### PR DESCRIPTION
**Description:**

Some of the end-to-end pipeline setup tutorials in docs were getting outdated. This PR refreshes them with the following changes:

* Add target naming step. As target naming is now mandatory in the UI, note when the modal pops up and a specific choice if applicable.
* Remove manual schema inference steps
* Update connector-specific information (scripts to run, properties that have changed, noting JWT auth for Snowflake)
* Noting newer capabilities like redaction and field selection where applicable

**Documentation links affected:**

Mainly docs in the `getting-started/tutorials` section

**Notes for reviewers:**

Thanks for reviewing!
