### PR TITLE
docs: clarify BYOK KMS is decrypt-only and identity may not be in dashboard

### DIFF
--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -249,18 +249,22 @@ been encrypted.
 Estuary supports customers encrypting secrets with keys from AWS Key Management Service, Google Cloud Platform KMS, and Azure Key Vault.
 
 :::important
-When deploying catalogs onto the managed Estuary runtime, you must grant **decrypt**
-access on your KMS key to the appropriate identity for your data plane. On GCP KMS,
-this is the `roles/cloudkms.cryptoKeyDecrypter` role. Estuary only decrypts your
-configuration at connector run time and never encrypts with your key, so the
-identity does not need encrypt access.
+When deploying catalogs onto the managed Estuary runtime, you must grant **decrypt-only**
+access on your KMS key to the appropriate identity for your data plane. Estuary
+decrypts your configuration only at connector run time and never encrypts with your
+key, so the identity never needs encrypt access. How you grant access depends on the
+provider:
 
-These identities vary by data plane. You can find your data plane's native-cloud
-identity under [Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings)
-in the Estuary dashboard. If your KMS provider differs from the cloud your data
-plane runs in (for example, encrypting with a GCP KMS key while your data plane
-runs on AWS), the identity you need may not be shown in the dashboard. Contact
-Estuary support to obtain it.
+- **GCP KMS**: grant the `roles/cloudkms.cryptoKeyDecrypter` role on the key to the data plane's GCP service account.
+- **AWS KMS**: add a key-policy statement allowing `kms:Decrypt` and `kms:DescribeKey` to the data plane's AWS IAM user.
+- **Azure Key Vault**: grant a decrypt key permission to the data plane's Azure application.
+
+Each data plane has a separate identity for GCP, AWS, and Azure, so you can use a KMS
+provider that differs from the cloud your data plane runs in (for example, a GCP KMS
+key with an AWS data plane). The dashboard surfaces your data plane's native-cloud
+identity under [Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings);
+the identity for a different provider may not be shown there, so contact Estuary
+support to obtain the one you need.
 :::
 
 The examples below provide a useful reference.

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -217,6 +217,15 @@ You can find the image name and latest tag in the connector's [reference](/refer
 
 These commands use the same encryption mechanism as the dashboard and ensure that your secrets are encrypted whenever you send your specifications to Estuary.
 
