### PR TITLE
ops-catalog: enable runtime v2 for ops/rollups/L2/catalog-stats

### DIFF
--- a/ops-catalog/reporting-L2-template.bundle.json
+++ b/ops-catalog/reporting-L2-template.bundle.json
@@ -121,7 +121,12 @@
               ]
             }
           }
-        ]
+        ],
+        "shards": {
+          "flags": {
+            "enable-runtime-v2": "true"
+          }
+        }
       }
     }
   }

--- a/ops-catalog/reporting-L2-template.flow.yaml
+++ b/ops-catalog/reporting-L2-template.flow.yaml
@@ -92,3 +92,6 @@ collections:
           source: ops/rollups/L1/BASE_NAME/catalog-stats
           shuffle:
             key: [/catalogName]
+      shards:
+        flags:
+          enable-runtime-v2: "true"


### PR DESCRIPTION
**Description:**

Set the `enable-runtime-v2` shard flag on the new L2 catalog-stats rollup in the template. `update_l2_reporting` republishes from this template and rewrites only each derivation's transforms and TypeScript module, so the flag must live here to survive republishes rather than being set on the live spec.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

