### PR TITLE
flowctl: normalize --prefix trailing slash

### DIFF
--- a/crates/flowctl/src/alerts/subscriptions/mod.rs
+++ b/crates/flowctl/src/alerts/subscriptions/mod.rs
@@ -103,7 +103,7 @@ struct ListAlertSubscriptions;
 
 async fn do_list(list: &List, ctx: &mut crate::CliContext) -> anyhow::Result<()> {
     let prefix = if let Some(pre) = list.prefix.clone() {
-        pre
+        crate::normalize_prefix(&pre)
     } else {
         let prefixes =
             crate::get_default_prefix_arguments(ctx, models::Capability::Read, 1).await?;
@@ -181,7 +181,7 @@ async fn do_subscribe(create: &SubscribeArgs, ctx: &mut crate::CliContext) -> an
         anyhow::anyhow!("no explicit email argument provided, and unable to determine the user email from the available authentication information. Please try logging in again, or pass an explicit email argument."))?;
 
     let prefix = if let Some(pre) = create.prefix.clone() {
-        pre
+        crate::normalize_prefix(&pre)
     } else {
         let prefix_vec =
             crate::get_default_prefix_arguments(ctx, models::Capability::Read, 1).await?;
@@ -297,7 +297,7 @@ struct DeleteSubscription;
 async fn do_unsubscribe(args: &UnsubscribeArgs, ctx: &mut crate::CliContext) -> anyhow::Result<()> {
     let email = resolve_email(&args.email, ctx)?;
     let prefix = if let Some(pre) = args.prefix.clone() {
-        pre
+        crate::normalize_prefix(&pre)
     } else {
         let prefix_vec =
             crate::get_default_prefix_arguments(ctx, models::Capability::Read, 1).await?;

--- a/crates/flowctl/src/catalog/list/mod.rs
+++ b/crates/flowctl/src/catalog/list/mod.rs
@@ -273,7 +273,7 @@ fn to_vars(list: &List) -> Vec<list_live_specs_query::LiveSpecsBy> {
     for prefix in list.name_selector.prefix.iter() {
         vars.push(list_live_specs_query::LiveSpecsBy {
             names: None,
-            prefix: Some(models::Prefix::new(prefix)),
+            prefix: Some(models::Prefix::new(crate::normalize_prefix(prefix))),
             catalog_type,
             data_plane_name: data_plane_name.clone(),
         });

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -419,6 +419,23 @@ fn format_user(email: Option<String>, full_name: Option<String>, id: Option<uuid
     )
 }
 
+/// Normalizes a user-supplied catalog prefix to end with '/', which
+/// `models::Prefix` requires. Without this, a slash-less `--prefix AcmeCo` is
+/// passed verbatim to the API and rejected as an unauthorized name, producing a
+/// misleading PermissionDenied error. An empty string is the valid root prefix
+/// and is left alone; already-slashed values, including API-sourced defaults,
+/// pass through untouched, so this is a safe no-op on them.
+pub(crate) fn normalize_prefix(prefix: &str) -> String {
+    if prefix.is_empty() || prefix.ends_with('/') {
+        return prefix.to_string();
+    }
+    tracing::warn!(
+        prefix,
+        "interpreting --prefix '{prefix}' as '{prefix}/'"
+    );
+    format!("{prefix}/")
+}
+
 /// Returns a default list of prefixes to use for commands that accept an
 /// optional prefix argument. This will return all of the distinct prefixes that
 /// the user has at least `min_capability` to. If the user has access to more
@@ -524,5 +541,14 @@ mod test {
 
         let fail_result = filter_default_prefixes(roles, 2);
         assert!(fail_result.is_err());
+    }
+
+    #[test]
+    fn test_normalize_prefix() {
+        assert_eq!(normalize_prefix("AcmeCo"), "AcmeCo/");
+        assert_eq!(normalize_prefix("AcmeCo/"), "AcmeCo/");
+        assert_eq!(normalize_prefix("AcmeCo/team"), "AcmeCo/team/");
+        assert_eq!(normalize_prefix("AcmeCo/team/"), "AcmeCo/team/");
+        assert_eq!(normalize_prefix(""), "");
     }
 }

--- a/crates/flowctl/src/raw/mod.rs
+++ b/crates/flowctl/src/raw/mod.rs
@@ -454,7 +454,7 @@ impl GazctlEnv {
         let (data_plane_name, prefix) = match (&self.data_plane, &self.prefix, &self.name) {
             (Some(dp), Some(pf), None) => {
                 // Traditional mode: --data-plane and --prefix
-                (dp.clone(), pf.clone())
+                (dp.clone(), crate::normalize_prefix(pf))
             }
             (None, None, Some(name)) => {
                 // New mode: --name (resolve data plane from catalog name)


### PR DESCRIPTION
**Description:**

`flowctl` now normalizes a user-supplied `--prefix` to end with `/`, which `models::Prefix` requires. Previously, passing a prefix without a trailing slash was sent to the API verbatim and rejected as an unauthorized name, causing a misleading `PermissionDenied` error even when the user had full access. Applies across `catalog list`/`pull-specs`/`delete`, `raw gazctl-env`, and `alerts subscriptions`.

**Workflow steps:**

`flowctl catalog pull-specs --prefix AcmeCo` now behaves the same as `--prefix AcmeCo/`. The trailing slash is added automatically with a stderr warning noting the change. Prefixes that already end in `/` are unchanged, so existing usage is unaffected. 

**Documentation links affected:**

None. The CLI `--prefix` help text already describes prefix semantics, the behavior is just more forgiving now. No difference in contract. 

**Notes for reviewers:**

Closes #2834. Closes #2608

