### PR TITLE
control-plane: add `closed` flag to data planes

### DIFF
--- a/.sqlx/query-87101040b0795647b0b9f144f24dc199f724caf45a9d9755a9fdc9fba9dc05e2.json
+++ b/.sqlx/query-87101040b0795647b0b9f144f24dc199f724caf45a9d9755a9fdc9fba9dc05e2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        WITH\n        data_plane_ids AS (\n            SELECT id\n            FROM UNNEST($1::flowid[]) AS t(id)\n        ),\n        data_plane_names AS (\n            SELECT name\n            FROM UNNEST($2::text[]) AS t(name)\n            -- User must be read-authorized to data-plane.\n            WHERE EXISTS (\n                SELECT 1\n                FROM internal.user_roles($3, 'read') AS r\n                WHERE starts_with(t.name, r.role_prefix)\n            )\n        )\n        SELECT\n            d.id AS \"control_id: Id\",\n            d.data_plane_name,\n            d.hmac_keys,\n            d.encrypted_hmac_keys AS \"encrypted_hmac_keys: models::RawValue\",\n            d.data_plane_fqdn,\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        WHERE\n            d.id IN (select id from data_plane_ids) OR\n            d.data_plane_name in (select name from data_plane_names)\n        ",
+  "query": "\n        WITH\n        data_plane_ids AS (\n            SELECT id\n            FROM UNNEST($1::flowid[]) AS t(id)\n        ),\n        data_plane_names AS (\n            SELECT name\n            FROM UNNEST($2::text[]) AS t(name)\n            -- User must be read-authorized to data-plane.\n            WHERE EXISTS (\n                SELECT 1\n                FROM internal.user_roles($3, 'read') AS r\n                WHERE starts_with(t.name, r.role_prefix)\n            )\n        )\n        SELECT\n            d.id AS \"control_id: Id\",\n            d.data_plane_name,\n            d.closed,\n            d.hmac_keys,\n            d.encrypted_hmac_keys AS \"encrypted_hmac_keys: models::RawValue\",\n            d.data_plane_fqdn,\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        WHERE\n            d.id IN (select id from data_plane_ids) OR\n            d.data_plane_name in (select name from data_plane_names)\n        ",
   "describe": {
     "columns": [
       {
@@ -15,46 +15,51 @@
       },
       {
         "ordinal": 2,
+        "name": "closed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
         "name": "hmac_keys",
         "type_info": "TextArray"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "encrypted_hmac_keys: models::RawValue",
         "type_info": "Json"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "data_plane_fqdn",
         "type_info": "Text"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "broker_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "reactor_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "dekaf_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "dekaf_registry_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "ops_logs_name: models::Collection",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "ops_stats_name: models::Collection",
         "type_info": "Text"
       }
@@ -88,11 +93,12 @@
       false,
       false,
       false,
+      false,
       true,
       true,
       false,
       false
     ]
   },
-  "hash": "f9600987a85eacfb073b32786dd898386994fc0bb0ace2a0cdc4f87580eac15a"
+  "hash": "87101040b0795647b0b9f144f24dc199f724caf45a9d9755a9fdc9fba9dc05e2"
 }

--- a/.sqlx/query-9130888110ad7bcaa4f3ecb3e25141fee5ca7366568f338fc580fc8d84059f82.json
+++ b/.sqlx/query-9130888110ad7bcaa4f3ecb3e25141fee5ca7366568f338fc580fc8d84059f82.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id AS \"control_id: models::Id\",\n            data_plane_name,\n            data_plane_fqdn,\n            hmac_keys,\n            encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            broker_address,\n            reactor_address,\n            dekaf_address,\n            dekaf_registry_address,\n            ops_logs_name AS \"ops_logs_name: models::Collection\",\n            ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes\n        WHERE data_plane_name = $1\n        ",
+  "query": "\n        SELECT\n            d.id AS \"control_id: models::Id\",\n            d.data_plane_name,\n            d.data_plane_fqdn,\n            d.closed,\n            d.hmac_keys,\n            d.encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        WHERE d.hmac_keys::text <> '{}' or d.encrypted_hmac_keys::text <> '{}'\n        ",
   "describe": {
     "columns": [
       {
@@ -20,51 +20,55 @@
       },
       {
         "ordinal": 3,
+        "name": "closed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
         "name": "hmac_keys",
         "type_info": "TextArray"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "encrypted_hmac_keys: models::RawValue",
         "type_info": "Json"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "broker_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "reactor_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "dekaf_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "dekaf_registry_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "ops_logs_name: models::Collection",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "ops_stats_name: models::Collection",
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Left": [
-        "Text"
-      ]
+      "Left": []
     },
     "nullable": [
+      false,
       false,
       false,
       false,
@@ -78,5 +82,5 @@
       false
     ]
   },
