### PR TITLE
flowctl: add raw split-shards to scale out V2 tasks

### DIFF
--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use gazette::broker::journal_spec;
 use proto_flow::flow;
 use proto_gazette::{
-    broker::{self, JournalSpec, Label, LabelSelector, LabelSet},
+    broker::{self, JournalSpec, LabelSelector, LabelSet},
     consumer::{self, ShardSpec},
     recoverylog,
 };
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::collections::BTreeMap;
 
 // A Shard or Journal change to be applied.
-#[derive(serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum Change {
     Shard(consumer::apply_request::Change),
     Journal(broker::apply_request::Change),
@@ -457,6 +457,30 @@ pub fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<
     Ok(v)
 }
 
+const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
+
+fn non_zero_shards_are_stateless(shard_template: &ShardSpec) -> bool {
+    let Some(set) = shard_template.labels.as_ref() else {
+        return false;
+    };
+    let task_type = labels::values(set, labels::TASK_TYPE)
+        .first()
+        .map(|l| l.value.as_str());
+
+    if !matches!(
+        task_type,
+        Some(labels::TASK_TYPE_DERIVATION) | Some(labels::TASK_TYPE_MATERIALIZATION)
+    ) {
+        return false;
+    }
+
+    // TODO(whb): Remove this check when all tasks are running runtime v2.
+    labels::values(set, RUNTIME_V2_FLAG)
+        .first()
+        .map(|l| l.value.as_str())
+        == Some("true")
+}
+
 /// Determine the consumer shard and broker recovery and ops journal changes
 /// required to converge the desired splits towards the `template`.
 pub fn task_changes<'a>(
@@ -513,10 +537,37 @@ pub fn task_changes<'a>(
             ..template.shard.clone()
         };
 
-        // Next resolve the shard's recovery-log JournalSpec.
-        let recovery_name = format!("{}/{}", shard_spec.recovery_log_prefix, shard_spec.id);
-        let recovery_split = recovery.remove(&recovery_name).unwrap_or_default();
+        // Stateless shards (non-zero shards of leaderful runtime-v2 tasks)
+        // acquire all state through the leader protocol and must not have
+        // recovery logs or hints.
+        let range_spec = labels::shard::decode_range_spec(&split)?;
+        let stateless = non_zero_shards_are_stateless(template.shard)
+            && (range_spec.key_begin != 0 || range_spec.r_clock_begin != 0);
 
+        if stateless {
+            shard_spec.recovery_log_prefix = String::new();
+            shard_spec.hint_prefix = String::new();
+            shard_spec.hint_backups = 0;
+            shard_spec.hot_standbys = 0;
+        }
+
+        // Next resolve the shard's recovery-log JournalSpec.
+        let recovery_name = format!("{}/{}", template.shard.recovery_log_prefix, shard_spec.id);
+
+        {
+            // TODO(whb): Safety check that no multi-shard V1 task gets flipped
+            // to the V2 runtime, which would delete its recovery logs for
+            // non-zero shards. This can be removed once there are no more
+            // multi-shard V1 tasks.
+            if stateless && recovery.contains_key(&recovery_name) {
+                anyhow::bail!(
+                    "stateless shard {} must not have a recovery log, but {recovery_name} exists",
+                    shard_spec.id,
+                );
+            }
+        }
+
+        let recovery_split = recovery.remove(&recovery_name).unwrap_or_default();
         let mut recovery_spec = JournalSpec {
             name: recovery_name,
             suspend: recovery_split.suspend, // Must be passed through.
@@ -545,14 +596,6 @@ pub fn task_changes<'a>(
             }
             shard_labels = labels::add_value(shard_labels, &label.name, &label.value);
 
-            // A shard which is actively being split from another
-            // parent (source) shard should not have hot standbys,
-            // since we must complete the split workflow to even know
-            // what hints they should begin recovery log replay from.
-            if label.name == labels::SPLIT_SOURCE {
-                shard_spec.hot_standbys = 0
-            }
-
             // A cordoned task is disabled with its recovery log marked read-only.
             if label.name == labels::CORDON {
                 shard_spec.disable = true;
@@ -569,11 +612,14 @@ pub fn task_changes<'a>(
             delete: String::new(),
             primary_hints,
         }));
