### PR TITLE
models: add dns_names to AzurePrivateLink for multi-hostname Azure Private Link

### DIFF
--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -612,6 +612,7 @@ mod test {
                 service_name: "service".to_string(),
                 resource_type: Some("managedInstance".to_string()),
                 dns_name: Some("privatelink.database.windows.net".to_string()),
+                dns_names: vec![],
             }),
         );
         assert_eq!(

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -331,6 +331,7 @@ type AzurePrivateLink {
 	location: String!
 	dnsName: String
 	resourceType: String
+	dnsNames: [String!]!
 }
 
 input AzurePrivateLinkInput {
@@ -338,6 +339,7 @@ input AzurePrivateLinkInput {
 	location: String!
 	dnsName: String
 	resourceType: String
+	dnsNames: [String!]! = []
 }
 
 type BillingAddress {

--- a/crates/models/src/private_links.rs
+++ b/crates/models/src/private_links.rs
@@ -66,6 +66,12 @@ pub struct AzurePrivateLink {
         skip_serializing_if = "is_none_or_empty"
     )]
     pub resource_type: Option<String>,
+    // Additional DNS zone names backed by this single endpoint, mirroring GCP
+    // PSC's `dns_record_names`. Empty by default and omitted on serialize, so
+    // historical rows round-trip byte-for-byte.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "async-graphql", graphql(default))]
+    pub dns_names: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -135,6 +141,44 @@ mod tests {
         assert_eq!(azure.dns_name.as_deref(), Some("d"));
         assert_eq!(azure.resource_type.as_deref(), Some("t"));
         assert_eq!(serde_json::to_string(&link).unwrap(), some);
+    }
+
+    #[test]
+    fn azure_dns_names_round_trip() {
+        // `dns_names` defaults to empty and is omitted on serialize, so the
+        // absent and legacy `dns_name`-only shapes round-trip unchanged; a
+        // populated list round-trips as a JSON array.
+        let absent = r#"{"service_name":"svc","location":"eastus"}"#;
+        let list =
+            r#"{"service_name":"svc","location":"eastus","dns_names":["dev.example","prd.example"]}"#;
+        let legacy =
+            r#"{"service_name":"svc","location":"eastus","dns_name":"privatelink.database.windows.net"}"#;
+
+        let link: PrivateLink = serde_json::from_str(absent).unwrap();
+        let PrivateLink::Azure(azure) = &link else {
+            panic!("expected Azure variant");
+        };
+        assert!(azure.dns_names.is_empty());
+        assert_eq!(serde_json::to_string(&link).unwrap(), absent);
+
+        let link: PrivateLink = serde_json::from_str(list).unwrap();
+        let PrivateLink::Azure(azure) = &link else {
+            panic!("expected Azure variant");
+        };
+        assert_eq!(azure.dns_name, None);
+        assert_eq!(azure.dns_names, vec!["dev.example", "prd.example"]);
+        assert_eq!(serde_json::to_string(&link).unwrap(), list);
+
+        let link: PrivateLink = serde_json::from_str(legacy).unwrap();
+        let PrivateLink::Azure(azure) = &link else {
+            panic!("expected Azure variant");
+        };
+        assert_eq!(
+            azure.dns_name.as_deref(),
+            Some("privatelink.database.windows.net")
+        );
+        assert!(azure.dns_names.is_empty());
+        assert_eq!(serde_json::to_string(&link).unwrap(), legacy);
     }
 
     #[test]


### PR DESCRIPTION
**Description:**

An Azure Private Link Service is a single private endpoint at one private IP, and it can front several hostnames multiplexed by port. `models::AzurePrivateLink` only allowed one `dns_name` per service, so the extra hostnames had nowhere to go.

This adds an optional `dns_names: Vec<String>` to `AzurePrivateLink`, matching `GCPPrivateServiceConnect.dns_record_names`. It uses `#[serde(default, skip_serializing_if = "Vec::is_empty")]` plus `graphql(default)`, so it defaults to absent and existing rows round-trip byte for byte.

This needs to land before (or with) the est-dry-dock change (estuary/est-dry-dock#339). The data-plane-controller deserializes `data_planes.private_links` into this struct and re-serializes it into the Pulumi stack config that est-dry-dock reads. `PrivateLink` is `#[serde(untagged)]` with fixed fields and no catch-all, so a `dns_names` added only to the est-dry-dock Pydantic model gets dropped before Pulumi sees it. The Rust field is what keeps it intact.

**Workflow steps:**

Nothing changes for existing configs. An operator can now set `dns_names: ["host-a", "host-b"]` on an Azure private-link row, through the `updateDataPlanePrivateLinks` mutation or a direct row edit, so one endpoint backs several private DNS zones. You can use `dns_name` and `dns_names` together, or drop `dns_name` and use `dns_names` alone; the effective set is the union of the two.

**Documentation links affected:**

None.

**Notes for reviewers:**

- New `azure_dns_names_round_trip` test covers three shapes: absent (omitted on serialize), a populated list that round-trips, and a legacy `dns_name`-only row.
- The `data_plane_parse` literal now sets `dns_names: vec![]`.
- `control-plane-api.graphql` was regenerated by the schema build. It adds `dnsNames: [String!]!` to the type and `dnsNames: [String!]! = []` to the input, and `graphql-schema-check` passes.
- No DPC or GraphQL snapshots change, because the field is omitted when empty and no fixture or query populates or selects it. I ran the models tests, the DPC lib tests, and the three integration snapshot suites (`test_private_links`, `test_preview`, `test_initial_convergence_and_release`) locally, and they all pass with no snapshot changes.
- One optional follow-up: the `data_planes_with_private_links` GraphQL test does not select `dnsNames`, so the field is not exercised through a query or mutation. The resolver is derive-generated and schema presence is checked in CI, so the risk is low.