### PR TITLE
mise: remove Lima VM host share and other VM tweaks

### DIFF
--- a/mise/README.md
+++ b/mise/README.md
@@ -52,11 +52,14 @@ source ~/.zshrc
 
 Choose based on your needs:
 
+Both VM types clone Flow using your forwarded SSH agent. Ensure a key is loaded
+before creating either VM (for example, `ssh-add ~/.ssh/id_ed25519`). Private
+keys remain on the host.
+
 **[Lima](https://lima-vm.io/) VM** (local, uses host resources):
 
 ```bash
-# Share a parent directory of your checkout (NOT your home directory)
-mise run vm:create-lima tiger ~/work
+mise run vm:create-lima tiger
 ```
 
 **GCP VM** (remote, more hardware available):
@@ -76,14 +79,15 @@ GCP VMs have an idle timer that automatically shuts down the instance when no SS
 **Lima:**
 
 ```bash
-cd ~/work/path/to/shared/repo
 limactl shell tiger
+cd ~/estuary/flow
 
 # Or use SSH directly. Note the lima- prefix when using `ssh`.
 ssh lima-tiger
 ```
 
-Note: Lima VMs use `/<vm-name>` as the home directory (e.g., `/tiger`) to avoid ambiguity with the host share, which is typically under `/home/<user>` or `/Users/<user>`.
+The repository is cloned onto the Lima VM's disk during creation. SSH agent
+forwarding allows the VM to authenticate to GitHub without copying private keys.
 
 **GCP:**
 
@@ -343,7 +347,7 @@ mise tasks
 
 | Task                                   | Description                                             |
 | -------------------------------------- | ------------------------------------------------------- |
-| `vm:create-lima <name> <share_dir>`    | Create a Lima VM                                        |
+| `vm:create-lima <name>`                | Create a Lima VM                                        |
 | `vm:create-gcp <project>`              | Create a GCP VM                                         |
 | `vm:port-forward <hostname>`           | Forward ports from VM to host                           |
 | `vm:claude <vm_name>`                  | Copy Claude Code token into VM                          |

--- a/mise/tasks/bootstrap/ide-settings
+++ b/mise/tasks/bootstrap/ide-settings
@@ -32,7 +32,7 @@ cat > ${VSCODE_SETTINGS} << EOF
     // runnables.extraEnv is the env for tests RUN from the gutter, so it must
     // carry the per-stack runtime vars the tests read (FLOW_PG_URL, FLOW_CLUSTER,
     // FLOW_PORT_BIGTABLE, FLOW_STACK_NAME) and GOBIN/PATH for binaries the tests
-    // shell out to (flowctl-go, gazette), matching what `mise run` provides.
+    // shell out to (flowctl-go, gazette), matching the mise task environment.
     "rust-analyzer.runnables.extraEnv": {
         "CARGO_TARGET_DIR": "${CARGO_TARGET_DIR}",
         "GOBIN": "${GOBIN}",

--- a/mise/tasks/vm/create-gcp
+++ b/mise/tasks/vm/create-gcp
@@ -35,13 +35,14 @@ gcloud compute instances create ${INSTANCE_NAME} \
   --project ${usage_project:?} \
   --zone ${usage_zone:?} \
   --machine-type ${usage_machine_type:?} \
+  --enable-nested-virtualization \
   --image-family ${usage_image_family:?} \
   --image-project ubuntu-os-cloud \
   --network-interface subnet=default \
   --metadata ssh-keys="${SSH_KEYS}" \
   --tags dev-vm \
-  --labels dev-vm=true,owner=${USERNAME} \
-  --boot-disk-size 128GB \
+  --labels dev-vm=true,owner=${USERNAME},drataexclude=test-equipment \
+  --boot-disk-size 256GB \
   --boot-disk-type hyperdisk-balanced \
 
 # Add additional ssh configuration if not already present.
@@ -94,32 +95,13 @@ if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
   exit 1
 fi
 
-ssh ${INSTANCE_NAME} <<EOF
-# Install mise.
-curl -v https://mise.run | sh
-EOF
+# Copy GCP-only idle shutdown files before the shared bootstrap runs create-post.
+ssh ${INSTANCE_NAME} mkdir -p /tmp/idle-shutdown
+scp mise/tasks/vm/files/idle-shutdown.* ${INSTANCE_NAME}:/tmp/idle-shutdown/
 
-# Copy idle shutdown files to VM.
-scp -r mise/tasks/vm/files ${INSTANCE_NAME}:/tmp/idle-shutdown
-
-# Use a second shell, so that mise is now on the PATH.
-ssh ${INSTANCE_NAME} <<EOF
-mkdir -p ~/estuary
-pushd ~/estuary
-
-# Check out the flow repository.
-GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-git clone git@github.com:estuary/flow.git
-pushd flow
-
-# Attempt to switch to the host's current branch.
-# Don't fail if it doesn't exist (use the primary branch instead).
-git checkout $(git branch --show-current) || true
-
-# Boostrap the VM environment.
-~/.local/bin/mise trust .
-~/.local/bin/mise run vm:create-post
-EOF
+# Install and bootstrap Flow using the host's forwarded SSH agent.
+ssh ${INSTANCE_NAME} bash -s \
+  < mise/tasks/vm/files/bootstrap-flow.sh
 
 # Tear down the mux so the next connection picks up new group memberships.
 ssh -O exit ${INSTANCE_NAME} 2>/dev/null || true

--- a/mise/tasks/vm/create-lima
+++ b/mise/tasks/vm/create-lima
@@ -1,44 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#MISE description="Create an Lima VM with a shared host directory"
+#MISE description="Create a Lima development VM"
 #USAGE arg "<name>" help="The name of the VM to create"
-#USAGE arg "<share_dir>" help="The directory to share with the VM. Cannot be your home directory (for security reasons)."
 #USAGE flag "--cpu <cpu>" help="Number of CPUs to allocate to the VM. Defaults to all host CPUs."
-#USAGE flag "--memory <memory>" help="Amount of memory (in GiB) to allocate to the VM. Defaults to 12GB of memory."
+#USAGE flag "--memory <memory>" help="Amount of memory (in GiB) to allocate to the VM. Defaults to 16GB of memory."
 
-[[ $# -lt 2 ]] && { echo "Error: VM name and share directory are required"; exit 1; }
+[[ $# -lt 1 ]] && { echo "Error: VM name is required"; exit 1; }
 
 VM_NAME="${usage_name}"
 shift
-SHARE_DIR="${usage_share_dir}"
-shift
 
-# Determine the parent directory of this git checkout.
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-# Convert SHARE_DIR to absolute path.
-SHARE_DIR="$(realpath "${SHARE_DIR}")"
 
-# Ensure REPO_DIR is a subdirectory of SHARE_DIR.
-if [[ "${REPO_DIR}" != "${SHARE_DIR}"* ]]; then
-    cat << EOF
-Error: The shared directory must be a parent directory of the MISE installation
-(at: ${REPO_DIR}), so that the VM can access MISE tasks and resources.
-EOF
-    exit 1
-fi
-
-# Ensure SHARE_DIR isn't the user's home directory.
-if [[ "${SHARE_DIR}" == "${HOME}" ]]; then
-    cat << EOF
-Error: Sharing your home directory is not allowed, as this exposes any production
-credentials of your host to the VM, and VMs are intended to be fully isolated
-environments with no ambient authorizations (other than those explicitly provided).
-
-Recommendation: create a dedicated "work" directory under your home directory
-which contains all of your working checkouts and files, and share it instead.
-EOF
-    exit 1
+# Bootstrapping the repository requires the host's SSH identity.
+if ! ssh-add -L &>/dev/null; then
+  echo "ERROR: No SSH keys found in ssh-agent." >&2
+  echo "Please run 'ssh-add' to add your keys before creating a VM." >&2
+  echo "" >&2
+  echo "Example: ssh-add ~/.ssh/id_ed25519" >&2
+  exit 1
 fi
 
 # Detect OS and set defaults from host resources
@@ -51,6 +32,7 @@ elif [[ "$(uname)" == "Linux" ]]; then
 else
     echo "Unsupported OS: $(uname)"; exit 1
 fi
+MEMORY="${usage_memory:-16}"
 
 # make sure .ssh/config exists before we check to see if it needs modification
 if [[ -f ~/.ssh/config ]]; then
@@ -76,7 +58,6 @@ Include ~/.lima/*/ssh.config
 EOF
 fi
 
-# Create VM share directory
 TEMP_CONFIG=$(mktemp /tmp/lima-config-yaml-XXXXXX)
 
 # Generate config
@@ -84,10 +65,9 @@ cat > "${TEMP_CONFIG}" << EOF
 # Lima VM configuration for: ${VM_NAME}
 # Generated on: $(date) at ${TEMP_CONFIG}.
 
-# We use base template:_images/ubuntu-24.04 to bypass template:_default/mounts,
-# which mounts the entire home directory. We don't want this behavior
-# as we explicitly mount the desired share directory (only).
-base: [template:_images/ubuntu-24.04]
+# The public Ubuntu template includes Lima's default read-only host-home mount.
+# --mount-none below removes all mounts so the VM owns its development files.
+base: [template:ubuntu-24.04]
 EOF
 
 # Add OS-specific config
@@ -123,50 +103,38 @@ fi
 
 # Add common config
 cat >> "${TEMP_CONFIG}" << EOF
+# Return AAAA records to the guest. Actual IPv6 connectivity depends on the
+# selected Lima network and the host having a working IPv6 route.
 hostResolver:
   ipv6: true
 
 cpus: ${CPU}
-memory: 12GiB
+memory: ${MEMORY}GiB
 disk: 128GiB
 
 ssh:
-  forwardAgent: false
+  forwardAgent: true
 
 upgradePackages: true
-mountInotify: true
-
-user:
-  home: /${VM_NAME}
-  shell: /bin/bash
 
 containerd:
   # Turn off automatic installation of nerdctl.
   user: false
-
-mountType: virtiofs
-mounts:
-  - location: "${SHARE_DIR}"
-    writable: true
-
-provision:
-  - mode: user
-    script: ${REPO_DIR}/mise/install.sh
-  - mode: user
-    script: |
-      cd ${REPO_DIR}
-      /${VM_NAME}/.local/bin/mise trust
-      /${VM_NAME}/.local/bin/mise run vm:create-post
 EOF
 
-# Create the VM.
-limactl create --name=${VM_NAME} "${TEMP_CONFIG}"
+# Create the VM without the public template's default host-home mount.
+limactl create --tty=false --mount-none --name="${VM_NAME}" "${TEMP_CONFIG}"
 rm -f "${TEMP_CONFIG}"
 
 # Start the VM.
-limactl start ${VM_NAME}
-# Restart the user's session to reload groups.
-limactl shell ${VM_NAME} -- loginctl terminate-user ${USER} || true
+limactl start "${VM_NAME}"
+
+# Run the shared guest bootstrap from a session that has the host's SSH agent.
+limactl shell "${VM_NAME}" -- bash -s \
+  < "${REPO_DIR}/mise/tasks/vm/files/bootstrap-flow.sh"
+
+# Reconnect so subsequent shells pick up the groups added by create-post.
+limactl shell --reconnect "${VM_NAME}" -- true
 
 echo ""
 echo "VM created successfully!"

--- a/mise/tasks/vm/create-post
+++ b/mise/tasks/vm/create-post
@@ -4,12 +4,13 @@ set -euo pipefail
 #MISE hide=true
 
 mise run bootstrap:apt-packages-ci-base
-mise install
-mise run bootstrap:ide-settings
 
 # Back ~/cargo-target with a compressed, self-deduplicating btrfs filesystem
 # before anything builds into it (see mise/tasks/bootstrap/cargo-target-fs).
 mise run bootstrap:cargo-target-fs
+
+mise install
+mise run bootstrap:ide-settings
 
 rustup default stable
 

--- a/mise/tasks/vm/files/bootstrap-flow.sh
+++ b/mise/tasks/vm/files/bootstrap-flow.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep credentials on the host: callers provide an SSH session with agent
+# forwarding, and this command uses it only while cloning the repository.
+curl https://mise.run | sh
+export PATH="${HOME}/.local/bin:${PATH}"
+mkdir -p "${HOME}/estuary"
+cd "${HOME}/estuary"
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+  git clone git@github.com:estuary/flow.git
+cd flow
+
+mise trust
+mise run vm:create-post


### PR DESCRIPTION
Lima VMs now check out the flow repo to their VM-internal disk. This plays better with git worktrees: git gets confused when operating on volumes shared from the Mac host.

Also fix:
* A mis-ordering which prevented the ~/cargo-target btrfs mount from being created correctly
* A session restart issue with Lima impacting groups (docker) on first boot
* Add drata exclusions for GCP dev VMs
* Use a larger GCP disk
* Enable nested virtualization
