### PR TITLE
runtime/container: use ops::decode::Decoder for log lines

### DIFF
--- a/crates/ops/src/decode.rs
+++ b/crates/ops/src/decode.rs
@@ -147,7 +147,7 @@ where
     }
 
     fn rawline_to_log(&self, line: &str, lookahead: &[u8]) -> (Log, usize) {
-        let mut message = line[..line.len() - 1].to_string(); // Strip single trailing \n.
+        let mut message = line.strip_suffix('\n').unwrap_or(line).to_string();
         let mut consumed: usize = 0;
 
         // Attempt to consume additional whole lines of unstructured text.
@@ -360,9 +360,18 @@ Final line without a newline, which is not grouped into previous lines"#,
           {
             "ts": "2022-08-08T23:08:10+00:00",
             "level": "warn",
-            "message": "Final line without a newline, which is not grouped into previous line"
+            "message": "Final line without a newline, which is not grouped into previous lines"
           }
         ]
         "###);
+    }
+
+    #[test]
+    fn rawline_keeps_last_char_of_final_line_without_newline() {
+        let decoder = Decoder::new(|| std::time::UNIX_EPOCH);
+        let (log, _) = decoder.line_to_log("a final diagnostic", b"");
+        assert_eq!(log.message, "a final diagnostic");
+        let (log, _) = decoder.line_to_log("connector crashed ☃", b"");
+        assert_eq!(log.message, "connector crashed ☃");
     }
 }

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -210,6 +210,7 @@ pub async fn start(
         }
         std::mem::drop(ready_tx); // Signal that we're ready.
 
+        let decoder = ops::decode::Decoder::new(std::time::SystemTime::now);
         loop {
             line.clear();
 
@@ -222,15 +223,10 @@ pub async fn start(
                 Ok(_) => (),
             }
 
-            match serde_json::from_str(&line) {
-                Ok(log) => {
-                    let sanitized = sanitize_event_type(&quoted_task_name, log);
-                    log_handler.log(&sanitized)
-                }
-                Err(error) => {
-                    tracing::error!(?error, %line, "failed to parse ops::Log from container");
-                }
-            }
+            let (log, consume) = decoder.line_to_log(&line, stderr.buffer());
+            stderr.consume(consume);
+            let sanitized = sanitize_event_type(&quoted_task_name, log);
+            log_handler.log(&sanitized);
         }
     });
 

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -205,6 +205,7 @@ pub async fn start(
         }
         std::mem::drop(ready_tx); // Signal that we're ready.
 
+        let decoder = ops::decode::Decoder::new(std::time::SystemTime::now);
         loop {
             line.clear();
 
@@ -217,15 +218,10 @@ pub async fn start(
                 Ok(_) => (),
             }
 
-            match serde_json::from_str(&line) {
-                Ok(log) => {
-                    let sanitized = sanitize_event_type(&quoted_task_name, log);
-                    log_handler.log(&sanitized)
-                }
-                Err(error) => {
-                    tracing::error!(?error, %line, "failed to parse ops::Log from container");
-                }
-            }
+            let (log, consume) = decoder.line_to_log(&line, stderr.buffer());
+            stderr.consume(consume);
+            let sanitized = sanitize_event_type(&quoted_task_name, log);
+            log_handler.log(&sanitized);
         }
     });
 


### PR DESCRIPTION
**Description:**

`ops::decode::Decoder` transmutes log lines into ones that are compatible with our ops logs schema, inferring as much as it can from the source log when it isn't well-formed and ensuring it has all the required fields we need.

This is already used in `connector-init`, and that path covers everything coming from the connector process itself. But it misses logs emitted by the container runtime, and although these are rare, they are not in conformance with the ops logs schema and are not valid logs collection documents.

There is no separate schema validation check of documents written to logs journals, so it's really important that what we write there is valid per the schema.

This does duplicate the `decoder` work done in `connector-init`, and that may be an area for future optimization.

Manually tested by writing some non-conforming logs to `/proc/1/fd/2` in a running connector. Pre-fix, this resulted in a document being written to the logs journal missing a `ts` field, among other things. Post-fix, the logs are processed through `ops::decode::Decoder` as written in a a conforming way, as expected. This simulates a stderr write from the container runtime, which is otherwise difficult to directly induce.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

