### PR TITLE
data-plane-controller: restart setting

### DIFF
--- a/crates/data-plane-controller/src/service/worker.rs
+++ b/crates/data-plane-controller/src/service/worker.rs
@@ -445,6 +445,13 @@ impl Worker {
             .deployments
             .retain_mut(stack::Deployment::mark_current);
 
+        // Ansible has rolled any deployments with `restart` set, so consume the
+        // one-shot flag. With skip_serializing_if it simply vanishes from the
+        // written-back config, making the restart fire exactly once.
+        for deployment in state.stack.config.model.deployments.iter_mut() {
+            deployment.restart = false;
+        }
+
         // Compute dekaf addresses based on whether Dekaf is deployed with current > 0.
         let dekaf_deployed = state
             .stack

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -236,6 +236,10 @@ pub struct Deployment {
     pub tier: u8,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
+    // One-shot flag requesting a rolling restart of this deployment's instances.
+    // Ansible rolls them one host at a time; cleared after a successful run.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub restart: bool,
 }
 
 fn default_tier() -> u8 {
@@ -430,6 +434,7 @@ impl DataPlane {
                         rollout: _,            // Allowed to change.
                         tier: _,               // Allowed to change.
                         tag: _,                // Allowed to change.
+                        restart: _,            // Allowed to change.
                     },
                     next @ Deployment {
                         current: next_current,
@@ -441,6 +446,7 @@ impl DataPlane {
                         rollout: _,            // Allowed to change.
                         tier: _,               // Allowed to change.
                         tag: _,                // Allowed to change.
+                        restart: _,            // Allowed to change.
                     },
                 ) => {
                     if cur_current != next_current
@@ -522,6 +528,7 @@ impl DataPlane {
                 template: last.template.clone(),
                 tier: last.tier,
                 tag: last.tag.clone(),
+                restart: false,
             };
 
             last.rollout = Some(Rollout {


### PR DESCRIPTION
**Description:**

Self-clearing restart "flag" for deployments. This is so we can fire and forget rolling hosts if something requires a restart.

**Workflow steps:**

Set flag on deployment. Ansible side rolls these 1 at a time, carefully.

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

