### PR TITLE
docs: add Azure BYOC subscription provisioning prerequisites

### DIFF
--- a/site/docs/private-byoc/byoc-deployments/azure-byoc.md
+++ b/site/docs/private-byoc/byoc-deployments/azure-byoc.md
@@ -47,3 +47,50 @@ Finally, provide the following information to your Estuary point of contact:
  - Subscription ID (found in Subscriptions -> Overview)
  - Tenant ID (found in Tenant Properties)
  - Azure region
+
+## Prepare your subscription for provisioning
+
+After you have shared the details above, you may need to raise a few
+subscription limits so Estuary can provision the data plane. Depending on your
+subscription's existing limits, some of these may already be sufficient. You
+can do this in parallel with the steps above.
+
+{/* Quota families and vCPU counts are sourced from est-dry-dock
+    est_dry_dock/constants.py (azure_vm_size_by_role + initial_desired_instances,
+    at 2x steady-state). Refresh these if the fleet's default SKUs change. */}
+
+- **vCPU quota.** New Azure subscriptions often start with a low or zero vCPU
+  limit on many VM families, so you may need to raise quota in your target
+  region before Estuary can provision. Estuary's default data plane uses the
+  families below; request the following quota (in vCPUs) in your target region.
+  The quotas are set at roughly twice steady-state so that rolling upgrades,
+  which briefly run old and new VMs side by side, do not exhaust your limit:
+
+  | Azure quota family | vCPUs to request | |
+  |---|---|---|
+  | Standard DPSv6 Family | 12 | Default |
+  | Standard EPSv6 Family | 16 | Default |
+  | Standard EASv6 Family | 12 | Default |
+  | Standard DSv5 Family | 12 | Fallback |
+  | Standard ESv5 Family | 24 | Fallback |
+
+  The fallback families give Estuary an alternate VM generation to fall back on
+  if the defaults are capacity-constrained, which improves the chance of a
+  first-try deployment.
+- **Public IP quota.** Request a regional public IP quota of at least 40. A
+  data plane uses roughly 18 public IP addresses at steady state, but rolling
+  upgrades temporarily run old and new VMs side by side, so the count can
+  nearly double during an upgrade.
+- **Region choice.** Some Azure regions (notably East US and East US 2) are
+  more frequently capacity-constrained. To maximize the chance of a successful
+  deployment, Estuary provisions your data plane regionally by default (drawing
+  from the whole region's capacity pool) rather than pinning a specific
+  availability zone, which has no durability impact. If you are flexible on
+  region, you can also ask your Estuary contact which regions currently have
+  the smoothest availability.
+
+:::tip
+Estuary never changes your subscription settings without telling you. Quota
+increases are zero-cost ceiling changes; anything cost-bearing (such as a
+capacity reservation) is always your decision.
+:::


### PR DESCRIPTION
## What

Adds a "Prepare your subscription for provisioning" section to the Azure BYOC setup page covering the subscription-level limits a customer should raise before Estuary provisions a data plane:

- **vCPU quota** — new Azure subscriptions often default to a low or zero vCPU limit per family. Includes a table of the default VM families (and Intel v5 fallbacks) with vCPU counts at 2x steady-state for rolling upgrades.
- **Public IP quota** — request ~40, since rolling upgrades briefly double the instance count.
- **Region choice** — flags that East US / East US 2 are frequently capacity-constrained, and explains that Estuary provisions regionally (no pinned AZ) by default to maximize allocation success.

## Why

These prerequisites aren't documented anywhere today, so they surface as a back-and-forth during onboarding. Two recent Azure BYOC bring-ups hit the quota/capacity question. Sourcing them up front turns a multi-day round-trip into a single request.

## Notes

- The quota families/counts are pinned to est-dry-dock's current defaults; there's an MDX source comment (invisible on the rendered page) pointing the next editor at `est_dry_dock/constants.py` so the table can be refreshed if the fleet's default SKUs change.
- Regional-vs-zonal default was verified against est-dry-dock (`ask_cloud_zone` presents regional as the default choice; no proximity placement groups or zonal disks that regional scatter would break). Cross-AZ data transfer within a region is free as of Azure's June 2024 change, so regional placement carries no extra data cost.
