### PR TITLE
docs: clarify PrivateLink AllowedPrincipals differs for BYOC vs private

### DIFF
--- a/site/docs/private-byoc/privatelink.md
+++ b/site/docs/private-byoc/privatelink.md
@@ -18,8 +18,10 @@ To do so, you will first need to create a Virtual Private Cloud (VPC) endpoint s
 You can create or manage your endpoint services on the [AWS VPC dashboard](https://console.aws.amazon.com/vpc/). As you do so:
 
 * Specify the NLB you created.
-* Safelist your AWS VPC Account ID (such as `arn:aws:iam::12345:root`) to allow access to your VPC endpoint service.
-* By default, the endpoint service should be in the same region as your private deployment. To connect across regions, see [Cross-region setup](#cross-region) below.
+* Safelist the AWS principal that will create the connecting endpoint, so it's allowed to reach your VPC endpoint service. Which principal this is depends on your deployment type:
+  * **BYOC deployments**: safelist your own AWS account (`arn:aws:iam::<your-account-id>:root`). PrivateLink connections are provisioned through the IAM role you created for Estuary during BYOC setup, which lives in your own account.
+  * **Private deployments**: safelist Estuary's data-plane principal, `arn:aws:iam::770785070253:user/data-plane-ops`.
+* By default, the endpoint service should be in the same region as your Estuary data plane. To connect across regions, see [Cross-region setup](#cross-region) below.
 
 :::tip
 See the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) for the most up-to-date, detailed instructions on working with PrivateLink or contact your AWS representative for assistance.
@@ -73,7 +75,7 @@ Cross-region PrivateLink requires additional configuration on your side beyond t
 3. **NLB constraints** (per [AWS cross-region considerations](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html#endpoint-service-cross-region)):
    * The NLB must use the IPv4 or dualstack IP address type. Pure-IPv6 NLBs are not supported for cross-region access.
    * The NLB must use the default TCP idle timeout (`tcp.idle_timeout.seconds = 350`). Custom idle timeouts are not supported for cross-region.
-4. **AllowedPrincipals**: add `arn:aws:iam::770785070253:user/data-plane-ops` to the endpoint service's **Allow principals** tab. This is the specific IAM user Estuary uses to create cross-region VPC endpoints on your service.
+4. **AllowedPrincipals**: for **private deployments**, add `arn:aws:iam::770785070253:user/data-plane-ops` to the endpoint service's **Allow principals** tab. This is the specific IAM user Estuary uses to create cross-region VPC endpoints on your service. For **BYOC deployments**, this step isn't needed: the account you already safelisted in the [AWS PrivateLink](#aws-privatelink) step above is what creates the cross-region endpoint too, since PrivateLink connections for BYOC are always provisioned through your own assumed role, regardless of region.
 5. **Region availability**: confirm that both regions are in the same AWS partition (e.g., both `aws`, not one `aws-cn` or `aws-us-gov`). AWS does not support cross-region PrivateLink in a small set of Availability Zones — see the [AWS list of unsupported AZs](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html#endpoint-service-cross-region).
 
 #### What to send Estuary

--- a/site/docs/private-byoc/privatelink.md
+++ b/site/docs/private-byoc/privatelink.md
@@ -19,7 +19,7 @@ You can create or manage your endpoint services on the [AWS VPC dashboard](https
 
 * Specify the NLB you created.
 * Safelist the AWS principal that will create the connecting endpoint, so it's allowed to reach your VPC endpoint service. Which principal this is depends on your deployment type:
-  * **BYOC deployments**: safelist your own AWS account (`arn:aws:iam::<your-account-id>:root`). PrivateLink connections are provisioned through the IAM role you created for Estuary during BYOC setup, which lives in your own account.
+  * **BYOC deployments**: safelist your own AWS account (`arn:aws:iam::<your-account-id>:root`), or - to be more restrictive - the specific IAM role you created for Estuary during BYOC setup (`arn:aws:iam::<your-account-id>:role/<estuary-role>`). PrivateLink connections are provisioned by assuming that role, which lives in your own account.
   * **Private deployments**: safelist Estuary's data-plane principal, `arn:aws:iam::770785070253:user/data-plane-ops`.
 * By default, the endpoint service should be in the same region as your Estuary data plane. To connect across regions, see [Cross-region setup](#cross-region) below.
 


### PR DESCRIPTION
## Summary
- The PrivateLink page told every reader to safelist Estuary's data-plane-ops ARN (or gave an ambiguous "your account ID" instruction), with no distinction between private and BYOC deployments.
- For BYOC, PrivateLink connections are always provisioned through the customer's own assumed role, not Estuary's central account. Confirmed in est-dry-dock (resources/aws.py): new_provider() always assumes byoc.role_arn when a data plane has BYOC config, and new_private_link_endpoint() uses that same provider unconditionally for every endpoint it creates, same-region or cross-region (the cross-region branch only adds a service_region argument to the endpoint resource, it never changes which credentials make the call).
- Verified live: a BYOC customer's cross-region PrivateLink endpoint went live using only their own account root, no data-plane-ops ARN anywhere.
- Companion fix in est-dry-dock (estuary/est-dry-dock, branch fix/privatelink-details-byoc): the print_details CLI that generates our customer setup message had the same bug, unconditionally suggesting data-plane-ops regardless of deployment type.

## Test plan
- [ ] Docs build renders the changed sections correctly
- [ ] Sean confirms the BYOC/private distinction and wording are accurate