### PR TITLE
control-plane: refresh notification emails

### DIFF
--- a/crates/agent/src/integration_tests/tenant_alerts.rs
+++ b/crates/agent/src/integration_tests/tenant_alerts.rs
@@ -119,7 +119,10 @@ async fn test_tenant_alerts_happy_path() {
         .assert_alert_firing("deer/alerts/free_trial_ending", AlertType::FreeTrialEnding)
         .await;
     emails.assert_emails_sent(&["deer@new_user_onboarding.test"]);
-    assert_eq!("Next Up: Estuary Paid Tier", &emails.notifications[0].subject);
+    assert_eq!(
+        "Next Up: Estuary Paid Tier",
+        &emails.notifications[0].subject
+    );
 
     sqlx::query(
         r#"insert into stripe.customers (

--- a/crates/agent/src/integration_tests/tenant_alerts.rs
+++ b/crates/agent/src/integration_tests/tenant_alerts.rs
@@ -119,7 +119,7 @@ async fn test_tenant_alerts_happy_path() {
         .assert_alert_firing("deer/alerts/free_trial_ending", AlertType::FreeTrialEnding)
         .await;
     emails.assert_emails_sent(&["deer@new_user_onboarding.test"]);
-    assert_eq!("Estuary Flow: Paid Tier", &emails.notifications[0].subject);
+    assert_eq!("Next Up: Estuary Paid Tier", &emails.notifications[0].subject);
 
     sqlx::query(
         r#"insert into stripe.customers (
@@ -167,7 +167,7 @@ async fn test_tenant_alerts_happy_path() {
         .await;
     emails.assert_emails_sent(&["deer@new_user_onboarding.test"]);
     assert_eq!(
-        "Estuary: Thanks for Adding a Payment Method🎉",
+        "Estuary: Thanks for Adding a Payment Method 🎉",
         &emails.notifications[0].subject
     );
 

--- a/crates/notifications/src/auto_discover_failed.rs
+++ b/crates/notifications/src/auto_discover_failed.rs
@@ -7,7 +7,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Auto-discover failed for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Auto-discover failed for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering auto_discover_failed-fired-subject template")?;
 
@@ -19,10 +19,10 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-    <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+    <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
 </ul>
 <p class="body-text">
-    We are here to help ensure your data pipelines run smoothly.
+    We're here to help your data pipelines run smoothly.
 </p>"#,
         )
         .context("registering auto_discover_failed-fired-body template")?;
@@ -32,7 +32,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Auto-discover resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Auto-discover resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering auto_discover_failed-resolved-subject template")?;
 
@@ -46,7 +46,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     You can <a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">view your task</a> to confirm everything is working as expected, or update your alerting settings.
 </p>
 <p class="body-text">
-    We are here to help ensure your data pipelines run smoothly.
+    We're here to help your data pipelines run smoothly.
 </p>"#,
         )
         .context("registering auto_discover_failed-resolved-body template")?;

--- a/crates/notifications/src/background_publication_failed.rs
+++ b/crates/notifications/src/background_publication_failed.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Automated background publication failed for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Automated background publication failed for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering background_publication_failed-fired-subject template")?;
 
@@ -21,10 +21,10 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-    <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+    <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
 </ul>
 <p class="body-text">
-    We are here to help ensure your data pipelines run smoothly.
+    We're here to help your data pipelines run smoothly.
 </p>"#,
         )
         .context("registering background_publication_failed-fired-body template")?;
@@ -34,7 +34,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Automated background publication alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Automated background publication alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering background_publication_failed-resolved-subject template")?;
 
@@ -48,7 +48,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     You can <a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">view your task</a> to confirm everything is working as expected, or update your alerting settings.
 </p>
 <p class="body-text">
-    We are here to help ensure your data pipelines run smoothly.
+    We're here to help your data pipelines run smoothly.
 </p>"#,
         )
         .context("registering background_publication_failed-resolved-body template")?;

--- a/crates/notifications/src/data_movement_stalled.rs
+++ b/crates/notifications/src/data_movement_stalled.rs
@@ -8,7 +8,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Alert for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Alert for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering data_movement_stalled-fired-subject template")?;
 
@@ -27,7 +27,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Alert resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering data_movement_stalled-resolved-subject template")?;
 

--- a/crates/notifications/src/free_trial.rs
+++ b/crates/notifications/src/free_trial.rs
@@ -13,7 +13,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
             r#"{{#if arguments.has_credit_card}}
 <p class="body-text">Your Estuary account <span class="identifier">{{arguments.tenant}}</span> has started its 30-day free trial. This trial will end on <strong>{{arguments.trial_end}}</strong>. Billing will begin accruing then.</p>
 {{else}}
-<p class="body-text">We hope you're enjoying Estuary Flow. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">{{arguments.tenant}}</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>{{arguments.trial_end}}</strong>.</p>
+<p class="body-text">We hope you're enjoying Estuary. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">{{arguments.tenant}}</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>{{arguments.trial_end}}</strong>.</p>
 <p class="body-text">Please add payment information in the next 30 days to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
 <a href="{{> dashboard_billing_url}}" class="button">Add payment information</a>
 {{/if}}"#,
@@ -26,7 +26,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"{{#if arguments.has_credit_card}}Estuary Flow: Paid Tier{{else}}Estuary Paid Tier: Enter Payment Info to Continue Access{{/if}}"#,
+            r#"{{#if arguments.has_credit_card}}Estuary: Paid Tier{{else}}Estuary Paid Tier: Enter Payment Info to Continue Access{{/if}}"#,
         )
         .context("registering free_trial-resolved-subject template")?;
 
