### PR TITLE
local: make flow-plane-link robust to control-plane agent start-up

### DIFF
--- a/local/systemd/flow-plane-link@.service
+++ b/local/systemd/flow-plane-link@.service
@@ -11,12 +11,15 @@ RemainAfterExit=yes
 # Load instance-specific environment with data plane configuration
 EnvironmentFile=%h/flow-local/env/plane-link-%i.env
 
-# NOTE(johnny): Created publication races start-up of the reactor.
-ExecStartPre=sleep 2
-
 # Call control-plane API to register the data plane
 # Use printf to build JSON and avoid shell quoting complexities
 # DEKAF_ADDRESS and DEKAF_REGISTRY_ADDRESS are optional; if not set, omit them from the payload
+#
+# The curl --retry flags wait out control-plane agent start-up: --retry-connrefused
+# re-issues while the agent isn't listening yet, and --retry covers transient 5xx
+# during warm-up, bounded to 120s of 2s-spaced attempts. The agent binds its API
+# port only once it can serve (crates/agent/src/main.rs), so a connection being
+# accepted means ready; a non-transient 4xx still fails fast with its body.
 ExecStart=/bin/bash -c ' \
     if [ -n "${DEKAF_ADDRESS:-}" ] && [ -n "${DEKAF_REGISTRY_ADDRESS:-}" ]; then \
         printf "{\\"name\\":\\"%%s\\",\\"category\\":{\\"manual\\":{\\"brokerAddress\\":\\"%%s\\",\\"reactorAddress\\":\\"%%s\\",\\"hmacKeys\\":[\\"%%s\\"],\\"dekafAddress\\":\\"%%s\\",\\"dekafRegistryAddress\\":\\"%%s\\"}}}" \
@@ -29,6 +32,10 @@ ExecStart=/bin/bash -c ' \
         -X POST \
         -H "content-type: application/json" \
         -H "authorization: bearer ${SYSTEM_USER_TOKEN}" \
+        --retry 60 \
+        --retry-connrefused \
+        --retry-delay 2 \
+        --retry-max-time 120 \
         --fail-with-body \
         --data-binary @- \
         ${AGENT_API}/admin/create-data-plane \
@@ -42,6 +49,10 @@ ExecStart=/bin/bash -c ' \
         -X POST \
         -H "content-type: application/json" \
         -H "authorization: bearer ${SYSTEM_USER_TOKEN}" \
+        --retry 60 \
+        --retry-connrefused \
+        --retry-delay 2 \
+        --retry-max-time 120 \
         --fail-with-body \
         --data-binary @- \
         ${AGENT_API}/admin/update-l2-reporting \


### PR DESCRIPTION
## Problem

On a fresh `mise run local:stack`, `flow-plane-link` (a `Type=oneshot` unit that
curls the control-plane agent's admin API to register the data plane) gated on a
fixed `ExecStartPre=sleep 2`. That raced agent start-up: if the agent wasn't
listening within 2s, the first curl failed → the oneshot failed → `systemctl
start` returned non-zero to the `set -e` stack script, which then **aborted
before publishing the `local-view` ops catalog**. That catalog contains
`ops.us-central1.v1/stats-view`, the materialization that writes the
control-plane `inferred_schemas` table, so schema inference silently never
worked. `Restart=on-failure` retried the unit to success afterward, so the data
plane looked healthy while the ops materialization was just missing — easy to
misattribute.

## Fix

Drop the `sleep 2` and make the admin curls wait out agent start-up directly:

```
--retry 60 --retry-connrefused --retry-delay 2 --retry-max-time 120
```

- `--retry-connrefused` re-issues the request while the agent isn't listening yet
  (the actual race).
- `--retry` also covers a transient 5xx during warm-up.
- `--retry-max-time 120` bounds the wait to 120s of 2s-spaced attempts; a
  non-transient 4xx still fails fast with its body.

The agent binds its API port only once its DB pool is connected and it can serve
(`crates/agent/src/main.rs`), so a connection being accepted is a genuine
readiness signal. Retrying the real request (rather than probing a separate
readiness endpoint) keeps it to one mechanism.

The request body is piped via `--data-binary @-`; verified curl sends it intact
across a connection-refused retry (stdin isn't consumed until a connection
succeeds) and re-sends it on a post-connect 5xx retry.

## Verification

A fresh `mise run local:stack`:
- reaches the `local-view` publish and comes up;
- `flow-plane-link` succeeds first-try (`Result=success`, `NRestarts=0`), both
  admin POSTs return `200`;
- the `--retry-connrefused` path is exercised in the unit's journal;
- `ops.us-central1.v1/stats-view` is live, `inferred_schemas` populates, and the
  `tests/soak/` SQL suite passes (`SUM(balance)=0`, zero oracle mismatches, no
  negative-id sentinels).