### PR TITLE
parser: decode Parquet VARIANT columns to JSON (experimental)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5905,6 +5905,9 @@ name = "parser"
 version = "0.0.0"
 dependencies = [
  "apache-avro",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "assert_cmd",
  "base64 0.22.1",
  "bytes",
@@ -5917,6 +5920,7 @@ dependencies = [
  "doc",
  "encoding_rs",
  "flate2",
+ "half",
  "insta",
  "itertools 0.14.0",
  "json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -5901,6 +5901,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet-variant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56bf96fdaf5f9392b447cf1e60bfe4b72149ab3309aa3855c02813cc89ad93f"
+dependencies = [
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.11.4",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8bde078e883e197efe49d315bfa0ecf8f68879d32a2abf34eb09f40ea88f21"
+dependencies = [
+ "arrow-schema",
+ "base64 0.22.1",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "parser"
 version = "0.0.0"
 dependencies = [
@@ -5928,6 +5956,8 @@ dependencies = [
  "mime",
  "num-bigint",
  "parquet",
+ "parquet-variant",
+ "parquet-variant-json",
  "protobuf",
  "protobuf-json-mapping",
  "protobuf-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ apache-avro = { version = "0", default-features = false, features = [
     "zstandard",
     "bzip",
 ] }
+# Pinned to match `parquet`.
+arrow-array = "56"
+arrow-buffer = "56"
+arrow-schema = "56"
 
 # For some reason, the version requirement "0" resulted in cargo downgrading
 # this dependency to an incompatible version. The requirement here is intended
@@ -78,6 +82,7 @@ gcp_auth = "0.12"
 googleapis-tonic-google-bigtable-v2 = "0.36"
 graphql_client = "*"
 handlebars = "6"
+half = "2"
 hex = "0"
 hexdump = "0"
 humantime = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ num-format = "0"
 indicatif = "0"
 open = "3"
 parquet = { version = "56", features = ["json"] }
+# Experimental Parquet Variant support (semi-structured / shredded VARIANT
+# logical type). Used by the parser to decode variant columns to JSON.
+parquet-variant = "0.1"
+parquet-variant-json = "0.1"
 pathfinding = "4"
 pbjson = "0"
 pbjson-types = "0"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -34,7 +34,13 @@ flate2 = { workspace = true }
 itertools = { workspace = true }
 mime = { workspace = true }
 num-bigint = { workspace = true }
-parquet = { workspace = true }
+parquet = { workspace = true, features = ["arrow"] }
+arrow-array = { workspace = true }
+# 256-bit decimals.
+arrow-buffer = { workspace = true }
+arrow-schema = { workspace = true }
+# 16-bit floats.
+half = { workspace = true }
 protobuf = { workspace = true }
 protobuf-json-mapping = { workspace = true }
 protobuf-parse = { workspace = true }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -41,6 +41,9 @@ arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 # 16-bit floats.
 half = { workspace = true }
+# Experimental: decode the Parquet VARIANT logical type to JSON.
+parquet-variant = { workspace = true }
+parquet-variant-json = { workspace = true }
 protobuf = { workspace = true }
 protobuf-json-mapping = { workspace = true }
 protobuf-parse = { workspace = true }

--- a/crates/parser/src/format/mod.rs
+++ b/crates/parser/src/format/mod.rs
@@ -57,6 +57,9 @@ pub enum ParseError {
     #[error("failed to parse parquet: {0}")]
     Parquet(#[from] ParquetError),
 
+    #[error("failed to decode parquet via arrow: {0}")]
+    Arrow(#[from] ::arrow_schema::ArrowError),
+
     #[error("parquet file contains row group(s) larger than the 1GB maximum")]
     RowGroupTooLarge,
 }

--- a/crates/parser/src/format/parquet.rs
+++ b/crates/parser/src/format/parquet.rs
@@ -1,10 +1,49 @@
-//! Parser for the parquet format. This will accept any stream of parquet files, limited up to 1GB
-//! in size.
+//! Parser for the parquet format, limited to 1GB per row group.
+//!
+//! Files are decoded through parquet's Arrow reader ([`ParquetRecordBatchReader`]),
+//! converting each [`arrow_array::RecordBatch`] to one JSON object per row. Output
+//! is byte-for-byte identical to parquet's record API (decimals and timestamps as
+//! strings, binary as base64, non-finite floats as null); [`leaf_to_value`]
+//! reproduces that formatting and the tests below assert the equality.
+//!
+//! Legacy INT96 timestamps and INT64 nanosecond timestamps both decode to Arrow's
+//! `Timestamp(Nanosecond)`, but the record API renders INT96 as a millisecond
+//! string ([`int96_nanos_to_millis`]) and INT64 nanoseconds as a raw integer.
+//! Since the Arrow type cannot distinguish them, [`build_column_plans`] consults
+//! the parquet leaf schema to build a per-column [`ColPlan`].
+//!
+//! Arrow types not on the [`datatype_supported`] allow-list fall back to the
+//! record API. No type the parquet reader produces today hits this path; it is a
+//! defensive backstop.
 use super::{Input, Output, ParseError, Parser};
-use parquet::file::reader::{FileReader, SerializedFileReader};
+use arrow_array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array,
+    Decimal256Array, FixedSizeBinaryArray, Float16Array, Float32Array, Float64Array, Int8Array,
+    Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeListArray, LargeStringArray,
+    ListArray, MapArray, RecordBatch, StringArray, StringViewArray, StructArray,
+    Time32MillisecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow_schema::{DataType, TimeUnit};
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use chrono::{TimeZone, Utc};
+use num_bigint::{BigInt, Sign};
+use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
+use parquet::basic::Type as PhysicalType;
+use parquet::file::reader::SerializedFileReader;
 use parquet::record::reader::RowIter;
+use parquet::schema::types::SchemaDescriptor;
 use serde_json::Value;
 use std::convert::TryFrom;
+use std::sync::Arc;
+
+// Included as a module rather than an integration test so the tests below can
+// exercise the private decode path directly.
+#[cfg(test)]
+#[path = "../../tests/parquet_gen.rs"]
+mod parquet_gen;
 
 struct ParquetParser;
 
@@ -12,43 +51,480 @@ pub fn new_parser() -> Box<dyn Parser> {
     Box::new(ParquetParser)
 }
 
-// Maximum size for row groups (1GB)
 const MAX_RG_SIZE: i64 = 1024 * 1024 * 1024;
+
+// Bounds peak memory independent of file size.
+const BATCH_SIZE: usize = 8192;
 
 impl Parser for ParquetParser {
     fn parse(&self, content: Input) -> Result<Output, ParseError> {
         let file = content.into_file()?;
-        let file_reader = SerializedFileReader::try_from(file)?;
 
-        for rg in file_reader.metadata().row_groups() {
+        // Cloned so `file` stays available for the record-API fallback below.
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file.try_clone()?)?;
+
+        for rg in builder.metadata().row_groups() {
             if rg.total_byte_size() > MAX_RG_SIZE {
                 return Err(ParseError::RowGroupTooLarge);
             }
         }
 
-        let iter = file_reader.into_iter();
+        let arrow_supported = builder
+            .schema()
+            .fields()
+            .iter()
+            .all(|f| datatype_supported(f.data_type()));
 
-        let wrapped = ParquetIter {
-            inner: Box::new(iter),
-        };
-        Ok(Box::new(wrapped))
+        if arrow_supported {
+            let plans = build_column_plans(
+                builder.schema(),
+                builder.metadata().file_metadata().schema_descr(),
+            );
+            let reader = builder.with_batch_size(BATCH_SIZE).build()?;
+            drop(file);
+            Ok(Box::new(ArrowRowIter::new(reader, Arc::new(plans))))
+        } else {
+            drop(builder);
+            let file_reader = SerializedFileReader::try_from(file)?;
+            let iter = file_reader.into_iter();
+            Ok(Box::new(RecordRowIter {
+                inner: Box::new(iter),
+            }))
+        }
     }
 }
 
-struct ParquetIter<'a> {
-    inner: Box<RowIter<'a>>,
+/// Record-API fallback, matching the parser's prior output exactly.
+struct RecordRowIter {
+    inner: Box<RowIter<'static>>,
 }
 
-impl Iterator for ParquetIter<'_> {
+impl Iterator for RecordRowIter {
     type Item = Result<Value, ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next_elem = self.inner.next()?;
-        match next_elem {
+        match self.inner.next()? {
             Ok(row) => Some(Ok(row.to_json_value())),
             Err(e) => Some(Err(e.into())),
         }
     }
+}
+
+/// Yields rows by converting a whole record batch, then draining it.
+struct ArrowRowIter {
+    reader: ParquetRecordBatchReader,
+    plans: Arc<Vec<ColPlan>>,
+    buffered: std::vec::IntoIter<Value>,
+}
+
+impl ArrowRowIter {
+    fn new(reader: ParquetRecordBatchReader, plans: Arc<Vec<ColPlan>>) -> Self {
+        ArrowRowIter {
+            reader,
+            plans,
+            buffered: Vec::new().into_iter(),
+        }
+    }
+}
+
+impl Iterator for ArrowRowIter {
+    type Item = Result<Value, ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(value) = self.buffered.next() {
+                return Some(Ok(value));
+            }
+            match self.reader.next()? {
+                Ok(batch) => self.buffered = convert_batch(&batch, &self.plans).into_iter(),
+                Err(e) => return Some(Err(e.into())),
+            }
+        }
+    }
+}
+
+/// Carries the one distinction the Arrow schema loses: whether a
+/// `Timestamp(Nanosecond)` column came from a legacy INT96 (record API renders a
+/// millisecond string) or an INT64 nanosecond column (record API renders a raw
+/// integer).
+enum ColPlan {
+    Leaf,
+    Int96Millis,
+    Struct(Vec<ColPlan>),
+    List(Box<ColPlan>),
+    Map(Box<ColPlan>, Box<ColPlan>),
+}
+
+/// Walks the Arrow fields in lock-step with the parquet leaf columns, which
+/// enumerate in the same depth-first order.
+fn build_column_plans(schema: &arrow_schema::Schema, parquet: &SchemaDescriptor) -> Vec<ColPlan> {
+    let mut leaves = parquet.columns().iter().map(|c| c.physical_type());
+    schema
+        .fields()
+        .iter()
+        .map(|f| build_plan(f.data_type(), &mut leaves))
+        .collect()
+}
+
+fn build_plan(
+    data_type: &DataType,
+    leaves: &mut impl Iterator<Item = PhysicalType>,
+) -> ColPlan {
+    match data_type {
+        DataType::Struct(fields) => {
+            ColPlan::Struct(fields.iter().map(|f| build_plan(f.data_type(), leaves)).collect())
+        }
+        DataType::List(field) | DataType::LargeList(field) => {
+            ColPlan::List(Box::new(build_plan(field.data_type(), leaves)))
+        }
+        DataType::Map(entries, _) => match entries.data_type() {
+            DataType::Struct(kv) if kv.len() == 2 => {
+                let key = build_plan(kv[0].data_type(), leaves);
+                let value = build_plan(kv[1].data_type(), leaves);
+                ColPlan::Map(Box::new(key), Box::new(value))
+            }
+            _ => {
+                leaves.next();
+                ColPlan::Leaf
+            }
+        },
+        // Only a nanosecond timestamp's rendering depends on the physical type.
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => match leaves.next() {
+            Some(PhysicalType::INT96) => ColPlan::Int96Millis,
+            _ => ColPlan::Leaf,
+        },
+        _ => {
+            leaves.next();
+            ColPlan::Leaf
+        }
+    }
+}
+
+/// Column order does not affect output: `serde_json` serializes object keys
+/// sorted.
+fn convert_batch(batch: &RecordBatch, plans: &[ColPlan]) -> Vec<Value> {
+    let schema = batch.schema();
+    let columns = batch.columns();
+    let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+    let mut rows = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let mut object = serde_json::Map::with_capacity(columns.len());
+        for ((name, column), plan) in names.iter().zip(columns.iter()).zip(plans.iter()) {
+            object.insert((*name).to_string(), array_to_value(column.as_ref(), row, plan));
+        }
+        rows.push(Value::Object(object));
+    }
+    rows
+}
+
+fn array_to_value(array: &dyn Array, row: usize, plan: &ColPlan) -> Value {
+    if array.is_null(row) {
+        return Value::Null;
+    }
+
+    match plan {
+        ColPlan::Leaf => leaf_to_value(array, row),
+
+        ColPlan::Int96Millis => {
+            let nanos = downcast::<TimestampNanosecondArray>(array).value(row);
+            Value::String(convert_timestamp_millis_to_string(int96_nanos_to_millis(nanos)))
+        }
+
+        ColPlan::Struct(child_plans) => {
+            let structs = downcast::<StructArray>(array);
+            let fields = match array.data_type() {
+                DataType::Struct(fields) => fields,
+                _ => unreachable!("Struct plan on a non-struct array"),
+            };
+            let mut object = serde_json::Map::with_capacity(fields.len());
+            for ((field, column), child) in fields
+                .iter()
+                .zip(structs.columns().iter())
+                .zip(child_plans.iter())
+            {
+                object.insert(field.name().clone(), array_to_value(column.as_ref(), row, child));
+            }
+            Value::Object(object)
+        }
+
+        ColPlan::List(child) => {
+            let elements = match array.data_type() {
+                DataType::List(_) => downcast::<ListArray>(array).value(row),
+                DataType::LargeList(_) => downcast::<LargeListArray>(array).value(row),
+                other => unreachable!("List plan on a {:?} array", other),
+            };
+            list_to_value(elements.as_ref(), child)
+        }
+
+        ColPlan::Map(key_plan, value_plan) => {
+            let map = downcast::<MapArray>(array);
+            let offsets = map.value_offsets();
+            let (start, end) = (offsets[row] as usize, offsets[row + 1] as usize);
+            let keys = map.keys();
+            let values = map.values();
+            let mut object = serde_json::Map::with_capacity(end - start);
+            for i in start..end {
+                let key = array_to_value(keys.as_ref(), i, key_plan);
+                // Match the record API: string keys are used verbatim, other
+                // key types fall back to their JSON string representation.
+                let key = key
+                    .as_str()
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| key.to_string());
+                object.insert(key, array_to_value(values.as_ref(), i, value_plan));
+            }
+            Value::Object(object)
+        }
+    }
+}
+
+/// Converts a non-null scalar cell. Panics on types not cleared by
+/// [`datatype_supported`], which `parse` guarantees cannot reach here.
+fn leaf_to_value(array: &dyn Array, row: usize) -> Value {
+    match array.data_type() {
+        DataType::Null => Value::Null,
+        DataType::Boolean => Value::Bool(downcast::<BooleanArray>(array).value(row)),
+
+        DataType::Int8 => Value::Number(downcast::<Int8Array>(array).value(row).into()),
+        DataType::Int16 => Value::Number(downcast::<Int16Array>(array).value(row).into()),
+        DataType::Int32 => Value::Number(downcast::<Int32Array>(array).value(row).into()),
+        DataType::Int64 => Value::Number(downcast::<Int64Array>(array).value(row).into()),
+        DataType::UInt8 => Value::Number(downcast::<UInt8Array>(array).value(row).into()),
+        DataType::UInt16 => Value::Number(downcast::<UInt16Array>(array).value(row).into()),
+        DataType::UInt32 => Value::Number(downcast::<UInt32Array>(array).value(row).into()),
+        DataType::UInt64 => Value::Number(downcast::<UInt64Array>(array).value(row).into()),
+
+        DataType::Float16 => {
+            number_from_f64(f64::from(downcast::<Float16Array>(array).value(row)))
+        }
+        DataType::Float32 => {
+            number_from_f64(f64::from(downcast::<Float32Array>(array).value(row)))
+        }
+        DataType::Float64 => number_from_f64(downcast::<Float64Array>(array).value(row)),
+
+        DataType::Utf8 => Value::String(downcast::<StringArray>(array).value(row).to_owned()),
+        DataType::LargeUtf8 => {
+            Value::String(downcast::<LargeStringArray>(array).value(row).to_owned())
+        }
+        DataType::Utf8View => {
+            Value::String(downcast::<StringViewArray>(array).value(row).to_owned())
+        }
+
+        DataType::Binary => {
+            Value::String(BASE64_STANDARD.encode(downcast::<BinaryArray>(array).value(row)))
+        }
+        DataType::LargeBinary => {
+            Value::String(BASE64_STANDARD.encode(downcast::<LargeBinaryArray>(array).value(row)))
+        }
+        DataType::BinaryView => {
+            Value::String(BASE64_STANDARD.encode(downcast::<BinaryViewArray>(array).value(row)))
+        }
+        DataType::FixedSizeBinary(_) => Value::String(
+            BASE64_STANDARD.encode(downcast::<FixedSizeBinaryArray>(array).value(row)),
+        ),
+
+        DataType::Date32 => {
+            Value::String(convert_date_to_string(downcast::<Date32Array>(array).value(row)))
+        }
+        DataType::Time32(TimeUnit::Millisecond) => Value::String(convert_time_millis_to_string(
+            downcast::<Time32MillisecondArray>(array).value(row),
+        )),
+        DataType::Time64(TimeUnit::Microsecond) => Value::String(convert_time_micros_to_string(
+            downcast::<Time64MicrosecondArray>(array).value(row),
+        )),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => Value::String(
+            convert_timestamp_millis_to_string(
+                downcast::<TimestampMillisecondArray>(array).value(row),
+            ),
+        ),
+        DataType::Timestamp(TimeUnit::Microsecond, _) => Value::String(
+            convert_timestamp_micros_to_string(
+                downcast::<TimestampMicrosecondArray>(array).value(row),
+            ),
+        ),
+
+        // INT64 nanosecond time/timestamp columns have no legacy converted type,
+        // so the record API surfaces them as raw integers (INT96 is handled by
+        // ColPlan::Int96Millis before reaching here).
+        DataType::Time64(TimeUnit::Nanosecond) => {
+            Value::Number(downcast::<Time64NanosecondArray>(array).value(row).into())
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+            Value::Number(downcast::<TimestampNanosecondArray>(array).value(row).into())
+        }
+
+        DataType::Decimal128(_, scale) => {
+            let value = downcast::<Decimal128Array>(array).value(row);
+            Value::String(decimal_to_string(&value.to_be_bytes(), *scale as i32))
+        }
+        DataType::Decimal256(_, scale) => {
+            let value = downcast::<Decimal256Array>(array).value(row);
+            Value::String(decimal_to_string(&value.to_be_bytes(), *scale as i32))
+        }
+
+        other => unreachable!(
+            "leaf_to_value reached an unsupported data type {:?}; the schema check in parse \
+             should have routed this file to the record API",
+            other
+        ),
+    }
+}
+
+fn list_to_value(elements: &dyn Array, plan: &ColPlan) -> Value {
+    Value::Array(
+        (0..elements.len())
+            .map(|i| array_to_value(elements, i, plan))
+            .collect(),
+    )
+}
+
+const NANOS_IN_DAY: i64 = 24 * 60 * 60 * 1_000_000_000;
+const MILLIS_IN_DAY: i64 = 24 * 60 * 60 * 1_000;
+
+/// Reproduces `Int96::to_millis()` from the nanoseconds Arrow computed via
+/// `Int96::to_nanos()`. `to_millis` floors the day component and adds a
+/// non-negative intra-day remainder, so a plain `nanos / 1_000_000` diverges for
+/// pre-epoch values (Rust integer division truncates toward zero). Euclidean
+/// division recovers the exact split, matching `to_millis()` across the full
+/// i64-nanosecond range.
+fn int96_nanos_to_millis(nanos: i64) -> i64 {
+    let days = nanos.div_euclid(NANOS_IN_DAY);
+    let nanos_of_day = nanos.rem_euclid(NANOS_IN_DAY);
+    days * MILLIS_IN_DAY + nanos_of_day / 1_000_000
+}
+
+fn downcast<T: 'static>(array: &dyn Array) -> &T {
+    array
+        .as_any()
+        .downcast_ref::<T>()
+        .expect("arrow array downcast matched its DataType")
+}
+
+/// Non-finite floats (NaN, infinities) have no JSON number form; the record API
+/// maps them to null.
+fn number_from_f64(value: f64) -> Value {
+    serde_json::Number::from_f64(value)
+        .map(Value::Number)
+        .unwrap_or(Value::Null)
+}
+
+/// Allow-list of Arrow types whose conversion is verified equal to the record
+/// API; anything else falls back to the record API in `parse`.
+fn datatype_supported(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Null
+        | DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_)
+        | DataType::Date32
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _) => true,
+
+        // Millisecond/microsecond units render as strings via legacy converted
+        // types. Nanosecond units are also supported: an INT64 nanosecond column
+        // renders as a raw integer (via `leaf_to_value`), and an INT96 column is
+        // handled through `ColPlan::Int96Millis`. Second units cannot originate
+        // from a parquet file, so they are left out.
+        DataType::Time32(TimeUnit::Millisecond)
+        | DataType::Time64(TimeUnit::Microsecond)
+        | DataType::Time64(TimeUnit::Nanosecond)
+        | DataType::Timestamp(TimeUnit::Millisecond, _)
+        | DataType::Timestamp(TimeUnit::Microsecond, _)
+        | DataType::Timestamp(TimeUnit::Nanosecond, _) => true,
+
+        DataType::Struct(fields) => fields.iter().all(|f| datatype_supported(f.data_type())),
+        DataType::List(field) | DataType::LargeList(field) => {
+            datatype_supported(field.data_type())
+        }
+        DataType::Map(entries, _) => match entries.data_type() {
+            DataType::Struct(fields) => fields.iter().all(|f| datatype_supported(f.data_type())),
+            _ => false,
+        },
+
+        _ => false,
+    }
+}
+
+// The functions below are exact reimplementations of the private
+// `convert_*_to_string` helpers in `parquet::record::api`. They share the same
+// chrono version as `parquet`, so identical calls yield identical output. Any
+// change here must be checked against the differential test.
+
+fn convert_date_to_string(value: i32) -> String {
+    const NUM_SECONDS_IN_DAY: i64 = 60 * 60 * 24;
+    let dt = Utc
+        .timestamp_opt(value as i64 * NUM_SECONDS_IN_DAY, 0)
+        .unwrap();
+    format!("{}", dt.format("%Y-%m-%d"))
+}
+
+fn convert_timestamp_millis_to_string(value: i64) -> String {
+    let dt = Utc.timestamp_millis_opt(value).unwrap();
+    format!("{}", dt.format("%Y-%m-%d %H:%M:%S%.3f %:z"))
+}
+
+fn convert_timestamp_micros_to_string(value: i64) -> String {
+    let dt = Utc.timestamp_micros(value).unwrap();
+    format!("{}", dt.format("%Y-%m-%d %H:%M:%S%.6f %:z"))
+}
+
+fn convert_time_millis_to_string(value: i32) -> String {
+    let total_ms = value as u64;
+    let hours = total_ms / (60 * 60 * 1000);
+    let minutes = (total_ms % (60 * 60 * 1000)) / (60 * 1000);
+    let seconds = (total_ms % (60 * 1000)) / 1000;
+    let millis = total_ms % 1000;
+    format!("{hours:02}:{minutes:02}:{seconds:02}.{millis:03}")
+}
+
+fn convert_time_micros_to_string(value: i64) -> String {
+    let total_us = value as u64;
+    let hours = total_us / (60 * 60 * 1000 * 1000);
+    let minutes = (total_us % (60 * 60 * 1000 * 1000)) / (60 * 1000 * 1000);
+    let seconds = (total_us % (60 * 1000 * 1000)) / (1000 * 1000);
+    let micros = total_us % (1000 * 1000);
+    format!("{hours:02}:{minutes:02}:{seconds:02}.{micros:06}")
+}
+
+/// Reimplementation of `convert_decimal_to_string`. `data` is the two's-complement
+/// big-endian value; leading sign-extension bytes do not change the result, so a
+/// wider representation (e.g. i128 bytes for a value stored in fewer parquet
+/// bytes) produces the identical string.
+fn decimal_to_string(data: &[u8], scale: i32) -> String {
+    let num = BigInt::from_signed_bytes_be(data);
+
+    let negative = i32::from(num.sign() == Sign::Minus);
+    let mut num_str = num.to_string();
+    let mut point = num_str.len() as i32 - scale - negative;
+
+    if point <= 0 {
+        while point < 0 {
+            num_str.insert(negative as usize, '0');
+            point += 1;
+        }
+        num_str.insert_str(negative as usize, "0.");
+    } else {
+        num_str.insert((point + negative) as usize, '.');
+    }
+
+    num_str
 }
 
 #[cfg(test)]
