### PR TITLE
Bound too-large error messages over RPC

### DIFF
--- a/crates/runtime-next/src/leader/derive/handler.rs
+++ b/crates/runtime-next/src/leader/derive/handler.rs
@@ -246,8 +246,8 @@ where
 
     // Best-effort broadcast of terminal error to all shards.
     let status = match err.downcast_ref::<tonic::Status>() {
-        Some(status) => status.clone(),
-        None => tonic::Status::unknown(format!("{err:?}")),
+        Some(status) => crate::bound_status(status.clone()),
+        None => crate::bounded_unknown_status(format!("{err:?}")),
     };
     for tx in error_tx {
         let _ = tx.send(Err(status.clone()));

--- a/crates/runtime-next/src/leader/materialize/handler.rs
+++ b/crates/runtime-next/src/leader/materialize/handler.rs
@@ -262,8 +262,8 @@ where
 
     // Best-effort broadcast of terminal error to all shards.
     let status = match err.downcast_ref::<tonic::Status>() {
-        Some(status) => status.clone(),
-        None => tonic::Status::unknown(format!("{err:?}")),
+        Some(status) => crate::bound_status(status.clone()),
+        None => crate::bounded_unknown_status(format!("{err:?}")),
     };
     for tx in error_tx {
         let _ = tx.send(Err(status.clone()));

--- a/crates/runtime-next/src/lib.rs
+++ b/crates/runtime-next/src/lib.rs
@@ -111,14 +111,71 @@ impl RuntimeProtocol {
     }
 }
 
+/// Maximum byte length of a `tonic::Status` message that we build from a
+/// formatted error. gRPC status text rides in an HTTP/2 trailer; an oversized
+/// trailer forces the header block across many CONTINUATION frames, tripping
+/// `h2`'s `too_many_continuations` guard, which aborts the connection and
+/// *replaces* the real status text with an opaque transport error
+///
+/// The ceiling exists so that *any* error, anticipated or not, stays within a
+/// single HTTP/2 frame (default `max_frame_size` is 16 KiB) and never needs a
+/// CONTINUATION frame at all. The `grpc-message` trailer is percent-encoded, so
+/// a byte can expand up to 3x (`%XX`); 4 KiB raw is ≤ 12 KiB encoded, fitting
+/// one frame even in the worst case.
+pub const MAX_STATUS_MESSAGE_LEN: usize = 4096;
+
 // Map an anyhow::Error into a tonic::Status.
-// If the error is already a Status, it's downcast.
-// Otherwise, an internal error is used to wrap a formatted anyhow::Error chain.
+// If the error is already a Status, it's downcast (and bounded).
+// Otherwise, an internal error is used to wrap a formatted anyhow::Error chain,
+// bounded to MAX_STATUS_MESSAGE_LEN.
 pub fn anyhow_to_status(err: anyhow::Error) -> tonic::Status {
     match err.downcast::<tonic::Status>() {
-        Ok(status) => status,
-        Err(err) => tonic::Status::unknown(format!("{err:?}")),
+        Ok(status) => bound_status(status),
+        Err(err) => bounded_unknown_status(format!("{err:?}")),
     }
+}
+
+/// Build a `tonic::Status::unknown` whose message is bounded to
+/// [`MAX_STATUS_MESSAGE_LEN`] bytes. The anyhow debug format leads with the
+/// error's top-level context and appends lower-level detail, so truncating the
+/// tail preserves the human-meaningful prefix.
+pub(crate) fn bounded_unknown_status(message: String) -> tonic::Status {
+    tonic::Status::unknown(bound_message(message))
+}
+
+/// Bound the message of a `Status` we did not format ourselves — one round
+/// tripped from a peer or produced by a connector — preserving its code,
+/// details, and metadata. Guards the same h2 trailer limit as
+/// [`bounded_unknown_status`] so that e.g. a misbehaving connector emitting a
+/// huge message can't produce a status that's dropped in transit. Returns the
+/// status untouched when its message already fits.
+pub(crate) fn bound_status(status: tonic::Status) -> tonic::Status {
+    if status.message().len() <= MAX_STATUS_MESSAGE_LEN {
+        return status;
+    }
+    tonic::Status::with_details_and_metadata(
+        status.code(),
+        bound_message(status.message().to_string()),
+        bytes::Bytes::copy_from_slice(status.details()),
+        status.metadata().clone(),
+    )
+}
+
+/// Truncate `message` to at most [`MAX_STATUS_MESSAGE_LEN`] bytes, cutting the
+/// tail on a UTF-8 boundary and marking the elision. Returns it unchanged when
+/// it already fits.
+fn bound_message(mut message: String) -> String {
+    if message.len() > MAX_STATUS_MESSAGE_LEN {
+        const SUFFIX: &str = "… [truncated]";
+        // Reserve room for SUFFIX and back off to a UTF-8 char boundary.
+        let mut end = MAX_STATUS_MESSAGE_LEN - SUFFIX.len();
+        while !message.is_char_boundary(end) {
+            end -= 1;
+        }
+        message.truncate(end);
+        message.push_str(SUFFIX);
+    }
+    message
 }
 
 // Map a tonic::Status into an anyhow::Error.

--- a/crates/runtime-next/tests/status_message_bounds.rs
+++ b/crates/runtime-next/tests/status_message_bounds.rs
@@ -1,0 +1,63 @@
+//! Regression coverage for estuary/flow#3177: an oversized error must not
+//! produce a `tonic::Status` message that exceeds the h2 trailer limit and
+//! gets swallowed as `too_many_continuations`. Errors are truncated (from the
+//! tail) so the message stays bounded while preserving the root-cause prefix.
+
+#[test]
+fn oversized_error_is_bounded_and_keeps_prefix() {
+    // Mimic the causal-hint-timeout error: a real prefix followed by an
+    // unbounded per-journal dump.
+    let prefix = "causal hint resolution timed out: 1413 hint(s) unresolved across 537 journal(s)";
+    let detail = "\n  journal \"acmeCo/collection/pivot=00\" binding=1 producer=... last_commit=... hinted_commit=...".repeat(2000);
+    let err = anyhow::anyhow!("{prefix}{detail}");
+
+    let status = runtime_next::anyhow_to_status(err);
+    let message = status.message();
+
+    assert!(
+        message.len() <= runtime_next::MAX_STATUS_MESSAGE_LEN,
+        "message len {} exceeds cap {}",
+        message.len(),
+        runtime_next::MAX_STATUS_MESSAGE_LEN,
+    );
+    assert!(
+        message.starts_with(prefix),
+        "message lost its root-cause prefix: {message:?}",
+    );
+    assert!(
+        message.ends_with("… [truncated]"),
+        "truncated message should carry the truncation marker: {message:?}",
+    );
+}
+
+#[test]
+fn oversized_preexisting_status_is_bounded_preserving_code() {
+    // A Status that we did not format ourselves — e.g. round-tripped from a
+    // misbehaving connector — must also be bounded, and not only when it
+    // carries the `Unknown` code (`Unknown` alone is flattened to a string by
+    // `status_to_anyhow`; other codes downcast straight back to a Status).
+    let huge = "connector went haywire ".repeat(2000);
+    let status = tonic::Status::internal(huge);
+    let err = runtime_next::status_to_anyhow(status);
+
+    let status = runtime_next::anyhow_to_status(err);
+
+    assert_eq!(status.code(), tonic::Code::Internal);
+    assert!(status.message().len() <= runtime_next::MAX_STATUS_MESSAGE_LEN);
+    assert!(status.message().starts_with("connector went haywire"));
+    assert!(status.message().ends_with("… [truncated]"));
+}
+
+#[test]
+fn small_error_is_not_truncated() {
+    let err = anyhow::anyhow!("causal hint resolution timed out: 1 hint(s) unresolved");
+    let status = runtime_next::anyhow_to_status(err);
+    let message = status.message();
+
+    // Under-budget messages pass through without a truncation marker. (We avoid
+    // asserting exact equality because anyhow's `{:?}` appends a backtrace when
+    // `RUST_BACKTRACE` is set.)
+    assert!(message.starts_with("causal hint resolution timed out: 1 hint(s) unresolved"));
+    assert!(!message.ends_with("… [truncated]"));
+    assert!(message.len() <= runtime_next::MAX_STATUS_MESSAGE_LEN);
+}

--- a/crates/shuffle/src/frontier.rs
+++ b/crates/shuffle/src/frontier.rs
@@ -300,6 +300,10 @@ pub enum Error {
 }
 
 impl Frontier {
+    /// Maximum number of unresolved-hint lines rendered by
+    /// [`Self::describe_unresolved`] before the remainder is elided.
+    const DESCRIBE_UNRESOLVED_MAX_LINES: usize = 20;
+
     /// Construct a `Frontier` from journal entries and per-shard flushed LSNs,
     /// validating that entries are sorted and unique on `(journal, binding)` and
     /// that producers within each entry are sorted and unique on `producer`.
@@ -577,6 +581,48 @@ impl Frontier {
             bytes_read_delta,
             bytes_behind_delta,
         )
+    }
+
+    /// Render a bounded, human-readable description of producers with an
+    /// unresolved causal hint (`hinted_commit > last_commit`), one indented
+    /// line each. At most [`Self::DESCRIBE_UNRESOLVED_MAX_LINES`] lines are
+    /// emitted; any remainder is elided as `… and N more unresolved hint(s)`.
+    pub fn describe_unresolved(&self) -> String {
+        use std::fmt::Write;
+
+        let mut out = String::new();
+        let mut rendered = 0;
+
+        'journals: for jf in &self.journals {
+            for p in &jf.producers {
+                if p.hinted_commit <= p.last_commit {
+                    continue;
+                }
+                if rendered == Self::DESCRIBE_UNRESOLVED_MAX_LINES {
+                    break 'journals;
+                }
+                write!(
+                    &mut out,
+                    "\n  journal {:?} binding={} producer={:?} \
+                         last_commit={:?} hinted_commit={:?}",
+                    jf.journal.as_ref(),
+                    jf.binding,
+                    p.producer,
+                    p.last_commit,
+                    p.hinted_commit,
+                )
+                .unwrap();
+                rendered += 1;
+            }
+        }
+
+        // `unresolved_hints` is maintained as the exact count of unresolved
+        // producers, so the remainder needs no second walk.
+        let remaining = self.unresolved_hints.saturating_sub(rendered);
+        if remaining != 0 {
+            write!(&mut out, "\n  … and {remaining} more unresolved hint(s)").unwrap();
+        }
+        out
     }
 }
 
