### PR TITLE
agent-api: survive direct VPC egress cold-start on instance startup

### DIFF
--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -198,12 +198,6 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 async fn async_main(args: Args) -> Result<(), anyhow::Error> {
-    // Bind early in the application lifecycle, to not fail requests which may dispatch
-    // as soon as the process is up (for example, Tilt on local stacks).
-    let api_listener = tokio::net::TcpListener::bind(format!("[::]:{}", args.api_port))
-        .await
-        .context("failed to bind server port")?;
-
     let flowctl_go = locate_bin::locate("flowctl-go")?;
 
     // The HOSTNAME variable will be set to the name of the pod in k8s
@@ -230,24 +224,40 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
     };
 
     let pg_pool = sqlx::postgres::PgPoolOptions::new()
-            .acquire_timeout(std::time::Duration::from_secs(5))
-            .after_release(|conn, meta| {
-                let fut = async move {
-                    let r =tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                                        conn.ping()
-                                    });
-                    if let Err(err) = r.await {
-                        tracing::warn!(error = ?err, conn_meta = ?meta, "connection was put back in a bad state, removing from the pool");
-                        Ok(false)
-                    } else {
-                        Ok(true) // connection is good
-                    }
-                };
-                fut.boxed()
-            })
-            .connect_with(pg_options)
-        .await
-        .context("connecting to database")?;
+        .acquire_timeout(std::time::Duration::from_secs(5))
+        .after_release(|conn, meta| {
+            let fut = async move {
+                let r = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    conn.ping()
+                });
+                if let Err(err) = r.await {
+                    tracing::warn!(error = ?err, conn_meta = ?meta, "connection was put back in a bad state, removing from the pool");
+                    Ok(false)
+                } else {
+                    Ok(true) // connection is good
+                }
+            };
+            fut.boxed()
+        })
+        .connect_lazy_with(pg_options);
+
+    // A fresh Cloud Run instance with direct VPC egress can take tens of seconds
+    // before its network interface passes outbound traffic. Retry the initial
+    // connection against a generous deadline, rather than raising the pool's
+    // acquire_timeout, which also bounds request-path acquires at runtime.
+    let connect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
+    loop {
+        match pg_pool.acquire().await {
+            Ok(_) => break,
+            Err(err) if tokio::time::Instant::now() < connect_deadline => {
+                tracing::warn!(error = ?err, "initial database connection failed; retrying");
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+            Err(err) => {
+                return Err(anyhow::Error::new(err).context("connecting to database"));
+            }
+        }
+    }
 
     // Periodically log information about the connection pool to aid in debugging.
     let pool_copy = pg_pool.clone();
@@ -339,6 +349,12 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         &args.allow_origin,
         alert_config_defaults,
     )?;
+    // Bind only now that the database is connected and we're able to serve.
+    // Cloud Run's TCP startup probe gates traffic on this port being open:
+    // binding earlier routes requests to an instance that cannot yet serve them.
+    let api_listener = tokio::net::TcpListener::bind(format!("[::]:{}", args.api_port))
+        .await
+        .context("failed to bind server port")?;
     let api_server = axum::serve(api_listener, api_router).with_graceful_shutdown(shutdown.clone());
     let api_server = async move { anyhow::Result::Ok(api_server.await?) };
 


### PR DESCRIPTION
**Description:**

Since agent-api moved behind direct VPC egress for a stable NAT IP (#3044, estuary/security#729), every Cloud Run instance started while the VPC network interface is still warming up (~20–80s of no outbound connectivity on a fresh instance) crashed at startup: the initial database connection ran under the pool's 5-second `acquire_timeout`, timed out, and the process exited(1). Cloud Run logs show this crash-loop 15–40 times per day on routine autoscaling, and today's deploy (revision `agent-api-00078-xhb`, 16:12 UTC) produced 1000+ user-facing 500s in an hour.

agent-api fails differently from the oidc-discovery-server case fixed in #3062: it bound its API port at the top of `async_main`, before connecting to the database. Cloud Run's default TCP startup probe therefore passed instantly, the revision was marked Ready, and 100% of traffic shifted onto instances that died seconds later — surfacing as `The request failed because the instance could not start successfully` rather than a failed deploy.

**Changes:**

- Create the pool with `connect_lazy_with()` and retry the initial acquire against a 120-second deadline (matching the margin chosen in #3062). The pool's `acquire_timeout` stays at 5 seconds — unlike oidc-discovery-server, it also bounds request-path acquires at runtime and must remain short. This is why #3062 deliberately didn't touch agent-api.
- Bind the API port only after the database connection succeeds, so the TCP startup probe gates traffic on actual readiness. On deploys, traffic now stays on the old revision until the new one can really serve; on scale-up, no requests are routed to a warming instance. Trade-off: on local stacks, requests during startup now see connection-refused instead of queuing behind the bound-but-not-serving port.

No deploy workflow changes needed: the default startup probe window (240s) comfortably covers the 120-second retry deadline.

**Local testing:**

Ran the agent binary against a Postgres that only became reachable at t=25s (delayed socat forward to a local Supabase, mimicking the NIC warmup):

- t=1–25s: API port never bound, process stayed alive, logging `WARN initial database connection failed; retrying (PoolTimedOut)` every ~6s — the same cadence that previously ended in exit(1).
- t=26s: within a second of the database becoming reachable, the pool connected, the port bound, and HTTP requests were served.
- Also verified the deadline-exceeded path fails with `Error: connecting to database` rather than hanging.

**Rollout:**

Merge, then dispatch the `deploy-agent-api` workflow. The deploy itself is the first real test: the new revision should hold traffic on the old one for the duration of the warmup instead of throwing 500s.