@@ -34,11 +34,11 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
         .register_template_string(
             &resolved_body,
             r#"{{#if arguments.has_credit_card}}
-<p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
+<p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
 <p class="body-text">Since you have already added a payment method, no action is required. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a> anytime!</p>
 <a href="https://dashboard.estuary.dev" class="button">🌊 View your data flows</a>
 {{else}}
-<p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
+<p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">{{arguments.tenant}}</span> is officially over.</p>
 <p class="body-text">Please add payment information immediately to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
 <a href="{{> dashboard_billing_url}}" class="button">Add payment information</a>
 {{/if}}"#,

--- a/crates/notifications/src/free_trial_ending.rs
+++ b/crates/notifications/src/free_trial_ending.rs
@@ -6,14 +6,14 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     let (fired_subject, fired_body) =
         template_names(models::status::AlertType::FreeTrialEnding, false);
     registry
-        .register_template_string(&fired_subject, r#"Estuary Flow: Paid Tier"#)
+        .register_template_string(&fired_subject, r#"Next Up: Estuary Paid Tier"#)
         .context("registering free_trial_ending-fired-subject template")?;
 
     registry
         .register_template_string(
             &fired_body,
             r#"{{#if arguments.has_credit_card}}
-<p class="body-text">Just so you know, your free trial for <span class="identifier">{{arguments.tenant}}</span> will be ending on <strong>{{arguments.trial_end}}</strong>. Since you have already added a payment method, no action is required.</p>
+<p class="body-text">As a reminder, your free trial for <span class="identifier">{{arguments.tenant}}</span> will be ending on <strong>{{arguments.trial_end}}</strong>. Since you have already added a payment method, no action is required.</p>
 <a href="{{> dashboard_billing_url}}" class="button">📈 View your stats</a>
 {{else}}
 <p class="body-text">Your free trial for <span class="identifier">{{arguments.tenant}}</span> is ending on <strong>{{arguments.trial_end}}</strong>, at which point your account will begin accruing usage. Please enter a payment method in order to continue using the platform after your trial ends. We'd be sad to see you go!</p>

--- a/crates/notifications/src/lib.rs
+++ b/crates/notifications/src/lib.rs
@@ -419,7 +419,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Auto-discover failed for capture acmeCo/test/capture",
+            "Estuary: Auto-discover failed for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("auto_discover_failed_fired_body", email.body);
     }
@@ -440,7 +440,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Auto-discover resolved for capture acmeCo/test/capture",
+            "Estuary: Auto-discover resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("auto_discover_failed_resolved_body", email.body);
     }
@@ -461,7 +461,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Automated background publication failed for capture acmeCo/test/capture",
+            "Estuary: Automated background publication failed for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("background_publication_failed_fired_body", email.body);
     }
@@ -482,7 +482,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Automated background publication alert resolved for capture acmeCo/test/capture",
+            "Estuary: Automated background publication alert resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("background_publication_failed_resolved_body", email.body);
     }
@@ -505,7 +505,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Alert for materialization acmeCo/test/materialization",
+            "Estuary: Alert for materialization acmeCo/test/materialization",
         );
         insta::assert_snapshot!("data_movement_stalled_fired_body", email.body);
     }