@@ -58,9 +534,169 @@ mod test {
     use super::*;
     use serde_json::json;
 
+    use super::parquet_gen::{
+        Codec, write_flat_parquet, write_int96_timestamp_parquet, write_rich_parquet,
+        write_timestamp_nanos_parquet,
+    };
+
     fn input_for_file(rel_path: impl AsRef<std::path::Path>) -> Input {
         let file = File::open(rel_path).expect("failed to open file");
         Input::File(file)
+    }
+
+    /// Reference output: the record-API path (`RowIter` + `to_json_value`) that
+    /// the parser used before the Arrow fast path existed.
+    fn record_reference(path: &std::path::Path) -> Vec<Value> {
+        let file = File::open(path).unwrap();
+        let reader = SerializedFileReader::try_from(file).unwrap();
+        reader
+            .into_iter()
+            .map(|r| r.expect("record row").to_json_value())
+            .collect()
+    }
+
+    /// Actual output: the full `ParquetParser`, which selects the Arrow path for
+    /// schemas cleared by `datatype_supported`.
+    fn parser_output(path: &std::path::Path) -> Vec<Value> {
+        let input = Input::File(File::open(path).unwrap());
+        ParquetParser
+            .parse(input)
+            .expect("parser output")
+            .map(|r| r.expect("parsed row"))
+            .collect()
+    }
+
+    /// Nanosecond (INT64) timestamps now decode via the Arrow fast path and must
+    /// match the record API, which — lacking a legacy converted type — renders
+    /// them as raw integers.
+    #[test]
+    fn nanosecond_timestamps_match_record_api() {
+        let dir = tempdir::TempDir::new("pq-nanos").unwrap();
+        let path = dir.path().join("nanos.parquet");
+        write_timestamp_nanos_parquet(&path, 1_000);
+
+        assert_uses_arrow_path(&path);
+        assert_eq!(
+            record_reference(&path),
+            parser_output(&path),
+            "nanosecond output must match the record API"
+        );
+
+        // The record API renders nanosecond timestamps as raw integers; confirm
+        // the Arrow path preserves that rather than formatting a string.
+        let ts = parser_output(&path)
+            .iter()
+            .find_map(|row| row.get("ts_nanos").filter(|v| !v.is_null()).cloned())
+            .expect("expected a non-null timestamp");
+        assert!(
+            ts.is_i64() || ts.is_u64(),
+            "nanosecond timestamp should be a raw integer, got {ts}"
+        );
+    }
+
+    /// Legacy INT96 timestamps now decode via the Arrow fast path. The record API
+    /// renders them as millisecond strings via `Int96::to_millis()`; the Arrow
+    /// path must reproduce that exactly, including for the pre-epoch sample.
+    #[test]
+    fn int96_timestamps_match_record_api() {
+        let dir = tempdir::TempDir::new("pq-int96").unwrap();
+        let path = dir.path().join("int96.parquet");
+        write_int96_timestamp_parquet(&path, 1_000);
+
+        assert_uses_arrow_path(&path);
+
+        let reference = record_reference(&path);
+        let actual = parser_output(&path);
+        assert_eq!(reference.len(), actual.len());
+        for (i, (r, a)) in reference.iter().zip(actual.iter()).enumerate() {
+            assert_eq!(r, a, "INT96 mismatch at row {i}\n  record: {r}\n  arrow:  {a}");
+        }
+
+        // Confirm we actually rendered a timestamp string (not an integer), and
+        // that the pre-epoch sample is present and correctly formatted.
+        let strings: Vec<&str> = actual
+            .iter()
+            .filter_map(|row| row.get("ts").and_then(|v| v.as_str()))
+            .collect();
+        assert!(
+            strings.iter().any(|s| s.starts_with("1969-12-31")),
+            "expected the pre-epoch INT96 sample to render as a 1969 timestamp"
+        );
+    }
+
+    /// The Arrow allow-list must still reject genuinely unsupported Arrow types,
+    /// routing them to the record fallback. Durations are not producible by the
+    /// parquet reader, but guard the decision directly.
+    #[test]
+    fn unsupported_datatype_is_rejected() {
+        assert!(!datatype_supported(&DataType::Duration(TimeUnit::Second)));
+        assert!(!datatype_supported(&DataType::Timestamp(TimeUnit::Second, None)));
+        assert!(!datatype_supported(&DataType::Struct(
+            vec![arrow_schema::Field::new(
+                "d",
+                DataType::Duration(TimeUnit::Second),
+                true,
+            )]
+            .into()
+        )));
+    }
+
+    fn assert_uses_arrow_path(path: &std::path::Path) {
+        let file = File::open(path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        assert!(
+            builder
+                .schema()
+                .fields()
+                .iter()
+                .all(|f| datatype_supported(f.data_type())),
+            "fixture schema must exercise the Arrow path, not the record fallback"
+        );
+    }
+
+    /// For every supported schema and compression codec, the Arrow path emits the
+    /// same JSON documents and the same serialized bytes as the record API.
+    #[test]
+    fn arrow_path_matches_record_api() {
+        let dir = tempdir::TempDir::new("pq-diff").unwrap();
+        let codecs = [Codec::Uncompressed, Codec::Snappy, Codec::Gzip, Codec::Zstd];
+
+        for codec in codecs {
+            for (name, writer) in [
+                (
+                    "rich",
+                    &write_rich_parquet as &dyn Fn(&std::path::Path, usize, usize, Codec),
+                ),
+                ("flat", &write_flat_parquet),
+            ] {
+                let path = dir.path().join(format!("{name}-{codec:?}.parquet"));
+                // Multiple row groups (rows_per_group < total) to exercise batch
+                // boundaries crossing row groups.
+                writer(&path, 5_000, 900, codec);
+
+                assert_uses_arrow_path(&path);
+
+                let reference = record_reference(&path);
+                let actual = parser_output(&path);
+
+                assert_eq!(
+                    reference.len(),
+                    actual.len(),
+                    "row count mismatch for {name}/{codec:?}"
+                );
+                for (i, (r, a)) in reference.iter().zip(actual.iter()).enumerate() {
+                    assert_eq!(
+                        r, a,
+                        "value mismatch at row {i} for {name}/{codec:?}\n  record: {r}\n  arrow:  {a}"
+                    );
+                    assert_eq!(
+                        serde_json::to_string(r).unwrap(),
+                        serde_json::to_string(a).unwrap(),
+                        "serialized mismatch at row {i} for {name}/{codec:?}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -102,74 +738,4 @@ mod test {
         // 50 total items
         assert_eq!(output.count(), 148);
     }
-
-    /* The tests below have been run on TLC Trip Record Data, January 2024
-       Yellow Taxi Trip Records and For-Hire Vehicle Trip Records
-       They have been commented due to the file sizes of these datasets
-       It is recommended to run these tests against these files when changing the behavior
-       of the parser
-       Specifically download the two files for January 2024 and uncomment these tests:
-       https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
-
-    #[test]
-    fn parse_sample_file_fhv() {
-        let input = input_for_file("tests/examples/fhv_tripdata.parquet");
-        let mut output = ParquetParser
-            .parse(input)
-            .expect("must return output iterator");
-
-        let first = output
-            .next()
-            .expect("expected a result")
-            .expect("must parse object Ok");
-        assert_eq!(json!({
-            "Affiliated_base_number": "B00014",
-            "DOlocationID": null,
-            "PUlocationID": null,
-            "SR_Flag": null,
-            "dispatching_base_num": "B00053",
-            "dropOff_datetime": "2024-01-01 02:13:00 +00:00",
-            "pickup_datetime": "2024-01-01 00:15:00 +00:00",
-        }), first);
-
-        // 50 total items
-        assert_eq!(output.count(), 1290115);
-    }
-
-    #[test]
-    fn parse_sample_file_yellow() {
-        let input = input_for_file("tests/examples/yellow_tripdata.parquet");
-        let mut output = ParquetParser
-            .parse(input)
-            .expect("must return output iterator");
-
-        let first = output
-            .next()
-            .expect("expected a result")
-            .expect("must parse object Ok");
-        assert_eq!(json!({
-            "Airport_fee": 0.0,
-            "DOLocationID": 79,
-            "PULocationID": 186,
-            "RatecodeID": 1,
-            "VendorID": 2,
-            "congestion_surcharge": 2.5,
-            "extra": 1.0,
-            "fare_amount": 17.7,
-            "improvement_surcharge": 1.0,
-            "mta_tax": 0.5,
-            "passenger_count": 1,
-            "payment_type": 2,
-            "store_and_fwd_flag": "N",
-            "tip_amount": 0.0,
-            "tolls_amount": 0.0,
-            "total_amount": 22.7,
-            "tpep_dropoff_datetime": "2024-01-01 01:17:43 +00:00",
-            "tpep_pickup_datetime": "2024-01-01 00:57:55 +00:00",
-            "trip_distance": 1.72
-        }), first);
-
-        // 50 total items
-        assert_eq!(output.count(), 2964623);
-    }*/
 }

--- a/crates/parser/src/format/parquet.rs
+++ b/crates/parser/src/format/parquet.rs
@@ -15,6 +15,10 @@
 //! Arrow types not on the [`datatype_supported`] allow-list fall back to the
 //! record API. No type the parquet reader produces today hits this path; it is a
 //! defensive backstop.
+//!
+//! The one intentional departure from the record API is the VARIANT logical type
+//! ([`variant_to_value`]): the record API emits base64 of the raw variant binary,
+//! while this decodes it to the JSON value it encodes.
 use super::{Input, Output, ParseError, Parser};
 use arrow_array::{
     Array, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array,
@@ -31,11 +35,14 @@ use base64::prelude::BASE64_STANDARD;
 use chrono::{TimeZone, Utc};
 use num_bigint::{BigInt, Sign};
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
-use parquet::basic::Type as PhysicalType;
+use parquet::basic::{LogicalType, Type as PhysicalType};
 use parquet::file::reader::SerializedFileReader;
 use parquet::record::reader::RowIter;
-use parquet::schema::types::SchemaDescriptor;
+use parquet::schema::types::{SchemaDescriptor, Type as SchemaType};
+use parquet_variant::Variant;
+use parquet_variant_json::VariantToJson;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -114,7 +121,7 @@ impl Iterator for RecordRowIter {
 struct ArrowRowIter {
     reader: ParquetRecordBatchReader,
     plans: Arc<Vec<ColPlan>>,
-    buffered: std::vec::IntoIter<Value>,
+    buffered: std::vec::IntoIter<Result<Value, ParseError>>,
 }
 
 impl ArrowRowIter {
@@ -132,8 +139,8 @@ impl Iterator for ArrowRowIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(value) = self.buffered.next() {
-                return Some(Ok(value));
+            if let Some(result) = self.buffered.next() {
+                return Some(result);
             }
             match self.reader.next()? {
                 Ok(batch) => self.buffered = convert_batch(&batch, &self.plans).into_iter(),
@@ -150,37 +157,84 @@ impl Iterator for ArrowRowIter {
 enum ColPlan {
     Leaf,
     Int96Millis,
+    /// An (unshredded) VARIANT group: decode `{metadata, value}` binary into the
+    /// JSON value it encodes. Unlike every other plan, this intentionally departs
+    /// from the record API, which cannot decode variant and emits base64 blobs.
+    Variant,
     Struct(Vec<ColPlan>),
     List(Box<ColPlan>),
     Map(Box<ColPlan>, Box<ColPlan>),
 }
 
-/// Walks the Arrow fields in lock-step with the parquet leaf columns, which
-/// enumerate in the same depth-first order.
+/// Walks the Arrow fields in lock-step with the parquet leaf columns (same
+/// depth-first order), and scans the parquet schema for VARIANT-annotated groups,
+/// which the Arrow schema shows as a plain struct.
 fn build_column_plans(schema: &arrow_schema::Schema, parquet: &SchemaDescriptor) -> Vec<ColPlan> {
+    let mut variant_paths = HashSet::new();
+    collect_variant_paths(parquet.root_schema(), "", &mut variant_paths);
+
     let mut leaves = parquet.columns().iter().map(|c| c.physical_type());
     schema
         .fields()
         .iter()
-        .map(|f| build_plan(f.data_type(), &mut leaves))
+        .map(|f| build_plan(f.data_type(), f.name(), &variant_paths, &mut leaves))
         .collect()
+}
+
+/// Records the dotted paths of every group annotated with the VARIANT logical
+/// type. Variant internals are not descended into.
+fn collect_variant_paths(group: &SchemaType, prefix: &str, out: &mut HashSet<String>) {
+    for field in group.get_fields() {
+        let path = if prefix.is_empty() {
+            field.name().to_string()
+        } else {
+            format!("{prefix}.{}", field.name())
+        };
+        if !field.is_group() {
+            continue;
+        }
+        if matches!(field.get_basic_info().logical_type(), Some(LogicalType::Variant)) {
+            out.insert(path);
+        } else {
+            collect_variant_paths(field, &path, out);
+        }
+    }
 }
 
 fn build_plan(
     data_type: &DataType,
+    path: &str,
+    variant_paths: &HashSet<String>,
     leaves: &mut impl Iterator<Item = PhysicalType>,
 ) -> ColPlan {
     match data_type {
-        DataType::Struct(fields) => {
-            ColPlan::Struct(fields.iter().map(|f| build_plan(f.data_type(), leaves)).collect())
+        // A VARIANT group reads as a `Struct{metadata, value}`. Detect it by the
+        // parquet annotation plus that exact unshredded shape; consume its two
+        // leaf columns to keep the leaf iterator aligned. Shredded variants (with
+        // a `typed_value`) are not yet handled and fall through to a plain struct.
+        DataType::Struct(fields)
+            if variant_paths.contains(path) && is_unshredded_variant(fields) =>
+        {
+            leaves.next();
+            leaves.next();
+            ColPlan::Variant
         }
-        DataType::List(field) | DataType::LargeList(field) => {
-            ColPlan::List(Box::new(build_plan(field.data_type(), leaves)))
-        }
+        DataType::Struct(fields) => ColPlan::Struct(
+            fields
+                .iter()
+                .map(|f| build_plan(f.data_type(), &child_path(path, f.name()), variant_paths, leaves))
+                .collect(),
+        ),
+        DataType::List(field) | DataType::LargeList(field) => ColPlan::List(Box::new(build_plan(
+            field.data_type(),
+            &child_path(path, field.name()),
+            variant_paths,
+            leaves,
+        ))),
         DataType::Map(entries, _) => match entries.data_type() {
             DataType::Struct(kv) if kv.len() == 2 => {
-                let key = build_plan(kv[0].data_type(), leaves);
-                let value = build_plan(kv[1].data_type(), leaves);
+                let key = build_plan(kv[0].data_type(), path, variant_paths, leaves);
+                let value = build_plan(kv[1].data_type(), path, variant_paths, leaves);
                 ColPlan::Map(Box::new(key), Box::new(value))
             }
             _ => {
@@ -200,9 +254,26 @@ fn build_plan(
     }
 }
 
+fn child_path(prefix: &str, name: &str) -> String {
+    format!("{prefix}.{name}")
+}
+
+/// The canonical unshredded VARIANT layout: exactly a `metadata` and a `value`
+/// binary field.
+fn is_unshredded_variant(fields: &arrow_schema::Fields) -> bool {
+    fields.len() == 2
+        && fields.iter().any(|f| f.name() == "metadata" && is_binary(f.data_type()))
+        && fields.iter().any(|f| f.name() == "value" && is_binary(f.data_type()))
+}
+
+fn is_binary(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Binary | DataType::LargeBinary | DataType::BinaryView)
+}
+
 /// Column order does not affect output: `serde_json` serializes object keys
-/// sorted.
-fn convert_batch(batch: &RecordBatch, plans: &[ColPlan]) -> Vec<Value> {
+/// sorted. A row failing to convert (only VARIANT can) becomes an `Err` in its
+/// slot, matching how the record path surfaces per-row errors.
+fn convert_batch(batch: &RecordBatch, plans: &[ColPlan]) -> Vec<Result<Value, ParseError>> {
     let schema = batch.schema();
     let columns = batch.columns();
     let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
@@ -210,26 +281,37 @@ fn convert_batch(batch: &RecordBatch, plans: &[ColPlan]) -> Vec<Value> {
     let mut rows = Vec::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {
         let mut object = serde_json::Map::with_capacity(columns.len());
+        let mut error = None;
         for ((name, column), plan) in names.iter().zip(columns.iter()).zip(plans.iter()) {
-            object.insert((*name).to_string(), array_to_value(column.as_ref(), row, plan));
+            match array_to_value(column.as_ref(), row, plan) {
+                Ok(value) => {
+                    object.insert((*name).to_string(), value);
+                }
+                Err(e) => {
+                    error = Some(e);
+                    break;
+                }
+            }
         }
-        rows.push(Value::Object(object));
+        rows.push(error.map_or_else(|| Ok(Value::Object(object)), Err));
     }
     rows
 }
 
-fn array_to_value(array: &dyn Array, row: usize, plan: &ColPlan) -> Value {
+fn array_to_value(array: &dyn Array, row: usize, plan: &ColPlan) -> Result<Value, ParseError> {
     if array.is_null(row) {
-        return Value::Null;
+        return Ok(Value::Null);
     }
 
     match plan {
-        ColPlan::Leaf => leaf_to_value(array, row),
+        ColPlan::Leaf => Ok(leaf_to_value(array, row)),
 
         ColPlan::Int96Millis => {
             let nanos = downcast::<TimestampNanosecondArray>(array).value(row);
-            Value::String(convert_timestamp_millis_to_string(int96_nanos_to_millis(nanos)))
+            Ok(Value::String(convert_timestamp_millis_to_string(int96_nanos_to_millis(nanos))))
         }
+
+        ColPlan::Variant => variant_to_value(array, row),
 
         ColPlan::Struct(child_plans) => {
             let structs = downcast::<StructArray>(array);
@@ -243,9 +325,9 @@ fn array_to_value(array: &dyn Array, row: usize, plan: &ColPlan) -> Value {
                 .zip(structs.columns().iter())
                 .zip(child_plans.iter())
             {
-                object.insert(field.name().clone(), array_to_value(column.as_ref(), row, child));
+                object.insert(field.name().clone(), array_to_value(column.as_ref(), row, child)?);
             }
-            Value::Object(object)
+            Ok(Value::Object(object))
         }
 
         ColPlan::List(child) => {
@@ -265,17 +347,48 @@ fn array_to_value(array: &dyn Array, row: usize, plan: &ColPlan) -> Value {
             let values = map.values();
             let mut object = serde_json::Map::with_capacity(end - start);
             for i in start..end {
-                let key = array_to_value(keys.as_ref(), i, key_plan);
+                let key = array_to_value(keys.as_ref(), i, key_plan)?;
                 // Match the record API: string keys are used verbatim, other
                 // key types fall back to their JSON string representation.
                 let key = key
                     .as_str()
                     .map(|s| s.to_owned())
                     .unwrap_or_else(|| key.to_string());
-                object.insert(key, array_to_value(values.as_ref(), i, value_plan));
+                object.insert(key, array_to_value(values.as_ref(), i, value_plan)?);
             }
-            Value::Object(object)
+            Ok(Value::Object(object))
         }
+    }
+}
+
+/// Decodes an unshredded VARIANT cell into the JSON value it encodes. This is
+/// the one conversion with no record-API equivalent: the record path emits
+/// base64 of the raw variant binary.
+fn variant_to_value(array: &dyn Array, row: usize) -> Result<Value, ParseError> {
+    let structs = downcast::<StructArray>(array);
+    let metadata = binary_field(structs, "metadata", row);
+    let value = binary_field(structs, "value", row);
+
+    let variant = Variant::try_new(metadata, value)?;
+    let mut buffer = Vec::new();
+    variant.to_json(&mut buffer)?;
+    Ok(serde_json::from_slice(&buffer)?)
+}
+
+/// The variant metadata/value fields are required, so a null is read as empty.
+fn binary_field<'a>(structs: &'a StructArray, name: &str, row: usize) -> &'a [u8] {
+    let column = structs
+        .column_by_name(name)
+        .expect("variant struct must have the named binary field");
+    if column.is_null(row) {
+        return &[];
+    }
+    let column = column.as_ref();
+    match column.data_type() {
+        DataType::Binary => downcast::<BinaryArray>(column).value(row),
+        DataType::LargeBinary => downcast::<LargeBinaryArray>(column).value(row),
+        DataType::BinaryView => downcast::<BinaryViewArray>(column).value(row),
+        other => unreachable!("variant {name} field is {other:?}, expected binary"),
     }
 }
 
@@ -371,12 +484,11 @@ fn leaf_to_value(array: &dyn Array, row: usize) -> Value {
     }
 }
 
-fn list_to_value(elements: &dyn Array, plan: &ColPlan) -> Value {
-    Value::Array(
-        (0..elements.len())
-            .map(|i| array_to_value(elements, i, plan))
-            .collect(),
-    )
+fn list_to_value(elements: &dyn Array, plan: &ColPlan) -> Result<Value, ParseError> {
+    let values = (0..elements.len())
+        .map(|i| array_to_value(elements, i, plan))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Value::Array(values))
 }
 
 const NANOS_IN_DAY: i64 = 24 * 60 * 60 * 1_000_000_000;
@@ -535,8 +647,8 @@ mod test {
     use serde_json::json;
 
     use super::parquet_gen::{
-        Codec, write_flat_parquet, write_int96_timestamp_parquet, write_rich_parquet,
-        write_timestamp_nanos_parquet,
+        Codec, VARIANT_JSON_SAMPLES, write_flat_parquet, write_int96_timestamp_parquet,
+        write_rich_parquet, write_timestamp_nanos_parquet, write_variant_parquet,
     };
 
     fn input_for_file(rel_path: impl AsRef<std::path::Path>) -> Input {
@@ -622,6 +734,35 @@ mod test {
             strings.iter().any(|s| s.starts_with("1969-12-31")),
             "expected the pre-epoch INT96 sample to render as a 1969 timestamp"
         );
+    }
+
+    /// VARIANT columns decode to the JSON they encode (a deliberate departure
+    /// from the record API, which emits base64 of the raw variant binary). This
+    /// is a golden round-trip: JSON -> variant -> parquet -> parser -> JSON.
+    #[test]
+    fn variant_decodes_to_json() {
+        let dir = tempdir::TempDir::new("pq-variant").unwrap();
+        let path = dir.path().join("variant.parquet");
+        let rows = 600;
+        write_variant_parquet(&path, rows);
+
+        // The variant group reads as Struct{metadata,value} of binary, which is
+        // Arrow-eligible, so this exercises the fast path.
+        assert_uses_arrow_path(&path);
+
+        let actual = parser_output(&path);
+        assert_eq!(actual.len(), rows);
+        for (i, row) in actual.iter().enumerate() {
+            let expected: Value =
+                serde_json::from_str(VARIANT_JSON_SAMPLES[i % VARIANT_JSON_SAMPLES.len()]).unwrap();
+            assert_eq!(
+                row.get("v"),
+                Some(&expected),
+                "variant row {i} should decode to its source JSON, got {row}"
+            );
+            // The id column still decodes normally alongside the variant.
+            assert_eq!(row.get("id"), Some(&Value::Number((i as i64).into())));
+        }
     }
 
     /// The Arrow allow-list must still reject genuinely unsupported Arrow types,

--- a/crates/parser/src/main.rs
+++ b/crates/parser/src/main.rs
@@ -33,11 +33,10 @@ pub struct ParseArgs {
     pub config_file: Option<String>,
 
     /// Path to a file with the data to parse. Defaults to '-', which represents stdin.
-    /// Passing a value other that '-' will default the filename in the config to the given file.
-    /// Some formats, like Excel files, can't really be parsed in a single pass. You need to be
-    /// able to seek around the file. This option enables those files to be passed as files, which
-    /// allows the parser to avoid duplicating the work of writing the stream to a temporary file.
-    /// Note that that's not actually implemented yet, but that's the intent of this option.
+    /// Passing a value other than '-' defaults the filename in the config to that path, and
+    /// opens the file directly as a seekable input rather than buffering stdin to a temporary
+    /// file. Seek-oriented formats (parquet, Excel) can then read footers and row groups
+    /// without a full pre-read.
     #[clap(long = "file", default_value = "-")]
     pub file: String,
 }

--- a/crates/parser/tests/file_input_test.rs
+++ b/crates/parser/tests/file_input_test.rs
@@ -1,0 +1,60 @@
+//! Reading a file via `--file` must produce the same output as piping the same
+//! bytes through stdin, across every format.
+
+mod testutil;
+
+use parser::ParseConfig;
+use testutil::{input_for_file, run_parser, run_parser_reading_file};
+
+/// `filename` is set in the config so both paths infer the same format.
+fn assert_file_matches_stream(path: &str) {
+    let config = ParseConfig {
+        filename: Some(path.to_string()),
+        ..Default::default()
+    };
+
+    let stream_result = run_parser(&config, input_for_file(path), false);
+    let file_result = run_parser_reading_file(&config, path, false);
+
+    assert_eq!(
+        stream_result.exit_code, 0,
+        "stream parse of {path} should succeed"
+    );
+    assert_eq!(
+        file_result.exit_code, 0,
+        "--file parse of {path} should succeed"
+    );
+    assert_eq!(
+        stream_result.raw_stdout, file_result.raw_stdout,
+        "--file output must match stdin output for {path}"
+    );
+    assert!(
+        !file_result.parsed.is_empty(),
+        "expected at least one record from {path}"
+    );
+}
+
+#[test]
+fn parquet_file_input_matches_stream() {
+    assert_file_matches_stream("tests/examples/iris.parquet");
+}
+
+#[test]
+fn csv_file_input_matches_stream() {
+    assert_file_matches_stream("tests/examples/valid-big-nums.csv");
+}
+
+#[test]
+fn json_file_input_matches_stream() {
+    assert_file_matches_stream("tests/examples/valid.json");
+}
+
+#[test]
+fn jsonl_file_input_matches_stream() {
+    assert_file_matches_stream("tests/examples/valid.jsonl");
+}
+
+#[test]
+fn avro_file_input_matches_stream() {
+    assert_file_matches_stream("tests/examples/valid-avro-snappy.avro");
+}

--- a/crates/parser/tests/parquet_gen.rs
+++ b/crates/parser/tests/parquet_gen.rs
@@ -15,11 +15,14 @@ use arrow_array::builder::{
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit};
 use parquet::arrow::ArrowWriter;
-use parquet::basic::Compression;
-use parquet::data_type::{Int64Type, Int96, Int96Type};
+use parquet::basic::{Compression, LogicalType, Repetition, Type as PhysicalType};
+use parquet::data_type::{ByteArray, ByteArrayType, Int64Type, Int96, Int96Type};
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::parser::parse_message_type;
+use parquet::schema::types::Type as SchemaType;
+use parquet_variant::VariantBuilder;
+use parquet_variant_json::JsonToVariant;
 
 /// Compression codec to apply to written row groups.
 #[derive(Debug, Clone, Copy)]
@@ -233,6 +236,86 @@ pub fn write_timestamp_nanos_parquet(path: &std::path::Path, total_rows: usize) 
     )
     .unwrap();
     writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// JSON documents encoded, one per row (cycled), into the VARIANT fixture.
+/// Covers objects, arrays, nesting, and scalars so the decode is exercised
+/// across variant value kinds.
+pub const VARIANT_JSON_SAMPLES: &[&str] = &[
+    r#"{"name":"acme","active":true,"count":3}"#,
+    r#"[1,2,3,"four",null]"#,
+    r#"{"nested":{"a":1,"b":[true,false]},"tags":["x","y"]}"#,
+    r#"42"#,
+    r#""just a string""#,
+    r#"{"mixed":[{"k":1},{"k":2}],"f":1.5,"n":null}"#,
+];
+
+/// Writes a parquet file whose `v` column is an unshredded VARIANT group
+/// (`required group v (VARIANT) { required binary metadata; required binary
+/// value }`), with values encoding [`VARIANT_JSON_SAMPLES`] in row order. Uses
+/// the low-level writer because arrow cannot emit VARIANT groups.
+pub fn write_variant_parquet(path: &std::path::Path, total_rows: usize) {
+    let metadata_field = SchemaType::primitive_type_builder("metadata", PhysicalType::BYTE_ARRAY)
+        .with_repetition(Repetition::REQUIRED)
+        .build()
+        .unwrap();
+    let value_field = SchemaType::primitive_type_builder("value", PhysicalType::BYTE_ARRAY)
+        .with_repetition(Repetition::REQUIRED)
+        .build()
+        .unwrap();
+    let variant_group = SchemaType::group_type_builder("v")
+        .with_repetition(Repetition::REQUIRED)
+        .with_logical_type(Some(LogicalType::Variant))
+        .with_fields(vec![Arc::new(metadata_field), Arc::new(value_field)])
+        .build()
+        .unwrap();
+    let id_field = SchemaType::primitive_type_builder("id", PhysicalType::INT64)
+        .with_repetition(Repetition::REQUIRED)
+        .build()
+        .unwrap();
+    let schema = Arc::new(
+        SchemaType::group_type_builder("schema")
+            .with_fields(vec![Arc::new(id_field), Arc::new(variant_group)])
+            .build()
+            .unwrap(),
+    );
+
+    // Encode each row's JSON sample into (metadata, value) variant buffers.
+    let mut metadatas = Vec::with_capacity(total_rows);
+    let mut values = Vec::with_capacity(total_rows);
+    for i in 0..total_rows {
+        let mut builder = VariantBuilder::new();
+        builder
+            .append_json(VARIANT_JSON_SAMPLES[i % VARIANT_JSON_SAMPLES.len()])
+            .unwrap();
+        let (metadata, value) = builder.finish();
+        metadatas.push(ByteArray::from(metadata));
+        values.push(ByteArray::from(value));
+    }
+    let ids: Vec<i64> = (0..total_rows as i64).collect();
+
+    let props = Arc::new(
+        WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build(),
+    );
+    let file = std::fs::File::create(path).expect("create fixture file");
+    let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
+    let mut rg = writer.next_row_group().unwrap();
+
+    // Leaf columns are written in order: id, v.metadata, v.value.
+    let mut col = rg.next_column().unwrap().unwrap();
+    col.typed::<Int64Type>().write_batch(&ids, None, None).unwrap();
+    col.close().unwrap();
+    let mut col = rg.next_column().unwrap().unwrap();
+    col.typed::<ByteArrayType>().write_batch(&metadatas, None, None).unwrap();
+    col.close().unwrap();
+    let mut col = rg.next_column().unwrap().unwrap();
+    col.typed::<ByteArrayType>().write_batch(&values, None, None).unwrap();
+    col.close().unwrap();
+
+    rg.close().unwrap();
     writer.close().unwrap();
 }
 

--- a/crates/parser/tests/parquet_gen.rs
+++ b/crates/parser/tests/parquet_gen.rs
@@ -1,0 +1,389 @@
+//! Generators for parquet test fixtures, written to caller-owned paths so
+//! nothing is checked into git.
+
+// Compiled both standalone and via `#[path]` include; not every generator is
+// used from every inclusion.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use arrow_array::builder::{
+    BooleanBuilder, Date32Builder, Decimal128Builder, Float64Builder, Int64Builder,
+    ListBuilder, StringBuilder, StructBuilder, TimestampMicrosecondBuilder,
+    TimestampNanosecondBuilder,
+};
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::data_type::{Int64Type, Int96, Int96Type};
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::parser::parse_message_type;
+
+/// Compression codec to apply to written row groups.
+#[derive(Debug, Clone, Copy)]
+pub enum Codec {
+    Uncompressed,
+    Snappy,
+    Gzip,
+    Zstd,
+}
+
+impl Codec {
+    fn to_parquet(self) -> Compression {
+        match self {
+            Codec::Uncompressed => Compression::UNCOMPRESSED,
+            Codec::Snappy => Compression::SNAPPY,
+            Codec::Gzip => Compression::GZIP(Default::default()),
+            Codec::Zstd => Compression::ZSTD(Default::default()),
+        }
+    }
+}
+
+/// Schema covering the edge cases the parser must handle identically:
+/// nullable primitives, logical types (timestamp/decimal/date), binary-free
+/// nesting (struct), and repeated fields (list).
+fn rich_schema() -> Arc<Schema> {
+    let nested_fields = Fields::from(vec![
+        Field::new("inner_int", DataType::Int64, true),
+        Field::new("inner_str", DataType::Utf8, true),
+    ]);
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("maybe_int", DataType::Int64, true),
+        Field::new("ratio", DataType::Float64, true),
+        Field::new("label", DataType::Utf8, true),
+        Field::new("flag", DataType::Boolean, true),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())),
+            true,
+        ),
+        Field::new("day", DataType::Date32, true),
+        Field::new("amount", DataType::Decimal128(20, 4), true),
+        Field::new("nested", DataType::Struct(nested_fields.clone()), true),
+        Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new("item", DataType::Int64, true))),
+            true,
+        ),
+    ]))
+}
+
+/// Builds a single record batch of `rows` rows following [`rich_schema`], with
+/// deterministic values and interspersed nulls so that repeated invocations
+/// produce identical bytes.
+fn rich_batch(schema: &Arc<Schema>, rows: usize, row_offset: usize) -> RecordBatch {
+    let mut id = Int64Builder::new();
+    let mut maybe_int = Int64Builder::new();
+    let mut ratio = Float64Builder::new();
+    let mut label = StringBuilder::new();
+    let mut flag = BooleanBuilder::new();
+    let mut ts = TimestampMicrosecondBuilder::new().with_timezone("+00:00");
+    let mut day = Date32Builder::new();
+    let mut amount = Decimal128Builder::new()
+        .with_precision_and_scale(20, 4)
+        .unwrap();
+
+    let nested_fields = match schema.field_with_name("nested").unwrap().data_type() {
+        DataType::Struct(f) => f.clone(),
+        _ => unreachable!(),
+    };
+    let mut nested = StructBuilder::new(
+        nested_fields,
+        vec![Box::new(Int64Builder::new()), Box::new(StringBuilder::new())],
+    );
+    let mut tags = ListBuilder::new(Int64Builder::new());
+
+    for i in row_offset..(row_offset + rows) {
+        id.append_value(i as i64);
+
+        // Every 7th row is null, to exercise definition levels.
+        if i % 7 == 0 {
+            maybe_int.append_null();
+        } else {
+            maybe_int.append_value((i as i64) * 3 - 1);
+        }
+
+        if i % 5 == 0 {
+            ratio.append_null();
+        } else {
+            ratio.append_value((i as f64) / 4.0);
+        }
+
+        if i % 3 == 0 {
+            label.append_null();
+        } else {
+            label.append_value(format!("row-{}", i));
+        }
+
+        flag.append_value(i % 2 == 0);
+
+        // 1_700_000_000 seconds is 2023-11-14T22:13:20Z; add per-row micros.
+        ts.append_value(1_700_000_000_000_000 + (i as i64) * 1_000_000);
+
+        // Days since epoch; ~2021-05 onward.
+        day.append_value(18_800 + (i as i32 % 900));
+
+        if i % 11 == 0 {
+            amount.append_null();
+        } else {
+            // Scale 4: store value * 10_000.
+            amount.append_value((i as i128) * 12_345 + 6_789);
+        }
+
+        let nested_int = nested
+            .field_builder::<Int64Builder>(0)
+            .unwrap();
+        if i % 4 == 0 {
+            nested_int.append_null();
+        } else {
+            nested_int.append_value((i as i64) + 100);
+        }
+        let nested_str = nested.field_builder::<StringBuilder>(1).unwrap();
+        nested_str.append_value(format!("n{}", i % 13));
+        // Whole struct is null every 9th row.
+        nested.append(i % 9 != 0);
+
+        if i % 6 == 0 {
+            tags.append_null();
+        } else {
+            let values = tags.values();
+            for k in 0..(i % 4) {
+                values.append_value((i * 10 + k) as i64);
+            }
+            tags.append(true);
+        }
+    }
+
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(id.finish()),
+        Arc::new(maybe_int.finish()),
+        Arc::new(ratio.finish()),
+        Arc::new(label.finish()),
+        Arc::new(flag.finish()),
+        Arc::new(ts.finish()),
+        Arc::new(day.finish()),
+        Arc::new(amount.finish()),
+        Arc::new(nested.finish()),
+        Arc::new(tags.finish()),
+    ];
+    RecordBatch::try_new(schema.clone(), arrays).unwrap()
+}
+
+/// Writes a parquet file with the rich edge-case schema to `path`, split into
+/// row groups of `rows_per_group` and compressed with `codec`.
+pub fn write_rich_parquet(
+    path: &std::path::Path,
+    total_rows: usize,
+    rows_per_group: usize,
+    codec: Codec,
+) {
+    let schema = rich_schema();
+    let props = WriterProperties::builder()
+        .set_compression(codec.to_parquet())
+        .set_max_row_group_size(rows_per_group)
+        .build();
+
+    let file = std::fs::File::create(path).expect("create fixture file");
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+
+    let mut written = 0;
+    while written < total_rows {
+        let n = rows_per_group.min(total_rows - written);
+        let batch = rich_batch(&schema, n, written);
+        writer.write(&batch).unwrap();
+        written += n;
+    }
+    writer.close().unwrap();
+}
+
+/// Writes a nanosecond-precision timestamp column. These have no legacy
+/// converted type, so the record API renders them as raw integers.
+pub fn write_timestamp_nanos_parquet(path: &std::path::Path, total_rows: usize) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new(
+            "ts_nanos",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
+            true,
+        ),
+    ]));
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+
+    let file = std::fs::File::create(path).expect("create fixture file");
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+
+    let mut id = Int64Builder::new();
+    let mut ts = TimestampNanosecondBuilder::new().with_timezone("+00:00");
+    for i in 0..total_rows {
+        id.append_value(i as i64);
+        if i % 4 == 0 {
+            ts.append_null();
+        } else {
+            ts.append_value(1_700_000_000_000_000_000 + (i as i64) * 1_000_000_000);
+        }
+    }
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id.finish()), Arc::new(ts.finish())],
+    )
+    .unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// Matches `parquet::data_type`'s JULIAN_DAY_OF_EPOCH.
+const JULIAN_DAY_OF_EPOCH: i64 = 2_440_588;
+
+fn int96_from(days_since_epoch: i64, nanos_of_day: i64) -> Int96 {
+    let julian = (days_since_epoch + JULIAN_DAY_OF_EPOCH) as u64;
+    let nanos = nanos_of_day as u64;
+    let mut v = Int96::new();
+    // value = [nanos_of_day low 32, nanos_of_day high 32, julian day].
+    v.set_data(
+        (nanos & 0xFFFF_FFFF) as u32,
+        (nanos >> 32) as u32,
+        julian as u32,
+    );
+    v
+}
+
+/// Writes a parquet file with a legacy INT96 timestamp column using the
+/// low-level writer (arrow cannot emit INT96). Values deliberately include a
+/// pre-epoch date and sub-millisecond components to exercise the negative-day
+/// and truncation edges of the INT96 -> millisecond reconstruction.
+pub fn write_int96_timestamp_parquet(path: &std::path::Path, total_rows: usize) {
+    let message_type = "
+        message schema {
+            REQUIRED INT64 id;
+            OPTIONAL INT96 ts;
+        }
+    ";
+    let schema = Arc::new(parse_message_type(message_type).unwrap());
+    let props = Arc::new(
+        WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build(),
+    );
+    let file = std::fs::File::create(path).expect("create fixture file");
+    let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
+
+    // (days since epoch, nanoseconds within the day). Covers epoch, pre-epoch,
+    // and assorted sub-second values.
+    let samples: [(i64, i64); 5] = [
+        (19_675, 12 * 3_600 * 1_000_000_000), // 2023-11-14 12:00:00
+        (0, 0),                               // 1970-01-01 00:00:00
+        (-1, 500_000),                        // 1969-12-31 00:00:00.0005ms
+        (-365, 3_600 * 1_000_000_000),        // ~1969-01-01 01:00:00
+        (100, 123_456_789),                   // 1970-04-11 00:00:00.123456789
+    ];
+
+    let mut rg = writer.next_row_group().unwrap();
+
+    // Column 0: id (REQUIRED INT64).
+    let mut col = rg.next_column().unwrap().unwrap();
+    let ids: Vec<i64> = (0..total_rows as i64).collect();
+    col.typed::<Int64Type>().write_batch(&ids, None, None).unwrap();
+    col.close().unwrap();
+
+    // Column 1: ts (OPTIONAL INT96) with every 5th value null.
+    let mut col = rg.next_column().unwrap().unwrap();
+    let mut values = Vec::new();
+    let mut def_levels = Vec::with_capacity(total_rows);
+    for i in 0..total_rows {
+        if i % 5 == 0 {
+            def_levels.push(0);
+        } else {
+            def_levels.push(1);
+            let (days, nanos) = samples[i % samples.len()];
+            values.push(int96_from(days, nanos));
+        }
+    }
+    col.typed::<Int96Type>()
+        .write_batch(&values, Some(&def_levels), None)
+        .unwrap();
+    col.close().unwrap();
+
+    rg.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Writes a simple wide-ish numeric/string parquet suitable for throughput
+/// benchmarking: no nested types, so per-row conversion cost dominates.
+pub fn write_flat_parquet(
+    path: &std::path::Path,
+    total_rows: usize,
+    rows_per_group: usize,
+    codec: Codec,
+) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, false),
+        Field::new("b", DataType::Int64, true),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Utf8, true),
+        Field::new("e", DataType::Boolean, false),
+        Field::new(
+            "f",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())),
+            true,
+        ),
+    ]));
+    let props = WriterProperties::builder()
+        .set_compression(codec.to_parquet())
+        .set_max_row_group_size(rows_per_group)
+        .build();
+
+    let file = std::fs::File::create(path).expect("create fixture file");
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+
+    let mut written = 0;
+    while written < total_rows {
+        let n = rows_per_group.min(total_rows - written);
+
+        let mut a = Int64Builder::new();
+        let mut b = Int64Builder::new();
+        let mut c = Float64Builder::new();
+        let mut d = StringBuilder::new();
+        let mut e = BooleanBuilder::new();
+        let mut f = TimestampMicrosecondBuilder::new().with_timezone("+00:00");
+        for i in written..(written + n) {
+            a.append_value(i as i64);
+            if i % 8 == 0 {
+                b.append_null();
+            } else {
+                b.append_value((i as i64) << 1);
+            }
+            if i % 5 == 0 {
+                c.append_null();
+            } else {
+                c.append_value((i as f64) * 1.5);
+            }
+            if i % 3 == 0 {
+                d.append_null();
+            } else {
+                d.append_value(format!("val-{}", i));
+            }
+            e.append_value(i % 2 == 0);
+            f.append_value(1_700_000_000_000_000 + (i as i64) * 250_000);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(a.finish()),
+                Arc::new(b.finish()),
+                Arc::new(c.finish()),
+                Arc::new(d.finish()),
+                Arc::new(e.finish()),
+                Arc::new(f.finish()),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        written += n;
+    }
+    writer.close().unwrap();
+}