@@ -1123,5 +1169,49 @@ mod test {
         ]);
         let err = Frontier::decode(proto).unwrap_err();
         assert!(format!("{err}").contains("not ordered"));
+    }
+
+    #[test]
+    fn test_describe_unresolved_caps_and_elides() {
+        // More unresolved journals than the render cap: the first
+        // DESCRIBE_UNRESOLVED_MAX_LINES render and the remainder is elided.
+        let extra = 5;
+        let count = Frontier::DESCRIBE_UNRESOLVED_MAX_LINES + extra;
+        let journals: Vec<_> = (0..count)
+            .map(|i| jf(&format!("journal/{i:02}"), 0, vec![pf(0x01, 10, 20, -100)]))
+            .collect();
+        let f = Frontier {
+            journals,
+            flushed_lsn: vec![],
+            unresolved_hints: count,
+        };
+
+        let desc = f.describe_unresolved();
+        let rendered = desc.matches("journal \"").count();
+
+        assert_eq!(rendered, Frontier::DESCRIBE_UNRESOLVED_MAX_LINES);
+        assert!(
+            desc.ends_with(&format!("… and {extra} more unresolved hint(s)")),
+            "{desc}",
+        );
+    }
+
+    #[test]
+    fn test_describe_unresolved_skips_resolved_and_omits_elision() {
+        // Under the cap and with a resolved producer mixed in: only unresolved
+        // producers render, and there is no elision line.
+        let f = Frontier {
+            journals: vec![
+                jf("journal/A", 0, vec![pf(0x01, 10, 20, -100)]), // unresolved
+                jf("journal/B", 1, vec![pf(0x03, 30, 0, -200)]),  // no hint → skipped
+            ],
+            flushed_lsn: vec![],
+            unresolved_hints: 1,
+        };
+
+        let desc = f.describe_unresolved();
+        assert!(desc.contains("journal \"journal/A\""), "{desc}");
+        assert!(!desc.contains("journal/B"), "{desc}");
+        assert!(!desc.contains("more unresolved"), "{desc}");
     }
 }

