### PR TITLE
dekaf: log fetch frame when zero offset

### DIFF
--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -464,7 +464,20 @@ async fn handle_api(
         }
 
         ApiKey::Fetch => {
-            let (header, request) = dec_request(frame, version)?;
+            let (header, request) = dec_request::<messages::FetchRequest>(frame.clone(), version)?;
+            if request
+                .topics
+                .iter()
+                .any(|t| t.partitions.iter().any(|p| p.fetch_offset == 0))
+            {
+                tracing::debug!(
+                    ?version,
+                    ?header,
+                    ?request,
+                    frame = hex::encode(&frame),
+                    "request contains a zero fetch_offset"
+                );
+            }
             Ok(enc_resp(out, &header, session.fetch(request).await?))
         }
 


### PR DESCRIPTION
**Description:**

Additional logging to validate the frame parsing to troubleshoot an ongoing issue with Singlestore.  Occasional frames are parsed with a zero offset but on the Singlestore side frames are logged with the correct offset.

**Workflow steps:**

Enable debug logging.

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

