### PR TITLE
doc: drop EXPERIMENTAL note from associative reduction keyword

### DIFF
--- a/crates/doc/src/reduce/strategy.rs
+++ b/crates/doc/src/reduce/strategy.rs
@@ -107,7 +107,6 @@ pub struct LastWriteWins {
     /// The default is true. When set to false, then unequal left- and right-hand
     /// values may not reduce associatively and both documents must be retained
     /// until a full reduction can be performed.
-    /// EXPERIMENTAL: This keyword may be removed in the future.
     #[serde(default = "true_value")]
     pub associative: bool,
 }


### PR DESCRIPTION
## What

Removes the `EXPERIMENTAL: This keyword may be removed in the future.` line from the doc comment on the `associative` field of `LastWriteWins` (`crates/doc/src/reduce/strategy.rs`).

No behavior change — comment only.

## Why

Per @jgraettinger in [Slack](https://estuaryworkspace.slack.com/archives/C08LJ60MDBQ/p1780492513240229), the `associative` keyword is "very stable." We're documenting `associative: false` for advanced users (estuary/flow#3008), so the in-code "may be removed" note now contradicts both the guidance and the public docs.

@jgraettinger — flagging for your approval since you confirmed the stability.
