### PR TITLE
notifications: use "Estuary" in alert email subjects (#3000)

### DIFF
--- a/crates/notifications/src/auto_discover_failed.rs
+++ b/crates/notifications/src/auto_discover_failed.rs
@@ -7,7 +7,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Auto-discover failed for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Auto-discover failed for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering auto_discover_failed-fired-subject template")?;
 
@@ -32,7 +32,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Auto-discover resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Auto-discover resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering auto_discover_failed-resolved-subject template")?;
 

--- a/crates/notifications/src/background_publication_failed.rs
+++ b/crates/notifications/src/background_publication_failed.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Automated background publication failed for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Automated background publication failed for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering background_publication_failed-fired-subject template")?;
 
@@ -34,7 +34,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Automated background publication alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Automated background publication alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering background_publication_failed-resolved-subject template")?;
 

--- a/crates/notifications/src/data_movement_stalled.rs
+++ b/crates/notifications/src/data_movement_stalled.rs
@@ -8,7 +8,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Alert for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Alert for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering data_movement_stalled-fired-subject template")?;
 
@@ -27,7 +27,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering data_movement_stalled-resolved-subject template")?;
 

--- a/crates/notifications/src/free_trial.rs
+++ b/crates/notifications/src/free_trial.rs
@@ -13,7 +13,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
             r#"{{#if arguments.has_credit_card}}
 <p class="body-text">Your Estuary account <span class="identifier">{{arguments.tenant}}</span> has started its 30-day free trial. This trial will end on <strong>{{arguments.trial_end}}</strong>. Billing will begin accruing then.</p>
 {{else}}
-<p class="body-text">We hope you're enjoying Estuary Flow. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">{{arguments.tenant}}</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>{{arguments.trial_end}}</strong>.</p>
+<p class="body-text">We hope you're enjoying Estuary. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">{{arguments.tenant}}</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>{{arguments.trial_end}}</strong>.</p>
 <p class="body-text">Please add payment information in the next 30 days to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
 <a href="{{> dashboard_billing_url}}" class="button">Add payment information</a>
 {{/if}}"#,
@@ -34,11 +34,11 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
         .register_template_string(
             &resolved_body,
             r#"{{#if arguments.has_credit_card}}
-<p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
+<p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
 <p class="body-text">Since you have already added a payment method, no action is required. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a> anytime!</p>
 <a href="https://dashboard.estuary.dev" class="button">🌊 View your data flows</a>
 {{else}}
-<p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
+<p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
 <p class="body-text">Please add payment information immediately to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
 <a href="{{> dashboard_billing_url}}" class="button">Add payment information</a>
 {{/if}}"#,

--- a/crates/notifications/src/free_trial.rs
+++ b/crates/notifications/src/free_trial.rs
@@ -26,7 +26,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"{{#if arguments.has_credit_card}}Estuary Flow: Paid Tier{{else}}Estuary Paid Tier: Enter Payment Info to Continue Access{{/if}}"#,
+            r#"{{#if arguments.has_credit_card}}Estuary: Paid Tier{{else}}Estuary Paid Tier: Enter Payment Info to Continue Access{{/if}}"#,
         )
         .context("registering free_trial-resolved-subject template")?;
 

--- a/crates/notifications/src/free_trial_ending.rs
+++ b/crates/notifications/src/free_trial_ending.rs
@@ -6,7 +6,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     let (fired_subject, fired_body) =
         template_names(models::status::AlertType::FreeTrialEnding, false);
     registry
-        .register_template_string(&fired_subject, r#"Estuary Flow: Paid Tier"#)
+        .register_template_string(&fired_subject, r#"Estuary: Paid Tier"#)
         .context("registering free_trial_ending-fired-subject template")?;
 
     registry

--- a/crates/notifications/src/lib.rs
+++ b/crates/notifications/src/lib.rs
@@ -1023,6 +1023,71 @@ mod tests {
     }
 
     #[test]
+    fn test_task_idle_fired() {
+        let email = test_single_email(
+            AlertType::TaskIdle,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_a()],
+                "spec_type": "capture",
+                "disable_at": "2024-02-14",
+            }),
+            State::Fired,
+        );
+
+        assert_email(
+            &email,
+            user_a(),
+            EXPECT_IDEMPOTENCY_KEY_FIRED,
+            "Estuary: capture acmeCo/test/capture has not moved data",
+        );
+        insta::assert_snapshot!("task_idle_fired_body", email.body);
+    }
+
+    #[test]
+    fn test_task_auto_disabled_failing_fired() {
+        let email = test_single_email(
+            AlertType::TaskAutoDisabledFailing,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_a()],
+                "spec_type": "capture",
+                "failing_since": "2024-01-01",
+            }),
+            State::Fired,
+        );
+
+        assert_email(
+            &email,
+            user_a(),
+            EXPECT_IDEMPOTENCY_KEY_FIRED,
+            "Estuary: capture acmeCo/test/capture has been automatically disabled",
+        );
+        insta::assert_snapshot!("task_auto_disabled_failing_fired_body", email.body);
+    }
+
+    #[test]
+    fn test_task_auto_disabled_idle_fired() {
+        let email = test_single_email(
+            AlertType::TaskAutoDisabledIdle,
+            "acmeCo/test/capture",
+            json!({
+                "recipients": [user_a()],
+                "spec_type": "capture",
+            }),
+            State::Fired,
+        );
+
+        assert_email(
+            &email,
+            user_a(),
+            EXPECT_IDEMPOTENCY_KEY_FIRED,
+            "Estuary: capture acmeCo/test/capture has been automatically disabled",
+        );
+        insta::assert_snapshot!("task_auto_disabled_idle_fired_body", email.body);
+    }
+
+    #[test]
     fn test_no_recipients() {
         expect_no_email(
             AlertType::AutoDiscoverFailed,

--- a/crates/notifications/src/lib.rs
+++ b/crates/notifications/src/lib.rs
@@ -419,7 +419,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Auto-discover failed for capture acmeCo/test/capture",
+            "Estuary: Auto-discover failed for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("auto_discover_failed_fired_body", email.body);
     }
@@ -440,7 +440,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Auto-discover resolved for capture acmeCo/test/capture",
+            "Estuary: Auto-discover resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("auto_discover_failed_resolved_body", email.body);
     }