@@ -528,7 +528,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Alert resolved for materialization acmeCo/test/materialization",
+            "Estuary: Alert resolved for materialization acmeCo/test/materialization",
         );
         insta::assert_snapshot!("data_movement_stalled_resolved_body", email.body);
     }
@@ -606,7 +606,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Paid Tier",
+            "Estuary: Paid Tier",
         );
         insta::assert_snapshot!("free_trial_resolved_with_cc_body", email.body);
     }
@@ -660,7 +660,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Paid Tier",
+            "Next Up: Estuary Paid Tier",
         );
         insta::assert_snapshot!("free_trial_ending_fired_with_cc_body", email.body);
     }
@@ -684,7 +684,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Paid Tier",
+            "Next Up: Estuary Paid Tier",
         );
         insta::assert_snapshot!("free_trial_ending_fired_without_cc_body", email.body);
     }
@@ -798,7 +798,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary: Thanks for Adding a Payment Method🎉",
+            "Estuary: Thanks for Adding a Payment Method 🎉",
         );
         insta::assert_snapshot!(
             "missing_payment_method_resolved_free_trial_body",
@@ -831,7 +831,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary: Thanks for Adding a Payment Method🎉",
+            "Estuary: Thanks for Adding a Payment Method 🎉",
         );
         insta::assert_snapshot!("missing_payment_method_resolved_paid_body", email.body);
     }
@@ -856,7 +856,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: Task failure detected for capture acmeCo/test/capture",
+            "Estuary: Task failure detected for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("shard_failed_fired_body", email.body);
     }
@@ -881,7 +881,7 @@ mod tests {
             &email,
             user_b(),
             EXPECT_IDEMPOTENCY_KEY_RESOLVED,
-            "Estuary Flow: Task failure resolved for capture acmeCo/test/capture",
+            "Estuary: Task failure resolved for capture acmeCo/test/capture",
         );
         insta::assert_snapshot!("shard_failed_resolved_body", email.body);
     }
@@ -970,7 +970,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+            "Estuary: capture acmeCo/test/capture is chronically failing",
         );
         insta::assert_snapshot!("task_chronically_failing_fired_body", email.body);
     }
@@ -995,7 +995,7 @@ mod tests {
             &email,
             user_a(),
             EXPECT_IDEMPOTENCY_KEY_FIRED,
-            "Estuary Flow: capture acmeCo/test/capture is chronically failing",
+            "Estuary: capture acmeCo/test/capture is chronically failing",
         );
         assert!(
             email.body.contains("failing since 2025-05-01"),

--- a/crates/notifications/src/missing_payment_method.rs
+++ b/crates/notifications/src/missing_payment_method.rs
@@ -8,14 +8,14 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary: Thanks for Adding a Payment Method🎉"#,
+            r#"Estuary: Thanks for Adding a Payment Method 🎉"#,
         )
         .context("registering missing_payment_method-resolved-subject template")?;
 
     registry
         .register_template_string(
             &resolved_body,
-            r#"<p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">{{arguments.tenant}}</span>. {{#if (eq arguments.plan_state "free_trial")}}After your free trial ends on <strong>{{arguments.trial_end}}</strong>, you will automatically be switched the paid tier.{{else}}You are now on the paid tier.{{/if}}</p>
+            r#"<p class="body-text">We hope you're enjoying Estuary! We have received your payment method for your account <span class="identifier">{{arguments.tenant}}</span>. {{#if (eq arguments.plan_state "free_trial")}}After your free trial ends on <strong>{{arguments.trial_end}}</strong>, you will automatically be switched to the paid tier.{{else}}You are now on the paid tier.{{/if}}</p>
 <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
 
 <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">
@@ -32,14 +32,14 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 <div style="margin-top: 15px;">
     <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How can I access Estuary Support?</p>
     <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-        <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our slack.</p>
+        <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our <a href="https://go.estuary.dev/slack">Slack community</a>.</p>
     </div>
 </div>
 
 <div style="margin-top: 15px;">
-    <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Is it possible to schedule data flows?</p>
+    <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How do I estimate my monthly bill?</p>
     <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-        <p class="body-text" style="margin-bottom: 0;">Estuary moves most data in real-time by default, without the need for scheduling, but you can add "update delays" to data warehouses to enable more downtime on your warehouse for cost savings. This can be enabled under "advanced settings" and default settings are 30 minutes for a warehouse.</p>
+        <p class="body-text" style="margin-bottom: 0;">Estuary charges based on throughput and connector usage. See our simple <a href="https://estuary.dev/pricing/#pricing-calculator">pricing calculator</a> to estimate costs based on expected usage or <a href="https://docs.estuary.dev/getting-started/pricing/">read more about pricing plans</a>.</p>
     </div>
 </div>"#,
         )

