### PR TITLE
runtime-next: durably seed initial connector state as {} to match V1

### DIFF
--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -295,10 +295,11 @@ where
         .map(|(i, b)| (b.state_key.clone(), i as u32))
         .collect();
     sorted_state_keys.sort();
-    let (mut db, recover) = db
+    let (mut db, mut recover) = db
         .scan(sorted_state_keys)
         .await
         .context("scanning RocksDB")?;
+    db = db.seed_connector_state(&mut recover).await?;
     let proto::Recover {
         ack_intents,
         connector_state_json,
@@ -331,7 +332,7 @@ where
             capture: Some(spec.clone()),
             version: version.clone(),
             range: Some(range.clone()),
-            state_json: non_empty_state(&connector_state_json),
+            state_json: connector_state_json,
         }),
         ..Default::default()
     };
@@ -459,7 +460,7 @@ async fn apply_loop<L: crate::LogHandler>(
             version: next_version.to_string(),
             last_capture: last_spec.clone(),
             last_version: last_version.clone(),
-            state_json: non_empty_state(connector_state_json),
+            state_json: connector_state_json.clone(),
         };
 
         let (connector_tx, mut connector_rx, _container) = connector::start(
@@ -537,16 +538,6 @@ async fn apply_loop<L: crate::LogHandler>(
         "capture apply loop did not converge after {MAX_APPLY_ITERATIONS} iterations; \
          connector continues to return state patches"
     );
-}
-
-/// Connector `state_json` defaults to an empty JSON object when no state has
-/// been persisted yet, since connectors expect a JSON document.
-fn non_empty_state(connector_state_json: &bytes::Bytes) -> bytes::Bytes {
-    if connector_state_json.is_empty() {
-        bytes::Bytes::from_static(b"{}")
-    } else {
-        connector_state_json.clone()
-    }
 }
 
 fn labels_build_for(spec: &flow::CaptureSpec) -> String {

--- a/crates/runtime-next/src/shard/derive/startup.rs
+++ b/crates/runtime-next/src/shard/derive/startup.rs
@@ -151,10 +151,13 @@ where
         .collect();
     sorted_state_keys.sort();
 
-    let (mut db, recover) = db
+    let (mut db, mut recover) = db
         .scan(sorted_state_keys)
         .await
         .context("scanning RocksDB")?;
+    if shard_index == 0 {
+        db = db.seed_connector_state(&mut recover).await?;
+    }
 
     _ = leader_tx.send(proto::Derive {
         recover: Some(recover),
@@ -207,7 +210,7 @@ where
             collection: Some(open_spec),
             version,
             range,
-            state_json: non_empty_state(&connector_state_json),
+            state_json: connector_state_json,
         }),
         ..Default::default()
     };
@@ -267,14 +270,4 @@ where
         task,
         write_shape,
     })
-}
-
-/// Connector `state_json` defaults to an empty JSON object when no state has
-/// been persisted, since connectors expect a JSON document.
-fn non_empty_state(connector_state_json: &bytes::Bytes) -> bytes::Bytes {
-    if connector_state_json.is_empty() {
-        bytes::Bytes::from_static(b"{}")
-    } else {
-        connector_state_json.clone()
-    }
 }

--- a/crates/runtime-next/src/shard/materialize/startup.rs
+++ b/crates/runtime-next/src/shard/materialize/startup.rs
@@ -139,10 +139,13 @@ where
         .collect();
     sorted_state_keys.sort();
 
-    let (mut db, recover) = db
+    let (mut db, mut recover) = db
         .scan(sorted_state_keys)
         .await
         .context("scanning RocksDB")?;
+    if shard_index == 0 {
+        db = db.seed_connector_state(&mut recover).await?;
+    }
 
     _ = leader_tx.send(proto::Materialize {
         recover: Some(recover),

--- a/crates/runtime-next/src/shard/rocksdb.rs
+++ b/crates/runtime-next/src/shard/rocksdb.rs
@@ -200,6 +200,38 @@ impl RocksDB {
             .await
             .unwrap()
     }
+
+    /// Durably seed `{}` as the connector-state base when none was recovered,
+    /// reflecting it in `recover`. A no-op if state is already present.
+    ///
+    /// Connector state is only ever updated via Merge, and the merge operator
+    /// treats the first operand on an absent key as the base document — where a
+    /// JSON `null` is a literal value, not a deletion. Without a base, a
+    /// connector's first checkpoint of e.g. `{"k": null}` is retained verbatim
+    /// instead of reducing to `{}`; a `{}` base makes it a genuine merge patch.
+    ///
+    /// Call only on the connector-state-bearing shard: the capture shard, or
+    /// shard zero of a derivation/materialization, whose recovered state the
+    /// leader broadcasts to its peers. Other shards must recover empty so their
+    /// `Recover` stays `default()`.
+    pub async fn seed_connector_state(self, recover: &mut proto::Recover) -> anyhow::Result<Self> {
+        if !recover.connector_state_json.is_empty() {
+            return Ok(self);
+        }
+
+        let mut wb = rocksdb::WriteBatch::default();
+        wb.put(recovery::KEY_CONNECTOR_STATE, b"{}");
+        let mut wo = rocksdb::WriteOptions::new();
+        wo.set_sync(true);
+
+        let db = self
+            .write_opt(wb, wo)
+            .await
+            .context("seeding initial connector state")?;
+
+        recover.connector_state_json = bytes::Bytes::from_static(b"{}");
+        Ok(db)
+    }
 }
 
 // Unpack a RocksDbDescriptor into its rocksdb::Options and path.
@@ -568,6 +600,35 @@ mod test {
         assert_eq!(
             state.connector_state_json,
             bytes::Bytes::from_static(br#"{"a":"c","ans":42,"d":"e","n":null}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_task_seeds_connector_state_base() {
+        let db = RocksDB::open(None).await.unwrap();
+
+        let (db, mut recover) = db.scan(Vec::new()).await.unwrap();
+        let db = db.seed_connector_state(&mut recover).await.unwrap();
+        assert_eq!(
+            recover.connector_state_json,
+            bytes::Bytes::from_static(b"{}")
+        );
+
+        let db = db
+            .persist::<&str>(
+                &proto::Persist {
+                    connector_patches_json: bytes::Bytes::from_static(b"[{\"stateKey\":null}\t]"),
+                    ..Default::default()
+                },
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (_db, recover) = db.scan(Vec::new()).await.unwrap();
+        assert_eq!(
+            recover.connector_state_json,
+            bytes::Bytes::from_static(b"{}")
         );
     }
 


### PR DESCRIPTION
**Description:**

Connector state is only updated via RocksDB Merge, and the merge operator treats the first operand on an absent key as the base document -- where a JSON null is a literal value, not a deletion. So a task first published on Runtime-V2 stores a connector's first checkpoint of e.g. `{"stateKey": null}` verbatim instead of reducing it to {}, corrupting its state from the first patch onward.

Mirror V1's `load_connector_state`: when the recovery scan finds no connector state, durably seed `{}` as the base and reflect it in the recovered `Recover`, so the first checkpoint reduces as a genuine merge patch. Seed only on the state-bearing shard -- the capture shard, or shard zero of a derivation or materialization, whose state the leader broadcasts to peers; other shards must recover an empty Recover.

This replaces a `non_empty_state` helper that substituted `{}` only on the connector-facing `Open`/`Apply` requests: it changed what the connector saw, not what the runtime stored, so the mis-store still happened.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

