### PR TITLE
docs: clarify column-level SELECT grants unsupported for MySQL/MariaDB CDC

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -42,6 +42,8 @@ To meet these requirements, do the following:
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
+It cannot be restricted to a subset of columns within a table; see
+[Column-level permissions](#column-level-permissions) for details.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret';
@@ -104,6 +106,26 @@ This is desirable in most cases, as it ensures that a complete view of your tabl
 However, you may find it appropriate to skip the backfill, especially for extremely large tables.
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
+
+## Column-level permissions
+
+The capture user's `SELECT` privilege can be limited to specific tables, but not to a
+subset of columns within a table. Column-scoped grants do not restrict what the connector
+captures, and they prevent it from running:
+
+- During backfill, the connector reads each table with `SELECT *`, which requires `SELECT`
+  on every column. A column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl`
+  makes the backfill (and the connector's per-table validation check) fail with a
+  `cannot read from table` error.
+- Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
+  is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
+  contains every column of a changed row, so column-level grants have no effect on what is
+  streamed during replication.
+
+Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
+tables. To keep specific columns, such as sensitive fields, out of the pipeline, use
+[redaction](/features/redaction.md) to drop or hash those fields at capture time so they
+never land in the collection.
 
 ## Configuration
 

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -40,11 +40,10 @@ To meet these requirements, do the following:
 
 1. Create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table, because the connector
-reads ongoing changes from the binary log, which always includes every column. See
-[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret';
@@ -107,26 +106,6 @@ This is desirable in most cases, as it ensures that a complete view of your tabl
 However, you may find it appropriate to skip the backfill, especially for extremely large tables.
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
-
-## Column-level permissions unsupported
-
-The capture user's `SELECT` privilege can be limited to specific tables, but not to a
-subset of columns within a table, because most of what the connector reads never goes
-through `SELECT`:
-
-- Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
-  is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
-  contains every column of a changed row, so column-level grants have no effect on what is
-  streamed during replication.
-- The initial backfill does use `SELECT`, but reads each table with `SELECT *` (as does the
-  connector's per-table validation check), which requires `SELECT` on every column. A
-  column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl` makes the backfill and
-  the validation check fail with a `cannot read from table` error.
-
-Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
-tables. To keep specific columns, such as sensitive fields, out of the pipeline, use
-[redaction](/features/redaction.md) to drop or hash those fields at capture time so they
-never land in the collection.
 
 ## Configuration
 

--- a/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/site/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -42,8 +42,9 @@ To meet these requirements, do the following:
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table; see
-[Column-level permissions](#column-level-permissions) for details.
+It cannot be restricted to a subset of columns within a table, because the connector
+reads ongoing changes from the binary log, which always includes every column. See
+[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret';
@@ -107,20 +108,20 @@ However, you may find it appropriate to skip the backfill, especially for extrem
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
 
-## Column-level permissions
+## Column-level permissions unsupported
 
 The capture user's `SELECT` privilege can be limited to specific tables, but not to a
-subset of columns within a table. Column-scoped grants do not restrict what the connector
-captures, and they prevent it from running:
+subset of columns within a table, because most of what the connector reads never goes
+through `SELECT`:
 
-- During backfill, the connector reads each table with `SELECT *`, which requires `SELECT`
-  on every column. A column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl`
-  makes the backfill (and the connector's per-table validation check) fail with a
-  `cannot read from table` error.
 - Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
   is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
   contains every column of a changed row, so column-level grants have no effect on what is
   streamed during replication.
+- The initial backfill does use `SELECT`, but reads each table with `SELECT *` (as does the
+  connector's per-table validation check), which requires `SELECT` on every column. A
+  column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl` makes the backfill and
+  the validation check fail with a `cannot read from table` error.
 
 Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
 tables. To keep specific columns, such as sensitive fields, out of the pipeline, use

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -56,6 +56,8 @@ To meet these requirements, follow the steps for your hosting type.
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
+It cannot be restricted to a subset of columns within a table; see
+[Column-level permissions](#column-level-permissions) for details.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture
@@ -151,6 +153,8 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
+It cannot be restricted to a subset of columns within a table; see
+[Column-level permissions](#column-level-permissions) for details.
 
 :::tip
 Your username must be specified in the format `username@servername`.
@@ -212,6 +216,26 @@ This is desirable in most cases, as it ensures that a complete view of your tabl
 However, you may find it appropriate to skip the backfill, especially for extremely large tables.
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
+
+## Column-level permissions
+
+The capture user's `SELECT` privilege can be limited to specific tables, but not to a
+subset of columns within a table. Column-scoped grants do not restrict what the connector
+captures, and they prevent it from running:
+
+- During backfill, the connector reads each table with `SELECT *`, which requires `SELECT`
+  on every column. A column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl`
+  makes the backfill (and the connector's per-table validation check) fail with a
+  `cannot read from table` error.
+- Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
+  is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
+  contains every column of a changed row, so column-level grants have no effect on what is
+  streamed during replication.
+
+Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
+tables. To keep specific columns, such as sensitive fields, out of the pipeline, use
+[redaction](/features/redaction.md) to drop or hash those fields at capture time so they
+never land in the collection.
 
 ## Configuration
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -54,11 +54,10 @@ To meet these requirements, follow the steps for your hosting type.
 
 1. Create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table, because the connector
-reads ongoing changes from the binary log, which always includes every column. See
-[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture
@@ -152,11 +151,10 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 3. Using [MySQL workbench](https://docs.microsoft.com/en-us/azure/mysql/single-server/connect-workbench) or your preferred client,
    create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table, because the connector
-reads ongoing changes from the binary log, which always includes every column. See
-[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 :::tip
 Your username must be specified in the format `username@servername`.
@@ -218,26 +216,6 @@ This is desirable in most cases, as it ensures that a complete view of your tabl
 However, you may find it appropriate to skip the backfill, especially for extremely large tables.
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
-
-## Column-level permissions unsupported
-
-The capture user's `SELECT` privilege can be limited to specific tables, but not to a
-subset of columns within a table, because most of what the connector reads never goes
-through `SELECT`:
-
-- Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
-  is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
-  contains every column of a changed row, so column-level grants have no effect on what is
-  streamed during replication.
-- The initial backfill does use `SELECT`, but reads each table with `SELECT *` (as does the
-  connector's per-table validation check), which requires `SELECT` on every column. A
-  column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl` makes the backfill and
-  the validation check fail with a `cannot read from table` error.
-
-Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
-tables. To keep specific columns, such as sensitive fields, out of the pipeline, use
-[redaction](/features/redaction.md) to drop or hash those fields at capture time so they
-never land in the collection.
 
 ## Configuration
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -56,8 +56,9 @@ To meet these requirements, follow the steps for your hosting type.
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table; see
-[Column-level permissions](#column-level-permissions) for details.
+It cannot be restricted to a subset of columns within a table, because the connector
+reads ongoing changes from the binary log, which always includes every column. See
+[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture
@@ -153,8 +154,9 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 
 The `SELECT` permission can be restricted to just the tables that need to be
 captured, but automatic discovery requires `information_schema` access as well.
-It cannot be restricted to a subset of columns within a table; see
-[Column-level permissions](#column-level-permissions) for details.
+It cannot be restricted to a subset of columns within a table, because the connector
+reads ongoing changes from the binary log, which always includes every column. See
+[Column-level permissions unsupported](#column-level-permissions-unsupported) for details.
 
 :::tip
 Your username must be specified in the format `username@servername`.
@@ -217,20 +219,20 @@ However, you may find it appropriate to skip the backfill, especially for extrem
 
 In this case, you may turn off backfilling on a per-table basis. See [properties](#properties) for details.
 
-## Column-level permissions
+## Column-level permissions unsupported
 
 The capture user's `SELECT` privilege can be limited to specific tables, but not to a
-subset of columns within a table. Column-scoped grants do not restrict what the connector
-captures, and they prevent it from running:
+subset of columns within a table, because most of what the connector reads never goes
+through `SELECT`:
 
-- During backfill, the connector reads each table with `SELECT *`, which requires `SELECT`
-  on every column. A column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl`
-  makes the backfill (and the connector's per-table validation check) fail with a
-  `cannot read from table` error.
 - Ongoing changes are read from the binary log, not with `SELECT` queries. The binary log
   is authorized by the global `REPLICATION CLIENT` and `REPLICATION SLAVE` privileges and
   contains every column of a changed row, so column-level grants have no effect on what is
   streamed during replication.
+- The initial backfill does use `SELECT`, but reads each table with `SELECT *` (as does the
+  connector's per-table validation check), which requires `SELECT` on every column. A
+  column-scoped grant such as `GRANT SELECT (col1, col2) ON db.tbl` makes the backfill and
+  the validation check fail with a `cannot read from table` error.
 
 Grant table-level `SELECT` (as shown in [Setup](#setup)) so the connector can read its
 tables. To keep specific columns, such as sensitive fields, out of the pipeline, use


### PR DESCRIPTION
## What

Adds a `Column-level permissions` section to the MySQL and MariaDB CDC capture connector docs, and a one-line pointer to it from the Setup steps.

## Why

A customer tried to limit what leaves their database by granting column-scoped `SELECT` (`GRANT SELECT (col1, col2) ...`) to the capture user. This does not work and actively breaks the capture, but the docs only said `SELECT` could be restricted "to just the tables," which implies column scoping is fine.

Confirmed in `estuary/connectors` `source-mysql`:
- Backfill builds `SELECT *` (`backfill.go` `keylessScanQuery` / `buildScanQuery`), and the per-table prerequisite check runs `SELECT * ... LIMIT 0` (`prerequisites.go`). A column-scoped grant fails both with `cannot read from table`.
- CDC reads the binary log, authorized by the global `REPLICATION CLIENT` / `REPLICATION SLAVE` privileges, and decodes every column in the row image (`replication.go`). Column grants have no effect on the replication stream.

The new section explains both failure modes and points users to redaction to keep specific columns out of the pipeline.

## Scope

Covers the two canonical pages (`MySQL.md`, `MariaDB.md`). The RDS/Aurora/Cloud SQL variant pages were left for a follow-up; happy to extend if preferred.
