### PR TITLE
control-plane: reserve privileged tenant names

### DIFF
--- a/supabase/migrations/20260627120000_reserve_privileged_tenant_names.sql
+++ b/supabase/migrations/20260627120000_reserve_privileged_tenant_names.sql
@@ -7,6 +7,10 @@
 -- The onboarding existence check (control_plane_api::directives::beta_onboard::tenant_exists)
 -- compares case-insensitively, so a single lowercase entry covers all case variants.
 -- Idempotent: safe to re-run and coexists with any names already inserted directly.
+--
+-- estuary_support/ (and the estuarysupport/ variant) is the support role, which holds grants
+-- across many tenants. That role has no `tenants` row, so the name is otherwise provisionable;
+-- reserving it prevents a user from claiming it and inheriting fleet-wide support access.
 
 insert into internal.illegal_tenant_names (name) values
   ('admin/'),
@@ -21,5 +25,7 @@ insert into internal.illegal_tenant_names (name) values
   ('everyone/'),
   ('internal/'),
   ('system/'),
-  ('billing/')
+  ('billing/'),
+  ('estuary_support/'),
+  ('estuarysupport/')
 on conflict (name) do nothing;

--- a/supabase/migrations/20260627120000_reserve_privileged_tenant_names.sql
+++ b/supabase/migrations/20260627120000_reserve_privileged_tenant_names.sql
@@ -1,0 +1,25 @@
+-- Reserve privileged / role-sounding tenant names so they cannot be provisioned by users.
+-- Names like "admin", "root", or "support" are easily confused with platform roles or with
+-- the `admin` grant capability, and make poor (and potentially misleading) tenant prefixes.
+-- Reserving them also ensures a user cannot provision the name and thereby inherit any
+-- role_grants that were previously created with that name as the subject.
+--
+-- The onboarding existence check (control_plane_api::directives::beta_onboard::tenant_exists)
+-- compares case-insensitively, so a single lowercase entry covers all case variants.
+-- Idempotent: safe to re-run and coexists with any names already inserted directly.
+
+insert into internal.illegal_tenant_names (name) values
+  ('admin/'),
+  ('admin1/'),
+  ('administrator/'),
+  ('root/'),
+  ('superuser/'),
+  ('support/'),
+  ('security/'),
+  ('compliance/'),
+  ('developers/'),
+  ('everyone/'),
+  ('internal/'),
+  ('system/'),
+  ('billing/')
+on conflict (name) do nothing;


### PR DESCRIPTION
## What

Adds a migration that reserves a set of privileged / role-sounding names in `internal.illegal_tenant_names` so users cannot provision them as tenants:

`admin`, `admin1`, `administrator`, `root`, `superuser`, `support`, `security`, `compliance`, `developers`, `everyone`, `internal`, `system`, `billing`.

## Why

These names collide conceptually with platform roles and with the `admin` grant capability, and make misleading tenant prefixes. Reserving a name also prevents a user from provisioning it and inheriting any `role_grants` that were previously created with that name as the subject. This complements an operational cleanup of stale role_grants whose subject was one of these names.

## Notes

- The onboarding existence check (`control_plane_api::directives::beta_onboard::tenant_exists`) compares case-insensitively, so a single lowercase entry covers all case variants.
- Idempotent (`on conflict do nothing`); coexists with any names already inserted directly in an environment.
- The list is a starting set; reviewers should feel free to add/trim (e.g. other platform-reserved prefixes).
- Follow-up (separate issue): grant creation does not validate that the subject role exists, so reserving names mitigates but does not fully prevent stale-grant inheritance.