### PR TITLE
runtime-next: add minimum interval for post-txn triggers

### DIFF
--- a/crates/models/src/snapshots/models__triggers__test__trigger-config-schema.snap
+++ b/crates/models/src/snapshots/models__triggers__test__trigger-config-schema.snap
@@ -15,6 +15,15 @@ expression: schema
       "items": {
         "$ref": "#/$defs/TriggerConfig"
       }
+    },
+    "interval": {
+      "title": "Minimum interval between trigger deliveries.",
+      "description": "A burst of transactions within the interval collapses into a single\ndelivery covering the full span.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^\\d+(s|m|h|d)$"
     }
   },
   "additionalProperties": false,

--- a/crates/models/src/triggers.rs
+++ b/crates/models/src/triggers.rs
@@ -8,6 +8,16 @@ use std::time::Duration;
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Triggers {
+    /// # Minimum interval between trigger deliveries.
+    /// A burst of transactions within the interval collapses into a single
+    /// delivery covering the full span.
+    #[schemars(schema_with = "super::duration_schema")]
+    #[serde(
+        default,
+        with = "humantime_serde",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub interval: Option<Duration>,
     /// # Trigger Configurations
     /// List of webhook triggers to fire when new data is materialized.
     pub config: Vec<TriggerConfig>,
@@ -92,6 +102,24 @@ impl TriggerVariables {
             run_id: "2024-01-01T00:00:00.000Z".to_string(),
         }
     }
+
+    /// Merge `other` into `self`, widening this window to cover both. Used to
+    /// collapse a burst of debounced transactions into a single delivery.
+    pub fn merge(&mut self, other: &TriggerVariables) {
+        for name in &other.collection_names {
+            if !self.collection_names.contains(name) {
+                self.collection_names.push(name.clone());
+            }
+        }
+        self.collection_names.sort();
+
+        if other.flow_published_at_min < self.flow_published_at_min {
+            self.flow_published_at_min = other.flow_published_at_min.clone();
+        }
+        if other.flow_published_at_max > self.flow_published_at_max {
+            self.flow_published_at_max = other.flow_published_at_max.clone();
+        }
+    }
 }
 
 /// Render a single payload template string with the given context.
@@ -124,19 +152,23 @@ pub fn build_template_context(
 
 /// Original values of HMAC-excluded fields for a single trigger config,
 /// captured by `strip_hmac_excluded_fields` and restored by
-/// `restore_hmac_excluded_fields`.
+/// `restore_hmac_excluded_fields`. `interval` is the shared top-level
+/// `Triggers.interval`, duplicated into every record so the token remains a
+/// flat per-config Vec for external consumers (flow-web).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HmacExcludedOriginals {
     pub payload_template: String,
     pub timeout: Duration,
     pub max_attempts: u32,
+    pub interval: Option<Duration>,
 }
 
-/// Replace HMAC-excluded fields in each trigger config with placeholder values,
-/// returning the original values. Call `restore_hmac_excluded_fields` after the
-/// SOPS operation to put the originals back.
+/// Replace HMAC-excluded fields with placeholder values, returning the
+/// original values. Call `restore_hmac_excluded_fields` after the SOPS
+/// operation to put the originals back.
 pub fn strip_hmac_excluded_fields(triggers: &mut Triggers) -> Vec<HmacExcludedOriginals> {
+    let interval = std::mem::take(&mut triggers.interval);
     triggers
         .config
         .iter_mut()
@@ -144,6 +176,7 @@ pub fn strip_hmac_excluded_fields(triggers: &mut Triggers) -> Vec<HmacExcludedOr
             payload_template: std::mem::take(&mut config.payload_template),
             timeout: std::mem::replace(&mut config.timeout, Duration::ZERO),
             max_attempts: std::mem::replace(&mut config.max_attempts, 0),
+            interval,
         })
         .collect()
 }