-        changes.push(Change::Journal(broker::apply_request::Change {
-            expect_mod_revision: recovery_split.mod_revision,
-            upsert: Some(recovery_spec),
-            delete: String::new(),
-        }));
+
+        if !stateless {
+            changes.push(Change::Journal(broker::apply_request::Change {
+                expect_mod_revision: recovery_split.mod_revision,
+                upsert: Some(recovery_spec),
+                delete: String::new(),
+            }));
+        }
     }
 
     // Any remaining recovery logs are not paired with an active shard, and are deleted.
@@ -914,27 +960,13 @@ pub fn map_partition_to_split(
 }
 
 /// Map a parent ShardSplit into two splits subdivided on either key or r-clock.
-#[allow(dead_code, unused_variables, unused_assignments)]
-fn map_shard_to_split(
+pub fn map_shard_to_split(
     parent: &ShardSplit,
     split_on_key: bool,
 ) -> anyhow::Result<(ShardSplit, ShardSplit)> {
     let parent_range = labels::shard::decode_range_spec(&parent.labels)?;
 
-    // Confirm the shard doesn't have an ongoing split.
-    if let Some(Label { value, .. }) = labels::values(&parent.labels, labels::SPLIT_SOURCE).first()
-    {
-        anyhow::bail!(
-            "shard {} is already splitting from source {value}",
-            parent.id
-        );
-    }
-    if let Some(Label { value, .. }) = labels::values(&parent.labels, labels::SPLIT_TARGET).first()
-    {
-        anyhow::bail!("shard {} is already splitting to target {value}", parent.id);
-    }
-
-    // Pick a split point of the parent range, which will divide the future
+    // Pick a split point of the parent range, which will divide the
     // LHS & RHS children.
     let (mut lhs_range, mut rhs_range) = (parent_range.clone(), parent_range.clone());
 
@@ -947,13 +979,8 @@ fn map_shard_to_split(
         (lhs_range.r_clock_end, rhs_range.r_clock_begin) = (pivot - 1, pivot);
     }
 
-    // Deep-copy parent labels for the desired LHS / RHS updates.
-    let (mut lhs_labels, mut rhs_labels) = (parent.labels.clone(), parent.labels.clone());
-
-    // Update the `rhs` range but not the `lhs` range at this time.
-    // That will happen when the `rhs` shard finishes playback
-    // and completes the split workflow.
-    rhs_labels = labels::shard::encode_range_spec(rhs_labels, &rhs_range);
+    let lhs_labels = labels::shard::encode_range_spec(parent.labels.clone(), &lhs_range);
+    let rhs_labels = labels::shard::encode_range_spec(parent.labels.clone(), &rhs_range);
 
     // Extract the Shard ID prefix and map into a new RHS Shard ID.
     let id_prefix = labels::shard::id_prefix(&parent.id)
@@ -963,10 +990,6 @@ fn map_shard_to_split(
         "{id_prefix}{}",
         labels::shard::id_suffix(&rhs_labels).expect("we encoded the range spec")
     );
-
-    // Mark the parent & child specs as having an in-progress split.
-    lhs_labels = labels::set_value(lhs_labels, labels::SPLIT_TARGET, &rhs_id);
-    rhs_labels = labels::set_value(rhs_labels, labels::SPLIT_SOURCE, &parent.id);
 
     Ok((
         ShardSplit {
@@ -1276,6 +1299,96 @@ mod test {
             insta::assert_json_snapshot!("update", (partition_changes, task_changes));
         }
 
+        // Case: leaderful tasks have stateless non-zero shards.
+        {
+            let shard_template = ShardSpec {
+                labels: Some(labels::set_value(
+                    shard_template.labels.clone().unwrap_or_default(),
+                    RUNTIME_V2_FLAG,
+                    "true",
+                )),
+                ..shard_template.clone()
+            };
+            let v2_template = TaskTemplate {
+                shard: &shard_template,
+                recovery: recovery_template,
+            };
+
+            let mut shards = Vec::new();
+            let mut recovery_logs = Vec::new();
+
+            for range in [
+                flow::RangeSpec {
+                    key_begin: 0,
+                    key_end: 0x7fffffff,
+                    r_clock_begin: 0,
+                    r_clock_end: u32::MAX,
+                },
+                flow::RangeSpec {
+                    key_begin: 0x80000000,
+                    key_end: u32::MAX,
+                    r_clock_begin: 0,
+                    r_clock_end: u32::MAX,
+                },
+            ] {
+                let labels = labels::shard::encode_range_spec(LabelSet::default(), &range);
+                let id = format!(
+                    "{}/{}",
+                    shard_template.id,
+                    labels::shard::id_suffix(&labels).unwrap()
+                );
+                // Only shard zero has a recovery log.
+                if range.key_begin == 0 {
+                    recovery_logs.push(JournalSplit {
+                        name: format!("{}/{}", shard_template.recovery_log_prefix, id),
+                        labels: LabelSet::default(),
+                        mod_revision: 333,
+                        suspend: None,
+                    });
+                }
+                shards.push(ShardSplit {
+                    id,
+                    labels,
+                    mod_revision: 222,
+                    primary_hints: None,
+                });
+            }
+
+            let changes = task_changes(
+                Some(v2_template),
+                shards.clone(),
+                recovery_logs,
+                (ops_logs_spec.name.clone(), None, Vec::new()),
+                (ops_stats_spec.name.clone(), None, Vec::new()),
+            )
+            .unwrap();
+
+            insta::assert_json_snapshot!("update-v2-stateless", changes);
+
+            // A recovery log paired with a stateless shard is refused.
+            let stray = JournalSplit {
+                name: format!("{}/{}", shard_template.recovery_log_prefix, shards[1].id),
+                labels: LabelSet::default(),
+                mod_revision: 333,
+                suspend: None,
+            };
+            let err = task_changes(
+                Some(v2_template),
+                shards.clone(),
+                vec![stray.clone()],
+                (ops_logs_spec.name.clone(), None, Vec::new()),
+                (ops_stats_spec.name.clone(), None, Vec::new()),
+            )
+            .unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "stateless shard {} must not have a recovery log, but {} exists",
+                    shards[1].id, stray.name
+                )
+            );
+        }
+
         // Case: test creation of new specs.
         {
             let shards = apply_initial_splits(Some(task_template), 4, Vec::new()).unwrap();
@@ -1546,19 +1659,6 @@ mod test {
                     "clock_changes",
                     clock_changes,
                 ])
-            );
-
-            // Expect that an attempt to split an already-splitting parent fails.
-            let err = map_shard_to_split(&key_lhs, true).unwrap_err();
-            assert_eq!(
-                err.to_string(),
-                "shard derivation/example/derivation/2020202020202020/10000000-60000000 is already splitting to target derivation/example/derivation/2020202020202020/20000000-60000000"
-            );
-
-            let err = map_shard_to_split(&key_rhs, true).unwrap_err();
-            assert_eq!(
-                err.to_string(),
-                "shard derivation/example/derivation/2020202020202020/20000000-60000000 is already splitting from source derivation/example/derivation/2020202020202020/10000000-60000000"
             );
         }
 

--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -457,8 +457,6 @@ pub fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<
     Ok(v)
 }
 
