### PR TITLE
dekaf: improve logging

### DIFF
--- a/crates/dekaf/src/log_appender.rs
+++ b/crates/dekaf/src/log_appender.rs
@@ -16,7 +16,10 @@ use std::{
     marker::PhantomData,
     mem,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::SystemTime,
 };
 use tokio::sync::mpsc::error::TrySendError;
@@ -268,6 +271,7 @@ impl GazetteAppender {
 pub struct TaskForwarder<W: TaskWriter> {
     tx: tokio::sync::mpsc::Sender<TaskWriterMessage>,
     _handle: Arc<tokio::task::JoinHandle<()>>,
+    task_name_recorded: Arc<AtomicBool>,
     _ph: PhantomData<W>,
 }
 
@@ -309,6 +313,7 @@ impl<W: TaskWriter + Clone + 'static> TaskForwarder<W> {
         Self {
             tx: logs_tx,
             _handle: Arc::new(handle),
+            task_name_recorded: Arc::new(AtomicBool::new(false)),
             _ph: Default::default(),
         }
     }
@@ -554,7 +559,11 @@ impl<W: TaskWriter + Clone + 'static> TaskForwarder<W> {
 
         // Also set the task name on the parent span so it's included in the logs. This also adds it
         // to the logs that Dekaf writes to stdout, which makes debugging issues much easier.
-        tracing::Span::current().record_hierarchical(SESSION_TASK_NAME_FIELD_MARKER, name);
+        // Record only once per session: the fmt field formatter appends rather than replaces, so a
+        // repeatedly-reauthenticating client would otherwise duplicate `task_name` per log line.
+        if !self.task_name_recorded.swap(true, Ordering::Relaxed) {
+            tracing::Span::current().record_hierarchical(SESSION_TASK_NAME_FIELD_MARKER, name);
+        }
     }
 
     pub fn send_log_message(&self, log: ops::Log) {

--- a/crates/dekaf/src/logging.rs
+++ b/crates/dekaf/src/logging.rs
@@ -34,6 +34,8 @@ pub fn install() {
     // We want to be able to control Dekaf's own logging output via the RUST_LOG environment variable like usual.
     let fmt_layer = tracing_subscriber::fmt::Layer::default()
         .with_writer(std::io::stderr)
+        // Only emit ANSI color codes when stderr is a TTY, so they don't bloat container logs.
+        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
         .with_filter(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(LevelFilter::WARN.into()) // Otherwise it's ERROR.

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -147,7 +147,7 @@ impl Collection {
                 if let Some(binding) = task_auth.get_binding_for_topic(topic_name).await? {
                     binding
                 } else {
-                    tracing::warn!("{topic_name} is not a binding of {}", task_auth.task_name);
+                    tracing::debug!("{topic_name} is not a binding of {}", task_auth.task_name);
                     return Ok(CollectionStatus::not_found());
                 }
             }
@@ -155,7 +155,7 @@ impl Collection {
                 let Some(binding) = utils::get_binding_for_topic(spec, topic_name)
                     .context("failed to get binding for topic in redirected session")?
                 else {
-                    tracing::warn!("{topic_name} is not a binding of {}", spec.name);
+                    tracing::debug!("{topic_name} is not a binding of {}", spec.name);
                     return Ok(CollectionStatus::not_found());
                 };
                 binding
@@ -280,7 +280,7 @@ impl Collection {
         // This happens when a collection was reset and journals haven't been created yet,
         // or when a collection exists but no data has ever been written.
         if partitions.is_empty() {
-            tracing::warn!(
+            tracing::debug!(
                 collection_name,
                 "Collection binding exists but has no journals available"
             );


### PR DESCRIPTION
**Description:**

Some fixes related to logging, and log levels for normal conditions:

- Demote the per-metadata-poll "no journals" / "not a binding" warnings to debug.
- Record the session's task_name span field once, not on every (re)auth; the formatter appends re-recorded fields, so it was duplicated per line.
- Disable ANSI colors on non-TTY stderr so escape codes don't get logged.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