@@ -153,6 +186,7 @@ pub fn restore_hmac_excluded_fields(
     triggers: &mut Triggers,
     originals: Vec<HmacExcludedOriginals>,
 ) {
+    triggers.interval = originals.first().and_then(|orig| orig.interval);
     for (config, orig) in triggers.config.iter_mut().zip(originals) {
         config.payload_template = orig.payload_template;
         config.timeout = orig.timeout;
@@ -193,6 +227,7 @@ mod test {
     #[test]
     fn strip_and_restore_hmac_excluded_fields() {
         let mut triggers = Triggers {
+            interval: Some(Duration::from_secs(1800)),
             config: vec![TriggerConfig {
                 url: "https://example.com/webhook".to_string(),
                 method: HttpMethod::POST,

--- a/crates/runtime-next/src/leader/materialize/actor.rs
+++ b/crates/runtime-next/src/leader/materialize/actor.rs
@@ -32,6 +32,8 @@ pub struct Actor {
         Option<BoxFuture<'static, tonic::Result<(crate::Publisher, BTreeMap<String, Bytes>)>>>,
     // Task being executed by this actor.
     task: Task,
+    // Leader-lifetime trigger debounce accumulator and last-fire times.
+    trigger_debounce: fsm::TriggerDebounce,
     // Future for an in-flight trigger dispatch, if any.
     trigger_fut: Option<BoxFuture<'static, anyhow::Result<()>>>,
 }
@@ -55,6 +57,7 @@ impl Actor {
             shard_tx,
             stats_write_fut: None,
             task,
+            trigger_debounce: fsm::TriggerDebounce::default(),
             trigger_fut: None,
         }
     }
@@ -124,6 +127,7 @@ impl Actor {
             let action: fsm::Action;
             let prev_kind = tail.kind();
             (action, tail) = tail.step(
+                &self.trigger_debounce,
                 self.intents_write_fut.is_none(),
                 now,
                 &mut ready_shard_rx,
@@ -148,6 +152,7 @@ impl Actor {
             (action, head) = head.step(
                 &mut binding_bytes_behind,
                 &mut close_requested,
+                &mut self.trigger_debounce,
                 &mut self.legacy_checkpoint,
                 now,
                 &mut ready_frontier,

--- a/crates/runtime-next/src/leader/materialize/fsm.rs
+++ b/crates/runtime-next/src/leader/materialize/fsm.rs
@@ -168,6 +168,7 @@ impl Head {
         self,
         binding_bytes_behind: &mut [i64],
         close_requested: &mut bool,
+        debounce: &mut TriggerDebounce,
         legacy_checkpoint: &mut Option<(shuffle::Frontier, consumer::Checkpoint)>,
         now: uuid::Clock,
         ready_frontier: &mut Option<shuffle::Frontier>,
@@ -178,13 +179,23 @@ impl Head {
         task: &Task,
     ) -> (Action, Head) {
         match self {
-            Head::Idle(s) => s.step(now, close_requested, ready_frontier, stopping, tail, task),
+            Head::Idle(s) => s.step(
+                now,
+                close_requested,
+                debounce,
+                ready_frontier,
+                stopping,
+                tail,
+                task,
+            ),
             Head::Extend(s) => s.step(shard_rx),
             Head::Flush(s) => s.step(now, shard_rx, task),
             Head::Persist(s) => s.step(shard_rx),
             Head::Store(s) => s.step(binding_bytes_behind, shard_rx, task),
             Head::WriteStats(s) => s.step(legacy_checkpoint, stats_write_idle, task),
-            Head::StartCommit(s) => s.step(legacy_checkpoint, now, shard_rx, stopping),
+            Head::StartCommit(s) => {
+                s.step(debounce, legacy_checkpoint, now, shard_rx, stopping, task)
+            }
             Head::Stop => panic!("HeadFSM::Stop observed at step boundary"),
         }
     }
@@ -207,6 +218,7 @@ impl Tail {
     /// Dispatch to the current sub-state's `step()`.
     pub fn step(
         self,
+        debounce: &TriggerDebounce,
         intents_write_idle: bool,
         now: uuid::Clock,
         shard_rx: &mut Option<(usize, proto::Materialize)>,
@@ -218,7 +230,7 @@ impl Tail {
             Tail::Begin(s) => s.step(stopping, task),
             Tail::WriteIntents(s) => s.step(intents_write_idle),
             Tail::Acknowledge(s) => s.step(now, shard_rx, task),
-            Tail::Trigger(s) => s.step(now, trigger_call_running),
+            Tail::Trigger(s) => s.step(debounce, now, trigger_call_running),
             Tail::Persist(s) => s.step(shard_rx),
             Tail::Done(_) => (Action::Idle, self),
         }
@@ -256,6 +268,7 @@ impl HeadIdle {
         mut self,
         now: uuid::Clock,
         close_requested: &mut bool,
+        debounce: &mut TriggerDebounce,
         ready_frontier: &mut Option<shuffle::Frontier>,
         stopping: bool,
         tail: &mut Tail,
@@ -325,8 +338,31 @@ impl HeadIdle {
             );
         }
 
-        // Should we begin to close the transaction?
+        // No transaction is open. Fire a debounced window that has come
+        // due while the task is quiet.
         if !is_open {
+            if let Tail::Done(done) = tail
+                && let Some(compiled) = &task.triggers
+            {
+                if let Some(window) = debounce.take_due(now, compiled.interval) {
+                    let shard_patches = std::mem::take(&mut done.shard_patches);
+                    *tail = Tail::Trigger(TailTrigger { shard_patches });
+
+                    return (
+                        Action::CallTrigger {
+                            triggers: compiled.clone(),
+                            trigger_params: serde_json::to_vec(&window)
+                                .expect("TriggerVariables always serialize")
+                                .into(),
+                        },
+                        Head::Idle(self),
+                    );
+                }
+                // Nothing due: wake when the pending window comes due.
+                if let Some(wake_after) = debounce.next_due(now, compiled.interval) {
+                    return (Action::Sleep { wake_after }, Head::Idle(self));
+                }
+            }
             return (Action::Idle, Head::Idle(self));
         } else if may_close {
             let Self { mut extents, .. } = self;
@@ -625,9 +661,7 @@ impl HeadStore {
         // We've received all expected Stored responses.
 
         let Self {
-            extents,
-            mut pending,
-            ..
+            extents, pending, ..
         } = self;
 
         // Fold deltas from the extents Frontier into per-binding "bytes behind" gauges.
@@ -636,33 +670,6 @@ impl HeadStore {
                 continue; // Reachable if shuffle service reports invalid binding indices.
             };
             *entry += jf.bytes_behind_delta;
-        }
-
-        // Compose the trigger payload now that we have a complete txn-wide view.
-        if task.triggers.is_some() && !extents.bindings.is_empty() {
-            let collection_names: Vec<String> = extents
-                .bindings
-                .keys()
-                .filter_map(|idx| task.binding_collection_names.get(*idx as usize).cloned())
-                .collect();
-
-            let mut it = extents
-                .bindings
-                .values()
-                .map(|extents| (extents.min_source_clock, extents.max_source_clock));
-            let init = it.next().unwrap_or_default();
-            let (min, max) = it.fold(init, |(min, max), (a, b)| (min.min(a), max.max(b)));
-
-            pending.trigger_params = serde_json::to_vec(&models::TriggerVariables {
-                collection_names,
-                connector_image: task.connector_image.clone(),
-                materialization_name: task.shard_ref.name.clone(),
-                flow_published_at_min: tokens::DateTime::from(min.to_time()).to_rfc3339(),
-                flow_published_at_max: tokens::DateTime::from(max.to_time()).to_rfc3339(),
-                run_id: tokens::DateTime::from(extents.open.to_time()).to_rfc3339(),
-            })
-            .unwrap()
-            .into();
         }
 
         let action = match build_stats_doc(task, &extents, binding_bytes_behind) {
@@ -768,10 +775,12 @@ pub struct HeadStartCommit {
 impl HeadStartCommit {
     pub fn step(
         mut self,
+        debounce: &mut TriggerDebounce,
         legacy_checkpoint: &Option<(shuffle::Frontier, consumer::Checkpoint)>,
         now: uuid::Clock,
         shard_rx: &mut Option<(usize, proto::Materialize)>,
         stopping: bool,
+        task: &Task,
     ) -> (Action, Head) {
         // Did we receive an expected StartedCommit response?
         if let Some((
@@ -809,6 +818,12 @@ impl HeadStartCommit {
             ..
         } = self;
 
+        // Merge this transaction's window into the debounce accumulator
+        if let Some(window) = compute_trigger_window(task, &extents) {
+            debounce.accumulate(&window);
+        }
+        let (trigger_params_json, delete_trigger_params) = debounce.to_persist();
+
         let Extents {
             close, frontier, ..
         } = extents;
@@ -828,9 +843,10 @@ impl HeadStartCommit {
             committed_frontier: Some(shuffle::JournalFrontier::encode(&frontier.journals)),
             connector_patches_json: take_patches(&mut pending.persist_patches),
             delete_ack_intents: true,
+            delete_trigger_params,
             legacy_checkpoint,
             max_keys: std::mem::take(&mut pending.max_key_deltas),
-            trigger_params_json: pending.trigger_params.clone(),
+            trigger_params_json,
             ..Default::default()
         };
 
@@ -843,6 +859,16 @@ impl HeadStartCommit {
             // resume from Tail::Begin.
             (Action::Idle, Head::Stop)
         } else {
+            // Move a due window out of the accumulator; the Tail delivers it
+            // post-Acknowledge and then persists the emptied accumulator.
+            if let Some(compiled) = &task.triggers
+                && let Some(window) = debounce.take_due(now, compiled.interval)
+            {
+                pending.trigger_params = serde_json::to_vec(&window)
+                    .expect("TriggerVariables always serialize")
+                    .into();
+            }
+
             // Rotate to begin a next transaction. `idempotent_replay`
             // is one-shot — only the first transaction of a session may replay
             // recovered hints, so post-Rotate HeadIdle is always non-replay.
@@ -1038,7 +1064,12 @@ pub struct TailTrigger {
 }
 
 impl TailTrigger {
-    pub fn step(self, now: uuid::Clock, trigger_call_running: bool) -> (Action, Tail) {
+    pub fn step(
+        self,
+        debounce: &TriggerDebounce,
+        now: uuid::Clock,
+        trigger_call_running: bool,
+    ) -> (Action, Tail) {
         if trigger_call_running {
             return (Action::Idle, Tail::Trigger(self));
         }
@@ -1046,10 +1077,12 @@ impl TailTrigger {
         let Self { shard_patches } = self;
 
         let seq_no = now.as_u64();
+        let (trigger_params_json, delete_trigger_params) = debounce.to_persist();
         let action = Action::Persist {
             persist: proto::Persist {
                 seq_no,
-                delete_trigger_params: true,
+                delete_trigger_params,
+                trigger_params_json,
                 ..Default::default()
             },
         };
@@ -1101,6 +1134,99 @@ impl TailPersist {
 #[derive(Debug, Default)]
 pub struct TailDone {
     pub shard_patches: bytes::Bytes,
+}
+
+/// Leader-lifetime debounce state for materialization triggers. Accumulates
+/// per-transaction windows and gates firing to at most once per the task's
+/// configured trigger `interval`.
+#[derive(Debug, Default)]
+pub struct TriggerDebounce {
+    /// Accumulated, not-yet-fired window. Persisted.
+    pub pending: Option<models::TriggerVariables>,
+    /// Wall-clock of the last fire. In-memory only.
+    pub last_fire: Option<uuid::Clock>,
+}
+
+impl TriggerDebounce {
+    /// Merge one committed transaction's `window` into the accumulator.
+    pub fn accumulate(&mut self, window: &models::TriggerVariables) {
+        match &mut self.pending {
+            Some(acc) => acc.merge(window),
+            None => self.pending = Some(window.clone()),
+        }
+    }
+
+    /// Remove and return the accumulated window if it's due to fire now
+    pub fn take_due(
+        &mut self,
+        now: uuid::Clock,
+        interval: Option<Duration>,
+    ) -> Option<models::TriggerVariables> {
+        let due = match (interval, self.last_fire) {
+            (Some(interval), Some(last)) => uuid::Clock::delta(now, last) >= interval,
+            _ => true, // No interval configured, or never fired.
+        };
+        if !due {
+            return None;
+        }
+        let window = self.pending.take()?;
+        self.last_fire = Some(now);
+        Some(window)
+    }
+
+    /// Duration until the pending window comes due, or None when no window is
+    /// pending or it has no future deadline.
+    pub fn next_due(&self, now: uuid::Clock, interval: Option<Duration>) -> Option<Duration> {
+        if self.pending.is_none() {
+            return None;
+        }
+        let (Some(interval), Some(last)) = (interval, self.last_fire) else {
+            return None;
+        };
+        Some(interval.saturating_sub(uuid::Clock::delta(now, last)))
+    }
+
+    /// Encode the accumulator for a `proto::Persist`
+    pub fn to_persist(&self) -> (bytes::Bytes, bool) {
+        match &self.pending {
+            None => (bytes::Bytes::new(), true),
+            Some(window) => (
+                serde_json::to_vec(window)
+                    .expect("TriggerVariables always serialize")
+                    .into(),
+                false,
+            ),
+        }
+    }
+}
+
+/// Compose this transaction's trigger window from its committed `extents`, or None
+fn compute_trigger_window(task: &Task, extents: &Extents) -> Option<models::TriggerVariables> {
+    if task.triggers.is_none() || extents.bindings.is_empty() {
+        return None;
+    }
+
+    let collection_names: Vec<String> = extents
+        .bindings
+        .keys()
+        .filter_map(|idx| task.binding_collection_names.get(*idx as usize).cloned())
+        .collect();
+
+    let mut it = extents
+        .bindings
+        .values()
+        .map(|extents| (extents.min_source_clock, extents.max_source_clock));
+    let init = it.next().unwrap_or_default();
+    let (min, max) = it.fold(init, |(min, max), (a, b)| (min.min(a), max.max(b)));
+
+    Some(models::TriggerVariables {
+        collection_names,
+        connector_image: task.connector_image.clone(),
+        materialization_name: task.shard_ref.name.clone(),
+        flow_published_at_min: tokens::DateTime::from(min.to_time()).to_rfc3339(),
+        flow_published_at_max: tokens::DateTime::from(max.to_time()).to_rfc3339(),
+        run_id: tokens::DateTime::from(extents.open.to_time()).to_rfc3339(),
+    })
 }
 
 // Extend separate accrued patches for a future Persist vs future shard broadcast,
@@ -1183,6 +1309,7 @@ mod tests {
     struct Ctx {
         binding_bytes_behind: Vec<i64>,
         close_requested: bool,
+        debounce: TriggerDebounce,
         intents_idle: bool,
         legacy_checkpoint: Option<(shuffle::Frontier, consumer::Checkpoint)>,
         now: uuid::Clock,
@@ -1201,6 +1328,7 @@ mod tests {
             head.step(
                 &mut self.binding_bytes_behind,
                 &mut self.close_requested,
+                &mut self.debounce,
                 &mut self.legacy_checkpoint,
                 self.now,
                 &mut self.ready_frontier,
@@ -1215,6 +1343,7 @@ mod tests {
         fn step_tail(&mut self, tail: Tail) -> (Action, Tail) {
             self.now.tick();
             tail.step(
+                &self.debounce,
                 self.intents_idle,
                 self.now,
                 &mut self.shard_rx,
@@ -1239,7 +1368,20 @@ mod tests {
             peers: (0..n_shards).map(|i| format!("shard-{i}")).collect(),
             shard_ref: ops::ShardRef::default(),
             triggers: Some(std::sync::Arc::new(
-                super::super::triggers::CompiledTriggers::compile(vec![]).unwrap(),
+                super::super::triggers::CompiledTriggers::compile(models::Triggers {
+                    // No interval: fire every transaction that materializes data
+                    interval: None,
+                    config: vec![models::TriggerConfig {
+                        url: "https://example.com/hook".to_string(),
+                        method: models::HttpMethod::POST,
+                        headers: Default::default(),
+                        payload_template: "{}".to_string(),
+                        timeout: Duration::from_secs(30),
+                        max_attempts: 3,
+                    }],
+                    sops: None,
+                })
+                .unwrap(),
             )),
         }
     }
@@ -1383,6 +1525,7 @@ mod tests {
         let mut ctx = Ctx {
             binding_bytes_behind: vec![0; task.binding_collection_names.len()],
             close_requested: false,
+            debounce: TriggerDebounce::default(),
             intents_idle: true,
             legacy_checkpoint: None,
             now: uuid::Clock::from_unix(1_700_000_000, 0),
@@ -1737,12 +1880,167 @@ mod tests {
     }
 
     /// Verifies aggregation of L:Loaded `max_key_delta` across shards and Load cycles.
+    // On recovery, `handler` seeds `Tail::Begin` with the persisted trigger
+    // accumulator as the window to fire. The Tail must re-fire it verbatim
+    // (at-least-once), and it flows independently of the live (empty) accumulator.
+    #[test]
+    fn recovery_refires_persisted_accumulator() {
+        let recovered = models::TriggerVariables::placeholder();
+        let serialized = serde_json::to_vec(&recovered).unwrap();
+
+        let mut ctx = Ctx {
+            binding_bytes_behind: vec![0; 1],
+            close_requested: false,
+            debounce: TriggerDebounce::default(),
+            intents_idle: true,
+            legacy_checkpoint: None,
+            now: uuid::Clock::from_unix(1_700_000_000, 0),
+            pending_ack_intents: BTreeMap::new(),
+            ready_frontier: None,
+            shard_rx: None,
+            stats_idle: false,
+            stopping: false,
+            task: mk_task(1),
+            trigger_running: false,
+        };
+
+        // Recovery injects the persisted accumulator as the Tail's to_fire set.
+        let mut tail = Tail::Begin(TailBegin {
+            pending: PendingDeltas {
+                trigger_params: Bytes::from(serialized),
+                ..Default::default()
+            },
+        });
+
+        // Begin → Acknowledge.
+        let (action, t) = ctx.step_tail(tail);
+        tail = t;
+        assert!(matches!(action, Action::Acknowledge { .. }));
+
+        // Single shard Acknowledged, no patches → WriteIntents (CallTrigger chained).
+        ctx.shard_rx = Some(mk_acknowledged(0, b""));
+        let (action, t) = ctx.step_tail(tail);
+        tail = t;
+        assert!(matches!(action, Action::WriteIntents { .. }));
+
+        // Intents written → CallTrigger carrying the recovered window verbatim.
+        let (action, _t) = ctx.step_tail(tail);
+        let params = match action {
+            Action::CallTrigger { trigger_params, .. } => trigger_params,
+            other => panic!("expected CallTrigger, got {other:?}"),
+        };
+        let fired: models::TriggerVariables = serde_json::from_slice(&params).unwrap();
+        assert_eq!(fired, recovered, "recovered accumulator re-fires verbatim");
+        assert!(
+            ctx.debounce.pending.is_none(),
+            "recovery re-fire does not touch the live accumulator",
+        );
+    }
+
+    // A debounced window fires from Idle once its interval elapses, with no
+    // further transaction: HeadIdle sleeps until the deadline, then emits
+    // CallTrigger and rotates the Tail through its normal fire →
+    // Persist(reduced accumulator) → Done sequence.
+    #[test]
+    fn idle_fires_debounced_window_after_interval() {
+        let mut task = mk_task(1);
+        task.triggers = Some(std::sync::Arc::new(
+            super::super::triggers::CompiledTriggers::compile(models::Triggers {
+                interval: Some(Duration::from_secs(600)),
+                config: vec![models::TriggerConfig {
+                    url: "https://example.com/hook".to_string(),
+                    method: models::HttpMethod::POST,
+                    headers: Default::default(),
+                    payload_template: "{}".to_string(),
+                    timeout: Duration::from_secs(30),
+                    max_attempts: 3,
+                }],
+                sops: None,
+            })
+            .unwrap(),
+        ));
+
+        let t0 = uuid::Clock::from_unix(1_700_000_000, 0);
+        let mut ctx = Ctx {
+            binding_bytes_behind: vec![0; 1],
+            close_requested: false,
+            debounce: TriggerDebounce::default(),
+            intents_idle: true,
+            legacy_checkpoint: None,
+            now: t0,
+            pending_ack_intents: BTreeMap::new(),
+            ready_frontier: None,
+            shard_rx: None,
+            stats_idle: false,
+            stopping: false,
+            task,
+            trigger_running: false,
+        };
+
+        // Seed: triggers last fired at t0, and a window accumulated since.
+        ctx.debounce.last_fire = Some(t0);
+        ctx.debounce.pending = Some(models::TriggerVariables::placeholder());
+
+        let mut tail = Tail::Done(TailDone {
+            shard_patches: Bytes::new(),
+        });
+        let mut head = Head::Idle(HeadIdle::default());
+
+        // Idle before the deadline: Head sleeps until the window comes due.
+        ctx.now = uuid::Clock::from_unix(1_700_000_100, 0); // t0 + 100s.
+        let (action, h) = ctx.step_head(head, &mut tail);
+        head = h;
+        let Action::Sleep { wake_after } = action else {
+            panic!("expected Sleep, got {action:?}");
+        };
+        assert!(
+            wake_after > Duration::from_secs(499) && wake_after <= Duration::from_secs(500),
+            "expected ~500s until due, got {wake_after:?}",
+        );
+
+        // Past the deadline: fire from Idle, with no transaction in flight.
+        ctx.now = uuid::Clock::from_unix(1_700_000_601, 0); // t0 + 601s.
+        let (action, h) = ctx.step_head(head, &mut tail);
+        head = h;
+        let params = match action {
+            Action::CallTrigger { trigger_params, .. } => trigger_params,
+            other => panic!("expected CallTrigger, got {other:?}"),
+        };
+        let fired: models::TriggerVariables = serde_json::from_slice(&params).unwrap();
+        assert_eq!(fired, models::TriggerVariables::placeholder());
+        assert!(matches!(head, Head::Idle(_)));
+        assert!(matches!(tail, Tail::Trigger(_)));
+        assert!(ctx.debounce.pending.is_none());
+        assert_eq!(ctx.debounce.last_fire, Some(ctx.now));
+
+        // Trigger completes → Persist deleting the (now empty) accumulator → Done.
+        let (action, t) = ctx.step_tail(tail);
+        tail = t;
+        let persist = match action {
+            Action::Persist { persist } => persist,
+            other => panic!("expected Persist, got {other:?}"),
+        };
+        assert!(persist.delete_trigger_params);
+        assert!(persist.trigger_params_json.is_empty());
+
+        ctx.shard_rx = Some(mk_tail_persisted(&tail));
+        let (action, t) = ctx.step_tail(tail);
+        tail = t;
+        assert!(matches!(action, Action::Idle));
+        assert!(matches!(tail, Tail::Done(_)));
+
+        // Head is quiescent again: nothing pending, no timer to arm.
+        let (action, _h) = ctx.step_head(head, &mut tail);
+        assert!(matches!(action, Action::Idle));
+    }
+
     #[test]
     fn loaded_max_key_delta_reduction() {
         let task = mk_task(2);
         let mut ctx = Ctx {
             binding_bytes_behind: vec![0; task.binding_collection_names.len()],
             close_requested: false,
+            debounce: TriggerDebounce::default(),
             intents_idle: true,
             legacy_checkpoint: None,
             now: uuid::Clock::from_unix(1_700_000_000, 0),
@@ -1984,6 +2282,7 @@ mod tests {
             let mut ctx = Ctx {
                 binding_bytes_behind: vec![0; 3],
                 close_requested: false,
+                debounce: TriggerDebounce::default(),
                 intents_idle: false,
                 legacy_checkpoint: None,
                 now: uuid::Clock::from_unix(1_700_000_000, 0),
@@ -2028,5 +2327,62 @@ mod tests {
             .tests(200)
             .max_tests(400)
             .quickcheck(prop as fn(u64) -> bool);
+    }
+}
+
+#[cfg(test)]
+mod debounce_tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn window(collection: &str, min: &str, max: &str) -> models::TriggerVariables {
+        models::TriggerVariables {
+            collection_names: vec![collection.to_string()],
+            connector_image: "img".to_string(),
+            materialization_name: "mat".to_string(),
+            flow_published_at_min: min.to_string(),
+            flow_published_at_max: max.to_string(),
+            run_id: min.to_string(),
+        }
+    }
+
+    fn t(secs: u64) -> uuid::Clock {
+        uuid::Clock::from_unix(secs, 0)
+    }
+
+    // A burst of transactions within one interval collapses into a single
+    // delivery whose window spans the union of the collapsed transactions.
+    #[test]
+    fn burst_within_interval_collapses_to_one_fire() {
+        let interval = Some(Duration::from_secs(600));
+        let mut d = TriggerDebounce::default();
+
+        // First qualifying txn: never fired, so it's due immediately.
+        d.accumulate(&window("c", "t00", "t00"));
+        assert!(d.take_due(t(0), interval).is_some(), "first txn fires");
+
+        // Two more txns inside the 600s window: accumulated but suppressed.
+        d.accumulate(&window("c", "t01", "t01"));
+        assert!(d.take_due(t(60), interval).is_none(), "debounced at t=60");
+        d.accumulate(&window("c", "t02", "t02"));
+        assert!(d.take_due(t(120), interval).is_none(), "debounced at t=120");
+
+        // Once the interval elapses, the single fire covers the merged window.
+        let w = d.take_due(t(600), interval).expect("fires once elapsed");
+        assert_eq!(w.flow_published_at_min, "t01", "min spans the burst");
+        assert_eq!(w.flow_published_at_max, "t02", "max spans the burst");
+        assert!(d.pending.is_none(), "accumulator drained after fire");
+    }
+
+    // With no interval, every qualifying transaction fires (pre-debounce behavior).
+    #[test]
+    fn no_interval_fires_every_transaction() {
+        let mut d = TriggerDebounce::default();
+
+        for i in 0..3 {
+            d.accumulate(&window("c", "t", "t"));
+            assert!(d.take_due(t(i), None).is_some(), "fires on txn {i}");
+            assert!(d.pending.is_none());
+        }
     }
 }

--- a/crates/runtime-next/src/leader/materialize/task.rs
+++ b/crates/runtime-next/src/leader/materialize/task.rs
@@ -119,8 +119,8 @@ async fn decrypt_and_compile_triggers(
 
     models::triggers::restore_hmac_excluded_fields(&mut decrypted, originals);
 
-    let compiled = triggers::CompiledTriggers::compile(decrypted.config)
-        .context("compiling trigger templates")?;
+    let compiled =
+        triggers::CompiledTriggers::compile(decrypted).context("compiling trigger templates")?;
 
     Ok(compiled)
 }

--- a/crates/runtime-next/src/leader/materialize/triggers.rs
+++ b/crates/runtime-next/src/leader/materialize/triggers.rs
@@ -3,13 +3,21 @@ use models::TriggerVariables;
 
 /// Pre-compiled trigger templates and their associated configs.
 pub struct CompiledTriggers {
+    /// Minimum interval between deliveries, shared by all configured triggers.
+    pub interval: Option<std::time::Duration>,
     pub configs: Vec<models::TriggerConfig>,
     registry: handlebars::Handlebars<'static>,
 }
 
 impl CompiledTriggers {
     /// Compile all trigger payload templates into a shared Handlebars registry.
-    pub fn compile(configs: Vec<models::TriggerConfig>) -> anyhow::Result<Self> {
+    pub fn compile(triggers: models::Triggers) -> anyhow::Result<Self> {
+        let models::Triggers {
+            interval,
+            config: configs,
+            sops: _,
+        } = triggers;
+
         let mut registry = handlebars::Handlebars::new();
         registry.set_strict_mode(true);
         registry.register_escape_fn(handlebars::no_escape);
@@ -20,7 +28,11 @@ impl CompiledTriggers {
                 .with_context(|| format!("compiling trigger {index} template"))?;
         }
 
-        Ok(Self { configs, registry })
+        Ok(Self {
+            interval,
+            configs,
+            registry,
+        })
     }
 
     /// Render the template for trigger `index` with the given context.
@@ -262,7 +274,12 @@ mod test {
         trigger
             .headers
             .insert("Authorization".to_string(), "Bearer my-secret".to_string());
-        let compiled = CompiledTriggers::compile(vec![trigger.clone()]).unwrap();
+        let compiled = CompiledTriggers::compile(models::Triggers {
+            interval: None,
+            config: vec![trigger.clone()],
+            sops: None,
+        })
+        .unwrap();
         let context =
             models::build_template_context(&TriggerVariables::placeholder(), &trigger.headers);
         let rendered = compiled.render(0, &context).unwrap();
@@ -347,7 +364,12 @@ mod test {
                 make_trigger_with_url(&format!("http://{addr}/webhook"), r#"{"event": "test"}"#);
             trigger.max_attempts = case.max_attempts;
 
-            let compiled = CompiledTriggers::compile(vec![trigger]).unwrap();
+            let compiled = CompiledTriggers::compile(models::Triggers {
+                interval: None,
+                config: vec![trigger],
+                sops: None,
+            })
+            .unwrap();
             let result = send_webhooks(
                 &compiled,
                 &TriggerVariables::placeholder(),

--- a/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
+++ b/crates/sources/tests/snapshots/schema_generation__catalog_schema_snapshot.snap
@@ -1890,6 +1890,15 @@ expression: "&schema"
           "items": {
             "$ref": "#/$defs/TriggerConfig"
           }
+        },
+        "interval": {
+          "title": "Minimum interval between trigger deliveries.",
+          "description": "A burst of transactions within the interval collapses into a single\ndelivery covering the full span.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^\\d+(s|m|h|d)$"
         }
       },
       "additionalProperties": false,

--- a/site/docs/concepts/materialization/materialization-triggers.md
+++ b/site/docs/concepts/materialization/materialization-triggers.md
@@ -10,8 +10,9 @@ been materialized — for example, to kick off a dbt run, send a Slack message,
 or call a custom API.
 
 Triggers are configured on the materialization itself and fire once per
-committed transaction. Each trigger sends an HTTP request whose URL, method,
-headers, and JSON body you define. The body is a
+committed transaction (or at most once per `interval`, when one is set). Each
+trigger sends an HTTP request whose URL, method, headers, and JSON body you
+define. The body is a
 [Handlebars](https://handlebarsjs.com/) template that can reference transaction
 metadata and secret header values.
 
@@ -60,6 +61,11 @@ materializations:
     # Webhook triggers fired after each committed transaction.
     # Optional, type: object
     triggers:
+      # Minimum interval between deliveries, shared by all configured
+      # triggers. When set, bursts of transactions collapse into at most
+      # one delivery per interval.
+      # Optional. Default: unset (fire on every transaction).
+      interval: 30m
       config:
         - # URL of the webhook endpoint.
           # Required, type: string
@@ -97,6 +103,7 @@ materializations:
 
 | Property | Title | Description | Type | Default |
 |---|---|---|---|---|
+| **`/triggers/interval`** | Interval | Minimum interval between deliveries, shared by all configured triggers. A burst of transactions collapses into at most one delivery per interval, covering the full span. Unset: fire on every transaction. | string (duration) | unset |
 | **`/triggers/config`** | Trigger Configurations | List of webhook triggers to fire when new data is materialized. | array | |
 | **`/triggers/config/*/url`** | URL | URL of the webhook endpoint. Must be a valid URL. | string | |
 | **`/triggers/config/*/method`** | HTTP Method | HTTP method for the request. One of `POST`, `PUT`, or `PATCH`. | string | `POST` |
@@ -287,6 +294,6 @@ after initial publication without re-entering all secret header values:
 - `method`
 - `headers` (keys and encrypted values)
 
-The remaining fields (`payloadTemplate`, `timeout`, `maxAttempts`) are
-excluded from the SOPS integrity check, so you can modify them freely without
-needing to re-enter your secret header values.
+The remaining fields (`payloadTemplate`, `timeout`, `maxAttempts`, and the
+top-level `interval`) are excluded from the SOPS integrity check, so you can
+modify them freely without needing to re-enter your secret header values.


### PR DESCRIPTION
**Description:**

Adds an optional minimum fire interval (debounce) to materialization webhook triggers, for the V2 runtime. Fixes #3060.

Triggers previously fired once per committed transaction that materialized data, so a burst of transactions produced a burst of webhook deliveries (potentially costly). With an `interval` set, a burst collapses into at most one delivery per interval, whose payload covers the union of the collapsed transactions.  The old connector-side dbt trigger had an equivalent debounce, this generalizes it to runtime triggers.

Mechanically: each trigger config accumulates a pending window in a leader-lifetime accumulator, keyed by the config's method+URL. At commit time the accumulator is persisted and configs whose interval has elapsed fire with their accumulated window. The rest keep accumulating and fire either at the first commit at-or-after their interval elapses (fast path) or, if the task goes quiet, from the leader's idle loop once the deadline passes (so a debounced window never hangs waiting for a next transaction).

**Workflow steps:**

Add `interval` to a trigger config on a materialization:

```yaml
triggers:
  config:
    - url: "https://cloud.getdbt.com/api/v2/accounts/123/jobs/456/run/"
      headers:
        Authorization: "Token dbt-token"
      payloadTemplate: |
        {"cause": "Estuary trigger {{run_id}}"}
      interval: 30m
```

Unset preserves today's fire-every-transaction behavior; existing specs are unchanged. The field is per-config, so e.g. a Slack notification can fire every transaction while a dbt run on the same materialization is debounced to 30m.

**Documentation links affected:**

- `site/docs/concepts/materialization/materialization-triggers.md` — updated in this PR: `interval` added to the spec example, properties table, and SOPS-excluded-fields list.

**Notes for reviewers:**

- **Two fire paths, one decision function.** A due window normally fires with the transaction that made it due (commit path, no added latency). If the task goes quiet — frontiers only arrive when journal content advances — `HeadIdle` fires due windows from idle and otherwise sleeps until the earliest pending deadline, so a burst's tail is delivered within its interval even with no further commits. The idle fire requires `Tail::Done` and rotates the Tail into its normal `Trigger` → `Persist` → `Done` sequence, so it can't race a commit-path fire.
- **Persisted format change + compatibility.** The durable "trigger-params" blob changes from a single `TriggerVariables` to a `{method+url → TriggerVariables}` map. Both runtimes decode through the new serde-untagged `models::triggers::PersistedTriggerParams` (the formats are mutually unambiguous), so: V2 recovering a pre-upgrade blob fans it out to all configs (its original fire-all semantics), and V1 after a V2→V1 rollback merges a map blob into one window (its normal fire-all behavior). Residual: a *binary* downgrade to a release before this PR has neither fallback — don't downgrade past this release while a trigger is mid-debounce.
- **Debounce state is in-memory** (`last_fire`): a leader failover resets the window, worst case one early fire — same as pre-debounce behavior. Recovery re-fires the persisted accumulator verbatim (at-least-once), which can also mean one early fire post-recovery.
- **Duplicate configs** (same method+URL) aren't supported since the key is the debounce identity: first config wins, later duplicates WARN at task startup and never fire. A pending window whose config was removed on republish is dropped with a WARN rather than failing the task (failing would crash-loop, since the config stays gone for the build's life).
- **V1 is otherwise untouched**: it accepts but ignores `interval` (no debounce), and its only code change is the tolerant `PersistedTriggerParams` decode above.
