### PR TITLE
gazette: only mint pre-signed fragment URLs when actively polled

### DIFF
--- a/crates/gazette/src/journal/read/mod.rs
+++ b/crates/gazette/src/journal/read/mod.rs
@@ -40,6 +40,14 @@ impl Client {
                 {
                     Ok(()) => {
                         attempt = 0;
+
+                        // Yield now rather than looping immediately back into
+                        // `read_some`, which issues a request for metadata &
+                        // maybe a pre-signed fragment URL. Callers may not
+                        // immediately consume the resulting stream, and the
+                        // pre-signed URL might expire in that case. Wait until
+                        // actively polled again to mint any pre-signed URLs.
+                        () = tokio::task::yield_now().await;
                         continue;
                     }
                     Err(err) => err,


### PR DESCRIPTION
**Description:**

`read()` looped straight from one fragment into the next `read_some`, whose metadata RPC may mint a pre-signed fragment URL with a short (~60s) TTL. A consumer that then parked the read before the GET ran let the URL expire, so the GET failed non-retryably (GCS returns 400 for an expired V2 signature) and the read failed.

Yield before re-entering `read_some` so its metadata RPC, and thus any pre-signed URL, fires only once we're polled again — when the consumer is actually ready to pull the next fragment — keeping the sign-to-GET window inside a single active read.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