-  "hash": "66af8a581c8cbdcab8877d50c3ebcb23163d0d213c5e6c74a30d15d62ab79955"
+  "hash": "9130888110ad7bcaa4f3ecb3e25141fee5ca7366568f338fc580fc8d84059f82"
 }

--- a/.sqlx/query-e9b03454f1ae6814f69264782b897457822f6a32c4d113e8b44ef0013d1da6af.json
+++ b/.sqlx/query-e9b03454f1ae6814f69264782b897457822f6a32c4d113e8b44ef0013d1da6af.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            d.id AS \"control_id: models::Id\",\n            d.data_plane_name,\n            d.data_plane_fqdn,\n            d.hmac_keys,\n            d.encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            d.broker_address,\n            d.reactor_address,\n            d.dekaf_address,\n            d.dekaf_registry_address,\n            d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n            d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes d\n        WHERE d.hmac_keys::text <> '{}' or d.encrypted_hmac_keys::text <> '{}'\n        ",
+  "query": "\n        SELECT\n            id AS \"control_id: models::Id\",\n            data_plane_name,\n            data_plane_fqdn,\n            closed,\n            hmac_keys,\n            encrypted_hmac_keys as \"encrypted_hmac_keys: models::RawValue\",\n            broker_address,\n            reactor_address,\n            dekaf_address,\n            dekaf_registry_address,\n            ops_logs_name AS \"ops_logs_name: models::Collection\",\n            ops_stats_name AS \"ops_stats_name: models::Collection\"\n        FROM data_planes\n        WHERE data_plane_name = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -20,49 +20,57 @@
       },
       {
         "ordinal": 3,
+        "name": "closed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
         "name": "hmac_keys",
         "type_info": "TextArray"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "encrypted_hmac_keys: models::RawValue",
         "type_info": "Json"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "broker_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "reactor_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "dekaf_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "dekaf_registry_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "ops_logs_name: models::Collection",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "ops_stats_name: models::Collection",
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Text"
+      ]
     },
     "nullable": [
+      false,
       false,
       false,
       false,
@@ -76,5 +84,5 @@
       false
     ]
   },
-  "hash": "135e56a90465e7efa0822a471f0c0e56a340c3ff7710f753ab8c97df4fd783b7"
+  "hash": "e9b03454f1ae6814f69264782b897457822f6a32c4d113e8b44ef0013d1da6af"
 }

--- a/.sqlx/query-f133c223a0df27245c413ef1ef8d94773a3c9ce12c6c34161874455e206e35dc.json
+++ b/.sqlx/query-f133c223a0df27245c413ef1ef8d94773a3c9ce12c6c34161874455e206e35dc.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                d.id AS \"control_id: Id\",\n                d.data_plane_name,\n                d.hmac_keys,\n                d.encrypted_hmac_keys AS \"encrypted_hmac_keys: models::RawValue\",\n                d.data_plane_fqdn,\n                d.broker_address,\n                d.reactor_address,\n                d.dekaf_address,\n                d.dekaf_registry_address,\n                d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n                d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n            FROM data_planes d\n            WHERE data_plane_name = $1\n            AND EXISTS (\n                SELECT 1 FROM internal.user_roles($2, 'read') r\n                WHERE starts_with($1, r.role_prefix)\n            )\n            ",
+  "query": "\n            SELECT\n                d.id AS \"control_id: Id\",\n                d.data_plane_name,\n                d.closed,\n                d.hmac_keys,\n                d.encrypted_hmac_keys AS \"encrypted_hmac_keys: models::RawValue\",\n                d.data_plane_fqdn,\n                d.broker_address,\n                d.reactor_address,\n                d.dekaf_address,\n                d.dekaf_registry_address,\n                d.ops_logs_name AS \"ops_logs_name: models::Collection\",\n                d.ops_stats_name AS \"ops_stats_name: models::Collection\"\n            FROM data_planes d\n            WHERE data_plane_name = $1\n            AND EXISTS (\n                SELECT 1 FROM internal.user_roles($2, 'read') r\n                WHERE starts_with($1, r.role_prefix)\n            )\n            ",
   "describe": {
     "columns": [
       {
@@ -15,46 +15,51 @@
       },
       {
         "ordinal": 2,
+        "name": "closed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
         "name": "hmac_keys",
         "type_info": "TextArray"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "encrypted_hmac_keys: models::RawValue",
         "type_info": "Json"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "data_plane_fqdn",
         "type_info": "Text"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "broker_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "reactor_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "dekaf_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "dekaf_registry_address",
         "type_info": "Text"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "ops_logs_name: models::Collection",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "ops_stats_name: models::Collection",
         "type_info": "Text"
       }
@@ -73,11 +78,12 @@
       false,
       false,
       false,
+      false,
       true,
       true,
       false,
       false
     ]
   },
