### PR TITLE
docs: avoiding backfills during a database failover or host change

### DIFF
--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -283,7 +283,7 @@ In this case, many connectors allow you to turn off backfilling on a per-stream 
 
 ### Preventing backfills during database upgrades and failovers
 
-During an upgrade, some databases invalidate a replication slot, binlog position, CDC tables, or similar. As Estuary relies on these methods to keep its place, upgrades will disrupt the Estuary pipeline in these cases. The same is true of a failover or promotion that moves the capture onto a new writer - for example a standby promotion, a migration to a new instance, or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region - because the new writer does not carry the old writer's CDC position.
+During an upgrade, some databases invalidate a replication slot, binlog position, CDC tables, or similar. As Estuary relies on these methods to keep its place, upgrades will disrupt the Estuary pipeline in these cases. The same is true of a failover or promotion that moves the capture onto a new writer - for example a standby promotion or a migration to a new instance - because the new writer does not carry the old writer's CDC position.
 
 - If the operation **will not** affect these resources, the Estuary connector should simply resume when it completes and no action is required.
 - If the operation **will** affect these or similar resources, you may need to trigger a backfill afterward.
@@ -292,7 +292,7 @@ The easiest and most bulletproof solution when this happens is to backfill all b
 
 However, it is common to want to avoid a full backfill when performing this sort of database maintenance, as these backfills may take some time and require a significant amount of extra data movement even if nothing has actually changed. Some connectors provide features which may be used to accomplish this, however they typically require some amount of extra setup or user knowledge to guarantee certain invariants (put simply: if there were a more efficient way to re-establish consistency in the general case, that's what we would already be doing when asked to backfill the data again).
 
-For example, Postgres deletes or requires users to drop logical replication slots during a major version upgrade, and a promoted standby or Aurora Global Database secondary does not carry the slot at all. To prevent a full backfill, follow these steps:
+For example, Postgres deletes or requires users to drop logical replication slots during a major version upgrade. To prevent a full backfill, follow these steps:
 
 1. Pause database writes so no further changes can occur.
 
@@ -304,12 +304,12 @@ For example, Postgres deletes or requires users to drop logical replication slot
 4. Backfill all bindings of the capture using the ["Only Changes" backfill mode](#resource-configuration-backfill-modes) and make sure to select "Incremental Backfill (Advanced)" from the drop down.
    - This will not cause a full backfill. "Backfilling" all bindings at once resets the WAL (Write-Ahead Log) or binlog position for the capture, essentially allowing it to "jump ahead" to the current end. The "Only Changes" mode will skip re-reading existing table content. Incremental backfill will append new data to your current collection.
    - **4a. Same host** (in-place upgrade): no other change is needed.
-   - **4b. New host** (failover, promotion, or migration to a new instance): in the same edit, also update the capture's `address` to the new writer's endpoint. Changing `address` on its own is not enough - the connector resumes from the stored position and fails (MySQL `ERROR 1236`, or a PostgreSQL replication slot / LSN mismatch). For MySQL, point at the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
+   - **4b. New host** (failover, promotion, or migration to a new instance): in the same edit, also update the capture's `address` to the new writer's endpoint. Changing `address` on its own is not enough - the connector would try to resume from a stored CDC position that does not exist on the new server.
 
 5. Resume database writes (on the new writer, if the host changed).
 
 :::note
-If a host change lands you on a database in another region reachable over [AWS PrivateLink](/private-byoc/privatelink), you can register that region's endpoint with Estuary ahead of time so its DNS name is ready before you need it. See [cross-region PrivateLink](/private-byoc/privatelink#cross-region).
+If the new writer is reachable over [AWS PrivateLink](/private-byoc/privatelink), you can register its endpoint with Estuary ahead of time so the DNS name is ready before you need it. See [Pre-registering an endpoint ahead of time](/private-byoc/privatelink#pre-registering-an-endpoint-ahead-of-time).
 :::
 
 ## Resource configuration backfill modes

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -281,56 +281,35 @@ Preventing backfills when possible can help save costs and computational resourc
 
 In this case, many connectors allow you to turn off backfilling on a per-stream or per-table basis. See each individual connector's properties for details.
 
-### Preventing backfills during database upgrades
+### Preventing backfills during database upgrades and failovers
 
-During an upgrade, some databases invalidate a replication slot, binlog position, CDC tables, or similar. As Estuary relies on these methods to keep its place, upgrades will disrupt the Estuary pipeline in these cases.
+During an upgrade, some databases invalidate a replication slot, binlog position, CDC tables, or similar. As Estuary relies on these methods to keep its place, upgrades will disrupt the Estuary pipeline in these cases. The same is true of a failover or promotion that moves the capture onto a new writer - for example a standby promotion, a migration to a new instance, or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region - because the new writer does not carry the old writer's CDC position.
 
-- If a database upgrade **will not** affect these resources, the Estuary connector should simply resume when the upgrade completes and no action is required.
-- If a database upgrade **will** affect these or similar resources, you may need to trigger a backfill after the upgrade completes.
+- If the operation **will not** affect these resources, the Estuary connector should simply resume when it completes and no action is required.
+- If the operation **will** affect these or similar resources, you may need to trigger a backfill afterward.
 
-The easiest and most bulletproof solution when this happens is to backfill all bindings of the impacted capture(s) after performing the upgrade. This will permit the captures to recreate entities as necessary, establish a new CDC position, and then backfill all table contents to ensure that any changes which might have occurred in the meantime are correctly captured.
+The easiest and most bulletproof solution when this happens is to backfill all bindings of the impacted capture(s) afterward. This will permit the captures to recreate entities as necessary, establish a new CDC position, and then backfill all table contents to ensure that any changes which might have occurred in the meantime are correctly captured.
 
 However, it is common to want to avoid a full backfill when performing this sort of database maintenance, as these backfills may take some time and require a significant amount of extra data movement even if nothing has actually changed. Some connectors provide features which may be used to accomplish this, however they typically require some amount of extra setup or user knowledge to guarantee certain invariants (put simply: if there were a more efficient way to re-establish consistency in the general case, that's what we would already be doing when asked to backfill the data again).
 
-For example, Postgres currently deletes or requires users to drop logical replication slots during a major version upgrade. To prevent a full backfill during the upgrade, follow these steps:
+For example, Postgres deletes or requires users to drop logical replication slots during a major version upgrade, and a promoted standby or Aurora Global Database secondary does not carry the slot at all. To prevent a full backfill, follow these steps:
 
 1. Pause database writes so no further changes can occur.
 
 2. Monitor the current capture to ensure captures are fully up-to-date.
    - These two steps ensure the connector won't miss any changes.
 
-3. Perform the database upgrade.
+3. Perform the database upgrade or failover.
 
 4. Backfill all bindings of the capture using the ["Only Changes" backfill mode](#resource-configuration-backfill-modes) and make sure to select "Incremental Backfill (Advanced)" from the drop down.
-   - This will not cause a full backfill. "Backfilling" all bindings at once resets the WAL (Write-Ahead Log) position for the capture, essentially allowing it to "jump ahead" to the current end of the WAL. The "Only Changes" mode will skip re-reading existing table content.  Incremental backfill will append new data to your current collection.
+   - This will not cause a full backfill. "Backfilling" all bindings at once resets the WAL (Write-Ahead Log) or binlog position for the capture, essentially allowing it to "jump ahead" to the current end. The "Only Changes" mode will skip re-reading existing table content. Incremental backfill will append new data to your current collection.
+   - **4a. Same host** (in-place upgrade): no other change is needed.
+   - **4b. New host** (failover, promotion, or migration to a new instance): in the same edit, also update the capture's `address` to the new writer's endpoint. Changing `address` on its own is not enough - the connector resumes from the stored position and fails (MySQL `ERROR 1236`, or a PostgreSQL replication slot / LSN mismatch). For MySQL, point at the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
 
-5. Resume database writes.
-
-### Preventing backfills during a failover or regional cutover
-
-A planned failover - promoting a standby, or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region - breaks CDC continuity the same way an upgrade does, because the new writer does not carry the old writer's CDC position:
-
-- **PostgreSQL**: a logical replication slot is not replicated to a promoted standby or to an Aurora Global Database secondary region. The new writer has no slot, and Postgres can only create a fresh slot at the *current* WAL position, never an earlier one. Your publication and watermarks table are present on the promoted cluster (they are replicated with the data volume); only the slot is missing.
-- **MySQL**: binlog coordinates are specific to each server, so the file and offset tracked against the old writer are meaningless on the new one. Capture from the **writer** endpoint - reader endpoints report `log_bin = OFF` and fail the connector's prerequisite check.
-
-If you can pause writes, you can avoid a full backfill using the same approach as for an [upgrade](#preventing-backfills-during-database-upgrades), with one extra step when the failover also changes the database host:
-
-1. Pause database writes so no further changes can occur.
-
-2. Monitor the current capture to ensure it is fully up-to-date.
-
-3. Perform the failover (promote the standby or the secondary region).
-
-4. Edit the capture and, in a single publish:
-   - If the new writer has a different host - for example a promoted Aurora Global Database secondary, which has its own regional endpoint - update the capture's `address` to the new writer endpoint. Changing `address` on its own is not enough: the connector resumes from the stored CDC position and fails (MySQL `ERROR 1236`, or a PostgreSQL replication slot / LSN mismatch).
-   - Backfill all bindings using the ["Only Changes" backfill mode](#resource-configuration-backfill-modes) with "Incremental Backfill (Advanced)" selected. This resets the CDC position to the new writer's current end without re-reading table contents.
-
-5. Resume database writes on the new writer.
-
-Because writes were paused from the moment the capture caught up until the new position was established, no changes fall in the gap, so there is no data loss and no full backfill.
+5. Resume database writes (on the new writer, if the host changed).
 
 :::note
-If the new writer is reachable over [AWS PrivateLink](/private-byoc/privatelink), you can register the standby region's endpoint with Estuary ahead of time so its DNS name is ready before you need it. See [cross-region PrivateLink](/private-byoc/privatelink#cross-region).
+If a host change lands you on a database in another region reachable over [AWS PrivateLink](/private-byoc/privatelink), you can register that region's endpoint with Estuary ahead of time so its DNS name is ready before you need it. See [cross-region PrivateLink](/private-byoc/privatelink#cross-region).
 :::
 
 ## Resource configuration backfill modes
@@ -347,7 +326,7 @@ bindings:
 ```
 
 :::warning
-In general, you should not change this setting. Make sure you understand your use case, such as [preventing backfills](#preventing-backfills-during-database-upgrades).
+In general, you should not change this setting. Make sure you understand your use case, such as [preventing backfills](#preventing-backfills-during-database-upgrades-and-failovers).
 :::
 
 The following modes are available:

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -306,6 +306,33 @@ For example, Postgres currently deletes or requires users to drop logical replic
 
 5. Resume database writes.
 
+### Preventing backfills during a failover or regional cutover
+
+A planned failover - promoting a standby, or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region - breaks CDC continuity the same way an upgrade does, because the new writer does not carry the old writer's CDC position:
+
+- **PostgreSQL**: a logical replication slot is not replicated to a promoted standby or to an Aurora Global Database secondary region. The new writer has no slot, and Postgres can only create a fresh slot at the *current* WAL position, never an earlier one. Your publication and watermarks table are present on the promoted cluster (they are replicated with the data volume); only the slot is missing.
+- **MySQL**: binlog coordinates are specific to each server, so the file and offset tracked against the old writer are meaningless on the new one. Capture from the **writer** endpoint - reader endpoints report `log_bin = OFF` and fail the connector's prerequisite check.
+
+If you can pause writes, you can avoid a full backfill using the same approach as for an [upgrade](#preventing-backfills-during-database-upgrades), with one extra step when the failover also changes the database host:
+
+1. Pause database writes so no further changes can occur.
+
+2. Monitor the current capture to ensure it is fully up-to-date.
+
+3. Perform the failover (promote the standby or the secondary region).
+
+4. Edit the capture and, in a single publish:
+   - If the new writer has a different host - for example a promoted Aurora Global Database secondary, which has its own regional endpoint - update the capture's `address` to the new writer endpoint. Changing `address` on its own is not enough: the connector resumes from the stored CDC position and fails (MySQL `ERROR 1236`, or a PostgreSQL replication slot / LSN mismatch).
+   - Backfill all bindings using the ["Only Changes" backfill mode](#resource-configuration-backfill-modes) with "Incremental Backfill (Advanced)" selected. This resets the CDC position to the new writer's current end without re-reading table contents.
+
+5. Resume database writes on the new writer.
+
+Because writes were paused from the moment the capture caught up until the new position was established, no changes fall in the gap, so there is no data loss and no full backfill.
+
+:::note
+If the new writer is reachable over [AWS PrivateLink](/private-byoc/privatelink), you can register the standby region's endpoint with Estuary ahead of time so its DNS name is ready before you need it. See [cross-region PrivateLink](/private-byoc/privatelink#cross-region).
+:::
+
 ## Resource configuration backfill modes
 
 The connectors that use CDC (Change Data Capture) allow fine-grained control of backfills for individual tables. These bindings include a "Backfill Mode" dropdown in their resource configuration. This setting then translates to a `mode` field for that resource in the specification. For example:

--- a/site/docs/private-byoc/privatelink.md
+++ b/site/docs/private-byoc/privatelink.md
@@ -98,7 +98,7 @@ When accessing services cross-region, you must use the **regional** DNS name (e.
 
 #### Pre-registering a standby region for disaster recovery
 
-If you run an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) or another multi-region failover topology, you can register the standby region's endpoint service with Estuary ahead of time. The cross-region endpoint sits idle and does not affect your live connection, and the DNS name Estuary returns is stable. When you fail over, repoint the capture's `address` to that DNS name and follow [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover) to resume CDC without a full backfill.
+If you run an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) or another multi-region failover topology, you can register the standby region's endpoint service with Estuary ahead of time. The cross-region endpoint sits idle and does not affect your live connection, and the DNS name Estuary returns is stable. When you fail over, repoint the capture's `address` to that DNS name and follow [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers) to resume CDC without a full backfill.
 
 ### Variations
 

--- a/site/docs/private-byoc/privatelink.md
+++ b/site/docs/private-byoc/privatelink.md
@@ -96,9 +96,9 @@ When accessing services cross-region, you must use the **regional** DNS name (e.
 * **Connection request never appears in your console**: check that Estuary's principal is on **Allow principals** *and* that the data plane region is in your endpoint service's Supported Regions list.
 * **Connection accepted but the connector still fails to resolve the host**: verify the connector is using the *regional* DNS name returned by Estuary, not a zonal variant.
 
-#### Pre-registering a standby region for disaster recovery
+#### Pre-registering an endpoint ahead of time
 
-If you run an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) or another multi-region failover topology, you can register the standby region's endpoint service with Estuary ahead of time. The cross-region endpoint sits idle and does not affect your live connection, and the DNS name Estuary returns is stable. When you fail over, repoint the capture's `address` to that DNS name and follow [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers) to resume CDC without a full backfill.
+You can register an additional endpoint service with Estuary before you need it, such as a standby or backup database kept ready for upgrades, failover, or disaster recovery. It sits idle without affecting your live connection, and the DNS name Estuary returns is stable, so cutting over is just a matter of repointing the capture's `address`. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
 
 ### Variations
 

--- a/site/docs/private-byoc/privatelink.md
+++ b/site/docs/private-byoc/privatelink.md
@@ -96,6 +96,10 @@ When accessing services cross-region, you must use the **regional** DNS name (e.
 * **Connection request never appears in your console**: check that Estuary's principal is on **Allow principals** *and* that the data plane region is in your endpoint service's Supported Regions list.
 * **Connection accepted but the connector still fails to resolve the host**: verify the connector is using the *regional* DNS name returned by Estuary, not a zonal variant.
 
+#### Pre-registering a standby region for disaster recovery
+
+If you run an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) or another multi-region failover topology, you can register the standby region's endpoint service with Estuary ahead of time. The cross-region endpoint sits idle and does not affect your live connection, and the DNS name Estuary returns is stable. When you fail over, repoint the capture's `address` to that DNS name and follow [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover) to resume CDC without a full backfill.
+
 ### Variations
 
 Certain services may use AWS PrivateLink in unique ways. More detailed instructions for these services are provided below.

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -324,7 +324,7 @@ The `"binlog retention period is too short"` error should normally be fixed by s
 
 MySQL binlog coordinates are specific to each server, so they do not carry over when you fail over to a new writer, for example by promoting a standby or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region. After a failover, the capture's stored position is invalid on the new writer and replication fails with `ERROR 1236`. Always capture from the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
 
-If the failover is planned and you can pause writes, you can re-establish the capture on the new writer without a full backfill. See [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover).
+If the failover is planned and you can pause writes, you can re-establish the capture on the new writer without a full backfill. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
 
 ### Empty Collection Key
 

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -320,6 +320,12 @@ The concern is that if a capture is disabled or the server becomes unreachable f
 
 The `"binlog retention period is too short"` error should normally be fixed by setting a longer retention period as described in these setup instructions. However, advanced users who understand the risks can use the `skip_binlog_retention_check` configuration option to disable this safety.
 
+### Failover and Host Changes
+
+MySQL binlog coordinates are specific to each server, so they do not carry over when you fail over to a new writer, for example by promoting a standby or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region. After a failover, the capture's stored position is invalid on the new writer and replication fails with `ERROR 1236`. Always capture from the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
+
+If the failover is planned and you can pause writes, you can re-establish the capture on the new writer without a full backfill. See [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover).
+
 ### Empty Collection Key
 
 Every Estuary collection must declare a [key](/concepts/collections.md#keys) which is used to group its documents. When testing your capture, if you encounter an error indicating collection key cannot be empty, you will need to either add a key to the table in your source, or manually edit the generated specification and specify keys for the collection before publishing to the catalog as documented [here](/concepts/collections.md#empty-keys).

--- a/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -322,7 +322,7 @@ The `"binlog retention period is too short"` error should normally be fixed by s
 
 ### Failover and Host Changes
 
-MySQL binlog coordinates are specific to each server, so they do not carry over when you fail over to a new writer, for example by promoting a standby or switching an [Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) over to a secondary region. After a failover, the capture's stored position is invalid on the new writer and replication fails with `ERROR 1236`. Always capture from the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
+MySQL binlog coordinates are specific to each server, so they do not carry over when you fail over to a new writer, for example by promoting a standby. After a failover, the capture's stored position is invalid on the new writer and replication fails with `ERROR 1236`. Always capture from the **writer** endpoint; reader endpoints report `log_bin = OFF` and fail the prerequisite check.
 
 If the failover is planned and you can pause writes, you can re-establish the capture on the new writer without a full backfill. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -240,6 +240,8 @@ In this case, you may turn off backfilling on a per-table basis. See [properties
 
 If the replication slot is dropped or invalidated — for example after a major version upgrade, a failover, or a WAL size limit being exceeded — the capture will fail and require manual recovery. See [PostgreSQL replication slot recovery](/guides/troubleshooting/postgres-replication-slot-recovery) for step-by-step instructions.
 
+If the failover is planned and you can pause writes (including promoting an Amazon Aurora Global Database secondary region, whose cluster does not carry the slot), you can re-establish the capture without a full backfill. See [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover).
+
 ## WAL Retention and Tuning Parameters
 
 Postgres logical replication works by reading change events from the writeahead log,

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -240,7 +240,7 @@ In this case, you may turn off backfilling on a per-table basis. See [properties
 
 If the replication slot is dropped or invalidated — for example after a major version upgrade, a failover, or a WAL size limit being exceeded — the capture will fail and require manual recovery. See [PostgreSQL replication slot recovery](/guides/troubleshooting/postgres-replication-slot-recovery) for step-by-step instructions.
 
-If the failover is planned and you can pause writes (including promoting an Amazon Aurora Global Database secondary region, whose cluster does not carry the slot), you can re-establish the capture without a full backfill. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
+If the failover is planned and you can pause writes, you can re-establish the capture without a full backfill. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
 
 ## WAL Retention and Tuning Parameters
 

--- a/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/site/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -240,7 +240,7 @@ In this case, you may turn off backfilling on a per-table basis. See [properties
 
 If the replication slot is dropped or invalidated — for example after a major version upgrade, a failover, or a WAL size limit being exceeded — the capture will fail and require manual recovery. See [PostgreSQL replication slot recovery](/guides/troubleshooting/postgres-replication-slot-recovery) for step-by-step instructions.
 
-If the failover is planned and you can pause writes (including promoting an Amazon Aurora Global Database secondary region, whose cluster does not carry the slot), you can re-establish the capture without a full backfill. See [Preventing backfills during a failover or regional cutover](/reference/backfilling-data/#preventing-backfills-during-a-failover-or-regional-cutover).
+If the failover is planned and you can pause writes (including promoting an Amazon Aurora Global Database secondary region, whose cluster does not carry the slot), you can re-establish the capture without a full backfill. See [Preventing backfills during database upgrades and failovers](/reference/backfilling-data/#preventing-backfills-during-database-upgrades-and-failovers).
 
 ## WAL Retention and Tuning Parameters
 


### PR DESCRIPTION
## What

Documents how to avoid a full backfill when a CDC source moves to a new writer, including failovers, standby promotions, instance migrations, and Amazon Aurora Global Database regional switchovers.

The existing "Preventing backfills during database upgrades" section already covers the pause-writes / "Only Changes" procedure, but it was framed entirely around in-place upgrades (same host). It never mentioned failover or a host change, and had no MySQL specifics. A user searching for failover behavior landed nowhere, even though the procedure is the right answer.

## Approach

Rather than add a parallel section, this generalizes the existing one. The new-host case is a step variant, not a separate procedure.

- `guides/backfilling-data.md`: renamed the heading to "Preventing backfills during database upgrades and failovers"; generalized the intro to cover failovers/promotions/migrations (Aurora Global Database as one example); split step 4 into 4a (same host, no extra change) and 4b (new host: also repoint the capture `address`, because the new writer does not carry the old CDC position). Updated the internal anchor reference.
- `reference/Connectors/.../PostgreSQL.md` and `.../MySQL.md`: short pointers into that section. MySQL had no failover guidance at all.
- `private-byoc/privatelink.md`: note in the cross-region section about pre-registering another region's endpoint ahead of a host change, cross-linked back.

## Why these specifics are correct

- Postgres: logical replication slots are not replicated to a promoted standby or Aurora Global Database secondary cluster; a new slot can only start at the current WAL position. The publication and watermarks table do carry over with the storage volume.
- MySQL: binlog coordinates are per-server, so the stored file+offset is invalid on the new writer (`ERROR 1236`); capture must use the writer endpoint (readers report `log_bin = OFF`).
- Neither connector validates server identity on reconnect, so editing `address` alone resumes the stale cursor and fails. Verified against the connector source.

## Notes

No new page; this extends and cross-links existing content. Prompted by a customer asking for a repeatable regional-failover pattern for an Aurora Global Database.