--- a/crates/shuffle/src/session/state.rs
+++ b/crates/shuffle/src/session/state.rs
@@ -509,32 +509,13 @@ impl CheckpointPipeline {
         }
 
         // Stall horizon exceeded and still unresolved: build a detailed error.
-        let mut details = String::new();
-        for jf in &self.unresolved.journals {
-            for p in &jf.producers {
-                if p.hinted_commit <= p.last_commit {
-                    continue;
-                }
-
-                use std::fmt::Write;
-                write!(
-                    &mut details,
-                    "\n  journal {:?} binding={} producer={:?} \
-                         last_commit={:?} hinted_commit={:?}",
-                    jf.journal.as_ref(),
-                    jf.binding,
-                    p.producer,
-                    p.last_commit,
-                    p.hinted_commit,
-                )
-                .unwrap();
-            }
-        }
-
+        // The detail is bounded (see `Frontier::describe_unresolved`) so the
+        // error survives gRPC status propagation and the log pipeline.
         anyhow::bail!(
-            "causal hint resolution timed out: {} hint(s) unresolved across {} journal(s){details}",
+            "causal hint resolution timed out: {} hint(s) unresolved across {} journal(s){}",
             self.unresolved.unresolved_hints,
             self.unresolved.journals.len(),
+            self.unresolved.describe_unresolved(),
         );
     }
 


