### PR TITLE
runtime: opt-in relaxation of inferred date-time formats on read-side validation

### DIFF
--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -13,6 +13,11 @@ pub const FLAG_PREFIX: &str = "estuary.dev/flag/";
 // Flag which enables the V2 task runtime.
 // TODO(whb): remove once the runtime-v2 migration is complete.
 pub const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
+// Flag which relaxes read-side enforcement of `date`, `date-time`, and `time`
+// `format` keywords originating from a collection's inferred schema. It lets a
+// task tolerate historical documents whose date-time values predate a
+// tightening of the RFC3339 `format` validator. Opt-in, per-task. See #3133.
+pub const RELAX_INFERRED_DATETIME_FLAG: &str = "estuary.dev/flag/relax-inferred-datetime-formats";
 pub const KEY_BEGIN: &str = "estuary.dev/key-begin";
 pub const KEY_BEGIN_MIN: &str = "00000000";
 pub const KEY_END: &str = "estuary.dev/key-end";

--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -16,7 +16,7 @@ pub const RUNTIME_V2_FLAG: &str = "estuary.dev/flag/enable-runtime-v2";
 // Flag which relaxes read-side enforcement of `date`, `date-time`, and `time`
 // `format` keywords originating from a collection's inferred schema. It lets a
 // task tolerate historical documents whose date-time values predate a
-// tightening of the RFC3339 `format` validator. Opt-in, per-task. See #3133.
+// tightening of the RFC3339 `format` validator. Opt-in, per-task.
 pub const RELAX_INFERRED_DATETIME_FLAG: &str = "estuary.dev/flag/relax-inferred-datetime-formats";
 pub const KEY_BEGIN: &str = "estuary.dev/key-begin";
 pub const KEY_BEGIN_MIN: &str = "00000000";

--- a/crates/labels/src/lib.rs
+++ b/crates/labels/src/lib.rs
@@ -249,6 +249,22 @@ pub fn maybe_one<'s>(set: &'s LabelSet, name: &str) -> Result<&'s str, Error> {
     }
 }
 
+/// Return whether shard feature-flag `flag` (a fully-qualified flag label such
+/// as [`RELAX_INFERRED_DATETIME_FLAG`]) is set to "true" within a task's
+/// `shard_template` labels. Task runtimes call this to gate per-task behavior
+/// at the point they build read-side validators. A missing shard template,
+/// missing labels, or any non-"true" value all read as disabled.
+pub fn shard_flag_enabled(
+    shard_template: Option<&proto_gazette::consumer::ShardSpec>,
+    flag: &str,
+) -> bool {
+    shard_template
+        .and_then(|shard| shard.labels.as_ref())
+        .and_then(|set| maybe_one(set, flag).ok())
+        .map(|value| value == "true")
+        .unwrap_or(false)
+}
+
 /// Returns whether `set` is matched by `selector`, faithfully porting gazette's
 /// `LabelSelector.Matches` (`go.gazette.dev/core/broker/protocol`):
 /// an excluded label matching any of `set` is a non-match; otherwise every
