### PR TITLE
Docs: Embed PostgreSQL capture video

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -2,6 +2,8 @@
 sidebar_position: 6
 ---
 
+import ReactPlayer from "react-player";
+
 # PostgreSQL
 
 This connector uses change data capture (CDC) to continuously capture updates in a PostgreSQL database into one or more Estuary collections.
@@ -19,6 +21,8 @@ Setup instructions are provided for the following platforms:
 - [Amazon Aurora](#amazon-aurora)
 - [Google Cloud SQL](./google-cloud-sql-postgres/)
 - [Azure Database for PostgreSQL](#azure-database-for-postgresql)
+
+<ReactPlayer controls url="https://www.youtube.com/watch?v=10BLaiRc9uU?t=355" />
 
 ## Prerequisites
 


### PR DESCRIPTION
**Description:**

We have a new Postgres CDC video. This is a small PR to embed it in our docs. Playback will start at the tutorial; docs users likely do not need the introductory Postgres and CDC information.

**Documentation links affected:**

Postgres capture reference docs

**Notes for reviewers:**

Thanks for reviewing!
