### PR TITLE
proto-flow: tolerate unknown JSON fields in connector protocols

### DIFF
--- a/crates/proto-flow/build.rs
+++ b/crates/proto-flow/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .register_descriptors(&std::fs::read(b.descriptor_path).expect("read descriptors"))
         .unwrap()
         .btree_map(["."]) // Make ordering stable for snapshots.
+        .ignore_unknown_fields()
         .build(&[
             ".flow",
             ".capture",

--- a/crates/proto-flow/src/capture.serde.rs
+++ b/crates/proto-flow/src/capture.serde.rs
@@ -80,6 +80,7 @@ impl<'de> serde::Deserialize<'de> for Request {
             Open,
             Acknowledge,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -108,7 +109,7 @@ impl<'de> serde::Deserialize<'de> for Request {
                             "open" => Ok(GeneratedField::Open),
                             "acknowledge" => Ok(GeneratedField::Acknowledge),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -180,6 +181,9 @@ impl<'de> serde::Deserialize<'de> for Request {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Request {
@@ -227,6 +231,7 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Checkpoints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -249,7 +254,7 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
                     {
                         match value {
                             "checkpoints" => Ok(GeneratedField::Checkpoints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -278,6 +283,9 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
                             checkpoints__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -357,6 +365,7 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
             LastCapture,
             LastVersion,
             StateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -383,7 +392,7 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
                             "lastCapture" | "last_capture" => Ok(GeneratedField::LastCapture),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
                             "state" | "state_json" => Ok(GeneratedField::StateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -440,6 +449,9 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
                             state_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -508,6 +520,7 @@ impl<'de> serde::Deserialize<'de> for request::Discover {
             Name,
             ConnectorType,
             ConfigJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -532,7 +545,7 @@ impl<'de> serde::Deserialize<'de> for request::Discover {
                             "name" => Ok(GeneratedField::Name),
                             "connectorType" | "connector_type" => Ok(GeneratedField::ConnectorType),
                             "config" | "config_json" => Ok(GeneratedField::ConfigJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -575,6 +588,9 @@ impl<'de> serde::Deserialize<'de> for request::Discover {
                             config_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -646,6 +662,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
             Version,
             Range,
             StateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -671,7 +688,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             "version" => Ok(GeneratedField::Version),
                             "range" => Ok(GeneratedField::Range),
                             "state" | "state_json" => Ok(GeneratedField::StateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -721,6 +738,9 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             state_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -780,6 +800,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
         enum GeneratedField {
             ConnectorType,
             ConfigJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -803,7 +824,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                         match value {
                             "connectorType" | "connector_type" => Ok(GeneratedField::ConnectorType),
                             "config" | "config_json" => Ok(GeneratedField::ConfigJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -839,6 +860,9 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                             config_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -930,6 +954,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
             Bindings,
             LastCapture,
             LastVersion,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -957,7 +982,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                             "bindings" => Ok(GeneratedField::Bindings),
                             "lastCapture" | "last_capture" => Ok(GeneratedField::LastCapture),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1021,6 +1046,9 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                                 return Err(serde::de::Error::duplicate_field("lastVersion"));
                             }
                             last_version__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1087,6 +1115,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
             ResourceConfigJson,
             Collection,
             Backfill,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1111,7 +1140,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
                             "resourceConfig" | "resource_config_json" => Ok(GeneratedField::ResourceConfigJson),
                             "collection" => Ok(GeneratedField::Collection),
                             "backfill" => Ok(GeneratedField::Backfill),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1156,6 +1185,9 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
                             backfill__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1268,6 +1300,7 @@ impl<'de> serde::Deserialize<'de> for Response {
             SourcedSchema,
             Checkpoint,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1298,7 +1331,7 @@ impl<'de> serde::Deserialize<'de> for Response {
                             "sourcedSchema" | "sourced_schema" => Ok(GeneratedField::SourcedSchema),
                             "checkpoint" => Ok(GeneratedField::Checkpoint),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1384,6 +1417,9 @@ impl<'de> serde::Deserialize<'de> for Response {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Response {
@@ -1442,6 +1478,7 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
         enum GeneratedField {
             ActionDescription,
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1465,7 +1502,7 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
                         match value {
                             "actionDescription" | "action_description" => Ok(GeneratedField::ActionDescription),
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1499,6 +1536,9 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1553,6 +1593,7 @@ impl<'de> serde::Deserialize<'de> for response::Captured {
         enum GeneratedField {
             Binding,
             DocJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1576,7 +1617,7 @@ impl<'de> serde::Deserialize<'de> for response::Captured {
                         match value {
                             "binding" => Ok(GeneratedField::Binding),
                             "doc" | "doc_json" => Ok(GeneratedField::DocJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1614,6 +1655,9 @@ impl<'de> serde::Deserialize<'de> for response::Captured {
                             doc_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1657,6 +1701,7 @@ impl<'de> serde::Deserialize<'de> for response::Checkpoint {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1679,7 +1724,7 @@ impl<'de> serde::Deserialize<'de> for response::Checkpoint {
                     {
                         match value {
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1706,6 +1751,9 @@ impl<'de> serde::Deserialize<'de> for response::Checkpoint {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1748,6 +1796,7 @@ impl<'de> serde::Deserialize<'de> for response::Discovered {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bindings,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1770,7 +1819,7 @@ impl<'de> serde::Deserialize<'de> for response::Discovered {
                     {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1797,6 +1846,9 @@ impl<'de> serde::Deserialize<'de> for response::Discovered {
                                 return Err(serde::de::Error::duplicate_field("bindings"));
                             }
                             bindings__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1896,6 +1948,7 @@ impl<'de> serde::Deserialize<'de> for response::discovered::Binding {
             Disable,
             ResourcePath,
             IsFallbackKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1924,7 +1977,7 @@ impl<'de> serde::Deserialize<'de> for response::discovered::Binding {
                             "disable" => Ok(GeneratedField::Disable),
                             "resourcePath" | "resource_path" => Ok(GeneratedField::ResourcePath),
                             "isFallbackKey" | "is_fallback_key" => Ok(GeneratedField::IsFallbackKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1998,6 +2051,9 @@ impl<'de> serde::Deserialize<'de> for response::discovered::Binding {
                             }
                             is_fallback_key__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(response::discovered::Binding {
@@ -2046,6 +2102,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ExplicitAcknowledgements,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2068,7 +2125,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                     {
                         match value {
                             "explicitAcknowledgements" | "explicit_acknowledgements" => Ok(GeneratedField::ExplicitAcknowledgements),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2095,6 +2152,9 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                                 return Err(serde::de::Error::duplicate_field("explicitAcknowledgements"));
                             }
                             explicit_acknowledgements__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2148,6 +2208,7 @@ impl<'de> serde::Deserialize<'de> for response::SourcedSchema {
         enum GeneratedField {
             Binding,
             SchemaJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2171,7 +2232,7 @@ impl<'de> serde::Deserialize<'de> for response::SourcedSchema {
                         match value {
                             "binding" => Ok(GeneratedField::Binding),
                             "documentSchema" | "schema_json" => Ok(GeneratedField::SchemaJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2209,6 +2270,9 @@ impl<'de> serde::Deserialize<'de> for response::SourcedSchema {
                             schema_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2300,6 +2364,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
             DocumentationUrl,
             Oauth2,
             ResourcePathPointers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2327,7 +2392,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             "documentationUrl" | "documentation_url" => Ok(GeneratedField::DocumentationUrl),
                             "oauth2" => Ok(GeneratedField::Oauth2),
                             "resourcePathPointers" | "resource_path_pointers" => Ok(GeneratedField::ResourcePathPointers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2396,6 +2461,9 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             }
                             resource_path_pointers__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(response::Spec {
@@ -2442,6 +2510,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bindings,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2464,7 +2533,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                     {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2491,6 +2560,9 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                                 return Err(serde::de::Error::duplicate_field("bindings"));
                             }
                             bindings__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2534,6 +2606,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ResourcePath,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2556,7 +2629,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
                     {
                         match value {
                             "resourcePath" | "resource_path" => Ok(GeneratedField::ResourcePath),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2583,6 +2656,9 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
                                 return Err(serde::de::Error::duplicate_field("resourcePath"));
                             }
                             resource_path__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/derive.serde.rs
+++ b/crates/proto-flow/src/derive.serde.rs
@@ -89,6 +89,7 @@ impl<'de> serde::Deserialize<'de> for Request {
             StartCommit,
             Reset,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -118,7 +119,7 @@ impl<'de> serde::Deserialize<'de> for Request {
                             "startCommit" | "start_commit" => Ok(GeneratedField::StartCommit),
                             "reset" => Ok(GeneratedField::Reset),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -197,6 +198,9 @@ impl<'de> serde::Deserialize<'de> for Request {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Request {
@@ -248,6 +252,7 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             StatePatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -270,7 +275,7 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
                     {
                         match value {
                             "statePatches" | "state_patches_json" => Ok(GeneratedField::StatePatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -299,6 +304,9 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
                             state_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -368,6 +376,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
             Version,
             Range,
             StateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -393,7 +402,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             "version" => Ok(GeneratedField::Version),
                             "range" => Ok(GeneratedField::Range),
                             "state" | "state_json" => Ok(GeneratedField::StateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -443,6 +452,9 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             state_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -515,6 +527,7 @@ impl<'de> serde::Deserialize<'de> for request::Read {
             Uuid,
             Shuffle,
             DocJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -540,7 +553,7 @@ impl<'de> serde::Deserialize<'de> for request::Read {
                             "uuid" => Ok(GeneratedField::Uuid),
                             "shuffle" => Ok(GeneratedField::Shuffle),
                             "doc" | "doc_json" => Ok(GeneratedField::DocJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -592,6 +605,9 @@ impl<'de> serde::Deserialize<'de> for request::Read {
                             doc_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -658,6 +674,7 @@ impl<'de> serde::Deserialize<'de> for request::read::Shuffle {
             KeyJson,
             Packed,
             Hash,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -682,7 +699,7 @@ impl<'de> serde::Deserialize<'de> for request::read::Shuffle {
                             "key" | "key_json" => Ok(GeneratedField::KeyJson),
                             "packed" => Ok(GeneratedField::Packed),
                             "hash" => Ok(GeneratedField::Hash),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -730,6 +747,9 @@ impl<'de> serde::Deserialize<'de> for request::read::Shuffle {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(request::read::Shuffle {
@@ -765,6 +785,7 @@ impl<'de> serde::Deserialize<'de> for request::Reset {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -785,7 +806,7 @@ impl<'de> serde::Deserialize<'de> for request::Reset {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -858,6 +879,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
         enum GeneratedField {
             ConnectorType,
             ConfigJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -881,7 +903,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                         match value {
                             "connectorType" | "connector_type" => Ok(GeneratedField::ConnectorType),
                             "config" | "config_json" => Ok(GeneratedField::ConfigJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -917,6 +939,9 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                             config_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -961,6 +986,7 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RuntimeCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -983,7 +1009,7 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
                     {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1010,6 +1036,9 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
                                 return Err(serde::de::Error::duplicate_field("runtimeCheckpoint"));
                             }
                             runtime_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1131,6 +1160,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
             ImportMap,
             LastCollection,
             LastVersion,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1161,7 +1191,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                             "importMap" | "import_map" => Ok(GeneratedField::ImportMap),
                             "lastCollection" | "last_collection" => Ok(GeneratedField::LastCollection),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1248,6 +1278,9 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                                 return Err(serde::de::Error::duplicate_field("lastVersion"));
                             }
                             last_version__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1336,6 +1369,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Transform {
             ShuffleLambdaConfigJson,
             LambdaConfigJson,
             Backfill,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1362,7 +1396,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Transform {
                             "shuffleLambdaConfig" | "shuffle_lambda_config_json" => Ok(GeneratedField::ShuffleLambdaConfigJson),
                             "lambdaConfig" | "lambda_config_json" => Ok(GeneratedField::LambdaConfigJson),
                             "backfill" => Ok(GeneratedField::Backfill),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1423,6 +1457,9 @@ impl<'de> serde::Deserialize<'de> for request::validate::Transform {
                             backfill__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1521,6 +1558,7 @@ impl<'de> serde::Deserialize<'de> for Response {
             Flushed,
             StartedCommit,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1549,7 +1587,7 @@ impl<'de> serde::Deserialize<'de> for Response {
                             "flushed" => Ok(GeneratedField::Flushed),
                             "startedCommit" | "started_commit" => Ok(GeneratedField::StartedCommit),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1621,6 +1659,9 @@ impl<'de> serde::Deserialize<'de> for Response {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Response {
@@ -1676,6 +1717,7 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
         enum GeneratedField {
             State,
             More,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1699,7 +1741,7 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
                         match value {
                             "state" => Ok(GeneratedField::State),
                             "more" => Ok(GeneratedField::More),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1733,6 +1775,9 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
                                 return Err(serde::de::Error::duplicate_field("more"));
                             }
                             more__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1777,6 +1822,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RuntimeCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1799,7 +1845,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                     {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1826,6 +1872,9 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                                 return Err(serde::de::Error::duplicate_field("runtimeCheckpoint"));
                             }
                             runtime_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1871,6 +1920,7 @@ impl<'de> serde::Deserialize<'de> for response::Published {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             DocJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1893,7 +1943,7 @@ impl<'de> serde::Deserialize<'de> for response::Published {
                     {
                         match value {
                             "doc" | "doc_json" => Ok(GeneratedField::DocJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1922,6 +1972,9 @@ impl<'de> serde::Deserialize<'de> for response::Published {
                             doc_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2003,6 +2056,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
             ResourceConfigSchemaJson,
             DocumentationUrl,
             Oauth2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2029,7 +2083,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             "resourceConfigSchema" | "resource_config_schema_json" => Ok(GeneratedField::ResourceConfigSchemaJson),
                             "documentationUrl" | "documentation_url" => Ok(GeneratedField::DocumentationUrl),
                             "oauth2" => Ok(GeneratedField::Oauth2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2091,6 +2145,9 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             }
                             oauth2__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(response::Spec {
@@ -2136,6 +2193,7 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2158,7 +2216,7 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
                     {
                         match value {
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2185,6 +2243,9 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2236,6 +2297,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
         enum GeneratedField {
             Transforms,
             GeneratedFiles,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2259,7 +2321,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                         match value {
                             "transforms" => Ok(GeneratedField::Transforms),
                             "generatedFiles" | "generated_files" => Ok(GeneratedField::GeneratedFiles),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2295,6 +2357,9 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                             generated_files__ = Some(
                                 map_.next_value::<std::collections::BTreeMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2339,6 +2404,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Transform {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ReadOnly,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2361,7 +2427,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Transform {
                     {
                         match value {
                             "readOnly" | "read_only" => Ok(GeneratedField::ReadOnly),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2388,6 +2454,9 @@ impl<'de> serde::Deserialize<'de> for response::validated::Transform {
                                 return Err(serde::de::Error::duplicate_field("readOnly"));
                             }
                             read_only__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/flow.serde.rs
+++ b/crates/proto-flow/src/flow.serde.rs
@@ -32,6 +32,7 @@ impl<'de> serde::Deserialize<'de> for AdvanceTimeRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             AdvanceSeconds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -54,7 +55,7 @@ impl<'de> serde::Deserialize<'de> for AdvanceTimeRequest {
                     {
                         match value {
                             "advanceSeconds" | "advance_seconds" => Ok(GeneratedField::AdvanceSeconds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -83,6 +84,9 @@ impl<'de> serde::Deserialize<'de> for AdvanceTimeRequest {
                             advance_seconds__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -117,6 +121,7 @@ impl<'de> serde::Deserialize<'de> for AdvanceTimeResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -137,7 +142,7 @@ impl<'de> serde::Deserialize<'de> for AdvanceTimeResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -188,6 +193,7 @@ impl<'de> serde::Deserialize<'de> for BuildApi {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -208,7 +214,7 @@ impl<'de> serde::Deserialize<'de> for BuildApi {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -314,6 +320,7 @@ impl<'de> serde::Deserialize<'de> for build_api::Config {
             SourceType,
             ConnectorNetwork,
             ProjectRoot,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -341,7 +348,7 @@ impl<'de> serde::Deserialize<'de> for build_api::Config {
                             "sourceType" | "source_type" => Ok(GeneratedField::SourceType),
                             "connectorNetwork" | "connector_network" => Ok(GeneratedField::ConnectorNetwork),
                             "projectRoot" | "project_root" => Ok(GeneratedField::ProjectRoot),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -403,6 +410,9 @@ impl<'de> serde::Deserialize<'de> for build_api::Config {
                                 return Err(serde::de::Error::duplicate_field("projectRoot"));
                             }
                             project_root__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -536,6 +546,7 @@ impl<'de> serde::Deserialize<'de> for CaptureSpec {
             NetworkPorts,
             InactiveBindings,
             RedactSalt,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -567,7 +578,7 @@ impl<'de> serde::Deserialize<'de> for CaptureSpec {
                             "networkPorts" | "network_ports" => Ok(GeneratedField::NetworkPorts),
                             "inactiveBindings" | "inactive_bindings" => Ok(GeneratedField::InactiveBindings),
                             "redactSalt" | "redact_salt" => Ok(GeneratedField::RedactSalt),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -664,6 +675,9 @@ impl<'de> serde::Deserialize<'de> for CaptureSpec {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(CaptureSpec {
@@ -751,6 +765,7 @@ impl<'de> serde::Deserialize<'de> for capture_spec::Binding {
             Collection,
             Backfill,
             StateKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -777,7 +792,7 @@ impl<'de> serde::Deserialize<'de> for capture_spec::Binding {
                             "collection" => Ok(GeneratedField::Collection),
                             "backfill" => Ok(GeneratedField::Backfill),
                             "stateKey" | "state_key" => Ok(GeneratedField::StateKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -836,6 +851,9 @@ impl<'de> serde::Deserialize<'de> for capture_spec::Binding {
                                 return Err(serde::de::Error::duplicate_field("stateKey"));
                             }
                             state_key__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1040,6 +1058,7 @@ impl<'de> serde::Deserialize<'de> for CollectionSpec {
             AckTemplateJson,
             PartitionTemplate,
             Derivation,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1071,7 +1090,7 @@ impl<'de> serde::Deserialize<'de> for CollectionSpec {
                             "ackTemplate" | "ack_template_json" => Ok(GeneratedField::AckTemplateJson),
                             "partitionTemplate" | "partition_template" => Ok(GeneratedField::PartitionTemplate),
                             "derivation" => Ok(GeneratedField::Derivation),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1167,6 +1186,9 @@ impl<'de> serde::Deserialize<'de> for CollectionSpec {
                                 return Err(serde::de::Error::duplicate_field("derivation"));
                             }
                             derivation__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1300,6 +1322,7 @@ impl<'de> serde::Deserialize<'de> for collection_spec::Derivation {
             NetworkPorts,
             InactiveTransforms,
             RedactSalt,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1330,7 +1353,7 @@ impl<'de> serde::Deserialize<'de> for collection_spec::Derivation {
                             "networkPorts" | "network_ports" => Ok(GeneratedField::NetworkPorts),
                             "inactiveTransforms" | "inactive_transforms" => Ok(GeneratedField::InactiveTransforms),
                             "redactSalt" | "redact_salt" => Ok(GeneratedField::RedactSalt),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1417,6 +1440,9 @@ impl<'de> serde::Deserialize<'de> for collection_spec::Derivation {
                             redact_salt__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1745,6 +1771,7 @@ impl<'de> serde::Deserialize<'de> for collection_spec::derivation::Transform {
             NotAfter,
             Backfill,
             StateKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1780,7 +1807,7 @@ impl<'de> serde::Deserialize<'de> for collection_spec::derivation::Transform {
                             "notAfter" | "not_after" => Ok(GeneratedField::NotAfter),
                             "backfill" => Ok(GeneratedField::Backfill),
                             "stateKey" | "state_key" => Ok(GeneratedField::StateKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1909,6 +1936,9 @@ impl<'de> serde::Deserialize<'de> for collection_spec::derivation::Transform {
                             }
                             state_key__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(collection_spec::derivation::Transform {
@@ -1975,6 +2005,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorState {
         enum GeneratedField {
             UpdatedJson,
             MergePatch,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1998,7 +2029,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorState {
                         match value {
                             "updated" | "updated_json" => Ok(GeneratedField::UpdatedJson),
                             "mergePatch" | "merge_patch" => Ok(GeneratedField::MergePatch),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2034,6 +2065,9 @@ impl<'de> serde::Deserialize<'de> for ConnectorState {
                                 return Err(serde::de::Error::duplicate_field("mergePatch"));
                             }
                             merge_patch__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2146,6 +2180,7 @@ impl<'de> serde::Deserialize<'de> for ExtractApi {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2166,7 +2201,7 @@ impl<'de> serde::Deserialize<'de> for ExtractApi {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2334,6 +2369,7 @@ impl<'de> serde::Deserialize<'de> for extract_api::Config {
             SchemaJson,
             FieldPtrs,
             Projections,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2359,7 +2395,7 @@ impl<'de> serde::Deserialize<'de> for extract_api::Config {
                             "schemaJson" | "schema_json" => Ok(GeneratedField::SchemaJson),
                             "fieldPtrs" | "field_ptrs" => Ok(GeneratedField::FieldPtrs),
                             "projections" => Ok(GeneratedField::Projections),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2409,6 +2445,9 @@ impl<'de> serde::Deserialize<'de> for extract_api::Config {
                                 return Err(serde::de::Error::duplicate_field("projections"));
                             }
                             projections__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2479,6 +2518,7 @@ impl<'de> serde::Deserialize<'de> for FieldSelection {
             Values,
             Document,
             FieldConfigJsonMap,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2504,7 +2544,7 @@ impl<'de> serde::Deserialize<'de> for FieldSelection {
                             "values" => Ok(GeneratedField::Values),
                             "document" => Ok(GeneratedField::Document),
                             "fieldConfig" | "field_config_json_map" => Ok(GeneratedField::FieldConfigJsonMap),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2555,6 +2595,9 @@ impl<'de> serde::Deserialize<'de> for FieldSelection {
                                 map_.next_value::<std::collections::BTreeMap<_, crate::RawJSONDeserialize>>()?
                                     .into_iter().map(|(k,v)| (k, v.0)).collect()
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2707,6 +2750,7 @@ impl<'de> serde::Deserialize<'de> for Inference {
             Reduce,
             Redact,
             ContentMediaType,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2741,7 +2785,7 @@ impl<'de> serde::Deserialize<'de> for Inference {
                             "reduce" => Ok(GeneratedField::Reduce),
                             "redact" => Ok(GeneratedField::Redact),
                             "contentMediaType" | "content_media_type" => Ok(GeneratedField::ContentMediaType),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2858,6 +2902,9 @@ impl<'de> serde::Deserialize<'de> for Inference {
                             }
                             content_media_type__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Inference {
@@ -2939,6 +2986,7 @@ impl<'de> serde::Deserialize<'de> for inference::Array {
             HasMaxItems,
             MaxItems,
             ItemTypes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2964,7 +3012,7 @@ impl<'de> serde::Deserialize<'de> for inference::Array {
                             "hasMaxItems" | "has_max_items" => Ok(GeneratedField::HasMaxItems),
                             "maxItems" | "max_items" => Ok(GeneratedField::MaxItems),
                             "itemTypes" | "item_types" => Ok(GeneratedField::ItemTypes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3016,6 +3064,9 @@ impl<'de> serde::Deserialize<'de> for inference::Array {
                                 return Err(serde::de::Error::duplicate_field("itemTypes"));
                             }
                             item_types__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3167,6 +3218,7 @@ impl<'de> serde::Deserialize<'de> for inference::Numeric {
             Minimum,
             HasMaximum,
             Maximum,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3192,7 +3244,7 @@ impl<'de> serde::Deserialize<'de> for inference::Numeric {
                             "minimum" => Ok(GeneratedField::Minimum),
                             "hasMaximum" | "has_maximum" => Ok(GeneratedField::HasMaximum),
                             "maximum" => Ok(GeneratedField::Maximum),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3244,6 +3296,9 @@ impl<'de> serde::Deserialize<'de> for inference::Numeric {
                             maximum__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3509,6 +3564,7 @@ impl<'de> serde::Deserialize<'de> for inference::String {
             MaxLength,
             StrMinimum,
             StrMaximum,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3536,7 +3592,7 @@ impl<'de> serde::Deserialize<'de> for inference::String {
                             "maxLength" | "max_length" => Ok(GeneratedField::MaxLength),
                             "strMinimum" | "str_minimum" => Ok(GeneratedField::StrMinimum),
                             "strMaximum" | "str_maximum" => Ok(GeneratedField::StrMaximum),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3600,6 +3656,9 @@ impl<'de> serde::Deserialize<'de> for inference::String {
                                 return Err(serde::de::Error::duplicate_field("strMaximum"));
                             }
                             str_maximum__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3665,6 +3724,7 @@ impl<'de> serde::Deserialize<'de> for IngestRequest {
             Collection,
             BuildId,
             DocsJsonVec,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3689,7 +3749,7 @@ impl<'de> serde::Deserialize<'de> for IngestRequest {
                             "collection" => Ok(GeneratedField::Collection),
                             "buildId" | "build_id" => Ok(GeneratedField::BuildId),
                             "docs" | "docs_json_vec" => Ok(GeneratedField::DocsJsonVec),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3733,6 +3793,9 @@ impl<'de> serde::Deserialize<'de> for IngestRequest {
                                 Some(map_.next_value::<Vec<crate::RawJSONDeserialize>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3789,6 +3852,7 @@ impl<'de> serde::Deserialize<'de> for IngestResponse {
         enum GeneratedField {
             JournalWriteHeads,
             JournalEtcd,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3812,7 +3876,7 @@ impl<'de> serde::Deserialize<'de> for IngestResponse {
                         match value {
                             "journalWriteHeads" | "journal_write_heads" => Ok(GeneratedField::JournalWriteHeads),
                             "journalEtcd" | "journal_etcd" => Ok(GeneratedField::JournalEtcd),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3849,6 +3913,9 @@ impl<'de> serde::Deserialize<'de> for IngestResponse {
                                 return Err(serde::de::Error::duplicate_field("journalEtcd"));
                             }
                             journal_etcd__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3969,6 +4036,7 @@ impl<'de> serde::Deserialize<'de> for MaterializationSpec {
             NetworkPorts,
             InactiveBindings,
             TriggersJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3999,7 +4067,7 @@ impl<'de> serde::Deserialize<'de> for MaterializationSpec {
                             "networkPorts" | "network_ports" => Ok(GeneratedField::NetworkPorts),
                             "inactiveBindings" | "inactive_bindings" => Ok(GeneratedField::InactiveBindings),
                             "triggers" | "triggers_json" => Ok(GeneratedField::TriggersJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4086,6 +4154,9 @@ impl<'de> serde::Deserialize<'de> for MaterializationSpec {
                             triggers_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4253,6 +4324,7 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::Binding {
             Backfill,
             StateKey,
             SerPolicy,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4288,7 +4360,7 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::Binding {
                             "backfill" => Ok(GeneratedField::Backfill),
                             "stateKey" | "state_key" => Ok(GeneratedField::StateKey),
                             "serPolicy" | "ser_policy" => Ok(GeneratedField::SerPolicy),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4413,6 +4485,9 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::Binding {
                             }
                             ser_policy__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(materialization_spec::Binding {
@@ -4477,6 +4552,7 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::binding::DeprecatedS
         enum GeneratedField {
             GroupName,
             PartitionSelector,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4500,7 +4576,7 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::binding::DeprecatedS
                         match value {
                             "groupName" | "group_name" => Ok(GeneratedField::GroupName),
                             "partitionSelector" | "partition_selector" => Ok(GeneratedField::PartitionSelector),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4534,6 +4610,9 @@ impl<'de> serde::Deserialize<'de> for materialization_spec::binding::DeprecatedS
                                 return Err(serde::de::Error::duplicate_field("partitionSelector"));
                             }
                             partition_selector__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4670,6 +4749,7 @@ impl<'de> serde::Deserialize<'de> for NetworkPort {
             Number,
             Protocol,
             Public,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4694,7 +4774,7 @@ impl<'de> serde::Deserialize<'de> for NetworkPort {
                             "number" => Ok(GeneratedField::Number),
                             "protocol" => Ok(GeneratedField::Protocol),
                             "public" => Ok(GeneratedField::Public),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4737,6 +4817,9 @@ impl<'de> serde::Deserialize<'de> for NetworkPort {
                                 return Err(serde::de::Error::duplicate_field("public"));
                             }
                             public__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4880,6 +4963,7 @@ impl<'de> serde::Deserialize<'de> for OAuth2 {
             RefreshTokenBody,
             RefreshTokenHeadersJsonMap,
             RefreshTokenResponseJsonMap,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4913,7 +4997,7 @@ impl<'de> serde::Deserialize<'de> for OAuth2 {
                             "refreshTokenBody" | "refresh_token_body" => Ok(GeneratedField::RefreshTokenBody),
                             "refreshTokenHeaders" | "refresh_token_headers_json_map" => Ok(GeneratedField::RefreshTokenHeadersJsonMap),
                             "refreshTokenResponseMap" | "refresh_token_response_json_map" => Ok(GeneratedField::RefreshTokenResponseJsonMap),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5030,6 +5114,9 @@ impl<'de> serde::Deserialize<'de> for OAuth2 {
                                     .into_iter().map(|(k,v)| (k, v.0)).collect()
                             );
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(OAuth2 {
@@ -5124,6 +5211,7 @@ impl<'de> serde::Deserialize<'de> for Projection {
             IsPartitionKey,
             IsPrimaryKey,
             Inference,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5151,7 +5239,7 @@ impl<'de> serde::Deserialize<'de> for Projection {
                             "isPartitionKey" | "is_partition_key" => Ok(GeneratedField::IsPartitionKey),
                             "isPrimaryKey" | "is_primary_key" => Ok(GeneratedField::IsPrimaryKey),
                             "inference" => Ok(GeneratedField::Inference),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5213,6 +5301,9 @@ impl<'de> serde::Deserialize<'de> for Projection {
                                 return Err(serde::de::Error::duplicate_field("inference"));
                             }
                             inference__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5288,6 +5379,7 @@ impl<'de> serde::Deserialize<'de> for RangeSpec {
             KeyEnd,
             RClockBegin,
             RClockEnd,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5313,7 +5405,7 @@ impl<'de> serde::Deserialize<'de> for RangeSpec {
                             "keyEnd" | "key_end" => Ok(GeneratedField::KeyEnd),
                             "rClockBegin" | "r_clock_begin" => Ok(GeneratedField::RClockBegin),
                             "rClockEnd" | "r_clock_end" => Ok(GeneratedField::RClockEnd),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5370,6 +5462,9 @@ impl<'de> serde::Deserialize<'de> for RangeSpec {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(RangeSpec {
@@ -5406,6 +5501,7 @@ impl<'de> serde::Deserialize<'de> for ResetStateRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5426,7 +5522,7 @@ impl<'de> serde::Deserialize<'de> for ResetStateRequest {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -5477,6 +5573,7 @@ impl<'de> serde::Deserialize<'de> for ResetStateResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5497,7 +5594,7 @@ impl<'de> serde::Deserialize<'de> for ResetStateResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -5575,6 +5672,7 @@ impl<'de> serde::Deserialize<'de> for SerPolicy {
             StrTruncateAfter,
             NestedObjTruncateAfter,
             ArrayTruncateAfter,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5599,7 +5697,7 @@ impl<'de> serde::Deserialize<'de> for SerPolicy {
                             "strTruncateAfter" | "str_truncate_after" => Ok(GeneratedField::StrTruncateAfter),
                             "nestedObjTruncateAfter" | "nested_obj_truncate_after" => Ok(GeneratedField::NestedObjTruncateAfter),
                             "arrayTruncateAfter" | "array_truncate_after" => Ok(GeneratedField::ArrayTruncateAfter),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5646,6 +5744,9 @@ impl<'de> serde::Deserialize<'de> for SerPolicy {
                             array_truncate_after__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5698,6 +5799,7 @@ impl<'de> serde::Deserialize<'de> for Slice {
         enum GeneratedField {
             Begin,
             End,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5721,7 +5823,7 @@ impl<'de> serde::Deserialize<'de> for Slice {
                         match value {
                             "begin" => Ok(GeneratedField::Begin),
                             "end" => Ok(GeneratedField::End),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5759,6 +5861,9 @@ impl<'de> serde::Deserialize<'de> for Slice {
                             end__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5812,6 +5917,7 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyRequest {
         enum GeneratedField {
             Open,
             Data,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5835,7 +5941,7 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyRequest {
                         match value {
                             "open" => Ok(GeneratedField::Open),
                             "data" => Ok(GeneratedField::Data),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5871,6 +5977,9 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyRequest {
                             data__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5941,6 +6050,7 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_request::Open {
             ShardId,
             TargetPort,
             ClientAddr,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5966,7 +6076,7 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_request::Open {
                             "shardId" | "shard_id" => Ok(GeneratedField::ShardId),
                             "targetPort" | "target_port" => Ok(GeneratedField::TargetPort),
                             "clientAddr" | "client_addr" => Ok(GeneratedField::ClientAddr),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6016,6 +6126,9 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_request::Open {
                                 return Err(serde::de::Error::duplicate_field("clientAddr"));
                             }
                             client_addr__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6072,6 +6185,7 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyResponse {
         enum GeneratedField {
             OpenResponse,
             Data,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6095,7 +6209,7 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyResponse {
                         match value {
                             "openResponse" | "open_response" => Ok(GeneratedField::OpenResponse),
                             "data" => Ok(GeneratedField::Data),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6131,6 +6245,9 @@ impl<'de> serde::Deserialize<'de> for TaskNetworkProxyResponse {
                             data__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6184,6 +6301,7 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_response::OpenResponse 
         enum GeneratedField {
             Status,
             Header,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6207,7 +6325,7 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_response::OpenResponse 
                         match value {
                             "status" => Ok(GeneratedField::Status),
                             "header" => Ok(GeneratedField::Header),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6241,6 +6359,9 @@ impl<'de> serde::Deserialize<'de> for task_network_proxy_response::OpenResponse 
                                 return Err(serde::de::Error::duplicate_field("header"));
                             }
                             header__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6378,6 +6499,7 @@ impl<'de> serde::Deserialize<'de> for TestSpec {
         enum GeneratedField {
             Name,
             Steps,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6401,7 +6523,7 @@ impl<'de> serde::Deserialize<'de> for TestSpec {
                         match value {
                             "name" => Ok(GeneratedField::Name),
                             "steps" => Ok(GeneratedField::Steps),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6435,6 +6557,9 @@ impl<'de> serde::Deserialize<'de> for TestSpec {
                                 return Err(serde::de::Error::duplicate_field("steps"));
                             }
                             steps__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6532,6 +6657,7 @@ impl<'de> serde::Deserialize<'de> for test_spec::Step {
             Collection,
             DocsJsonVec,
             Partitions,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6560,7 +6686,7 @@ impl<'de> serde::Deserialize<'de> for test_spec::Step {
                             "collection" => Ok(GeneratedField::Collection),
                             "docs" | "docs_json_vec" => Ok(GeneratedField::DocsJsonVec),
                             "partitions" => Ok(GeneratedField::Partitions),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6634,6 +6760,9 @@ impl<'de> serde::Deserialize<'de> for test_spec::Step {
                                 return Err(serde::de::Error::duplicate_field("partitions"));
                             }
                             partitions__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6765,6 +6894,7 @@ impl<'de> serde::Deserialize<'de> for UuidParts {
         enum GeneratedField {
             Node,
             Clock,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6788,7 +6918,7 @@ impl<'de> serde::Deserialize<'de> for UuidParts {
                         match value {
                             "node" => Ok(GeneratedField::Node),
                             "clock" => Ok(GeneratedField::Clock),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6826,6 +6956,9 @@ impl<'de> serde::Deserialize<'de> for UuidParts {
                             clock__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/materialize.serde.rs
+++ b/crates/proto-flow/src/materialize.serde.rs
@@ -21,6 +21,7 @@ impl<'de> serde::Deserialize<'de> for Extra {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -41,7 +42,7 @@ impl<'de> serde::Deserialize<'de> for Extra {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -108,6 +109,7 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateBindingAgainstConstraints {
         enum GeneratedField {
             Binding,
             Constraints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -131,7 +133,7 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateBindingAgainstConstraints {
                         match value {
                             "binding" => Ok(GeneratedField::Binding),
                             "constraints" => Ok(GeneratedField::Constraints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -167,6 +169,9 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateBindingAgainstConstraints {
                             constraints__ = Some(
                                 map_.next_value::<std::collections::BTreeMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -220,6 +225,7 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateExistingProjectionRequest {
         enum GeneratedField {
             ExistingBinding,
             ProposedBinding,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -243,7 +249,7 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateExistingProjectionRequest {
                         match value {
                             "existingBinding" | "existing_binding" => Ok(GeneratedField::ExistingBinding),
                             "proposedBinding" | "proposed_binding" => Ok(GeneratedField::ProposedBinding),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -277,6 +283,9 @@ impl<'de> serde::Deserialize<'de> for extra::ValidateExistingProjectionRequest {
                                 return Err(serde::de::Error::duplicate_field("proposedBinding"));
                             }
                             proposed_binding__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -396,6 +405,7 @@ impl<'de> serde::Deserialize<'de> for Request {
             StartCommit,
             Acknowledge,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -427,7 +437,7 @@ impl<'de> serde::Deserialize<'de> for Request {
                             "startCommit" | "start_commit" => Ok(GeneratedField::StartCommit),
                             "acknowledge" => Ok(GeneratedField::Acknowledge),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -520,6 +530,9 @@ impl<'de> serde::Deserialize<'de> for Request {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Request {
@@ -573,6 +586,7 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             StatePatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -595,7 +609,7 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
                     {
                         match value {
                             "statePatches" | "state_patches_json" => Ok(GeneratedField::StatePatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -624,6 +638,9 @@ impl<'de> serde::Deserialize<'de> for request::Acknowledge {
                             state_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -703,6 +720,7 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
             LastMaterialization,
             LastVersion,
             StateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -729,7 +747,7 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
                             "lastMaterialization" | "last_materialization" => Ok(GeneratedField::LastMaterialization),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
                             "state" | "state_json" => Ok(GeneratedField::StateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -787,6 +805,9 @@ impl<'de> serde::Deserialize<'de> for request::Apply {
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(request::Apply {
@@ -835,6 +856,7 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             StatePatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -857,7 +879,7 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
                     {
                         match value {
                             "statePatches" | "state_patches_json" => Ok(GeneratedField::StatePatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -886,6 +908,9 @@ impl<'de> serde::Deserialize<'de> for request::Flush {
                             state_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -950,6 +975,7 @@ impl<'de> serde::Deserialize<'de> for request::Load {
             Binding,
             KeyJson,
             KeyPacked,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -974,7 +1000,7 @@ impl<'de> serde::Deserialize<'de> for request::Load {
                             "binding" => Ok(GeneratedField::Binding),
                             "key" | "key_json" => Ok(GeneratedField::KeyJson),
                             "keyPacked" | "key_packed" => Ok(GeneratedField::KeyPacked),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1021,6 +1047,9 @@ impl<'de> serde::Deserialize<'de> for request::Load {
                             key_packed__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1092,6 +1121,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
             Version,
             Range,
             StateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1117,7 +1147,7 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             "version" => Ok(GeneratedField::Version),
                             "range" => Ok(GeneratedField::Range),
                             "state" | "state_json" => Ok(GeneratedField::StateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1167,6 +1197,9 @@ impl<'de> serde::Deserialize<'de> for request::Open {
                             state_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1226,6 +1259,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
         enum GeneratedField {
             ConnectorType,
             ConfigJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1249,7 +1283,7 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                         match value {
                             "connectorType" | "connector_type" => Ok(GeneratedField::ConnectorType),
                             "config" | "config_json" => Ok(GeneratedField::ConfigJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1285,6 +1319,9 @@ impl<'de> serde::Deserialize<'de> for request::Spec {
                             config_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1340,6 +1377,7 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
         enum GeneratedField {
             RuntimeCheckpoint,
             StatePatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1363,7 +1401,7 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
                             "statePatches" | "state_patches_json" => Ok(GeneratedField::StatePatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1399,6 +1437,9 @@ impl<'de> serde::Deserialize<'de> for request::StartCommit {
                             state_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1513,6 +1554,7 @@ impl<'de> serde::Deserialize<'de> for request::Store {
             DocJson,
             Exists,
             Delete,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1542,7 +1584,7 @@ impl<'de> serde::Deserialize<'de> for request::Store {
                             "doc" | "doc_json" => Ok(GeneratedField::DocJson),
                             "exists" => Ok(GeneratedField::Exists),
                             "delete" => Ok(GeneratedField::Delete),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1630,6 +1672,9 @@ impl<'de> serde::Deserialize<'de> for request::Store {
                                 return Err(serde::de::Error::duplicate_field("delete"));
                             }
                             delete__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1727,6 +1772,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
             Bindings,
             LastMaterialization,
             LastVersion,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1754,7 +1800,7 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                             "bindings" => Ok(GeneratedField::Bindings),
                             "lastMaterialization" | "last_materialization" => Ok(GeneratedField::LastMaterialization),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1818,6 +1864,9 @@ impl<'de> serde::Deserialize<'de> for request::Validate {
                                 return Err(serde::de::Error::duplicate_field("lastVersion"));
                             }
                             last_version__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1902,6 +1951,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
             FieldConfigJsonMap,
             Backfill,
             GroupBy,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1928,7 +1978,7 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
                             "fieldConfig" | "field_config_json_map" => Ok(GeneratedField::FieldConfigJsonMap),
                             "backfill" => Ok(GeneratedField::Backfill),
                             "groupBy" | "group_by" => Ok(GeneratedField::GroupBy),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1990,6 +2040,9 @@ impl<'de> serde::Deserialize<'de> for request::validate::Binding {
                                 return Err(serde::de::Error::duplicate_field("groupBy"));
                             }
                             group_by__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2104,6 +2157,7 @@ impl<'de> serde::Deserialize<'de> for Response {
             StartedCommit,
             Acknowledged,
             Internal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2134,7 +2188,7 @@ impl<'de> serde::Deserialize<'de> for Response {
                             "startedCommit" | "started_commit" => Ok(GeneratedField::StartedCommit),
                             "acknowledged" => Ok(GeneratedField::Acknowledged),
                             "$internal" | "internal" => Ok(GeneratedField::Internal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2220,6 +2274,9 @@ impl<'de> serde::Deserialize<'de> for Response {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Response {
@@ -2269,6 +2326,7 @@ impl<'de> serde::Deserialize<'de> for response::Acknowledged {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2291,7 +2349,7 @@ impl<'de> serde::Deserialize<'de> for response::Acknowledged {
                     {
                         match value {
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2318,6 +2376,9 @@ impl<'de> serde::Deserialize<'de> for response::Acknowledged {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2369,6 +2430,7 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
         enum GeneratedField {
             ActionDescription,
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2392,7 +2454,7 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
                         match value {
                             "actionDescription" | "action_description" => Ok(GeneratedField::ActionDescription),
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2426,6 +2488,9 @@ impl<'de> serde::Deserialize<'de> for response::Applied {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2469,6 +2534,7 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2491,7 +2557,7 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
                     {
                         match value {
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2518,6 +2584,9 @@ impl<'de> serde::Deserialize<'de> for response::Flushed {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2571,6 +2640,7 @@ impl<'de> serde::Deserialize<'de> for response::Loaded {
         enum GeneratedField {
             Binding,
             DocJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2594,7 +2664,7 @@ impl<'de> serde::Deserialize<'de> for response::Loaded {
                         match value {
                             "binding" => Ok(GeneratedField::Binding),
                             "doc" | "doc_json" => Ok(GeneratedField::DocJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2632,6 +2702,9 @@ impl<'de> serde::Deserialize<'de> for response::Loaded {
                             doc_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2685,6 +2758,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
         enum GeneratedField {
             RuntimeCheckpoint,
             DisableLoadOptimization,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2708,7 +2782,7 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
                             "disableLoadOptimization" | "disable_load_optimization" => Ok(GeneratedField::DisableLoadOptimization),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2742,6 +2816,9 @@ impl<'de> serde::Deserialize<'de> for response::Opened {
                                 return Err(serde::de::Error::duplicate_field("disableLoadOptimization"));
                             }
                             disable_load_optimization__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2824,6 +2901,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
             ResourceConfigSchemaJson,
             DocumentationUrl,
             Oauth2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2850,7 +2928,7 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             "resourceConfigSchema" | "resource_config_schema_json" => Ok(GeneratedField::ResourceConfigSchemaJson),
                             "documentationUrl" | "documentation_url" => Ok(GeneratedField::DocumentationUrl),
                             "oauth2" => Ok(GeneratedField::Oauth2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2912,6 +2990,9 @@ impl<'de> serde::Deserialize<'de> for response::Spec {
                             }
                             oauth2__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(response::Spec {
@@ -2957,6 +3038,7 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2979,7 +3061,7 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
                     {
                         match value {
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3006,6 +3088,9 @@ impl<'de> serde::Deserialize<'de> for response::StartedCommit {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3048,6 +3133,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bindings,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3070,7 +3156,7 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                     {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3097,6 +3183,9 @@ impl<'de> serde::Deserialize<'de> for response::Validated {
                                 return Err(serde::de::Error::duplicate_field("bindings"));
                             }
                             bindings__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3184,6 +3273,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
             DeltaUpdates,
             SerPolicy,
             ProjectionConstraints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3211,7 +3301,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
                             "deltaUpdates" | "delta_updates" => Ok(GeneratedField::DeltaUpdates),
                             "serPolicy" | "ser_policy" => Ok(GeneratedField::SerPolicy),
                             "projectionConstraints" | "projection_constraints" => Ok(GeneratedField::ProjectionConstraints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3275,6 +3365,9 @@ impl<'de> serde::Deserialize<'de> for response::validated::Binding {
                                 return Err(serde::de::Error::duplicate_field("projectionConstraints"));
                             }
                             projection_constraints__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3341,6 +3434,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Constraint {
             Type,
             Reason,
             FoldedField,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3365,7 +3459,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::Constraint {
                             "type" => Ok(GeneratedField::Type),
                             "reason" => Ok(GeneratedField::Reason),
                             "foldedField" | "folded_field" => Ok(GeneratedField::FoldedField),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3406,6 +3500,9 @@ impl<'de> serde::Deserialize<'de> for response::validated::Constraint {
                                 return Err(serde::de::Error::duplicate_field("foldedField"));
                             }
                             folded_field__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3547,6 +3644,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::ProjectionConstraint 
         enum GeneratedField {
             Field,
             Constraint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3570,7 +3668,7 @@ impl<'de> serde::Deserialize<'de> for response::validated::ProjectionConstraint 
                         match value {
                             "field" => Ok(GeneratedField::Field),
                             "constraint" => Ok(GeneratedField::Constraint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3604,6 +3702,9 @@ impl<'de> serde::Deserialize<'de> for response::validated::ProjectionConstraint 
                                 return Err(serde::de::Error::duplicate_field("constraint"));
                             }
                             constraint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/ops.serde.rs
+++ b/crates/proto-flow/src/ops.serde.rs
@@ -82,6 +82,7 @@ impl<'de> serde::Deserialize<'de> for Log {
             Message,
             FieldsJsonMap,
             Spans,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -110,7 +111,7 @@ impl<'de> serde::Deserialize<'de> for Log {
                             "message" => Ok(GeneratedField::Message),
                             "fields" | "fields_json_map" => Ok(GeneratedField::FieldsJsonMap),
                             "spans" => Ok(GeneratedField::Spans),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -182,6 +183,9 @@ impl<'de> serde::Deserialize<'de> for Log {
                                 return Err(serde::de::Error::duplicate_field("spans"));
                             }
                             spans__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -313,6 +317,7 @@ impl<'de> serde::Deserialize<'de> for Meta {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Uuid,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -335,7 +340,7 @@ impl<'de> serde::Deserialize<'de> for Meta {
                     {
                         match value {
                             "uuid" => Ok(GeneratedField::Uuid),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -362,6 +367,9 @@ impl<'de> serde::Deserialize<'de> for Meta {
                                 return Err(serde::de::Error::duplicate_field("uuid"));
                             }
                             uuid__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -495,6 +503,7 @@ impl<'de> serde::Deserialize<'de> for ShardLabeling {
             LogsJournal,
             StatsJournal,
             Flags,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -527,7 +536,7 @@ impl<'de> serde::Deserialize<'de> for ShardLabeling {
                             "logsJournal" | "logs_journal" => Ok(GeneratedField::LogsJournal),
                             "statsJournal" | "stats_journal" => Ok(GeneratedField::StatsJournal),
                             "flags" => Ok(GeneratedField::Flags),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -627,6 +636,9 @@ impl<'de> serde::Deserialize<'de> for ShardLabeling {
                                 map_.next_value::<std::collections::BTreeMap<_, _>>()?
                             );
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ShardLabeling {
@@ -714,6 +726,7 @@ impl<'de> serde::Deserialize<'de> for ShardRef {
             KeyBegin,
             RClockBegin,
             Build,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -740,7 +753,7 @@ impl<'de> serde::Deserialize<'de> for ShardRef {
                             "keyBegin" | "key_begin" => Ok(GeneratedField::KeyBegin),
                             "rClockBegin" | "r_clock_begin" => Ok(GeneratedField::RClockBegin),
                             "build" => Ok(GeneratedField::Build),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -795,6 +808,9 @@ impl<'de> serde::Deserialize<'de> for ShardRef {
                                 return Err(serde::de::Error::duplicate_field("build"));
                             }
                             build__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -909,6 +925,7 @@ impl<'de> serde::Deserialize<'de> for Stats {
             Derive,
             Materialize,
             Interval,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -939,7 +956,7 @@ impl<'de> serde::Deserialize<'de> for Stats {
                             "derive" => Ok(GeneratedField::Derive),
                             "materialize" => Ok(GeneratedField::Materialize),
                             "interval" => Ok(GeneratedField::Interval),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1031,6 +1048,9 @@ impl<'de> serde::Deserialize<'de> for Stats {
                             }
                             interval__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Stats {
@@ -1097,6 +1117,7 @@ impl<'de> serde::Deserialize<'de> for stats::CaptureBinding {
             Right,
             Out,
             LastPublishedAt,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1121,7 +1142,7 @@ impl<'de> serde::Deserialize<'de> for stats::CaptureBinding {
                             "right" => Ok(GeneratedField::Right),
                             "out" => Ok(GeneratedField::Out),
                             "lastPublishedAt" | "last_published_at" => Ok(GeneratedField::LastPublishedAt),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1162,6 +1183,9 @@ impl<'de> serde::Deserialize<'de> for stats::CaptureBinding {
                                 return Err(serde::de::Error::duplicate_field("lastPublishedAt"));
                             }
                             last_published_at__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1231,6 +1255,7 @@ impl<'de> serde::Deserialize<'de> for stats::Derive {
             Published,
             Out,
             LastPublishedAt,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1256,7 +1281,7 @@ impl<'de> serde::Deserialize<'de> for stats::Derive {
                             "published" => Ok(GeneratedField::Published),
                             "out" => Ok(GeneratedField::Out),
                             "lastPublishedAt" | "last_published_at" => Ok(GeneratedField::LastPublishedAt),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1306,6 +1331,9 @@ impl<'de> serde::Deserialize<'de> for stats::Derive {
                                 return Err(serde::de::Error::duplicate_field("lastPublishedAt"));
                             }
                             last_published_at__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1379,6 +1407,7 @@ impl<'de> serde::Deserialize<'de> for stats::derive::Transform {
             Input,
             LastSourcePublishedAt,
             BytesBehind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1404,7 +1433,7 @@ impl<'de> serde::Deserialize<'de> for stats::derive::Transform {
                             "input" => Ok(GeneratedField::Input),
                             "lastSourcePublishedAt" | "last_source_published_at" => Ok(GeneratedField::LastSourcePublishedAt),
                             "bytesBehind" | "bytes_behind" => Ok(GeneratedField::BytesBehind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1454,6 +1483,9 @@ impl<'de> serde::Deserialize<'de> for stats::derive::Transform {
                             bytes_behind__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1513,6 +1545,7 @@ impl<'de> serde::Deserialize<'de> for stats::DocsAndBytes {
         enum GeneratedField {
             DocsTotal,
             BytesTotal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1536,7 +1569,7 @@ impl<'de> serde::Deserialize<'de> for stats::DocsAndBytes {
                         match value {
                             "docsTotal" | "docs_total" => Ok(GeneratedField::DocsTotal),
                             "bytesTotal" | "bytes_total" => Ok(GeneratedField::BytesTotal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1574,6 +1607,9 @@ impl<'de> serde::Deserialize<'de> for stats::DocsAndBytes {
                             bytes_total__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1627,6 +1663,7 @@ impl<'de> serde::Deserialize<'de> for stats::Interval {
         enum GeneratedField {
             UptimeSeconds,
             UsageRate,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1650,7 +1687,7 @@ impl<'de> serde::Deserialize<'de> for stats::Interval {
                         match value {
                             "uptimeSeconds" | "uptime_seconds" => Ok(GeneratedField::UptimeSeconds),
                             "usageRate" | "usage_rate" => Ok(GeneratedField::UsageRate),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1688,6 +1725,9 @@ impl<'de> serde::Deserialize<'de> for stats::Interval {
                             usage_rate__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1767,6 +1807,7 @@ impl<'de> serde::Deserialize<'de> for stats::MaterializeBinding {
             Out,
             LastSourcePublishedAt,
             BytesBehind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1793,7 +1834,7 @@ impl<'de> serde::Deserialize<'de> for stats::MaterializeBinding {
                             "out" => Ok(GeneratedField::Out),
                             "lastSourcePublishedAt" | "last_source_published_at" => Ok(GeneratedField::LastSourcePublishedAt),
                             "bytesBehind" | "bytes_behind" => Ok(GeneratedField::BytesBehind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1850,6 +1891,9 @@ impl<'de> serde::Deserialize<'de> for stats::MaterializeBinding {
                             bytes_behind__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/runtime.serde.rs
+++ b/crates/proto-flow/src/runtime.serde.rs
@@ -41,6 +41,7 @@ impl<'de> serde::Deserialize<'de> for Applied {
         enum GeneratedField {
             ActionDescription,
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -64,7 +65,7 @@ impl<'de> serde::Deserialize<'de> for Applied {
                         match value {
                             "actionDescription" | "action_description" => Ok(GeneratedField::ActionDescription),
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -100,6 +101,9 @@ impl<'de> serde::Deserialize<'de> for Applied {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -184,6 +188,7 @@ impl<'de> serde::Deserialize<'de> for Apply {
             LastSpec,
             LastVersion,
             ConnectorStateJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -210,7 +215,7 @@ impl<'de> serde::Deserialize<'de> for Apply {
                             "lastSpec" | "last_spec" => Ok(GeneratedField::LastSpec),
                             "lastVersion" | "last_version" => Ok(GeneratedField::LastVersion),
                             "connectorStateJson" | "connector_state_json" => Ok(GeneratedField::ConnectorStateJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -271,6 +276,9 @@ impl<'de> serde::Deserialize<'de> for Apply {
                             connector_state_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -435,6 +443,7 @@ impl<'de> serde::Deserialize<'de> for Capture {
             CloseNow,
             Stop,
             Stopped,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -471,7 +480,7 @@ impl<'de> serde::Deserialize<'de> for Capture {
                             "closeNow" | "close_now" => Ok(GeneratedField::CloseNow),
                             "stop" => Ok(GeneratedField::Stop),
                             "stopped" => Ok(GeneratedField::Stopped),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -597,6 +606,9 @@ impl<'de> serde::Deserialize<'de> for Capture {
                             }
                             stopped__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Capture {
@@ -652,6 +664,7 @@ impl<'de> serde::Deserialize<'de> for capture::Opened {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Container,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -674,7 +687,7 @@ impl<'de> serde::Deserialize<'de> for capture::Opened {
                     {
                         match value {
                             "container" => Ok(GeneratedField::Container),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -701,6 +714,9 @@ impl<'de> serde::Deserialize<'de> for capture::Opened {
                                 return Err(serde::de::Error::duplicate_field("container"));
                             }
                             container__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -764,6 +780,7 @@ impl<'de> serde::Deserialize<'de> for CaptureRequestExt {
             LogLevel,
             RocksdbDescriptor,
             StartCommit,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -788,7 +805,7 @@ impl<'de> serde::Deserialize<'de> for CaptureRequestExt {
                             "logLevel" | "log_level" => Ok(GeneratedField::LogLevel),
                             "rocksdbDescriptor" | "rocksdb_descriptor" => Ok(GeneratedField::RocksdbDescriptor),
                             "startCommit" | "start_commit" => Ok(GeneratedField::StartCommit),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -829,6 +846,9 @@ impl<'de> serde::Deserialize<'de> for CaptureRequestExt {
                                 return Err(serde::de::Error::duplicate_field("startCommit"));
                             }
                             start_commit__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -874,6 +894,7 @@ impl<'de> serde::Deserialize<'de> for capture_request_ext::StartCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RuntimeCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -896,7 +917,7 @@ impl<'de> serde::Deserialize<'de> for capture_request_ext::StartCommit {
                     {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -923,6 +944,9 @@ impl<'de> serde::Deserialize<'de> for capture_request_ext::StartCommit {
                                 return Err(serde::de::Error::duplicate_field("runtimeCheckpoint"));
                             }
                             runtime_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -989,6 +1013,7 @@ impl<'de> serde::Deserialize<'de> for CaptureResponseExt {
             Opened,
             Captured,
             Checkpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1014,7 +1039,7 @@ impl<'de> serde::Deserialize<'de> for CaptureResponseExt {
                             "opened" => Ok(GeneratedField::Opened),
                             "captured" => Ok(GeneratedField::Captured),
                             "checkpoint" => Ok(GeneratedField::Checkpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1062,6 +1087,9 @@ impl<'de> serde::Deserialize<'de> for CaptureResponseExt {
                                 return Err(serde::de::Error::duplicate_field("checkpoint"));
                             }
                             checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1121,6 +1149,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Captured {
         enum GeneratedField {
             KeyPacked,
             PartitionsPacked,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1144,7 +1173,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Captured {
                         match value {
                             "keyPacked" | "key_packed" => Ok(GeneratedField::KeyPacked),
                             "partitionsPacked" | "partitions_packed" => Ok(GeneratedField::PartitionsPacked),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1182,6 +1211,9 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Captured {
                             partitions_packed__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1236,6 +1268,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Checkpoint {
         enum GeneratedField {
             Stats,
             PollResult,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1259,7 +1292,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Checkpoint {
                         match value {
                             "stats" => Ok(GeneratedField::Stats),
                             "pollResult" | "poll_result" => Ok(GeneratedField::PollResult),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1293,6 +1326,9 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Checkpoint {
                                 return Err(serde::de::Error::duplicate_field("pollResult"));
                             }
                             poll_result__ = Some(map_.next_value::<capture_response_ext::PollResult>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1337,6 +1373,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Opened {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RuntimeCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1359,7 +1396,7 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Opened {
                     {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1386,6 +1423,9 @@ impl<'de> serde::Deserialize<'de> for capture_response_ext::Opened {
                                 return Err(serde::de::Error::duplicate_field("runtimeCheckpoint"));
                             }
                             runtime_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1500,6 +1540,7 @@ impl<'de> serde::Deserialize<'de> for CloseNow {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1520,7 +1561,7 @@ impl<'de> serde::Deserialize<'de> for CloseNow {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -1587,6 +1628,7 @@ impl<'de> serde::Deserialize<'de> for CombineRequest {
         enum GeneratedField {
             Open,
             Add,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1610,7 +1652,7 @@ impl<'de> serde::Deserialize<'de> for CombineRequest {
                         match value {
                             "open" => Ok(GeneratedField::Open),
                             "add" => Ok(GeneratedField::Add),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1644,6 +1686,9 @@ impl<'de> serde::Deserialize<'de> for CombineRequest {
                                 return Err(serde::de::Error::duplicate_field("add"));
                             }
                             add__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1706,6 +1751,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::Add {
             Binding,
             DocJson,
             Front,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1730,7 +1776,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::Add {
                             "binding" => Ok(GeneratedField::Binding),
                             "docJson" | "doc_json" => Ok(GeneratedField::DocJson),
                             "front" => Ok(GeneratedField::Front),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1776,6 +1822,9 @@ impl<'de> serde::Deserialize<'de> for combine_request::Add {
                             }
                             front__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(combine_request::Add {
@@ -1819,6 +1868,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::Open {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bindings,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1841,7 +1891,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::Open {
                     {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1868,6 +1918,9 @@ impl<'de> serde::Deserialize<'de> for combine_request::Open {
                                 return Err(serde::de::Error::duplicate_field("bindings"));
                             }
                             bindings__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1963,6 +2016,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::open::Binding {
             SerPolicy,
             UuidPtr,
             Values,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1991,7 +2045,7 @@ impl<'de> serde::Deserialize<'de> for combine_request::open::Binding {
                             "serPolicy" | "ser_policy" => Ok(GeneratedField::SerPolicy),
                             "uuidPtr" | "uuid_ptr" => Ok(GeneratedField::UuidPtr),
                             "values" => Ok(GeneratedField::Values),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2062,6 +2116,9 @@ impl<'de> serde::Deserialize<'de> for combine_request::open::Binding {
                                 return Err(serde::de::Error::duplicate_field("values"));
                             }
                             values__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2159,6 +2216,7 @@ impl<'de> serde::Deserialize<'de> for CombineResponse {
             Front,
             KeyPacked,
             ValuesPacked,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2186,7 +2244,7 @@ impl<'de> serde::Deserialize<'de> for CombineResponse {
                             "front" => Ok(GeneratedField::Front),
                             "keyPacked" | "key_packed" => Ok(GeneratedField::KeyPacked),
                             "valuesPacked" | "values_packed" => Ok(GeneratedField::ValuesPacked),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2257,6 +2315,9 @@ impl<'de> serde::Deserialize<'de> for CombineResponse {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(CombineResponse {
@@ -2295,6 +2356,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorProxyRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2315,7 +2377,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorProxyRequest {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2391,6 +2453,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorProxyResponse {
             Address,
             ProxyId,
             Log,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2415,7 +2478,7 @@ impl<'de> serde::Deserialize<'de> for ConnectorProxyResponse {
                             "address" => Ok(GeneratedField::Address),
                             "proxyId" | "proxy_id" => Ok(GeneratedField::ProxyId),
                             "log" => Ok(GeneratedField::Log),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2456,6 +2519,9 @@ impl<'de> serde::Deserialize<'de> for ConnectorProxyResponse {
                                 return Err(serde::de::Error::duplicate_field("log"));
                             }
                             log__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2528,6 +2594,7 @@ impl<'de> serde::Deserialize<'de> for Container {
             NetworkPorts,
             MappedHostPorts,
             UsageRate,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2553,7 +2620,7 @@ impl<'de> serde::Deserialize<'de> for Container {
                             "networkPorts" | "network_ports" => Ok(GeneratedField::NetworkPorts),
                             "mappedHostPorts" | "mapped_host_ports" => Ok(GeneratedField::MappedHostPorts),
                             "usageRate" | "usage_rate" => Ok(GeneratedField::UsageRate),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2606,6 +2673,9 @@ impl<'de> serde::Deserialize<'de> for Container {
                             usage_rate__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2851,6 +2921,7 @@ impl<'de> serde::Deserialize<'de> for Derive {
             CloseNow,
             Stop,
             Stopped,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2897,7 +2968,7 @@ impl<'de> serde::Deserialize<'de> for Derive {
                             "closeNow" | "close_now" => Ok(GeneratedField::CloseNow),
                             "stop" => Ok(GeneratedField::Stop),
                             "stopped" => Ok(GeneratedField::Stopped),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3093,6 +3164,9 @@ impl<'de> serde::Deserialize<'de> for Derive {
                             }
                             stopped__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Derive {
@@ -3161,6 +3235,7 @@ impl<'de> serde::Deserialize<'de> for derive::Flush {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3183,7 +3258,7 @@ impl<'de> serde::Deserialize<'de> for derive::Flush {
                     {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3212,6 +3287,9 @@ impl<'de> serde::Deserialize<'de> for derive::Flush {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3265,6 +3343,7 @@ impl<'de> serde::Deserialize<'de> for derive::Flushed {
         enum GeneratedField {
             ConnectorPatchesJson,
             More,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3288,7 +3367,7 @@ impl<'de> serde::Deserialize<'de> for derive::Flushed {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
                             "more" => Ok(GeneratedField::More),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3324,6 +3403,9 @@ impl<'de> serde::Deserialize<'de> for derive::Flushed {
                                 return Err(serde::de::Error::duplicate_field("more"));
                             }
                             more__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3367,6 +3449,7 @@ impl<'de> serde::Deserialize<'de> for derive::Load {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Frontier,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3389,7 +3472,7 @@ impl<'de> serde::Deserialize<'de> for derive::Load {
                     {
                         match value {
                             "frontier" => Ok(GeneratedField::Frontier),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3416,6 +3499,9 @@ impl<'de> serde::Deserialize<'de> for derive::Load {
                                 return Err(serde::de::Error::duplicate_field("frontier"));
                             }
                             frontier__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3469,6 +3555,7 @@ impl<'de> serde::Deserialize<'de> for derive::Loaded {
         enum GeneratedField {
             Bindings,
             CombinerUsageBytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3492,7 +3579,7 @@ impl<'de> serde::Deserialize<'de> for derive::Loaded {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
                             "combinerUsageBytes" | "combiner_usage_bytes" => Ok(GeneratedField::CombinerUsageBytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3528,6 +3615,9 @@ impl<'de> serde::Deserialize<'de> for derive::Loaded {
                             combiner_usage_bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3615,6 +3705,7 @@ impl<'de> serde::Deserialize<'de> for derive::loaded::Binding {
             MaxSourceClock,
             SourcedDocsTotal,
             SourcedBytesTotal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3641,7 +3732,7 @@ impl<'de> serde::Deserialize<'de> for derive::loaded::Binding {
                             "maxSourceClock" | "max_source_clock" => Ok(GeneratedField::MaxSourceClock),
                             "sourcedDocsTotal" | "sourced_docs_total" => Ok(GeneratedField::SourcedDocsTotal),
                             "sourcedBytesTotal" | "sourced_bytes_total" => Ok(GeneratedField::SourcedBytesTotal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3707,6 +3798,9 @@ impl<'de> serde::Deserialize<'de> for derive::loaded::Binding {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(derive::loaded::Binding {
@@ -3761,6 +3855,7 @@ impl<'de> serde::Deserialize<'de> for derive::Opened {
         enum GeneratedField {
             Container,
             ConnectorCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3784,7 +3879,7 @@ impl<'de> serde::Deserialize<'de> for derive::Opened {
                         match value {
                             "container" => Ok(GeneratedField::Container),
                             "connectorCheckpoint" | "connector_checkpoint" => Ok(GeneratedField::ConnectorCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3818,6 +3913,9 @@ impl<'de> serde::Deserialize<'de> for derive::Opened {
                                 return Err(serde::de::Error::duplicate_field("connectorCheckpoint"));
                             }
                             connector_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3862,6 +3960,7 @@ impl<'de> serde::Deserialize<'de> for derive::StartCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3884,7 +3983,7 @@ impl<'de> serde::Deserialize<'de> for derive::StartCommit {
                     {
                         match value {
                             "connectorCheckpoint" | "connector_checkpoint" => Ok(GeneratedField::ConnectorCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3911,6 +4010,9 @@ impl<'de> serde::Deserialize<'de> for derive::StartCommit {
                                 return Err(serde::de::Error::duplicate_field("connectorCheckpoint"));
                             }
                             connector_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3945,6 +4047,7 @@ impl<'de> serde::Deserialize<'de> for derive::StartedCommit {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3965,7 +4068,7 @@ impl<'de> serde::Deserialize<'de> for derive::StartedCommit {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -4016,6 +4119,7 @@ impl<'de> serde::Deserialize<'de> for derive::Store {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4036,7 +4140,7 @@ impl<'de> serde::Deserialize<'de> for derive::Store {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -4140,6 +4244,7 @@ impl<'de> serde::Deserialize<'de> for derive::Stored {
             DrainedDocsTotal,
             DrainedBytesTotal,
             PublisherCommit,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4166,7 +4271,7 @@ impl<'de> serde::Deserialize<'de> for derive::Stored {
                             "drainedDocsTotal" | "drained_docs_total" => Ok(GeneratedField::DrainedDocsTotal),
                             "drainedBytesTotal" | "drained_bytes_total" => Ok(GeneratedField::DrainedBytesTotal),
                             "publisherCommit" | "publisher_commit" => Ok(GeneratedField::PublisherCommit),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4229,6 +4334,9 @@ impl<'de> serde::Deserialize<'de> for derive::Stored {
                                 return Err(serde::de::Error::duplicate_field("publisherCommit"));
                             }
                             publisher_commit__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4295,6 +4403,7 @@ impl<'de> serde::Deserialize<'de> for derive::stored::PublisherCommit {
             Producer,
             Clock,
             Journals,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4319,7 +4428,7 @@ impl<'de> serde::Deserialize<'de> for derive::stored::PublisherCommit {
                             "producer" => Ok(GeneratedField::Producer),
                             "clock" => Ok(GeneratedField::Clock),
                             "journals" => Ok(GeneratedField::Journals),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4364,6 +4473,9 @@ impl<'de> serde::Deserialize<'de> for derive::stored::PublisherCommit {
                                 return Err(serde::de::Error::duplicate_field("journals"));
                             }
                             journals__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4428,6 +4540,7 @@ impl<'de> serde::Deserialize<'de> for DeriveRequestExt {
             LogLevel,
             RocksdbDescriptor,
             Open,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4452,7 +4565,7 @@ impl<'de> serde::Deserialize<'de> for DeriveRequestExt {
                             "logLevel" | "log_level" => Ok(GeneratedField::LogLevel),
                             "rocksdbDescriptor" | "rocksdb_descriptor" => Ok(GeneratedField::RocksdbDescriptor),
                             "open" => Ok(GeneratedField::Open),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4493,6 +4606,9 @@ impl<'de> serde::Deserialize<'de> for DeriveRequestExt {
                                 return Err(serde::de::Error::duplicate_field("open"));
                             }
                             open__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4538,6 +4654,7 @@ impl<'de> serde::Deserialize<'de> for derive_request_ext::Open {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             SqliteVfsUri,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4560,7 +4677,7 @@ impl<'de> serde::Deserialize<'de> for derive_request_ext::Open {
                     {
                         match value {
                             "sqliteVfsUri" | "sqlite_vfs_uri" => Ok(GeneratedField::SqliteVfsUri),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4587,6 +4704,9 @@ impl<'de> serde::Deserialize<'de> for derive_request_ext::Open {
                                 return Err(serde::de::Error::duplicate_field("sqliteVfsUri"));
                             }
                             sqlite_vfs_uri__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4653,6 +4773,7 @@ impl<'de> serde::Deserialize<'de> for DeriveResponseExt {
             Opened,
             Published,
             Flushed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4678,7 +4799,7 @@ impl<'de> serde::Deserialize<'de> for DeriveResponseExt {
                             "opened" => Ok(GeneratedField::Opened),
                             "published" => Ok(GeneratedField::Published),
                             "flushed" => Ok(GeneratedField::Flushed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4727,6 +4848,9 @@ impl<'de> serde::Deserialize<'de> for DeriveResponseExt {
                             }
                             flushed__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(DeriveResponseExt {
@@ -4771,6 +4895,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Flushed {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Stats,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4793,7 +4918,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Flushed {
                     {
                         match value {
                             "stats" => Ok(GeneratedField::Stats),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4820,6 +4945,9 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Flushed {
                                 return Err(serde::de::Error::duplicate_field("stats"));
                             }
                             stats__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4863,6 +4991,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Opened {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RuntimeCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4885,7 +5014,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Opened {
                     {
                         match value {
                             "runtimeCheckpoint" | "runtime_checkpoint" => Ok(GeneratedField::RuntimeCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4912,6 +5041,9 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Opened {
                                 return Err(serde::de::Error::duplicate_field("runtimeCheckpoint"));
                             }
                             runtime_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4979,6 +5111,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Published {
             MaxClock,
             KeyPacked,
             PartitionsPacked,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5003,7 +5136,7 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Published {
                             "maxClock" | "max_clock" => Ok(GeneratedField::MaxClock),
                             "keyPacked" | "key_packed" => Ok(GeneratedField::KeyPacked),
                             "partitionsPacked" | "partitions_packed" => Ok(GeneratedField::PartitionsPacked),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5050,6 +5183,9 @@ impl<'de> serde::Deserialize<'de> for derive_response_ext::Published {
                             partitions_packed__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5141,6 +5277,7 @@ impl<'de> serde::Deserialize<'de> for Join {
             ShuffleDirectory,
             ShuffleEndpoint,
             LeaderEndpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5168,7 +5305,7 @@ impl<'de> serde::Deserialize<'de> for Join {
                             "shuffleDirectory" | "shuffle_directory" => Ok(GeneratedField::ShuffleDirectory),
                             "shuffleEndpoint" | "shuffle_endpoint" => Ok(GeneratedField::ShuffleEndpoint),
                             "leaderEndpoint" | "leader_endpoint" => Ok(GeneratedField::LeaderEndpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5234,6 +5371,9 @@ impl<'de> serde::Deserialize<'de> for Join {
                                 return Err(serde::de::Error::duplicate_field("leaderEndpoint"));
                             }
                             leader_endpoint__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5308,6 +5448,7 @@ impl<'de> serde::Deserialize<'de> for join::Shard {
             Labeling,
             Reactor,
             EtcdCreateRevision,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5333,7 +5474,7 @@ impl<'de> serde::Deserialize<'de> for join::Shard {
                             "labeling" => Ok(GeneratedField::Labeling),
                             "reactor" => Ok(GeneratedField::Reactor),
                             "etcdCreateRevision" | "etcd_create_revision" => Ok(GeneratedField::EtcdCreateRevision),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5384,6 +5525,9 @@ impl<'de> serde::Deserialize<'de> for join::Shard {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(join::Shard {
@@ -5431,6 +5575,7 @@ impl<'de> serde::Deserialize<'de> for Joined {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             MaxEtcdRevision,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5453,7 +5598,7 @@ impl<'de> serde::Deserialize<'de> for Joined {
                     {
                         match value {
                             "maxEtcdRevision" | "max_etcd_revision" => Ok(GeneratedField::MaxEtcdRevision),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5482,6 +5627,9 @@ impl<'de> serde::Deserialize<'de> for Joined {
                             max_etcd_revision__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5756,6 +5904,7 @@ impl<'de> serde::Deserialize<'de> for Materialize {
             CloseNow,
             Stop,
             Stopped,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5806,7 +5955,7 @@ impl<'de> serde::Deserialize<'de> for Materialize {
                             "closeNow" | "close_now" => Ok(GeneratedField::CloseNow),
                             "stop" => Ok(GeneratedField::Stop),
                             "stopped" => Ok(GeneratedField::Stopped),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6030,6 +6179,9 @@ impl<'de> serde::Deserialize<'de> for Materialize {
                             }
                             stopped__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Materialize {
@@ -6102,6 +6254,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledge {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6124,7 +6277,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledge {
                     {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6153,6 +6306,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledge {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6198,6 +6354,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledged {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6220,7 +6377,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledged {
                     {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6249,6 +6406,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Acknowledged {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6294,6 +6454,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Flush {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6316,7 +6477,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Flush {
                     {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6345,6 +6506,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Flush {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6398,6 +6562,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Flushed {
         enum GeneratedField {
             Bindings,
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6421,7 +6586,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Flushed {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6457,6 +6622,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Flushed {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6522,6 +6690,7 @@ impl<'de> serde::Deserialize<'de> for materialize::flushed::Binding {
             Index,
             LoadedDocsTotal,
             LoadedBytesTotal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6546,7 +6715,7 @@ impl<'de> serde::Deserialize<'de> for materialize::flushed::Binding {
                             "index" => Ok(GeneratedField::Index),
                             "loadedDocsTotal" | "loaded_docs_total" => Ok(GeneratedField::LoadedDocsTotal),
                             "loadedBytesTotal" | "loaded_bytes_total" => Ok(GeneratedField::LoadedBytesTotal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6594,6 +6763,9 @@ impl<'de> serde::Deserialize<'de> for materialize::flushed::Binding {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(materialize::flushed::Binding {
@@ -6637,6 +6809,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Load {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Frontier,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6659,7 +6832,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Load {
                     {
                         match value {
                             "frontier" => Ok(GeneratedField::Frontier),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6686,6 +6859,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Load {
                                 return Err(serde::de::Error::duplicate_field("frontier"));
                             }
                             frontier__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6739,6 +6915,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Loaded {
         enum GeneratedField {
             Bindings,
             CombinerUsageBytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6762,7 +6939,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Loaded {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
                             "combinerUsageBytes" | "combiner_usage_bytes" => Ok(GeneratedField::CombinerUsageBytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6798,6 +6975,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Loaded {
                             combiner_usage_bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6896,6 +7076,7 @@ impl<'de> serde::Deserialize<'de> for materialize::loaded::Binding {
             SourcedDocsTotal,
             SourcedBytesTotal,
             MaxKeyDelta,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6923,7 +7104,7 @@ impl<'de> serde::Deserialize<'de> for materialize::loaded::Binding {
                             "sourcedDocsTotal" | "sourced_docs_total" => Ok(GeneratedField::SourcedDocsTotal),
                             "sourcedBytesTotal" | "sourced_bytes_total" => Ok(GeneratedField::SourcedBytesTotal),
                             "maxKeyDelta" | "max_key_delta" => Ok(GeneratedField::MaxKeyDelta),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6998,6 +7179,9 @@ impl<'de> serde::Deserialize<'de> for materialize::loaded::Binding {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(materialize::loaded::Binding {
@@ -7053,6 +7237,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Opened {
         enum GeneratedField {
             Container,
             ConnectorCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7076,7 +7261,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Opened {
                         match value {
                             "container" => Ok(GeneratedField::Container),
                             "connectorCheckpoint" | "connector_checkpoint" => Ok(GeneratedField::ConnectorCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7110,6 +7295,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Opened {
                                 return Err(serde::de::Error::duplicate_field("connectorCheckpoint"));
                             }
                             connector_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7165,6 +7353,7 @@ impl<'de> serde::Deserialize<'de> for materialize::StartCommit {
         enum GeneratedField {
             ConnectorPatchesJson,
             ConnectorCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7188,7 +7377,7 @@ impl<'de> serde::Deserialize<'de> for materialize::StartCommit {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
                             "connectorCheckpoint" | "connector_checkpoint" => Ok(GeneratedField::ConnectorCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7224,6 +7413,9 @@ impl<'de> serde::Deserialize<'de> for materialize::StartCommit {
                                 return Err(serde::de::Error::duplicate_field("connectorCheckpoint"));
                             }
                             connector_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7270,6 +7462,7 @@ impl<'de> serde::Deserialize<'de> for materialize::StartedCommit {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ConnectorPatchesJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7292,7 +7485,7 @@ impl<'de> serde::Deserialize<'de> for materialize::StartedCommit {
                     {
                         match value {
                             "connectorPatches" | "connector_patches_json" => Ok(GeneratedField::ConnectorPatchesJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7321,6 +7514,9 @@ impl<'de> serde::Deserialize<'de> for materialize::StartedCommit {
                             connector_patches_json__ = 
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7355,6 +7551,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Store {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7375,7 +7572,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Store {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -7434,6 +7631,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Stored {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bindings,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7456,7 +7654,7 @@ impl<'de> serde::Deserialize<'de> for materialize::Stored {
                     {
                         match value {
                             "bindings" => Ok(GeneratedField::Bindings),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7483,6 +7681,9 @@ impl<'de> serde::Deserialize<'de> for materialize::Stored {
                                 return Err(serde::de::Error::duplicate_field("bindings"));
                             }
                             bindings__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7547,6 +7748,7 @@ impl<'de> serde::Deserialize<'de> for materialize::stored::Binding {
             Index,
             StoredDocsTotal,
             StoredBytesTotal,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7571,7 +7773,7 @@ impl<'de> serde::Deserialize<'de> for materialize::stored::Binding {
                             "index" => Ok(GeneratedField::Index),
                             "storedDocsTotal" | "stored_docs_total" => Ok(GeneratedField::StoredDocsTotal),
                             "storedBytesTotal" | "stored_bytes_total" => Ok(GeneratedField::StoredBytesTotal),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7618,6 +7820,9 @@ impl<'de> serde::Deserialize<'de> for materialize::stored::Binding {
                             stored_bytes_total__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7674,6 +7879,7 @@ impl<'de> serde::Deserialize<'de> for MaterializeRequestExt {
         enum GeneratedField {
             LogLevel,
             RocksdbDescriptor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7697,7 +7903,7 @@ impl<'de> serde::Deserialize<'de> for MaterializeRequestExt {
                         match value {
                             "logLevel" | "log_level" => Ok(GeneratedField::LogLevel),
                             "rocksdbDescriptor" | "rocksdb_descriptor" => Ok(GeneratedField::RocksdbDescriptor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7731,6 +7937,9 @@ impl<'de> serde::Deserialize<'de> for MaterializeRequestExt {
                                 return Err(serde::de::Error::duplicate_field("rocksdbDescriptor"));
                             }
                             rocksdb_descriptor__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7782,6 +7991,7 @@ impl<'de> serde::Deserialize<'de> for MaterializeResponseExt {
         enum GeneratedField {
             Container,
             Flushed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7805,7 +8015,7 @@ impl<'de> serde::Deserialize<'de> for MaterializeResponseExt {
                         match value {
                             "container" => Ok(GeneratedField::Container),
                             "flushed" => Ok(GeneratedField::Flushed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7839,6 +8049,9 @@ impl<'de> serde::Deserialize<'de> for MaterializeResponseExt {
                                 return Err(serde::de::Error::duplicate_field("flushed"));
                             }
                             flushed__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -7882,6 +8095,7 @@ impl<'de> serde::Deserialize<'de> for materialize_response_ext::Flushed {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Stats,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -7904,7 +8118,7 @@ impl<'de> serde::Deserialize<'de> for materialize_response_ext::Flushed {
                     {
                         match value {
                             "stats" => Ok(GeneratedField::Stats),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -7931,6 +8145,9 @@ impl<'de> serde::Deserialize<'de> for materialize_response_ext::Flushed {
                                 return Err(serde::de::Error::duplicate_field("stats"));
                             }
                             stats__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -8013,6 +8230,7 @@ impl<'de> serde::Deserialize<'de> for Open {
             Range,
             ConnectorStateJson,
             MaxKeys,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -8039,7 +8257,7 @@ impl<'de> serde::Deserialize<'de> for Open {
                             "range" => Ok(GeneratedField::Range),
                             "state" | "connector_state_json" => Ok(GeneratedField::ConnectorStateJson),
                             "maxKeys" | "max_keys" => Ok(GeneratedField::MaxKeys),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -8101,6 +8319,9 @@ impl<'de> serde::Deserialize<'de> for Open {
                                 map_.next_value::<std::collections::BTreeMap<::pbjson::private::NumberDeserialize<u32>, ::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|(k,v)| (k.0, v.0)).collect()
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -8299,6 +8520,7 @@ impl<'de> serde::Deserialize<'de> for Persist {
             MaxKeys,
             DeleteTriggerParams,
             TriggerParamsJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -8336,7 +8558,7 @@ impl<'de> serde::Deserialize<'de> for Persist {
                             "maxKeys" | "max_keys" => Ok(GeneratedField::MaxKeys),
                             "deleteTriggerParams" | "delete_trigger_params" => Ok(GeneratedField::DeleteTriggerParams),
                             "triggerParams" | "trigger_params_json" => Ok(GeneratedField::TriggerParamsJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -8487,6 +8709,9 @@ impl<'de> serde::Deserialize<'de> for Persist {
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Persist {
@@ -8546,6 +8771,7 @@ impl<'de> serde::Deserialize<'de> for Persisted {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             SeqNo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -8568,7 +8794,7 @@ impl<'de> serde::Deserialize<'de> for Persisted {
                     {
                         match value {
                             "seqNo" | "seq_no" => Ok(GeneratedField::SeqNo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -8597,6 +8823,9 @@ impl<'de> serde::Deserialize<'de> for Persisted {
                             seq_no__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -8809,6 +9038,7 @@ impl<'de> serde::Deserialize<'de> for Recover {
             LegacyCheckpoint,
             MaxKeys,
             TriggerParamsJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -8840,7 +9070,7 @@ impl<'de> serde::Deserialize<'de> for Recover {
                             "legacyCheckpoint" | "legacy_checkpoint" => Ok(GeneratedField::LegacyCheckpoint),
                             "maxKeys" | "max_keys" => Ok(GeneratedField::MaxKeys),
                             "triggerParams" | "trigger_params_json" => Ok(GeneratedField::TriggerParamsJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -8947,6 +9177,9 @@ impl<'de> serde::Deserialize<'de> for Recover {
                                 Some(map_.next_value::<crate::RawJSONDeserialize>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Recover {
@@ -9009,6 +9242,7 @@ impl<'de> serde::Deserialize<'de> for RocksDbDescriptor {
         enum GeneratedField {
             RocksdbEnvMemptr,
             RocksdbPath,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9032,7 +9266,7 @@ impl<'de> serde::Deserialize<'de> for RocksDbDescriptor {
                         match value {
                             "rocksdbEnvMemptr" | "rocksdb_env_memptr" => Ok(GeneratedField::RocksdbEnvMemptr),
                             "rocksdbPath" | "rocksdb_path" => Ok(GeneratedField::RocksdbPath),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -9068,6 +9302,9 @@ impl<'de> serde::Deserialize<'de> for RocksDbDescriptor {
                                 return Err(serde::de::Error::duplicate_field("rocksdbPath"));
                             }
                             rocksdb_path__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -9112,6 +9349,7 @@ impl<'de> serde::Deserialize<'de> for SessionLoop {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RocksdbDescriptor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9134,7 +9372,7 @@ impl<'de> serde::Deserialize<'de> for SessionLoop {
                     {
                         match value {
                             "rocksdbDescriptor" | "rocksdb_descriptor" => Ok(GeneratedField::RocksdbDescriptor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -9161,6 +9399,9 @@ impl<'de> serde::Deserialize<'de> for SessionLoop {
                                 return Err(serde::de::Error::duplicate_field("rocksdbDescriptor"));
                             }
                             rocksdb_descriptor__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -9290,6 +9531,7 @@ impl<'de> serde::Deserialize<'de> for ShuffleRequest {
             ShuffleIndex,
             Derivation,
             Materialization,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9322,7 +9564,7 @@ impl<'de> serde::Deserialize<'de> for ShuffleRequest {
                             "shuffleIndex" | "shuffle_index" => Ok(GeneratedField::ShuffleIndex),
                             "derivation" => Ok(GeneratedField::Derivation),
                             "materialization" => Ok(GeneratedField::Materialization),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -9425,6 +9667,9 @@ impl<'de> serde::Deserialize<'de> for ShuffleRequest {
                                 return Err(serde::de::Error::duplicate_field("materialization"));
                             }
                             materialization__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -9562,6 +9807,7 @@ impl<'de> serde::Deserialize<'de> for ShuffleResponse {
             Offsets,
             UuidParts,
             PackedKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9593,7 +9839,7 @@ impl<'de> serde::Deserialize<'de> for ShuffleResponse {
                             "offsets" => Ok(GeneratedField::Offsets),
                             "uuidParts" | "uuid_parts" => Ok(GeneratedField::UuidParts),
                             "packedKey" | "packed_key" => Ok(GeneratedField::PackedKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -9693,6 +9939,9 @@ impl<'de> serde::Deserialize<'de> for ShuffleResponse {
                             }
                             packed_key__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ShuffleResponse {
@@ -9735,6 +9984,7 @@ impl<'de> serde::Deserialize<'de> for Stop {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9755,7 +10005,7 @@ impl<'de> serde::Deserialize<'de> for Stop {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -9806,6 +10056,7 @@ impl<'de> serde::Deserialize<'de> for Stopped {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9826,7 +10077,7 @@ impl<'de> serde::Deserialize<'de> for Stopped {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -9924,6 +10175,7 @@ impl<'de> serde::Deserialize<'de> for Task {
             MaxTransactions,
             SqliteVfsUri,
             PublisherId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -9950,7 +10202,7 @@ impl<'de> serde::Deserialize<'de> for Task {
                             "maxTransactions" | "max_transactions" => Ok(GeneratedField::MaxTransactions),
                             "sqliteVfsUri" | "sqlite_vfs_uri" => Ok(GeneratedField::SqliteVfsUri),
                             "publisherId" | "publisher_id" => Ok(GeneratedField::PublisherId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -10011,6 +10263,9 @@ impl<'de> serde::Deserialize<'de> for Task {
                             publisher_id__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -10095,6 +10350,7 @@ impl<'de> serde::Deserialize<'de> for TaskServiceConfig {
             UdsPath,
             ContainerNetwork,
             Plane,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -10121,7 +10377,7 @@ impl<'de> serde::Deserialize<'de> for TaskServiceConfig {
                             "udsPath" | "uds_path" => Ok(GeneratedField::UdsPath),
                             "containerNetwork" | "container_network" => Ok(GeneratedField::ContainerNetwork),
                             "plane" => Ok(GeneratedField::Plane),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -10178,6 +10434,9 @@ impl<'de> serde::Deserialize<'de> for TaskServiceConfig {
                                 return Err(serde::de::Error::duplicate_field("plane"));
                             }
                             plane__ = Some(map_.next_value::<Plane>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-flow/src/shuffle.serde.rs
+++ b/crates/proto-flow/src/shuffle.serde.rs
@@ -56,6 +56,7 @@ impl<'de> serde::Deserialize<'de> for CollectionPartitions {
             PartitionSelector,
             NotBefore,
             NotAfter,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -81,7 +82,7 @@ impl<'de> serde::Deserialize<'de> for CollectionPartitions {
                             "partitionSelector" | "partition_selector" => Ok(GeneratedField::PartitionSelector),
                             "notBefore" | "not_before" => Ok(GeneratedField::NotBefore),
                             "notAfter" | "not_after" => Ok(GeneratedField::NotAfter),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -129,6 +130,9 @@ impl<'de> serde::Deserialize<'de> for CollectionPartitions {
                                 return Err(serde::de::Error::duplicate_field("notAfter"));
                             }
                             not_after__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -183,6 +187,7 @@ impl<'de> serde::Deserialize<'de> for Frontier {
         enum GeneratedField {
             Journals,
             FlushedLsn,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -206,7 +211,7 @@ impl<'de> serde::Deserialize<'de> for Frontier {
                         match value {
                             "journals" => Ok(GeneratedField::Journals),
                             "flushedLsn" | "flushed_lsn" => Ok(GeneratedField::FlushedLsn),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -243,6 +248,9 @@ impl<'de> serde::Deserialize<'de> for Frontier {
                                 Some(map_.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -334,6 +342,7 @@ impl<'de> serde::Deserialize<'de> for JournalFrontier {
             BytesReadDelta,
             BytesBehindDelta,
             Producers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -361,7 +370,7 @@ impl<'de> serde::Deserialize<'de> for JournalFrontier {
                             "bytesReadDelta" | "bytes_read_delta" => Ok(GeneratedField::BytesReadDelta),
                             "bytesBehindDelta" | "bytes_behind_delta" => Ok(GeneratedField::BytesBehindDelta),
                             "producers" => Ok(GeneratedField::Producers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -432,6 +441,9 @@ impl<'de> serde::Deserialize<'de> for JournalFrontier {
                             }
                             producers__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(JournalFrontier {
@@ -494,6 +506,7 @@ impl<'de> serde::Deserialize<'de> for LogRequest {
             Open,
             Append,
             Flush,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -518,7 +531,7 @@ impl<'de> serde::Deserialize<'de> for LogRequest {
                             "open" => Ok(GeneratedField::Open),
                             "append" => Ok(GeneratedField::Append),
                             "flush" => Ok(GeneratedField::Flush),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -559,6 +572,9 @@ impl<'de> serde::Deserialize<'de> for LogRequest {
                                 return Err(serde::de::Error::duplicate_field("flush"));
                             }
                             flush__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -699,6 +715,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Append {
             PackedKey,
             DocArchived,
             SourceByteLength,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -731,7 +748,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Append {
                             "packedKey" | "packed_key" => Ok(GeneratedField::PackedKey),
                             "docArchived" | "doc_archived" => Ok(GeneratedField::DocArchived),
                             "sourceByteLength" | "source_byte_length" => Ok(GeneratedField::SourceByteLength),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -849,6 +866,9 @@ impl<'de> serde::Deserialize<'de> for log_request::Append {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(log_request::Append {
@@ -902,6 +922,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Flush {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Cycle,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -924,7 +945,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Flush {
                     {
                         match value {
                             "cycle" => Ok(GeneratedField::Cycle),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -953,6 +974,9 @@ impl<'de> serde::Deserialize<'de> for log_request::Flush {
                             cycle__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1022,6 +1046,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Open {
             Shards,
             SliceShardIndex,
             LogShardIndex,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1047,7 +1072,7 @@ impl<'de> serde::Deserialize<'de> for log_request::Open {
                             "shards" => Ok(GeneratedField::Shards),
                             "sliceShardIndex" | "slice_shard_index" => Ok(GeneratedField::SliceShardIndex),
                             "logShardIndex" | "log_shard_index" => Ok(GeneratedField::LogShardIndex),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1102,6 +1127,9 @@ impl<'de> serde::Deserialize<'de> for log_request::Open {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(log_request::Open {
@@ -1154,6 +1182,7 @@ impl<'de> serde::Deserialize<'de> for LogResponse {
         enum GeneratedField {
             Opened,
             Flushed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1177,7 +1206,7 @@ impl<'de> serde::Deserialize<'de> for LogResponse {
                         match value {
                             "opened" => Ok(GeneratedField::Opened),
                             "flushed" => Ok(GeneratedField::Flushed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1211,6 +1240,9 @@ impl<'de> serde::Deserialize<'de> for LogResponse {
                                 return Err(serde::de::Error::duplicate_field("flushed"));
                             }
                             flushed__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1267,6 +1299,7 @@ impl<'de> serde::Deserialize<'de> for log_response::Flushed {
         enum GeneratedField {
             Cycle,
             FlushedLsn,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1290,7 +1323,7 @@ impl<'de> serde::Deserialize<'de> for log_response::Flushed {
                         match value {
                             "cycle" => Ok(GeneratedField::Cycle),
                             "flushedLsn" | "flushed_lsn" => Ok(GeneratedField::FlushedLsn),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1329,6 +1362,9 @@ impl<'de> serde::Deserialize<'de> for log_response::Flushed {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(log_response::Flushed {
@@ -1363,6 +1399,7 @@ impl<'de> serde::Deserialize<'de> for log_response::Opened {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1383,7 +1420,7 @@ impl<'de> serde::Deserialize<'de> for log_response::Opened {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -1476,6 +1513,7 @@ impl<'de> serde::Deserialize<'de> for ProducerFrontier {
             LastCommit,
             HintedCommit,
             Offset,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1501,7 +1539,7 @@ impl<'de> serde::Deserialize<'de> for ProducerFrontier {
                             "lastCommit" | "last_commit" => Ok(GeneratedField::LastCommit),
                             "hintedCommit" | "hinted_commit" => Ok(GeneratedField::HintedCommit),
                             "offset" => Ok(GeneratedField::Offset),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1557,6 +1595,9 @@ impl<'de> serde::Deserialize<'de> for ProducerFrontier {
                             offset__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1620,6 +1661,7 @@ impl<'de> serde::Deserialize<'de> for SessionRequest {
             Open,
             ResumeCheckpoint,
             NextCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1644,7 +1686,7 @@ impl<'de> serde::Deserialize<'de> for SessionRequest {
                             "open" => Ok(GeneratedField::Open),
                             "resumeCheckpoint" | "resume_checkpoint" => Ok(GeneratedField::ResumeCheckpoint),
                             "nextCheckpoint" | "next_checkpoint" => Ok(GeneratedField::NextCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1686,6 +1728,9 @@ impl<'de> serde::Deserialize<'de> for SessionRequest {
                             }
                             next_checkpoint__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(SessionRequest {
@@ -1721,6 +1766,7 @@ impl<'de> serde::Deserialize<'de> for session_request::NextCheckpoint {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1741,7 +1787,7 @@ impl<'de> serde::Deserialize<'de> for session_request::NextCheckpoint {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -1808,6 +1854,7 @@ impl<'de> serde::Deserialize<'de> for session_request::Open {
         enum GeneratedField {
             Task,
             Shards,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1831,7 +1878,7 @@ impl<'de> serde::Deserialize<'de> for session_request::Open {
                         match value {
                             "task" => Ok(GeneratedField::Task),
                             "shards" => Ok(GeneratedField::Shards),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1865,6 +1912,9 @@ impl<'de> serde::Deserialize<'de> for session_request::Open {
                                 return Err(serde::de::Error::duplicate_field("shards"));
                             }
                             shards__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1917,6 +1967,7 @@ impl<'de> serde::Deserialize<'de> for SessionResponse {
         enum GeneratedField {
             Opened,
             NextCheckpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1940,7 +1991,7 @@ impl<'de> serde::Deserialize<'de> for SessionResponse {
                         match value {
                             "opened" => Ok(GeneratedField::Opened),
                             "nextCheckpoint" | "next_checkpoint" => Ok(GeneratedField::NextCheckpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1974,6 +2025,9 @@ impl<'de> serde::Deserialize<'de> for SessionResponse {
                                 return Err(serde::de::Error::duplicate_field("nextCheckpoint"));
                             }
                             next_checkpoint__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2009,6 +2063,7 @@ impl<'de> serde::Deserialize<'de> for session_response::Opened {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2029,7 +2084,7 @@ impl<'de> serde::Deserialize<'de> for session_response::Opened {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2112,6 +2167,7 @@ impl<'de> serde::Deserialize<'de> for Shard {
             Range,
             Endpoint,
             Directory,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2137,7 +2193,7 @@ impl<'de> serde::Deserialize<'de> for Shard {
                             "range" => Ok(GeneratedField::Range),
                             "endpoint" => Ok(GeneratedField::Endpoint),
                             "directory" => Ok(GeneratedField::Directory),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2185,6 +2241,9 @@ impl<'de> serde::Deserialize<'de> for Shard {
                                 return Err(serde::de::Error::duplicate_field("directory"));
                             }
                             directory__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2255,6 +2314,7 @@ impl<'de> serde::Deserialize<'de> for SliceRequest {
             Start,
             StartRead,
             Progress,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2280,7 +2340,7 @@ impl<'de> serde::Deserialize<'de> for SliceRequest {
                             "start" => Ok(GeneratedField::Start),
                             "startRead" | "start_read" => Ok(GeneratedField::StartRead),
                             "progress" => Ok(GeneratedField::Progress),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2328,6 +2388,9 @@ impl<'de> serde::Deserialize<'de> for SliceRequest {
                                 return Err(serde::de::Error::duplicate_field("progress"));
                             }
                             progress__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2399,6 +2462,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Open {
             Task,
             Shards,
             ShardIndex,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2424,7 +2488,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Open {
                             "task" => Ok(GeneratedField::Task),
                             "shards" => Ok(GeneratedField::Shards),
                             "shardIndex" | "shard_index" => Ok(GeneratedField::ShardIndex),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2477,6 +2541,9 @@ impl<'de> serde::Deserialize<'de> for slice_request::Open {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(slice_request::Open {
@@ -2513,6 +2580,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Progress {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2533,7 +2601,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Progress {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2584,6 +2652,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Start {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2604,7 +2673,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::Start {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2709,6 +2778,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::StartRead {
             ModRevision,
             Route,
             Checkpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2736,7 +2806,7 @@ impl<'de> serde::Deserialize<'de> for slice_request::StartRead {
                             "modRevision" | "mod_revision" => Ok(GeneratedField::ModRevision),
                             "route" => Ok(GeneratedField::Route),
                             "checkpoint" => Ok(GeneratedField::Checkpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2805,6 +2875,9 @@ impl<'de> serde::Deserialize<'de> for slice_request::StartRead {
                             }
                             checkpoint__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(slice_request::StartRead {
@@ -2868,6 +2941,7 @@ impl<'de> serde::Deserialize<'de> for SliceResponse {
             Opened,
             ListingAdded,
             Progressed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2892,7 +2966,7 @@ impl<'de> serde::Deserialize<'de> for SliceResponse {
                             "opened" => Ok(GeneratedField::Opened),
                             "listingAdded" | "listing_added" => Ok(GeneratedField::ListingAdded),
                             "progressed" => Ok(GeneratedField::Progressed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2933,6 +3007,9 @@ impl<'de> serde::Deserialize<'de> for SliceResponse {
                                 return Err(serde::de::Error::duplicate_field("progressed"));
                             }
                             progressed__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3015,6 +3092,7 @@ impl<'de> serde::Deserialize<'de> for slice_response::ListingAdded {
             CreateRevision,
             ModRevision,
             Route,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3041,7 +3119,7 @@ impl<'de> serde::Deserialize<'de> for slice_response::ListingAdded {
                             "createRevision" | "create_revision" => Ok(GeneratedField::CreateRevision),
                             "modRevision" | "mod_revision" => Ok(GeneratedField::ModRevision),
                             "route" => Ok(GeneratedField::Route),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3103,6 +3181,9 @@ impl<'de> serde::Deserialize<'de> for slice_response::ListingAdded {
                             }
                             route__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(slice_response::ListingAdded {
@@ -3140,6 +3221,7 @@ impl<'de> serde::Deserialize<'de> for slice_response::Opened {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3160,7 +3242,7 @@ impl<'de> serde::Deserialize<'de> for slice_response::Opened {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -3234,6 +3316,7 @@ impl<'de> serde::Deserialize<'de> for Task {
             CollectionPartitions,
             Derivation,
             Materialization,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3258,7 +3341,7 @@ impl<'de> serde::Deserialize<'de> for Task {
                             "collectionPartitions" | "collection_partitions" => Ok(GeneratedField::CollectionPartitions),
                             "derivation" => Ok(GeneratedField::Derivation),
                             "materialization" => Ok(GeneratedField::Materialization),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3300,6 +3383,9 @@ impl<'de> serde::Deserialize<'de> for Task {
                             }
                             task__ = map_.next_value::<::std::option::Option<_>>()?.map(task::Task::Materialization)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-gazette/build.rs
+++ b/crates/proto-gazette/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .register_descriptors(&std::fs::read(b.descriptor_path).expect("read descriptors"))
         .unwrap()
         .btree_map(["."])
+        .ignore_unknown_fields()
         .build(&[".protocol", ".consumer", ".recoverylog"])
         .expect("building pbjson");
 }

--- a/crates/proto-gazette/src/consumer.serde.rs
+++ b/crates/proto-gazette/src/consumer.serde.rs
@@ -39,6 +39,7 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
         enum GeneratedField {
             Changes,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -62,7 +63,7 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
                         match value {
                             "changes" => Ok(GeneratedField::Changes),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -98,6 +99,9 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -169,6 +173,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
             Upsert,
             Delete,
             PrimaryHints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -194,7 +199,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                             "upsert" => Ok(GeneratedField::Upsert),
                             "delete" => Ok(GeneratedField::Delete),
                             "primaryHints" | "primary_hints" => Ok(GeneratedField::PrimaryHints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -244,6 +249,9 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                                 return Err(serde::de::Error::duplicate_field("primaryHints"));
                             }
                             primary_hints__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -309,6 +317,7 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
             Status,
             Header,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -333,7 +342,7 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
                             "status" => Ok(GeneratedField::Status),
                             "header" => Ok(GeneratedField::Header),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -376,6 +385,9 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -431,6 +443,7 @@ impl<'de> serde::Deserialize<'de> for Checkpoint {
         enum GeneratedField {
             Sources,
             AckIntents,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -454,7 +467,7 @@ impl<'de> serde::Deserialize<'de> for Checkpoint {
                         match value {
                             "sources" => Ok(GeneratedField::Sources),
                             "ackIntents" | "ack_intents" => Ok(GeneratedField::AckIntents),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -493,6 +506,9 @@ impl<'de> serde::Deserialize<'de> for Checkpoint {
                                 map_.next_value::<std::collections::BTreeMap<_, ::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|(k,v)| (k, v.0)).collect()
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -549,6 +565,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::ProducerState {
         enum GeneratedField {
             LastAck,
             Begin,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -572,7 +589,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::ProducerState {
                         match value {
                             "lastAck" | "last_ack" => Ok(GeneratedField::LastAck),
                             "begin" => Ok(GeneratedField::Begin),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -610,6 +627,9 @@ impl<'de> serde::Deserialize<'de> for checkpoint::ProducerState {
                             begin__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -664,6 +684,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::Source {
         enum GeneratedField {
             ReadThrough,
             Producers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -687,7 +708,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::Source {
                         match value {
                             "readThrough" | "read_through" => Ok(GeneratedField::ReadThrough),
                             "producers" => Ok(GeneratedField::Producers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -723,6 +744,9 @@ impl<'de> serde::Deserialize<'de> for checkpoint::Source {
                                 return Err(serde::de::Error::duplicate_field("producers"));
                             }
                             producers__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -776,6 +800,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::source::ProducerEntry {
         enum GeneratedField {
             Id,
             State,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -799,7 +824,7 @@ impl<'de> serde::Deserialize<'de> for checkpoint::source::ProducerEntry {
                         match value {
                             "id" => Ok(GeneratedField::Id),
                             "state" => Ok(GeneratedField::State),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -835,6 +860,9 @@ impl<'de> serde::Deserialize<'de> for checkpoint::source::ProducerEntry {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -896,6 +924,7 @@ impl<'de> serde::Deserialize<'de> for ConsumerSpec {
             ProcessSpec,
             ShardLimit,
             Exiting,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -920,7 +949,7 @@ impl<'de> serde::Deserialize<'de> for ConsumerSpec {
                             "processSpec" | "process_spec" => Ok(GeneratedField::ProcessSpec),
                             "shardLimit" | "shard_limit" => Ok(GeneratedField::ShardLimit),
                             "exiting" => Ok(GeneratedField::Exiting),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -963,6 +992,9 @@ impl<'de> serde::Deserialize<'de> for ConsumerSpec {
                                 return Err(serde::de::Error::duplicate_field("exiting"));
                             }
                             exiting__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1017,6 +1049,7 @@ impl<'de> serde::Deserialize<'de> for GetHintsRequest {
         enum GeneratedField {
             Shard,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1040,7 +1073,7 @@ impl<'de> serde::Deserialize<'de> for GetHintsRequest {
                         match value {
                             "shard" => Ok(GeneratedField::Shard),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1076,6 +1109,9 @@ impl<'de> serde::Deserialize<'de> for GetHintsRequest {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1157,6 +1193,7 @@ impl<'de> serde::Deserialize<'de> for GetHintsResponse {
             PrimaryHints,
             BackupHints,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1183,7 +1220,7 @@ impl<'de> serde::Deserialize<'de> for GetHintsResponse {
                             "primaryHints" | "primary_hints" => Ok(GeneratedField::PrimaryHints),
                             "backupHints" | "backup_hints" => Ok(GeneratedField::BackupHints),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1241,6 +1278,9 @@ impl<'de> serde::Deserialize<'de> for GetHintsResponse {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(GetHintsResponse {
@@ -1286,6 +1326,7 @@ impl<'de> serde::Deserialize<'de> for get_hints_response::ResponseHints {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Hints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1308,7 +1349,7 @@ impl<'de> serde::Deserialize<'de> for get_hints_response::ResponseHints {
                     {
                         match value {
                             "hints" => Ok(GeneratedField::Hints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1335,6 +1376,9 @@ impl<'de> serde::Deserialize<'de> for get_hints_response::ResponseHints {
                                 return Err(serde::de::Error::duplicate_field("hints"));
                             }
                             hints__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1387,6 +1431,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
         enum GeneratedField {
             Selector,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1410,7 +1455,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                         match value {
                             "selector" => Ok(GeneratedField::Selector),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1446,6 +1491,9 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1517,6 +1565,7 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
             Header,
             Shards,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1542,7 +1591,7 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
                             "header" => Ok(GeneratedField::Header),
                             "shards" => Ok(GeneratedField::Shards),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1592,6 +1641,9 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1675,6 +1727,7 @@ impl<'de> serde::Deserialize<'de> for list_response::Shard {
             Route,
             Status,
             CreateRevision,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1701,7 +1754,7 @@ impl<'de> serde::Deserialize<'de> for list_response::Shard {
                             "route" => Ok(GeneratedField::Route),
                             "status" => Ok(GeneratedField::Status),
                             "createRevision" | "create_revision" => Ok(GeneratedField::CreateRevision),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1761,6 +1814,9 @@ impl<'de> serde::Deserialize<'de> for list_response::Shard {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(list_response::Shard {
@@ -1816,6 +1872,7 @@ impl<'de> serde::Deserialize<'de> for ReplicaStatus {
         enum GeneratedField {
             Code,
             Errors,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1839,7 +1896,7 @@ impl<'de> serde::Deserialize<'de> for ReplicaStatus {
                         match value {
                             "code" => Ok(GeneratedField::Code),
                             "errors" => Ok(GeneratedField::Errors),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1873,6 +1930,9 @@ impl<'de> serde::Deserialize<'de> for ReplicaStatus {
                                 return Err(serde::de::Error::duplicate_field("errors"));
                             }
                             errors__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2101,6 +2161,7 @@ impl<'de> serde::Deserialize<'de> for ShardSpec {
             DisableWaitForAck,
             RingBufferSize,
             ReadChannelSize,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2135,7 +2196,7 @@ impl<'de> serde::Deserialize<'de> for ShardSpec {
                             "disableWaitForAck" | "disable_wait_for_ack" => Ok(GeneratedField::DisableWaitForAck),
                             "ringBufferSize" | "ring_buffer_size" => Ok(GeneratedField::RingBufferSize),
                             "readChannelSize" | "read_channel_size" => Ok(GeneratedField::ReadChannelSize),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2255,6 +2316,9 @@ impl<'de> serde::Deserialize<'de> for ShardSpec {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ShardSpec {
@@ -2319,6 +2383,7 @@ impl<'de> serde::Deserialize<'de> for shard_spec::Source {
         enum GeneratedField {
             Journal,
             MinOffset,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2342,7 +2407,7 @@ impl<'de> serde::Deserialize<'de> for shard_spec::Source {
                         match value {
                             "journal" => Ok(GeneratedField::Journal),
                             "minOffset" | "min_offset" => Ok(GeneratedField::MinOffset),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2378,6 +2443,9 @@ impl<'de> serde::Deserialize<'de> for shard_spec::Source {
                             min_offset__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2450,6 +2518,7 @@ impl<'de> serde::Deserialize<'de> for StatRequest {
             Shard,
             ReadThrough,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2475,7 +2544,7 @@ impl<'de> serde::Deserialize<'de> for StatRequest {
                             "shard" => Ok(GeneratedField::Shard),
                             "readThrough" | "read_through" => Ok(GeneratedField::ReadThrough),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2528,6 +2597,9 @@ impl<'de> serde::Deserialize<'de> for StatRequest {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2615,6 +2687,7 @@ impl<'de> serde::Deserialize<'de> for StatResponse {
             ReadThrough,
             PublishAt,
             Extension,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2641,7 +2714,7 @@ impl<'de> serde::Deserialize<'de> for StatResponse {
                             "readThrough" | "read_through" => Ok(GeneratedField::ReadThrough),
                             "publishAt" | "publish_at" => Ok(GeneratedField::PublishAt),
                             "extension" => Ok(GeneratedField::Extension),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2704,6 +2777,9 @@ impl<'de> serde::Deserialize<'de> for StatResponse {
                             extension__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2851,6 +2927,7 @@ impl<'de> serde::Deserialize<'de> for UnassignRequest {
             Shards,
             OnlyFailed,
             DryRun,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2875,7 +2952,7 @@ impl<'de> serde::Deserialize<'de> for UnassignRequest {
                             "shards" => Ok(GeneratedField::Shards),
                             "onlyFailed" | "only_failed" => Ok(GeneratedField::OnlyFailed),
                             "dryRun" | "dry_run" => Ok(GeneratedField::DryRun),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2916,6 +2993,9 @@ impl<'de> serde::Deserialize<'de> for UnassignRequest {
                                 return Err(serde::de::Error::duplicate_field("dryRun"));
                             }
                             dry_run__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2970,6 +3050,7 @@ impl<'de> serde::Deserialize<'de> for UnassignResponse {
         enum GeneratedField {
             Status,
             Shards,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2993,7 +3074,7 @@ impl<'de> serde::Deserialize<'de> for UnassignResponse {
                         match value {
                             "status" => Ok(GeneratedField::Status),
                             "shards" => Ok(GeneratedField::Shards),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3027,6 +3108,9 @@ impl<'de> serde::Deserialize<'de> for UnassignResponse {
                                 return Err(serde::de::Error::duplicate_field("shards"));
                             }
                             shards__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-gazette/src/protocol.serde.rs
+++ b/crates/proto-gazette/src/protocol.serde.rs
@@ -114,6 +114,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
             Suspend,
             MinEtcdRevision,
             Content,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -145,7 +146,7 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                             "suspend" => Ok(GeneratedField::Suspend),
                             "minEtcdRevision" | "min_etcd_revision" => Ok(GeneratedField::MinEtcdRevision),
                             "content" => Ok(GeneratedField::Content),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -241,6 +242,9 @@ impl<'de> serde::Deserialize<'de> for AppendRequest {
                             content__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -429,6 +433,7 @@ impl<'de> serde::Deserialize<'de> for AppendResponse {
             TotalChunks,
             DelayedChunks,
             StoreHealthError,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -457,7 +462,7 @@ impl<'de> serde::Deserialize<'de> for AppendResponse {
                             "totalChunks" | "total_chunks" => Ok(GeneratedField::TotalChunks),
                             "delayedChunks" | "delayed_chunks" => Ok(GeneratedField::DelayedChunks),
                             "storeHealthError" | "store_health_error" => Ok(GeneratedField::StoreHealthError),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -531,6 +536,9 @@ impl<'de> serde::Deserialize<'de> for AppendResponse {
                             }
                             store_health_error__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(AppendResponse {
@@ -578,6 +586,7 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Changes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -600,7 +609,7 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
                     {
                         match value {
                             "changes" => Ok(GeneratedField::Changes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -627,6 +636,9 @@ impl<'de> serde::Deserialize<'de> for ApplyRequest {
                                 return Err(serde::de::Error::duplicate_field("changes"));
                             }
                             changes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -688,6 +700,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
             ExpectModRevision,
             Upsert,
             Delete,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -712,7 +725,7 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                             "expectModRevision" | "expect_mod_revision" => Ok(GeneratedField::ExpectModRevision),
                             "upsert" => Ok(GeneratedField::Upsert),
                             "delete" => Ok(GeneratedField::Delete),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -755,6 +768,9 @@ impl<'de> serde::Deserialize<'de> for apply_request::Change {
                                 return Err(serde::de::Error::duplicate_field("delete"));
                             }
                             delete__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -809,6 +825,7 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
         enum GeneratedField {
             Status,
             Header,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -832,7 +849,7 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
                         match value {
                             "status" => Ok(GeneratedField::Status),
                             "header" => Ok(GeneratedField::Header),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -866,6 +883,9 @@ impl<'de> serde::Deserialize<'de> for ApplyResponse {
                                 return Err(serde::de::Error::duplicate_field("header"));
                             }
                             header__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -927,6 +947,7 @@ impl<'de> serde::Deserialize<'de> for BrokerSpec {
             ProcessSpec,
             JournalLimit,
             Exiting,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -951,7 +972,7 @@ impl<'de> serde::Deserialize<'de> for BrokerSpec {
                             "processSpec" | "process_spec" => Ok(GeneratedField::ProcessSpec),
                             "journalLimit" | "journal_limit" => Ok(GeneratedField::JournalLimit),
                             "exiting" => Ok(GeneratedField::Exiting),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -994,6 +1015,9 @@ impl<'de> serde::Deserialize<'de> for BrokerSpec {
                                 return Err(serde::de::Error::duplicate_field("exiting"));
                             }
                             exiting__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1189,6 +1213,7 @@ impl<'de> serde::Deserialize<'de> for Fragment {
             BackingStore,
             ModTime,
             PathPostfix,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1218,7 +1243,7 @@ impl<'de> serde::Deserialize<'de> for Fragment {
                             "backingStore" | "backing_store" => Ok(GeneratedField::BackingStore),
                             "modTime" | "mod_time" => Ok(GeneratedField::ModTime),
                             "pathPostfix" | "path_postfix" => Ok(GeneratedField::PathPostfix),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1301,6 +1326,9 @@ impl<'de> serde::Deserialize<'de> for Fragment {
                             }
                             path_postfix__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(Fragment {
@@ -1350,6 +1378,7 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             FragmentStore,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1372,7 +1401,7 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                     {
                         match value {
                             "fragmentStore" | "fragment_store" => Ok(GeneratedField::FragmentStore),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1399,6 +1428,9 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                                 return Err(serde::de::Error::duplicate_field("fragmentStore"));
                             }
                             fragment_store__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1460,6 +1492,7 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthResponse {
             Status,
             Header,
             StoreHealthError,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1484,7 +1517,7 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthResponse {
                             "status" => Ok(GeneratedField::Status),
                             "header" => Ok(GeneratedField::Header),
                             "storeHealthError" | "store_health_error" => Ok(GeneratedField::StoreHealthError),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1525,6 +1558,9 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthResponse {
                                 return Err(serde::de::Error::duplicate_field("storeHealthError"));
                             }
                             store_health_error__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1636,6 +1672,7 @@ impl<'de> serde::Deserialize<'de> for FragmentsRequest {
             PageLimit,
             SignatureTtl,
             DoNotProxy,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1665,7 +1702,7 @@ impl<'de> serde::Deserialize<'de> for FragmentsRequest {
                             "pageLimit" | "page_limit" => Ok(GeneratedField::PageLimit),
                             "signatureTTL" => Ok(GeneratedField::SignatureTtl),
                             "doNotProxy" | "do_not_proxy" => Ok(GeneratedField::DoNotProxy),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1750,6 +1787,9 @@ impl<'de> serde::Deserialize<'de> for FragmentsRequest {
                             }
                             do_not_proxy__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(FragmentsRequest {
@@ -1827,6 +1867,7 @@ impl<'de> serde::Deserialize<'de> for FragmentsResponse {
             Header,
             Fragments,
             NextPageToken,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1852,7 +1893,7 @@ impl<'de> serde::Deserialize<'de> for FragmentsResponse {
                             "header" => Ok(GeneratedField::Header),
                             "fragments" => Ok(GeneratedField::Fragments),
                             "nextPageToken" | "next_page_token" => Ok(GeneratedField::NextPageToken),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1902,6 +1943,9 @@ impl<'de> serde::Deserialize<'de> for FragmentsResponse {
                             next_page_token__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1956,6 +2000,7 @@ impl<'de> serde::Deserialize<'de> for fragments_response::Fragment {
         enum GeneratedField {
             Spec,
             SignedUrl,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1979,7 +2024,7 @@ impl<'de> serde::Deserialize<'de> for fragments_response::Fragment {
                         match value {
                             "spec" => Ok(GeneratedField::Spec),
                             "signedUrl" | "signed_url" => Ok(GeneratedField::SignedUrl),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2013,6 +2058,9 @@ impl<'de> serde::Deserialize<'de> for fragments_response::Fragment {
                                 return Err(serde::de::Error::duplicate_field("signedUrl"));
                             }
                             signed_url__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2073,6 +2121,7 @@ impl<'de> serde::Deserialize<'de> for Header {
             ProcessId,
             Route,
             Etcd,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2097,7 +2146,7 @@ impl<'de> serde::Deserialize<'de> for Header {
                             "processId" | "process_id" => Ok(GeneratedField::ProcessId),
                             "route" => Ok(GeneratedField::Route),
                             "etcd" => Ok(GeneratedField::Etcd),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2138,6 +2187,9 @@ impl<'de> serde::Deserialize<'de> for Header {
                                 return Err(serde::de::Error::duplicate_field("etcd"));
                             }
                             etcd__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2217,6 +2269,7 @@ impl<'de> serde::Deserialize<'de> for header::Etcd {
             MemberId,
             Revision,
             RaftTerm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2242,7 +2295,7 @@ impl<'de> serde::Deserialize<'de> for header::Etcd {
                             "memberId" | "member_id" => Ok(GeneratedField::MemberId),
                             "revision" => Ok(GeneratedField::Revision),
                             "raftTerm" | "raft_term" => Ok(GeneratedField::RaftTerm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2298,6 +2351,9 @@ impl<'de> serde::Deserialize<'de> for header::Etcd {
                             raft_term__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2394,6 +2450,7 @@ impl<'de> serde::Deserialize<'de> for JournalSpec {
             Flags,
             MaxAppendRate,
             Suspend,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2422,7 +2479,7 @@ impl<'de> serde::Deserialize<'de> for JournalSpec {
                             "flags" => Ok(GeneratedField::Flags),
                             "maxAppendRate" | "max_append_rate" => Ok(GeneratedField::MaxAppendRate),
                             "suspend" => Ok(GeneratedField::Suspend),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2497,6 +2554,9 @@ impl<'de> serde::Deserialize<'de> for JournalSpec {
                                 return Err(serde::de::Error::duplicate_field("suspend"));
                             }
                             suspend__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2678,6 +2738,7 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Fragment {
             Retention,
             FlushInterval,
             PathPostfixTemplate,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2706,7 +2767,7 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Fragment {
                             "retention" => Ok(GeneratedField::Retention),
                             "flushInterval" | "flush_interval" => Ok(GeneratedField::FlushInterval),
                             "pathPostfixTemplate" | "path_postfix_template" => Ok(GeneratedField::PathPostfixTemplate),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2778,6 +2839,9 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Fragment {
                             }
                             path_postfix_template__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(journal_spec::Fragment {
@@ -2837,6 +2901,7 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Suspend {
         enum GeneratedField {
             Level,
             Offset,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2860,7 +2925,7 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Suspend {
                         match value {
                             "level" => Ok(GeneratedField::Level),
                             "offset" => Ok(GeneratedField::Offset),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2896,6 +2961,9 @@ impl<'de> serde::Deserialize<'de> for journal_spec::Suspend {
                             offset__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3029,6 +3097,7 @@ impl<'de> serde::Deserialize<'de> for Label {
             Name,
             Value,
             Prefix,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3053,7 +3122,7 @@ impl<'de> serde::Deserialize<'de> for Label {
                             "name" => Ok(GeneratedField::Name),
                             "value" => Ok(GeneratedField::Value),
                             "prefix" => Ok(GeneratedField::Prefix),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3094,6 +3163,9 @@ impl<'de> serde::Deserialize<'de> for Label {
                                 return Err(serde::de::Error::duplicate_field("prefix"));
                             }
                             prefix__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3146,6 +3218,7 @@ impl<'de> serde::Deserialize<'de> for LabelSelector {
         enum GeneratedField {
             Include,
             Exclude,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3169,7 +3242,7 @@ impl<'de> serde::Deserialize<'de> for LabelSelector {
                         match value {
                             "include" => Ok(GeneratedField::Include),
                             "exclude" => Ok(GeneratedField::Exclude),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3203,6 +3276,9 @@ impl<'de> serde::Deserialize<'de> for LabelSelector {
                                 return Err(serde::de::Error::duplicate_field("exclude"));
                             }
                             exclude__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3246,6 +3322,7 @@ impl<'de> serde::Deserialize<'de> for LabelSet {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Labels,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3268,7 +3345,7 @@ impl<'de> serde::Deserialize<'de> for LabelSet {
                     {
                         match value {
                             "labels" => Ok(GeneratedField::Labels),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3295,6 +3372,9 @@ impl<'de> serde::Deserialize<'de> for LabelSet {
                                 return Err(serde::de::Error::duplicate_field("labels"));
                             }
                             labels__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3354,6 +3434,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
             Selector,
             Watch,
             WatchResume,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3378,7 +3459,7 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                             "selector" => Ok(GeneratedField::Selector),
                             "watch" => Ok(GeneratedField::Watch),
                             "watchResume" | "watch_resume" => Ok(GeneratedField::WatchResume),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3419,6 +3500,9 @@ impl<'de> serde::Deserialize<'de> for ListRequest {
                                 return Err(serde::de::Error::duplicate_field("watchResume"));
                             }
                             watch_resume__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3481,6 +3565,7 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
             Status,
             Header,
             Journals,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3505,7 +3590,7 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
                             "status" => Ok(GeneratedField::Status),
                             "header" => Ok(GeneratedField::Header),
                             "journals" => Ok(GeneratedField::Journals),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3546,6 +3631,9 @@ impl<'de> serde::Deserialize<'de> for ListResponse {
                                 return Err(serde::de::Error::duplicate_field("journals"));
                             }
                             journals__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3620,6 +3708,7 @@ impl<'de> serde::Deserialize<'de> for list_response::Journal {
             ModRevision,
             Route,
             CreateRevision,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3645,7 +3734,7 @@ impl<'de> serde::Deserialize<'de> for list_response::Journal {
                             "modRevision" | "mod_revision" => Ok(GeneratedField::ModRevision),
                             "route" => Ok(GeneratedField::Route),
                             "createRevision" | "create_revision" => Ok(GeneratedField::CreateRevision),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3697,6 +3786,9 @@ impl<'de> serde::Deserialize<'de> for list_response::Journal {
                             create_revision__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3750,6 +3842,7 @@ impl<'de> serde::Deserialize<'de> for ProcessSpec {
         enum GeneratedField {
             Id,
             Endpoint,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3773,7 +3866,7 @@ impl<'de> serde::Deserialize<'de> for ProcessSpec {
                         match value {
                             "id" => Ok(GeneratedField::Id),
                             "endpoint" => Ok(GeneratedField::Endpoint),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3807,6 +3900,9 @@ impl<'de> serde::Deserialize<'de> for ProcessSpec {
                                 return Err(serde::de::Error::duplicate_field("endpoint"));
                             }
                             endpoint__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3858,6 +3954,7 @@ impl<'de> serde::Deserialize<'de> for process_spec::Id {
         enum GeneratedField {
             Zone,
             Suffix,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3881,7 +3978,7 @@ impl<'de> serde::Deserialize<'de> for process_spec::Id {
                         match value {
                             "zone" => Ok(GeneratedField::Zone),
                             "suffix" => Ok(GeneratedField::Suffix),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3915,6 +4012,9 @@ impl<'de> serde::Deserialize<'de> for process_spec::Id {
                                 return Err(serde::de::Error::duplicate_field("suffix"));
                             }
                             suffix__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4035,6 +4135,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
             EndOffset,
             BeginModTime,
             MinEtcdRevision,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4065,7 +4166,7 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                             "endOffset" | "end_offset" => Ok(GeneratedField::EndOffset),
                             "beginModTime" | "begin_mod_time" => Ok(GeneratedField::BeginModTime),
                             "minEtcdRevision" | "min_etcd_revision" => Ok(GeneratedField::MinEtcdRevision),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4156,6 +4257,9 @@ impl<'de> serde::Deserialize<'de> for ReadRequest {
                             min_etcd_revision__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4264,6 +4368,7 @@ impl<'de> serde::Deserialize<'de> for ReadResponse {
             Fragment,
             FragmentUrl,
             Content,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4292,7 +4397,7 @@ impl<'de> serde::Deserialize<'de> for ReadResponse {
                             "fragment" => Ok(GeneratedField::Fragment),
                             "fragmentUrl" | "fragment_url" => Ok(GeneratedField::FragmentUrl),
                             "content" => Ok(GeneratedField::Content),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4367,6 +4472,9 @@ impl<'de> serde::Deserialize<'de> for ReadResponse {
                             content__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4469,6 +4577,7 @@ impl<'de> serde::Deserialize<'de> for ReplicateRequest {
             DeprecatedJournal,
             Content,
             ContentDelta,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4497,7 +4606,7 @@ impl<'de> serde::Deserialize<'de> for ReplicateRequest {
                             "deprecatedJournal" | "deprecated_journal" => Ok(GeneratedField::DeprecatedJournal),
                             "content" => Ok(GeneratedField::Content),
                             "contentDelta" | "content_delta" => Ok(GeneratedField::ContentDelta),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4570,6 +4679,9 @@ impl<'de> serde::Deserialize<'de> for ReplicateRequest {
                             content_delta__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4644,6 +4756,7 @@ impl<'de> serde::Deserialize<'de> for ReplicateResponse {
             Header,
             Fragment,
             Registers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4669,7 +4782,7 @@ impl<'de> serde::Deserialize<'de> for ReplicateResponse {
                             "header" => Ok(GeneratedField::Header),
                             "fragment" => Ok(GeneratedField::Fragment),
                             "registers" => Ok(GeneratedField::Registers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4717,6 +4830,9 @@ impl<'de> serde::Deserialize<'de> for ReplicateResponse {
                                 return Err(serde::de::Error::duplicate_field("registers"));
                             }
                             registers__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4778,6 +4894,7 @@ impl<'de> serde::Deserialize<'de> for Route {
             Members,
             Primary,
             Endpoints,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4802,7 +4919,7 @@ impl<'de> serde::Deserialize<'de> for Route {
                             "members" => Ok(GeneratedField::Members),
                             "primary" => Ok(GeneratedField::Primary),
                             "endpoints" => Ok(GeneratedField::Endpoints),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4845,6 +4962,9 @@ impl<'de> serde::Deserialize<'de> for Route {
                                 return Err(serde::de::Error::duplicate_field("endpoints"));
                             }
                             endpoints__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4909,6 +5029,7 @@ impl<'de> serde::Deserialize<'de> for Sha1Sum {
             Part1,
             Part2,
             Part3,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4933,7 +5054,7 @@ impl<'de> serde::Deserialize<'de> for Sha1Sum {
                             "part1" => Ok(GeneratedField::Part1),
                             "part2" => Ok(GeneratedField::Part2),
                             "part3" => Ok(GeneratedField::Part3),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4980,6 +5101,9 @@ impl<'de> serde::Deserialize<'de> for Sha1Sum {
                             part3__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/crates/proto-gazette/src/recoverylog.serde.rs
+++ b/crates/proto-gazette/src/recoverylog.serde.rs
@@ -46,6 +46,7 @@ impl<'de> serde::Deserialize<'de> for FsmHints {
             Log,
             LiveNodes,
             Properties,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -70,7 +71,7 @@ impl<'de> serde::Deserialize<'de> for FsmHints {
                             "log" => Ok(GeneratedField::Log),
                             "liveNodes" | "live_nodes" => Ok(GeneratedField::LiveNodes),
                             "properties" => Ok(GeneratedField::Properties),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -111,6 +112,9 @@ impl<'de> serde::Deserialize<'de> for FsmHints {
                                 return Err(serde::de::Error::duplicate_field("properties"));
                             }
                             properties__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -165,6 +169,7 @@ impl<'de> serde::Deserialize<'de> for FnodeSegments {
         enum GeneratedField {
             Fnode,
             Segments,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -188,7 +193,7 @@ impl<'de> serde::Deserialize<'de> for FnodeSegments {
                         match value {
                             "fnode" => Ok(GeneratedField::Fnode),
                             "segments" => Ok(GeneratedField::Segments),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -224,6 +229,9 @@ impl<'de> serde::Deserialize<'de> for FnodeSegments {
                                 return Err(serde::de::Error::duplicate_field("segments"));
                             }
                             segments__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -275,6 +283,7 @@ impl<'de> serde::Deserialize<'de> for Property {
         enum GeneratedField {
             Path,
             Content,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -298,7 +307,7 @@ impl<'de> serde::Deserialize<'de> for Property {
                         match value {
                             "path" => Ok(GeneratedField::Path),
                             "content" => Ok(GeneratedField::Content),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -332,6 +341,9 @@ impl<'de> serde::Deserialize<'de> for Property {
                                 return Err(serde::de::Error::duplicate_field("content"));
                             }
                             content__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -464,6 +476,7 @@ impl<'de> serde::Deserialize<'de> for RecordedOp {
             Unlink,
             Write,
             Property,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -496,7 +509,7 @@ impl<'de> serde::Deserialize<'de> for RecordedOp {
                             "unlink" => Ok(GeneratedField::Unlink),
                             "write" => Ok(GeneratedField::Write),
                             "property" => Ok(GeneratedField::Property),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -604,6 +617,9 @@ impl<'de> serde::Deserialize<'de> for RecordedOp {
                             }
                             property__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(RecordedOp {
@@ -655,6 +671,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Create {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Path,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -677,7 +694,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Create {
                     {
                         match value {
                             "path" => Ok(GeneratedField::Path),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -704,6 +721,9 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Create {
                                 return Err(serde::de::Error::duplicate_field("path"));
                             }
                             path__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -756,6 +776,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Link {
         enum GeneratedField {
             Fnode,
             Path,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -779,7 +800,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Link {
                         match value {
                             "fnode" => Ok(GeneratedField::Fnode),
                             "path" => Ok(GeneratedField::Path),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -815,6 +836,9 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Link {
                                 return Err(serde::de::Error::duplicate_field("path"));
                             }
                             path__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -880,6 +904,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Write {
             Fnode,
             Offset,
             Length,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -904,7 +929,7 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Write {
                             "fnode" => Ok(GeneratedField::Fnode),
                             "offset" => Ok(GeneratedField::Offset),
                             "length" => Ok(GeneratedField::Length),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -951,6 +976,9 @@ impl<'de> serde::Deserialize<'de> for recorded_op::Write {
                             length__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1056,6 +1084,7 @@ impl<'de> serde::Deserialize<'de> for Segment {
             LastSeqNo,
             LastOffset,
             Log,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1084,7 +1113,7 @@ impl<'de> serde::Deserialize<'de> for Segment {
                             "lastSeqNo" | "last_seq_no" => Ok(GeneratedField::LastSeqNo),
                             "lastOffset" | "last_offset" => Ok(GeneratedField::LastOffset),
                             "log" => Ok(GeneratedField::Log),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1165,6 +1194,9 @@ impl<'de> serde::Deserialize<'de> for Segment {
                                 return Err(serde::de::Error::duplicate_field("log"));
                             }
                             log__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }


### PR DESCRIPTION
**Description:**

Generate the .flow, .capture, .derive, and .materialize serde impls with pbjson's `ignore_unknown_fields`, so a reader built against an older protocol revision skips fields it doesn't recognize instead of failing to deserialize.

`.flow` is included because connector Request/Response messages embed flow.CollectionSpec and friends, which deserialize via their own impls. The internal .ops, .runtime, and .shuffle protocols stay strict.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

