### PR TITLE
grant authenticated SELECT on bundles so PostgREST representation works

### DIFF
--- a/supabase/migrations/20260601120000_grant_bundles_select.sql
+++ b/supabase/migrations/20260601120000_grant_bundles_select.sql
@@ -1,0 +1,20 @@
+begin;
+
+-- Migration 20260511120000 added the `bundles` column to user_grants and
+-- role_grants with deliberately column-scoped grants that excluded `bundles`,
+-- so PostgREST-facing roles could neither read nor write it.
+--
+-- That broke dashboard grant mutations: supabase-js issues insert/update/delete
+-- with `Prefer: return=representation`, which PostgREST executes as
+-- `... RETURNING *`. The `*` expands to every column, including `bundles`, and
+-- `authenticated` lacks SELECT on it, so Postgres rejects the whole statement
+-- with `42501 permission denied for table ...`.
+--
+-- Grant SELECT (only) on `bundles` so representation works. Writes remain
+-- blocked: there is still no INSERT/UPDATE column grant on `bundles`, so
+-- PostgREST-facing roles can read but cannot set it.
+
+grant select (bundles) on user_grants to authenticated;
+grant select (bundles) on role_grants to authenticated;
+
+commit;

--- a/supabase/tests/auth.test.sql
+++ b/supabase/tests/auth.test.sql
@@ -112,6 +112,20 @@ returns setof text as $$
     'alice role_grants visibility'
   );
 
+  -- PostgREST `return=representation` (used by every dashboard insert/update/delete)
+  -- issues `RETURNING *`, so `authenticated` must be able to read every column of
+  -- rows it can mutate. A column-level grant that omits a column breaks this even
+  -- though RLS permits the row. `select *` expands to all columns and regresses the
+  -- moment a column is added without a matching read grant.
+  select lives_ok(
+    $i$ select * from user_grants $i$,
+    'authenticated can select * from user_grants (PostgREST representation)'
+  );
+  select lives_ok(
+    $i$ select * from role_grants $i$,
+    'authenticated can select * from role_grants (PostgREST representation)'
+  );
+
   set role postgres;
 
   select results_eq(


### PR DESCRIPTION
## Problem

Removing a user_grant in the dashboard failed with `42501 permission denied for table user_grants`. Migration `20260511120000` replaced the table-level grant with column-level grants that exclude `bundles` (part of our recent authorization refactor), but supabase mutations use `Prefer: return=representation`, which PostgREST runs as `RETURNING *` — selecting `bundles`, which `authenticated` can't read. Same break applies to grant insert/update, and it all applies to role_grants, too.

## Fix

Grant `SELECT (bundles)` to `authenticated` on `user_grants` and `role_grants`. Reads only — writes to `bundles` stay restricted to `service_role`.