### PR TITLE
shuffle: log canonical journal name in slice read events

### DIFF
--- a/crates/shuffle/src/slice/actor.rs
+++ b/crates/shuffle/src/slice/actor.rs
@@ -481,7 +481,7 @@ impl SliceActor {
     ) -> anyhow::Result<()> {
         let read_state = &mut self.reads[read.id() as usize];
         let binding = &self.topology.bindings[read_state.binding_index as usize];
-        let journal = read.fragment().journal.clone();
+        let journal = read_state.journal.to_string();
 
         let Some(result) = result else {
             service_kit::event!(


### PR DESCRIPTION
## Problem

Transient `UnexpectedEof` WARNs from `shuffle::slice` (and the other read events in `process_read_result`) log an **empty** `journal` field, making them unactionable — you can't tell which journal the retrying read belongs to.

## Root cause

`process_read_result` bound the logged `journal` from `read.fragment().journal`, i.e. the read's most-recently-observed *fragment metadata*. `ReadLines` seeds its fragment to `broker::Fragment::default()` (empty journal) and overwrites it only when a `ReadResponse` carrying a fragment flows through. An `UnexpectedEof` is produced exactly when the per-iteration blocking metadata fetch closes with zero `ReadResponse`s (a benign broker long-poll cancellation), so that iteration contributes no fragment.

Because a `ReadLines` is built once per read and persists across retries, the journal is empty precisely for reads that have **never once** observed a fragment-bearing response — which is exactly the perpetually caught-up *tailing* reads sitting at the write head, whose blocking metadata reads keep closing with EOF. So the reads most prone to logging these WARNs are the ones guaranteed to log an empty journal.

## Fix

Log `read_state.journal` instead — the canonical journal name (`Box<str>`), always populated at construction, and already the source used by the stall-track events and `map_read_error`. One-line change; this single binding feeds every event in `process_read_result`.

Observability only — does not touch the underlying stall behavior.