### PR TITLE
dekaf: log tls handshake eof instead of returning as error

### DIFF
--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -457,11 +457,18 @@ async fn serve(
     // Optionally drive TLS handshake if needed
     let socket: Box<dyn Connection> = match tls_acceptor {
         Some(acceptor) => {
-            let tls_stream = tokio::time::timeout(tls_handshake_timeout, acceptor.accept(socket))
+            match tokio::time::timeout(tls_handshake_timeout, acceptor.accept(socket))
                 .await
                 .context("TLS handshake timed out")?
-                .context("TLS handshake failed")?;
-            Box::new(tls_stream)
+            {
+                Ok(tls_stream) => Box::new(tls_stream),
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    // A TLS connection that immediately closes is probably an health probe.
+                    tracing::debug!(reason = %e, "client disconnected");
+                    return Ok(());
+                }
+                Err(e) => return Err(e).context("TLS handshake failed"),
+            }
         }
         None => Box::new(socket),
     };


### PR DESCRIPTION
This just quiets the logs a bit.  It looks like this frequently happens due to a local connection, probably a health check.  When backtraces are enabled this results in a lot of logging for something that isn't an issue.

