### PR TITLE
agent: flag to create new captures as runtime-v2

### DIFF
--- a/.sqlx/query-9a35831f768dc6a9315d2bfe0b462969292e8065ca2889430e482768a0e36e72.json
+++ b/.sqlx/query-9a35831f768dc6a9315d2bfe0b462969292e8065ca2889430e482768a0e36e72.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select catalog_name\n               from live_specs\n               where catalog_name = any($1::text[]) and spec is not null",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "catalog_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9a35831f768dc6a9315d2bfe0b462969292e8065ca2889430e482768a0e36e72"
+}

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -177,6 +177,7 @@ pub struct TestHarness {
     pub controller_exec: crate::controllers::executor::LiveSpecControllerExecutor<TestControlPlane>,
     pub directive_exec: crate::directives::DirectiveHandler,
     pub alert_sender: self::alerts::TestSender,
+    pub runtime_v2_new_captures: bool,
     // Control plane API app instance for GraphQL queries
     control_plane_app: Option<Arc<control_plane_api::App>>,
 }
@@ -278,6 +279,7 @@ impl HarnessBuilder {
             directive_exec,
             control_plane_app: None,
             alert_sender: alerts::TestSender::new(),
+            runtime_v2_new_captures: false,
         };
         harness.truncate_tables().await;
         harness.setup_test_connectors().await;
@@ -1118,6 +1120,7 @@ impl TestHarness {
             task_types::PUBLICATIONS => Server::new().register(PublicationsExecutor {
                 publisher: self.publisher.clone(),
                 pg_pool: self.pool.clone(),
+                runtime_v2_new_captures: self.runtime_v2_new_captures,
             }),
             task_types::DISCOVERS => Server::new().register(DiscoverExecutor {
                 handler: self.discover_handler.clone(),

--- a/crates/agent/src/integration_tests/user_publications.rs
+++ b/crates/agent/src/integration_tests/user_publications.rs
@@ -463,3 +463,136 @@ async fn assert_publication_excluded(
         }
     }
 }
+
+/// The runtime-v2 capture rollout (`RuntimeV2Rollout` initializer) stamps
+/// `enable-runtime-v2: true` into the model of a *newly-created* capture when
+/// enabled. Covers: a capture created while it's off is untouched; a new capture
+/// created while it's on is enabled in both the committed model and the
+/// built-spec shard label; an explicit flag is preserved; and an existing
+/// capture is never retroactively enabled on republish.
+#[tokio::test]
+async fn test_runtime_v2_new_captures() {
+    let mut harness = TestHarness::init("test_runtime_v2_new_captures").await;
+    let user = harness.setup_tenant("cats").await;
+
+    let collection = || {
+        serde_json::json!({
+            "schema": { "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] },
+            "key": ["/id"]
+        })
+    };
+    let capture = |target: &str, prefix: &str| {
+        serde_json::json!({
+            "endpoint": { "connector": {
+                "image": "ghcr.io/estuary/source-hello-world:dev",
+                "config": {}
+            }},
+            "bindings": [ {
+                "resource": { "name": "greetings", "prefix": prefix },
+                "target": target
+            } ]
+        })
+    };
+    // The `enable-runtime-v2` value in a capture's committed model, if any.
+    async fn model_flag(harness: &mut TestHarness, name: &str) -> Option<String> {
+        let state = harness.get_controller_state(name).await;
+        let models::AnySpec::Capture(model) = state.live_spec.as_ref().unwrap() else {
+            panic!("expected a capture model");
+        };
+        model
+            .shards
+            .flags
+            .get(&models::Token::new(models::ENABLE_RUNTIME_V2))
+            .map(|v| v.as_str().to_string())
+    }
+    // The `enable-runtime-v2` value on a built capture's shard template, if any.
+    fn built_capture_v2_label(spec: &proto_flow::AnyBuiltSpec) -> Option<String> {
+        let proto_flow::AnyBuiltSpec::Capture(capture) = spec else {
+            return None;
+        };
+        let set = capture.shard_template.as_ref()?.labels.as_ref()?;
+        labels::values(set, labels::RUNTIME_V2_FLAG)
+            .first()
+            .map(|l| l.value.clone())
+    }
+
+    // Rollout disabled: a capture created now is left on v1.
+    harness.runtime_v2_new_captures = false;
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/early-out": collection() },
+        "captures": { "cats/early": capture("cats/early-out", "Hello {}!") },
+    }));
+    let result = harness
+        .user_publication(user, "rollout disabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "a capture created while the rollout is off must be unflagged"
+    );
+
+    // Rollout enabled from here on.
+    harness.runtime_v2_new_captures = true;
+
+    // A newly-created capture is enabled onto v2; one that pins itself to v1 is
+    // left alone.
+    let mut pinned = capture("cats/pinned-out", "Hello {}!");
+    pinned["shards"] = serde_json::json!({ "flags": { "enable-runtime-v2": "false" } });
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/auto-out": collection(), "cats/pinned-out": collection() },
+        "captures": { "cats/auto": capture("cats/auto-out", "Hello {}!"), "cats/pinned": pinned },
+    }));
+    let result = harness
+        .user_publication(user, "rollout enabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+
+    // cats/auto: enabled in the committed model AND emitted as the built-spec label.
+    assert_eq!(
+        model_flag(&mut harness, "cats/auto").await.as_deref(),
+        Some("true"),
+        "a new capture is enabled in the model"
+    );
+    let state = harness.get_controller_state("cats/auto").await;
+    assert_eq!(
+        built_capture_v2_label(state.built_spec.as_ref().unwrap()).as_deref(),
+        Some("true"),
+        "the flag is emitted as the built-spec shard label"
+    );
+
+    // cats/pinned: an explicit flag is never changed.
+    assert_eq!(
+        model_flag(&mut harness, "cats/pinned").await.as_deref(),
+        Some("false"),
+        "an explicit `false` is preserved"
+    );
+
+    // Republishing `cats/early` (created while the rollout was off) with a real
+    // edit does NOT retroactively enable it: only new captures are stamped.
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/early-out": collection() },
+        "captures": { "cats/early": capture("cats/early-out", "Hola {}!") },
+    }));
+    let result = harness
+        .user_publication(user, "republish existing", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "an existing capture must stay unflagged on republish"
+    );
+}

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -152,6 +152,13 @@ struct Args {
     #[arg(value_parser = humantime::parse_duration)]
     tenant_alert_interval: std::time::Duration,
 
+    /// When `true`, any *newly-created* capture without an explicit
+    /// `enable-runtime-v2` shard flag is published onto runtime v2. Existing
+    /// captures are unaffected, and an explicit per-task flag always takes
+    /// precedence.
+    #[clap(long, env = "RUNTIME_V2_NEW_CAPTURES", default_value = "false")]
+    runtime_v2_new_captures: bool,
+
     #[command(flatten)]
     controller_config: agent::controllers::ControllerConfig,
 }
