### PR TITLE
docs: Describe SQL Server replica suport

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
@@ -7,11 +7,13 @@ periodically executing queries and translating the results into JSON documents.
 
 Estuary offers three main SQL Server capture connectors and their variants (platform-specific versions for managed providers). All three work across self-hosted and cloud-managed deployments.
 
-| Connector | Mechanism | Latency | Key Strengths |
-|-----------|-----------|---------|---------------|
-| **Batch** (this connector) | Periodic polling | Minutes to hours | Views, custom queries, minimal setup |
-| [Change Tracking](http://go.estuary.dev/source-sqlserver-ct) | Change tracking | Real-time | Computed columns, lower storage overhead |
-| [CDC](http://go.estuary.dev/source-sqlserver) | Log-based change capture | Real-time | Full audit history, tables without primary keys |
+| Connector | Mechanism | Latency | Read Replica Support | Key Strengths |
+|-----------|-----------|---------|----------------------|---------------|
+| **Batch** (this connector) | Periodic polling | Minutes to hours | Yes | Views, custom queries, minimal setup |
+| [Change Tracking](http://go.estuary.dev/source-sqlserver-ct) | Change tracking | Real-time | No | Computed columns, lower storage overhead |
+| [CDC](http://go.estuary.dev/source-sqlserver) | Log-based change capture | Real-time | Yes\* | Full audit history, tables without primary keys |
+
+\* CDC can capture from a read replica, but the CDC worker must run on the primary instance.
 
 **Choose Batch when:**
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
@@ -11,11 +11,13 @@ in a Microsoft SQL Server database into one or more Estuary collections.
 
 Estuary offers three main SQL Server capture connectors and their variants (platform-specific versions for managed providers). All three work across self-hosted and cloud-managed deployments.
 
-| Connector | Mechanism | Latency | Key Strengths |
-|-----------|-----------|---------|---------------|
-| **Change Tracking** (this connector) | Change tracking | Real-time | Computed columns, lower storage overhead |
-| [CDC](http://go.estuary.dev/source-sqlserver) | Log-based change capture | Real-time | Full audit history, tables without primary keys |
-| [Batch](http://go.estuary.dev/source-sqlserver-batch) | Periodic polling | Minutes to hours | Views, custom queries, minimal setup |
+| Connector | Mechanism | Latency | Read Replica Support | Key Strengths |
+|-----------|-----------|---------|----------------------|---------------|
+| **Change Tracking** (this connector) | Change tracking | Real-time | No | Computed columns, lower storage overhead |
+| [CDC](http://go.estuary.dev/source-sqlserver) | Log-based change capture | Real-time | Yes\* | Full audit history, tables without primary keys |
+| [Batch](http://go.estuary.dev/source-sqlserver-batch) | Periodic polling | Minutes to hours | Yes | Views, custom queries, minimal setup |
+
+\* CDC can capture from a read replica, but the CDC worker must run on the primary instance.
 
 **Choose Change Tracking when:**
 
@@ -49,6 +51,10 @@ Setup instructions are provided for the following platforms:
 ## Prerequisites
 
 To capture change events from SQL Server tables using this connector, you need:
+
+- A connection to the primary database instance. Change Tracking must capture
+  from the primary instance, as Change Tracking data is not available on read
+  replicas or secondary instances.
 
 - Primary keys on all tables you intend to capture. Change Tracking does not support tables without primary keys.
 

--- a/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/site/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -10,11 +10,13 @@ This connector uses change data capture (CDC) to continuously capture updates in
 
 Estuary offers three main SQL Server capture connectors and their variants (platform-specific versions for managed providers). All three work across self-hosted and cloud-managed deployments.
 
-| Connector | Mechanism | Latency | Key Strengths |
-|-----------|-----------|---------|---------------|
-| **CDC** (this connector) | Log-based change capture | Real-time | Full audit history, tables without primary keys |
-| [Change Tracking](http://go.estuary.dev/source-sqlserver-ct) | Change tracking | Real-time | Computed columns, lower storage overhead |
-| [Batch](http://go.estuary.dev/source-sqlserver-batch) | Periodic polling | Minutes to hours | Views, custom queries, minimal setup |
+| Connector | Mechanism | Latency | Read Replica Support | Key Strengths |
+|-----------|-----------|---------|----------------------|---------------|
+| **CDC** (this connector) | Log-based change capture | Real-time | Yes\* | Full audit history, tables without primary keys |
+| [Change Tracking](http://go.estuary.dev/source-sqlserver-ct) | Change tracking | Real-time | No | Computed columns, lower storage overhead |
+| [Batch](http://go.estuary.dev/source-sqlserver-batch) | Periodic polling | Minutes to hours | Yes | Views, custom queries, minimal setup |
+
+\* CDC can capture from a read replica, but the CDC worker must run on the primary instance.
 
 **Choose CDC when:**
 


### PR DESCRIPTION
**Description:**

Adds a note to the source-sqlserver-ct docs noting that it can only capture from the primary DB instance.

Also adds a "Read Replica Support" column to the comparison table for all three SQL Server captures since that seems like probably a pretty important dimension of comparison between the three.
