### PR TITLE
flowctl-go: builds-root flag for shards split

### DIFF
--- a/go/flowctl-go/cmd-shards-split.go
+++ b/go/flowctl-go/cmd-shards-split.go
@@ -24,6 +24,7 @@ type cmdShardsSplit struct {
 	DryRun        bool                  `long:"dry-run" description:"Print actions that would be taken, but don't actually take them"`
 	Shard         string                `long:"shard" required:"true" description:"Shard to split"`
 	SplitOnRClock bool                  `long:"split-rclock" description:"Split on rotated clock (instead of on key)"`
+	BuildsRoot    string                `long:"builds-root" required:"true" description:"Builds root URL from which the task's built specification is loaded"`
 	Diagnostics   mbp.DiagnosticsConfig `group:"Debug" namespace:"debug" env-namespace:"DEBUG"`
 }
 
@@ -45,11 +46,7 @@ func (cmd cmdShardsSplit) execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	buildsRoot, err := getBuildsRoot(ctx, gazctlcmd.ShardsCfg.Consumer)
-	if err != nil {
-		return err
-	}
-	builds, err := flow.NewBuildService(buildsRoot.String())
+	builds, err := flow.NewBuildService(cmd.BuildsRoot)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:**

Require builds-root to be supplied as a flag, since the `/debug/vars` endpoint is typically not accessible via the same endpoint as the consumer address.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

