### PR TITLE
Restart Materializations sessions before IAM token expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,6 +4428,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 

--- a/crates/iam-auth/Cargo.toml
+++ b/crates/iam-auth/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/iam-auth/src/providers/aws.rs
+++ b/crates/iam-auth/src/providers/aws.rs
@@ -60,9 +60,13 @@ pub async fn generate_tokens(config: &AWSConfig, task_name: &str) -> anyhow::Res
         .credentials()
         .context("no credentials returned from STS AssumeRoleWithWebIdentity")?;
 
+    let expires_at = std::time::SystemTime::try_from(*credentials.expiration())
+        .context("STS credential expiration is not a valid timestamp")?;
+
     Ok(AWSTokens {
         access_key_id: credentials.access_key_id().to_string(),
         secret_access_key: credentials.secret_access_key().to_string(),
         session_token: credentials.session_token().to_string(),
+        expires_at,
     })
 }

--- a/crates/iam-auth/src/providers/azure.rs
+++ b/crates/iam-auth/src/providers/azure.rs
@@ -14,7 +14,7 @@ pub async fn generate_tokens(config: &AzureConfig, task_name: &str) -> anyhow::R
         google_sign_jwt(task_name, task_name, "api://AzureADTokenExchange").await?;
 
     // Step 2: Exchange signed JWT for target App Registration access token
