### PR TITLE
runtime: strip the V2 committed-close marker for derivations

### DIFF
--- a/crates/runtime/src/derive/protocol.rs
+++ b/crates/runtime/src/derive/protocol.rs
@@ -327,7 +327,7 @@ pub fn recv_client_start_commit(
     txn: &mut Transaction,
 ) -> anyhow::Result<(Request, rocksdb::WriteBatch)> {
     let verify = verify("client", "StartCommit with runtime_checkpoint");
-    let request = verify.not_eof(request)?;
+    let mut request = verify.not_eof(request)?;
 
     let Request {
         start_commit:
@@ -335,7 +335,7 @@ pub fn recv_client_start_commit(
                 runtime_checkpoint: Some(runtime_checkpoint),
             }),
         ..
-    } = &request
+    } = &mut request
     else {
         return verify.fail(request);
     };
@@ -343,6 +343,17 @@ pub fn recv_client_start_commit(
     // TODO(johnny): Diff the previous and current checkpoint to build a
     // merge-able, incremental update that's written to the WriteBatch.
     let _last_checkpoint = last_checkpoint;
+
+    // The V2 leader stamps a synthetic "committed-close" source into the
+    // consumer.Checkpoint on each commit, recording the V2 RocksDB epoch.
+    // If V1 inherits a checkpoint from a prior V2 run, the marker is
+    // preserved verbatim across V1 commits. A subsequent V2 rollforward
+    // would then mistake the stale marker for an in-sync RocksDB state
+    // and ignore the legacy_checkpoint, resuming from V2's stale frontier
+    // and re-processing whatever V1 had advanced past. Strip the marker
+    // so V2 startup treats V1's advanced sources as authoritative.
+    runtime_checkpoint.sources.remove("committed-close");
+    let runtime_checkpoint = runtime_checkpoint.clone();
 
     let mut wb = rocksdb::WriteBatch::default();
 
@@ -352,7 +363,7 @@ pub fn recv_client_start_commit(
     );
     wb.put(RocksDB::CHECKPOINT_KEY, runtime_checkpoint.encode_to_vec());
 
-    txn.checkpoint = runtime_checkpoint.clone();
+    txn.checkpoint = runtime_checkpoint;
 
     Ok((request, wb))
 }


### PR DESCRIPTION
**Description:**

The V2 leader stamps a synthetic "committed-close" source into the checkpoint each commit. On rollback to V1, V1 preserves it; a later roll-forward to V2 mistakes the stale marker for in-sync state, ignores V1's advanced checkpoint, and rewinds to V2's stale frontier. Strip it on each V1 derivation start-commit, mirroring the materialize fix (475e9b9c1e3).

Only affects runtime-authoritative (TypeScript/Python) derivations; SQLite is immune (remote-store authoritative -- V2 rebuilds its frontier from the connector checkpoint).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

