### PR TITLE
supabase: qualify replace_data_plane_releases DELETE for PostgREST

### DIFF
--- a/supabase/migrations/20260623120000_replace_data_plane_releases_safe_delete.sql
+++ b/supabase/migrations/20260623120000_replace_data_plane_releases_safe_delete.sql
@@ -1,0 +1,31 @@
+begin;
+
+-- replace_data_plane_releases cleared the table with an unqualified DELETE. Postgres
+-- rejects that under sql_safe_updates, which the PostgREST execution context enables,
+-- raising "DELETE requires a WHERE clause"; the direct psql path did not enforce it.
+-- Add an always-true predicate so the full-table replace still removes every row.
+-- CREATE OR REPLACE keeps the existing execute grant to data_plane_releases_ci.
+create or replace function public.replace_data_plane_releases(payload jsonb) returns integer
+    language plpgsql
+    as $$
+declare
+  inserted integer;
+begin
+  delete from data_plane_releases where true;
+
+  insert into data_plane_releases (active, data_plane_id, max_tier, next_image, prev_image, step)
+    select
+      (e->>'active')::boolean,
+      (e->>'data_plane_id')::public.flowid,
+      (e->>'max_tier')::smallint,
+      e->>'next_image',
+      e->>'prev_image',
+      (e->>'step')::integer
+    from jsonb_array_elements(payload) as e;
+
+  get diagnostics inserted = row_count;
+  return inserted;
+end
+$$;
+
+commit;


### PR DESCRIPTION
## Summary
The ops "Release Data Planes" workflow was cut over to call
`replace_data_plane_releases` over PostgREST instead of a direct psql
connection. The first master run failed:

    {"code":"21000","message":"DELETE requires a WHERE clause"}

The function clears the table with an unqualified `delete from
data_plane_releases`. The PostgREST execution context runs under
`sql_safe_updates`, which rejects an unqualified DELETE; the direct psql path
never enforced this, so it only surfaced after the cutover.

## Change
New migration that `create or replace`s the function, changing the delete to
`delete from data_plane_releases where true`. The always-true predicate
satisfies the safe-update guard while still removing every row, and the
full-table replace stays atomic (delete + insert in one call). `create or
replace` on the same signature preserves the existing execute grant to
`data_plane_releases_ci`; nothing else changes.

## Rollout
Takes effect once the migration is applied to the production database; the
"Release Data Planes" workflow passes on its next run after that.
