### PR TITLE
supabase: scoped refresh tokens so CI writes via PostgREST instead of direct psql

### DIFF
--- a/supabase/migrations/20260608120000_scoped_ci_tokens.sql
+++ b/supabase/migrations/20260608120000_scoped_ci_tokens.sql
@@ -1,0 +1,218 @@
+begin;
+
+-- Lets specific database roles be reached over PostgREST using a revocable refresh
+-- token, instead of a direct psql/5432 connection. This is so that CI writes which
+-- currently connect directly to the database survive the upcoming network allowlist,
+-- which cannot cover GitHub-hosted runner IPs.
+--
+-- A refresh token may carry an optional `pg_role`. generate_access_token stamps it
+-- into the access token's `role` claim, and PostgREST uses that claim for SET ROLE.
+-- The credential is revoked by deleting the single refresh_tokens row, which is why
+-- this is preferred over a long-lived JWT signed with the (effectively unrotatable)
+-- shared JWT secret.
+
+-- Null preserves all existing behavior; only machine credentials set this.
+alter table public.refresh_tokens
+  add column pg_role text;
+
+comment on column public.refresh_tokens.pg_role is
+  'Optional Postgres role stamped into the access token `role` claim by generate_access_token. '
+  'Null yields the default ''authenticated'' role. Used for scoped, revocable machine credentials.';
+
+-- Identical to the prior definition except the `role` claim, which now honors a
+-- token's pg_role. When pg_role is null the emitted claims are byte-for-byte unchanged,
+-- so the shared user-authentication path is unaffected.
+create or replace function public.generate_access_token(refresh_token_id public.flowid, secret text) returns json
+    language plpgsql security definer
+    as $$
+declare
+  rt refresh_tokens;
+  rt_new_secret text;
+  access_token text;
+begin
+
+  select * into rt from refresh_tokens where
+    refresh_tokens.id = refresh_token_id;
+
+  if not found then
+    raise 'could not find refresh_token with the given `refresh_token_id`';
+  end if;
+
+  if rt.hash <> crypt(secret, rt.hash) then
+    raise 'invalid secret provided';
+  end if;
+
+  if (rt.updated_at + rt.valid_for) < now() then
+    raise 'refresh_token has expired.';
+  end if;
+
+  select sign(json_build_object(
+    'exp', trunc(extract(epoch from (now() + interval '1 hour'))),
+    'iat', trunc(extract(epoch from (now()))),
+    'sub', rt.user_id,
+    'aud', 'authenticated',
+    'role', coalesce(rt.pg_role, 'authenticated')
+  ), internal.access_token_jwt_secret()) into access_token
+  limit 1;
+
+  if rt.multi_use = false then
+    rt_new_secret = gen_random_uuid();
+    update refresh_tokens
+      set
+        hash = crypt(rt_new_secret, gen_salt('bf')),
+        uses = (uses + 1),
+        updated_at = clock_timestamp()
+      where refresh_tokens.id = rt.id;
+  else
+    -- re-set the updated_at timer so the token's validity is refreshed
+    update refresh_tokens
+      set
+        uses = (uses + 1),
+        updated_at = clock_timestamp()
+      where refresh_tokens.id = rt.id;
+  end if;
+
+  if rt_new_secret is null then
+    return json_build_object(
+      'access_token', access_token
+    );
+  else
+    return json_build_object(
+      'access_token', access_token,
+      'refresh_token', json_build_object(
+        'id', rt.id,
+        'secret', rt_new_secret
+        )
+    );
+  end if;
+commit;
+end
+$$;
+
+-- A dedicated, grant-less identity to own CI refresh tokens. Because it holds no
+-- user_grants or role_grants, an access token minted for it is inert if presented to
+-- agent-api (it authenticates as a user with no capabilities); its only use is the
+-- PostgREST role assumption granted below. The refresh_tokens.user_id foreign key
+-- requires a real auth.users row, mirroring the support@estuary.dev fixture in seed.sql.
+insert into auth.users (id, email)
+  values ('c100b07b-0000-0000-0000-000000000001', 'ci-bot@estuary.dev')
+  on conflict (id) do nothing;
+
+-- Mint a revocable, multi-use refresh token bound to a scoped role, for CI use over
+-- PostgREST. Admin-gated and restricted to an explicit allowlist; without the allowlist
+-- this would be a privilege-escalation path (any caller could mint a service_role token).
+-- Returns {id, secret}; revoke by deleting the refresh_tokens row.
+create function public.create_scoped_refresh_token(target_role text, valid_for interval, detail text default null)
+    returns json
+    language plpgsql security definer
+    as $$
+declare
+  new_secret text;
+  rt refresh_tokens;
+  service_user_id constant uuid = 'c100b07b-0000-0000-0000-000000000001';
+begin
+  if not exists (
+    select 1 from internal.user_roles(auth_uid(), 'admin')
+    where role_prefix = 'ops/'
+  ) then
+    raise 'must be an admin of the ops/ tenant to create a scoped refresh token';
+  end if;
+
+  if target_role not in ('github_action_connector_refresh', 'data_plane_releases_ci') then
+    raise 'target_role % is not an allowlisted scoped role', target_role;
+  end if;
+
+  new_secret = gen_random_uuid();
+
+  insert into refresh_tokens (detail, user_id, multi_use, valid_for, hash, pg_role)
+  values (
+    detail,
+    service_user_id,
+    true,
+    valid_for,
+    crypt(new_secret, gen_salt('bf')),
+    target_role
+  ) returning * into rt;
+
+  return json_build_object('id', rt.id, 'secret', new_secret);
+end
+$$;
+
+alter function public.create_scoped_refresh_token(text, interval, text) owner to postgres;
+
+comment on function public.create_scoped_refresh_token(text, interval, text) is
+  'Admin-only. Create a revocable, multi-use refresh token bound to an allowlisted scoped '
+  'Postgres role, for machine (CI) use over PostgREST. Revoke by deleting the refresh_tokens row.';
+
+revoke execute on function public.create_scoped_refresh_token(text, interval, text) from public;
+grant execute on function public.create_scoped_refresh_token(text, interval, text) to authenticated;
+
+-- Allow PostgREST (which logs in as `authenticator`) to SET ROLE to these scoped roles.
+-- This is the wiring that makes the scoped access token usable; it mirrors how `dekaf`
+-- is already a member of authenticator. SET ROLE evaluates privileges and RLS exactly as
+-- a direct login as the role would, so behavior matches the current psql path.
+grant github_action_connector_refresh to authenticator;
+grant data_plane_releases_ci to authenticator;
+
+-- Re-queue connector tag publishing. SECURITY INVOKER: runs as the assumed role
+-- (github_action_connector_refresh), which already holds UPDATE on connector_tags and
+-- SELECT on connectors. The AFTER UPDATE trigger create_connector_tag_task then enqueues
+-- the agent task, exactly as the prior direct UPDATE did. Returns the number of rows requeued.
+create function public.requeue_connector_tag(image_name text, image_tags text[]) returns integer
+    language plpgsql
+    as $$
+declare
+  requeued integer;
+begin
+  update connector_tags ct
+    set job_status = '{"type": "queued"}', updated_at = clock_timestamp()
+    where ct.connector_id in (
+            select c.id from connectors c where c.image_name = requeue_connector_tag.image_name
+          )
+      and ct.image_tag = any(image_tags);
+  get diagnostics requeued = row_count;
+  return requeued;
+end
+$$;
+
+comment on function public.requeue_connector_tag(text, text[]) is
+  'Re-queue publishing of the given connector image tags by setting job_status to queued. '
+  'Replaces the direct UPDATE that connector CI ran over psql.';
+
+revoke execute on function public.requeue_connector_tag(text, text[]) from public;
+grant execute on function public.requeue_connector_tag(text, text[]) to github_action_connector_refresh;
+
+-- Replace the full data_plane_releases set in one transaction. SECURITY INVOKER: runs as
+-- data_plane_releases_ci, which holds DELETE and INSERT on the table. PostgREST has no COPY,
+-- so the ops workflow's CSV becomes a JSON array of release rows. Returns the number inserted.
+create function public.replace_data_plane_releases(payload jsonb) returns integer
+    language plpgsql
+    as $$
+declare
+  inserted integer;
+begin
+  delete from data_plane_releases;
+
+  insert into data_plane_releases (active, data_plane_id, max_tier, next_image, prev_image, step)
+    select
+      (e->>'active')::boolean,
+      (e->>'data_plane_id')::public.flowid,
+      (e->>'max_tier')::smallint,
+      e->>'next_image',
+      e->>'prev_image',
+      (e->>'step')::integer
+    from jsonb_array_elements(payload) as e;
+
+  get diagnostics inserted = row_count;
+  return inserted;
+end
+$$;
+
+comment on function public.replace_data_plane_releases(jsonb) is
+  'Atomically replace all data_plane_releases rows from a JSON array. '
+  'Replaces the DELETE + COPY that the ops release-data-planes workflow ran over psql.';
+
+revoke execute on function public.replace_data_plane_releases(jsonb) from public;
+grant execute on function public.replace_data_plane_releases(jsonb) to data_plane_releases_ci;
+
+commit;

