### PR TITLE
runtime: `observable` connector log lines

### DIFF
--- a/go/protocols/ops/README.md
+++ b/go/protocols/ops/README.md
@@ -45,3 +45,24 @@ Flow does not have any log levels more sever than `error` for several reasons:
   doesn't help to make it sound more scary.
 - If it's really more severe than `error`, then it's probably something that the
   infrastructure operator should look into, not the user.
+
+### Operator-observable connector logs:
+
+Connector logs only ever flow to the user's `ops/<tenant>/logs` collection; their
+volume is far too high to ship into the data-plane's own observability pipeline
+(the reactor's `logrus` stream, which Promtail forwards to Loki/Grafana). A
+connector may opt a _specific_ log line into that pipeline by setting the field
+`observable` to `true` in the line's structured fields, e.g.:
+
+```json
+{"level":"warn","message":"upstream API rate limited us","fields":{"observable":true,"endpoint":"/v2/sync"}}
+```
+
+The runtime forwards such lines into its `logrus` stream, tagged with the `task`
+name so they're attributable in Grafana (Promtail only adds Kubernetes pod labels).
+Forwarding respects the reactor's configured `logrus` level, so a marked line below
+that level is still dropped.
+
+`observable` is intended for rare, high-signal lines that an _operator_ would want
+to alert or dashboard on — not for bulk connector output. The line is still
+published to the user's `ops/<tenant>/logs` collection as usual.

--- a/go/protocols/ops/local_publisher.go
+++ b/go/protocols/ops/local_publisher.go
@@ -24,6 +24,15 @@ func NewLocalPublisher(labels ShardLabeling) *LocalPublisher {
 func (p *LocalPublisher) Labels() ShardLabeling { return p.labels }
 
 func (p *LocalPublisher) PublishLog(log Log) {
+	LogToLogrus(log, p.labels.TaskName)
+}
+
+// LogToLogrus emits an ops Log to the process's standard logrus logger,
+// attaching `taskName` (when non-empty) as the `task` field. The log's level
+// is mapped onto the logrus level, so emission is gated by the logger's
+// configured level. It's used both by LocalPublisher and to forward
+// operator-observable connector logs into the data-plane's own log stream.
+func LogToLogrus(log Log, taskName string) {
 	var level logrus.Level
 	switch log.Level {
 	case Log_trace:
@@ -55,8 +64,8 @@ func (p *LocalPublisher) PublishLog(log Log) {
 		}
 	}
 
-	if p.labels.TaskName != "" && fields["task"] == nil {
-		fields["task"] = p.labels.TaskName
+	if taskName != "" && fields["task"] == nil {
+		fields["task"] = taskName
 	}
 	logger.WithFields(fields).Log(level, log.Message)
 }

--- a/go/runtime/ops_publisher.go
+++ b/go/runtime/ops_publisher.go
@@ -30,6 +30,12 @@ type OpsPublisher struct {
 
 var _ ops.Publisher = &OpsPublisher{}
 
+// observableField is the connector log field which, when set to JSON `true`,
+// opts the log line into forwarding from the per-task ops journal into this
+// process's own log stream, and onward to data-plane observability
+// (Promtail -> Loki -> Grafana).
+const observableField = "observable"
+
 func NewOpsPublisher(logsPublisher *message.Publisher) *OpsPublisher {
 	return &OpsPublisher{logsPublisher: logsPublisher, mu: sync.Mutex{}}
 }
@@ -94,6 +100,11 @@ func (p *OpsPublisher) PublishLog(out ops.Log) {
 	out.Meta = &ops.Meta{Uuid: string(pf.DocumentUUIDPlaceholder)}
 	out.Shard = p.shard
 
+	// Connectors opt specific high-signal lines into our log stream (and onward
+	// to operator observability) by marking them `observable: true`. The full
+	// connector log volume only ever flows to the per-task ops journal below.
+	p.maybeForwardObservable(out)
+
 	var buf bytes.Buffer
 	if err := (&jsonpb.Marshaler{}).Marshal(&buf, &out); err != nil {
 		panic(fmt.Errorf("marshal of *ops.Log should always succeed but: %w", err))
@@ -117,6 +128,28 @@ func (p *OpsPublisher) PublishLog(out ops.Log) {
 			Doc:  json.RawMessage(buf.Bytes()),
 		},
 	)
+}
+
+// maybeForwardObservable forwards an `observable`-marked log into this
+// process's logrus stream, tagged with the task name so it's attributable in
+// downstream observability. Emission is gated by the process's configured
+// logrus level (via LogToLogrus).
+//
+// SECURITY: This feature is currently UNRESTRICTED -- any connector that sets
+// `observable: true` has its line forwarded into our operator log stream (and
+// onward to Loki/Grafana), with no rate limiting or other guardrails. It is
+// therefore only safe so long as it is scoped to TRUSTED, first-party
+// connectors (today, public data-planes already restrict connector images to
+// `ghcr.io/estuary/` -- see validate_connector_image in runtime/container.rs).
+// Allowing untrusted connectors to use it would be unwise: a misbehaving or
+// malicious connector could flood operator observability. This feature should
+// always remain scoped to trusted connectors unless and until proper guardrails
+// (e.g. rate limiting and/or an explicit per-task opt-in) are added.
+func (p *OpsPublisher) maybeForwardObservable(out ops.Log) {
+	if string(out.FieldsJsonMap[observableField]) != "true" {
+		return
+	}
+	ops.LogToLogrus(out, p.labels.TaskName)
 }
 
 func shardKeyAndPartitions(shard *ops.ShardRef, ts *types.Timestamp) (tuple.Tuple, tuple.Tuple) {

--- a/go/runtime/ops_publisher_test.go
+++ b/go/runtime/ops_publisher_test.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/estuary/flow/go/protocols/ops"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeForwardObservable(t *testing.T) {
+	// Redirect the standard logger into a buffer using the JSON formatter, so we
+	// can make stable assertions on what (if anything) was forwarded.
+	var logger = logrus.StandardLogger()
+	var origOut, origFormatter, origLevel = logger.Out, logger.Formatter, logger.Level
+	t.Cleanup(func() {
+		logger.SetOutput(origOut)
+		logger.SetFormatter(origFormatter)
+		logger.SetLevel(origLevel)
+	})
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetLevel(logrus.InfoLevel)
+
+	var newPublisher = func() *OpsPublisher {
+		var p = &OpsPublisher{}
+		p.labels.TaskName = "acmeCo/test/task"
+		return p
+	}
+	var log = func(level ops.Log_Level, message string, observable bool) ops.Log {
+		var fields = map[string]json.RawMessage{}
+		if observable {
+			fields[observableField] = json.RawMessage("true")
+		}
+		return ops.Log{Level: level, Message: message, FieldsJsonMap: fields}
+	}
+
+	t.Run("marked line is forwarded and tagged with task", func(t *testing.T) {
+		buf.Reset()
+		newPublisher().maybeForwardObservable(log(ops.Log_info, "hello", true))
+		require.Contains(t, buf.String(), `"msg":"hello"`)
+		require.Contains(t, buf.String(), `"task":"acmeCo/test/task"`)
+	})
+
+	t.Run("unmarked line is not forwarded", func(t *testing.T) {
+		buf.Reset()
+		newPublisher().maybeForwardObservable(log(ops.Log_info, "hello", false))
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("observable:false is not forwarded", func(t *testing.T) {
+		buf.Reset()
+		var l = log(ops.Log_info, "hello", false)
+		l.FieldsJsonMap[observableField] = json.RawMessage("false")
+		newPublisher().maybeForwardObservable(l)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("respects the logger's level", func(t *testing.T) {
+		buf.Reset()
+		// Logger is at Info; a marked debug line must be filtered out.
+		newPublisher().maybeForwardObservable(log(ops.Log_debug, "hello", true))
+		require.Empty(t, buf.String())
+	})
+}


### PR DESCRIPTION
**Description:**

- Allow connectors to emit log lines with `fields.observable: true`, and pass those logs through to reactor stderr so they get picked up by promtrail -> loki -> grafana. Useful for sending signals for observability.
- This is currently unchecked, however we should make sure that we limit this function only to trusted connectors to avoid connectors being able to flood our grafana.
- Tested by running a `local:stack` and inside it running a locally modified version of a connector that emits `fields.observable: true` and verifying the reactor logs include that log with task name
- Note that these logs are also controlled by reactor log level... that's intentional because I think it is not a good idea to have `log: debug, observable: true`, as debug logs tend to be more verbose and frequent...

The modified connector had this line:
```
	log.WithField("observable", true).Info("a pass-through connector log")
```

and in local stack I got:

```
mahdi@lima-tiger:/Users/mahdi/workshop/flow$ journalctl --user -f -u flow-reactor@local-cluster-8099
Jun 09 18:55:34 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:34+01:00" level=info msg="created new pipe for task logs" log_read_fd=209 logs_write_fd=225 task_name=connector-proxy-1781027734417482969
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="solved for maximum assignment" asn.last=9 asn.next=10 asn.next.add=1 asn.next.rem=0 asn.next.same=9 dur="73.416µs" hash.last=13279148684028699570 hash.next=17294749396401263939 item.slots=10 item.total=10 mem.slots=1024 mem.total=1 rev=1641 root=/flow/local-cluster
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="starting local shard" id=capture/test/hello-world/15130c01bc0002b3/00000000-00000000 route="{[{local fancy-hagfish}] 0 []}"
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="promoted to primary" id=capture/test/hello-world/15130c01bc0002b3/00000000-00000000 log=recovery/capture/test/hello-world/15130c01bc0002b3/00000000-00000000
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="began recovering shard store from log" dir=/tmp/capture_test_hello-world_15130c01bc0002b3_00000000-00000000-378173748 id=capture/test/hello-world/15130c01bc0002b3/00000000-00000000 log=recovery/capture/test/hello-world/15130c01bc0002b3/00000000-00000000
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="completed playback" dir=/tmp/capture_test_hello-world_15130c01bc0002b3_00000000-00000000-378173748 files=0 lastLog=recovery/capture/test/hello-world/15130c01bc0002b3/00000000-00000000 nextChecksum=3812609140 nextSeqNo=2
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="created new pipe for task logs" log_read_fd=301 logs_write_fd=306 task_name=test/hello-world
Jun 09 18:55:35 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:35+01:00" level=info msg="now tailing live log" id=capture/test/hello-world/15130c01bc0002b3/00000000-00000000 log=recovery/capture/test/hello-world/15130c01bc0002b3/00000000-00000000
Jun 09 18:55:37 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:37+01:00" level=info msg="a pass-through connector log" observable=true task=test/hello-world
Jun 09 18:55:37 lima-tiger flowctl-go[38630]: time="2026-06-09T18:55:37+01:00" level=info msg="created partition" attempt=0 journal="test/events/15130c01bc0002b3/pivot=00" readThrough=1651
```

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

