### PR TITLE
flowctl: chunk API requests by url size rather than fixed count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,16 @@ Keep READMEs current - update with code changes.
 
 ## Development Guidelines
 
+### Customer data
+- NEVER write customer data into any git-checked file (source, tests, comments,
+  fixtures, snapshots, docs, commit messages). This is absolute.
+- This explicitly includes customer task/catalog names (e.g. tenant prefixes and
+  collection paths), endpoint configs, credentials, hostnames, and any data
+  values sampled from a customer's system.
+- When a real-world example is needed — such as reproducing a bug report — use a
+  fictitious tenant like `acmeCo/` and invented names that preserve the relevant
+  shape (length, nesting depth) without the original identifiers.
+
 ### Implementation
 - Use `var myVar = ...` in Go. Do NOT use `myVar := ...` (unless required due to shadowing)
 - Write comments that document "why" - rationale, broader context, and non-obvious detail

--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use futures::{FutureExt, TryStreamExt};
-use itertools::Itertools;
 use proto_flow::flow;
 use tables::CatalogResolver;
 
@@ -289,17 +288,30 @@ impl Resolver {
         prefixes.sort();
         prefixes.dedup();
 
-        let storage_mappings = flow_client_next::postgrest::exec::<Vec<StorageMappingRow>>(
-            self.pg
-                .from("storage_mappings")
-                .select("catalog_prefix,id,spec")
-                .in_("catalog_prefix", prefixes),
-            self.access_token.as_deref(),
-        )
-        .await
-        .context("failed to fetch storage mappings")?;
+        let storage_mappings = chunk_names(&prefixes)
+            .into_iter()
+            .map(|prefixes| {
+                let builder = self
+                    .pg
+                    .from("storage_mappings")
+                    .select("catalog_prefix,id,spec")
+                    .in_("catalog_prefix", prefixes);
+                let access_token = self.access_token.clone();
 
-        for row in storage_mappings {
+                async move {
+                    flow_client_next::postgrest::exec::<Vec<StorageMappingRow>>(
+                        builder,
+                        access_token.as_deref(),
+                    )
+                    .await
+                }
+            })
+            .collect::<futures::stream::FuturesUnordered<_>>()
+            .try_collect::<Vec<Vec<StorageMappingRow>>>()
+            .await
+            .context("failed to fetch storage mappings")?;
+
+        for row in storage_mappings.into_iter().flatten() {
             // TODO(johnny): The PostgREST API does not surface recovery/ mappings.
             // Work around for now, by synthesizing them. This should switch to GraphQL.
             if row.catalog_prefix.starts_with("recovery/") {
@@ -364,9 +376,7 @@ impl Resolver {
             dependency_hash: Option<String>,
         }
 
-        let rows = catalog_names
-            .into_iter()
-            .chunks(API_FETCH_CHUNK_SIZE)
+        let rows = chunk_names(catalog_names)
             .into_iter()
             .map(|names| {
                 let builder = self
@@ -464,9 +474,7 @@ impl Resolver {
             pub md5: String,
         }
 
-        let rows = catalog_names
-            .into_iter()
-            .chunks(API_FETCH_CHUNK_SIZE)
+        let rows = chunk_names(catalog_names)
             .into_iter()
             .map(|names| {
                 let builder = self
@@ -501,7 +509,119 @@ impl Resolver {
     }
 }
 
-// API_BATCH_SIZE is used to chunk a set of API entities fetched in a single request.
-// PostgREST passes query predicates as URL parameters, so if we don't chunk requests
-// then we run into URL length limits.
-const API_FETCH_CHUNK_SIZE: usize = 25;
+// PostgREST passes query predicates (like `column=in.(a,b,c)`) as URL query
+// parameters, so fetching a large set of catalog names in a single request can
+// produce a URL that exceeds a server or proxy length limit. We therefore split
+// fetches into chunks bounded by the encoded length of the names they contain,
+// which adapts to how long the names are: deeply-nested names (which
+// percent-encode each `/` to `%2F`) can be well over 100 characters each.
+//
+// Encoded-length budget, in characters, for the names within a single chunk.
+// Chosen so the overall URL stays comfortably below the ~2048 byte limit that
+// stricter proxies impose, after accounting for the scheme, host, and path.
+const API_FETCH_URL_BUDGET: usize = 1800;
+
+/// Estimate the percent-encoded length that `name` contributes to a URL query.
+/// Unreserved characters map to a single byte, and everything else (notably the
+/// `/` path separators within catalog names) expands to a three-byte `%XX`
+/// escape. This intentionally over-estimates rather than under-estimates.
+fn encoded_len(name: &str) -> usize {
+    name.bytes()
+        .map(|b| {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+                1
+            } else {
+                3
+            }
+        })
+        .sum()
+}
+
+/// Split `names` into chunks whose combined encoded length stays within
+/// [`API_FETCH_URL_BUDGET`]. A name longer than the budget on its own still
+/// occupies a chunk by itself, as that's the best we can do without a different
+/// query mechanism.
+fn chunk_names<'a>(names: &[&'a str]) -> Vec<Vec<&'a str>> {
+    let mut chunks = Vec::new();
+    let mut chunk: Vec<&'a str> = Vec::new();
+    let mut chunk_len = 0;
+
+    for &name in names {
+        let cost = encoded_len(name) + 3; // +3 for the `%2C` value separator.
+
+        if !chunk.is_empty() && chunk_len + cost > API_FETCH_URL_BUDGET {
+            chunks.push(std::mem::take(&mut chunk));
+            chunk_len = 0;
+        }
+        chunk.push(name);
+        chunk_len += cost;
+    }
+    if !chunk.is_empty() {
+        chunks.push(chunk);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod test {
+    use super::{API_FETCH_URL_BUDGET, chunk_names, encoded_len};
+
+    fn chunk_encoded_len(chunk: &[&str]) -> usize {
+        chunk.iter().map(|n| encoded_len(n) + 3).sum()
+    }
+
+    // Every chunk must fit within the budget, unless it holds a single name that
+    // is itself larger than the budget (which we can't split further).
+    fn assert_chunks_within_budget(chunks: &[Vec<&str>], expected_total: usize) {
+        for chunk in chunks {
+            assert!(
+                chunk_encoded_len(chunk) <= API_FETCH_URL_BUDGET || chunk.len() == 1,
+                "chunk of {} names exceeded budget at {} chars",
+                chunk.len(),
+                chunk_encoded_len(chunk),
+            );
+        }
+        assert_eq!(chunks.iter().map(Vec::len).sum::<usize>(), expected_total);
+    }
+
+    #[test]
+    fn short_names_pack_into_a_single_chunk() {
+        let names: Vec<String> = (0..60).map(|i| format!("acmeCo/c{i}")).collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+
+        let chunks = chunk_names(&refs);
+        // 60 short names encode to well under the budget, so they all fit in one
+        // request.
+        assert_eq!(chunks.len(), 1);
+        assert_chunks_within_budget(&chunks, refs.len());
+    }
+
+    #[test]
+    fn long_names_split_below_the_url_budget() {
+        // Deeply-nested names, each of which percent-encodes to over 100 chars.
+        let names: Vec<String> = (0..40)
+            .map(|i| {
+                format!("acmeCo/prod/source/aurora_postgres/data/main_db/documents/table_{i:03}")
+            })
+            .collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+
+        let chunks = chunk_names(&refs);
+        assert!(chunks.len() > 1, "long names should split into many chunks");
+        assert_chunks_within_budget(&chunks, refs.len());
+    }
+
+    #[test]
+    fn a_single_oversized_name_gets_its_own_chunk() {
+        let huge = "x/".repeat(API_FETCH_URL_BUDGET); // Far larger than the budget.
+        let refs = vec!["a", huge.as_str(), "b"];
+
+        let chunks = chunk_names(&refs);
+        assert_eq!(chunks, vec![vec!["a"], vec![huge.as_str()], vec!["b"]]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_chunks() {
+        assert!(chunk_names(&[]).is_empty());
+    }
+}


### PR DESCRIPTION
**Description:**

- The current mechanism chunks requests by 25 items, but sometimes some catalog names are so long that even with 25 items per request it is too much (I hit it myself)
- Replace that logic with splitting by actual catalog name lengths added up. Tested this on the case that was failing for me and it works

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

