### PR TITLE
dekaf: prevent cached `TimeoutNoData` fetch responses from incorrectly signaling EOF

### DIFF
--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -35,6 +35,40 @@ struct PendingRead {
     handle: tokio_util::task::AbortOnDropHandle<anyhow::Result<(Read, BatchResult)>>,
 }
 
+/// Resolve a current, non-regressing high watermark for a Fetch response.
+async fn resolve_high_watermark(
+    auth: &SessionAuthentication,
+    collection_name: &str,
+    partition_index: usize,
+    expected_leader_epoch: i32,
+    observed_high_watermark: i64,
+) -> anyhow::Result<i64> {
+    let collection = match Collection::new(auth, collection_name).await?.ready() {
+        Ok(collection) => collection,
+        Err(reason) => bail!(
+            "cannot refresh Fetch high watermark for unavailable collection {}: {reason:?}",
+            collection_name
+        ),
+    };
+    anyhow::ensure!(
+        collection.binding_backfill_counter as i32 == expected_leader_epoch,
+        "leader epoch changed while refreshing Fetch high watermark"
+    );
+
+    let current_high_watermark = collection
+        .fetch_partition_offset(partition_index, -1)
+        .await?
+        .with_context(|| {
+            format!(
+                "partition {} of collection {} disappeared",
+                partition_index, collection_name
+            )
+        })?
+        .offset;
+
+    Ok(observed_high_watermark.max(current_high_watermark))
+}
+
 #[derive(Clone, Debug)]
 enum SessionDataPreviewState {
     Unknown,
@@ -1122,9 +1156,18 @@ impl Session {
                             ),
                         ));
 
+                        let response_high_watermark = resolve_high_watermark(
+                            self.auth.as_ref().unwrap(),
+                            key.0.as_str(),
+                            partition_request.partition as usize,
+                            pending.leader_epoch,
+                            pending.last_write_head,
+                        )
+                        .await?;
+
                         partition_data = partition_data
-                            .with_high_watermark(pending.last_write_head)
-                            .with_last_stable_offset(pending.last_write_head)
+                            .with_high_watermark(response_high_watermark)
+                            .with_last_stable_offset(response_high_watermark)
                             .with_current_leader(
                                 messages::fetch_response::LeaderIdAndEpoch::default()
                                     .with_leader_id(messages::BrokerId(1))

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -1156,14 +1156,37 @@ impl Session {
                             ),
                         ));
 
