### PR TITLE
runtime: fix recursive read-lock deadlock in capture-v2 buildJoin

### DIFF
--- a/go/runtime/capture_v2.go
+++ b/go/runtime/capture_v2.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
-	"github.com/estuary/flow/go/labels"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
@@ -130,7 +129,7 @@ func (c *captureAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.En
 
 	// Build Join from this current shard topology, and send.
 	var join *pr.Join
-	if join, err = c.buildJoin(shard); err != nil {
+	if join, err = c.buildJoin(); err != nil {
 		return fmt.Errorf("building Join: %w", err)
 	}
 	_ = c.client.Send(&pr.Capture{Join: join})
@@ -228,27 +227,30 @@ func (c *captureAppV2) Coordinator() *shuffle.Coordinator {
 	panic("runtime-v2: Coordinator unreachable")
 }
 
-func (c *captureAppV2) buildJoin(shard consumer.Shard) (*pr.Join, error) {
+func (c *captureAppV2) buildJoin() (*pr.Join, error) {
+	// Use the term's already-captured ShardSpec and labeling rather than
+	// shard.Spec(). Gazette's shard.Spec() re-acquires State.KS.Mu for read,
+	// and since it aliases the lock we hold below, a recursive read-lock under
+	// a queued Etcd writer would deadlock (Go blocks new readers once a writer
+	// waits). c.term is a coherent topology snapshot, so this is also correct.
+	var shardSpec = c.term.shardSpec
+
 	var ks = c.host.service.State.KS
 	ks.Mu.RLock()
 	defer ks.Mu.RUnlock()
 
 	var state = c.host.service.State
 	var rev = ks.Header.Revision
-	var asn, createRev, ok = primaryAssignment(state, shard.Spec().Id)
+	var asn, createRev, ok = primaryAssignment(state, shardSpec.Id)
 	if !ok {
-		return nil, fmt.Errorf("local shard %s does not have a PRIMARY assignment", shard.Spec().Id)
-	}
-	var labeling, err = labels.ParseShardLabels(shard.Spec().LabelSet)
-	if err != nil {
-		return nil, fmt.Errorf("parsing labels for %s: %w", shard.Spec().Id, err)
+		return nil, fmt.Errorf("local shard %s does not have a PRIMARY assignment", shardSpec.Id)
 	}
 
 	return &pr.Join{
 		EtcdModRevision: rev,
 		Shards: []*pr.Join_Shard{{
-			Id:                 shard.Spec().Id.String(),
-			Labeling:           &labeling,
+			Id:                 shardSpec.Id.String(),
+			Labeling:           &c.term.labels,
 			Reactor:            &pb.ProcessSpec_ID{Zone: asn.MemberZone, Suffix: asn.MemberSuffix},
 			EtcdCreateRevision: createRev,
 		}},


### PR DESCRIPTION
## Summary

Fixes a recursive read-lock deadlock in the V2 capture runtime, traced from a production goroutine dump (`reactor005`) where tens of thousands of goroutines were parked on `KS.Mu` read-lock acquisition.

`captureAppV2.buildJoin` held `KS.Mu.RLock` and then called `shard.Spec()` several times. Gazette's `shard.Spec()` re-acquires `s.resolved.RLock`, which **aliases the same `KS.Mu`**. When the Etcd watcher's `KeySpace.Apply` writer queued between the outer and recursive read locks, `sync.RWMutex` — which blocks new readers once a writer is waiting — deadlocked:

- the recursive `shard.Spec()` `RLock` could not proceed past the queued writer, while
- the writer could not proceed until the outer `RLock` released, which only happens when `buildJoin` returns.

That stalled the keyspace lock for every subsequent reader (`ShardList`, `Resolver.Resolve`, metrics, shuffle reads, …), amplified by proxy goroutines waiting on `ShardList` RPCs.

## Fix

Read from the term's already-captured `c.term.shardSpec` and `c.term.labels` instead of calling `shard.Spec()` under the lock. This mirrors `buildLeaderfulJoin` (already used by the derive and materialize V2 paths) and is also more correct: the term is a coherent topology snapshot rather than a possibly-newer spec read mid-session. The now-unused `shard` parameter and `go/labels` import are dropped.

The derive and materialize V2 paths do **not** have this bug — they already route through `buildLeaderfulJoin`, which uses the term-captured spec and never calls `shard.Spec()` inside its lock region.

## Test plan

- [x] `go build -tags libsqlite3 ./go/runtime/`