### PR TITLE
shuffle, gazette: guard against wedged reads

### DIFF
--- a/crates/gazette/src/journal/mod.rs
+++ b/crates/gazette/src/journal/mod.rs
@@ -42,10 +42,23 @@ impl Client {
     /// Build a reqwest Client suited for fetching journal fragments.
     /// This client should be built once and cloned across many Clients.
     pub fn new_fragment_client() -> reqwest::Client {
-        // Use HTTP/1 for fetching fragments, as storage backends may have
-        // restricted HTTP/2 flow control and we may have concurrent streams
-        // with high throughput / stuffed flow control windows.
-        reqwest::Client::builder().http1_only().build().unwrap()
+        reqwest::Client::builder()
+            // Use HTTP/1 for fetching fragments, as storage backends may have
+            // restricted HTTP/2 flow control and we may have concurrent streams
+            // with high throughput / stuffed flow control windows that we expect
+            // to read in specific orders (leading to live-lock).
+            .http1_only()
+            // Bound connection establishment (TCP + TLS). Without this a storage
+            // endpoint that accepts the socket but never completes the handshake
+            // wedges a fragment fetch forever — TCP keepalive can't help while the
+            // peer is still ACKing. reqwest sets no connect timeout by default.
+            .connect_timeout(std::time::Duration::from_secs(30))
+            // We don't use `read_timeout` because it's a little heavy (a boxed
+            // future with every read), and because we may poll infrequently,
+            // but reqwest biases toward `read_timeout` rather than completion
+            // of a ready read.
+            .build()
+            .unwrap()
     }
 
     /// Build a Client which dispatches request to the given default endpoint with the given Metadata.

--- a/crates/shuffle/src/slice/actor.rs
+++ b/crates/shuffle/src/slice/actor.rs
@@ -124,6 +124,12 @@ impl SliceActor {
         let mut ticker = tokio::time::interval(crate::ACTOR_TICKER_INTERVAL);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+        // Warning mechanism which is armed on tick and disarmed on read.
+        // This is a coarse mechanism as it's disarmed by any read, including
+        // completions of tailing bindings that don't unblock the heap,
+        // but it's cheap and gives us noisy optics into truly wedged tasks.
+        let mut stall_armed = false;
+
         let mut loop_count: u64 = 0;
         loop {
             loop_count += 1;
@@ -177,10 +183,16 @@ impl SliceActor {
                 }
                 Some((result, read)) = self.pending_reads.next() => {
                     self.on_pending_read_resolved(result, read)?;
+                    stall_armed = false;
                 }
 
                 // Periodic tick ensures tracing fires even when idle.
-                _ = ticker.tick() => {}
+                _ = ticker.tick() => {
+                    if stall_armed {
+                        self.emit_stall_warnings();
+                    }
+                    stall_armed = true;
+                }
             }
         }
 
@@ -470,6 +482,39 @@ impl SliceActor {
             "{}",
             message,
         );
+    }
+
+    fn emit_stall_warnings(&self) {
+        for read in &self.pending_reads {
+            let Some(read) = read.get_ref() else {
+                continue; // Read has already resolved.
+            };
+            if read.tailing() {
+                continue; // Tailing reads don't stall heap drain.
+            }
+
+            let read_state = &self.reads[read.id() as usize];
+            let fragment = read.fragment();
+            let mod_time = if fragment.mod_time != 0 {
+                tokens::DateTime::from_timestamp_secs(fragment.mod_time)
+            } else {
+                None
+            };
+
+            service_kit::event!(
+                tracing::Level::WARN,
+                "stall",
+                read_id = read.id(),
+                binding = read_state.binding_index,
+                journal = read_state.journal.to_string(),
+                read_offset = read_state.read_offset,
+                write_head = read.write_head(),
+                fragment_mod_time = service_kit::event::debug(mod_time),
+                fragment_begin = fragment.begin,
+                fragment_end = fragment.end,
+                "read is stalled awaiting broker I/O",
+            );
+        }
     }
 
     /// Parse a LinesBatch into documents and push a ReadyRead onto the heap, or


### PR DESCRIPTION
Two defensive measures for the class of V2 materialization stalls where a read hangs indefinitely on broker/storage I/O.

## gazette: bound fragment-fetch connection establishment

Add a 30s `connect_timeout` to the HTTP/1 fragment-fetch client. Without it, a storage endpoint that accepts the socket but never completes the TCP+TLS handshake wedges a fragment fetch forever — TCP keepalive can't help while the peer is still ACKing, and reqwest sets no connect timeout by default. We deliberately avoid `read_timeout` (it's heavier — a boxed future on every read — and biases toward timeout over completion of a ready read given we may poll infrequently).

## shuffle: stall diagnostics for wedged reads

Emit periodic `WARN` diagnostics for non-tailing pending reads that make no progress across a ticker interval (60s). The mechanism arms on tick and disarms on any resolved read, so a warning requires a full inter-tick interval with zero reads resolving before firing. It's coarse — any read completion (including tailing bindings that don't unblock the heap) disarms it — but cheap, and gives noisy optics into truly wedged tasks. Each warning carries read_id, binding, journal, read/write offsets, and fragment metadata.