### PR TITLE
locate-bin: don't resolve a sibling directory as the binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,6 +5119,7 @@ name = "locate-bin"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "tempfile",
  "tracing",
  "which",
 ]

--- a/crates/locate-bin/Cargo.toml
+++ b/crates/locate-bin/Cargo.toml
@@ -12,3 +12,6 @@ license.workspace = true
 which = "4.4.0"
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/locate-bin/src/lib.rs
+++ b/crates/locate-bin/src/lib.rs
@@ -1,25 +1,93 @@
 use anyhow::Context;
-use std::path::PathBuf;
-use which::which;
+use std::path::{Path, PathBuf};
 
+/// Locate the absolute path of `binary`.
+///
+/// The binary is first sought alongside the currently-running program,
+/// and otherwise is resolved from the `$PATH`.
 pub fn locate(binary: &str) -> anyhow::Result<PathBuf> {
-    // Look for binary alongside this program.
+    // Look for the binary alongside this program.
     let this_program = std::env::args().next().unwrap();
 
-    tracing::debug!(%this_program, "attempting to find '{binary}'");
-    let mut bin = std::path::Path::new(&this_program)
-        .parent()
-        .unwrap()
-        .join(binary);
+    locate_inner(Path::new(&this_program), binary, |binary| {
+        Ok(which::which(binary)?)
+    })
+}
 
-    // Fall back to the $PATH.
-    if !bin.exists() {
-        bin = which(binary).with_context(|| {
-            format!("failed to locate '{binary}' alongside '{this_program}' or on the $PATH")
+// `locate_inner` factors the resolution policy out of the ambient process
+// environment (the running program's path and the `$PATH` lookup) so that it
+// can be exercised deterministically by unit tests.
+fn locate_inner(
+    this_program: &Path,
+    binary: &str,
+    on_path: impl FnOnce(&str) -> anyhow::Result<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    tracing::debug!(this_program = %this_program.display(), "attempting to find '{binary}'");
+    let mut bin = this_program.parent().unwrap().join(binary);
+
+    // If `bin` doesn't resolve to a file, then fall back to the $PATH.
+    // Note a sibling *directory* named like `binary` must not shadow the lookup.
+    if !bin.is_file() {
+        bin = on_path(binary).with_context(|| {
+            format!(
+                "failed to locate '{binary}' alongside '{}' or on the $PATH",
+                this_program.display()
+            )
         })?;
     } else {
         bin = bin.canonicalize().unwrap();
     }
     tracing::debug!(executable = %bin.display(), "resolved {binary}");
     Ok(bin)
+}
+
+#[cfg(test)]
+mod test {
+    use super::locate_inner;
+    use std::path::PathBuf;
+
+    // Stands in for an empty `$PATH`.
+    fn not_on_path(binary: &str) -> anyhow::Result<PathBuf> {
+        anyhow::bail!("'{binary}' is not on the $PATH")
+    }
+
+    #[test]
+    fn resolves_a_sibling_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let this_program = dir.path().join("flowctl-go");
+        let sibling = dir.path().join("sops");
+        std::fs::write(&sibling, b"#!/bin/sh\ntrue\n").unwrap();
+
+        // The sibling file is resolved (and canonicalized) without ever
+        // consulting the $PATH.
+        let located = locate_inner(&this_program, "sops", not_on_path).unwrap();
+        assert_eq!(located, sibling.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn sibling_directory_does_not_shadow_the_path() {
+        // Regression: a sibling *directory* sharing the binary's name (e.g. a
+        // `go/` source tree next to the program) must not be returned in place
+        // of the actual `go` executable found on the $PATH.
+        let dir = tempfile::tempdir().unwrap();
+        let this_program = dir.path().join("flowctl-go");
+        std::fs::create_dir(dir.path().join("go")).unwrap();
+
+        let from_path = PathBuf::from("/usr/local/bin/go");
+        let located = locate_inner(&this_program, "go", |_| Ok(from_path.clone())).unwrap();
+        assert_eq!(located, from_path);
+    }
+
+    #[test]
+    fn missing_everywhere_is_a_contextual_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let this_program = dir.path().join("flowctl-go");
+
+        let err = locate_inner(&this_program, "nonesuch", not_on_path).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to locate 'nonesuch'") && msg.contains("$PATH"),
+            "unexpected error: {msg}",
+        );
+    }
 }


### PR DESCRIPTION
`locate()` joined the binary name onto the running program's directory and used `Path::exists()` to decide whether to use it or fall back to the $PATH. `exists()` is true for any entry, so a sibling directory sharing the binary's name (e.g. a `go/` source tree next to the program) was canonicalized and returned in place of the real `go` executable.

Gate on `is_file()` instead, which is false for both directories and missing paths. Factor the resolution policy into a private `locate_inner` that takes the program path and $PATH lookup as parameters, decoupling it from the process environment so it can be unit-tested, and add tests covering sibling-file resolution, the directory regression, and the not-found error.