### PR TITLE
dekaf: use projection_constraints only, no constraints

### DIFF
--- a/crates/dekaf-connector/src/lib.rs
+++ b/crates/dekaf-connector/src/lib.rs
@@ -135,25 +135,26 @@ where
                             parsed_outer_config.variant.clone()
                         ))?;
 
-                        let constraints = binding
+                        let projection_constraints = binding
                             .collection
                             .context("collection must exist")?
                             .projections
                             .iter()
-                            .map(|projection| {
-                                (
-                                    projection.field.clone(),
-                                    constraint_for_projection(&projection, &parsed_inner_config),
-                                )
+                            .map(|projection| validated::ProjectionConstraint {
+                                field: projection.field.clone(),
+                                constraint: Some(constraint_for_projection(
+                                    &projection,
+                                    &parsed_inner_config,
+                                )),
                             })
-                            .collect::<BTreeMap<_, _>>();
+                            .collect::<Vec<_>>();
 
                         Ok::<proto_flow::materialize::response::validated::Binding, anyhow::Error>(
                             validated::Binding {
                                 case_insensitive_fields: false,
-                                constraints,
+                                constraints: BTreeMap::new(),
                                 delta_updates: true,
-                                projection_constraints: Vec::new(),
+                                projection_constraints,
                                 resource_path: vec![resource_config.topic_name],
                                 ser_policy: None,
                             },


### PR DESCRIPTION
**Description:**

- Migrate dekaf to use `projection_constraints` instead of `constraints`. Preparation for #3104 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