@@ -461,7 +461,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Automated background publication failed for capture acmeCo/test/capture",
+            "Estuary: Automated background publication failed for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("background_publication_failed_fired_body", email.body);
     }
@@ -482,7 +482,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Automated background publication alert resolved for capture acmeCo/test/capture",
+            "Estuary: Automated background publication alert resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("background_publication_failed_resolved_body", email.body);
     }
@@ -505,7 +505,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Alert for materialization acmeCo/test/materialization",
+            "Estuary: Alert for materialization acmeCo/test/materialization",
         );
         insta::assert_snapshot!("data_movement_stalled_fired_body", email.body);
     }
@@ -528,7 +528,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Alert resolved for materialization acmeCo/test/materialization",
+            "Estuary: Alert resolved for materialization acmeCo/test/materialization",
         );
         insta::assert_snapshot!("data_movement_stalled_resolved_body", email.body);
     }
@@ -606,7 +606,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Paid Tier",
+            "Estuary: Paid Tier",
         );
         insta::assert_snapshot!("free_trial_resolved_with_cc_body", email.body);
     }
@@ -660,7 +660,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Paid Tier",
+            "Estuary: Paid Tier",
         );
         insta::assert_snapshot!("free_trial_ending_fired_with_cc_body", email.body);
     }
@@ -684,7 +684,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Paid Tier",
+            "Estuary: Paid Tier",
         );
         insta::assert_snapshot!("free_trial_ending_fired_without_cc_body", email.body);
     }
@@ -856,7 +856,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Task failure detected for capture acmeCo/test/capture",
+            "Estuary: Task failure detected for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("shard_failed_fired_body", email.body);
     }
@@ -881,7 +881,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Task failure resolved for capture acmeCo/test/capture",
+            "Estuary: Task failure resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("shard_failed_resolved_body", email.body);
     }
@@ -970,7 +970,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+            "Estuary: capture acmeCo/test/capture is chronically failing",
         );
         insta::assert_snapshot!("task_chronically_failing_fired_body", email.body);
     }