--- a/crates/notifications/src/shard_failed.rs
+++ b/crates/notifications/src/shard_failed.rs
@@ -6,7 +6,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: Task failure detected for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Task failure detected for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering shard_failed-fired-subject template")?;
 
@@ -18,10 +18,11 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-    <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+    <li>If this {{arguments.spec_type}} experiences transient failures, consider <a href="https://docs.estuary.dev/guides/notifications/customize-alerts">configuring notifications</a> to have a higher failure threshold</li>
+    <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
 </ul>
 <p class="body-text">
-    We are here to help ensure your data pipelines run smoothly.
+    We're here to help your data pipelines run smoothly.
 </p>"#,
         )
         .context("registering shard_failed-fired-body template")?;
@@ -32,7 +33,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &resolved_subject,
-            r#"Estuary Flow: Task failure resolved for {{arguments.spec_type}} {{catalog_name}}"#,
+            r#"Estuary: Task failure resolved for {{arguments.spec_type}} {{catalog_name}}"#,
         )
         .context("registering shard_failed-resolved-subject template")?;
 

--- a/crates/notifications/src/snapshots/notifications__tests__auto_discover_failed_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__auto_discover_failed_fired_body.snap
@@ -45,10 +45,10 @@ expression: email.body
             </p>
             <ul>
                 <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-                <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+                <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
             </ul>
             <p class="body-text">
-                We are here to help ensure your data pipelines run smoothly.
+                We're here to help your data pipelines run smoothly.
             </p>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/snapshots/notifications__tests__auto_discover_failed_resolved_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__auto_discover_failed_resolved_body.snap
@@ -47,7 +47,7 @@ expression: email.body
                 You can <a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">view your task</a> to confirm everything is working as expected, or update your alerting settings.
             </p>
             <p class="body-text">
-                We are here to help ensure your data pipelines run smoothly.
+                We're here to help your data pipelines run smoothly.
             </p>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/snapshots/notifications__tests__background_publication_failed_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__background_publication_failed_fired_body.snap
@@ -45,10 +45,10 @@ expression: email.body
             </p>
             <ul>
                 <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-                <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+                <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
             </ul>
             <p class="body-text">
-                We are here to help ensure your data pipelines run smoothly.
+                We're here to help your data pipelines run smoothly.
             </p>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/snapshots/notifications__tests__background_publication_failed_resolved_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__background_publication_failed_resolved_body.snap
@@ -47,7 +47,7 @@ expression: email.body
                 You can <a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">view your task</a> to confirm everything is working as expected, or update your alerting settings.
             </p>
             <p class="body-text">
-                We are here to help ensure your data pipelines run smoothly.
+                We're here to help your data pipelines run smoothly.
             </p>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_ending_fired_with_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_ending_fired_with_cc_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">Just so you know, your free trial for <span class="identifier">acmeCo/</span> will be ending on <strong>2024-02-14</strong>. Since you have already added a payment method, no action is required.</p>
+            <p class="body-text">As a reminder, your free trial for <span class="identifier">acmeCo/</span> will be ending on <strong>2024-02-14</strong>. Since you have already added a payment method, no action is required.</p>
             <a href="http://dashboard.estuary.test/admin/billing" class="button">📈 View your stats</a>
             <div class="signature">
                 Thanks,<br>

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_fired_without_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_fired_without_cc_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you're enjoying Estuary Flow. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">acmeCo/</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>2024-02-14</strong>.</p>
+            <p class="body-text">We hope you're enjoying Estuary. Our free tier includes 10 GB/month and 2 connectors. Your account <span class="identifier">acmeCo/</span> has now exceeded that, so it has been transitioned to a 30 day free trial ending on <strong>2024-02-14</strong>.</p>
             <p class="body-text">Please add payment information in the next 30 days to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
             <a href="http://dashboard.estuary.test/admin/billing" class="button">Add payment information</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_with_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_with_cc_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
+            <p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
             <p class="body-text">Since you have already added a payment method, no action is required. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a> anytime!</p>
             <a href="https://dashboard.estuary.dev" class="button">🌊 View your data flows</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_without_cc_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__free_trial_resolved_without_cc_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
