### PR TITLE
dekaf: serve the document containing a mid-document fetch offset

### DIFF
--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -18,6 +18,9 @@ use lz4_flex::frame::BlockMode;
 pub struct Read {
     /// Journal offset to be served by this Read.
     /// (Actual next offset may be larger if a fragment was removed).
+    /// The underlying journal read begins up to OFFSET_READBACK bytes
+    /// earlier, and documents which end at-or-before this offset are
+    /// suppressed rather than served.
     pub(crate) offset: i64,
     /// Most-recent journal write head observed by this Read.
     pub(crate) last_write_head: i64,
@@ -44,9 +47,6 @@ pub struct Read {
 
     // Include task name in emitted metrics
     task_name: String,
-
-    // Offset before which no documents should be emitted
-    offset_start: i64,
 
     deletes: DeletionMode,
 
@@ -78,6 +78,27 @@ pub enum ReadTarget {
     Docs(usize),
 }
 
+/// Journal reads begin this many bytes before the offset being served, and
+/// `next_batch` suppresses documents which end at-or-before that offset.
+/// Dekaf maps each document to the Kafka offset of its final byte, so a
+/// consumer may fetch at an offset which lands in the middle of a document,
+/// for example when it plans fetches by numerically partitioning the offset
+/// space. Reading backwards lets such a fetch serve its containing document,
+/// which a read started at the fetch offset would scan past and drop.
+/// It's sized to be larger than the maximum size of a single document (64MB).
+const OFFSET_READBACK: i64 = 1 << 26; // 64MB
+
+/// Map an offset to be served into the journal offset at which its read
+/// begins, up to OFFSET_READBACK bytes earlier. Non-positive offsets have
+/// special broker semantics (-1 reads from the write head) and pass through.
+fn readback_offset(offset: i64) -> i64 {
+    if offset > 0 {
+        (offset - OFFSET_READBACK).max(0)
+    } else {
+        offset
+    }
+}
+
 impl Read {
     pub async fn new(
         task_state_listener: task_manager::TaskStateListener,
@@ -98,13 +119,21 @@ impl Read {
             .name
             .as_str();
 
+        // Data-preview reads pass a fragment-start offset, which is always a
+        // document boundary, and don't require reading backwards.
+        let stream_offset = if rewrite_offsets_from.is_none() {
+            readback_offset(offset)
+        } else {
+            offset
+        };
+
         let (stream, stream_exp) = Self::new_stream(
             collection.not_before,
             task_state_listener.clone(),
             partition_template_name.to_owned(),
             partition.spec.name.clone(),
             buffer_size,
-            offset,
+            stream_offset,
         )
         .await?;
 
@@ -137,7 +166,6 @@ impl Read {
             },
             rewrite_offsets_from,
             deletes: auth.deletions(),
-            offset_start: offset,
             partition_leader_epoch: collection.binding_backfill_counter as i32,
         })
     }
@@ -148,7 +176,7 @@ impl Read {
         partition_template_name: String,
         journal_name: String,
         buffer_size: usize,
-        offset_start: i64,
+        offset: i64,
     ) -> anyhow::Result<(ReadJsonLines, std::time::SystemTime)> {
         let (not_before_sec, _) = not_before
             .map(|c: Clock| Clock::to_unix(&c))
@@ -184,7 +212,7 @@ impl Read {
         Ok((
             client.read_json_lines(
                 broker::ReadRequest {
-                    offset: offset_start,
+                    offset,
                     block: true,
                     journal: journal_name.clone(),
                     begin_mod_time: not_before_sec as i64,
@@ -219,7 +247,7 @@ impl Read {
                 self.partition_template_name.clone(),
                 self.journal_name.clone(),
                 self.buffer_size,
-                self.offset,
+                readback_offset(self.offset),
             )
             .await?;
         }
@@ -319,14 +347,23 @@ impl Read {
             let (root, next_offset) = match read {
                 ReadJsonLine::Meta(response) => {
                     self.last_write_head = response.write_head;
-                    // Skip self.offset forward in case we're skipping past a gap
-                    self.offset = response.offset;
+                    // Skip self.offset forward in case we're skipping past a gap,
+                    // but never move it backward: the journal read begins up to
+                    // OFFSET_READBACK bytes before the offset being served.
+                    self.offset = self.offset.max(response.offset);
                     continue;
                 }
                 ReadJsonLine::Doc { root, next_offset } => (root, next_offset),
             };
 
-            if next_offset < self.offset_start {
+            // Suppress documents which end at-or-before the offset being
+            // served, scanned over because the journal read began up to
+            // OFFSET_READBACK bytes earlier. This must be inclusive: a
+            // document ending exactly at `self.offset` maps to Kafka offset
+            // `self.offset - 1`, which consumers have already read. Notably,
+            // a caught-up consumer polling at the write head must not be
+            // re-served the trailing transaction ACK.
+            if next_offset <= self.offset {
                 continue;
             }
 

--- a/crates/dekaf/tests/e2e/fetch_offsets.rs
+++ b/crates/dekaf/tests/e2e/fetch_offsets.rs
@@ -1,0 +1,189 @@
+use super::DekafTestEnv;
+use super::raw_kafka::TestKafkaClient;
+use anyhow::Context;
+use bytes::Buf;
+use kafka_protocol::messages;
+use kafka_protocol::records::{Record, RecordBatchDecoder};
+use serde_json::json;
+use std::time::Duration;
+
+const FIXTURE: &str = include_str!("fixtures/basic.flow.yaml");
+const TOPIC: &str = "test_topic";
+const PARTITION: i32 = 0;
+
+/// Decode all records, including control records, from a raw FetchResponse.
+///
+/// Unlike the rdkafka consumer, this surfaces exactly what Dekaf put on the
+/// wire: librdkafka silently filters out control records and records below
+/// the fetch offset, which masks bugs in which documents a fetch serves.
+fn decode_fetch_records(resp: &messages::FetchResponse) -> anyhow::Result<Vec<Record>> {
+    let partition = resp
+        .responses
+        .iter()
+        .find(|t| t.topic.as_str() == TOPIC)
+        .and_then(|t| t.partitions.iter().find(|p| p.partition_index == PARTITION))
+        .context("missing partition in fetch response")?;
+
+    anyhow::ensure!(
+        partition.error_code == 0,
+        "fetch returned error code {}",
+        partition.error_code
+    );
+
+    let Some(mut buf) = partition.records.clone() else {
+        return Ok(Vec::new());
+    };
+
+    let mut records = Vec::new();
+    while buf.has_remaining() {
+        records.extend(RecordBatchDecoder::decode(&mut buf)?.records);
+    }
+    Ok(records)
+}
+
+async fn fetch_records_at(
+    client: &mut TestKafkaClient,
+    offset: i64,
+) -> anyhow::Result<Vec<Record>> {
+    let resp = client
+        .fetch_with_epoch(TOPIC, PARTITION, offset, -1)
+        .await?;
+    decode_fetch_records(&resp)
+}
+
+/// Fetch at `offset`, retrying empty responses (e.g. while the server-side
+/// read is still starting up) until records arrive.
+async fn fetch_records_at_nonempty(
+    client: &mut TestKafkaClient,
+    offset: i64,
+) -> anyhow::Result<Vec<Record>> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let records = fetch_records_at(client, offset).await?;
+        if !records.is_empty() {
+            return Ok(records);
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for a non-empty fetch at offset {offset}"
+        );
+    }
+}
+
+/// Resolve the earliest (-2) or latest (-1) offset via ListOffsets.
+async fn resolve_offset(client: &mut TestKafkaClient, timestamp: i64) -> anyhow::Result<i64> {
+    let resp = client
+        .list_offsets_with_epoch(TOPIC, PARTITION, timestamp, -1)
+        .await?;
+    let partition = resp
+        .topics
+        .iter()
+        .find(|t| t.name.as_str() == TOPIC)
+        .and_then(|t| t.partitions.iter().find(|p| p.partition_index == PARTITION))
+        .context("missing partition in ListOffsets response")?;
+    anyhow::ensure!(
+        partition.error_code == 0,
+        "ListOffsets returned error code {}",
+        partition.error_code
+    );
+    Ok(partition.offset)
+}
+
+/// Read all records in [low, high), in order, including control records.
+async fn read_all_records(
+    client: &mut TestKafkaClient,
+    low: i64,
+    high: i64,
+) -> anyhow::Result<Vec<Record>> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let mut records: Vec<Record> = Vec::new();
+
+    while records.last().map_or(true, |r| r.offset < high - 1) {
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out reading records through offset {high}"
+        );
+        let pos = records.last().map_or(low, |r| r.offset + 1);
+        records.extend(fetch_records_at(client, pos).await?);
+    }
+    Ok(records)
+}
+
+fn payload(i: usize) -> serde_json::Value {
+    json!({"id": format!("doc-{i:02}"), "value": "x".repeat(64)})
+}
+
+/// A fetch at an offset which lands inside a document must serve that
+/// document, not skip forward to the next one.
+///
+/// Dekaf maps each document to the Kafka offset of its final byte, so the
+/// document containing a fetch offset is exactly the record that offset
+/// addresses. Consumers like SingleStore plan per-shard fetches by
+/// numerically dividing the offset space, so mid-document fetch offsets
+/// occur routinely, and skipping forward silently drops the document.
+#[tokio::test]
+async fn test_fetch_mid_document_returns_containing_document() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("fetch_mid_doc", FIXTURE).await?;
+    env.inject_documents("data", (0..8).map(payload)).await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let low = resolve_offset(&mut client, -2).await?;
+    let high = resolve_offset(&mut client, -1).await?;
+    let all = read_all_records(&mut client, low, high).await?;
+
+    // Target a data record far enough from the write head that this cannot be
+    // mistaken for a data-preview fetch.
+    let target_index = {
+        let data_indices: Vec<usize> = (0..all.len()).filter(|&i| !all[i].control).collect();
+        data_indices[data_indices.len() / 2]
+    };
+    let target_offset = all[target_index].offset;
+
+    assert!(
+        high - target_offset >= 13,
+        "fetch offset must be far enough from the write head to avoid data-preview detection"
+    );
+
+    // A Kafka record's offset is its document's final byte, which is inside
+    // the journal document. Fetching there must serve that record first.
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+    let records = fetch_records_at_nonempty(&mut client, target_offset).await?;
+
+    assert_eq!(records.first().map(|r| r.offset), Some(target_offset));
+
+    Ok(())
+}
+
+/// A caught-up consumer polling at the write head must receive no records.
+///
+/// The final bytes of the journal are the trailing transaction ACK, whose
+/// Kafka offset is one before the write head. Reading backwards from the
+/// requested offset must not re-serve it: this regressed when readback was
+/// first introduced (see 98041fc2fe7), causing consumers to periodically
+/// re-read just the last ACK message.
+#[tokio::test]
+async fn test_fetch_at_write_head_returns_no_records() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("fetch_write_head", FIXTURE).await?;
+    env.inject_documents("data", [payload(0)]).await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let high = resolve_offset(&mut client, -1).await?;
+    let records = fetch_records_at(&mut client, high).await?;
+    assert!(
+        records.is_empty(),
+        "fetch at write head {high} must return no records, got offsets {:?}",
+        records.iter().map(|r| r.offset).collect::<Vec<_>>(),
+    );
+
+    Ok(())
+}

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -7,6 +7,7 @@ mod basic;
 mod collection_reset;
 mod consumer_group;
 mod empty_fetch;
+mod fetch_offsets;
 mod list_offsets;
 mod migration;
 mod not_ready;


### PR DESCRIPTION
Dekaf maps each document to the Kafka offset of its final byte, so a document occupies a range of offsets rather than a single one. Consumers which plan fetches by numerically dividing the offset space between shards (SingleStore pipelines do this) routinely issue fetches at offsets that land inside a document. Reads previously started exactly at the fetch offset and skipped forward past the partial document, so a document spanning a shard-range boundary was served to neither shard: the shard owning the earlier range discarded it as out-of-range, and the shard owning its offset never saw it.

Journal reads now begin up to `OFFSET_READBACK` (64MB, larger than any single document) before the requested offset, and `next_batch` suppresses documents which end at-or-before the offset being served:

* A fetch landing inside a document serves that document first, at that document's Kafka offset.
* Suppression is inclusive (`next_offset <= self.offset`): a document ending exactly at the fetch offset maps to Kafka offset `fetch_offset - 1`, which the consumer already read. The earlier readback (added in #1733, removed in #1745) used an exclusive check, which re-served the trailing transaction ACK to caught-up consumers polling at the write head.
* `Meta` responses advance the read's offset but never move it backward, so reported progress cannot regress to the readback start.
* Data-preview reads are unchanged: they start at a fragment boundary, which is always a document boundary, and skip the readback.

The focused e2e tests use a raw Kafka client that decodes on-the-wire record batches. Librdkafka silently filters control records and records below the fetch offset, so rdkafka-based tests cannot observe which records a fetch actually served.

* `test_fetch_mid_document_returns_containing_document` fetches at a data record's Kafka offset (the document's final byte) and verifies that record is served first.
* `test_fetch_at_write_head_returns_no_records` starts a fresh server-side read at the write head and verifies that no records, including the trailing ACK, are served.

Validation:

* `cargo test -p dekaf --lib`
* `cargo test -p dekaf --test e2e --no-run`