+:::note
+Auto-encryption uses Estuary's managed encryption key, not a customer-managed
+(bring-your-own) KMS key. To encrypt your configurations with your own key, you
+must encrypt them yourself before publishing, as described in
+[Controlling encryption with `sops`](#controlling-encryption-with-sops). A
+plain-text config published without manual encryption is encrypted with Estuary's
+default key, and your own key is not used.
+:::
+
 This does not, by default, encrypt secrets in your local environment.
 If you want to encrypt local files, you can overwrite your local plain-text configuration with Estuary's encrypted version. To do so, run:
 
@@ -240,11 +249,18 @@ been encrypted.
 Estuary supports customers encrypting secrets with keys from AWS Key Management Service, Google Cloud Platform KMS, and Azure Key Vault.
 
 :::important
-When deploying catalogs onto the managed Estuary runtime, you must grant access to
-decrypt your KMS key to the appropriate identity for your data plane and KMS.
-These identities vary by data plane, find yours under
-[Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings)
-in the Estuary dashboard.
+When deploying catalogs onto the managed Estuary runtime, you must grant **decrypt**
+access on your KMS key to the appropriate identity for your data plane. On GCP KMS,
+this is the `roles/cloudkms.cryptoKeyDecrypter` role. Estuary only decrypts your
+configuration at connector run time and never encrypts with your key, so the
+identity does not need encrypt access.
+
+These identities vary by data plane. You can find your data plane's native-cloud
+identity under [Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings)
+in the Estuary dashboard. If your KMS provider differs from the cloud your data
+plane runs in (for example, encrypting with a GCP KMS key while your data plane
+runs on AWS), the identity you need may not be shown in the dashboard. Contact
+Estuary support to obtain it.
 :::
 
 The examples below provide a useful reference.

--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -243,31 +243,24 @@ You can also implement `sops` manually if you are writing a Data Flow specificat
 
 This can be useful if you need to maintain strict control over how credentials
 are encrypted. In this case, you own the KMS key and grant Estuary access for
-decryption. `flowctl` will not modify endpoint configurations that have already
-been encrypted.
+**decryption**. Estuary decrypts your configuration only at connector run time
+and never encrypts with your key, so Estuary never needs encrypt access.
 
-Estuary supports customers encrypting secrets with keys from AWS Key Management Service, Google Cloud Platform KMS, and Azure Key Vault.
+Estuary supports customers encrypting secrets with keys from AWS Key Management Service,
+Google Cloud Platform KMS, and Azure Key Vault. Each data plane has a separate identity for
+GCP, AWS, and Azure, so you can use a KMS provider that differs from the cloud your data
+plane runs in (for example, a GCP KMS key with an AWS data plane). Contact Estuary support
+to obtain the correct data plane identity for your use case.
 
-:::important
-When deploying catalogs onto the managed Estuary runtime, you must grant **decrypt-only**
-access on your KMS key to the appropriate identity for your data plane. Estuary
-decrypts your configuration only at connector run time and never encrypts with your
-key, so the identity never needs encrypt access. How you grant access depends on the
-provider:
+How you grant decryption access then depends on the provider:
 
 - **GCP KMS**: grant the `roles/cloudkms.cryptoKeyDecrypter` role on the key to the data plane's GCP service account.
 - **AWS KMS**: add a key-policy statement allowing `kms:Decrypt` and `kms:DescribeKey` to the data plane's AWS IAM user.
 - **Azure Key Vault**: grant a decrypt key permission to the data plane's Azure application.
 
-Each data plane has a separate identity for GCP, AWS, and Azure, so you can use a KMS
-provider that differs from the cloud your data plane runs in (for example, a GCP KMS
-key with an AWS data plane). The dashboard surfaces your data plane's native-cloud
-identity under [Admin > Settings > Data Planes](https://dashboard.estuary.dev/admin/settings);
-the identity for a different provider may not be shown there, so contact Estuary
-support to obtain the one you need.
-:::
-
-The examples below provide a useful reference.
+Once you've granted permissions for the data plane identity, reference the examples below
+to encrypt secrets with `sops`. `flowctl` will not modify endpoint configurations that
+have already been encrypted this way.
 
 #### Example: Protect a configuration
 


### PR DESCRIPTION
## What

Three clarifications to the secret-encryption section of `concepts/flowctl`:

1. **Decrypt-only.** The data plane identity needs decrypt access on your KMS key, not encrypt. On GCP KMS that is `roles/cloudkms.cryptoKeyDecrypter`. Estuary only decrypts at connector run time and never encrypts with your key.
2. **Auto-encryption uses Estuary's key.** `flowctl` 0.5.18+ and the dashboard auto-encrypt plain-text configs with Estuary's managed key, not a bring-your-own key. To use your own key you must encrypt manually before publishing, otherwise your key is never exercised.
3. **Cross-cloud identity not in dashboard.** When the KMS provider differs from the data plane's cloud (for example a GCP KMS key with an AWS data plane), the GCP service account to grant is not surfaced under Admin > Settings > Data Planes. Added a note to contact support.

## Why

A customer asked whether the data plane service account needs Encrypt/Decrypt on their GCP KMS key. The page said to grant "access to decrypt" but never stated decrypt-only, did not warn that auto-encryption bypasses bring-your-own keys, and pointed at a dashboard panel that does not display the cross-cloud identity.

Verified against the source:
- The config-encryption service sends `config` + `schema` with no keychain and falls back to its single default key, so plain-text publishes use Estuary's key (`crates/config-encryption`, `crates/flowctl/src/draft/encrypt.rs`).
- Data plane provisioning grants `roles/cloudkms.cryptoKeyDecrypter` to the data plane service account (est-dry-dock).
