### PR TITLE
Incidental fixes: gazette Append retry, connector-init image, materialize tear-down

### DIFF
--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -94,6 +94,21 @@ impl Error {
                     true
                 }
 
+                // A broker aborts an Append RPC when its client fails to sustain
+                // the minimum data rate (gazette's MinAppendRate flow-control
+                // policing). This sheds a slow or contended client so others may
+                // proceed; the append rolled back cleanly and is safe to retry.
+                // Gazette surfaces it as an Unknown status wrapping
+                // ErrFlowControlUnderflow, so match on the stable core phrase
+                // rather than the wrapped-context prefix.
+                tonic::Code::Unknown
+                    if status
+                        .message()
+                        .contains("didn't sustain the minimum append data rate") =>
+                {
+                    true
+                }
+
                 _ => false, // Others are not.
             },
 
@@ -196,5 +211,25 @@ fn backoff(attempt: usize) -> std::time::Duration {
         2 | 3 => std::time::Duration::from_millis(100),
         4 | 5 => std::time::Duration::from_secs(1),
         _ => std::time::Duration::from_secs(5),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Error;
+
+    #[test]
+    fn test_flow_control_underflow_is_transient() {
+        // A broker aborts a too-slow Append RPC by returning ErrFlowControlUnderflow
+        // wrapped with "append stream" context, delivered as an Unknown-coded gRPC
+        // status. It must be retried, not treated as a hard failure.
+        let err = Error::Grpc(tonic::Status::unknown(
+            "append stream: client stream didn't sustain the minimum append data rate",
+        ));
+        assert!(err.is_transient());
+
+        // Other Unknown-coded statuses remain fatal, so we don't retry genuine
+        // server-side errors indefinitely.
+        assert!(!Error::Grpc(tonic::Status::unknown("some other failure")).is_transient());
     }
 }

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -17,8 +17,10 @@ const USAGE_RATE_LABEL: &str = "dev.estuary.usage-rate";
 const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
 const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
+// `flow-connector-init` is extracted from this image when a locally-built copy
+// isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.24-30-ga3eba41f95";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/crates/runtime-next/src/leader/materialize/fsm.rs
+++ b/crates/runtime-next/src/leader/materialize/fsm.rs
@@ -266,7 +266,7 @@ impl HeadIdle {
 
         // Termination condition: stop at a clean transaction boundary.
         if stopping && !is_open && tail_done {
-            return (Action::Idle, Head::Stop);
+            return (Action::PollAgain, Head::Stop);
         }
         // Clear stale close_requested from after prior transaction close.
         if !is_open {
@@ -841,7 +841,7 @@ impl HeadStartCommit {
             // (commit) without starting any post-commit activity: that's left
             // for the next session, which will recover our commit state and
             // resume from Tail::Begin.
-            (Action::Idle, Head::Stop)
+            (Action::PollAgain, Head::Stop)
         } else {
             // Rotate to begin a next transaction. `idempotent_replay`
             // is one-shot — only the first transaction of a session may replay
@@ -1727,11 +1727,13 @@ mod tests {
         }
 
         // Final Persisted under stopping: HeadStartCommit chained
-        // (next_action, next_state) = (Idle, Head::Stop) — no Rotate.
+        // (next_action, next_state) = (PollAgain, Head::Stop) — no Rotate.
+        // PollAgain (not Idle) lets the actor loop exit `while !Head::Stop`
+        // immediately rather than parking for a 60s ACTOR_TICK_INTERVAL.
         ctx.shard_rx = Some(mk_head_persisted(&head));
         let (action, h) = ctx.step_head(head, &mut tail);
         head = h;
-        assert!(matches!(action, Action::Idle));
+        assert!(matches!(action, Action::PollAgain));
         assert!(matches!(head, Head::Stop));
         assert!(matches!(tail, Tail::Done(_)));
     }

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -17,8 +17,10 @@ const USAGE_RATE_LABEL: &str = "dev.estuary.usage-rate";
 const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
 const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
+// `flow-connector-init` is extracted from this image when a locally-built copy
+// isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/flow:v0.5.24-30-ga3eba41f95";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/tests/soak/materialization/views.flow.yaml
+++ b/tests/soak/materialization/views.flow.yaml
@@ -25,7 +25,7 @@ materializations:
   test/soak/views:
     endpoint:
       connector:
-        image: ghcr.io/estuary/materialize-postgres:13946b2
+        image: ghcr.io/estuary/materialize-postgres:dev
         config:
           address: supabase_db_flow:5432
           database: postgres


### PR DESCRIPTION
## What & why

A handful of small, independent fixes that were originally carried along on the
`flowctl preview` re-tooling branch (#3117) but don't depend on — and aren't
required by — that work. Splitting them out so they can land on their own.

- **gazette: retry `Append` flow-control underflow instead of hard-failing.** A
  broker aborts an Append when the client can't sustain `MinAppendRate`; the
  rollback is clean and safe to retry (gazette's Go `AppendService` retries
  indefinitely). It surfaces as an Unknown-coded gRPC status that
  `Error::is_transient()` treated as terminal. Classify the underflow as
  transient so it rides the existing retry + backoff in `journal::Client::append`.

- **runtime: source `flow-connector-init` from the reactor image.** The pinned
  extraction image `ghcr.io/estuary/flow` is no longer published; its newest tag
  predates the `projection_constraints` Validated field by ~6 months. An old
  `flow-connector-init` silently drops that field, so materializations emitting
  list-form constraints fail validation with a spurious "group-by key field has no
  constraint" error. Repoint both the V1 `runtime` and `runtime-next` pins at the
  reactor image (same statically-linked binary, tracks current flow).

- **runtime-next: fix materialize 60s tear-down stall.** The materialize leader
  FSM returned `Action::Idle` at a clean transaction boundary while stopping,
  parking the actor for a full 60s `ACTOR_TICK_INTERVAL` before it noticed
  `Head::Stop`. Return `Action::PollAgain` to re-poll immediately, matching the
  capture / derive FSMs.

- **tests/soak: materialize `views` on `materialize-postgres:dev`.** The
  synchronous `StartedCommit` change the V2 remote-authoritative checkpoint path
  needs has merged into `:dev`, so drop the branch-build pin.
