### PR TITLE
gazette: surface fragment store diagnostic on FRAGMENT_STORE_UNHEALTHY

### DIFF
--- a/crates/gazette/src/journal/append.rs
+++ b/crates/gazette/src/journal/append.rs
@@ -118,11 +118,18 @@ impl Client {
         let mut resp = result?.into_inner();
 
         if resp.status() == broker::Status::Ok {
-            Ok(resp)
-        } else {
-            req.header = resp.header.take();
-            Err(Error::BrokerStatus(resp.status()))
+            return Ok(resp);
         }
+        req.header = resp.header.take();
+
+        // A refused append carries the failing store's diagnostic in
+        // `store_health_error`; surface it rather than the bare status.
+        if resp.status() == broker::Status::FragmentStoreUnhealthy {
+            return Err(Error::FragmentStoreUnhealthy(std::mem::take(
+                &mut resp.store_health_error,
+            )));
+        }
+        Err(Error::BrokerStatus(resp.status()))
     }
 }
 

--- a/crates/gazette/src/journal/mod.rs
+++ b/crates/gazette/src/journal/mod.rs
@@ -160,6 +160,12 @@ impl Client {
             .map_err(crate::Error::Grpc)?
             .into_inner();
 
+        // Surface the store's own diagnostic, which `check_ok` would discard.
+        if resp.status() == broker::Status::FragmentStoreUnhealthy {
+            return Err(crate::Error::FragmentStoreUnhealthy(
+                resp.store_health_error,
+            ));
+        }
         check_ok(resp.status(), resp)
     }
 

--- a/crates/gazette/src/lib.rs
+++ b/crates/gazette/src/lib.rs
@@ -23,6 +23,8 @@ pub enum Error {
     BearerToken(#[source] tonic::metadata::errors::InvalidMetadataValue),
     #[error("unexpected broker status: {0:?}")]
     BrokerStatus(broker::Status),
+    #[error("fragment store is unhealthy: {0}")]
+    FragmentStoreUnhealthy(String),
     #[error("unexpected consumer status: {0:?}")]
     ConsumerStatus(consumer::Status),
     #[error("failed to parse document at journal offset range {location:?}")]
@@ -130,6 +132,10 @@ impl Error {
                 // All other errors are not transient (callers may special case).
                 _ => false,
             },
+
+            // The store has failed its health check for an extended period;
+            // this is a persistent operator-level condition, not transient.
+            Error::FragmentStoreUnhealthy(_) => false,
 
             Error::AppendRead(_) => false,
             Error::BearerToken(_) => false,


### PR DESCRIPTION
## Problem

The broker's `AppendResponse` and `FragmentStoreHealthResponse` both carry a `store_health_error` string — the actual diagnostic from the failing fragment store — populated when the status is `FRAGMENT_STORE_UNHEALTHY`. But the `gazette` crate collapsed every non-OK status into `Error::BrokerStatus(status)`, which holds only the enum value. The response (and its `store_health_error`) was discarded, so upstack callers saw only the generic `"unexpected broker status: FragmentStoreUnhealthy"`.

## Fix

- Add a dedicated `Error::FragmentStoreUnhealthy(String)` variant (Display: `"fragment store is unhealthy: {0}"`). A new variant, rather than a field on `BrokerStatus`, avoids churning the ~15 call sites that pattern-match `BrokerStatus(broker::Status::X)` as a tuple.
- Classify it as non-transient in `is_transient()`, matching prior behavior (the status means the store has failed its health check for an extended period).
- The two response types carrying `store_health_error` (append and `fragment_store_health`) now special-case `FRAGMENT_STORE_UNHEALTHY` and move that string into the new error before the response is dropped.

## Bonus

This also fixes the `storage_mappings.rs` GraphQL health-check consumer. Its existing `Ok(Err(err)) => Some(err.to_string())` arm previously produced the useless generic status string; it now surfaces the store's real diagnostic.

Retry semantics are unchanged: the append `Stream` still retries on its own loop regardless of `is_transient()`.

`cargo check` passes for `gazette` and dependent crates (`publisher`, `shuffle`, `dekaf`, `control-plane-api`, `migrate`); `cargo fmt` applied.