--- a/crates/parser/tests/testutil.rs
+++ b/crates/parser/tests/testutil.rs
@@ -51,6 +51,64 @@ pub fn run_test(config: &ParseConfig, input: Input) -> CommandResult {
     return run_parser(config, input, true);
 }
 
+/// Runs the parser CLI reading its data from `file_path` via `--file` rather than
+/// piping bytes through stdin.
+pub fn run_parser_reading_file(config: &ParseConfig, file_path: &str, debug: bool) -> CommandResult {
+    use std::io::BufRead;
+    use std::process::{Command, Stdio};
+
+    let tmp = TempDir::new("jsonl-parser-test").unwrap();
+    let cfg_path = tmp.path().join("config.json");
+    let mut cfg_file = File::create(&cfg_path).unwrap();
+    serde_json::to_writer_pretty(&mut cfg_file, config).expect("failed to write config");
+    std::mem::drop(cfg_file);
+
+    let debug_env = if debug {
+        vec![("PARSER_LOG", "parser=debug")]
+    } else {
+        vec![]
+    };
+
+    let output = Command::cargo_bin("flow-parser")
+        .expect("to find flow-parser binary")
+        .args(&[
+            "parse",
+            "--config-file",
+            cfg_path.to_str().unwrap(),
+            "--file",
+            file_path,
+        ])
+        .stdin(Stdio::null())
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .envs(debug_env)
+        .output()
+        .expect("failed to run parser process");
+
+    let exit_code = output.status.code().unwrap_or_else(|| {
+        println!("child process exited abnormally: {:?}", output.status);
+        -1
+    });
+    let mut parsed = Vec::new();
+    for line in output.stdout.lines() {
+        parsed.push(
+            serde_json::from_str(&line.unwrap()).expect("failed to deserialize parser output"),
+        );
+    }
+    let raw_stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if debug {
+        println!("parser stderr:\n{}", stderr);
+    }
+
+    CommandResult {
+        parsed,
+        exit_code,
+        raw_stdout,
+    }
+}
+
 pub fn run_parser(config: &ParseConfig, input: Input, debug: bool) -> CommandResult {
     use std::io::BufRead;
     use std::process::{Command, Stdio};

--- a/go/parser/run.go
+++ b/go/parser/run.go
@@ -15,6 +15,9 @@ import (
 const ProgramName = "flow-parser"
 
 // ParseStream invokes the parser using the given config file and Reader of data to parse.
+// The data is piped to the parser via stdin. This is the right choice for streaming formats
+// (CSV/JSON/NDJSON), where parsing can overlap with an in-flight download.
+//
 // The callback is called as JSON documents are emitted by the parser, and receives
 // batches of documents in JSON format. Each record includes a single trailing newline.
 // The data provided to the callback is from a shared buffer, and must not be retained after the
@@ -31,17 +34,50 @@ func ParseStream(
 	input io.Reader,
 	callback func(lines []json.RawMessage) error,
 ) error {
+	return runParser(ctx, configPath, input, "", callback)
+}
+
+// ParseFile invokes the parser against an already-local, seekable file at inputPath, passed
+// via the parser's `--file` flag rather than piped through stdin. This lets seek-oriented
+// formats (parquet, Excel) read footers and row groups by random access instead of buffering
+// the whole input to a temporary file. Prefer it whenever the input is already on local disk.
+//
+// The callback contract matches ParseStream.
+func ParseFile(
+	ctx context.Context,
+	configPath string,
+	inputPath string,
+	callback func(lines []json.RawMessage) error,
+) error {
+	return runParser(ctx, configPath, nil, inputPath, callback)
+}
+
+// runParser executes flow-parser and dispatches its stdout to callback. Exactly one of input
+// (piped to stdin) or inputPath (passed via --file) supplies the data; inputPath takes
+// precedence when non-empty.
+func runParser(
+	ctx context.Context,
+	configPath string,
+	input io.Reader,
+	inputPath string,
+	callback func(lines []json.RawMessage) error,
+) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var cmd = exec.CommandContext(ctx, ProgramName, "parse", "--config-file", configPath)
 	var stdoutErr error
 
+	if inputPath != "" {
+		cmd.Args = append(cmd.Args, "--file", inputPath)
+	} else {
+		cmd.Stdin = input
+	}
+
 	if log.IsLevelEnabled(log.DebugLevel) {
 		cmd.Args = append(cmd.Args, "--log", "debug")
 	}
 
-	cmd.Stdin = input
 	cmd.Stdout = &parserStdout{
 		onLines: callback,
 		onError: func(err error) {


### PR DESCRIPTION
## Stacked on #3151

This is stacked on top of #3151 ("parser: columnar Arrow decode for parquet, and --file input"). Both target `master`, so until #3151 merges this PR's diff includes that commit too — **review only the top commit here, and merge after #3151.**

## What

Recognizes the Parquet VARIANT logical type — which arrow-rs reads as a plain `Struct{metadata, value}` of binary — and decodes the variant binary into the JSON value it encodes, via the experimental `parquet-variant` / `parquet-variant-json` crates.

- Detection scans the parquet schema for VARIANT-annotated groups; the unshredded `{metadata, value}` shape becomes a `ColPlan::Variant`.
- The converter is now fallible, so a malformed variant surfaces as a parse error rather than a panic. Non-variant files are unaffected (throughput unchanged; the record-API equality test still passes).

## Intentional behavior change

Unlike the rest of the parser, this departs from the record API, which cannot decode variant and emits base64 of the raw binary. Downstream would now see structured JSON where it previously saw an opaque `{metadata, value}` struct. Verified by a golden round-trip test (JSON → variant → parquet → parser → JSON) over objects, arrays, nesting, and scalars.

## Scope / caveats

- Unshredded variant only; shredded variants (`typed_value`) and variants nested inside list/map are not detected yet and fall back to the base64 rendering.
- Pulls experimental `0.1.0` crates into the shipped binary.

Draft — this is a validation spike. Opening for discussion on whether variant support is wanted before hardening (feature-gate, shredded support, direct Variant→Value without the JSON text round-trip).
