### PR TITLE
ci: fix Platform Build by packaging Go binaries from per-checkout $GOBIN

### DIFF
--- a/mise/tasks/ci/package
+++ b/mise/tasks/ci/package
@@ -33,8 +33,8 @@ ln ${CARGO_TARGET_DIR}/release/dekaf ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/flowctl ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/oidc-discovery-server ${PACKAGE_DIR}/
 ln ${CARGO_TARGET_DIR}/release/runtime-sidecar ${PACKAGE_DIR}/
-ln ${HOME}/go/bin/gazette ${PACKAGE_DIR}/
-ln ${HOME}/go/bin/flowctl-go ${PACKAGE_DIR}/
+ln ${GOBIN}/gazette ${PACKAGE_DIR}/
+ln ${GOBIN}/flowctl-go ${PACKAGE_DIR}/
 ln $(which etcd) ${PACKAGE_DIR}/
 
 cp crates/flow-web/pkg/estuary-flow-web-*.tgz ${HOME}/flow-package/estuary-flow-web.tgz


### PR DESCRIPTION
## Problem

Platform Build is red on `master`:

```
ln: failed to access '/home/runner/go/bin/gazette': No such file or directory
```

## Root cause

The multi-worktree change (`fec63eca6f6` / `d1ebe24b9f4`) moved Go binaries to a **per-checkout** `$GOBIN` (`~/cargo-target/<stack>/go-bin`, set in `mise/tasks/local/stack-env`) and updated `build:gazette` and `build:flowctl-go` to write there. But `ci:package` was left hardlinking from the old shared `~/go/bin`, which is no longer populated — so packaging fails.

## Fix

Point `ci:package` at `${GOBIN}` to match the build tasks. `$GOBIN` is ambient in the CI job since the step runs via `mise run`.