### PR TITLE
docs: document associative: false for disabling key deduplication

### DIFF
--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -107,7 +107,6 @@ pub struct LastWriteWins {
     /// The default is true. When set to false, then unequal left- and right-hand
     /// values may not reduce associatively and both documents must be retained
     /// until a full reduction can be performed.
-    /// EXPERIMENTAL: This keyword may be removed in the future.
     #[serde(default = "true_value")]
     pub associative: bool,
 }

--- a/site/docs/concepts/advanced/reduction-strategies/README.md
+++ b/site/docs/concepts/advanced/reduction-strategies/README.md
@@ -45,3 +45,5 @@ Estuary does _not_ guarantee that documents are reduced in sequential order, dir
 Taken together, these total-order and exactly-once guarantees mean that reduction strategies must be _associative_ \[as in (2 + 3) + 4 = 2 + (3 + 4) ], but need not be commutative \[ 2 + 3 = 3 + 2 ] or idempotent \[ S u S = S ]. They expand the palette of strategies that can be implemented, and allow for more efficient implementations as compared to, for example [CRDTs](https://en.wikipedia.org/wiki/Conflict-free\_replicated\_data\_type).
 
 In this documentation, we’ll refer to the “left-hand side” (LHS) as the preceding document and the “right-hand side” (RHS) as the following one. Keep in mind that both the LHS and RHS may themselves represent a combination of still more ordered documents because, for example, reductions are applied _associatively_.
+
+If your use case requires retaining every document for a key rather than reducing them, you can mark `lastWriteWins` reductions as non-associative with `associative: false`. See [Disabling associative reduction](firstwritewins-and-lastwritewins.md#disabling-associative-reduction).

--- a/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
+++ b/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
@@ -33,3 +33,54 @@ tests:
         documents:
           - { key: "key", fww: "one", lww: "two" }
 ```
+
+## Disabling associative reduction
+
+By default, Estuary assumes `lastWriteWins` reductions are **associative** — that
+documents sharing a collection key can be combined incrementally, in any grouping,
+without changing the final result (see [Reduction guarantees](./#reduction-guarantees)).
+This is what produces one row per key: same-key documents are progressively combined
+down to a single value.
+
+Setting `associative: false` tells the runtime that same-key documents **cannot** be
+safely combined incrementally. Instead of collapsing them, the runtime holds each
+document back until a full reduction against the base document can be performed — or,
+if the materialization uses [delta updates](/concepts/materialization/#delta-updates),
+combines them never.
+
+```yaml
+collections:
+  - name: example/reductions/no-dedup
+    schema:
+      type: object
+      # Applied at the document root, this disables incremental combining
+      # on the collection key.
+      reduce:
+        strategy: lastWriteWins
+        associative: false
+      properties:
+        id: { type: integer }
+      required: [id]
+    key: [/id]
+```
+
+To preserve **every** document for a key end-to-end (no deduplication at any stage),
+pair `associative: false` on the collection with a **delta-updates** materialization:
+
+* `associative: false` stops same-key documents from being combined as they're
+  written to and read from the collection.
+* Delta updates skips the destination's load-reduce-store cycle, so the
+  materialization never merges a new document into the existing row for its key.
+
+Delta updates alone is not sufficient: without `associative: false`, same-key
+documents that land in the same materialization transaction can still be combined
+before they're written. Both knobs are needed for a fully un-reduced stream.
+
+This is the mechanism CDC **history mode** uses to retain the full change history of
+a source row, rather than just its latest state.
+
+:::note
+`associative: false` is an advanced control. The default associative behavior is
+correct for the large majority of use cases — reach out to Estuary support before
+using it if you're unsure whether it fits yours.
+:::

--- a/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
+++ b/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
@@ -53,8 +53,6 @@ collections:
   - name: example/reductions/no-dedup
     schema:
       type: object
-      # Applied at the document root, this disables incremental combining
-      # on the collection key.
       reduce:
         strategy: lastWriteWins
         associative: false
@@ -64,13 +62,19 @@ collections:
     key: [/id]
 ```
 
+`associative: false` can be set on any reduce annotation, not just the document root.
+A non-associative reduction at any location holds back incremental combining of the
+**entire** document, so the example above — annotating the root — is the simplest way
+to stop same-key documents from being combined on the collection key.
+
 To preserve **every** document for a key end-to-end (no deduplication at any stage),
 you need both `associative: false` on the collection **and** a **delta-updates**
 materialization, because reductions happen at more than one place:
 
-* **At capture time**, documents are combined with a *partial* (associative)
-  reduction before they're written to the collection. `associative: false` is what
-  stops unequal same-key documents from being merged here.
+* **At capture or derivation time**, documents sharing a key are combined with a
+  *partial* (associative) reduction within each transaction before they're written to
+  the collection. `associative: false` is what stops unequal same-key documents from
+  being merged here.
 * **A standard materialization** loads the existing destination row and performs a
   *full* reduction of new documents into it — always one row per key. The
   `associative` flag has no effect on a full reduction, so this step must be removed

--- a/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
+++ b/site/docs/concepts/advanced/reduction-strategies/firstwritewins-and-lastwritewins.md
@@ -65,16 +65,24 @@ collections:
 ```
 
 To preserve **every** document for a key end-to-end (no deduplication at any stage),
-pair `associative: false` on the collection with a **delta-updates** materialization:
+you need both `associative: false` on the collection **and** a **delta-updates**
+materialization, because reductions happen at more than one place:
 
-* `associative: false` stops same-key documents from being combined as they're
-  written to and read from the collection.
-* Delta updates skips the destination's load-reduce-store cycle, so the
-  materialization never merges a new document into the existing row for its key.
+* **At capture time**, documents are combined with a *partial* (associative)
+  reduction before they're written to the collection. `associative: false` is what
+  stops unequal same-key documents from being merged here.
+* **A standard materialization** loads the existing destination row and performs a
+  *full* reduction of new documents into it — always one row per key. The
+  `associative` flag has no effect on a full reduction, so this step must be removed
+  with [delta updates](/concepts/materialization/#delta-updates).
+* **A delta-updates materialization** still combines documents with a *partial*
+  reduction within each transaction, so `associative: false` is needed here too —
+  otherwise same-key documents that land in one transaction are merged before they're
+  written to the destination.
 
-Delta updates alone is not sufficient: without `associative: false`, same-key
-documents that land in the same materialization transaction can still be combined
-before they're written. Both knobs are needed for a fully un-reduced stream.
+In short: delta updates removes the full reduction at the destination, and
+`associative: false` prevents merging at every remaining (partial) reduction stage.
+Either knob alone still deduplicates.
 
 This is the mechanism CDC **history mode** uses to retain the full change history of
 a source row, rather than just its latest state.


### PR DESCRIPTION
## What

Documents the `associative: false` reduction annotation, which lets advanced users disable deduplication on the collection key — and removes the now-inaccurate `EXPERIMENTAL` note from the keyword's code comment.

- **firstwritewins-and-lastwritewins.md** — new "Disabling associative reduction" section explaining the flag, when same-key documents are held back vs. combined, and how to pair it with a delta-updates materialization for a fully un-reduced stream.
- **README.md** (the Reduction Strategies landing page) — one-line pointer from the "Reduction guarantees" section to the new content.
- **crates/doc/src/reduce/strategy.rs** — drops `EXPERIMENTAL: This keyword may be removed in the future.` from the `associative` field comment (comment-only, no behavior change).

## Why

Recurring support question: "can a collection be configured to not deduplicate at all on the key?" The mechanism (`associative: false` + delta updates) was undocumented. @jgraettinger confirmed in [Slack](https://estuaryworkspace.slack.com/archives/C08LJ60MDBQ/p1780492513240229) the flag is "very stable" and reasonable to document for advanced users — which also makes the in-code "may be removed" note inaccurate.

The wording follows Johnny's description of the actual mechanism: `associative: false` tells the reduction machinery that same-key documents cannot be safely combined incrementally, so they're held back until a full reduction against the base document can be performed (or never, under delta updates).

@jgraettinger — flagging the comment removal for your approval since you confirmed the stability.

## Test plan

- [ ] Render preview builds cleanly
- [ ] "Disabling associative reduction" anchor resolves from the README link
