### PR TITLE
validation/collection: exclude `flow://inferred-schema` from the managed-defs redact check

### DIFF
--- a/crates/validation/src/collection.rs
+++ b/crates/validation/src/collection.rs
@@ -891,11 +891,10 @@ fn check_read_schema_redact_in_write_schema(
 // Scan `$defs` entries whose `$id` is one of the system-managed schema URIs
 // for any nested `redact` annotation. These subtrees are owned by the system:
 // discover overwrites `flow://connector-schema`, and validation-time inlining
-// replaces `flow://inferred-schema`, `flow://write-schema`, and
-// `flow://relaxed-write-schema`. Annotations placed inside them are silently
-// lost on the next publication. We discriminate by `$id` (the canonical URI
-// that drives `$ref` resolution), not by the `$defs` key (which is convention
-// only and can be renamed).
+// replaces `flow://write-schema` and `flow://relaxed-write-schema`. Annotations
+// placed inside them are silently lost on the next publication. We discriminate
+// by `$id` (the canonical URI that drives `$ref` resolution), not by the `$defs`
+// key (which is convention only and can be renamed).
 fn check_redact_in_managed_defs(
     scope: Scope,
     model: &models::Schema,
@@ -903,7 +902,6 @@ fn check_redact_in_managed_defs(
     errors: &mut tables::Errors,
 ) {
     const MANAGED_IDS: &[&str] = &[
-        models::Schema::REF_INFERRED_SCHEMA_URL,
         models::Schema::REF_WRITE_SCHEMA_URL,
         models::Schema::REF_RELAXED_WRITE_SCHEMA_URL,
         models::Schema::REF_CONNECTOR_SCHEMA_URL,

--- a/crates/validation/tests/scenario_tests.rs
+++ b/crates/validation/tests/scenario_tests.rs
@@ -2080,6 +2080,37 @@ test://example/catalog.yaml:
 }
 
 #[test]
+fn test_redact_inside_inferred_schema_def_is_allowed() {
+    // Regression: a collection that pairs schema inference with redaction. The
+    // live inferred schema faithfully carries the write schema's `redact`
+    // annotation, and validation inlines it into `$defs/flow://inferred-schema`
+    // before the managed-defs scan runs. That system-generated `redact` must
+    // not be flagged as a misplacement, which previously trapped such
+    // collections in a failed-publish loop the moment their inferred schema
+    // next updated.
+    let errors = common::run_errors(
+        include_str!("schema_inference.yaml"),
+        r#"
+driver:
+  liveInferredSchemas:
+    testing/foobar:
+      properties:
+        timestamp:
+          redact: { strategy: sha256 }
+
+test://example/catalog.yaml:
+  collections:
+    testing/foobar:
+      writeSchema:
+        properties:
+          timestamp:
+            redact: { strategy: sha256 }
+"#,
+    );
+    insta::assert_debug_snapshot!(errors, @"[]");
+}
+
+#[test]
 fn test_materialization_too_many_bindings() {
     let bindings_count = validation::MAX_BINDINGS + 1;
 


### PR DESCRIPTION
#2931 added `RedactInsideManagedDefs`, which scans a collection's `$defs` for `redact` annotations inside system-managed schema subtrees (`flow://connector-schema`, `flow://write-schema`, `flow://relaxed-write-schema`, `flow://inferred-schema`) and rejects the publication, on the basis that those subtrees are overwritten on every build so a `redact` placed inside one is silently lost. Including `flow://inferred-schema` in that set was incorrect.

## The regression

When a collection uses schema inference, its `redact` annotations flow from the write schema into the inferred schema, and validation inlines that inferred schema into `$defs/flow://inferred-schema` before it runs the footgun check. The check found the `redact` there and rejected the publication, telling the user to "move the annotation to the top level" when it already was at the top level of the write schema.

Because the controller only republishes a collection when its inferred schema changes, the failure surfaced per-collection whenever that collection's inferred schema next updated, at which point its background publication entered a failed-publish loop. The check also couldn't ever flag a genuine misplacement inside `flow://inferred-schema`: that subtree is overwritten with the inferred schema on every build _before_ the check ran.

## The fix

Drop `flow://inferred-schema` from the scanned IDs. A `redact` inside it reflects the write schema rather than a misplacement, and the dangerous case (a `redact` in the effective read schema with no write-schema counterpart) is still caught by `ReadSchemaRedactNotInWriteSchema`. The other three managed subtrees remain scanned