### PR TITLE
supabase: grant anon SELECT on connector catalog columns

### DIFF
--- a/supabase/migrations/20260605120000_anon_connector_grants.sql
+++ b/supabase/migrations/20260605120000_anon_connector_grants.sql
@@ -1,0 +1,8 @@
+-- Allow unauthenticated (anon) access to public connector catalog metadata,
+-- excluding sensitive columns such as oauth2 configuration.
+
+GRANT SELECT (id, created_at, external_url, image_name, short_description,
+              long_description, title, logo_url, recommended)
+    ON public.connectors TO anon;
+GRANT SELECT (connector_id, protocol, documentation_url)
+    ON public.connector_tags TO anon;


### PR DESCRIPTION
## Motivation

We're pulling the direct Postgres connection out of the marketing site. Today every marketing-site build connects to the Supabase pooler with a `gatsby_reader` Postgres password (`GATSBY_DB_*` CI secrets). The goal is to read the same two tables through the PostgREST API with the publishable anon key instead, leaving the marketing site with **zero secrets**.

Currently that fails — `anon` has no grants on either table:

```
curl /rest/v1/connectors?select=id&limit=1  (with anon key)
→ HTTP 401 {"code":"42501","message":"permission denied for table connectors"}
```

## Change

Column-level `GRANT SELECT ... TO anon` on `public.connectors` and `public.connector_tags`, covering exactly the columns the marketing site queries:

- `connectors`: `id, created_at, external_url, image_name, short_description, long_description, title, logo_url, recommended`
- `connector_tags`: `connector_id, protocol, documentation_url`

Notes:
- `long_description` is required by the site but is **not** in the existing `authenticated` column grants, so simply mirroring those would have broken connector pages/search.
- oauth2 configuration (`oauth2_client_id`, `oauth2_client_secret`, `oauth2_spec`, `oauth2_injected_values`) and control-plane-only `connector_tags` columns (spec schemas, image tags, job status, logs tokens) remain inaccessible to anon.
- Neither table has RLS; access is purely role grants, so no policy work is needed.

## Verification

Applied via `supabase db reset` locally, then confirmed `pg_attribute.attacl` shows `anon=r` on exactly the listed columns and nothing else.