### PR TITLE
data-plane-controller: fix db timeout

### DIFF
--- a/crates/data-plane-controller/src/job/mod.rs
+++ b/crates/data-plane-controller/src/job/mod.rs
@@ -108,8 +108,11 @@ pub async fn run_job(args: JobArgs) -> anyhow::Result<()> {
         pg_options = pg_options.ssl_mode(sqlx::postgres::PgSslMode::Prefer);
     }
 
+    // On Cloud Run with direct VPC egress, a fresh instance's network interface
+    // can take ~40s to begin passing traffic, during which all outbound
+    // connections fail
     let pg_pool = sqlx::postgres::PgPoolOptions::new()
-        .acquire_timeout(std::time::Duration::from_secs(30))
+        .acquire_timeout(std::time::Duration::from_secs(120))
         .connect_with(pg_options)
         .await
         .context("connecting to database")?;

--- a/crates/data-plane-controller/src/service/mod.rs
+++ b/crates/data-plane-controller/src/service/mod.rs
@@ -53,8 +53,11 @@ pub async fn run_service(args: ServiceArgs) -> anyhow::Result<()> {
         pg_options = pg_options.ssl_mode(sqlx::postgres::PgSslMode::Prefer);
     }
 
+    // On Cloud Run with direct VPC egress, a fresh instance's network interface
+    // can take ~40s to begin passing traffic, during which all outbound
+    // connections fail
     let pg_pool = sqlx::postgres::PgPoolOptions::new()
-        .acquire_timeout(std::time::Duration::from_secs(30))
+        .acquire_timeout(std::time::Duration::from_secs(120))
         .connect_with(pg_options)
         .await
         .context("connecting to database")?;


### PR DESCRIPTION
**Description:**

Changes DB timeout from 30s to 2m, which should be enough for it to find an open connection

We actually had to do this for the OIDC server too, stands to reason it needs to happen here: https://github.com/estuary/flow/pull/3062/changes

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

N/A

