### PR TITLE
control-plane-api: retry Stripe customer search on index-lag misses

### DIFF
--- a/crates/control-plane-api/src/billing/stripe_impl.rs
+++ b/crates/control-plane-api/src/billing/stripe_impl.rs
@@ -43,6 +43,36 @@ impl BillingProvider for StripeBillingProvider {
         .await
     }
 
+    /// Stripe's customer-search index is eventually consistent and can even be
+    /// non-monotonic: a customer that matched a moment ago may transiently drop
+    /// out of a later search. Every caller of `require_customer` (setting or
+    /// deleting a payment method) only reaches it after a SetupIntent has
+    /// already created the customer, so a search miss is virtually always index
+    /// lag rather than a true absence. Retry a bounded number of times with
+    /// exponential backoff before surfacing the error, overriding the trait's
+    /// single-shot default.
+    async fn require_customer(&self, tenant: &str) -> anyhow::Result<stripe::Customer> {
+        const MAX_ATTEMPTS: u32 = 6;
+        const MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+
+        let mut delay = std::time::Duration::from_millis(500);
+        for attempt in 1..=MAX_ATTEMPTS {
+            if let Some(customer) = self.find_customer(tenant).await? {
+                return Ok(customer);
+            }
+            if attempt < MAX_ATTEMPTS {
+                tracing::debug!(
+                    tenant,
+                    attempt,
+                    "Stripe customer search missed; retrying after index lag"
+                );
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_DELAY);
+            }
+        }
+        anyhow::bail!("no Stripe customer exists for tenant '{tenant}'")
+    }
+
     async fn create_customer(
         &self,
         tenant: &str,


### PR DESCRIPTION
## Problem

The **Stripe integration test** step of the Platform Test CI job flakes frequently. Every recent failure I pulled shares one identical error — the mutations abort with `no Stripe customer exists for tenant`:

| Run | Assertion |
|-----|-----------|
| [29248258820](https://github.com/estuary/flow/actions/runs/29248258820) | `card_a should be set as primary` |
| [29223924809](https://github.com/estuary/flow/actions/runs/29223924809) | `card_a should be set as primary` |
| [29126176839](https://github.com/estuary/flow/actions/runs/29126176839) | `card_b should become primary…` |
| [29113243430](https://github.com/estuary/flow/actions/runs/29113243430) | `card_a should be set as primary` |

## Root cause

`setBillingPaymentMethod` / `deleteBillingPaymentMethod` resolve the customer via `require_customer` → `find_customer` → Stripe's **customer search API**. That index is eventually consistent *and non-monotonic*: a customer that matched a moment earlier can transiently drop out of a later query. The test proves it — `wait_for_customer_searchable` succeeds (cards attach to the returned `customer.id`), yet the mutation's search seconds later misses. A single miss aborts the whole mutation.

This is also a real production fragility, not just a test artifact: a live user whose customer exists but is momentarily absent from search would hit the same spurious error.

## Fix

Override `require_customer` in `StripeBillingProvider` with bounded retry-on-miss + exponential backoff (6 attempts, capped at 3s, ~9.5s worst case). Every caller only reaches it *after* a SetupIntent created the customer, so a miss is virtually always index lag. The trait's single-shot default still applies to the in-memory mock, keeping unit tests instant and deterministic.

## On splitting the step into a parallel CI job

Considered and recommend against a fully separate job: the test runs in ~20s but needs the compiled test binary + RocksDB + musl/gnu toolchains + a running Supabase — a standalone job would repeat that multi-minute build for a 20s test. Inline it reuses everything Platform Test already built. The real pain was the flake failing the required job, which this fix addresses at the root. If further isolation is still wanted, the cheap options are moving the step to the end of the job (today it runs before doctest/gotest/catalog-test and cancels them on failure) and/or marking it `continue-on-error`.

## Testing

Verified via compile + code-path review. The live Stripe path can't be exercised locally without a testmode key; it'll get its real workout on CI.