### PR TITLE
docs: per-command Docker requirements for flowctl (#2968)

### DIFF
--- a/site/docs/concepts/flowctl.md
+++ b/site/docs/concepts/flowctl.md
@@ -39,10 +39,38 @@ flowctl binaries for MacOS and Linux are available. For Windows, [install Window
 
    You can also find the source files on GitHub [here](https://go.estuary.dev/flowctl).
 
-2. Some flowctl commands, such as `flowctl generate`, require a Docker daemon to be running.
-   Make sure you have [Docker](https://www.docker.com/) installed to use these commands.
+2. Some flowctl commands run connectors on your machine and require a container runtime such as [Docker](https://www.docker.com/) to be running.
+   See [Docker requirements](#docker-requirements) below for which commands need it.
 
 3. To connect to your Estuary account and start a session, [use an authentication token](/reference/authentication/#authenticating-estuary-using-the-cli) from the web app.
+
+## Docker requirements
+
+flowctl needs a running Docker daemon whenever a command must run a connector image on your machine.
+Whether that happens depends on both the command and the type of entity you're working with:
+
+* **SQLite derivations** run in-process within flowctl itself, so they never require Docker.
+* **TypeScript and Python derivations** run as connector images, so any command that executes or validates them locally requires Docker.
+* **Captures and materializations** are connector images as well, but most commands validate them on the control plane rather than locally.
+
+| Command | SQLite derivation | TypeScript / Python derivation | Capture / Materialization |
+| --- | --- | --- | --- |
+| `flowctl preview` | No | Yes | Yes |
+| `flowctl catalog test` | No | Yes | No¹ |
+| `flowctl catalog publish` | No | Yes² | No¹ |
+| `flowctl generate` | No | Yes | Only to generate a missing endpoint configuration stub |
+
+¹ Capture and materialization connectors are not validated locally; the control plane validates them as part of the (dry-run) publication.
+
+² Publishing validates derivation connectors locally before submitting to the control plane, so a TypeScript or Python derivation requires Docker even though execution happens in the data plane.
+
+:::info
+If a `flowctl preview` or `flowctl catalog test` of a TypeScript or Python derivation hangs or times out,
+check that your Docker daemon is running — a stopped daemon is the most common cause.
+:::
+
+Podman is also supported: set the `DOCKER_CLI` environment variable to `podman`.
+There is no CLI flag for this; only the environment variable is read.
 
 ## User guides
 
@@ -358,6 +386,8 @@ If you're developing locally with `flowctl`, watch out for these errors:
 * `Failed to locate sops`: sops may not be installed correctly. See these [installation instructions](https://github.com/getsops/sops/releases) and ensure sops is on your PATH. For details on working with sops, see [Protecting secrets](#protecting-secrets) above.
 
 * `Decrypting sops document failed`: ensure you have correctly applied a KMS key using sops to your configuration file. See above for [examples](#example-protect-a-configuration). Note that you will not be able to decrypt credentials entered via Estuary's web app.
+
+* `flowctl preview` or `flowctl catalog test` hangs or times out on a TypeScript or Python derivation: check that your Docker daemon is running. These derivations execute as connector images, unlike SQLite derivations. See [Docker requirements](#docker-requirements) above.
 
 Since updates are released regularly, make sure you're using the latest version of `flowctl`. You can see the latest versions and changelogs on the [Flow releases](https://github.com/estuary/flow/releases) page.
 


### PR DESCRIPTION
**Description:**

`docs/concepts/flowctl.md` said only that "some flowctl commands, such as `flowctl generate`, require a Docker daemon", which understates the requirement. A user writing their first TypeScript or Python derivation hits hangs and timeouts in `flowctl preview` / `flowctl catalog test` with nothing pointing at Docker as the missing prerequisite — while SQL-only walkthroughs work without Docker and set the opposite expectation.

This adds a **Docker requirements** section with a per-command matrix, plus a troubleshooting entry for the hang/timeout symptom. Each cell is derived from the actual dispatch paths rather than the issue's proposed table (one correction — see notes):

- SQLite derivations dispatch in-process via `derive_sqlite::connector()` (`crates/runtime/src/derive/connector.rs`) — never need Docker. TypeScript/Python derivations run as connector images (`ghcr.io/estuary/derive-{typescript,python}`).
- `preview` uses `local_specs::load_and_validate_full` — all connectors run locally.
- `catalog test` **and** `catalog publish` both use `local_specs::load_and_validate`, which validates derivation connectors locally but not capture/materialization connectors.
- `generate` needs a capture/materialization connector image only to spec a missing endpoint config stub.
- Podman is supported via the `DOCKER_CLI` env var (`crates/runtime/src/container.rs`), with no CLI flag.

Fixes #2968

**Workflow steps:**

No behavior changes — documentation only. Readers of [concepts/flowctl](https://docs.estuary.dev/concepts/flowctl/) now get:

1. Installation step 2 links to the new section instead of the vague one-liner.
2. A "Docker requirements" section: three orienting bullets, the command × entity matrix, a hang/timeout admonition, and the podman note.
3. A troubleshooting entry for "preview / catalog test hangs or times out on a TypeScript or Python derivation".

**Documentation links affected:**

* [concepts/flowctl](https://docs.estuary.dev/concepts/flowctl/) — new `#docker-requirements` anchor; installation step 2 and troubleshooting both link to it. No existing anchors moved or removed.

**Notes for reviewers:**

- **One divergence from the issue's proposed table, in favor of what the code does:** the issue marks `flowctl catalog publish` as never needing Docker ("control-plane handles execution"). But `catalog/publish.rs` calls the same `local_specs::load_and_validate` as `catalog test`, which runs derivation connectors locally — so publishing a TS/Python derivation does require Docker, even though execution happens in the data plane. The table and footnote ² reflect that.
- Verified with a full `docusaurus build`: the section renders with its table, footnotes, and admonition, and the `#docker-requirements` anchor resolves. (The build then fails post-render in the redirect plugin on `hubspot-real-time` — a macOS case-insensitivity collision between the `docusaurus.config.js:113` redirect and `HubSpot-real-time.md` that exists on master and doesn't occur on case-sensitive CI filesystems; happy to file it separately.)
- No overlap with #3001/#2976 (Docker daemon *error* improvements for #2969) — those touch `container.rs` and the flowctl README; this is the user-facing docs side.
