### PR TITLE
docs: retain_existing_data_on_backfill no longer requires allow_existing_tables_for_new_bindings

### DIFF
--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -129,7 +129,7 @@ Skips truncating destination tables when a backfill is triggered.
 - **Use case:** Preserving historical data in the destination when a schema change triggers an automatic backfill.
 - **Caveats:**
   - May result in duplicate or inconsistent data if the source collection contains updated versions of previously materialized documents.
-  - Enabling this flag also disables the connector's load optimization for keys reset by the backfill, so retained rows are matched and updated in place instead of duplicated. Pairing with [`allow_existing_tables_for_new_bindings`](#allow_existing_tables_for_new_bindings) is only needed separately when the binding itself is new and the destination table existed before Estuary started writing to it.
+  - When this flag is enabled, backfilled rows are matched against existing rows and updated in place, rather than inserted as duplicates. Pairing with [`allow_existing_tables_for_new_bindings`](#allow_existing_tables_for_new_bindings) is only needed separately when the binding itself is new and the destination table existed before Estuary started writing to it.
   - If collection keys or the destination table schema change in incompatible ways, the connector will still drop and recreate the table even with this flag enabled.
 - **Applies to:** Most SQL and warehouse materialization connectors.
 

--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -129,7 +129,7 @@ Skips truncating destination tables when a backfill is triggered.
 - **Use case:** Preserving historical data in the destination when a schema change triggers an automatic backfill.
 - **Caveats:**
   - May result in duplicate or inconsistent data if the source collection contains updated versions of previously materialized documents.
-  - When this flag is enabled, backfilled rows are matched against existing rows and updated in place, rather than inserted as duplicates. Pairing with [`allow_existing_tables_for_new_bindings`](#allow_existing_tables_for_new_bindings) is only needed separately when the binding itself is new and the destination table existed before Estuary started writing to it.
+  - When this flag is enabled, backfilled rows are matched against existing rows and updated in place, rather than inserted as duplicates.
   - If collection keys or the destination table schema change in incompatible ways, the connector will still drop and recreate the table even with this flag enabled.
 - **Applies to:** Most SQL and warehouse materialization connectors.
 

--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -129,7 +129,7 @@ Skips truncating destination tables when a backfill is triggered.
 - **Use case:** Preserving historical data in the destination when a schema change triggers an automatic backfill.
 - **Caveats:**
   - May result in duplicate or inconsistent data if the source collection contains updated versions of previously materialized documents.
-  - On a table that already contains data, pair this with [`allow_existing_tables_for_new_bindings`](#allow_existing_tables_for_new_bindings). Without it, a backfill can insert duplicate copies of rows whose keys already exist instead of updating them. `allow_existing_tables_for_new_bindings` makes the backfill match and update those rows in place, so they merge instead of duplicating.
+  - Enabling this flag also disables the connector's load optimization for keys reset by the backfill, so retained rows are matched and updated in place instead of duplicated. Pairing with [`allow_existing_tables_for_new_bindings`](#allow_existing_tables_for_new_bindings) is only needed separately when the binding itself is new and the destination table existed before Estuary started writing to it.
   - If collection keys or the destination table schema change in incompatible ways, the connector will still drop and recreate the table even with this flag enabled.
 - **Applies to:** Most SQL and warehouse materialization connectors.
 

--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -129,7 +129,7 @@ Skips truncating destination tables when a backfill is triggered.
 - **Use case:** Preserving historical data in the destination when a schema change triggers an automatic backfill.
 - **Caveats:**
   - May result in duplicate or inconsistent data if the source collection contains updated versions of previously materialized documents.
-  - When this flag is enabled, backfilled rows are matched against existing rows and updated in place, rather than inserted as duplicates.
+  - When this flag is enabled, backfilled rows are matched against existing rows and updated in place, rather than inserted as duplicates (this flag disables the load key optimization).
   - If collection keys or the destination table schema change in incompatible ways, the connector will still drop and recreate the table even with this flag enabled.
 - **Applies to:** Most SQL and warehouse materialization connectors.
 


### PR DESCRIPTION
## Summary
- [estuary/connectors#4757](https://github.com/estuary/connectors/pull/4757) (merged 2026-07-06, resolves [estuary/connectors#4702](https://github.com/estuary/connectors/issues/4702)) made `retain_existing_data_on_backfill` disable the connector's load key optimization on its own, so it merges retained rows correctly during a backfill without needing `allow_existing_tables_for_new_bindings` as a companion flag for that purpose.
- Updates the stale caveat on the feature flags page that told users to pair the two flags to avoid duplicates.
- `allow_existing_tables_for_new_bindings` still matters on its own for adopting a pre-existing table on a brand new binding — that part of the doc is unchanged.

## Test plan
- [ ] Docs build (no code change, prose only)