### PR TITLE
notifications: trial bucket retention is 20 days, not 30

### DIFF
--- a/crates/notifications/src/missing_payment_method.rs
+++ b/crates/notifications/src/missing_payment_method.rs
@@ -25,7 +25,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 <div style="margin-top: 15px;">
     <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Where is my data stored?</p>
     <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-        <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 30 day retention policy. Now that you have a paid account, you can update this to store data in your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
+        <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 20 day retention policy. Now that you have a paid account, you can update this to store data in your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
     </div>
 </div>
 

--- a/crates/notifications/src/missing_payment_method.rs
+++ b/crates/notifications/src/missing_payment_method.rs
@@ -25,7 +25,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 <div style="margin-top: 15px;">
     <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Where is my data stored?</p>
     <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-        <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 20 day retention policy. Now that you have a paid account, you can update this to store data in your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
+        <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 20 day retention policy. If you haven't already, now is a great time to update your <a href="https://docs.estuary.dev/getting-started/installation/">storage mappings</a> to use your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
     </div>
 </div>
 

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
@@ -50,7 +50,7 @@ expression: email.body
             <div style="margin-top: 15px;">
                 <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Where is my data stored?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 30 day retention policy. Now that you have a paid account, you can update this to store data in your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
+                    <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 20 day retention policy. If you haven't already, now is a great time to update your <a href="https://docs.estuary.dev/getting-started/installation/">storage mappings</a> to use your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
                 </div>
             </div>
             

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
@@ -50,7 +50,7 @@ expression: email.body
             <div style="margin-top: 15px;">
                 <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Where is my data stored?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 30 day retention policy. Now that you have a paid account, you can update this to store data in your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
+                    <p class="body-text" style="margin-bottom: 0;">By default, all collection data is stored in an Estuary-owned cloud storage bucket with a 20 day retention policy. If you haven't already, now is a great time to update your <a href="https://docs.estuary.dev/getting-started/installation/">storage mappings</a> to use your own cloud storage bucket. We support GCS, S3, and Azure Blob storage.</p>
                 </div>
             </div>
             


### PR DESCRIPTION
## What

The missing-payment-method notification email told customers their data is stored in an Estuary-owned trial bucket "with a 30 day retention policy." The trial bucket (`estuary-trial`) retention is **20 days**, not 30.

```
crates/notifications/src/missing_payment_method.rs:28
- ...cloud storage bucket with a 30 day retention policy.
+ ...cloud storage bucket with a 20 day retention policy.
```

## Why

20 days is the correct value and matches what the docs already say:
- [concepts/storage-mappings](https://docs.estuary.dev/concepts/storage-mappings/): "Data in Estuary's cloud storage bucket is deleted 20 days after collection."
- [getting-started/quickstart](https://docs.estuary.dev/getting-started/quickstart/) and the installation page say the same.

The retention was reduced from 30 to 20 a while back; the docs were updated but this email string was missed.

## Scope

Only the storage-retention sentence changed. The 30-day references in `free_trial.rs` and the UI register/billing copy are the **account free-trial period**, which is genuinely 30 days, and are intentionally left untouched.