### PR TITLE
deploy: route control-plane services through the VPC NAT for a stable egress IP

### DIFF
--- a/.github/workflows/deploy-agent-api.yaml
+++ b/.github/workflows/deploy-agent-api.yaml
@@ -39,6 +39,8 @@ jobs:
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
           timeout: 10m
+          # Egress via a dedicated subnet on the data-plane-controller VPC (its own NAT IP) for a stable outbound IP.
+          flags: '--network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic'
 
           env_vars: |-
             BUILDS_ROOT=gs://estuary-control/builds/

--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -51,7 +51,8 @@ jobs:
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
           timeout: 3600s
-          flags: '--args=service --no-allow-unauthenticated --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com'
+          # Declare the VPC egress (previously set out-of-band) in code so it survives a full replace.
+          flags: '--args=service --no-allow-unauthenticated --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com --network=data-plane-controller --subnet=data-plane-controller-sn1 --vpc-egress=all-traffic'
 
           env_vars: |-
             DPC_DATABASE_CA=/etc/db-ca.crt
@@ -113,7 +114,10 @@ jobs:
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
           timeout: 2h # Self-cancels after 1 hour, with 1 hour grace period.
-          flags: '--args=job --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com'
+          # Egress via the dedicated control-plane-api subnet (its own NAT IP). The job
+          # connects to the database and dispatches to the service over HTTPS; it does no
+          # provisioning SSH, so it does not need the data-plane-controller egress IP.
+          flags: '--args=job --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com --network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic'
 
           env_vars: |-
             DPC_DATABASE_CA=/etc/db-ca.crt

--- a/.github/workflows/deploy-oidc-discovery-server.yaml
+++ b/.github/workflows/deploy-oidc-discovery-server.yaml
@@ -48,6 +48,8 @@ jobs:
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
           port: 8080
+          # Egress via a dedicated subnet on the data-plane-controller VPC (its own NAT IP) for a stable outbound IP.
+          flags: '--network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic'
 
           env_vars: |-
             DATABASE_CA=/etc/db-ca.crt


### PR DESCRIPTION
**Description:**

Routes the control-plane Cloud Run services through a Cloud NAT in the `data-plane-controller` VPC so they egress from a stable IP instead of Cloud Run's dynamic Google IPs. `agent-api` and `oidc-discovery-server` use a dedicated `control-plane-api-sn1` subnet with its own NAT IP, kept separate from the `data-plane-controller-service` egress IP; that service stays on its existing subnet.

Adds `flags: '--network=… --subnet=… --vpc-egress=all-traffic'` to:

- `deploy-agent-api.yaml` (subnet `control-plane-api-sn1`; new VPC egress)
- `deploy-oidc-discovery-server.yaml` (subnet `control-plane-api-sn1`; new VPC egress)
- `deploy-data-plane-controller.yaml` (subnet `data-plane-controller-sn1`; backfill of config previously set out-of-band, so it survives a full replace)

**Supporting infra:** the `control-plane-api-sn1` subnet, its reserved NAT IP, and a dedicated Cloud NAT (with the existing NAT scoped to only `data-plane-controller-sn1`) are already provisioned. This PR only adds the deploy-time egress flags.

**Workflow steps:**

- Merge, then run each deploy workflow (`workflow_dispatch`) to apply. This is a real egress behavior change for `agent-api` and `oidc-discovery-server`: all of their outbound traffic begins flowing through the NAT, so roll out deliberately and watch service health and Cloud NAT metrics.

**Notes for reviewers:**

- No application code; CI/deploy config only.
- After redeploy, `gcloud run services describe <svc> --region us-central1 --project estuary-control --format="yaml(spec.template.metadata.annotations)"` shows `run.googleapis.com/network-interfaces` (`control-plane-api-sn1`) and `vpc-access-egress: all-traffic`.
- `agent-api` is the high-volume service; its dedicated NAT has dynamic port allocation enabled.
