### PR TITLE
runtime: drain shuffle topology on graceful leader shutdown

### DIFF
--- a/crates/runtime-next/src/leader/derive/actor.rs
+++ b/crates/runtime-next/src/leader/derive/actor.rs
@@ -55,7 +55,7 @@ impl Actor {
         &mut self,
         mut head: fsm::Head,
         mut tail: fsm::Tail,
-        session: shuffle::SessionClient,
+        mut session: shuffle::SessionClient,
         shard_rx: Vec<BoxStream<'static, tonic::Result<proto::Derive>>>,
     ) -> anyhow::Result<()> {
         service_kit::event!(
@@ -74,15 +74,10 @@ impl Actor {
             .map(next_shard_rx)
             .collect();
 
-        // Build a stream of frontier checkpoints from the shuffle Session.
-        let frontier_rx = futures::stream::unfold(session, |mut session| async {
-            let result = session.next_checkpoint().await;
-            Some((result, session))
-        });
-        let mut frontier_rx = std::pin::pin!(frontier_rx);
-
         // Per-binding absolute measure, into which deltas are reduced.
         let mut binding_bytes_behind = vec![0; self.task.binding_collection_names.len()];
+        // We keep exactly one NextCheckpoint request in flight while idle.
+        let mut checkpoint_requested = false;
         // When true, Head should close its current open transaction ASAP.
         let mut close_requested = false;
         // Iteration counter for the per-loop trace event.
@@ -199,6 +194,12 @@ impl Actor {
                 );
             }
 
+            // Keep one NextCheckpoint in flight whenever we can accept a frontier.
+            if ready_frontier.is_none() && !checkpoint_requested {
+                session.request_checkpoint();
+                checkpoint_requested = true;
+            }
+
             tokio::select! {
                 biased;
 
@@ -245,12 +246,14 @@ impl Actor {
                     }
                     shard_rx.push(next_shard_rx((shard_index, rx)));
                 }
-                // Poll for a next frontier when otherwise idle.
-                Some(result) = frontier_rx.next(), if ready_frontier.is_none() => {
+                // Receive a requested NextCheckpoint frontier.
+                result = session.recv_checkpoint(), if checkpoint_requested => {
                     let frontier = result?;
                     let (journals, journal_producers, bytes_read_delta, bytes_behind_delta) = frontier.measures();
                     let unresolved_hints = frontier.unresolved_hints;
+
                     ready_frontier = Some(frontier);
+                    checkpoint_requested = false;
 
                     service_kit::event!(
                         tracing::Level::DEBUG,
@@ -279,12 +282,23 @@ impl Actor {
             "derive Actor::serve exiting; broadcasting Stopped",
         );
 
+        // Broadcast L:Stopped. Each shard, upon observing it, removes its shuffle
+        // log segment files — releasing any disk back-pressure held by the
+        // co-located shuffle Log RPC so the Session topology can drain.
         for tx in &self.shard_tx {
             let _ = tx.send(Ok(proto::Derive {
                 stopped: Some(proto::Stopped {}),
                 ..Default::default()
             }));
         }
+
+        // Close the shuffle Session, blocking until the entire
+        // Session→Slice→Log topology has drained to EOF and exited. This depends
+        // on the shard segment removals above to release disk back-pressure.
+        () = session
+            .close()
+            .await
+            .context("closing shuffle Session on Stop")?;
 
         Ok(())
     }

--- a/crates/runtime-next/src/leader/materialize/actor.rs
+++ b/crates/runtime-next/src/leader/materialize/actor.rs
@@ -64,7 +64,7 @@ impl Actor {
         &mut self,
         mut head: fsm::Head,
         mut tail: fsm::Tail,
-        session: shuffle::SessionClient,
+        mut session: shuffle::SessionClient,
         shard_rx: Vec<BoxStream<'static, tonic::Result<proto::Materialize>>>,
     ) -> anyhow::Result<()> {
         service_kit::event!(
@@ -83,15 +83,10 @@ impl Actor {
             .map(next_shard_rx)
             .collect();
 
-        // Build a stream of frontier checkpoints from the shuffle Session.
-        let frontier_rx = futures::stream::unfold(session, |mut session| async {
-            let result = session.next_checkpoint().await;
-            Some((result, session))
-        });
-        let mut frontier_rx = std::pin::pin!(frontier_rx);
-
         // Per-binding absolute measure, into which deltas are reduced.
         let mut binding_bytes_behind = vec![0; self.task.binding_collection_names.len()];
+        // We keep exactly one NextCheckpoint request in flight while idle.
+        let mut checkpoint_requested = false;
         // When true, Head should close its current open transaction ASAP.
         let mut close_requested = false;
         // Iteration counter for the per-loop trace event.
@@ -211,6 +206,12 @@ impl Actor {
                 );
             }
 
+            // Keep one NextCheckpoint in flight whenever we can accept a frontier.
+            if ready_frontier.is_none() && !checkpoint_requested {
+                session.request_checkpoint();
+                checkpoint_requested = true;
+            }
+
             tokio::select! {
                 biased;
 
@@ -267,12 +268,14 @@ impl Actor {
                     }
                     shard_rx.push(next_shard_rx((shard_index, rx)));
                 }
-                // Poll for a next frontier when otherwise idle.
-                Some(result) = frontier_rx.next(), if ready_frontier.is_none() => {
+                // Receive a requested NextCheckpoint frontier.
+                result = session.recv_checkpoint(), if checkpoint_requested => {
                     let frontier = result?;
                     let (journals, journal_producers, bytes_read_delta, bytes_behind_delta) = frontier.measures();
                     let unresolved_hints = frontier.unresolved_hints;
+
                     ready_frontier = Some(frontier);
+                    checkpoint_requested = false;
 
                     service_kit::event!(
                         tracing::Level::DEBUG,
@@ -301,12 +304,23 @@ impl Actor {
             "materialize Actor::serve exiting; broadcasting Stopped",
         );
 
+        // Broadcast L:Stopped. Each shard, upon observing it, removes its shuffle
+        // log segment files — releasing any disk back-pressure held by the
+        // co-located shuffle Log RPC so the Session topology can drain.
         for tx in &self.shard_tx {
             let _ = tx.send(Ok(proto::Materialize {
                 stopped: Some(proto::Stopped {}),
                 ..Default::default()
             }));
         }
+
+        // Close the shuffle Session, blocking until the entire
+        // Session→Slice→Log topology has drained to EOF and exited. This depends
+        // on the shard segment removals above to release disk back-pressure.
+        () = session
+            .close()
+            .await
+            .context("closing shuffle Session on Stop")?;
 
         Ok(())
     }

--- a/crates/runtime-next/src/shard/derive/actor.rs
+++ b/crates/runtime-next/src/shard/derive/actor.rs
@@ -250,7 +250,24 @@ impl Actor {
             }
         }
 
-        // After Stopped, the leader's stream must EOF.
+        // We observed L:Stopped, which the leader sends only at a transaction
+        // boundary — so we're idle and own the shuffle Reader. Remove our shuffle
+        // log segment files now, before blocking on the leader's EOF below. The
+        // leader is concurrently closing its shuffle SessionClient; deleting these
+        // segments releases any disk back-pressure held by the co-located Log RPC,
+        // letting the shuffle topology drain to EOF so the leader's close() can
+        // complete. Only then does the leader drop our channel, delivering the EOF
+        // we await next.
+        let Phase::Idle { shuffle_reader, .. } = &phase else {
+            anyhow::bail!("leader sent Stopped while shard was not idle");
+        };
+        shuffle::log::remove_shard_segments(
+            shuffle_reader.directory(),
+            shuffle_reader.shard_index(),
+        )
+        .context("removing shuffle log segments on Stop")?;
+
+        // After Stopped and shuffle session drain, the leader's stream must EOF.
         let verify = crate::verify("Derive", "leader EOF after Stopped", "leader");
         verify.eof(leader_rx.next().await)?;
 
@@ -548,7 +565,8 @@ mod tests {
         }]);
         let write_shape = task.write_shape.clone();
         let db = crate::shard::RocksDB::open(None).await.unwrap();
-        let shuffle_reader = shuffle::log::Reader::new(std::path::Path::new("/dev/null"), 0);
+        let shuffle_dir = tempfile::tempdir().unwrap();
+        let shuffle_reader = shuffle::log::Reader::new(shuffle_dir.path(), 0);
 
         let actor = Actor::new(
             connector_init::Codec::Proto,

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -247,7 +247,24 @@ impl Actor {
             }
         }
 
-        // After Stopped, the leader's stream must EOF.
+        // We observed L:Stopped, which the leader sends only at a transaction
+        // boundary — so we're idle and own the shuffle Reader. Remove our shuffle
+        // log segment files now, before blocking on the leader's EOF below. The
+        // leader is concurrently closing its shuffle SessionClient; deleting these
+        // segments releases any disk back-pressure held by the co-located Log RPC,
+        // letting the shuffle topology drain to EOF so the leader's close() can
+        // complete. Only then does the leader drop our channel, delivering the EOF
+        // we await next.
+        let Phase::Idle { shuffle_reader, .. } = &phase else {
+            anyhow::bail!("leader sent Stopped while shard was not idle");
+        };
+        shuffle::log::remove_shard_segments(
+            shuffle_reader.directory(),
+            shuffle_reader.shard_index(),
+        )
+        .context("removing shuffle log segments on Stop")?;
+
+        // After Stopped and shuffle session drain, the leader's stream must EOF.
         let verify = crate::verify("Materialize", "leader EOF after Stopped", "leader");
         verify.eof(leader_rx.next().await)?;
 
@@ -662,7 +679,8 @@ mod tests {
 
         let accumulator =
             crate::Accumulator::new(super::super::task::combine_spec(&[]).unwrap()).unwrap();
-        let shuffle_reader = shuffle::log::Reader::new(std::path::Path::new("/dev/null"), 0);
+        let shuffle_dir = tempfile::tempdir().unwrap();
+        let shuffle_reader = shuffle::log::Reader::new(shuffle_dir.path(), 0);
 
         let serve_handle = tokio::spawn(async move {
             let mut conn_stream = conn_stream;

--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -67,6 +67,30 @@ The recovery model is fail-fast: if a terminal error occurs with a component of
 any shard, the entire topology is torn down and all logs are discarded,
 to be rebuilt anew on a next Session.
 
+### Shutdown
+
+The topology tears down through a single path: the coordinator drops (EOFs) its
+Session request stream, the Session propagates this to its Slices by closing
+their request streams, and each Slice in turn to its Logs. Each actor observes
+the EOF, then drains its downstream peers' EOFs before exiting.
+
+This interacts subtly with disk back-pressure. When a Log engages back-pressure
+(§8), it stops draining a Slice's `Append`s, which parks that Slice's request
+stream — so the Log no longer polls it and cannot observe its EOF. A Slice whose
+`Append` is parked at a back-pressured Log therefore can't drain that Log to EOF,
+and shutdown wedges from the Log upward. Back-pressure normally releases only as
+the downstream coordinator consumes the local log and reclaims segments — which
+stops happening once the coordinator is shutting down.
+
+A coordinator breaks this by relieving the back-pressure out-of-band: it removes
+each shard's log segment files (`remove_shard_segments`). The co-located Log's
+sealed-segment reclaim observes the unlinks, drops `disk_backlog_bytes` below
+threshold, and releases back-pressure — so the parked Slice streams re-arm, reach
+EOF, and the whole topology drains. Because this discards any log not yet
+consumed, a coordinator does it only once it will request no further checkpoints,
+then calls `SessionClient::close()` (which blocks until the Session→Slice→Log
+topology has fully drained).
+
 ### Authorization
 
 When the `Service` is built with a `proto_grpc::Signer` (the sidecar; `None` in

--- a/crates/shuffle/src/client.rs
+++ b/crates/shuffle/src/client.rs
@@ -66,19 +66,28 @@ impl SessionClient {
         })
     }
 
-    /// Send NextCheckpoint and read back the frontier response.
-    pub async fn next_checkpoint(&mut self) -> anyhow::Result<crate::Frontier> {
+    /// Send a `NextCheckpoint` request without awaiting its response.
+    ///
+    /// Pair with [`Self::recv_checkpoint`]. At most one request may be
+    /// outstanding at a time. Best-effort: a send error (the Session having
+    /// exited, or — invariant violation — a full request channel) surfaces
+    /// causally as an error or EOF from a subsequent `recv_checkpoint`.
+    pub fn request_checkpoint(&self) {
         tracing::debug!("requesting NextCheckpoint");
 
-        let verify = crate::verify("SessionResponse", "next_checkpoint", "(in-process)", 0);
+        let _: Result<(), _> = self.request_tx.try_send(shuffle::SessionRequest {
+            next_checkpoint: Some(shuffle::session_request::NextCheckpoint {}),
+            ..Default::default()
+        });
+    }
 
-        let _: Result<(), _> = self
-            .request_tx
-            .send(shuffle::SessionRequest {
-                next_checkpoint: Some(shuffle::session_request::NextCheckpoint {}),
-                ..Default::default()
-            })
-            .await;
+    /// Await the frontier response to a previously-issued
+    /// [`Self::request_checkpoint`].
+    ///
+    /// Cancel-safe: dropping the returned future before it completes loses no
+    /// response, so it may be re-awaited (e.g. across `select!` iterations).
+    pub async fn recv_checkpoint(&mut self) -> anyhow::Result<crate::Frontier> {
+        let verify = crate::verify("SessionResponse", "next_checkpoint", "(in-process)", 0);
 
         let proto = match verify.not_eof(self.response_rx.recv().await)? {
             shuffle::SessionResponse {
@@ -94,6 +103,15 @@ impl SessionClient {
             "received NextCheckpoint"
         );
         Ok(frontier)
+    }
+
+    /// Send NextCheckpoint and read back the frontier response.
+    ///
+    /// NOT cancel-safe: if dropped after the request is sent but before the
+    /// response arrives, a later call sends a second, redundant request.
+    pub async fn next_checkpoint(&mut self) -> anyhow::Result<crate::Frontier> {
+        self.request_checkpoint();
+        self.recv_checkpoint().await
     }
 
     /// Cleanly close the session by dropping the request sender and reading server EOF.

--- a/crates/shuffle/src/log/mod.rs
+++ b/crates/shuffle/src/log/mod.rs
@@ -98,6 +98,64 @@ pub(crate) fn segment_path(
     directory.join(filename)
 }
 
+/// Remove all on-disk log segment files for `shard_index` within `directory`.
+///
+/// Segments are matched by the `mem-{shard_index:03}-seg-*.flog` naming of
+/// `segment_path`, scoped to this shard; files of sibling shards and transient
+/// `.compress-*` files are left untouched. A never-created or already-removed
+/// directory is treated as success, and per-file `NotFound` is tolerated — the
+/// owning Log's `SealedSegment` / `Writer` `Drop`s may race these unlinks.
+///
+/// This is the escape hatch for tearing down a back-pressured Session. A Log
+/// engages disk back-pressure once its sealed-segment backlog exceeds the
+/// configured threshold, and releases it only as those segments are reclaimed —
+/// normally by a shard worker consuming its local log and unlinking what it has
+/// read. A coordinator shutting down stops consuming, so that back-pressure (and
+/// the Slice EOF propagation it blocks) would never release on its own. Removing
+/// a shard's segment files makes the Log's reclaim observe the unlinks and drop
+/// its backlog below the threshold, so it resumes draining and reaches EOF. See
+/// the crate README "Shutdown" notes.
+pub fn remove_shard_segments(directory: &std::path::Path, shard_index: u32) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    // Matches the `mem-{shard_index:03}-seg-{segment:012x}.flog` naming of
+    // `segment_path`, scoped to this shard.
+    let prefix = format!("mem-{shard_index:03}-seg-");
+
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(anyhow::Error::new(err))
+                .with_context(|| format!("reading shuffle log directory {directory:?}"));
+        }
+    };
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("listing shuffle log directory {directory:?}"))?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+
+        if !(name.starts_with(&prefix) && name.ends_with(".flog")) {
+            continue;
+        }
+        let path = entry.path();
+
+        match std::fs::remove_file(&path) {
+            Ok(()) => tracing::debug!(?path, "removed shuffle log segment on Stop"),
+            // Raced the Log RPC's own SealedSegment/Writer unlink — benign.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(anyhow::Error::new(err))
+                    .with_context(|| format!("removing shuffle log segment {path:?}"));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// LZ4-compress a raw block payload, returning the compressed bytes.
 pub(crate) fn lz4_compress(raw: &[u8]) -> anyhow::Result<Vec<u8>> {
     let mut buf = Vec::with_capacity(lz4::block::compress_bound(raw.len())?);
@@ -182,5 +240,48 @@ impl Metrics {
             segments_sealed: metrics::counter!("shuffle_log_segments_sealed", "shard_id" => shard_id.to_string()),
             disk_backlog_bytes: metrics::gauge!("shuffle_log_disk_backlog_bytes", "shard_id" => shard_id.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_remove_shard_segments_is_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // This shard's segments, a sibling shard's segment, a compression temp
+        // file, and an unrelated file.
+        let ours = [
+            super::segment_path(dir.path(), 0, 1),
+            super::segment_path(dir.path(), 0, 2),
+        ];
+        let sibling = super::segment_path(dir.path(), 1, 1);
+        let compress_tmp = dir
+            .path()
+            .join(".compress-mem-000-seg-000000000003.flogAB12");
+        let unrelated = dir.path().join("CURRENT");
+
+        for path in ours.iter().chain([&sibling, &compress_tmp, &unrelated]) {
+            std::fs::write(path, b"x").unwrap();
+        }
+
+        super::remove_shard_segments(dir.path(), 0).unwrap();
+
+        for path in &ours {
+            assert!(!path.exists(), "expected {path:?} removed");
+        }
+        assert!(sibling.exists(), "sibling shard segment must be retained");
+        assert!(compress_tmp.exists(), "compression temp must be retained");
+        assert!(unrelated.exists(), "unrelated file must be retained");
+
+        // Idempotent: a second call (segments now gone) still succeeds.
+        super::remove_shard_segments(dir.path(), 0).unwrap();
+    }
+
+    #[test]
+    fn test_remove_shard_segments_missing_dir_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-created");
+        super::remove_shard_segments(&missing, 0).unwrap();
     }
 }

--- a/crates/shuffle/src/log/reader/reader.rs
+++ b/crates/shuffle/src/log/reader/reader.rs
@@ -44,8 +44,14 @@ impl Reader {
         }
     }
 
+    /// Index of the shard this Reader is reading for.
     pub fn shard_index(&self) -> u32 {
         self.shard_index
+    }
+
+    /// Base directory holding this Reader's on-disk log segment files.
+    pub fn directory(&self) -> &std::path::Path {
+        &self.directory
     }
 
     /// Set or update the high-watermark flushed LSN confirmed by the log writer.


### PR DESCRIPTION
A back-pressured shuffle Log RPC could wedge graceful shutdown. When a Log engages disk back-pressure it stops draining a Slice's Appends, which parks that Slice's request stream so the Log no longer polls it and never observes its EOF. On shutdown the back-pressure never releases on its own (nothing is consuming the local log to reclaim segments), so the Log — and the Session/Slice actors draining it, and the leader awaiting them — hang, leaking tasks, fds, and on-disk segments.

Break the wedge by relieving the back-pressure out-of-band, reusing the existing sealed-segment reclaim path:

- shuffle: add `log::remove_shard_segments`, which unlinks a shard's segment files (scoped to the `mem-{idx:03}-seg-*.flog` naming; sibling shards and `.compress-*` temp files untouched; missing dir / per-file NotFound tolerated). The co-located Log's reclaim observes the unlinks, drops its backlog below threshold, and resumes draining to EOF.
- shuffle: split `SessionClient::next_checkpoint` into a sync `request_checkpoint` + cancel-safe `recv_checkpoint`, letting the leader own the SessionClient directly (instead of via `stream::unfold`) so it can `close()` it.
- runtime-next leaders: after broadcasting L:Stopped, synchronously `SessionClient::close()` — blocking until the whole topology drains — before EOFing shards. Intentionally un-timed: a Session that never drains is a liveness bug to surface, not mask.
- runtime-next shards: on L:Stopped (a transaction boundary, so we're idle and own the shuffle Reader), remove our segment files before awaiting leader EOF.