@@ -386,6 +402,33 @@ impl<'a> LabelJoin<'a> {
 #[cfg(test)]
 mod test {
     use crate::*;
+
+    #[test]
+    fn shard_flag_enabled_cases() {
+        let flag = RELAX_INFERRED_DATETIME_FLAG;
+
+        let shard_with = |value: &str| proto_gazette::consumer::ShardSpec {
+            labels: Some(build_set([(flag, value)])),
+            ..Default::default()
+        };
+
+        assert!(shard_flag_enabled(Some(&shard_with("true")), flag));
+
+        // Any value other than "true" reads as disabled.
+        assert!(!shard_flag_enabled(Some(&shard_with("false")), flag));
+
+        // Flag absent, no labels, or no shard template at all.
+        let no_flag = proto_gazette::consumer::ShardSpec {
+            labels: Some(build_set([(COLLECTION, "acmeCo/foo")])),
+            ..Default::default()
+        };
+        assert!(!shard_flag_enabled(Some(&no_flag), flag));
+        assert!(!shard_flag_enabled(
+            Some(&proto_gazette::consumer::ShardSpec::default()),
+            flag
+        ));
+        assert!(!shard_flag_enabled(None, flag));
+    }
 
     #[test]
     fn label_range_cases() {

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -118,7 +118,7 @@ impl Schema {
     /// (materialize / derive) document validation does not retroactively reject
     /// historical documents whose date-time values predate a tightening of the
     /// `format` validator, while leaving capture-time write-schema enforcement
-    /// and schema inference strict. See estuary/flow#3133.
+    /// and schema inference strict.
     pub fn relax_inferred_datetime_formats(&self) -> serde_json::Result<Self> {
         let mut bundle = serde_json::from_str::<serde_json::Value>(self.get())?;
 
@@ -191,7 +191,7 @@ pub struct AddDef<'a> {
 /// `format` values whose read-side enforcement is relaxed by
 /// [`Schema::relax_inferred_datetime_formats`]. These are exactly the formats
 /// whose validator delegates to the `time` crate, whose interpretation of
-/// RFC3339 has drifted over time (see estuary/flow#3133, #3108, #3116).
+/// RFC3339 has drifted over time.
 const RELAXED_DATETIME_FORMATS: [&str; 3] = ["date", "date-time", "time"];
 
 /// Recursively remove `date`/`date-time`/`time` `format` keywords from `node`

--- a/crates/models/src/schemas.rs
+++ b/crates/models/src/schemas.rs
@@ -104,6 +104,33 @@ impl Schema {
         Ok(Self(serde_json::value::to_raw_value(&relaxed)?.into()))
     }
 
+    /// Return a copy of this read-schema bundle in which `date`, `date-time`,
+    /// and `time` `format` keywords are removed from the inlined inferred
+    /// schema — the `$defs` entry keyed by [`Self::REF_INFERRED_SCHEMA_URL`].
+    /// Every other keyword, every other `$defs` entry, and the remainder of the
+    /// bundle are left exactly as-is. If the bundle does not inline an inferred
+    /// schema (e.g. a single-schema collection), this is a no-op copy.
+    ///
+    /// This is deliberately much narrower than [`Self::to_relaxed_schema`]: it
+    /// touches only `format`, only for the three formats whose validator
+    /// delegates to the `time` crate (whose RFC3339 interpretation has drifted
+    /// over time), and only within the inferred schema. It exists so read-side
+    /// (materialize / derive) document validation does not retroactively reject
+    /// historical documents whose date-time values predate a tightening of the
+    /// `format` validator, while leaving capture-time write-schema enforcement
+    /// and schema inference strict. See estuary/flow#3133.
+    pub fn relax_inferred_datetime_formats(&self) -> serde_json::Result<Self> {
+        let mut bundle = serde_json::from_str::<serde_json::Value>(self.get())?;
+
+        if let Some(inferred) = bundle
+            .get_mut("$defs")
+            .and_then(|defs| defs.get_mut(Self::REF_INFERRED_SCHEMA_URL))
+        {
+            relax_datetime_formats(inferred);
+        }
+        Ok(Self(RawValue::from_value(&bundle)))
+    }
+
     /// Extend this Schema with added $defs definitions.
     /// The $id keyword of definition is set to its id, and its id is also
     /// used to key the property of $defs under which the sub-schema lives.
@@ -159,6 +186,51 @@ pub struct AddDef<'a> {
     pub schema: &'a Schema,
     // Should this definition overwrite one that's already present?
     pub overwrite: bool,
+}
+
+/// `format` values whose read-side enforcement is relaxed by
+/// [`Schema::relax_inferred_datetime_formats`]. These are exactly the formats
+/// whose validator delegates to the `time` crate, whose interpretation of
+/// RFC3339 has drifted over time (see estuary/flow#3133, #3108, #3116).
+const RELAXED_DATETIME_FORMATS: [&str; 3] = ["date", "date-time", "time"];
+
+/// Recursively remove `date`/`date-time`/`time` `format` keywords from `node`
+/// and its sub-schemas. It descends *only* through schema-bearing keywords, so
+/// a `format` string appearing within a data-valued keyword (`enum`, `const`,
+/// `default`, ...) is never touched — only genuine `format` schema keywords are
+/// removed.
+fn relax_datetime_formats(node: &mut serde_json::Value) {
+    let serde_json::Value::Object(obj) = node else {
+        return;
+    };
+
+    if let Some(serde_json::Value::String(format)) = obj.get("format") {
+        if RELAXED_DATETIME_FORMATS.contains(&format.as_str()) {
+            _ = obj.remove("format");
+        }
+    }
+
+    // Keywords holding a map of named sub-schemas.
+    for keyword in ["properties", "patternProperties", "$defs", "definitions"] {
+        if let Some(serde_json::Value::Object(map)) = obj.get_mut(keyword) {
+            map.values_mut().for_each(relax_datetime_formats);
+        }
+    }
+    // Keywords holding an array of sub-schemas.
+    for keyword in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        if let Some(serde_json::Value::Array(arr)) = obj.get_mut(keyword) {
+            arr.iter_mut().for_each(relax_datetime_formats);
+        }
+    }
+    // Keywords holding a single sub-schema. `items` may hold either a single
+    // sub-schema or (for tuple validation) an array of sub-schemas.
+    for keyword in ["additionalProperties", "additionalItems", "items", "not"] {
+        match obj.get_mut(keyword) {
+            Some(serde_json::Value::Array(arr)) => arr.iter_mut().for_each(relax_datetime_formats),
+            Some(sub) => relax_datetime_formats(sub),
+            None => {}
+        }
+    }
 }
 
 /// RelaxedSchema is an opinionated relaxation of a JSON-Schema, which removes
@@ -557,5 +629,122 @@ mod test {
                 "additionalProperties": {}
             })
         );
+    }
+
+    #[test]
+    fn test_relax_inferred_datetime_only_touches_inferred_defs_formats() {
+        // A read-schema bundle shaped like one assembled by the control plane:
+        // the inferred schema is inlined as a `$defs` entry keyed by its URL,
+        // alongside the (relaxed) write schema, with a top-level `allOf`.
+        let bundle = schema!({
+            "$defs": {
+                "flow://inferred-schema": {
+                    "$id": "flow://inferred-schema",
+                    "type": "object",
+                    "required": ["ts"],
+                    "properties": {
+                        // date-time formats: relaxed away.
+                        "ts": { "type": "string", "format": "date-time", "minLength": 1 },
+                        "d": { "type": "string", "format": "date" },
+                        "t": { "type": "string", "format": "time" },
+                        // Non-time formats: preserved.
+                        "email": { "type": "string", "format": "email" },
+                        "ip": { "type": "string", "format": "ipv4" },
+                        // A property literally named "format" holding a
+                        // sub-schema must not be mistaken for a keyword.
+                        "format": { "type": "string" },
+                        // Nested containers are descended into.
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "inner_ts": { "type": "string", "format": "date-time" }
+                            },
+                            "additionalProperties": { "type": "string", "format": "time" }
+                        },
+                        "list": {
+                            "type": "array",
+                            "items": { "type": "string", "format": "date-time" }
+                        },
+                        // A `date-time` string appearing as *data* (enum/const/
+                        // default) is never touched.
+                        "kind": { "type": "string", "enum": ["date-time", "date"] },
+                        "constish": { "const": { "format": "date-time" } }
+                    }
+                },
+                "flow://write-schema": {
+                    "$id": "flow://write-schema",
+                    "properties": {
+                        // Author-declared format outside the inferred schema is
+                        // left strictly enforced.
+                        "authored": { "type": "string", "format": "date-time" }
+                    }
+                }
+            },
+            "allOf": [
+                {"$ref": "flow://write-schema"},
+                {"$ref": "flow://inferred-schema"}
+            ]
+        });
+
+        let relaxed = bundle.relax_inferred_datetime_formats().unwrap().to_value();
+
+        assert_eq!(
+            relaxed,
+            json!({
+                "$defs": {
+                    "flow://inferred-schema": {
+                        "$id": "flow://inferred-schema",
+                        "type": "object",
+                        "required": ["ts"],
+                        "properties": {
+                            "ts": { "type": "string", "minLength": 1 },
+                            "d": { "type": "string" },
+                            "t": { "type": "string" },
+                            "email": { "type": "string", "format": "email" },
+                            "ip": { "type": "string", "format": "ipv4" },
+                            "format": { "type": "string" },
+                            "nested": {
+                                "type": "object",
+                                "properties": {
+                                    "inner_ts": { "type": "string" }
+                                },
+                                "additionalProperties": { "type": "string" }
+                            },
+                            "list": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            },
+                            "kind": { "type": "string", "enum": ["date-time", "date"] },
+                            "constish": { "const": { "format": "date-time" } }
+                        }
+                    },
+                    // Untouched: only the inferred `$def` is relaxed.
+                    "flow://write-schema": {
+                        "$id": "flow://write-schema",
+                        "properties": {
+                            "authored": { "type": "string", "format": "date-time" }
+                        }
+                    }
+                },
+                "allOf": [
+                    {"$ref": "flow://write-schema"},
+                    {"$ref": "flow://inferred-schema"}
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_relax_inferred_datetime_is_noop_without_inferred_defs() {
+        // A single-schema collection (no inlined inferred schema) is unchanged,
+        // including any authored date-time formats.
+        let bundle = schema!({
+            "type": "object",
+            "properties": {
+                "ts": { "type": "string", "format": "date-time" }
+            }
+        });
+        let relaxed = bundle.relax_inferred_datetime_formats().unwrap().to_value();
+        assert_eq!(relaxed, bundle.to_value());
     }
 }

--- a/crates/runtime-next/src/shard/derive/task.rs
+++ b/crates/runtime-next/src/shard/derive/task.rs
@@ -125,7 +125,7 @@ impl Task {
 
         // Opt-in, per-task relaxation of read-side date-time `format`
         // enforcement inherited from each source collection's inferred schema.
-        // See build_transform and estuary/flow#3133.
+        // See build_transform.
         let relax_inferred_datetime = labels::shard_flag_enabled(
             shard_template.as_ref(),
             labels::RELAX_INFERRED_DATETIME_FLAG,

--- a/crates/runtime-next/src/shard/derive/task.rs
+++ b/crates/runtime-next/src/shard/derive/task.rs
@@ -1,3 +1,4 @@
+use crate::shard::task_schema::relax_inferred_datetime_formats;
 use anyhow::Context;
 use proto_flow::flow;
 
@@ -49,6 +50,7 @@ pub(super) struct Transform {
 fn build_transform(
     t: &flow::collection_spec::derivation::Transform,
     ser_policy: &doc::SerPolicy,
+    relax_inferred_datetime: bool,
 ) -> anyhow::Result<Transform> {
     let collection = t
         .collection
@@ -62,6 +64,17 @@ fn build_transform(
         collection.write_schema_json.clone()
     } else {
         collection.read_schema_json.clone()
+    };
+
+    // When enabled for this task, strip `date`/`date-time`/`time` `format`
+    // keywords contributed by the source collection's inferred schema so that
+    // historical, non-conforming values are not retroactively rejected when read
+    // into the derivation. Capture-time write-schema validation is unaffected.
+    let schema_json = if relax_inferred_datetime {
+        relax_inferred_datetime_formats(&schema_json)
+            .context("relaxing inferred date-time formats of read schema")?
+    } else {
+        schema_json
     };
 
     // Resolve the extractors of a transform's shuffle key, applied to source
@@ -106,8 +119,17 @@ impl Task {
         let flow::collection_spec::Derivation {
             transforms,
             redact_salt,
+            shard_template,
             ..
         } = derivation.as_ref().context("missing derivation")?;
+
+        // Opt-in, per-task relaxation of read-side date-time `format`
+        // enforcement inherited from each source collection's inferred schema.
+        // See build_transform and estuary/flow#3133.
+        let relax_inferred_datetime = labels::shard_flag_enabled(
+            shard_template.as_ref(),
+            labels::RELAX_INFERRED_DATETIME_FLAG,
+        );
 
         // The built `Transform.state_key` is intentionally left unpopulated until the
         // V2 derivation migration completes (the frozen V1 derive connectors reject the
@@ -123,7 +145,7 @@ impl Task {
 
         let sources = transforms
             .iter()
-            .map(|t| build_transform(t, &ser_policy))
+            .map(|t| build_transform(t, &ser_policy, relax_inferred_datetime))
             .collect::<anyhow::Result<Vec<Transform>>>()?;
 
         let partition_template = partition_template
@@ -202,5 +224,59 @@ impl Task {
             self.redact_salt.to_vec(),
             validator,
         ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // A source-collection read schema whose inlined inferred schema tags a
+    // field `format: date-time`, as the control plane assembles it.
+    const READ_SCHEMA: &str = r#"{
+        "$defs": {
+            "flow://inferred-schema": {
+                "$id": "flow://inferred-schema",
+                "type": "object",
+                "properties": { "ts": { "type": "string", "format": "date-time" } }
+            }
+        },
+        "allOf": [ { "$ref": "flow://inferred-schema" } ]
+    }"#;
+
+    fn transform_accepts(relax_inferred_datetime: bool, doc: &str) -> bool {
+        let spec = flow::collection_spec::derivation::Transform {
+            collection: Some(flow::CollectionSpec {
+                read_schema_json: bytes::Bytes::from(READ_SCHEMA),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let transform =
+            build_transform(&spec, &doc::SerPolicy::noop(), relax_inferred_datetime).unwrap();
+
+        let mut validator =
+            doc::Validator::new(doc::validation::build_bundle(&transform.schema_json).unwrap())
+                .unwrap();
+
+        let alloc = doc::HeapNode::new_allocator();
+        let mut de = serde_json::Deserializer::from_str(doc);
+        let node = doc::HeapNode::from_serde(&mut de, &alloc).unwrap();
+
+        validator.is_valid(&node)
+    }
+
+    #[test]
+    fn test_v2_transform_relaxes_inferred_datetime_when_flagged() {
+        let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
+        let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
+
+        // Flag OFF: the source read validator rejects the legacy value.
+        assert!(!transform_accepts(false, legacy));
+        assert!(transform_accepts(false, conforming));
+
+        // Flag ON: the legacy value is tolerated; conforming values still pass.
+        assert!(transform_accepts(true, legacy));
+        assert!(transform_accepts(true, conforming));
     }
 }

--- a/crates/runtime-next/src/shard/materialize/task.rs
+++ b/crates/runtime-next/src/shard/materialize/task.rs
@@ -21,8 +21,7 @@ pub fn build_bindings(
     } = spec;
 
     // Opt-in, per-task relaxation of read-side date-time `format` enforcement
-    // inherited from the collection's inferred schema. See build_binding and
-    // estuary/flow#3133.
+    // inherited from the collection's inferred schema. See build_binding.
     let relax_inferred_datetime = labels::shard_flag_enabled(
         shard_template.as_ref(),
         labels::RELAX_INFERRED_DATETIME_FLAG,

--- a/crates/runtime-next/src/shard/materialize/task.rs
+++ b/crates/runtime-next/src/shard/materialize/task.rs
@@ -1,4 +1,5 @@
 use super::Binding;
+use crate::shard::task_schema::relax_inferred_datetime_formats;
 use anyhow::Context;
 use proto_flow::flow;
 
@@ -14,10 +15,18 @@ pub fn build_bindings(
         name,
         network_ports: _,
         recovery_log_template: _,
-        shard_template: _,
+        shard_template,
         inactive_bindings: _,
         triggers_json: _,
     } = spec;
+
+    // Opt-in, per-task relaxation of read-side date-time `format` enforcement
+    // inherited from the collection's inferred schema. See build_binding and
+    // estuary/flow#3133.
+    let relax_inferred_datetime = labels::shard_flag_enabled(
+        shard_template.as_ref(),
+        labels::RELAX_INFERRED_DATETIME_FLAG,
+    );
 
     let ops::proto::ShardLabeling {
         range,
@@ -64,7 +73,9 @@ pub fn build_bindings(
     let bindings = bindings
         .into_iter()
         .enumerate()
-        .map(|(index, spec)| build_binding(spec, &ser_policy).context(index))
+        .map(|(index, spec)| {
+            build_binding(spec, &ser_policy, relax_inferred_datetime).context(index)
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     let shard_ref = ops::ShardRef {
@@ -82,6 +93,7 @@ pub fn build_bindings(
 fn build_binding(
     spec: &flow::materialization_spec::Binding,
     default_ser_policy: &doc::SerPolicy,
+    relax_inferred_datetime: bool,
 ) -> anyhow::Result<Binding> {
     let flow::materialization_spec::Binding {
         backfill: _,
@@ -162,6 +174,17 @@ fn build_binding(
     }
     .clone();
 
+    // When enabled for this task, strip `date`/`date-time`/`time` `format`
+    // keywords contributed by the collection's inferred schema so that
+    // historical, non-conforming values are not retroactively rejected on read.
+    // Capture-time write-schema validation is unaffected.
+    let read_schema_json = if relax_inferred_datetime {
+        relax_inferred_datetime_formats(&read_schema_json)
+            .context("relaxing inferred date-time formats of read schema")?
+    } else {
+        read_schema_json
+    };
+
     Ok(Binding {
         collection_name: collection_name.clone(),
         delta_updates: *delta_updates,
@@ -205,4 +228,59 @@ pub fn combine_spec(bindings: &[Binding]) -> anyhow::Result<doc::combine::Spec> 
         combiner_specs,
         Vec::new(),
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // A read schema whose inlined inferred schema tags a field
+    // `format: date-time`, as the control plane assembles it.
+    const READ_SCHEMA: &str = r#"{
+        "$defs": {
+            "flow://inferred-schema": {
+                "$id": "flow://inferred-schema",
+                "type": "object",
+                "properties": { "ts": { "type": "string", "format": "date-time" } }
+            }
+        },
+        "allOf": [ { "$ref": "flow://inferred-schema" } ]
+    }"#;
+
+    fn binding_accepts(relax_inferred_datetime: bool, doc: &str) -> bool {
+        let spec = flow::materialization_spec::Binding {
+            collection: Some(flow::CollectionSpec {
+                read_schema_json: bytes::Bytes::from(READ_SCHEMA),
+                ..Default::default()
+            }),
+            field_selection: Some(flow::FieldSelection::default()),
+            ..Default::default()
+        };
+        let binding =
+            build_binding(&spec, &doc::SerPolicy::noop(), relax_inferred_datetime).unwrap();
+
+        let mut validator =
+            doc::Validator::new(doc::validation::build_bundle(&binding.read_schema_json).unwrap())
+                .unwrap();
+
+        let alloc = doc::HeapNode::new_allocator();
+        let mut de = serde_json::Deserializer::from_str(doc);
+        let node = doc::HeapNode::from_serde(&mut de, &alloc).unwrap();
+
+        validator.is_valid(&node)
+    }
+
+    #[test]
+    fn test_v2_binding_relaxes_inferred_datetime_when_flagged() {
+        let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
+        let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
+
+        // Flag OFF: the read validator rejects the legacy value.
+        assert!(!binding_accepts(false, legacy));
+        assert!(binding_accepts(false, conforming));
+
+        // Flag ON: the legacy value is tolerated; conforming values still pass.
+        assert!(binding_accepts(true, legacy));
+        assert!(binding_accepts(true, conforming));
+    }
 }

--- a/crates/runtime-next/src/shard/mod.rs
+++ b/crates/runtime-next/src/shard/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod recovery;
 mod rocksdb;
 mod service;
 pub mod split_policy;
+mod task_schema;
 
 use rocksdb::RocksDB;
 pub use service::Service;

--- a/crates/runtime-next/src/shard/task_schema.rs
+++ b/crates/runtime-next/src/shard/task_schema.rs
@@ -1,6 +1,6 @@
 // Read-side schema handling shared by the V2 materialize and derive task
 // builders. Per-task flag reading lives in `labels::shard_flag_enabled`; the
-// relaxation itself is single-sourced in `models`. See estuary/flow#3133.
+// relaxation itself is single-sourced in `models`.
 
 /// Return `read_schema_json` with `date`/`date-time`/`time` `format` keywords
 /// stripped from its inlined inferred schema, leaving the rest of the bundle

--- a/crates/runtime-next/src/shard/task_schema.rs
+++ b/crates/runtime-next/src/shard/task_schema.rs
@@ -1,0 +1,16 @@
+// Read-side schema handling shared by the V2 materialize and derive task
+// builders. Per-task flag reading lives in `labels::shard_flag_enabled`; the
+// relaxation itself is single-sourced in `models`. See estuary/flow#3133.
+
+/// Return `read_schema_json` with `date`/`date-time`/`time` `format` keywords
+/// stripped from its inlined inferred schema, leaving the rest of the bundle
+/// untouched. See [`models::Schema::relax_inferred_datetime_formats`].
+pub fn relax_inferred_datetime_formats(
+    read_schema_json: &bytes::Bytes,
+) -> anyhow::Result<bytes::Bytes> {
+    let schema = models::Schema::new(models::RawValue::from_str(std::str::from_utf8(
+        read_schema_json,
+    )?)?);
+    let relaxed = schema.relax_inferred_datetime_formats()?;
+    Ok(bytes::Bytes::from(relaxed.get().to_string()))
+}

--- a/crates/runtime/src/derive/task.rs
+++ b/crates/runtime/src/derive/task.rs
@@ -49,7 +49,7 @@ impl Task {
 
         // Opt-in, per-task relaxation of read-side date-time `format`
         // enforcement inherited from each source collection's inferred schema.
-        // See Transform::new and estuary/flow#3133.
+        // See Transform::new.
         let relax_inferred_datetime = labels::shard_flag_enabled(
             shard_template.as_ref(),
             labels::RELAX_INFERRED_DATETIME_FLAG,
@@ -231,8 +231,8 @@ mod test {
 
     #[test]
     fn test_transform_relaxes_inferred_datetime_when_flagged() {
-        // A space-separated (non-RFC3339) timestamp — the historical shape from
-        // #3133 — read from a source collection into a derivation.
+        // A space-separated (non-RFC3339) timestamp, as historical documents of
+        // a source collection may hold, read into a derivation.
         let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
         let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
 

--- a/crates/runtime/src/derive/task.rs
+++ b/crates/runtime/src/derive/task.rs
@@ -1,4 +1,5 @@
 use super::{Task, Transform};
+use crate::task_schema::{relax_inferred_datetime_formats, shard_flag_enabled};
 use anyhow::Context;
 use proto_flow::derive::{Request, Response, request, response};
 use proto_flow::flow;
@@ -39,12 +40,20 @@ impl Task {
             connector_type: _,
             network_ports: _,
             recovery_log_template: _,
-            shard_template: _,
+            shard_template,
             shuffle_key_types: _,
             transforms,
             inactive_transforms: _,
             redact_salt,
         } = derivation.as_ref().context("missing derivation")?;
+
+        // Opt-in, per-task relaxation of read-side date-time `format`
+        // enforcement inherited from each source collection's inferred schema.
+        // See Transform::new and estuary/flow#3133.
+        let relax_inferred_datetime = shard_flag_enabled(
+            shard_template.as_ref(),
+            labels::RELAX_INFERRED_DATETIME_FLAG,
+        );
 
         if key.is_empty() {
             anyhow::bail!("collection key cannot be empty");
@@ -69,7 +78,7 @@ impl Task {
         let transforms = transforms
             .into_iter()
             .enumerate()
-            .map(|(index, spec)| Transform::new(spec).context(index))
+            .map(|(index, spec)| Transform::new(spec, relax_inferred_datetime).context(index))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
@@ -114,7 +123,10 @@ impl Task {
 }
 
 impl Transform {
-    pub fn new(spec: &flow::collection_spec::derivation::Transform) -> anyhow::Result<Self> {
+    pub fn new(
+        spec: &flow::collection_spec::derivation::Transform,
+        relax_inferred_datetime: bool,
+    ) -> anyhow::Result<Self> {
         let flow::collection_spec::derivation::Transform {
             backfill: _,
             collection,
@@ -152,6 +164,18 @@ impl Transform {
         }
         .clone();
 
+        // When enabled for this task, strip `date`/`date-time`/`time` `format`
+        // keywords contributed by the source collection's inferred schema so
+        // that historical, non-conforming values are not retroactively rejected
+        // when read into the derivation. Capture-time write-schema validation of
+        // the source is unaffected.
+        let read_schema_json = if relax_inferred_datetime {
+            relax_inferred_datetime_formats(&read_schema_json)
+                .context("relaxing inferred date-time formats of read schema")?
+        } else {
+            read_schema_json
+        };
+
         Ok(Self {
             collection_name: collection_name.clone(),
             name: name.clone(),
@@ -165,5 +189,59 @@ impl Transform {
         let validator =
             doc::Validator::new(built_schema).context("could not build a schema validator")?;
         Ok(validator)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // A source-collection read schema whose inlined inferred schema tags a
+    // field `format: date-time`, as the control plane assembles it.
+    const READ_SCHEMA: &str = r#"{
+        "$defs": {
+            "flow://inferred-schema": {
+                "$id": "flow://inferred-schema",
+                "type": "object",
+                "properties": { "ts": { "type": "string", "format": "date-time" } }
+            }
+        },
+        "allOf": [ { "$ref": "flow://inferred-schema" } ]
+    }"#;
+
+    fn transform_accepts(relax_inferred_datetime: bool, doc: &str) -> bool {
+        let spec = flow::collection_spec::derivation::Transform {
+            collection: Some(flow::CollectionSpec {
+                read_schema_json: bytes::Bytes::from(READ_SCHEMA),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut validator = Transform::new(&spec, relax_inferred_datetime)
+            .unwrap()
+            .validator()
+            .unwrap();
+
+        let alloc = doc::HeapNode::new_allocator();
+        let mut de = serde_json::Deserializer::from_str(doc);
+        let node = doc::HeapNode::from_serde(&mut de, &alloc).unwrap();
+
+        validator.is_valid(&node)
+    }
+
+    #[test]
+    fn test_transform_relaxes_inferred_datetime_when_flagged() {
+        // A space-separated (non-RFC3339) timestamp — the historical shape from
+        // #3133 — read from a source collection into a derivation.
+        let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
+        let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
+
+        // Flag OFF: the source read validator rejects the legacy value.
+        assert!(!transform_accepts(false, legacy));
+        assert!(transform_accepts(false, conforming));
+
+        // Flag ON: the legacy value is tolerated; conforming values still pass.
+        assert!(transform_accepts(true, legacy));
+        assert!(transform_accepts(true, conforming));
     }
 }

--- a/crates/runtime/src/derive/task.rs
+++ b/crates/runtime/src/derive/task.rs
@@ -1,5 +1,5 @@
 use super::{Task, Transform};
-use crate::task_schema::{relax_inferred_datetime_formats, shard_flag_enabled};
+use crate::task_schema::relax_inferred_datetime_formats;
 use anyhow::Context;
 use proto_flow::derive::{Request, Response, request, response};
 use proto_flow::flow;
@@ -50,7 +50,7 @@ impl Task {
         // Opt-in, per-task relaxation of read-side date-time `format`
         // enforcement inherited from each source collection's inferred schema.
         // See Transform::new and estuary/flow#3133.
-        let relax_inferred_datetime = shard_flag_enabled(
+        let relax_inferred_datetime = labels::shard_flag_enabled(
             shard_template.as_ref(),
             labels::RELAX_INFERRED_DATETIME_FLAG,
         );

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -11,6 +11,7 @@ mod image_connector;
 mod local_connector;
 mod materialize;
 mod rocksdb;
+mod task_schema;
 mod task_service;
 mod tokio_context;
 mod unary;

--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -27,8 +27,8 @@ impl Task {
         let range = range.context("missing range")?;
 
         // Opt-in, per-task relaxation of read-side date-time `format`
-        // enforcement inherited from the collection's inferred schema. See
-        // Binding::new and estuary/flow#3133.
+        // enforcement inherited from the collection's inferred schema.
+        // See Binding::new.
         let relax_inferred_datetime = labels::shard_flag_enabled(
             shard_template.as_ref(),
             labels::RELAX_INFERRED_DATETIME_FLAG,

--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -1,4 +1,5 @@
 use super::{Binding, Task};
+use crate::task_schema::{relax_inferred_datetime_formats, shard_flag_enabled};
 use anyhow::Context;
 use proto_flow::flow;
 use proto_flow::materialize::{Request, request};
@@ -19,11 +20,19 @@ impl Task {
             name,
             network_ports: _,
             recovery_log_template: _,
-            shard_template: _,
+            shard_template,
             inactive_bindings: _,
             triggers_json: _,
         } = spec.as_ref().context("missing materialization")?;
         let range = range.context("missing range")?;
+
+        // Opt-in, per-task relaxation of read-side date-time `format`
+        // enforcement inherited from the collection's inferred schema. See
+        // Binding::new and estuary/flow#3133.
+        let relax_inferred_datetime = shard_flag_enabled(
+            shard_template.as_ref(),
+            labels::RELAX_INFERRED_DATETIME_FLAG,
+        );
 
         if range.r_clock_begin != 0 || range.r_clock_end != u32::MAX {
             anyhow::bail!("materialization cannot split on r-clock: {range:?}");
@@ -62,7 +71,9 @@ impl Task {
         let bindings = bindings
             .into_iter()
             .enumerate()
-            .map(|(index, spec)| Binding::new(spec, &ser_policy).context(index))
+            .map(|(index, spec)| {
+                Binding::new(spec, &ser_policy, relax_inferred_datetime).context(index)
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         let shard_ref = ops::ShardRef {
@@ -103,6 +114,7 @@ impl Binding {
     pub fn new(
         spec: &flow::materialization_spec::Binding,
         default_ser_policy: &doc::SerPolicy,
+        relax_inferred_datetime: bool,
     ) -> anyhow::Result<Self> {
         let flow::materialization_spec::Binding {
             backfill: _,
@@ -177,6 +189,17 @@ impl Binding {
             read_schema_json
         }
         .clone();
+
+        // When enabled for this task, strip `date`/`date-time`/`time` `format`
+        // keywords contributed by the collection's inferred schema so that
+        // historical, non-conforming values are not retroactively rejected on
+        // read. Capture-time write-schema validation is unaffected.
+        let read_schema_json = if relax_inferred_datetime {
+            relax_inferred_datetime_formats(&read_schema_json)
+                .context("relaxing inferred date-time formats of read schema")?
+        } else {
+            read_schema_json
+        };
 
         let uuid_ptr = json::Pointer::from_str(uuid_ptr.as_str());
 

--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -1,5 +1,5 @@
 use super::{Binding, Task};
-use crate::task_schema::{relax_inferred_datetime_formats, shard_flag_enabled};
+use crate::task_schema::relax_inferred_datetime_formats;
 use anyhow::Context;
 use proto_flow::flow;
 use proto_flow::materialize::{Request, request};
@@ -29,7 +29,7 @@ impl Task {
         // Opt-in, per-task relaxation of read-side date-time `format`
         // enforcement inherited from the collection's inferred schema. See
         // Binding::new and estuary/flow#3133.
-        let relax_inferred_datetime = shard_flag_enabled(
+        let relax_inferred_datetime = labels::shard_flag_enabled(
             shard_template.as_ref(),
             labels::RELAX_INFERRED_DATETIME_FLAG,
         );

--- a/crates/runtime/src/task_schema.rs
+++ b/crates/runtime/src/task_schema.rs
@@ -1,0 +1,108 @@
+// Helpers shared by the materialize and derive task builders for read-side
+// schema handling. See estuary/flow#3133.
+
+/// Return whether the shard feature-flag `flag` (a fully-qualified flag label
+/// such as [`labels::RELAX_INFERRED_DATETIME_FLAG`]) is set to "true" within a
+/// task's `shard_template` labels. This mirrors the Go-side `LabelSet.ValueOf`
+/// check used by the v2 runtime dispatch, but reads the flag at the Rust
+/// task-build layer where read-side validators are constructed.
+pub fn shard_flag_enabled(
+    shard_template: Option<&proto_gazette::consumer::ShardSpec>,
+    flag: &str,
+) -> bool {
+    shard_template
+        .and_then(|shard| shard.labels.as_ref())
+        .and_then(|set| labels::maybe_one(set, flag).ok())
+        .map(|value| value == "true")
+        .unwrap_or(false)
+}
+
+/// Return `read_schema_json` with `date`/`date-time`/`time` `format` keywords
+/// stripped from its inlined inferred schema, leaving the rest of the bundle
+/// untouched. See [`models::Schema::relax_inferred_datetime_formats`].
+pub fn relax_inferred_datetime_formats(
+    read_schema_json: &bytes::Bytes,
+) -> anyhow::Result<bytes::Bytes> {
+    let schema = models::Schema::new(models::RawValue::from_str(std::str::from_utf8(
+        read_schema_json,
+    )?)?);
+    let relaxed = schema.relax_inferred_datetime_formats()?;
+    Ok(bytes::Bytes::from(relaxed.get().to_string()))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn shard_with_flag(value: Option<&str>) -> proto_gazette::consumer::ShardSpec {
+        let labels =
+            value.map(|value| labels::build_set([(labels::RELAX_INFERRED_DATETIME_FLAG, value)]));
+        proto_gazette::consumer::ShardSpec {
+            labels,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_shard_flag_enabled() {
+        let flag = labels::RELAX_INFERRED_DATETIME_FLAG;
+
+        let on = shard_with_flag(Some("true"));
+        assert!(shard_flag_enabled(Some(&on), flag));
+
+        // A value other than "true" does not enable the flag.
+        let off = shard_with_flag(Some("false"));
+        assert!(!shard_flag_enabled(Some(&off), flag));
+
+        // Flag absent, no labels, or no shard template at all.
+        let none = shard_with_flag(None);
+        assert!(!shard_flag_enabled(Some(&none), flag));
+        assert!(!shard_flag_enabled(None, flag));
+    }
+
+    // A read-schema bundle whose inlined inferred schema tags a field
+    // `format: date-time`, shaped as the control plane assembles it.
+    const READ_SCHEMA: &str = r#"{
+        "$defs": {
+            "flow://inferred-schema": {
+                "$id": "flow://inferred-schema",
+                "type": "object",
+                "properties": { "ts": { "type": "string", "format": "date-time" } }
+            }
+        },
+        "allOf": [ { "$ref": "flow://inferred-schema" } ]
+    }"#;
+
+    fn is_valid(read_schema_json: &bytes::Bytes, doc: &str) -> bool {
+        let mut validator =
+            doc::Validator::new(doc::validation::build_bundle(read_schema_json).unwrap()).unwrap();
+
+        let alloc = doc::HeapNode::new_allocator();
+        let mut de = serde_json::Deserializer::from_str(doc);
+        let node = doc::HeapNode::from_serde(&mut de, &alloc).unwrap();
+
+        validator.is_valid(&node)
+    }
+
+    #[test]
+    fn test_relax_inferred_datetime_read_side_behavior() {
+        let strict = bytes::Bytes::from(READ_SCHEMA);
+        let relaxed = relax_inferred_datetime_formats(&strict).unwrap();
+
+        // A space-separated (non-RFC3339) timestamp — the historical, already
+        // stored shape from #3133.
+        let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
+        // An RFC3339-conformant timestamp.
+        let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
+
+        // Flag OFF (strict): legacy value is rejected on read; this is the
+        // regression from #3116 that the flag exists to relieve.
+        assert!(!is_valid(&strict, legacy));
+        assert!(is_valid(&strict, conforming));
+
+        // Flag ON (relaxed): the legacy value is tolerated, while conforming
+        // values still validate.
+        assert!(is_valid(&relaxed, legacy));
+        assert!(is_valid(&relaxed, conforming));
+    }
+}

--- a/crates/runtime/src/task_schema.rs
+++ b/crates/runtime/src/task_schema.rs
@@ -1,6 +1,5 @@
 // Helper shared by the materialize and derive task builders for read-side
-// schema handling. See estuary/flow#3133. Per-task flag reading lives in
-// `labels::shard_flag_enabled`.
+// schema handling. Per-task flag reading lives in `labels::shard_flag_enabled`.
 
 /// Return `read_schema_json` with `date`/`date-time`/`time` `format` keywords
 /// stripped from its inlined inferred schema, leaving the rest of the bundle
@@ -48,14 +47,13 @@ mod test {
         let strict = bytes::Bytes::from(READ_SCHEMA);
         let relaxed = relax_inferred_datetime_formats(&strict).unwrap();
 
-        // A space-separated (non-RFC3339) timestamp — the historical, already
-        // stored shape from #3133.
+        // A space-separated (non-RFC3339) timestamp, as historical documents
+        // admitted under a more lenient format validator may hold.
         let legacy = r#"{"ts": "2026-06-17 12:46:17.375663+00:00"}"#;
         // An RFC3339-conformant timestamp.
         let conforming = r#"{"ts": "2026-06-17T12:46:17.375663+00:00"}"#;
 
-        // Flag OFF (strict): legacy value is rejected on read; this is the
-        // regression from #3116 that the flag exists to relieve.
+        // Flag OFF (strict): the legacy value is rejected on read.
         assert!(!is_valid(&strict, legacy));
         assert!(is_valid(&strict, conforming));
 

--- a/crates/runtime/src/task_schema.rs
+++ b/crates/runtime/src/task_schema.rs
@@ -1,21 +1,6 @@
-// Helpers shared by the materialize and derive task builders for read-side
-// schema handling. See estuary/flow#3133.
-
-/// Return whether the shard feature-flag `flag` (a fully-qualified flag label
-/// such as [`labels::RELAX_INFERRED_DATETIME_FLAG`]) is set to "true" within a
-/// task's `shard_template` labels. This mirrors the Go-side `LabelSet.ValueOf`
-/// check used by the v2 runtime dispatch, but reads the flag at the Rust
-/// task-build layer where read-side validators are constructed.
-pub fn shard_flag_enabled(
-    shard_template: Option<&proto_gazette::consumer::ShardSpec>,
-    flag: &str,
-) -> bool {
-    shard_template
-        .and_then(|shard| shard.labels.as_ref())
-        .and_then(|set| labels::maybe_one(set, flag).ok())
-        .map(|value| value == "true")
-        .unwrap_or(false)
-}
+// Helper shared by the materialize and derive task builders for read-side
+// schema handling. See estuary/flow#3133. Per-task flag reading lives in
+// `labels::shard_flag_enabled`.
 
 /// Return `read_schema_json` with `date`/`date-time`/`time` `format` keywords
 /// stripped from its inlined inferred schema, leaving the rest of the bundle
@@ -33,32 +18,6 @@ pub fn relax_inferred_datetime_formats(
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn shard_with_flag(value: Option<&str>) -> proto_gazette::consumer::ShardSpec {
-        let labels =
-            value.map(|value| labels::build_set([(labels::RELAX_INFERRED_DATETIME_FLAG, value)]));
-        proto_gazette::consumer::ShardSpec {
-            labels,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_shard_flag_enabled() {
-        let flag = labels::RELAX_INFERRED_DATETIME_FLAG;
-
-        let on = shard_with_flag(Some("true"));
-        assert!(shard_flag_enabled(Some(&on), flag));
-
-        // A value other than "true" does not enable the flag.
-        let off = shard_with_flag(Some("false"));
-        assert!(!shard_flag_enabled(Some(&off), flag));
-
-        // Flag absent, no labels, or no shard template at all.
-        let none = shard_with_flag(None);
-        assert!(!shard_flag_enabled(Some(&none), flag));
-        assert!(!shard_flag_enabled(None, flag));
-    }
 
     // A read-schema bundle whose inlined inferred schema tags a field
     // `format: date-time`, shaped as the control plane assembles it.


### PR DESCRIPTION
**Description:**

Fixes #3133.

#3116 correctly tightened the RFC3339 `date-time` format validator, but read-side (materialize/derive) document validation builds its validators from the collection read schema, which inlines the continuously-inferred schema — so historical documents whose date-time values were admitted before the tightening (e.g. space-separated `2026-06-17 12:46:17+00:00` under a field inference had tagged `format: date-time`) are now retroactively rejected on read. Field exclusion doesn't help (validation is whole-document, pre-projection), and any binding backfill re-reads old documents, so previously-healthy tasks re-break.

This adds an **opt-in, per-task shard feature flag** `estuary.dev/flag/relax-inferred-datetime-formats`. When set to `"true"` on a task's `shards.flags`, the task's read-side validators are built from a read schema in which `date`/`date-time`/`time` `format` keywords are stripped from the inlined `flow://inferred-schema` `$defs` entry — and from nothing else. All four read-side validator-build sites are covered:

| Runtime | Site |
|---|---|
| V1 materialize | `Binding::new` (`crates/runtime/src/materialize/task.rs`) |
| V1 derive | `Transform::new` (`crates/runtime/src/derive/task.rs`) |
| V2 materialize | `build_binding` (`crates/runtime-next/src/shard/materialize/task.rs`) |
| V2 derive | `build_transform` (`crates/runtime-next/src/shard/derive/task.rs`) |

The relaxation logic is single-sourced in `models::Schema::relax_inferred_datetime_formats()` — a new, additive function (`to_relaxed_schema()` is untouched). The flag reader is single-sourced in `labels::shard_flag_enabled()`.

Deliberately narrow, per the scoping in #3133:
- **`format` only** — inferred `type`/`required`/bounds remain enforced (they're structural guarantees connectors rely on).
- **`date`/`date-time`/`time` only** — the three formats whose validator delegates to the `time` crate, the dependency whose RFC3339 interpretation drifted (time-rs/time#700). Other formats stay strict.
- **Inferred schema only** — author-declared formats anywhere in the read schema, and the write-schema `$def`, remain strictly enforced.
- **Read-side only** — schema inference/detection and capture-time write-schema enforcement are unchanged and stay strict.
- **Off by default** — zero behavior change for tasks without the flag.

Because the flag is read at the runtime task-build layer from the task's own `shard_template` labels, rollout is per-task and requires no collection republish: enable the flag on an affected task's spec and it takes effect on the next shard assignment.

**Workflow steps:**

For a task failing with `Format mismatch: expected a DateTime` scoped under `flow://inferred-schema` (see #3133 section 3), add to the task's model:

```yaml
shards:
  flags:
    relax-inferred-datetime-formats: "true"
```

and publish. The flag is emitted as the `estuary.dev/flag/relax-inferred-datetime-formats` shard label and read by the runtime when building the task's read-side validators. Remove the flag to restore strict enforcement.

**Documentation links affected:**

None yet — this is an ops-facing escape hatch, not (yet) documented user-facing behavior. If we later decide to document `shards.flags` values, this one should be included.

**Notes for reviewers:**

- Reviewed commit-by-commit is easiest: V1 materialize → V1 derive → shared `labels::shard_flag_enabled` refactor → V2 (runtime-next).
- **V2 has a two-stage validation path**; the flag lands on the authoritative stage. The shuffle read pipeline's fast-path validator (`crates/shuffle/src/slice/read.rs`) is intentionally left strict — it only sets `FLAGS_SCHEMA_VALID`, it never faults. Documents without that flag are re-validated downstream against the (relaxed) binding/transform validator: derive in `shard/derive/scan.rs`, materialize in the combiner's handling of `!known_valid` docs (`doc/src/combine/memtable.rs`). Consequence: on flag-enabled tasks, legacy non-conforming docs always take the re-validation path — correct, with a small re-validation cost limited to those documents.
- `relax_datetime_formats` descends only through schema-bearing keywords, so `date-time` strings appearing as *data* (`enum`/`const`/`default`, or a property literally named `format`) are never touched — covered by tests. Its traversal list was cross-checked against everything `doc::shape::schema::to_schema()` can emit into an inferred schema.
- Tests at every site assert both flag states: OFF preserves today's strict behavior exactly; ON tolerates the #3133 reproduction value `2026-06-17 12:46:17.375663+00:00` while RFC3339-conformant values continue to validate.
- Per #3133, this touches a core validation path and should get review from owners of `crates/validation` / `crates/runtime` schema semantics.