+            <p class="body-text">We hope you are enjoying Estuary. Your free trial for account <span class="identifier">acmeCo/</span> is officially over.</p>
             <p class="body-text">Please add payment information immediately to continue using the platform. If you have any questions, feel free to reach out to <a href="mailto:support@estuary.dev">support@estuary.dev</a></p>
             <a href="http://dashboard.estuary.test/admin/billing" class="button">Add payment information</a>
             <div class="signature">

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_free_trial_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">acmeCo/</span>. After your free trial ends on <strong>2024-02-14</strong>, you will automatically be switched the paid tier.</p>
+            <p class="body-text">We hope you're enjoying Estuary! We have received your payment method for your account <span class="identifier">acmeCo/</span>. After your free trial ends on <strong>2024-02-14</strong>, you will automatically be switched to the paid tier.</p>
             <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
             
             <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">
@@ -57,14 +57,14 @@ expression: email.body
             <div style="margin-top: 15px;">
                 <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How can I access Estuary Support?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our slack.</p>
+                    <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our <a href="https://go.estuary.dev/slack">Slack community</a>.</p>
                 </div>
             </div>
             
             <div style="margin-top: 15px;">
-                <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Is it possible to schedule data flows?</p>
+                <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How do I estimate my monthly bill?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">Estuary moves most data in real-time by default, without the need for scheduling, but you can add "update delays" to data warehouses to enable more downtime on your warehouse for cost savings. This can be enabled under "advanced settings" and default settings are 30 minutes for a warehouse.</p>
+                    <p class="body-text" style="margin-bottom: 0;">Estuary charges based on throughput and connector usage. See our simple <a href="https://estuary.dev/pricing/#pricing-calculator">pricing calculator</a> to estimate costs based on expected usage or <a href="https://docs.estuary.dev/getting-started/pricing/">read more about pricing plans</a>.</p>
                 </div>
             </div>            <div class="signature">
                 Thanks,<br>

--- a/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__missing_payment_method_resolved_paid_body.snap
@@ -40,7 +40,7 @@ expression: email.body
         </div>
         <div class="divider"></div>
         <div class="email-content">
-            <p class="body-text">We hope you are enjoying Estuary Flow. We have received your payment method for your account <span class="identifier">acmeCo/</span>. You are now on the paid tier.</p>
+            <p class="body-text">We hope you're enjoying Estuary! We have received your payment method for your account <span class="identifier">acmeCo/</span>. You are now on the paid tier.</p>
             <a href="https://dashboard.estuary.dev/admin/billing" class="button">📈 See your bill</a>
             
             <hr style="border: 0; border-top: 1px dashed lightgrey; margin: 40px 0 10px 0;">
@@ -57,14 +57,14 @@ expression: email.body
             <div style="margin-top: 15px;">
                 <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How can I access Estuary Support?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our slack.</p>
+                    <p class="body-text" style="margin-bottom: 0;">Reach out to support@estuary.dev or join our <a href="https://go.estuary.dev/slack">Slack community</a>.</p>
                 </div>
             </div>
             
             <div style="margin-top: 15px;">
-                <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">Is it possible to schedule data flows?</p>
+                <p style="font-weight: bold; font-size: 19px; margin-bottom: 5px;">How do I estimate my monthly bill?</p>
                 <div style="border-left: 4px solid lightgrey; padding-left: 12px; margin-bottom: 15px;">
-                    <p class="body-text" style="margin-bottom: 0;">Estuary moves most data in real-time by default, without the need for scheduling, but you can add "update delays" to data warehouses to enable more downtime on your warehouse for cost savings. This can be enabled under "advanced settings" and default settings are 30 minutes for a warehouse.</p>
+                    <p class="body-text" style="margin-bottom: 0;">Estuary charges based on throughput and connector usage. See our simple <a href="https://estuary.dev/pricing/#pricing-calculator">pricing calculator</a> to estimate costs based on expected usage or <a href="https://docs.estuary.dev/getting-started/pricing/">read more about pricing plans</a>.</p>
                 </div>
             </div>            <div class="signature">
                 Thanks,<br>

--- a/crates/notifications/src/snapshots/notifications__tests__shard_failed_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__shard_failed_fired_body.snap
@@ -45,10 +45,11 @@ expression: email.body
             </p>
             <ul>
                 <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">Visit the task status and logs</a> for more information about the error</li>
