### PR TITLE
docs: add Stripe account API version prerequisite to stripe-realtime

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/stripe-realtime.md
+++ b/site/docs/reference/Connectors/capture-connectors/stripe-realtime.md
@@ -97,6 +97,7 @@ For captures with many connected accounts, the connector uses a priority-based r
 ## Prerequisites
 
 * An [API Key](https://docs.stripe.com/keys) for your Stripe account. This usually starts with `sk_live_` or `sk_test_` depending on your environment. Manage your Stripe keys in their [developer dashboard](https://dashboard.stripe.com/test/apikeys).
+* A Stripe account default [API version](https://docs.stripe.com/api/versioning) of [2016-07-06](https://docs.stripe.com/changelog/2016-07-06/filter-canceled-subscriptions-retrieve-individually) or later. To capture canceled subscriptions as well as active ones, the connector lists subscriptions with `status=all`. The connector's requests run under your account's default API version, and versions older than 2016-07-06 reject this filter with an error similar to `Invalid status: must be one of active, past_due, unpaid, ...`, which causes the Subscriptions, Subscription items, and Usage records backfills to fail. You can view and upgrade your account's default API version in the Stripe dashboard under [Workbench](https://docs.stripe.com/workbench). Note that upgrading the default version affects API calls that don't pin a version per request and webhook endpoints without their own pinned version.
 
 ## Configuration
 


### PR DESCRIPTION
The source-stripe-native connector lists subscriptions with `status=all` so canceled subscriptions are captured too. Stripe accounts whose default API version is older than [2016-07-06](https://docs.stripe.com/changelog/2016-07-06/filter-canceled-subscriptions-retrieve-individually) reject that filter with `Invalid status: must be one of active, past_due, unpaid, ...`, which crash-loops the Subscriptions, SubscriptionItems, and UsageRecords backfills. The connector doesn't pin a `Stripe-Version` header, so the account default applies (same failure mode as stripe/stripe-python#687).

This hit a user in support this week and the prerequisites only mentioned the API key, so this adds the minimum account API version, the symptom to recognize it by, and where to upgrade in the Stripe dashboard.