### PR TITLE
flowctl-go(api test): raise test-shard readiness window from ~3s to ~30s

### DIFF
--- a/go/flowctl-go/cmd-api-test.go
+++ b/go/flowctl-go/cmd-api-test.go
@@ -85,11 +85,11 @@ func (cmd apiTest) execute(ctx context.Context) error {
 	var ready bool
 	for attempt := 0; !ready; attempt++ {
 		// Poll task shards with a back-off.
-		switch attempt {
-		case 0: // No-op.
-		case 1, 2:
+		switch {
+		case attempt == 0: // No-op.
+		case attempt <= 2:
 			time.Sleep(time.Millisecond * 50)
-		case 3, 4, 5:
+		case attempt <= 32:
 			time.Sleep(time.Second)
 		default:
 			return fmt.Errorf("timed out waiting for test shards to become ready")


### PR DESCRIPTION
## Summary

The publication test phase waits for all test shards to reach PRIMARY before running test cases. That wait loop polls with a back-off that caps out at ~3.1s (6 polls). Shards backing TypeScript or Python derivations must boot a connector container on their path to PRIMARY, and booting several cold containers routinely exceeds that window. When it does, the test phase fails with `timed out waiting for test shards to become ready` and the publication fails even though the shards are healthy and simply mid-boot.

This surfaced when a publication that included TypeScript derivations was tested. The test activates each derivation with 3 splits, so 3 or 6 cold `derive-typescript` containers were being booted inside the 3.1s window and couldn't make it, and every dry-run test on the draft died at ~3-4s.

## Change

Raise the readiness window from ~3.1s to ~30s by extending the 1-second back-off polls. The initial 50ms polls are unchanged, so the common case where shards are already ready is unaffected. The ~30s ceiling stays within the existing 1-minute context deadline on the command, which leaves room for the test cases themselves to run.

## Risk

The risk is low: the change lengthens a timeout that already runs under a bounded deadline, and a genuinely stuck shard now surfaces the same error at ~30s instead of ~3s.