-  "hash": "6d0e1b7d53a61a032da213976b1d3437463571a8e795a4eab8d525960b7001d7"
+  "hash": "f133c223a0df27245c413ef1ef8d94773a3c9ce12c6c34161874455e206e35dc"
 }

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -157,6 +157,7 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
             SELECT
                 d.id AS "control_id: Id",
                 d.data_plane_name,
+                d.closed,
                 d.hmac_keys,
                 d.encrypted_hmac_keys AS "encrypted_hmac_keys: models::RawValue",
                 d.data_plane_fqdn,
@@ -399,6 +400,7 @@ mod test {
             control_id: Id::zero(),
             data_plane_name: "test-data-plane".to_string(),
             data_plane_fqdn: "data.plane.test".to_string(),
+            closed: false,
             hmac_keys: Vec::new(),
             encrypted_hmac_keys: models::RawValue::from_string("{}".to_string()).unwrap(),
             ops_logs_name: models::Collection::new("tha/logs"),

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -466,6 +466,7 @@ impl tables::CatalogResolver for NoOpCatalogResolver {
                 models::Id::zero(),
                 "ops/dp/public/noop".to_string(),
                 "noop.dp.estuary-data.com".to_string(),
+                false, // closed
                 vec!["hmac-key".to_string()],
                 models::RawValue::from_string("{}".to_string()).unwrap(),
                 models::Collection::new("ops/logs"),

--- a/crates/control-plane-api/src/publications/specs.rs
+++ b/crates/control-plane-api/src/publications/specs.rs
@@ -880,6 +880,7 @@ pub async fn resolve_live_specs(
         SELECT
             d.id AS "control_id: Id",
             d.data_plane_name,
+            d.closed,
             d.hmac_keys,
             d.encrypted_hmac_keys AS "encrypted_hmac_keys: models::RawValue",
             d.data_plane_fqdn,

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -1,3 +1,4 @@
+use super::filters;
 use async_graphql::{
     ComplexObject, Context, SimpleObject,
     types::connection::{self, Connection},
@@ -5,6 +6,14 @@ use async_graphql::{
 use std::collections::HashMap;
 
 const DEFAULT_PAGE_SIZE: usize = 50;
+
+/// Optional filter for the `dataPlanes` query. When omitted, all accessible
+/// data planes are returned.
+#[derive(Debug, Clone, Default, async_graphql::InputObject)]
+pub struct DataPlanesFilter {
+    /// Filter on the `closed` flag.
+    pub closed: Option<filters::BoolFilter>,
+}
 
 /// Cloud provider where the data plane is hosted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, async_graphql::Enum)]
@@ -36,6 +45,8 @@ pub struct DataPlane {
     pub tag: String,
     /// Whether this is a public data-plane.
     pub is_public: bool,
+    /// Whether this data plane is closed to new selection.
+    pub closed: bool,
     /// CIDR blocks for this data-plane.
     pub cidr_blocks: Vec<String>,
     /// GCP service account email for this data-plane.
@@ -363,9 +374,13 @@ impl DataPlanesQuery {
     ///
     /// Results are paginated and sorted by data_plane_name.
     /// Only data planes the user has at least read capability to are returned.
+    ///
+    /// `filter.closed.eq` restricts results to data planes whose `closed`
+    /// flag matches it; omitting it returns both open and closed planes.
     pub async fn data_planes(
         &self,
         ctx: &Context<'_>,
+        filter: Option<DataPlanesFilter>,
         after: Option<String>,
         before: Option<String>,
         first: Option<i32>,
@@ -374,6 +389,11 @@ impl DataPlanesQuery {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
         let snapshot = env.snapshot();
+
+        let closed_eq = filter
+            .as_ref()
+            .and_then(|f| f.closed.as_ref())
+            .and_then(|f| f.eq);
 
         // Filter to only data planes the user can read and that have valid
         // names, sorted by data_plane_name for consistent pagination.
@@ -395,6 +415,13 @@ impl DataPlanesQuery {
             })
             .collect();
         accessible_data_planes.sort_by(|a, b| a.data_plane_name.cmp(&b.data_plane_name));
+
+        // Narrow to the requested `closed` value before pagination, so page
+        // sizes and cursors stay correct. The flag rides along in the authz
+        // snapshot, so this needs no database round-trip.
+        if let Some(want_closed) = closed_eq {
+            accessible_data_planes.retain(|dp| dp.closed == want_closed);
+        }
 
         // Apply cursor-based pagination.
         let (rows, has_prev, has_next) =
@@ -446,6 +473,7 @@ impl DataPlanesQuery {
                     region,
                     tag,
                     is_public,
+                    closed: dp.closed,
                     cidr_blocks: details.map(|d| d.cidr_blocks.clone()).unwrap_or_default(),
                     gcp_service_account_email: details
                         .and_then(|d| d.gcp_service_account_email.clone()),
@@ -478,6 +506,8 @@ impl DataPlanesQuery {
     /// This query requires no authentication. It exposes only the name, cloud
     /// provider, and region of public data planes, so that account-creation
     /// flows can offer a data-plane selection before the user has signed up.
+    /// Closed planes are always excluded: this query drives new selection,
+    /// which is exactly what closing a plane retires it from.
     ///
     /// Results are paginated and sorted by name.
     pub async fn public_data_planes(
@@ -497,7 +527,7 @@ impl DataPlanesQuery {
             .filter_map(|dp| {
                 let (cloud_provider, region, _tag, is_public) =
                     parse_data_plane_name(&dp.data_plane_name)?;
-                is_public.then(|| PublicDataPlane {
+                (is_public && !dp.closed).then(|| PublicDataPlane {
                     name: dp.data_plane_name.clone(),
                     cloud_provider,
                     region,
@@ -759,6 +789,136 @@ mod tests {
             first_error_message(&denied)
                 .contains("the request is missing a required Authorization: Bearer token"),
             "expected an unauthenticated error, got: {denied}",
+        );
+    }
+
+    // `publicDataPlanes` drives pre-signup selection, so a closed plane must
+    // never appear. Closing one of the two public fixture planes must drop it
+    // while the other remains.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_graphql_public_data_planes_excludes_closed(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let closed_dp = "ops/dp/public/gcp-us-central1-c2";
+        let open_dp = "ops/dp/public/aws-us-west-2-c1";
+        sqlx::query("UPDATE data_planes SET closed = true WHERE data_plane_name = $1")
+            .bind(closed_dp)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // The snapshot is built after the update, so it captures closed = true.
+        let server =
+            test_server::TestServer::start(pool.clone(), test_server::snapshot(pool, false).await)
+                .await;
+
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        publicDataPlanes {
+                            edges { node { name } }
+                        }
+                    }
+                    "#
+                }),
+                None,
+            )
+            .await;
+
+        let names: Vec<&str> = response["data"]["publicDataPlanes"]["edges"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected edges, got: {response}"))
+            .iter()
+            .map(|e| e["node"]["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec![open_dp], "closed public plane must be excluded");
+    }
+
+    // The `filter.closed.eq` argument narrows the listing to matching planes,
+    // while omitting the filter returns both open and closed planes. The
+    // `data_planes` fixture leaves both public planes open by default; closing
+    // one exercises all three cases.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_graphql_data_planes_closed_filter(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let closed_dp = "ops/dp/public/gcp-us-central1-c2";
+        let open_dp = "ops/dp/public/aws-us-west-2-c1";
+        sqlx::query("UPDATE data_planes SET closed = true WHERE data_plane_name = $1")
+            .bind(closed_dp)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let server =
+            test_server::TestServer::start(pool.clone(), test_server::snapshot(pool, false).await)
+                .await;
+        let token = server.make_access_token(uuid::Uuid::from_bytes([0x11; 16]), None);
+
+        // Collects the sorted set of returned data-plane names for the given
+        // `filter` argument (JSON null when omitted).
+        async fn names(
+            server: &test_server::TestServer,
+            token: &str,
+            filter: serde_json::Value,
+        ) -> Vec<String> {
+            let response: serde_json::Value = server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                        query($filter: DataPlanesFilter) {
+                            dataPlanes(filter: $filter) {
+                                edges { node { name closed } }
+                            }
+                        }
+                        "#,
+                        "variables": { "filter": filter },
+                    }),
+                    Some(token),
+                )
+                .await;
+            let mut names: Vec<String> = response["data"]["dataPlanes"]["edges"]
+                .as_array()
+                .unwrap_or_else(|| panic!("expected edges, got: {response}"))
+                .iter()
+                .map(|e| e["node"]["name"].as_str().unwrap().to_string())
+                .collect();
+            names.sort();
+            names
+        }
+
+        // No filter: both planes, regardless of `closed`.
+        assert_eq!(
+            names(&server, &token, serde_json::Value::Null).await,
+            vec![open_dp.to_string(), closed_dp.to_string()],
+        );
+        // closed eq false -> only the open plane.
+        assert_eq!(
+            names(
+                &server,
+                &token,
+                serde_json::json!({ "closed": { "eq": false } })
+            )
+            .await,
+            vec![open_dp.to_string()],
+        );
+        // closed eq true -> only the closed plane.
+        assert_eq!(
+            names(
+                &server,
+                &token,
+                serde_json::json!({ "closed": { "eq": true } })
+            )
+            .await,
+            vec![closed_dp.to_string()],
         );
     }
 

--- a/crates/control-plane-api/src/server/snapshot.rs
+++ b/crates/control-plane-api/src/server/snapshot.rs
@@ -442,6 +442,7 @@ pub async fn try_fetch(
             d.id AS "control_id: models::Id",
             d.data_plane_name,
             d.data_plane_fqdn,
+            d.closed,
             d.hmac_keys,
             d.encrypted_hmac_keys as "encrypted_hmac_keys: models::RawValue",
             d.broker_address,

--- a/crates/control-plane-api/src/server/snapshot_fixture.json
+++ b/crates/control-plane-api/src/server/snapshot_fixture.json
@@ -61,6 +61,7 @@
       "control_id": "0101010101010101",
       "data_plane_name": "ops/dp/public/plane-one",
       "data_plane_fqdn": "fqdn1",
+      "closed": false,
       "hmac_keys": [
         "a2V5MQ==",
         "a2V5Mg=="
@@ -77,6 +78,7 @@
       "control_id": "0202020202020202",
       "data_plane_name": "ops/dp/public/plane-two",
       "data_plane_fqdn": "fqdn2",
+      "closed": false,
       "hmac_keys": [
         "a2V5Mw=="
       ],

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -711,6 +711,10 @@ type DataPlane {
 	"""
 	isPublic: Boolean!
 	"""
+	Whether this data plane is closed to new selection.
+	"""
+	closed: Boolean!
+	"""
 	CIDR blocks for this data-plane.
 	"""
 	cidrBlocks: [String!]!
@@ -789,6 +793,17 @@ type DataPlaneEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+"""
+Optional filter for the `dataPlanes` query. When omitted, all accessible
+data planes are returned.
+"""
+input DataPlanesFilter {
+	"""
+	Filter on the `closed` flag.
+	"""
+	closed: BoolFilter
 }
 
 input DateFilter {
@@ -1627,14 +1642,19 @@ type QueryRoot {
 	
 	Results are paginated and sorted by data_plane_name.
 	Only data planes the user has at least read capability to are returned.
+	
+	`filter.closed.eq` restricts results to data planes whose `closed`
+	flag matches it; omitting it returns both open and closed planes.
 	"""
-	dataPlanes(after: String, before: String, first: Int, last: Int): DataPlaneConnection!
+	dataPlanes(filter: DataPlanesFilter, after: String, before: String, first: Int, last: Int): DataPlaneConnection!
 	"""
 	Returns all public data planes.
 	
 	This query requires no authentication. It exposes only the name, cloud
 	provider, and region of public data planes, so that account-creation
 	flows can offer a data-plane selection before the user has signed up.
+	Closed planes are always excluded: this query drives new selection,
+	which is exactly what closing a plane retires it from.
 	
 	Results are paginated and sorted by name.
 	"""

--- a/crates/flowctl/src/local_specs.rs
+++ b/crates/flowctl/src/local_specs.rs
@@ -351,6 +351,7 @@ impl Resolver {
                 row.id,
                 row.data_plane_name,
                 String::new(),                 // data_plane_fqdn
+                false,                         // closed
                 Vec::new(),                    // hmac_keys
                 models::RawValue::default(),   // encrypted_hmac_keys
                 models::Collection::default(), // ops_logs_name

--- a/crates/migrate/src/lib.rs
+++ b/crates/migrate/src/lib.rs
@@ -523,6 +523,7 @@ async fn fetch_data_plane(pg_pool: &sqlx::PgPool, name: &str) -> anyhow::Result<
             id AS "control_id: models::Id",
             data_plane_name,
             data_plane_fqdn,
+            closed,
             hmac_keys,
             encrypted_hmac_keys as "encrypted_hmac_keys: models::RawValue",
             broker_address,

--- a/crates/tables/src/lib.rs
+++ b/crates/tables/src/lib.rs
@@ -79,6 +79,11 @@ tables!(
         val data_plane_name: String,
         // Unique and fully-qualified domain name of this data-plane.
         val data_plane_fqdn: String,
+        // Whether this data-plane is closed to new selection. Closed planes
+        // keep serving existing tasks but are hidden from the default
+        // `dataPlanes` listing, letting operators retire a plane from new
+        // selection without deleting its record.
+        val closed: bool,
         // HMAC-256 keys for this data-plane.
         // The first is used for signing, and any key may validate.
         val hmac_keys: Vec<String>,

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -876,6 +876,7 @@ mod test {
             models::Id::new([0, 0, 0, 0, 0, 0, 2, 2]),
             "test-plane".to_string(),
             "test-plane.example.com".to_string(),
+            false, // closed
             vec!["test-key".to_string()],
             models::RawValue::default(),
             models::Collection::new("ops/acmeCo/logs"),

--- a/crates/validation/tests/common.rs
+++ b/crates/validation/tests/common.rs
@@ -120,6 +120,7 @@ pub fn run(fixture_yaml: &str, patch_yaml: &str) -> Outcome {
             control_id,
             format!("ops/dp/public/test-{control_id}"),
             "the-data-plane.dp.estuary-data.com".to_string(),
+            false, // closed
             vec!["hmac-key".to_string()],
             models::RawValue::from_string("{}".to_string()).unwrap(),
             models::Collection::new("ops/logs"),

--- a/supabase/migrations/20260716120000_data_plane_closed.sql
+++ b/supabase/migrations/20260716120000_data_plane_closed.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Whether a data plane is closed to new selection. A closed data plane remains
+-- in the catalog (and keeps serving existing tasks) but is hidden from the
+-- default `dataPlanes` listing and from `publicDataPlanes`, so operators can
+-- retire a plane from new selection without deleting its record. Defaults to
+-- false so every existing plane stays open.
+ALTER TABLE public.data_planes
+ADD COLUMN closed boolean NOT NULL DEFAULT false;
+
+GRANT
+SELECT
+  (closed) ON public.data_planes TO authenticated;
+
+COMMENT ON COLUMN public.data_planes.closed IS 'Whether this data plane is closed to new selection';
+
+COMMIT;


### PR DESCRIPTION
## What

Adds a `closed` boolean to data planes and lets the `dataPlanes` query filter on it.

- **DB:** new `data_planes.closed` column, `boolean NOT NULL DEFAULT false` (existing planes stay open), with a `SELECT (closed)` grant to `authenticated`.
- **GraphQL:** `closed: Boolean!` on the `DataPlane` type, plus a `DataPlanesFilter` argument on `dataPlanes` carrying `closed: BoolFilter`. `filter.closed.eq` narrows to matching planes; omitting it returns both open and closed planes.

## Why

Lets operators retire a data plane from new selection - a closed plane keeps serving existing tasks but drops out of listings. "Closed" reflects that the plane is still fully live; it's only withheld from new selection.

## Notes

- `closed` rides on the authorization snapshot, so both the filter and the per-node value resolve in-memory with no database round-trip. The filter is applied before pagination, keeping page sizes and cursors correct. The snapshot lags the DB by up to one refresh interval, which is acceptable for a listing filter.
- The unauthenticated `publicDataPlanes` query (pre-signup selection) excludes closed planes unconditionally - a retired plane should never be offered to a new signup. It takes no filter argument.