-                        let response_high_watermark = resolve_high_watermark(
+                        let response_high_watermark = match resolve_high_watermark(
                             self.auth.as_ref().unwrap(),
                             key.0.as_str(),
                             partition_request.partition as usize,
                             pending.leader_epoch,
                             pending.last_write_head,
                         )
-                        .await?;
+                        .await
+                        {
+                            Ok(high_watermark) => high_watermark,
+                            Err(error) => {
+                                let error_code = if Self::is_redirect_error(&error) {
+                                    ResponseError::NotLeaderOrFollower.code()
+                                } else {
+                                    ResponseError::OffsetNotAvailable.code()
+                                };
+                                tracing::warn!(
+                                    ?error,
+                                    collection = key.0.as_str(),
+                                    partition = partition_request.partition,
+                                    "failed to refresh Fetch high watermark"
+                                );
+                                partition_responses.push(
+                                    PartitionData::default()
+                                        .with_partition_index(partition_request.partition)
+                                        .with_error_code(error_code),
+                                );
+                                self.reads.remove(&key);
+                                continue;
+                            }
+                        };
 
                         partition_data = partition_data
                             .with_high_watermark(response_high_watermark)

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -10,6 +10,7 @@ mod empty_fetch;
 mod list_offsets;
 mod migration;
 mod not_ready;
+mod partition_eofs;
 
 pub use harness::{
     ConnectionInfo, DekafTestEnv, cluster_name, cluster_name_2, connection_info_for_dataplane,

--- a/crates/dekaf/tests/e2e/partition_eofs.rs
+++ b/crates/dekaf/tests/e2e/partition_eofs.rs
@@ -1,0 +1,95 @@
+use super::DekafTestEnv;
+use rdkafka::Message;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::error::KafkaError;
+use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
+use serde_json::json;
+use std::time::Duration;
+
+const FIXTURE: &str = include_str!("fixtures/basic.flow.yaml");
+const TOPIC: &str = "test_topic";
+const PARTITION: i32 = 0;
+
+/// librdkafka must not report partition EOF when a newer high watermark is visible.
+///
+/// Dekaf caches an empty speculative read with the old high watermark. After
+/// ListOffsets observes new data, fetching again at the old watermark must
+/// return that data rather than surface the cached response as `PARTITION_EOF`.
+#[tokio::test]
+async fn test_librdkafka_does_not_report_eof_for_cached_timeout() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("librdkafka_cached_eof", FIXTURE).await?;
+    env.inject_documents("data", vec![json!({"id": "before"})])
+        .await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let consumer: StreamConsumer = rdkafka::ClientConfig::new()
+        .set("bootstrap.servers", &info.broker)
+        .set("security.protocol", "SASL_PLAINTEXT")
+        .set("sasl.mechanism", "PLAIN")
+        .set("sasl.username", &info.username)
+        .set("sasl.password", &token)
+        .set("group.id", format!("test-{}", uuid::Uuid::new_v4()))
+        .set("enable.auto.commit", "false")
+        .set("enable.partition.eof", "true")
+        .set("fetch.wait.max.ms", "100")
+        .create()?;
+
+    let (_, high) = consumer.fetch_watermarks(TOPIC, PARTITION, Duration::from_secs(10))?;
+    let mut assignment = TopicPartitionList::new();
+    assignment.add_partition_offset(TOPIC, PARTITION, Offset::Offset(high))?;
+    consumer.assign(&assignment)?;
+
+    // Establish librdkafka's EOF state and start Dekaf's next speculative read,
+    // then pause before librdkafka can consume that read's response.
+    match tokio::time::timeout(Duration::from_secs(10), consumer.recv()).await {
+        Ok(Err(KafkaError::PartitionEOF(partition))) if partition == PARTITION => {}
+        Ok(event) => anyhow::bail!("expected initial EOF at offset {high}, got {event:?}"),
+        Err(_) => anyhow::bail!("timed out waiting for initial EOF at offset {high}"),
+    }
+    consumer.pause(&assignment)?;
+
+    // Dekaf's already-started read uses fetch.wait.max.ms as its timeout.
+    // Once it expires, TimeoutNoData remains cached on this connection.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    env.inject_documents("data", vec![json!({"id": "after"})])
+        .await?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(45);
+    let new_high = loop {
+        let (_, latest) = consumer.fetch_watermarks(TOPIC, PARTITION, Duration::from_secs(10))?;
+        if latest > high {
+            break latest;
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for librdkafka to observe a watermark above {high}"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    };
+
+    // Reassignment resets librdkafka's EOF suppression. The cached response
+    // must not cause a new EOF now that ListOffsets proved the partition grew.
+    consumer.assign(&assignment)?;
+    consumer.resume(&assignment)?;
+    match tokio::time::timeout(Duration::from_secs(10), consumer.recv()).await {
+        Ok(Ok(message)) => assert!(
+            message.offset() >= high,
+            "expected a record at or after batch start {high}, got offset {}",
+            message.offset()
+        ),
+        Ok(Err(KafkaError::PartitionEOF(partition))) if partition == PARTITION => {
+            anyhow::bail!(
+                "librdkafka reported PARTITION_EOF at {high} after its watermark API observed {new_high}"
+            )
+        }
+        Ok(event) => anyhow::bail!("expected a record after offset {high}, got {event:?}"),
+        Err(_) => anyhow::bail!(
+            "timed out waiting for data after watermark advanced from {high} to {new_high}"
+        ),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Dekaf starts the next journal read immediately after serving a Fetch response, caching its result to reduce latency on the next Fetch.

If that read reaches `max_wait_ms` without data, Dekaf caches `TimeoutNoData` along with the then-current write head. This creates the following sequence:

1. A consumer reads through the current partition end.
2. Dekaf’s read-ahead caches `TimeoutNoData` and the old write head.
3. New data arrives.
4. ListOffsets observes the new partition end.
5. The consumer fetches from the old end.
6. Dekaf returns the cached empty response with `high_watermark == fetch_offset`.

That final response unintentionally signals partition EOF. `librdkafka` makes this decision directly from each Fetch response when its high watermark equals the current fetch position, it does not consult the newer watermark previously returned by ListOffsets: 

https://github.com/confluentinc/librdkafka/blob/c024ac13daf98667de2b8724986e97f489644c15/src/rdkafka_fetcher.c#L702-L708

The e2e test reproduced the incorrect signal directly through librdkafka:

> librdkafka reported PARTITION_EOF at 418 after its watermark API observed 835

This change refreshes the partition's write head before returning cached `TimeoutNoData` or `Suspended` results. The response stamps both the high watermark and last stable offset with the newer of the cached and live values. The response may still contain no records, but its indicated high watermark now tells librdkafka that more data exists, so it retries instead of reporting EOF. The existing read-ahead optimization and cached record-bearing responses remain unchanged.