@@ -350,6 +357,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
             .register(agent::publications::PublicationsExecutor {
                 publisher,
                 pg_pool: pg_pool.clone(),
+                runtime_v2_new_captures: args.runtime_v2_new_captures,
             })
             .register(agent::DiscoverExecutor {
                 handler: discover_handler,

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -7,14 +7,16 @@ use control_plane_api::{
     draft,
     publications::{
         ClearDraftErrors, DefaultRetryPolicy, DraftPublication, ExpandDraft, JobStatus,
-        PruneUnboundCollections, PublicationResult, Publisher, StatusType, UpdatePublicationsRow,
-        delete_draft, resolve, specs,
+        PruneUnboundCollections, PublicationResult, Publisher, RuntimeV2Rollout, StatusType,
+        UpdatePublicationsRow, delete_draft, resolve, specs,
     },
 };
 
 pub struct PublicationsExecutor {
     pub publisher: Publisher,
     pub pg_pool: sqlx::PgPool,
+    /// When true, newly-created captures are published onto runtime v2; see [`RuntimeV2Rollout`].
+    pub runtime_v2_new_captures: bool,
 }
 
 impl automations::Executor for PublicationsExecutor {
@@ -169,9 +171,14 @@ impl PublicationsExecutor {
             draft,
             verify_user_authz: true,
             default_data_plane_name: row.data_plane_name.clone().filter(|s| !s.is_empty()),
-            initialize: ExpandDraft {
-                filter_user_has_admin: true,
-            },
+            initialize: (
+                RuntimeV2Rollout {
+                    new_captures: self.runtime_v2_new_captures,
+                },
+                ExpandDraft {
+                    filter_user_has_admin: true,
+                },
+            ),
             finalize: PruneUnboundCollections,
             retry: DefaultRetryPolicy,
             with_commit: (

--- a/crates/control-plane-api/src/publications/initialize.rs
+++ b/crates/control-plane-api/src/publications/initialize.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use itertools::Itertools;
 use models::Capability;
 use std::future::Future;
@@ -94,6 +95,75 @@ impl Initialize for ExpandDraft {
         );
 
         draft.add_live(expanded_catalog);
+
+        Ok(())
+    }
+}
+
+pub struct RuntimeV2Rollout {
+    /// When true, newly-created captures without an explicit flag run runtime v2.
+    pub new_captures: bool,
+}
+
+impl Initialize for RuntimeV2Rollout {
+    #[tracing::instrument(level = "debug", skip_all, err)]
+    async fn initialize(
+        &self,
+        db: &sqlx::PgPool,
+        _user_id: Uuid,
+        draft: &mut tables::DraftCatalog,
+    ) -> anyhow::Result<()> {
+        if !self.new_captures {
+            return Ok(());
+        }
+        let flag = models::Token::new(models::ENABLE_RUNTIME_V2);
+
+        // Candidate captures: drafted, not a touch or deletion, whose model
+        // hasn't set the flag explicitly.
+        let is_candidate = |row: &tables::DraftCapture| {
+            !row.is_touch
+                && row
+                    .model
+                    .as_ref()
+                    .is_some_and(|model| !model.shards.flags.contains_key(&flag))
+        };
+        let candidates = draft
+            .captures
+            .iter()
+            .filter(|row| is_candidate(row))
+            .map(|row| row.capture.to_string())
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Ok(());
+        }
+
+        // Only *new* captures are enabled. A candidate that already has a
+        // non-tombstone live spec is an update, so it's left as-is. A tombstone
+        // (`spec is null`, a deleted spec a controller hasn't yet reaped) is
+        // excluded by `spec is not null`, so re-creating a capture counts as new.
+        let existing: std::collections::HashSet<String> = sqlx::query!(
+            r#"select catalog_name
+               from live_specs
+               where catalog_name = any($1::text[]) and spec is not null"#,
+            &candidates as &[String],
+        )
+        .fetch_all(db)
+        .await
+        .context("fetching existing capture names")?
+        .into_iter()
+        .map(|row| row.catalog_name)
+        .collect();
+
+        for row in draft.captures.iter_mut() {
+            if is_candidate(row) && !existing.contains(row.capture.as_str()) {
+                row.model
+                    .as_mut()
+                    .unwrap()
+                    .shards
+                    .flags
+                    .insert(flag.clone(), models::Token::new("true"));
+            }
+        }
 
         Ok(())
     }

--- a/crates/control-plane-api/src/publications/mod.rs
+++ b/crates/control-plane-api/src/publications/mod.rs
@@ -21,7 +21,7 @@ pub mod specs;
 pub use self::commit::{ClearDraftErrors, NoopWithCommit, UpdatePublicationsRow, WithCommit};
 pub use self::db::{Row, create, delete_draft, fetch_publication, resolve};
 pub use self::finalize::{FinalizeBuild, NoopFinalize, PruneUnboundCollections};
-pub use self::initialize::{ExpandDraft, Initialize, NoopInitialize};
+pub use self::initialize::{ExpandDraft, Initialize, NoopInitialize, RuntimeV2Rollout};
 pub use self::retry::{DefaultRetryPolicy, DoNotRetry, RetryPolicy};
 pub use models::publications::{JobStatus, LockFailure, StatusType};
 

--- a/crates/control-plane-api/src/server/update_l2_reporting.rs
+++ b/crates/control-plane-api/src/server/update_l2_reporting.rs
@@ -280,7 +280,7 @@ export class Derivation extends Types.IDerivation {"#
         models::RawValue::from_value(&serde_json::json!(l2_stats_new_module));
 
     l2_stats_new_shards.flags.insert(
-        models::Token::new("enable-runtime-v2"),
+        models::Token::new(models::ENABLE_RUNTIME_V2),
         models::Token::new("true"),
     );
 

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -67,7 +67,7 @@ pub use references::{
     tenant_from,
 };
 pub use schemas::Schema;
-pub use shards::ShardTemplate;
+pub use shards::{ENABLE_RUNTIME_V2, ShardTemplate};
 pub use source::{FullSource, OnIncompatibleSchemaChange, PartitionSelector, Source};
 pub use source_capture::{SourceDef, SourceType, TargetNaming};
 pub use tests::{TestDef, TestDocuments, TestStep, TestStepIngest, TestStepVerify};

--- a/crates/models/src/shards.rs
+++ b/crates/models/src/shards.rs
@@ -87,6 +87,11 @@ pub struct ShardTemplate {
     pub flags: BTreeMap<super::Token, super::Token>,
 }
 
+/// The `enable-runtime-v2` [`ShardTemplate::flags`] key, which selects the V2
+/// task runtime. It's emitted as the `estuary.dev/flag/enable-runtime-v2` shard
+/// label (`labels::RUNTIME_V2_FLAG`) at build time.
+pub const ENABLE_RUNTIME_V2: &str = "enable-runtime-v2";
+
 impl ShardTemplate {
     pub fn example() -> Self {
         Self {

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -98,7 +98,7 @@ fn builtin_derive_connector<C: serde::Serialize>(
     flags: &BTreeMap<models::Token, models::Token>,
 ) -> models::ConnectorConfig {
     let tag = flag_value(flags, "derive-image-tag").unwrap_or(
-        if flag_value(flags, "enable-runtime-v2") == Some("true") {
+        if flag_value(flags, models::ENABLE_RUNTIME_V2) == Some("true") {
             "stable"
         } else {
             "dev"
@@ -962,7 +962,12 @@ mod test {
         );
         // V2 tasks default to `:stable`.
         assert_eq!(
-            builtin_derive_connector(repo, &config, &flags(&[("enable-runtime-v2", "true")])).image,
+            builtin_derive_connector(
+                repo,
+                &config,
+                &flags(&[(models::ENABLE_RUNTIME_V2, "true")])
+            )
+            .image,
             "ghcr.io/estuary/derive-typescript:stable"
         );
         // An explicit `derive-image-tag` overrides either default.
@@ -970,7 +975,10 @@ mod test {
             builtin_derive_connector(
                 repo,
                 &config,
-                &flags(&[("enable-runtime-v2", "true"), ("derive-image-tag", "local")]),
+                &flags(&[
+                    (models::ENABLE_RUNTIME_V2, "true"),
+                    ("derive-image-tag", "local")
+                ]),
             )
             .image,
             "ghcr.io/estuary/derive-typescript:local"


### PR DESCRIPTION
**Description:**

Adds a `--runtime-v2-new-captures` flag (env `RUNTIME_V2_NEW_CAPTURES`) to the agent. When enabled, any newly-created capture that doesn't already set `enable-runtime-v2` is published with that shard flag set to `true`, placing it on the V2 runtime. Existing captures are never touched, and an explicit per-task flag always takes precedence.

This can be deployed inert: the flag defaults to false, so it only begins to take effect once the agent is configured to enable it.

Manually tested on a local stack: Many scenarios with the `RUNTIME_V2_NEW_CAPTURES` agent config on and off, with new & existing captures being published / re-published. Also, sanity checking of derivation and materialization publishing (unchanged).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

I ended up far from where I started. I was initially considering a mechanism in the runtime itself to decide to run a task on the V1 or V2 runtime, or some kind of computed shard label value. Both of these were complex and insufficient for various reasons: In the runtime, we don't have the creation time of the task readily available, computing the shard label value in all the places we'd need to was not trivial, and I don't think either way would readily extend to derivations since they need to make a decision at build time anyway about which image to run.

While these challenges are not intractable, I think this final "just add the spec flag to the spec" mechanism is the most obviously correct and least intrusive approach, and makes it very easy to tell which tasks are running V2.