-const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
-
 fn non_zero_shards_are_stateless(shard_template: &ShardSpec) -> bool {
     let Some(set) = shard_template.labels.as_ref() else {
         return false;
@@ -475,7 +473,7 @@ fn non_zero_shards_are_stateless(shard_template: &ShardSpec) -> bool {
     }
 
     // TODO(whb): Remove this check when all tasks are running runtime v2.
-    labels::values(set, RUNTIME_V2_FLAG)
+    labels::values(set, labels::RUNTIME_V2_FLAG)
         .first()
         .map(|l| l.value.as_str())
         == Some("true")
@@ -1304,7 +1302,7 @@ mod test {
             let shard_template = ShardSpec {
                 labels: Some(labels::set_value(
                     shard_template.labels.clone().unwrap_or_default(),
-                    RUNTIME_V2_FLAG,
+                    labels::RUNTIME_V2_FLAG,
                     "true",
                 )),
                 ..shard_template.clone()

--- a/crates/activate/src/snapshots/activate__test__shard_splits.snap
+++ b/crates/activate/src/snapshots/activate__test__shard_splits.snap
@@ -15,7 +15,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           },
           {
             "name": "estuary.dev/key-end",
-            "value": "2fffffff"
+            "value": "1fffffff"
           },
           {
             "name": "estuary.dev/rclock-begin",
@@ -24,10 +24,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           {
             "name": "estuary.dev/rclock-end",
             "value": "9fffffff"
-          },
-          {
-            "name": "estuary.dev/split-target",
-            "value": "derivation/example/derivation/2020202020202020/20000000-60000000"
           },
           {
             "name": "extra",
@@ -59,10 +55,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
             "value": "9fffffff"
           },
           {
-            "name": "estuary.dev/split-source",
-            "value": "derivation/example/derivation/2020202020202020/10000000-60000000"
-          },
-          {
             "name": "extra",
             "value": "1"
           }
@@ -92,11 +84,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           },
           {
             "name": "estuary.dev/rclock-end",
-            "value": "9fffffff"
-          },
-          {
-            "name": "estuary.dev/split-target",
-            "value": "derivation/example/derivation/2020202020202020/10000000-80000000"
+            "value": "7fffffff"
           },
           {
             "name": "extra",
@@ -126,10 +114,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
           {
             "name": "estuary.dev/rclock-end",
             "value": "9fffffff"
-          },
-          {
-            "name": "estuary.dev/split-source",
-            "value": "derivation/example/derivation/2020202020202020/10000000-60000000"
           },
           {
             "name": "extra",
@@ -167,7 +151,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/key-end",
-                "value": "2fffffff"
+                "value": "1fffffff"
               },
               {
                 "name": "estuary.dev/log-level",
@@ -184,10 +168,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               {
                 "name": "estuary.dev/rclock-end",
                 "value": "9fffffff"
-              },
-              {
-                "name": "estuary.dev/split-target",
-                "value": "derivation/example/derivation/2020202020202020/20000000-60000000"
               },
               {
                 "name": "estuary.dev/stats-journal",
@@ -263,6 +243,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
         "upsert": {
           "hintBackups": 2,
           "hintPrefix": "/estuary/flow/hints",
+          "hotStandbys": 3,
           "id": "derivation/example/derivation/2020202020202020/20000000-60000000",
           "labels": {
             "labels": [
@@ -297,10 +278,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               {
                 "name": "estuary.dev/rclock-end",
                 "value": "9fffffff"
-              },
-              {
-                "name": "estuary.dev/split-source",
-                "value": "derivation/example/derivation/2020202020202020/10000000-60000000"
               },
               {
                 "name": "estuary.dev/stats-journal",
@@ -410,11 +387,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               },
               {
                 "name": "estuary.dev/rclock-end",
-                "value": "9fffffff"
-              },
-              {
-                "name": "estuary.dev/split-target",
-                "value": "derivation/example/derivation/2020202020202020/10000000-80000000"
+                "value": "7fffffff"
               },
               {
                 "name": "estuary.dev/stats-journal",
@@ -490,6 +463,7 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
         "upsert": {
           "hintBackups": 2,
           "hintPrefix": "/estuary/flow/hints",
+          "hotStandbys": 3,
           "id": "derivation/example/derivation/2020202020202020/10000000-80000000",
           "labels": {
             "labels": [
@@ -524,10 +498,6 @@ expression: "json!([\"key_splits\", (&key_lhs, &key_rhs), \"clock_splits\",\n(&c
               {
                 "name": "estuary.dev/rclock-end",
                 "value": "9fffffff"
-              },
-              {
-                "name": "estuary.dev/split-source",
-                "value": "derivation/example/derivation/2020202020202020/10000000-60000000"
               },
               {
                 "name": "estuary.dev/stats-journal",

--- a/crates/activate/src/snapshots/activate__test__update-v2-stateless.snap
+++ b/crates/activate/src/snapshots/activate__test__update-v2-stateless.snap
@@ -1,0 +1,182 @@
+---
+source: crates/activate/src/lib.rs
+expression: changes
+---
+[
+  {
+    "Shard": {
+      "expectModRevision": "222",
+      "upsert": {
+        "id": "derivation/example/derivation/2020202020202020/00000000-00000000",
+        "recoveryLogPrefix": "recovery",
+        "hintPrefix": "/estuary/flow/hints",
+        "hintBackups": 2,
+        "maxTxnDuration": "60s",
+        "minTxnDuration": "0s",
+        "hotStandbys": 3,
+        "labels": {
+          "labels": [
+            {
+              "name": "app.gazette.dev/managed-by",
+              "value": "estuary.dev/flow"
+            },
+            {
+              "name": "estuary.dev/build",
+              "value": "0101010101010101"
+            },
+            {
+              "name": "estuary.dev/flag/enable-runtime-v2",
+              "value": "true"
+            },
+            {
+              "name": "estuary.dev/key-begin",
+              "value": "00000000"
+            },
+            {
+              "name": "estuary.dev/key-end",
+              "value": "7fffffff"
+            },
+            {
+              "name": "estuary.dev/log-level",
+              "value": "info"
+            },
+            {
+              "name": "estuary.dev/logs-journal",
+              "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
+            },
+            {
+              "name": "estuary.dev/rclock-begin",
+              "value": "00000000"
+            },
+            {
+              "name": "estuary.dev/rclock-end",
+              "value": "ffffffff"
+            },
+            {
+              "name": "estuary.dev/stats-journal",
+              "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
+            },
+            {
+              "name": "estuary.dev/task-name",
+              "value": "example/derivation"
+            },
+            {
+              "name": "estuary.dev/task-type",
+              "value": "derivation"
+            }
+          ]
+        },
+        "ringBufferSize": 65536,
+        "readChannelSize": 4096
+      }
+    }
+  },
+  {
+    "Journal": {
+      "expectModRevision": "333",
+      "upsert": {
+        "name": "recovery/derivation/example/derivation/2020202020202020/00000000-00000000",
+        "replication": 3,
+        "labels": {
+          "labels": [
+            {
+              "name": "app.gazette.dev/managed-by",
+              "value": "estuary.dev/flow"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-gazette-recoverylog"
+            },
+            {
+              "name": "estuary.dev/build",
+              "value": "0101010101010101"
+            },
+            {
+              "name": "estuary.dev/task-name",
+              "value": "example/derivation"
+            },
+            {
+              "name": "estuary.dev/task-type",
+              "value": "derivation"
+            }
+          ]
+        },
+        "fragment": {
+          "length": "268435456",
+          "compressionCodec": "SNAPPY",
+          "stores": [
+            "gs://example-bucket/"
+          ],
+          "refreshInterval": "300s",
+          "flushInterval": "172800s"
+        },
+        "flags": 4,
+        "maxAppendRate": "4194304"
+      }
+    }
+  },
+  {
+    "Shard": {
+      "expectModRevision": "222",
+      "upsert": {
+        "id": "derivation/example/derivation/2020202020202020/80000000-00000000",
+        "maxTxnDuration": "60s",
+        "minTxnDuration": "0s",
+        "labels": {
+          "labels": [
+            {
+              "name": "app.gazette.dev/managed-by",
+              "value": "estuary.dev/flow"
+            },
+            {
+              "name": "estuary.dev/build",
+              "value": "0101010101010101"
+            },
+            {
+              "name": "estuary.dev/flag/enable-runtime-v2",
+              "value": "true"
+            },
+            {
+              "name": "estuary.dev/key-begin",
+              "value": "80000000"
+            },
+            {
+              "name": "estuary.dev/key-end",
+              "value": "ffffffff"
+            },
+            {
+              "name": "estuary.dev/log-level",
+              "value": "info"
+            },
+            {
+              "name": "estuary.dev/logs-journal",
+              "value": "ops/tasks/BASE_NAME/logs/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
+            },
+            {
+              "name": "estuary.dev/rclock-begin",
+              "value": "00000000"
+            },
+            {
+              "name": "estuary.dev/rclock-end",
+              "value": "ffffffff"
+            },
+            {
+              "name": "estuary.dev/stats-journal",
+              "value": "ops/tasks/BASE_NAME/stats/2020202020202020/kind=derivation/name=example%2Fderivation/pivot=00"
+            },
+            {
+              "name": "estuary.dev/task-name",
+              "value": "example/derivation"
+            },
+            {
+              "name": "estuary.dev/task-type",
+              "value": "derivation"
+            }
+          ]
+        },
+        "ringBufferSize": 65536,
+        "readChannelSize": 4096
+      }
+    }
+  }
+]

--- a/crates/flowctl/src/dataplane.rs
+++ b/crates/flowctl/src/dataplane.rs
@@ -90,6 +90,59 @@ pub async fn user_task_authorization(
     ))
 }
 
+/// Authorize the user for administrative operations over a task's shards
+/// and recovery logs, returning the task's ops journal names and
+/// Admin-capability shard + journal clients.
+pub async fn user_task_admin(
+    rest: &flow_client_next::rest::Client,
+    user_tokens: &tokens::PendingWatch<UserToken>,
+    router: &gazette::Router,
+    task: &str,
+    data_plane: models::Name,
+) -> anyhow::Result<(
+    String,
+    String,
+    gazette::shard::Client,
+    gazette::journal::Client,
+)> {
+    let (ops_logs_journal, ops_stats_journal) = {
+        let watch = tokens::watch(workflows::UserTaskAuth {
+            client: rest.clone(),
+            user_tokens: user_tokens.clone(),
+            task: models::Name::new(task),
+            capability: models::Capability::Read,
+        });
+        let ready = watch.ready().await.token();
+        let model = ready.result()?;
+
+        (
+            model.ops_logs_journal.clone(),
+            model.ops_stats_journal.clone(),
+        )
+    };
+
+    let watch = tokens::watch(workflows::UserPrefixAuth {
+        client: rest.clone(),
+        user_tokens: user_tokens.clone(),
+        prefix: models::Prefix::new(format!("{task}/")),
+        data_plane,
+        capability: models::Capability::Admin,
+    });
+    let journal_client = workflows::user_prefix_auth::new_journal_client(
+        gazette::journal::Client::new_fragment_client(),
+        router.clone(),
+        watch.clone(),
+    );
+    let shard_client = workflows::user_prefix_auth::new_shard_client(router.clone(), watch);
+
+    Ok((
+        ops_logs_journal,
+        ops_stats_journal,
+        shard_client,
+        journal_client,
+    ))
+}
+
 /// Authorize the user to access a catalog prefix within a data-plane,
 /// returning the authorization model (broker/reactor addresses and tokens).
 pub async fn user_prefix_authorization(

--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -18,6 +18,7 @@ mod oauth;
 mod preview_next;
 mod shards;
 mod spec;
+mod split_shards;
 
 #[derive(Debug, clap::Args)]
 #[clap(rename_all = "kebab-case")]
@@ -72,6 +73,8 @@ pub enum Command {
     BearerLogs(BearerLogs),
     /// Print information about the shards for a given task
     ListShards(TaskSelector),
+    /// Split each shard of a task on either shuffled key or rotated clock.
+    SplitShards(split_shards::Split),
     /// Print environment variables for working with a given data-plane
     /// and prefix using Gazette's `gazctl`.
     GazctlEnv(GazctlEnv),
@@ -228,6 +231,7 @@ impl Advanced {
             Command::Stats(stats) => stats.run(ctx).await,
             Command::BearerLogs(bearer_logs) => bearer_logs.run(ctx).await,
             Command::ListShards(selector) => shards::do_list_shards(ctx, selector).await,
+            Command::SplitShards(split) => split_shards::do_split(ctx, split).await,
             Command::GazctlEnv(gazctl_env) => gazctl_env.run(ctx).await,
             Command::PreviewNext(preview) => preview.run(ctx).await,
         }

--- a/crates/flowctl/src/raw/split_shards.rs
+++ b/crates/flowctl/src/raw/split_shards.rs
@@ -1,0 +1,160 @@
+use anyhow::Context;
+
+#[derive(Debug, clap::Args)]
+#[clap(rename_all = "kebab-case")]
+pub struct Split {
+    #[clap(flatten)]
+    task: crate::ops::TaskSelector,
+    /// Split on rotated clock (derivations only).
+    #[clap(long)]
+    split_rclock: bool,
+    /// Print the changes that would be applied, without applying them.
+    #[clap(long)]
+    dry_run: bool,
+}
+
+pub async fn do_split(ctx: &mut crate::CliContext, args: &Split) -> anyhow::Result<()> {
+    let Split {
+        task,
+        split_rclock,
+        dry_run,
+    } = args;
+    let task_name = &task.task;
+
+    #[derive(serde::Deserialize)]
+    struct Row {
+        spec_type: String,
+        built_spec: Option<models::RawValue>,
+        data_plane_name: String,
+    }
+    let rows: Vec<Row> = flow_client_next::postgrest::exec(
+        ctx.pg
+            .from("live_specs_ext")
+            .select("spec_type,built_spec,data_plane_name")
+            .eq("catalog_name", task_name),
+        ctx.access_token().as_deref(),
+    )
+    .await?;
+
+    anyhow::ensure!(
+        rows.len() <= 1,
+        "found {} live specs matching {task_name}, but expected exactly one",
+        rows.len(),
+    );
+    let Some(Row {
+        spec_type,
+        built_spec: Some(built_spec),
+        data_plane_name,
+    }) = rows.into_iter().next()
+    else {
+        anyhow::bail!("task {task_name} was not found, or has no built specification");
+    };
+
+    let collection_spec: proto_flow::flow::CollectionSpec;
+    let materialization_spec: proto_flow::flow::MaterializationSpec;
+
+    let (task_type, template) = match spec_type.as_str() {
+        "capture" => anyhow::bail!("capture shards cannot be split yet"),
+        "collection" => {
+            collection_spec = serde_json::from_str(built_spec.get())
+                .context("parsing built collection specification")?;
+            (
+                ops::TaskType::Derivation,
+                activate::collection_template(Some(&collection_spec))?.1,
+            )
+        }
+        "materialization" => {
+            materialization_spec = serde_json::from_str(built_spec.get())
+                .context("parsing built materialization specification")?;
+            (
+                ops::TaskType::Materialization,
+                activate::materialization_template(Some(&materialization_spec))?,
+            )
+        }
+        _ => (ops::TaskType::InvalidType, None),
+    };
+    let template = template
+        .with_context(|| format!("{task_name} is not an active derivation or materialization"))?;
+
+    if *split_rclock && task_type != ops::TaskType::Derivation {
+        anyhow::bail!("only derivations can split on r-clock");
+    }
+
+    {
+        // TODO(whb): This check can be removed once the runtime-v2 migration is
+        // complete.
+        let is_runtime_v2 = template.shard.labels.as_ref().is_some_and(|set| {
+            set.labels.iter().any(|label| {
+                label.name == "estuary.dev/flag/enable-runtime-v2" && label.value == "true"
+            })
+        });
+        anyhow::ensure!(
+            is_runtime_v2,
+            "task {task_name} is not running the V2 runtime (its shards lack the \
+         `estuary.dev/flag/enable-runtime-v2: true` flag) and cannot be split",
+        );
+    }
+
+    let (ops_logs_journal, ops_stats_journal, shard_client, journal_client) =
+        crate::dataplane::user_task_admin(
+            &ctx.rest,
+            &ctx.user_tokens,
+            &ctx.router,
+            task_name,
+            models::Name::new(data_plane_name),
+        )
+        .await?;
+
+    // Fetch current shards and recovery logs. The task's ops journals already
+    // exist, so ops journal templates aren't needed.
+    let (shards, recovery, _ops_logs, _ops_stats) = activate::fetch_task_splits(
+        &journal_client,
+        &shard_client,
+        task_type,
+        task_name,
+        None,
+        None,
+    )
+    .await?;
+
+    anyhow::ensure!(!shards.is_empty(), "task {task_name} has no current shards",);
+
+    // Split every current shard into two. Derivation and materialization
+    // children are stateless: they start empty and acquire state through the
+    // task's leader protocol, so no recovery-log seeding is required.
+    let mut desired = Vec::with_capacity(shards.len() * 2);
+
+    for shard in &shards {
+        let (lhs, rhs) = activate::map_shard_to_split(shard, !split_rclock)
+            .with_context(|| format!("cannot split shard {}", shard.id))?;
+
+        for (verb, split) in [("Updating", &lhs), ("Creating", &rhs)] {
+            let range = labels::shard::decode_range_spec(&split.labels)?;
+            println!(
+                "{verb} shard {} with keys [{:08x}, {:08x}] and r-clocks [{:08x}, {:08x}].",
+                split.id, range.key_begin, range.key_end, range.r_clock_begin, range.r_clock_end,
+            );
+        }
+        desired.push(lhs);
+        desired.push(rhs);
+    }
+
+    let changes = activate::task_changes(
+        Some(template),
+        desired,
+        recovery,
+        (ops_logs_journal, None, Vec::new()),
+        (ops_stats_journal, None, Vec::new()),
+    )?;
+
+    if *dry_run {
+        println!("{}", serde_json::to_string_pretty(&changes)?);
+        println!("Dry run: no changes were applied.");
+        return Ok(());
+    }
+
+    activate::apply_changes(&journal_client, &shard_client, changes).await?;
+    println!("Split applied.");
+
+    Ok(())
+}

--- a/crates/flowctl/src/raw/split_shards.rs
+++ b/crates/flowctl/src/raw/split_shards.rs
@@ -84,14 +84,15 @@ pub async fn do_split(ctx: &mut crate::CliContext, args: &Split) -> anyhow::Resu
         // TODO(whb): This check can be removed once the runtime-v2 migration is
         // complete.
         let is_runtime_v2 = template.shard.labels.as_ref().is_some_and(|set| {
-            set.labels.iter().any(|label| {
-                label.name == "estuary.dev/flag/enable-runtime-v2" && label.value == "true"
-            })
+            set.labels
+                .iter()
+                .any(|label| label.name == labels::RUNTIME_V2_FLAG && label.value == "true")
         });
         anyhow::ensure!(
             is_runtime_v2,
             "task {task_name} is not running the V2 runtime (its shards lack the \
-         `estuary.dev/flag/enable-runtime-v2: true` flag) and cannot be split",
+         `{}: true` flag) and cannot be split",
+            labels::RUNTIME_V2_FLAG,
         );
     }
 

--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -10,6 +10,9 @@ pub const COLLECTION: &str = "estuary.dev/collection";
 pub const CORDON: &str = "estuary.dev/cordon";
 pub const FIELD_PREFIX: &str = "estuary.dev/field/";
 pub const FLAG_PREFIX: &str = "estuary.dev/flag/";
+// Flag which enables the V2 task runtime.
+// TODO(whb): remove once the runtime-v2 migration is complete.
+pub const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
 pub const KEY_BEGIN: &str = "estuary.dev/key-begin";
 pub const KEY_BEGIN_MIN: &str = "00000000";
 pub const KEY_END: &str = "estuary.dev/key-end";

--- a/crates/shuffle/src/service.rs
+++ b/crates/shuffle/src/service.rs
@@ -185,8 +185,22 @@ impl Service {
             // connection unexpectedly.
             // See: https://github.com/grpc/grpc/blob/master/doc/keepalive.md
             .http2_keep_alive_interval(std::time::Duration::from_secs(301))
-            .initial_connection_window_size(i32::MAX as u32)
-            .connect_lazy();
+            .initial_connection_window_size(i32::MAX as u32);
+
+        let channel = if endpoint.starts_with("http://") {
+            // In-process `http://` loopback used by `flowctl preview` and
+            // tests.
+            channel
+        } else {
+            channel
+                .tls_config(
+                    tonic::transport::ClientTlsConfig::new()
+                        .with_native_roots()
+                        .assume_http2(true),
+                )
+                .map_err(|err| tonic::Status::internal(err.to_string()))?
+        }
+        .connect_lazy();
 
         guard.insert(endpoint.to_string(), channel.clone());
         Ok(channel)


### PR DESCRIPTION
**Description:**

Enable shard splitting for Runtime V2 tasks using `flowctl`. Kept as a `flowctl raw` command now since it only supports derivations and materializations. Support for captures will come later, and is more complex since it will require manipulation of recovery logs. 

Also fixes an adjacent shuffle dial issue where multi-shard topologies must use a client TLS configuration when dialing a peer sidecar.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