-                <li>If you need help please reach out to our team via Slack (#support and #ask-ai) or reply to this email.</li>
+                <li>If this capture experiences transient failures, consider <a href="https://docs.estuary.dev/guides/notifications/customize-alerts">configuring notifications</a> to have a higher failure threshold</li>
+                <li>If you need help, please reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support and #ask-ai) or reply to this email</li>
             </ul>
             <p class="body-text">
-                We are here to help ensure your data pipelines run smoothly.
+                We're here to help your data pipelines run smoothly.
             </p>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/snapshots/notifications__tests__task_chronically_failing_fired_body.snap
+++ b/crates/notifications/src/snapshots/notifications__tests__task_chronically_failing_fired_body.snap
@@ -49,7 +49,7 @@ expression: email.body
             </p>
             <ul>
                 <li><a href="http://dashboard.estuary.test/captures/details/overview?catalogName=acmeCo/test/capture" target="_blank" rel="noopener">View the task status and logs</a></li>
-                <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+                <li>If you need help, reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support) or reply to this email</li>
             </ul>            <div class="signature">
                 Thanks,<br>
                 Estuary Team

--- a/crates/notifications/src/task_auto_disabled_failing.rs
+++ b/crates/notifications/src/task_auto_disabled_failing.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
         )
         .context("registering task_auto_disabled_failing-fired-subject template")?;
 
@@ -24,7 +24,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
-    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+    <li>If you need help, reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support) or reply to this email</li>
 </ul>"#,
         )
         .context("registering task_auto_disabled_failing-fired-body template")?;

--- a/crates/notifications/src/task_auto_disabled_idle.rs
+++ b/crates/notifications/src/task_auto_disabled_idle.rs
@@ -9,7 +9,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has been automatically disabled"#,
         )
         .context("registering task_auto_disabled_idle-fired-subject template")?;
 
@@ -21,7 +21,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
-    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+    <li>If you need help, reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support) or reply to this email</li>
 </ul>"#,
         )
         .context("registering task_auto_disabled_idle-fired-body template")?;

--- a/crates/notifications/src/task_chronically_failing.rs
+++ b/crates/notifications/src/task_chronically_failing.rs
@@ -7,7 +7,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} is chronically failing"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} is chronically failing"#,
         )
         .context("registering task_chronically_failing-fired-subject template")?;
 
@@ -22,7 +22,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
-    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+    <li>If you need help, reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support) or reply to this email</li>
 </ul>"#,
         )
         .context("registering task_chronically_failing-fired-body template")?;

--- a/crates/notifications/src/task_idle.rs
+++ b/crates/notifications/src/task_idle.rs
@@ -6,7 +6,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
     registry
         .register_template_string(
             &fired_subject,
-            r#"Estuary Flow: {{arguments.spec_type}} {{catalog_name}} has not moved data"#,
+            r#"Estuary: {{arguments.spec_type}} {{catalog_name}} has not moved data"#,
         )
         .context("registering task_idle-fired-subject template")?;
 
@@ -18,7 +18,7 @@ pub fn register_templates<'a>(registry: &mut handlebars::Handlebars<'a>) -> anyh
 </p>
 <ul>
     <li><a href="{{> spec_dashboard_overview_url}}" target="_blank" rel="noopener">View the task status and logs</a></li>
-    <li>If you need help, reach out to our team via Slack (#support) or reply to this email.</li>
+    <li>If you need help, reach out to our team via <a href="https://go.estuary.dev/slack">Slack</a> (#support) or reply to this email</li>
 </ul>"#,
         )
         .context("registering task_idle-fired-body template")?;


### PR DESCRIPTION
**Description:**

Language across notification emails was getting stale. This update makes the following changes to refresh it:

* Updates instances of `Estuary Flow` to `Estuary` (noted as a TODO in #3000)
* Minor reworks on language that felt stiff
* Adjusts information with new features (alert configurations) or to better fit the message theme (swaps out a sync schedule FAQ for a billing one in a trial/payment method email)
* Actually links out to Slack where mentioned rather than leaving it as an exercise to the user to find us

I may want to make some further tweaks in the future (eg. the trial emails could include more information along the way rather than only providing FAQs _after_ a user enters a payment method) but this fixes some of the main things for now.

Does not update the `alert_notifications` snapshot tests: see https://github.com/estuary/flow/pull/3079

**Verification:**

Verified to ensure all tests pass with:
```
cargo test --manifest-path crates/notifications/Cargo.toml
```

**Documentation links affected:**

None. We don't mention the specific content of notification emails in docs.

**Notes for reviewers:**

Please let me know if anything else is required; I'm not super familiar with updating the control plane.