@@ -995,7 +995,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+            "Estuary: capture acmeCo/test/capture is chronically failing",
         );
         assert!(
             email.body.contains("failing since 2025-05-01"),

--- a/crates/notifications/src/missing_payment_method.rs
+++ b/crates/notifications/src/missing_payment_method.rs
@@ -15,7 +15,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_body,
-            r#"<p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">{{arguments.tenant}}</span>. {{#if (eq arguments.plan_state "free_trial")}}After your free trial ends on <strong>{{arguments.trial_end}}</strong>, you will automatically be switched the paid tier.{{else}}You are now on the paid tier.{{/if}}</p>
+            r#"<p class="body-text">We hope you are enjoying Estuary. We have received your payment method for your account <span class="identifier">{{arguments.tenant}}</span>. {{#if (eq arguments.plan_state "free_trial")}}After your free trial ends on <strong>{{arguments.trial_end}}</strong>, you will automatically be switched the paid tier.{{else}}You are now on the paid tier.{{/if}}</p>
 <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
 
 <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">

--- a/crates/notifications/src/shard_failed.rs
+++ b/crates/notifications/src/shard_failed.rs
@@ -6,7 +6,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Task failure detected for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Task failure detected for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering shard_failed-fired-subject template")?;
 
@@ -32,7 +32,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Task failure resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Task failure resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering shard_failed-resolved-subject template")?;
 

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_fired_without_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_fired_without_cc_body.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/notifications/src/lib.rs
+assertion_line: 581
 expression: email.body
 ---
 <!DOCTYPE html>
@@ -40,7 +41,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you're enjoying Estuary Flow. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">acmeCo/</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>2024-02-14</strong>.</p>
+            <p class="body-text">We hope you're enjoying Estuary. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">acmeCo/</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>2024-02-14</strong>.</p>
             <p class="body-text">Please add payment information in the next 30 days to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
             <a href="http://dashboard.estuary.test/admin/billing" class="button">Add payment information</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_with_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_with_cc_body.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/notifications/src/lib.rs
+assertion_line: 611
 expression: email.body
 ---
 <!DOCTYPE html>
@@ -40,7 +41,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
+            <p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
             <p class="body-text">Since you have already added a payment method, no action is required. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a> anytime!</p>
             <a href="https://dashboard.estuary.dev" class="button">🌊 View your data flows</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_without_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_without_cc_body.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/notifications/src/lib.rs
+assertion_line: 641
 expression: email.body
 ---
 <!DOCTYPE html>
@@ -40,7 +41,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
+            <p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
             <p class="body-text">Please add payment information immediately to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
             <a href="http://dashboard.estuary.test/admin/billing" class="button">Add payment information</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/notifications/src/lib.rs
+assertion_line: 803
 expression: email.body
 ---
 <!DOCTYPE html>
@@ -40,7 +41,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">acmeCo/</span>. After your free trial ends on <strong>2024-02-14</strong>, you will automatically be switched the paid tier.</p>
+            <p class="body-text">We hope you are enjoying Estuary. We have received your payment method for your account <span class="identifier">acmeCo/</span>. After your free trial ends on <strong>2024-02-14</strong>, you will automatically be switched the paid tier.</p>
             <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
             
             <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/notifications/src/lib.rs
+assertion_line: 836
 expression: email.body
 ---
 <!DOCTYPE html>
@@ -40,7 +41,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">acmeCo/</span>. You are now on the paid tier.</p>
+            <p class="body-text">We hope you are enjoying Estuary. We have received your payment method for your account <span class="identifier">acmeCo/</span>. You are now on the paid tier.</p>
             <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
             
             <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">

--- a/crates/notifications/src/snapshots/notifications__tests__task_auto_disabled_failing_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__task_auto_disabled_failing_fired_body.snap
@@ -1,0 +1,60 @@
+---
+source: crates/notifications/src/lib.rs
+assertion_line: 1066
+expression: email.body
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { margin: 0; padding: 0; font-family: Ubuntu, Helvetica, Arial, sans-serif; }
+        .email-container { max-width: 600px; margin: 0 auto; }
+        .email-content { padding: 20px; }
+        .logo { text-align: center; padding: 20px 0; }
+        .divider { border-top: 1px dashed grey; margin: 20px 0; }
+        .dear-line { font-size: 20px; color: #512d0b; font-weight: bold; margin-bottom: 10px; }
+        .body-text { font-size: 17px; line-height: 1.4; margin-bottom: 10px; }
+        .signature { font-size: 14px; color: #000000; margin-top: 15px; }
+        .identifier { background-color: #dadada; padding: 2px 3px; border-radius: 2px; font-family: monospace; font-weight: bold; }
+        a { color: #5072EB; text-decoration: none; }
+        .button {
+            display: inline-block;
+            background-color: #5072EB;
+            color: white;
+            padding: 12px 24px;
+            border-radius: 4px;
+            text-decoration: none;
+            margin: 25px 0 0 0;
+            font-weight: 400;
+            font-size: 17px;
+        }
+        ul { margin: 10px 0; padding-left: 20px; }
+        li { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="logo">
+            <img src="https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//estuary_logo_comfy_14513ca434/estuary_logo_comfy_14513ca434.jpg" alt="Estuary Logo" style="max-width: 200px;">
+        </div>
+        <div class="divider"></div>
+        <div class="email-content">
+            <p class="body-text">
+                Your Estuary capture <span class="identifier">acmeCo/test/capture</span> has been automatically disabled because it has been failing since 2024-01-01.
+            </p>
+            <p class="body-text">
+                If you still need this task, re-enable it and address any configuration or connectivity issues preventing it from running. Otherwise, no further action is needed.
+            </p>
+            <ul>
+                <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">View the task status and logs</a></li>
+                <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+            </ul>            <div class="signature">
+                Thanks,<br>
+                Estuary Team
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/crates/notifications/src/snapshots/notifications__tests__task_auto_disabled_idle_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__task_auto_disabled_idle_fired_body.snap
@@ -1,0 +1,57 @@
+---
+source: crates/notifications/src/lib.rs
+assertion_line: 1087
+expression: email.body
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { margin: 0; padding: 0; font-family: Ubuntu, Helvetica, Arial, sans-serif; }
+        .email-container { max-width: 600px; margin: 0 auto; }
+        .email-content { padding: 20px; }
+        .logo { text-align: center; padding: 20px 0; }
+        .divider { border-top: 1px dashed grey; margin: 20px 0; }
+        .dear-line { font-size: 20px; color: #512d0b; font-weight: bold; margin-bottom: 10px; }
+        .body-text { font-size: 17px; line-height: 1.4; margin-bottom: 10px; }
+        .signature { font-size: 14px; color: #000000; margin-top: 15px; }
+        .identifier { background-color: #dadada; padding: 2px 3px; border-radius: 2px; font-family: monospace; font-weight: bold; }
+        a { color: #5072EB; text-decoration: none; }
+        .button {
+            display: inline-block;
+            background-color: #5072EB;
+            color: white;
+            padding: 12px 24px;
+            border-radius: 4px;
+            text-decoration: none;
+            margin: 25px 0 0 0;
+            font-weight: 400;
+            font-size: 17px;
+        }
+        ul { margin: 10px 0; padding-left: 20px; }
+        li { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="logo">
+            <img src="https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//estuary_logo_comfy_14513ca434/estuary_logo_comfy_14513ca434.jpg" alt="Estuary Logo" style="max-width: 200px;">
+        </div>
+        <div class="divider"></div>
+        <div class="email-content">
+            <p class="body-text">
+                Your Estuary capture <span class="identifier">acmeCo/test/capture</span> has been automatically disabled because it has not moved data. If you still need this task, re-enable it and verify that data is flowing. Otherwise, no further action is needed.
+            </p>
+            <ul>
+                <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">View the task status and logs</a></li>
+                <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+            </ul>            <div class="signature">
+                Thanks,<br>
+                Estuary Team
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/crates/notifications/src/snapshots/notifications__tests__task_idle_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__task_idle_fired_body.snap
@@ -1,0 +1,57 @@
+---
+source: crates/notifications/src/lib.rs
+assertion_line: 1044
+expression: email.body
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { margin: 0; padding: 0; font-family: Ubuntu, Helvetica, Arial, sans-serif; }
+        .email-container { max-width: 600px; margin: 0 auto; }
+        .email-content { padding: 20px; }
+        .logo { text-align: center; padding: 20px 0; }
+        .divider { border-top: 1px dashed grey; margin: 20px 0; }
+        .dear-line { font-size: 20px; color: #512d0b; font-weight: bold; margin-bottom: 10px; }
+        .body-text { font-size: 17px; line-height: 1.4; margin-bottom: 10px; }
+        .signature { font-size: 14px; color: #000000; margin-top: 15px; }
+        .identifier { background-color: #dadada; padding: 2px 3px; border-radius: 2px; font-family: monospace; font-weight: bold; }
+        a { color: #5072EB; text-decoration: none; }
+        .button {
+            display: inline-block;
+            background-color: #5072EB;
+            color: white;
+            padding: 12px 24px;
+            border-radius: 4px;
+            text-decoration: none;
+            margin: 25px 0 0 0;
+            font-weight: 400;
+            font-size: 17px;
+        }
+        ul { margin: 10px 0; padding-left: 20px; }
+        li { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="logo">
+            <img src="https://storage.googleapis.com/estuary-marketing-strapi-uploads/uploads//estuary_logo_comfy_14513ca434/estuary_logo_comfy_14513ca434.jpg" alt="Estuary Logo" style="max-width: 200px;">
+        </div>
+        <div class="divider"></div>
+        <div class="email-content">
+            <p class="body-text">
+                Your Estuary capture <span class="identifier">acmeCo/test/capture</span> has not moved data in over 30 days. If this task is no longer needed, you can disable or delete it. Otherwise, it will be disabled automatically on 2024-02-14.
+            </p>
+            <ul>
+                <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">View the task status and logs</a></li>
+                <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+            </ul>            <div class="signature">
+                Thanks,<br>
+                Estuary Team
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/crates/notifications/src/task_auto_disabled_failing.rs
+++ b/crates/notifications/src/task_auto_disabled_failing.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
         )
         .context("registering task_auto_disabled_failing-fired-subject template")?;
 

--- a/crates/notifications/src/task_auto_disabled_idle.rs
+++ b/crates/notifications/src/task_auto_disabled_idle.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
         )
         .context("registering task_auto_disabled_idle-fired-subject template")?;
 

--- a/crates/notifications/src/task_chronically_failing.rs
+++ b/crates/notifications/src/task_chronically_failing.rs
@@ -7,7 +7,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} is chronically failing"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} is chronically failing"#,
         )
         .context("registering task_chronically_failing-fired-subject template")?;
 

--- a/crates/notifications/src/task_idle.rs
+++ b/crates/notifications/src/task_idle.rs
@@ -6,7 +6,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has not moved data"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has not moved data"#,
         )
         .context("registering task_idle-fired-subject template")?;
 


### PR DESCRIPTION
**Description:**

Alert emails prefixed their subject with `Estuary Flow:`, while the rest of the product says just "Estuary". This drops "Flow" from the subject of every alert type, and from the remaining body prose.

This mostly finishes a migration that was already underway — `FreeTrial`'s fired subject was already `Estuary Free Trial`, `MissingPaymentMethod`'s was already `Estuary: …`, and several bodies already read "Your Estuary account" / "Your Estuary {{spec_type}}".

Three commits, so the last two can be dropped independently if you'd rather scope this tightly:

1. **Subjects** — `Estuary Flow:` → `Estuary:` across all 13 subject templates. This is what #3000 asks for.
2. **Bodies** — the free-trial and missing-payment-method bodies still read "We hope you are enjoying Estuary Flow". Prose rather than subject lines, but the same "cohesive messaging" point.
3. **Tests** — closes a coverage gap the rename exposed (see below).

Fixes #3000

**Workflow steps:**

No API or CLI surface changes; this only affects the subject and body text of outbound alert emails. For example, a failing capture previously sent:

```
Estuary Flow: Task failure detected for capture acmeCo/test/capture
```

and now sends:

```
Estuary: Task failure detected for capture acmeCo/test/capture
```

Affected alert types: `AutoDiscoverFailed`, `BackgroundPublicationFailed`, `DataMovementStalled`, `FreeTrial`, `FreeTrialEnding`, `ShardFailed`, `TaskAutoDisabledFailing`, `TaskAutoDisabledIdle`, `TaskChronicallyFailing`, `TaskIdle`.

**Documentation links affected:**

None. The subject strings live only in the `notifications` crate's handlebars templates; nothing under `site/` documents them.

**Notes for reviewers:**

- **A coverage gap turned up while doing this, and it's the part most worth a look.** The subject templates for `TaskIdle`, `TaskAutoDisabledFailing` and `TaskAutoDisabledIdle` had no test asserting them — I changed one to `BROKEN:` and the suite stayed green, so the rename was touching three lines nothing guarded. The third commit adds a fired-state test per type, following the existing `assert_email` + snapshot pattern; the same deliberate break now fails on `subject mismatch`. All three are fired-only, so there's no resolved case. Happy to split that commit into its own PR if you'd prefer it separate from a rename.
- **Snapshots:** only the `notifications__*` files are updated. The parallel `alert_notifications__*` set appears orphaned — no test renders them, and they don't regenerate — and #3079 is already removing them, so I left them alone rather than create a conflict. Each of the 5 updated snapshots is a one-line diff.
- `free_trial`'s resolved subject is a conditional; its `has_credit_card` branch becomes `Estuary: Paid Tier`, which lines up with the existing `else` branch (`Estuary Paid Tier: Enter Payment Info…`).
- Verified with `cargo test -p notifications` — 28 passing (25 existing + 3 new). `cargo fmt` clean.