--- a/supabase/tests/scoped_ci_tokens.test.sql
+++ b/supabase/tests/scoped_ci_tokens.test.sql
@@ -1,0 +1,129 @@
+-- Tests for scoped CI access tokens (20260608120000_scoped_ci_tokens.sql).
+-- Covers: the unchanged null-pg_role path, the scoped round trip ending in a
+-- connector_tag re-queue, the admin/allowlist guards on create_scoped_refresh_token,
+-- and that the scoped roles are assumable by `authenticator` (the PostgREST path).
+
+-- Decode the (unverified) claims of a JWT's payload segment. The payload is
+-- base64url, so map back to standard base64 and pad before decoding.
+create function tests.jwt_claims(token text) returns jsonb as $$
+  select convert_from(
+    decode(
+      rpad(
+        translate(split_part(token, '.', 2), '-_', '+/'),
+        ((length(split_part(token, '.', 2)) + 3) / 4) * 4,
+        '='
+      ),
+      'base64'
+    ),
+    'utf8'
+  )::jsonb;
+$$ language sql;
+
+
+create function tests.test_generate_access_token_null_role_unchanged()
+returns setof text as $$
+declare
+  rt_response jsonb;
+  response json;
+  claims jsonb;
+begin
+  delete from refresh_tokens;
+
+  -- A refresh token created the normal way has a null pg_role, so the emitted
+  -- claims must be exactly as before this migration.
+  perform set_authenticated_context('11111111-1111-1111-1111-111111111111');
+  select create_refresh_token(true, '1 day', 'null role') into rt_response;
+  select generate_access_token((rt_response->>'id')::flowid, rt_response->>'secret') into response;
+
+  -- jwt_claims lives in the `tests` schema, which `authenticated` cannot reach.
+  set role postgres;
+  claims := tests.jwt_claims(response->>'access_token');
+  return query select is(claims->>'role', 'authenticated', 'null pg_role still yields role=authenticated');
+  return query select is(claims->>'aud', 'authenticated', 'aud claim unchanged');
+  return query select is(claims->>'sub', '11111111-1111-1111-1111-111111111111', 'sub is the token user');
+end;
+$$ language plpgsql;
+
+
+create function tests.test_scoped_refresh_token_roundtrip()
+returns setof text as $$
+declare
+  rt_response jsonb;
+  response json;
+  claims jsonb;
+  requeued integer;
+begin
+  delete from refresh_tokens;
+
+  -- support@estuary.dev is an ops/ admin in the seed fixtures.
+  perform set_authenticated_context('ffffffff-ffff-ffff-ffff-ffffffffffff');
+  select create_scoped_refresh_token('github_action_connector_refresh', '1 day', 'ci') into rt_response;
+
+  return query select ok(rt_response ? 'id', 'scoped refresh token response has id');
+  return query select ok(rt_response ? 'secret', 'scoped refresh token response has secret');
+
+  -- The minted access token must carry the scoped role claim.
+  select generate_access_token((rt_response->>'id')::flowid, rt_response->>'secret') into response;
+  set role postgres;
+  claims := tests.jwt_claims(response->>'access_token');
+  return query select is(claims->>'role', 'github_action_connector_refresh', 'access token carries the scoped role');
+
+  -- And the scoped role can re-queue a connector tag via the new RPC.
+  set role postgres;
+  insert into connectors (id, image_name, title, short_description, logo_url, external_url, recommended) values
+    ('12:34:56:78:87:65:43:22', 'ghcr.io/estuary/scoped-test', '{"en-US":"t"}', '{"en-US":"d"}', '{"en-US":"l"}', 'http://foo.test', true);
+  insert into connector_tags (connector_id, image_tag, job_status) values
+    ('12:34:56:78:87:65:43:22', ':v1', '{"type": "success"}');
+
+  -- The test runner connects as the non-superuser `postgres`, which is not a
+  -- member of the scoped role; grant membership (rolled back with the test) so
+  -- we can assume it, as `authenticator` does over PostgREST in production.
+  -- Grant to the explicit role name, not `current_user`: `grant ... to current_user`
+  -- followed by `set role` segfaults the backend (a Postgres role-cache bug).
+  grant github_action_connector_refresh to postgres;
+  set role github_action_connector_refresh;
+  select requeue_connector_tag('ghcr.io/estuary/scoped-test', array[':v1', ':dev']) into requeued;
+  set role postgres;
+
+  return query select is(requeued, 1, 'requeue_connector_tag updated one matching tag');
+  return query select results_eq(
+    $i$ select job_status->>'type' from connector_tags
+        where connector_id = '12:34:56:78:87:65:43:22' and image_tag = ':v1' $i$,
+    $i$ values ('queued') $i$,
+    'connector_tag job_status was set to queued'
+  );
+end;
+$$ language plpgsql;
+
+
+create function tests.test_create_scoped_refresh_token_guards()
+returns setof text as $$
+begin
+  -- A non-admin (Alice) cannot mint a scoped token.
+  perform set_authenticated_context('11111111-1111-1111-1111-111111111111');
+  prepare not_admin as select create_scoped_refresh_token('github_action_connector_refresh', '1 day', 'x');
+  return query select throws_like('not_admin', '%admin of the ops/ tenant%', 'non-admin cannot create a scoped token');
+  deallocate not_admin;
+
+  -- Even an ops/ admin cannot target a role outside the allowlist.
+  perform set_authenticated_context('ffffffff-ffff-ffff-ffff-ffffffffffff');
+  prepare bad_role as select create_scoped_refresh_token('service_role', '1 day', 'x');
+  return query select throws_like('bad_role', '%not an allowlisted scoped role%', 'allowlist blocks arbitrary target roles');
+  deallocate bad_role;
+end;
+$$ language plpgsql;
+
+
+create function tests.test_scoped_roles_authenticator_membership()
+returns setof text as $$
+begin
+  -- PostgREST logs in as `authenticator` and SET ROLEs to the token's role claim,
+  -- which only works if authenticator is a member of the scoped role.
+  return query select ok(
+    pg_has_role('authenticator', 'github_action_connector_refresh', 'member'),
+    'authenticator can assume github_action_connector_refresh');
+  return query select ok(
+    pg_has_role('authenticator', 'data_plane_releases_ci', 'member'),
+    'authenticator can assume data_plane_releases_ci');
+end;
+$$ language plpgsql;


