### PR TITLE
labels: centralize RUNTIME_V2_FLAG constant

### DIFF
--- a/crates/activate/src/lib.rs
+++ b/crates/activate/src/lib.rs
@@ -457,8 +457,6 @@ pub fn unpack_journal_listing(resp: broker::ListResponse) -> anyhow::Result<Vec<
     Ok(v)
 }
 
-const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
-
 fn non_zero_shards_are_stateless(shard_template: &ShardSpec) -> bool {
     let Some(set) = shard_template.labels.as_ref() else {
         return false;
@@ -475,7 +473,7 @@ fn non_zero_shards_are_stateless(shard_template: &ShardSpec) -> bool {
     }
 
     // TODO(whb): Remove this check when all tasks are running runtime v2.
-    labels::values(set, RUNTIME_V2_FLAG)
+    labels::values(set, labels::RUNTIME_V2_FLAG)
         .first()
         .map(|l| l.value.as_str())
         == Some("true")
@@ -1304,7 +1302,7 @@ mod test {
             let shard_template = ShardSpec {
                 labels: Some(labels::set_value(
                     shard_template.labels.clone().unwrap_or_default(),
-                    RUNTIME_V2_FLAG,
+                    labels::RUNTIME_V2_FLAG,
                     "true",
                 )),
                 ..shard_template.clone()

--- a/crates/flowctl/src/raw/split_shards.rs
+++ b/crates/flowctl/src/raw/split_shards.rs
@@ -84,14 +84,15 @@ pub async fn do_split(ctx: &mut crate::CliContext, args: &Split) -> anyhow::Resu
         // TODO(whb): This check can be removed once the runtime-v2 migration is
         // complete.
         let is_runtime_v2 = template.shard.labels.as_ref().is_some_and(|set| {
-            set.labels.iter().any(|label| {
-                label.name == "estuary.dev/flag/enable-runtime-v2" && label.value == "true"
-            })
+            set.labels
+                .iter()
+                .any(|label| label.name == labels::RUNTIME_V2_FLAG && label.value == "true")
         });
         anyhow::ensure!(
             is_runtime_v2,
             "task {task_name} is not running the V2 runtime (its shards lack the \
-         `estuary.dev/flag/enable-runtime-v2: true` flag) and cannot be split",
+         `{}: true` flag) and cannot be split",
+            labels::RUNTIME_V2_FLAG,
         );
     }
 

--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -10,6 +10,9 @@ pub const COLLECTION: &str = "estuary.dev/collection";
 pub const CORDON: &str = "estuary.dev/cordon";
 pub const FIELD_PREFIX: &str = "estuary.dev/field/";
 pub const FLAG_PREFIX: &str = "estuary.dev/flag/";
+// Flag which enables the V2 task runtime.
+// TODO(whb): remove once the runtime-v2 migration is complete.
+pub const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
 pub const KEY_BEGIN: &str = "estuary.dev/key-begin";
 pub const KEY_BEGIN_MIN: &str = "00000000";
 pub const KEY_END: &str = "estuary.dev/key-end";


### PR DESCRIPTION
**Description:**

Stacked on #3021. The `estuary.dev/flag/enable-runtime-v2` label name was defined privately in the `activate` crate and hardcoded again in `flowctl`'s new `split-shards` command. This homes it in the `labels` crate alongside `FLAG_PREFIX` and reuses it at both sites (including the `split-shards` error message), so the checks cannot drift.

Note: `validation/derivation.rs` also references `enable-runtime-v2`, but as a bare flag name against the model's `shards.flags` rather than a shard label — left alone to keep this a pure no-op refactor.

**Workflow steps:**

None — no behavior change.

**Documentation links affected:**

None.

**Notes for reviewers:**

Intended to merge into #3021 before it lands on master.