### PR TITLE
runtime: let docker atomically assign published connector host ports

### DIFF
--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -154,19 +154,15 @@ pub async fn start<L: crate::Logger>(
     // When running locally, we publish ports so that connectors are accessible
     // on the host from Windows and MacOS (e.x. Docker Desktop).
     if matches!(plane, crate::Plane::Local) {
-        // Bind a random port, and then check what port was given to us.
-        let l = tokio::net::TcpListener::bind("0.0.0.0:0")
-            .await
-            .context("failed to bind random port")?;
-        let port = l.local_addr()?.port();
-        std::mem::drop(l); // Release so it can be re-bound.
-
         docker_args.append(&mut vec![
             // Support Docker Desktop in non-production contexts (for example, `flowctl`)
             // where the container IP is not directly addressable. As an alternative,
             // we ask Docker to provide mapped host ports that are then advertised
             // in the attached runtime::Container description.
-            format!("--publish=0.0.0.0:{port}:{CONNECTOR_INIT_PORT}"),
+            // An empty host port asks Docker to assign a free ephemeral port as
+            // the container starts. Unlike probing for a free port ourselves,
+            // this cannot race host-port allocations of other starting containers.
+            format!("--publish=0.0.0.0::{CONNECTOR_INIT_PORT}"),
             "--publish-all".to_string(),
         ]);
     }

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -144,19 +144,15 @@ pub async fn start(
     // When running locally, we publish ports so that connectors are accessible
     // on the host from Windows and MacOS (e.x. Docker Desktop).
     if matches!(plane, crate::Plane::Local) {
-        // Bind a random port, and then check what port was given to us.
-        let l = tokio::net::TcpListener::bind("0.0.0.0:0")
-            .await
-            .context("failed to bind random port")?;
-        let port = l.local_addr()?.port();
-        std::mem::drop(l); // Release so it can be re-bound.
-
         docker_args.append(&mut vec![
             // Support Docker Desktop in non-production contexts (for example, `flowctl`)
             // where the container IP is not directly addressable. As an alternative,
             // we ask Docker to provide mapped host ports that are then advertised
             // in the attached runtime::Container description.
-            format!("--publish=0.0.0.0:{port}:{CONNECTOR_INIT_PORT}"),
+            // An empty host port asks Docker to assign a free ephemeral port as
+            // the container starts. Unlike probing for a free port ourselves,
+            // this cannot race host-port allocations of other starting containers.
+            format!("--publish=0.0.0.0::{CONNECTOR_INIT_PORT}"),
             "--publish-all".to_string(),
         ]);
     }


### PR DESCRIPTION
## Description

Fixes the CI flake in #3161: `catalog-test` failing with

```
resetting internal state between test cases: rpc error: ... shard
derivation/examples/citi-bike/rides/ffffffffffffffff/55555555-00000000 !OK status SHARD_STOPPED
```

The `SHARD_STOPPED` is only the messenger. Earlier in the failing run, the shard's connector container failed to launch:

```
docker: ... Bind for 0.0.0.0:40077 failed: port is already allocated
servePrimary failed: completeRecovery: store.RestoreCheckpoint: failed to inspect a started docker container (did it crash?)
```

`container::start()` probed for a free host port by binding and immediately releasing a listener, then asking docker to publish that port — a TOCTOU race. `flowctl-go test` activates tasks with 3 initial splits, so ~40 containers start concurrently, each probing ports while docker's `--publish-all` also allocates ephemeral host ports. Occasionally one steals another's probed port before docker binds it. The `docker run` fails, shard recovery fails, and the shard stays stopped for the life of the temporary data-plane, so the next `ResetState` between test cases is fatal.

The fix: publish with an empty host port (`--publish=0.0.0.0::49092`); docker picks a free ephemeral port atomically as it starts the container, which cannot race other containers' allocations. The mapping was already discovered post-startup via `docker inspect`, so nothing needed the port ahead of time. Applied to both `runtime` and its `runtime-next` fork.

## Workflow steps

No user-facing changes; connector containers in local planes now use docker-assigned published ports (as `--publish-all` ports already were).

## Documentation links affected

None.

## Notes for reviewers

Verified locally against both container runtimes:
- docker: `cargo test -p runtime -p runtime-next --lib container::` passes, including the live `test_http_ingest_spec` which starts a real container and asserts the 49092 mapping is discovered.
- podman 4.9.3: `--publish=0.0.0.0::49092` auto-assigns the host port and reports it through `.NetworkSettings.Ports` with the empty `HostIp` that `inspect_container_network` already special-cases; `test_http_ingest_spec` passes in both crates with `DOCKER_CLI=podman`.


This change is [Reviewable](https://reviewable.io/reviews/estuary/flow)