### PR TITLE
flowctl: normalize --prefix trailing slash to avoid misleading PermissionDenied

### DIFF
--- a/crates/flowctl/src/catalog/list/mod.rs
+++ b/crates/flowctl/src/catalog/list/mod.rs
@@ -270,10 +270,19 @@ fn to_vars(list: &List) -> Vec<list_live_specs_query::LiveSpecsBy> {
     let catalog_type = list.type_selector.get_single_type_selection();
 
     let mut vars = Vec::new();
+    let mut seen_prefixes = std::collections::HashSet::new();
     for prefix in list.name_selector.prefix.iter() {
+        let prefix = normalize_prefix(prefix);
+        // Skip prefixes that normalize to an already-queued value. Because we
+        // append a trailing '/', a bare `acmeCo` and an explicit `acmeCo/`
+        // collapse to the same prefix; issuing both queries would list every
+        // matching spec twice.
+        if !seen_prefixes.insert(prefix.as_str().to_string()) {
+            continue;
+        }
         vars.push(list_live_specs_query::LiveSpecsBy {
             names: None,
-            prefix: Some(normalize_prefix(prefix)),
+            prefix: Some(prefix),
             catalog_type,
             data_plane_name: data_plane_name.clone(),
         });
@@ -312,7 +321,27 @@ fn normalize_prefix(prefix: &str) -> models::Prefix {
 
 #[cfg(test)]
 mod test {
-    use super::normalize_prefix;
+    use super::{List, normalize_prefix, to_vars};
+
+    #[test]
+    fn test_to_vars_dedups_prefixes() {
+        // A bare prefix and its trailing-slash form normalize to the same value;
+        // querying both would double-list every matching spec, so `to_vars`
+        // should emit a single query. The same-value-twice case dedups too.
+        let mut list = List::default();
+        list.name_selector.prefix = vec![
+            "acmeCo".to_string(),
+            "acmeCo/".to_string(),
+            "acmeCo".to_string(),
+            "acmeCo/widgets".to_string(),
+        ];
+
+        let prefixes = to_vars(&list)
+            .into_iter()
+            .map(|by| by.prefix.expect("prefix selector").as_str().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(prefixes, vec!["acmeCo/", "acmeCo/widgets/"]);
+    }
 
     #[test]
     fn test_normalize_prefix() {

--- a/crates/flowctl/src/catalog/list/mod.rs
+++ b/crates/flowctl/src/catalog/list/mod.rs
@@ -273,7 +273,7 @@ fn to_vars(list: &List) -> Vec<list_live_specs_query::LiveSpecsBy> {
     for prefix in list.name_selector.prefix.iter() {
         vars.push(list_live_specs_query::LiveSpecsBy {
             names: None,
-            prefix: Some(models::Prefix::new(prefix)),
+            prefix: Some(normalize_prefix(prefix)),
             catalog_type,
             data_plane_name: data_plane_name.clone(),
         });
@@ -293,4 +293,43 @@ fn to_vars(list: &List) -> Vec<list_live_specs_query::LiveSpecsBy> {
         });
     }
     vars
+}
+
+/// Normalizes a user-supplied `--prefix` value by appending a trailing '/' when
+/// it's missing. Estuary prefixes must end in a '/' (for example, `acmeCo/`).
+/// When the slash is omitted, the control plane treats the value as an
+/// unrecognized catalog name and returns a misleading `PermissionDenied` error
+/// even for fully-authorized users, so we fix it up here at the CLI boundary.
+/// An empty prefix is left as-is: it's a valid selector meaning "everything the
+/// user can access", and a bare "/" would be rejected.
+fn normalize_prefix(prefix: &str) -> models::Prefix {
+    if prefix.is_empty() || prefix.ends_with('/') {
+        models::Prefix::new(prefix)
+    } else {
+        models::Prefix::new(format!("{prefix}/"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::normalize_prefix;
+
+    #[test]
+    fn test_normalize_prefix() {
+        // A missing trailing slash is the reported foot-gun, and is filled in.
+        assert_eq!(normalize_prefix("acmeCo").as_str(), "acmeCo/");
+        assert_eq!(
+            normalize_prefix("acmeCo/widgets").as_str(),
+            "acmeCo/widgets/"
+        );
+        // Already-normalized prefixes pass through unchanged.
+        assert_eq!(normalize_prefix("acmeCo/").as_str(), "acmeCo/");
+        assert_eq!(
+            normalize_prefix("acmeCo/widgets/").as_str(),
+            "acmeCo/widgets/"
+        );
+        // An empty prefix stays empty (a valid "everything" selector); we must
+        // not turn it into the invalid "/".
+        assert_eq!(normalize_prefix("").as_str(), "");
+    }
 }


### PR DESCRIPTION
## Problem

`flowctl catalog pull-specs --prefix AcmeCo` (no trailing slash) returns a misleading error even for fully-authorized users:

```
PermissionDenied: johnsmith@acme.co is not authorized to access prefix or name 'AcmeCo' with required capability read
```

The value is passed verbatim to `models::Prefix::new`. Estuary prefixes must end in `/`, so the control plane treats `AcmeCo` as an unrecognized catalog *name* rather than a prefix and rejects it.

## Fix

Auto-normalize the prefix by appending a trailing `/` when it's missing. The fix lives in `to_vars` — the single point through which every `NameSelector`-based command routes its `--prefix` values:

- `catalog list`
- `catalog pull-specs`
- `catalog delete`

An **empty** prefix is deliberately left untouched: `""` is a valid selector meaning "everything the user can access", whereas `"/"` is invalid, so blindly appending would introduce a new bug.

## Testing

- New unit test `test_normalize_prefix` covers the missing-slash case, multi-segment prefixes, already-normalized input, and the empty edge case.
- `cargo test -p flowctl normalize_prefix` passes.

## Out of scope

`flowctl alerts subscriptions` and `flowctl raw` accept their own `--prefix` args that don't go through `NameSelector`, so they retain the same foot-gun. The issue scoped the fix to `NameSelector`; happy to fold those in as a follow-up if desired.

Closes #2834
