### PR TITLE
oidc-discovery-server: survive direct VPC egress cold-start on deploy

### DIFF
--- a/.github/workflows/deploy-oidc-discovery-server.yaml
+++ b/.github/workflows/deploy-oidc-discovery-server.yaml
@@ -49,7 +49,10 @@ jobs:
           image: ${{ steps.image-tag.outputs.image }}
           port: 8080
           # Egress via a dedicated subnet on the data-plane-controller VPC (its own NAT IP) for a stable outbound IP.
-          flags: '--network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic'
+          # Keep one warm instance: direct VPC egress cold-starts take ~40s for the network interface to begin
+          # passing traffic, so a min instance avoids that delay on scale-from-zero and keeps a ready instance
+          # serving while additional instances warm up during a scale-up.
+          flags: '--network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic --min-instances=1'
 
           env_vars: |-
             DATABASE_CA=/etc/db-ca.crt

--- a/crates/oidc-discovery-server/src/lib.rs
+++ b/crates/oidc-discovery-server/src/lib.rs
@@ -63,8 +63,14 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         pg_options = pg_options.ssl_mode(sqlx::postgres::PgSslMode::Prefer);
     }
 
+    // The port is bound only after this connection succeeds, so the acquire
+    // timeout doubles as the startup grace period. On Cloud Run with direct VPC
+    // egress, a fresh instance's network interface can take ~40s to begin
+    // passing traffic, during which all outbound connections fail. Allow well
+    // past that so the pool keeps retrying until egress is up rather than
+    // exiting and failing the deployment / scale-up.
     let pg_pool = sqlx::postgres::PgPoolOptions::new()
-        .acquire_timeout(std::time::Duration::from_secs(30))
+        .acquire_timeout(std::time::Duration::from_secs(120))
         .connect_with(pg_options)
         .await
         .context("connecting to database")?;


### PR DESCRIPTION
## Summary
`oidc-discovery-server` fails to deploy when running with Cloud Run direct VPC egress. On a fresh instance the VPC network interface takes roughly 20-40 seconds to begin passing outbound traffic; until then every outbound connection times out. The server opens its database connection at startup and binds its listening port only after that connection succeeds, with a 30 second pool acquire timeout. When the interface warmup exceeds the timeout, the process exits before binding the port, the startup probe fails, and the revision is rejected.

## Change
- Raise the database pool `acquire_timeout` from 30s to 120s. Because the port is bound only after the initial connection, this timeout also serves as the startup grace period. 120s leaves comfortable margin over the observed warmup, so the pool keeps retrying until egress is ready, then connects and binds normally.
- Add `--min-instances=1` to the deploy. One always-warm instance avoids the warmup delay on scale-from-zero and keeps a ready instance serving while additional instances warm up during a scale-up.

## Why this is sufficient
The port is not bound until the database connection succeeds, so Cloud Run does not route requests to an instance whose egress is not yet ready. Extending the timeout fixes the deploy and also prevents failed requests on scale events: a cold instance simply takes longer to become ready rather than serving while broken.

## Notes
- The warmup is a property of direct VPC egress, independent of DNS or the database; it was confirmed by connecting to the database IP directly from a fresh instance (first connection ~40s, every connection after ~30ms).
- Scope is limited to oidc-discovery-server. agent-api and data-plane-controller deploy successfully today and are unchanged. agent-api's shorter acquire timeout also governs its runtime pool behavior and is intentionally left as-is.