-    let access_token = exchange_azure_jwt_for_app_registration_token(
+    let (access_token, expires_at) = exchange_azure_jwt_for_app_registration_token(
         &signed_jwt,
         &config.azure_tenant_id,
         &config.azure_client_id,
@@ -24,20 +24,26 @@ pub async fn generate_tokens(config: &AzureConfig, task_name: &str) -> anyhow::R
 
     signed_jwt.zeroize();
 
-    Ok(AzureTokens { access_token })
+    Ok(AzureTokens {
+        access_token,
+        expires_at,
+    })
 }
 
-/// Exchange signed JWT for target App Registration access token
+/// Exchange signed JWT for target App Registration access token.
+/// Returns the access token and when it expires.
 async fn exchange_azure_jwt_for_app_registration_token(
     jwt_token: &str,
     tenant_id: &str,
     target_client_id: &str,
     scope: Option<&str>,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, std::time::SystemTime)> {
     use reqwest::header::CONTENT_TYPE;
     use std::collections::HashMap;
 
     let client = reqwest::Client::new();
+    // Taken prior to the request, so the computed expiry under-estimates expr
+    let now = std::time::SystemTime::now();
 
     let mut params = HashMap::new();
     params.insert("grant_type", "client_credentials");
@@ -76,9 +82,26 @@ async fn exchange_azure_jwt_for_app_registration_token(
         .await
         .context("failed to parse Azure App Registration token response")?;
 
-    response_json
+    let access_token = response_json
         .get("access_token")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .context("missing access_token in Azure App Registration token response")
+        .context("missing access_token in Azure App Registration token response")?;
+
+    // The v2.0 token endpoint returns `expires_in` as a JSON number of
+    // seconds, but v1.0-style responses encode it as a string.
+    //
+    // Entra ID grants roughly one hour by default, but a customer can extend
+    // that with a TokenLifetimePolicy on their App Registration. We honor
+    // whatever lifetime was actually granted, so such extensions lengthen
+    // connector sessions with no change on our side.
+    let expires_in = response_json
+        .get("expires_in")
+        .and_then(|v| v.as_u64().or_else(|| v.as_str()?.parse().ok()))
+        .context("missing expires_in in Azure App Registration token response")?;
+
+    Ok((
+        access_token,
+        now + std::time::Duration::from_secs(expires_in),
+    ))
 }

--- a/crates/iam-auth/src/providers/gcp.rs
+++ b/crates/iam-auth/src/providers/gcp.rs
@@ -32,7 +32,7 @@ pub async fn generate_tokens(config: &GCPConfig, task_name: &str) -> anyhow::Res
     signed_jwt.zeroize();
 
     // Step 3: Use the exchanged access token to impersonate the target service account
-    let impersonated_token =
+    let (impersonated_token, expires_at) =
         impersonate_service_account(&exchanged_token, &config.gcp_service_account_to_impersonate)
             .await?;
 
@@ -40,8 +40,16 @@ pub async fn generate_tokens(config: &GCPConfig, task_name: &str) -> anyhow::Res
 
     Ok(GCPTokens {
         access_token: impersonated_token,
+        expires_at,
     })
 }
+
+// GCP caps `generateAccessToken` lifetimes at one hour unless the customer's
+// org policy `constraints/iam.allowServiceAccountCredentialLifetimeExtension`
+// names the impersonated service account, which raises the cap to twelve hours.
+// First we'll try the extended lifetime, and iff that fails we fall back to the hour
+const EXTENDED_LIFETIME: std::time::Duration = std::time::Duration::from_secs(12 * 3600);
+const DEFAULT_LIFETIME: std::time::Duration = std::time::Duration::from_secs(3600);
 
 /// Get GCP access token from service account credentials JSON
 async fn get_gcp_token_from_credentials(credentials_json: &str) -> anyhow::Result<String> {
@@ -215,11 +223,29 @@ async fn exchange_jwt_for_service_account_token(
         .context("missing access_token in OAuth token exchange response")
 }
 
-/// Impersonate a service account using the generateAccessToken API
+/// Impersonate a service account using the generateAccessToken API.
+/// Returns the access token and when it expires.
 async fn impersonate_service_account(
     access_token: &str,
     target_service_account: &str,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, std::time::SystemTime)> {
+    match impersonate_with_lifetime(access_token, target_service_account, EXTENDED_LIFETIME).await {
+        Ok(ok) => Ok(ok),
+        Err(extended_err) => {
+            tracing::debug!(
+                error = ?extended_err,
+                "extended-lifetime GCP token was refused; falling back to the default lifetime"
+            );
+            impersonate_with_lifetime(access_token, target_service_account, DEFAULT_LIFETIME).await
+        }
+    }
+}
+
+async fn impersonate_with_lifetime(
+    access_token: &str,
+    target_service_account: &str,
+    lifetime: std::time::Duration,
+) -> anyhow::Result<(String, std::time::SystemTime)> {
     use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
     use serde_json::json;
 
@@ -232,8 +258,11 @@ async fn impersonate_service_account(
     let body = json!({
         "scope": ["https://www.googleapis.com/auth/cloud-platform"],
         "delegates": [],
-        "lifetime": "3600s" // 12 hours
+        "lifetime": format!("{}s", lifetime.as_secs()),
     });
+    // Taken prior to the request, so the computed expiry under-estimates the
+    // actual `expireTime` granted by GCP (which is what we want).
+    let now = std::time::SystemTime::now();
 
     let response = client
         .post(&url)
@@ -254,11 +283,13 @@ async fn impersonate_service_account(
         .await
         .context("failed to parse GCP generateAccessToken response")?;
 
-    response_json
+    let token = response_json
         .get("accessToken")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .context("missing accessToken in GCP generateAccessToken response")
+        .context("missing accessToken in GCP generateAccessToken response")?;
+
+    Ok((token, now + lifetime))
 }
 
 /// Create JWT token and exchange it for an access token using OAuth 2.0 service account flow

--- a/crates/iam-auth/src/tokens.rs
+++ b/crates/iam-auth/src/tokens.rs
@@ -13,16 +13,22 @@ pub struct AWSTokens {
     pub access_key_id: String,
     pub secret_access_key: String,
     pub session_token: String,
+    #[zeroize(skip)]
+    pub expires_at: std::time::SystemTime,
 }
 
 #[derive(Debug, Clone, Zeroize)]
 pub struct GCPTokens {
     pub access_token: String,
+    #[zeroize(skip)]
+    pub expires_at: std::time::SystemTime,
 }
 
 #[derive(Debug, Clone, Zeroize)]
 pub struct AzureTokens {
     pub access_token: String,
+    #[zeroize(skip)]
+    pub expires_at: std::time::SystemTime,
 }
 
 impl IAMTokens {
@@ -42,6 +48,7 @@ impl IAMTokens {
                 access_key_id,
                 secret_access_key,
                 session_token,
+                ..
             }) => {
                 credentials.insert(
                     "aws_access_key_id".to_string(),
@@ -56,13 +63,13 @@ impl IAMTokens {
                     serde_json::Value::String(session_token.clone()),
                 );
             }
-            IAMTokens::GCP(GCPTokens { access_token }) => {
+            IAMTokens::GCP(GCPTokens { access_token, .. }) => {
                 credentials.insert(
                     "gcp_access_token".to_string(),
                     serde_json::Value::String(access_token.clone()),
                 );
             }
-            IAMTokens::Azure(AzureTokens { access_token }) => {
+            IAMTokens::Azure(AzureTokens { access_token, .. }) => {
                 credentials.insert(
                     "azure_access_token".to_string(),
                     serde_json::Value::String(access_token.clone()),
@@ -71,6 +78,16 @@ impl IAMTokens {
         }
 
         Ok(parsed)
+    }
+
+    /// When the minted credentials expire and stop being honored by the
+    /// provider. Sessions using these tokens must be restarted before then.
+    pub fn expires_at(&self) -> std::time::SystemTime {
+        match self {
+            IAMTokens::AWS(tokens) => tokens.expires_at,
+            IAMTokens::GCP(tokens) => tokens.expires_at,
+            IAMTokens::Azure(tokens) => tokens.expires_at,
+        }
     }
 }
 
@@ -94,6 +111,7 @@ mod tests {
             access_key_id: "test_access_key_id".to_string(),
             secret_access_key: "test_secret_access_key".to_string(),
             session_token: "test_session_token".to_string(),
+            expires_at: std::time::UNIX_EPOCH,
         });
 
         assert_eq!(
@@ -123,6 +141,7 @@ mod tests {
 
         let tokens = IAMTokens::GCP(GCPTokens {
             access_token: "test_access_token".to_string(),
+            expires_at: std::time::UNIX_EPOCH,
         });
 
         assert_eq!(
@@ -150,6 +169,7 @@ mod tests {
 
         let tokens = IAMTokens::Azure(AzureTokens {
             access_token: "test_azure_access_token".to_string(),
+            expires_at: std::time::UNIX_EPOCH,
         });
 
         assert_eq!(

--- a/crates/runtime-next/src/shard/capture/actor.rs
+++ b/crates/runtime-next/src/shard/capture/actor.rs
@@ -30,6 +30,8 @@ pub(super) struct Actor {
     connector_tx: mpsc::Sender<Request>,
     // Per-session metrics counters.
     metrics: super::Metrics,
+    // When Some, a deadline at which we begin a graceful session stop.
+    token_restart_at: Option<tokio::time::Instant>,
 
     // --- Parked resources: `Some` unless borrowed by an in-flight future. ---
     // RocksDB is parked with its per-binding state keys.
@@ -76,11 +78,21 @@ impl Actor {
         publisher: crate::Publisher,
         shapes: Vec<doc::Shape>,
         task: std::sync::Arc<Task>,
+        token_restart_at: Option<std::time::SystemTime>,
     ) -> Self {
+        // Map the wall-clock deadline onto the monotonic clock driving `serve`.
+        let token_restart_at = token_restart_at.map(|at| {
+            let delay = at
+                .duration_since(std::time::SystemTime::now())
+                .unwrap_or_default();
+            tokio::time::Instant::now() + delay
+        });
+
         Self {
             task,
             connector_tx,
             metrics,
+            token_restart_at,
             db: Some((db, binding_state_keys)),
             publisher: Some(publisher),
             shapes: Some(shapes),
@@ -279,6 +291,16 @@ impl Actor {
                 // Process new connector messages last.
                 msg = connector_rx.next(), if matches!(ready_connector_rx, fsm::ConnectorRx::Pending) => {
                     self.on_connector_rx(&mut ready_connector_rx, msg)?;
+                }
+                // Next, a graceful session restart ahead of IAM token expiry
+                _ = maybe_deadline(self.token_restart_at) => {
+                    service_kit::event!(
+                        tracing::Level::INFO,
+                        "shard",
+                        "injected IAM credentials expire soon; stopping session gracefully",
+                    );
+                    stopping = true;
+                    self.token_restart_at = None;
                 }
 
                 // Lowest priority.
@@ -614,6 +636,14 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> Option<T> {
     }
 }
 
+/// Sleep until the deadline, or park forever when there isn't one.
+async fn maybe_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -719,6 +749,7 @@ mod tests {
             publisher,
             shapes,
             task,
+            None,
         );
 
         let serve = tokio::spawn(async move {
@@ -803,6 +834,7 @@ mod tests {
             publisher,
             shapes,
             task,
+            None,
         );
 
         // Seed a policy under which the observed journal is immediately due.

--- a/crates/runtime-next/src/shard/capture/connector.rs
+++ b/crates/runtime-next/src/shard/capture/connector.rs
@@ -17,6 +17,7 @@ pub async fn start<L: crate::LogHandler>(
     mpsc::Sender<Request>,
     BoxStream<'static, tonic::Result<Response>>,
     Option<crate::proto::Container>,
+    Option<std::time::SystemTime>,
 )> {
     let (endpoint, config_json, connector_type, catalog_name) = extract_endpoint(&mut initial)?;
     let (connector_tx, connector_rx) = mpsc::channel(crate::CHANNEL_BUFFER);
@@ -102,6 +103,7 @@ pub async fn start<L: crate::LogHandler>(
         response => return Err(verify.fail_msg(response)),
     };
 
+    let mut token_restart_at = None;
     if let Ok(Some(iam_config)) = iam_auth::extract_iam_auth_from_connector_config(
         config_json,
         &spec_response.config_schema_json,
@@ -111,13 +113,18 @@ pub async fn start<L: crate::LogHandler>(
                 .generate_tokens(task_name)
                 .await
                 .map_err(crate::anyhow_to_status)?;
+
+            token_restart_at = Some(crate::shard::token_restart_deadline(
+                std::time::SystemTime::now(),
+                tokens.expires_at(),
+            ));
             *config_json = tokens.inject_into(config_json)?.to_string().into();
             tokens.zeroize();
         }
     }
     _ = connector_tx.try_send(initial);
 
-    Ok((connector_tx, connector_rx, container))
+    Ok((connector_tx, connector_rx, container, token_restart_at))
 }
 
 fn extract_endpoint<'r>(

--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -108,7 +108,7 @@ async fn serve_unary<L: crate::LogHandler>(
     let is_spec = request.spec.is_some();
     let is_discover = request.discover.is_some();
     let is_validate = request.validate.is_some();
-    let (connector_tx, mut connector_rx, _container) =
+    let (connector_tx, mut connector_rx, _container, _token_restart_at) =
         connector::start(service, log_level, request).await?;
     std::mem::drop(connector_tx);
 
@@ -336,7 +336,7 @@ where
         }),
         ..Default::default()
     };
-    let (connector_tx, mut connector_rx, container) =
+    let (connector_tx, mut connector_rx, container, token_restart_at) =
         connector::start(service, log_level, open.clone()).await?;
     let verify = crate::verify("Capture", "Opened", "connector");
     let opened = match verify.not_eof(connector_rx.next().await)? {
@@ -398,6 +398,7 @@ where
         publisher,
         shapes,
         task.clone(),
+        token_restart_at,
     )
     .serve(connector_rx, controller_rx, head, tail)
     .await?;
@@ -463,7 +464,7 @@ async fn apply_loop<L: crate::LogHandler>(
             state_json: connector_state_json.clone(),
         };
 
-        let (connector_tx, mut connector_rx, _container) = connector::start(
+        let (connector_tx, mut connector_rx, _container, _token_restart_at) = connector::start(
             service,
             log_level,
             capture::Request {

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -55,6 +55,10 @@ pub(super) struct Actor {
     max_keys: Vec<(Bytes, Bytes)>,
     // Per-session metrics counters.
     metrics: super::Metrics,
+    // When Some, a deadline at which we ask the leader for a graceful session
+    // stop, ahead of the expiry of IAM credentials injected into the connector
+    // config. The session's restart re-runs the connector with fresh tokens.
+    token_restart_at: Option<tokio::time::Instant>,
 }
 
 impl Actor {
@@ -68,7 +72,16 @@ impl Actor {
         leader_tx: mpsc::UnboundedSender<proto::Materialize>,
         max_keys: Vec<(Bytes, Bytes)>,
         metrics: super::Metrics,
+        token_restart_at: Option<std::time::SystemTime>,
     ) -> Self {
+        // Map the wall-clock deadline onto the monotonic clock driving `serve`.
+        let token_restart_at = token_restart_at.map(|at| {
+            let delay = at
+                .duration_since(std::time::SystemTime::now())
+                .unwrap_or_default();
+            tokio::time::Instant::now() + delay
+        });
+
         Self {
             bindings,
             connector_pending: Vec::new(),
@@ -82,6 +95,7 @@ impl Actor {
             load_keys: Default::default(),
             max_keys,
             metrics,
+            token_restart_at,
         }
     }
 
@@ -242,6 +256,21 @@ impl Actor {
                 }
                 // Next, wait for capacity to send to the connector.
                 true = wake_connector_tx => {}
+                // Next, a graceful session restart ahead of IAM token expiry.
+                // The leader Stops at the next transaction boundary, and the
+                // restarted session mints fresh tokens for the connector.
+                _ = maybe_deadline(self.token_restart_at) => {
+                    service_kit::event!(
+                        tracing::Level::INFO,
+                        "leader",
+                        "injected IAM credentials expire soon; requesting graceful session stop",
+                    );
+                    _ = self.leader_tx.send(proto::Materialize {
+                        stop: Some(proto::Stop {}),
+                        ..Default::default()
+                    });
+                    self.token_restart_at = None;
+                }
                 // Periodic tick ensures the iteration trace fires even when otherwise idle.
                 _ = ticker.tick() => {}
             }
@@ -538,6 +567,13 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> T {
     }
 }
 
+async fn maybe_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -578,6 +614,7 @@ mod tests {
                 flushed: HashMap::new(),
                 max_keys: Vec::new(),
                 metrics: super::super::Metrics::new("test/shard"),
+                token_restart_at: None,
             },
             leader_rx,
             connector_rx,
@@ -675,6 +712,7 @@ mod tests {
             flushed: HashMap::new(),
             max_keys: Vec::new(),
             metrics: super::super::Metrics::new("test/shard"),
+            token_restart_at: None,
         };
 
         let accumulator =

--- a/crates/runtime-next/src/shard/materialize/connector.rs
+++ b/crates/runtime-next/src/shard/materialize/connector.rs
@@ -131,7 +131,7 @@ pub async fn start<L: crate::LogHandler>(
                 .await
                 .map_err(crate::anyhow_to_status)?;
 
-            token_restart_at = Some(token_restart_deadline(
+            token_restart_at = Some(crate::shard::token_restart_deadline(
                 std::time::SystemTime::now(),
                 tokens.expires_at(),
             ));
@@ -148,31 +148,6 @@ pub async fn start<L: crate::LogHandler>(
         codec,
         token_restart_at,
     ))
-}
-
-/// Deadline for beginning a graceful session restart ahead of IAM token
-/// expiry, so a transaction started near the deadline still has runway to
-/// commit with valid credentials. Short (1 hour) tokens can't afford a large
-/// margin; extended (12 hour) tokens trade some of their generous lifetime
-/// for more commit runway.
-fn token_restart_deadline(
-    now: std::time::SystemTime,
-    expires_at: std::time::SystemTime,
-) -> std::time::SystemTime {
-    use std::time::Duration;
-
-    const LONG_LIFETIME: Duration = Duration::from_secs(4 * 3600);
-    const LONG_MARGIN: Duration = Duration::from_secs(30 * 60);
-    const SHORT_MARGIN: Duration = Duration::from_secs(5 * 60);
-
-    let lifetime = expires_at.duration_since(now).unwrap_or_default();
-    let margin = if lifetime >= LONG_LIFETIME {
-        LONG_MARGIN
-    } else {
-        SHORT_MARGIN
-    };
-    // A pathologically short lifetime restarts immediately rather than never.
-    expires_at - margin.min(lifetime)
 }
 
 fn extract_endpoint<'r>(
@@ -253,35 +228,5 @@ fn extract_endpoint<'r>(
         ))
     } else {
         anyhow::bail!("invalid connector type: {connector_type}");
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::token_restart_deadline;
-    use std::time::{Duration, SystemTime};
-
-    #[test]
-    fn test_token_restart_deadline_margins() {
-        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-
-        // One-hour token restarts five minutes early.
-        let expires = now + Duration::from_secs(3600);
-        assert_eq!(
-            token_restart_deadline(now, expires),
-            expires - Duration::from_secs(5 * 60)
-        );
-
-        // Twelve-hour token restarts thirty minutes early.
-        let expires = now + Duration::from_secs(12 * 3600);
-        assert_eq!(
-            token_restart_deadline(now, expires),
-            expires - Duration::from_secs(30 * 60)
-        );
-
-        // A lifetime shorter than its margin restarts immediately, not never.
-        let expires = now + Duration::from_secs(60);
-        assert_eq!(token_restart_deadline(now, expires), now);
-        assert_eq!(token_restart_deadline(now, now), now);
     }
 }

--- a/crates/runtime-next/src/shard/materialize/connector.rs
+++ b/crates/runtime-next/src/shard/materialize/connector.rs
@@ -8,7 +8,9 @@ use zeroize::Zeroize;
 
 // Start a materialization connector as indicated by the `initial` Request.
 // Returns a pair of Streams for sending Requests and receiving Responses,
-// plus OpenExtras with decrypted trigger configs and connector metadata.
+// plus OpenExtras with decrypted trigger configs and connector metadata,
+// plus a deadline for gracefully restarting the session ahead of injected
+// IAM credential expiry (None when the task doesn't use IAM auth).
 pub async fn start<L: crate::LogHandler>(
     service: &crate::shard::Service<L>,
     log_level: ops::LogLevel,
@@ -18,6 +20,7 @@ pub async fn start<L: crate::LogHandler>(
     BoxStream<'static, tonic::Result<materialize::Response>>,
     Option<crate::proto::Container>,
     connector_init::Codec,
+    Option<std::time::SystemTime>,
 )> {
     let (endpoint, config_json, connector_type, catalog_name) = extract_endpoint(&mut initial)?;
     let (connector_tx, connector_rx) = mpsc::channel(crate::CHANNEL_BUFFER);
@@ -116,6 +119,7 @@ pub async fn start<L: crate::LogHandler>(
         response => return Err(verify.fail_msg(response)),
     };
 
+    let mut token_restart_at = None;
     if let Ok(Some(iam_config)) = iam_auth::extract_iam_auth_from_connector_config(
         config_json,
         &spec_response.config_schema_json,
@@ -127,13 +131,48 @@ pub async fn start<L: crate::LogHandler>(
                 .await
                 .map_err(crate::anyhow_to_status)?;
 
+            token_restart_at = Some(token_restart_deadline(
+                std::time::SystemTime::now(),
+                tokens.expires_at(),
+            ));
             *config_json = tokens.inject_into(config_json)?.to_string().into();
             tokens.zeroize();
         }
     }
     _ = connector_tx.try_send(initial);
 
-    Ok((connector_tx, connector_rx, container, codec))
+    Ok((
+        connector_tx,
+        connector_rx,
+        container,
+        codec,
+        token_restart_at,
+    ))
+}
+
+/// Deadline for beginning a graceful session restart ahead of IAM token
+/// expiry, so a transaction started near the deadline still has runway to
+/// commit with valid credentials. Short (1 hour) tokens can't afford a large
+/// margin; extended (12 hour) tokens trade some of their generous lifetime
+/// for more commit runway.
+fn token_restart_deadline(
+    now: std::time::SystemTime,
+    expires_at: std::time::SystemTime,
+) -> std::time::SystemTime {
+    use std::time::Duration;
+
+    const LONG_LIFETIME: Duration = Duration::from_secs(4 * 3600);
+    const LONG_MARGIN: Duration = Duration::from_secs(30 * 60);
+    const SHORT_MARGIN: Duration = Duration::from_secs(5 * 60);
+
+    let lifetime = expires_at.duration_since(now).unwrap_or_default();
+    let margin = if lifetime >= LONG_LIFETIME {
+        LONG_MARGIN
+    } else {
+        SHORT_MARGIN
+    };
+    // A pathologically short lifetime restarts immediately rather than never.
+    expires_at - margin.min(lifetime)
 }
 
 fn extract_endpoint<'r>(
@@ -214,5 +253,35 @@ fn extract_endpoint<'r>(
         ))
     } else {
         anyhow::bail!("invalid connector type: {connector_type}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::token_restart_deadline;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn test_token_restart_deadline_margins() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+        // One-hour token restarts five minutes early.
+        let expires = now + Duration::from_secs(3600);
+        assert_eq!(
+            token_restart_deadline(now, expires),
+            expires - Duration::from_secs(5 * 60)
+        );
+
+        // Twelve-hour token restarts thirty minutes early.
+        let expires = now + Duration::from_secs(12 * 3600);
+        assert_eq!(
+            token_restart_deadline(now, expires),
+            expires - Duration::from_secs(30 * 60)
+        );
+
+        // A lifetime shorter than its margin restarts immediately, not never.
+        let expires = now + Duration::from_secs(60);
+        assert_eq!(token_restart_deadline(now, expires), now);
+        assert_eq!(token_restart_deadline(now, now), now);
     }
 }

--- a/crates/runtime-next/src/shard/materialize/handler.rs
+++ b/crates/runtime-next/src/shard/materialize/handler.rs
@@ -81,7 +81,7 @@ pub async fn serve_unary<L: crate::LogHandler>(
     let is_validate = request.validate.is_some();
     let is_apply = request.apply.is_some();
 
-    let (connector_tx, mut connector_rx, _container, _codec) =
+    let (connector_tx, mut connector_rx, _container, _codec, _token_restart_at) =
         connector::start(service, log_level, request).await?;
     std::mem::drop(connector_tx); // Send EOF.
 
@@ -272,6 +272,7 @@ where
         leader_tx,
         max_keys,
         shuffle_reader,
+        token_restart_at,
     } = startup::run(
         controller_rx,
         controller_tx,
@@ -299,6 +300,7 @@ where
         leader_tx,
         max_keys,
         metrics,
+        token_restart_at,
     )
     .serve(
         accumulator,

--- a/crates/runtime-next/src/shard/materialize/startup.rs
+++ b/crates/runtime-next/src/shard/materialize/startup.rs
@@ -76,6 +76,7 @@ pub(super) struct Startup {
     pub leader_tx: mpsc::UnboundedSender<proto::Materialize>,
     pub max_keys: Vec<(bytes::Bytes, bytes::Bytes)>,
     pub shuffle_reader: shuffle::log::Reader,
+    pub token_restart_at: Option<std::time::SystemTime>,
 }
 
 pub(super) async fn run<R, L: crate::LogHandler>(
@@ -244,7 +245,7 @@ where
         }),
         ..Default::default()
     };
-    let (connector_tx, mut connector_rx, container, codec) =
+    let (connector_tx, mut connector_rx, container, codec, token_restart_at) =
         super::connector::start(service, log_level, initial).await?;
 
     // Read C:Opened from the connector.
@@ -306,5 +307,6 @@ where
         leader_tx,
         max_keys,
         shuffle_reader,
+        token_restart_at,
     })
 }

--- a/crates/runtime-next/src/shard/mod.rs
+++ b/crates/runtime-next/src/shard/mod.rs
@@ -112,6 +112,28 @@ pub fn finish_split(
     }
 }
 
+/// Deadline for beginning a graceful session restart ahead of IAM token
+/// expiry, so a transaction started near the deadline still has runway
+pub(crate) fn token_restart_deadline(
+    now: std::time::SystemTime,
+    expires_at: std::time::SystemTime,
+) -> std::time::SystemTime {
+    use std::time::Duration;
+
+    const LONG_LIFETIME: Duration = Duration::from_secs(4 * 3600);
+    const LONG_MARGIN: Duration = Duration::from_secs(30 * 60);
+    const SHORT_MARGIN: Duration = Duration::from_secs(5 * 60);
+
+    let lifetime = expires_at.duration_since(now).unwrap_or_default();
+    let margin = if lifetime >= LONG_LIFETIME {
+        LONG_MARGIN
+    } else {
+        SHORT_MARGIN
+    };
+    // A pathologically short lifetime restarts immediately rather than never.
+    expires_at - margin.min(lifetime)
+}
+
 /// Build gRPC client metadata bearing a self-signed `LEAD` token when `signer`
 /// is `Some`, scoped to `shard_id`'s task prefix so a leader stream opened with
 /// it can only operate on shards of this task. Empty metadata when `None`
@@ -128,10 +150,34 @@ pub(crate) fn leader_bearer(
 
 #[cfg(test)]
 mod tests {
-    use super::{finish_split, observe_throttle_samples, start_due_split};
+    use super::{finish_split, observe_throttle_samples, start_due_split, token_restart_deadline};
     use crate::shard::split_policy::SplitPolicy;
     use publisher::SplitOutcome;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn test_token_restart_deadline_margins() {
+        let now = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+        // One-hour token restarts five minutes early.
+        let expires = now + Duration::from_secs(3600);
+        assert_eq!(
+            token_restart_deadline(now, expires),
+            expires - Duration::from_secs(5 * 60)
+        );
+
+        // Twelve-hour token restarts thirty minutes early.
+        let expires = now + Duration::from_secs(12 * 3600);
+        assert_eq!(
+            token_restart_deadline(now, expires),
+            expires - Duration::from_secs(30 * 60)
+        );
+
+        // A lifetime shorter than its margin restarts immediately, not never.
+        let expires = now + Duration::from_secs(60);
+        assert_eq!(token_restart_deadline(now, expires), now);
+        assert_eq!(token_restart_deadline(now, now), now);
+    }
 
     fn sample(journal_name: &str, throttled: bool) -> publisher::ThrottleSample<'_> {
         publisher::ThrottleSample {

--- a/site/docs/guides/iam-auth/azure.md
+++ b/site/docs/guides/iam-auth/azure.md
@@ -37,3 +37,11 @@ For example, these are the issuer values for a few common public data planes:
 ![Add Federated Credential](../guide-images/azure-iam-2.png)
 
 Now take note of the Application ID and Tenant ID of your App Registration and use it when configuring Azure IAM.
+
+## Token Lifetime
+
+Microsoft Entra ID issues access tokens with a lifetime of roughly 1 hour by default.
+
+Estuary gracefully restarts long-running task sessions shortly before their credentials expire, minting fresh tokens on each restart. A 1-hour lifetime is sufficient for most tasks, but if your task runs very large transactions — for example, a materialization whose commits take a substantial fraction of an hour — a longer token lifetime gives each transaction more time to complete.
+
+To extend the lifetime, attach a [token lifetime policy](https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes) to your App Registration's service principal. Estuary honors whatever lifetime your tenant grants automatically — no Estuary-side configuration is needed.

--- a/site/docs/guides/iam-auth/gcp.md
+++ b/site/docs/guides/iam-auth/gcp.md
@@ -73,3 +73,11 @@ principal://iam.googleapis.com/projects/12345/locations/global/workloadIdentityP
 ![Workload Identity User Access Granted to Principal](../guide-images/gcp-iam-4-identity-user-access.png)
 
 Now when configuring the connector which supports GCP, you will need to provide the service account identifier which has access to the resource and the workload identity pool's audience (which you can find in the pool provider details page, also noted in the step when creating the provider).
+
+## Token Lifetime
+
+Google Cloud limits impersonated service account tokens to a maximum lifetime of 1 hour by default. Estuary always requests a 12-hour token first and automatically falls back to 1 hour if your project doesn't allow it, so no Estuary-side configuration is needed either way.
+
+Estuary gracefully restarts long-running task sessions shortly before their credentials expire, minting fresh tokens on each restart. A 1-hour lifetime is sufficient for most tasks, but if your task runs very large transactions — for example, a materialization whose commits take a substantial fraction of an hour — a longer token lifetime gives each transaction more time to complete.
+
+To enable 12-hour tokens, set the [`constraints/iam.allowServiceAccountCredentialLifetimeExtension`](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-service-accounts#extend_oauth_ttl) organization policy to include the service account Estuary impersonates. Estuary detects the extended lifetime automatically on the task's next session.


### PR DESCRIPTION
IAM tokens are minted once when a connector session starts and are never refreshed. Materializations hold a single long-lived session, so tasks using. GCP or Azure IAM auth (~1 hour tokens) fail once the token expires mid-session.  This PR makes materializations do a graceful shutdown just prior to their token expiration and also ensures we're using the longest token possible given the cloud and cloud settings.

### Cloud Refresher
Amazon: 12 hour tokens, always
Azure: 1 hour token default.  If set to allow longer tokens Azure will automatically deliver the longer tokens.
Google: 1 hour token, unless settings allow longer.  Note that even if the settings allow we still have to *request* the longer time.

### Changes

- **iam-auth**: all three providers now report the minted token's `expires_at`.
  - **GCP**: request a 12-hour token first, falling back to 1 hour when the customer's org policy doesn't allow lifetime extension. Enabling `iam.allowServiceAccountCredentialLifetimeExtension` is picked up automatically on the next session.
- **runtime-next**: when tokens are injected, the materialize shard computes a restart deadline (5 minutes before expiry for short-lived tokens, 30 minutes for 12-hour tokens) and asks the leader for a graceful stop when it elapses.  The session drains at a transaction boundary and its restart mints fresh tokens. Tasks without IAM auth are unchanged.
- **docs**: the GCP and Azure IAM guides gained "Token Lifetime" sections covering the customer-side policies above.

Because every transaction now starts with most of the token's lifetime ahead of it, a transaction is only at risk if it runs longer than the lifetime itself.  In those cases the remedy there is the cloud-side policy for 12-hour tokens.
