### PR TITLE
Updating migrations to better support testing.

### DIFF
--- a/supabase/migrations/00_polyfill.sql
+++ b/supabase/migrations/00_polyfill.sql
@@ -72,7 +72,18 @@ END
 $$;
 
 -- Required for postgres to give ownership of catalog_stats to stats_loader.
-grant stats_loader to postgres;
+-- Guarded to the primary `postgres` database: role membership is cluster-global
+-- (shared pg_auth_members). Re-applying it concurrently across the isolated
+-- `#[sqlx::test]` databases risks colliding on the same shared tuple. The
+-- membership is established once by the `postgres` run and inherited cluster-wide
+-- by the test databases, so they don't need to re-grant it.
+do $$
+begin
+    if current_database() = 'postgres' then
+        grant stats_loader to postgres;
+    end if;
+end
+$$;
 
 -- Required for stats materialization to create flow_checkpoints_v1 and flow_materializations_v2.
 grant create on schema public to stats_loader;

--- a/supabase/migrations/20260121180000_grant_dekaf_to_authenticated.sql
+++ b/supabase/migrations/20260121180000_grant_dekaf_to_authenticated.sql
@@ -1,7 +1,21 @@
 begin;
 
 -- These got dropped from the most recent migration rollup
-grant dekaf to authenticator;
-alter role dekaf nologin bypassrls;
+--
+-- Guarded to the primary `postgres` database: roles are cluster-global, so
+-- these GRANT / ALTER ROLE statements mutate the shared pg_auth_members /
+-- pg_authid catalogs. `#[sqlx::test]` isolates each test in its own database
+-- but runs them concurrently, and every test re-applies the full migration
+-- set; N concurrent runs updating the same `dekaf` tuple abort all but one
+-- with "tuple concurrently updated". Test databases inherit the cluster-wide
+-- roles from the `postgres` run and don't need these. See 00_polyfill.sql.
+do $$
+begin
+    if current_database() = 'postgres' then
+        grant dekaf to authenticator;
+        alter role dekaf nologin bypassrls;
+    end if;
+end
+$$;
 
 commit;

--- a/supabase/migrations/20260226124102_tcp_keepalives.sql
+++ b/supabase/migrations/20260226124102_tcp_keepalives.sql
@@ -3,6 +3,15 @@
 -- after a client unexpectedly disconnects. That's far too long, especially for our
 -- materialization connectors. This migration tunes the tcp keepalive settings to
 -- allow detecting dead connections much faster.
-alter database postgres set tcp_keepalives_idle = 60;
-alter database postgres set tcp_keepalives_interval = 10;
-alter database postgres set tcp_keepalives_count = 5;
+do $$
+begin
+    -- ALTER DATABASE mutates the shared pg_database row for `postgres`; guard
+    -- so parallel sqlx::test migration runs (each in its own database) don't
+    -- concurrently update that shared tuple ("tuple concurrently updated").
+    if current_database() = 'postgres' then
+        alter database postgres set tcp_keepalives_idle = 60;
+        alter database postgres set tcp_keepalives_interval = 10;
+        alter database postgres set tcp_keepalives_count = 5;
+    end if;
+end
+$$;

--- a/supabase/migrations/20260608120000_scoped_ci_tokens.sql
+++ b/supabase/migrations/20260608120000_scoped_ci_tokens.sql
@@ -151,8 +151,17 @@ grant execute on function public.create_scoped_refresh_token(text, interval, tex
 -- This is the wiring that makes the scoped access token usable; it mirrors how `dekaf`
 -- is already a member of authenticator. SET ROLE evaluates privileges and RLS exactly as
 -- a direct login as the role would, so behavior matches the current psql path.
-grant github_action_connector_refresh to authenticator;
-grant data_plane_releases_ci to authenticator;
+do $$
+begin
+    -- Cluster-global role memberships; guard so concurrent sqlx::test
+    -- migration runs don't update the shared pg_auth_members tuple at once
+    -- ("tuple concurrently updated"). See 00_polyfill.sql.
+    if current_database() = 'postgres' then
+        grant github_action_connector_refresh to authenticator;
+        grant data_plane_releases_ci to authenticator;
+    end if;
+end
+$$;
 
 -- Re-queue connector tag publishing. SECURITY INVOKER: runs as the assumed role
 -- (github_action_connector_refresh), which already holds UPDATE on connector_tags and


### PR DESCRIPTION
**Description:**

The migrations were causing test failure due to conflicting writes to the database. The migrations were talking directly to the DB to change permissions and configurations, this was causing conflicting write problems between tests using the `sqlx::test` functionality which re-applies migrations to the DB every time. The solution here is to guard against those migration changes by preventing them from running without the appropriate database name of `postgres`. Sqlx's test framework doesn't use the `postgres` name specifically, it appends a hash to the end of the test database name. 

**Workflow steps:**

N/A

**Documentation links affected:**

N/A

**Notes for reviewers:**

This work was reviewed, and understood by me, but I don't fully understand our entire DB structure yet. Claude seems to think that we are not enforcing checks on migrations when we doing migrations, only file names I have been unable to verify if this is the case. If it is the case then this will work fine and only improve testing, if it's not we need to reject this MR and find another solution.