### PR TITLE
json: require RFC3339 'T' separator in date-time format validator

### DIFF
--- a/crates/json/src/schema/formats.rs
+++ b/crates/json/src/schema/formats.rs
@@ -86,6 +86,13 @@ impl Format {
                 .is_ok()
             }
             Self::DateTime => {
+                // Since 0.3.37, `time`'s RFC3339 parser accepts any byte as the
+                // date/time separator (time-rs/time#700). JSON Schema's `date-time`
+                // is the RFC3339 ABNF rule, which permits only `T` (case-insensitive),
+                // so check the separator ourselves.
+                if !matches!(val.as_bytes().get(10), Some(b'T' | b't')) {
+                    return false;
+                }
                 time::OffsetDateTime::parse(val, &time::format_description::well_known::Rfc3339)
                     .is_ok()
             }
@@ -214,6 +221,10 @@ mod test {
             ("date-time", "2022-09-11T10:31:25+00:00", true),
             ("date-time", "2022-09-11T10:31:25-00:00", true),
             ("datetime", "2022-09-11T10:31:25.123Z", true), // Accepted alias.
+            ("date-time", "2022-09-11 10:31:25.123Z", false), // Space separator (regression: time-rs/time#700).
+            ("date-time", "2022-09-11x10:31:25.123Z", false), // Arbitrary separator.
+            ("date-time", "2022-09-11t10:31:25.123Z", true), // Lowercase `t` is valid per RFC3339 ABNF.
+            ("date-time", "2022-09-11", false),              // Date only, no separator position.
             ("date-time", "10:31:25.123Z", false),
             ("time", "10:31:25.123Z", true),
             ("time", "10:31:25.123z", true),


### PR DESCRIPTION
**Description:**

Fixes #3108. The `date-time` format validator silently drifted lenient when `time` was bumped 0.3.36 → 0.3.44 (#2302): since time-rs/time#700 the crate's RFC3339 parser accepts *any* byte as the date/time separator, not just a space. JSON Schema defines `format: date-time` as the RFC3339 ABNF rule, which permits only `T` (case-insensitive), so the validator now checks the separator byte explicitly before delegating to `time`.

**Workflow steps:**

No workflow change. Strings like `2022-09-11 10:31:25Z` are no longer detected or validated as `date-time` — schema inference stops mistagging mixed-format fields, and existing write schemas declaring `format: date-time` reject them.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Byte index 10 is safe because RFC3339 `full-date` is fixed-width; lowercase `t` stays accepted per ABNF case-insensitivity (consistent with existing lowercase `z` handling).
- Regression tests added to the `test_format_cases` table; `cargo test -p json` and `cargo test -p doc --features combine` pass with no snapshot fallout.