### PR DESCRIPTION
**Description:**

Adds a Supabase-native path for CI to write the control-plane database over PostgREST (HTTPS) instead of a direct psql connection on port 5432, ahead of the database network allowlist. A CIDR allowlist cannot cover GitHub-hosted runner IPs, which are a large, weekly-rotating pool of Azure addresses shared by every GitHub Actions tenant.

A `refresh_tokens` row may now carry an optional `pg_role`. `generate_access_token` stamps it into the access token's `role` claim, and PostgREST runs under that role. Two write RPCs expose exactly the operations CI performs today, each restricted to one role:

- `requeue_connector_tag(image_name, image_tags[])` for `github_action_connector_refresh`
- `replace_data_plane_releases(payload jsonb)` for `data_plane_releases_ci`

The credential is a single revocable `refresh_tokens` row (delete to revoke), rather than a long-lived JWT signed with the shared JWT secret, which is effectively unrotatable because it also signs every anon key, the service_role key, and all user sessions.

**Workflow steps:**

An `ops/` admin mints a token once per role:

```sql
select create_scoped_refresh_token('github_action_connector_refresh', '100 years', 'CI connector tag refresh');
select create_scoped_refresh_token('data_plane_releases_ci', '100 years', 'ops data_plane_releases');
```

CI exchanges it for a one-hour access token via `POST /rest/v1/rpc/generate_access_token`, then calls `requeue_connector_tag` / `replace_data_plane_releases` with that token as the bearer. The matching workflow changes ship as separate PRs in connectors, airbyte, source-salesforce-next, and ops. This PR is the additive database side and is safe to deploy on its own: nothing calls the new functions until those PRs merge.

**Documentation links affected:**

None.

**Notes for reviewers:**

- The `generate_access_token` change is a single line: `role` becomes `coalesce(rt.pg_role, 'authenticated')`. When `pg_role` is null the emitted claims are byte-identical, and a pgTAP test asserts that no-regression explicitly. This is the only edit to a shared auth-path function.
- `create_scoped_refresh_token` is admin-gated (`ops/` admin, the same check used by `create_data_plane` and `update_l2_reporting`) and hard-allowlists the two target roles. Without the allowlist it would be a privilege-escalation path.
- The two scoped roles are granted to `authenticator` so PostgREST can `SET ROLE` to them, the same wiring `dekaf` already uses in production.
- Tokens are owned by a dedicated grant-less `ci-bot@estuary.dev` `auth.users` row, so an access token is inert if presented to agent-api.
- pgTAP coverage: null-`pg_role` unchanged, scoped round trip (token role claim then `requeue_connector_tag` flips `job_status` to queued), admin and allowlist guards, and `authenticator` membership of both roles. Full `ci:sql-tap` suite passes.
- Deploy ordering: this should be live in prod before the workflow PRs merge; additive and safe alone.