### PR DESCRIPTION
**Description:**

Fixes #3177: an oversized runtime-v2 task error that masked the real failure. In the real case, we had a huge number of frontiers which ended up with a multi-thousand  line string. That string was too big to cross gRPC (the oversized HTTP/2 trailer tripped `h2`'s `too_many_continuations` guard, which aborted the connection and replaced the status text with an opaque `Some resource has been exhausted` / `h2 protocol error`) and was also truncated in the log pipeline. Net effect: the true cause was invisible on both paths and had to be reverse-engineered from the recovery-log DB.

Two independent fixes:

- **Bound gRPC status messages at the boundary** (the load-bearing fix). Any status message runtime-next emits is capped to `MAX_STATUS_MESSAGE_LEN` so it fits within a single HTTP/2 frame and never needs a CONTINUATION frame. Truncation is from the tail, preserving the root-cause prefix the anyhow format leads with. This covers both the errors we format ourselves *and* pass-through statuses (round-tripped from a peer or produced by a connector), so a misbehaving connector emitting a huge message can't produce a status that's dropped in transit.
- **Bound the causal-hint error at the source.** The per-producer detail is capped (first N lines, then `… and M more unresolved hint(s)`), which is what keeps it readable in the logs — the boundary cap only helps what crosses gRPC.

**Notes for reviewers:**

- Two commits — (1) bounds every gRPC status message runtime-next emits (errors we format *and* pass-through statuses from connectors/peers, with code/details/metadata preserved) so an oversized trailer can't be dropped as `too_many_continuations`, and (2) caps the causal-hint-timeout detail at the source so it stays readable in logs; the only un-capped statuses left are hand-built ones that are bounded by construction. 

- `MAX_STATUS_MESSAGE_LEN = 4096` stays inside one 16 KiB `h2` frame even under worst-case 3× `grpc-message` percent-encoding 

(I also want to point out that the short hash for the first commit is `8222222` which is a lot of 2's and so hopefully auspicious)