### PR TITLE
control-plane-api: don't lock injected ops collections during publications

### DIFF
--- a/crates/agent/src/integration_tests/locking_retries.rs
+++ b/crates/agent/src/integration_tests/locking_retries.rs
@@ -1,4 +1,4 @@
-use models::{CatalogType, Id};
+use models::{Capability, CatalogType, Id};
 use uuid::Uuid;
 
 use crate::{
@@ -371,15 +371,18 @@ async fn test_injected_ops_collections_are_not_locked() {
     .expect("failed to update ops storage mapping");
 
     let ops_names = control_plane_api::publications::specs::get_ops_collection_names();
-    let mut ops_collections = serde_json::Map::new();
-    for name in ops_names.iter() {
-        ops_collections.insert(name.clone(), minimal_collection(None));
-    }
+    let ops_draft = |collection: serde_json::Value| {
+        let collections = ops_names
+            .iter()
+            .map(|name| (name.clone(), collection.clone()))
+            .collect::<serde_json::Map<_, _>>();
+        draft_catalog(serde_json::json!({ "collections": collections }))
+    };
     let result = harness
         .user_publication(
             ops_user,
             "create ops collections",
-            draft_catalog(serde_json::json!({ "collections": ops_collections })),
+            ops_draft(minimal_collection(None)),
         )
         .await;
     assert!(
@@ -430,28 +433,14 @@ async fn test_injected_ops_collections_are_not_locked() {
     }
 
     // Bump the ops collections' `last_pub_id` while the owls build is still uncommitted.
-    // The schema change ensures this is a real model change and not a no-op publication.
-    let mut ops_collections = serde_json::Map::new();
-    for name in ops_names.iter() {
-        ops_collections.insert(
-            name.clone(),
-            serde_json::json!({
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "id": { "type": "string" },
-                        "note": { "type": "string" }
-                    }
-                },
-                "key": ["/id"]
-            }),
-        );
-    }
+    // The added property ensures this is a real model change and not a no-op publication.
+    let mut changed_collection = minimal_collection(None);
+    changed_collection["schema"]["properties"]["note"] = serde_json::json!({ "type": "string" });
     let result = harness
         .user_publication(
             ops_user,
             "republish ops collections",
-            draft_catalog(serde_json::json!({ "collections": ops_collections })),
+            ops_draft(changed_collection),
         )
         .await;
     assert!(
@@ -478,6 +467,80 @@ async fn test_injected_ops_collections_are_not_locked() {
         "expected owls commit to succeed, got: {:?}",
         result.status
     );
+
+    // In contrast, an ops collection which is a genuine dependency of a drafted spec
+    // must still be revision-checked. Publish a derivation reading an ops collection,
+    // bump the ops collections again before it commits, and expect a lock failure for
+    // the read collection, and only that one: the other ops collection is merely
+    // injected and remains skipped.
+    harness
+        .add_role_grant("owls/", "ops.us-central1.v1/", Capability::Read)
+        .await;
+    let reader_draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "owls/ops-report": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                "key": ["/id"],
+                "derive": {
+                    "using": { "sqlite": { "migrations": [] } },
+                    "transforms": [{
+                        "name": "fromLogs",
+                        "source": "ops.us-central1.v1/logs",
+                        "lambda": "select $id;",
+                        "shuffle": "any"
+                    }]
+                }
+            }
+        }
+    }));
+    let reader_build = harness
+        .publisher
+        .build(
+            user_id,
+            Id::new([22; 8]),
+            Some("ops reader pub".to_string()),
+            reader_draft,
+            Uuid::new_v4(),
+            None,
+            true,
+            0,
+        )
+        .await
+        .expect("reader build failed");
+    assert!(!reader_build.has_errors());
+
+    let result = harness
+        .user_publication(
+            ops_user,
+            "revert ops collections",
+            ops_draft(minimal_collection(None)),
+        )
+        .await;
+    assert!(
+        result.status.is_success(),
+        "reverting ops collections failed: {:?}",
+        result.status
+    );
+    let reverted_ops_pub = ops_last_pub_id(&mut harness, &ops_names).await;
+
+    let result = harness
+        .publisher
+        .commit(reader_build, &NoopWithCommit)
+        .await
+        .expect("reader commit failed");
+    assert_lock_failures(
+        &[(
+            "ops.us-central1.v1/logs",
+            republished_ops_pub,
+            Some(reverted_ops_pub),
+        )],
+        &result.status,
+    );
 }
 
 async fn ops_last_pub_id(
@@ -489,17 +552,12 @@ async fn ops_last_pub_id(
         .get_live_specs(ops_names.clone())
         .await
         .expect("failed to fetch ops live specs");
-    let pub_ids = live
-        .collections
-        .iter()
-        .map(|r| r.last_pub_id)
-        .collect::<std::collections::BTreeSet<_>>();
-    assert_eq!(
-        1,
-        pub_ids.len(),
-        "expected all ops collections to share one last_pub_id, got {pub_ids:?}"
-    );
-    pub_ids.into_iter().next().unwrap()
+    // The ops collections are always published together in this test, so any row's
+    // `last_pub_id` is representative.
+    live.collections
+        .first()
+        .expect("ops collections must exist")
+        .last_pub_id
 }
 
 async fn assert_last_pub_build(

--- a/crates/agent/src/integration_tests/locking_retries.rs
+++ b/crates/agent/src/integration_tests/locking_retries.rs
@@ -345,6 +345,163 @@ async fn test_publication_optimistic_locking_failures() {
     assert_eq!(2, result.retry_count);
 }
 
+// Regression test for estuary/sre#54: `resolve_live_specs` injects the ops collections
+// into every build, and they used to land in the passthrough set that
+// `verify_unchanged_revisions` locks with `FOR UPDATE`, serializing all publications in
+// the fleet on the same two `live_specs` rows. The injected ops collections must remain
+// in the build output, but must not be locked or revision-checked at commit time.
+#[tokio::test]
+async fn test_injected_ops_collections_are_not_locked() {
+    let mut harness = TestHarness::init("test_injected_ops_collections_are_not_locked").await;
+
+    // The test harness does not bootstrap the injected ops collections, so create them
+    // here in order to exercise the passthrough path at all.
+    let ops_user = harness.setup_tenant("ops.us-central1.v1").await;
+
+    // The migrations seed a storage mapping for `ops.us-central1.v1/` which does not
+    // permit any data planes, and `setup_tenant` leaves it in place (`on conflict do
+    // nothing`). Permit the test data plane so the ops collections can be published.
+    sqlx::query(
+        r#"update storage_mappings
+        set spec = '{"stores": [{"provider": "GCS", "bucket": "estuary-trial", "prefix": "collection-data/"}], "data_planes": ["ops/dp/public/test"]}'
+        where catalog_prefix = 'ops.us-central1.v1/'"#,
+    )
+    .execute(&harness.pool)
+    .await
+    .expect("failed to update ops storage mapping");
+
+    let ops_names = control_plane_api::publications::specs::get_ops_collection_names();
+    let mut ops_collections = serde_json::Map::new();
+    for name in ops_names.iter() {
+        ops_collections.insert(name.clone(), minimal_collection(None));
+    }
+    let result = harness
+        .user_publication(
+            ops_user,
+            "create ops collections",
+            draft_catalog(serde_json::json!({ "collections": ops_collections })),
+        )
+        .await;
+    assert!(
+        result.status.is_success(),
+        "creating ops collections failed: {:?}, errors: {:?}",
+        result.status,
+        result.errors
+    );
+    let initial_ops_pub = ops_last_pub_id(&mut harness, &ops_names).await;
+
+    let user_id = harness.setup_tenant("owls").await;
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "owls/hoots": minimal_collection(None),
+        },
+        "captures": {
+            "owls/capture": minimal_capture(None, &["owls/hoots"]),
+        }
+    }));
+    let build = harness
+        .publisher
+        .build(
+            user_id,
+            Id::new([21; 8]),
+            Some("owls pub".to_string()),
+            draft,
+            Uuid::new_v4(),
+            None,
+            true,
+            0,
+        )
+        .await
+        .expect("owls build failed");
+    assert!(!build.has_errors());
+
+    // The injected ops collections must still be present in the build output, since the
+    // runtime relies on them to know where to write logs and stats.
+    for ops_name in ops_names.iter() {
+        assert!(
+            build
+                .output
+                .built
+                .built_collections
+                .iter()
+                .any(|c| c.collection.as_str() == ops_name),
+            "expected {ops_name} to be included in the build output"
+        );
+    }
+
+    // Bump the ops collections' `last_pub_id` while the owls build is still uncommitted.
+    // The schema change ensures this is a real model change and not a no-op publication.
+    let mut ops_collections = serde_json::Map::new();
+    for name in ops_names.iter() {
+        ops_collections.insert(
+            name.clone(),
+            serde_json::json!({
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "note": { "type": "string" }
+                    }
+                },
+                "key": ["/id"]
+            }),
+        );
+    }
+    let result = harness
+        .user_publication(
+            ops_user,
+            "republish ops collections",
+            draft_catalog(serde_json::json!({ "collections": ops_collections })),
+        )
+        .await;
+    assert!(
+        result.status.is_success(),
+        "republishing ops collections failed: {:?}",
+        result.status
+    );
+    let republished_ops_pub = ops_last_pub_id(&mut harness, &ops_names).await;
+    assert!(
+        republished_ops_pub > initial_ops_pub,
+        "expected the ops republication to bump last_pub_id"
+    );
+
+    // The commit must succeed even though the ops collections' `last_pub_id` changed
+    // after the build, because the injected ops collections are neither locked nor
+    // revision-checked. Before the fix this failed with a lock failure on the ops rows.
+    let result = harness
+        .publisher
+        .commit(build, &NoopWithCommit)
+        .await
+        .expect("owls commit failed");
+    assert!(
+        result.status.is_success(),
+        "expected owls commit to succeed, got: {:?}",
+        result.status
+    );
+}
+
+async fn ops_last_pub_id(
+    harness: &mut TestHarness,
+    ops_names: &std::collections::BTreeSet<String>,
+) -> Id {
+    let live = harness
+        .control_plane()
+        .get_live_specs(ops_names.clone())
+        .await
+        .expect("failed to fetch ops live specs");
+    let pub_ids = live
+        .collections
+        .iter()
+        .map(|r| r.last_pub_id)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        1,
+        pub_ids.len(),
+        "expected all ops collections to share one last_pub_id, got {pub_ids:?}"
+    );
+    pub_ids.into_iter().next().unwrap()
+}
+
 async fn assert_last_pub_build(
     harness: &mut TestHarness,
     catalog_name: &str,

--- a/crates/control-plane-api/src/publications/specs.rs
+++ b/crates/control-plane-api/src/publications/specs.rs
@@ -572,14 +572,20 @@ async fn verify_unchanged_revisions(
         )
         .collect();
 
-    // Never lock or revision-check the injected ops collections. `resolve_live_specs`
-    // injects ops.us-central1.v1/{logs,stats} into *every* build so the runtime knows
-    // where to write telemetry; the publication does not modify them and has no
-    // correctness dependency on their `last_pub_id`. Locking them made every publication
-    // in the fleet take `FOR UPDATE` on the same two rows, serializing all publishes
-    // globally (estuary/sre#54). They stay in the build; we only skip locking them.
+    // Never lock or revision-check ops collections which are present only through
+    // injection. `resolve_live_specs` injects ops.us-central1.v1/{logs,stats} into
+    // *every* build so the runtime knows where to write telemetry; the publication does
+    // not modify them and has no correctness dependency on their `last_pub_id`. Locking
+    // them made every publication in the fleet take `FOR UPDATE` on the same two rows,
+    // serializing all publishes globally (estuary/sre#54). They stay in the build; we
+    // only skip locking them. An ops collection which is a genuine dependency of a
+    // drafted spec (e.g. a reporting derivation reading ops stats) is still locked and
+    // revision-checked, as is a drafted ops collection itself (via `update_live_specs`).
     let injected_ops = get_ops_collection_names();
-    expected.retain(|name, _| !injected_ops.contains(*name));
+    if expected.keys().any(|name| injected_ops.contains(*name)) {
+        let drafted_deps = drafted_dependencies(output);
+        expected.retain(|name, _| !injected_ops.contains(*name) || drafted_deps.contains(*name));
+    }
 
     let catalog_names = expected.keys().map(|k| *k).collect::<Vec<_>>();
     let live_revisions = db::lock_live_specs(&catalog_names, txn).await?;
@@ -602,7 +608,6 @@ async fn verify_unchanged_revisions(
     }
     // Remaining expected pub ids are for `live_specs` rows which have been deleted since we started the publication.
     for (catalog_name, expect_pub_id) in expected {
-        if !expect_pub_id.is_zero() {}
         errors.push(LockFailure {
             catalog_name: catalog_name.to_string(),
             actual: None,
@@ -610,6 +615,49 @@ async fn verify_unchanged_revisions(
         });
     }
     Ok(errors)
+}
+
+/// Returns the names of all collections and captures which drafted specs of this build
+/// read from or write to.
+fn drafted_dependencies(output: &build::Output) -> BTreeSet<String> {
+    let mut deps = BTreeSet::new();
+    for model in output
+        .built
+        .built_captures
+        .iter()
+        .filter(|r| !r.is_passthrough())
+        .filter_map(|r| r.model())
+    {
+        deps.extend(model.all_dependencies());
+    }
+    for model in output
+        .built
+        .built_collections
+        .iter()
+        .filter(|r| !r.is_passthrough())
+        .filter_map(|r| r.model())
+    {
+        deps.extend(model.all_dependencies());
+    }
+    for model in output
+        .built
+        .built_materializations
+        .iter()
+        .filter(|r| !r.is_passthrough())
+        .filter_map(|r| r.model())
+    {
+        deps.extend(model.all_dependencies());
+    }
+    for model in output
+        .built
+        .built_tests
+        .iter()
+        .filter(|r| !r.is_passthrough())
+        .filter_map(|r| r.model())
+    {
+        deps.extend(model.all_dependencies());
+    }
+    deps
 }
 
 fn to_raw_value<T: serde::Serialize, W, F>(
@@ -666,6 +714,12 @@ fn includes_escaped_null(json: &RawValue) -> bool {
 
 /// This is a temporary standin for a function that will lookup the ops collection names based on
 /// the data plane that's associated with the tenants of published tasks.
+///
+/// NOTE: `resolve_live_specs` (which injects these collections into every build) and
+/// `verify_unchanged_revisions` (which skips locking of injected collections at commit)
+/// must agree on this set. If this lookup becomes data-plane-dependent, both call sites
+/// need the same data-plane context, or the commit-time skip will diverge from what was
+/// actually injected at build time.
 pub fn get_ops_collection_names() -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     names.insert("ops.us-central1.v1/logs".to_string());

--- a/crates/control-plane-api/src/publications/specs.rs
+++ b/crates/control-plane-api/src/publications/specs.rs
@@ -571,6 +571,16 @@ async fn verify_unchanged_revisions(
                 .map(|r| (r.catalog_name().as_str(), r.expect_pub_id())),
         )
         .collect();
+
+    // Never lock or revision-check the injected ops collections. `resolve_live_specs`
+    // injects ops.us-central1.v1/{logs,stats} into *every* build so the runtime knows
+    // where to write telemetry; the publication does not modify them and has no
+    // correctness dependency on their `last_pub_id`. Locking them made every publication
+    // in the fleet take `FOR UPDATE` on the same two rows, serializing all publishes
+    // globally (estuary/sre#54). They stay in the build; we only skip locking them.
+    let injected_ops = get_ops_collection_names();
+    expected.retain(|name, _| !injected_ops.contains(*name));
+
     let catalog_names = expected.keys().map(|k| *k).collect::<Vec<_>>();
     let live_revisions = db::lock_live_specs(&catalog_names, txn).await?;
 


### PR DESCRIPTION
## Problem

Every publication takes `FOR UPDATE` on the `live_specs` rows of `ops.us-central1.v1/logs` and `ops.us-central1.v1/stats` (estuary/sre#54). `resolve_live_specs` injects those two collections into every build so the runtime knows where to write telemetry, and they then land in the passthrough set that `verify_unchanged_revisions` locks and revision-checks. The result is that all publications across the fleet serialize on the same two rows.

## Change

`verify_unchanged_revisions` now removes the injected ops collections from its expected set before locking. The publication does not modify them and has no correctness dependency on their `last_pub_id`, so there is nothing to lock or verify:

- The ops collections are still injected into every build; only the locking is skipped.
- A publication which actually drafts an ops collection is unaffected: drafted specs are not passthrough, and are still locked and validated through `update_live_specs`.
- Removing them from the expected set also removes them from the deleted-since-build check, so no spurious `LockFailure` is produced for them.

## Testing

- New regression test `test_injected_ops_collections_are_not_locked`: publishes the ops collections, builds an unrelated publication, republishes the ops collections to bump their `last_pub_id`, then commits the first build. Without the fix the commit fails with a `BuildIdLockFailure` on the two ops rows (verified); with the fix it succeeds. The test also asserts the ops collections remain present in the build output.
- `cargo nextest run -p control-plane-api -p agent`: 221 passed, 1 skipped (live Stripe test, skipped in CI as well).

After deploy, the `pg_locks` blocking tree should no longer show `ops.us-central1.v1/logs`/`stats` as the contended `live_specs` tuples, and concurrent publications of different tenants should no longer wait on each other.