### PR TITLE
proto-gazette: regenerate to pick up SUSPEND_KEEP

### DIFF
--- a/crates/proto-gazette/src/protocol.rs
+++ b/crates/proto-gazette/src/protocol.rs
@@ -535,6 +535,19 @@ pub mod append_request {
         /// persist content to the remote store as per usual -- but it can result in
         /// many small files if a journal is repeatedly suspended and resumed.
         Now = 3,
+        /// SUSPEND_KEEP proceeds without modifying the journal's suspension level:
+        /// a suspended journal is neither resumed (as SUSPEND_RESUME would) nor
+        /// failed (as SUSPEND_NO_RESUME would). This allows an empty append -- in
+        /// practice one issued by `gazctl journals reset-head` -- to reset the write
+        /// head of a partially-suspended journal through its single remaining
+        /// replica, without resuming it and thereby triggering a restoration of its
+        /// full replication topology. A fully-suspended journal still fails with
+        /// status SUSPENDED, as it has no replica able to serve the append.
+        ///
+        /// SUSPEND_KEEP appends may not carry content (doing so fails with
+        /// NOT_ALLOWED), as content would otherwise be committed through the
+        /// journal's reduced-replication topology.
+        Keep = 4,
     }
     impl Suspend {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -547,6 +560,7 @@ pub mod append_request {
                 Self::NoResume => "SUSPEND_NO_RESUME",
                 Self::IfFlushed => "SUSPEND_IF_FLUSHED",
                 Self::Now => "SUSPEND_NOW",
+                Self::Keep => "SUSPEND_KEEP",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -556,6 +570,7 @@ pub mod append_request {
                 "SUSPEND_NO_RESUME" => Some(Self::NoResume),
                 "SUSPEND_IF_FLUSHED" => Some(Self::IfFlushed),
                 "SUSPEND_NOW" => Some(Self::Now),
+                "SUSPEND_KEEP" => Some(Self::Keep),
                 _ => None,
             }
         }

--- a/crates/proto-gazette/src/protocol.serde.rs
+++ b/crates/proto-gazette/src/protocol.serde.rs
@@ -272,6 +272,7 @@ impl serde::Serialize for append_request::Suspend {
             Self::NoResume => "SUSPEND_NO_RESUME",
             Self::IfFlushed => "SUSPEND_IF_FLUSHED",
             Self::Now => "SUSPEND_NOW",
+            Self::Keep => "SUSPEND_KEEP",
         };
         serializer.serialize_str(variant)
     }
@@ -287,6 +288,7 @@ impl<'de> serde::Deserialize<'de> for append_request::Suspend {
             "SUSPEND_NO_RESUME",
             "SUSPEND_IF_FLUSHED",
             "SUSPEND_NOW",
+            "SUSPEND_KEEP",
         ];
 
         struct GeneratedVisitor;
@@ -331,6 +333,7 @@ impl<'de> serde::Deserialize<'de> for append_request::Suspend {
                     "SUSPEND_NO_RESUME" => Ok(append_request::Suspend::NoResume),
                     "SUSPEND_IF_FLUSHED" => Ok(append_request::Suspend::IfFlushed),
                     "SUSPEND_NOW" => Ok(append_request::Suspend::Now),
+                    "SUSPEND_KEEP" => Ok(append_request::Suspend::Keep),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }


### PR DESCRIPTION
**Description:**

Mechanical regeneration only; no local .proto changes. The gazette bump in adf5ee04e5 (go.mod: bump gazette to latest) pulled in broker commit 8537ed9, which adds the SUSPEND_KEEP append-suspension mode, but the checked-in bindings were never regenerated to match. This adds the resulting AppendRequest.Suspend::Keep variant and its serde mappings.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

