### PR TITLE
Update mcp-integration.md

### DIFF
--- a/site/docs/features/mcp-integration.md
+++ b/site/docs/features/mcp-integration.md
@@ -107,19 +107,21 @@ Add to your Claude Desktop config file:
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+Prerequisites for Windows: Install Node.js if you don't have it (includes npx).
 
 ```json
 {
   "mcpServers": {
     "estuary": {
-      "type": "http",
-      "url": "https://estuary.mcp.kapa.ai"
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://estuary.mcp.kapa.ai"]
     }
   }
 }
 ```
 
-Restart Claude Desktop for changes to take effect.
+Restart Claude Desktop for changes to take effect. On first use, it will open a browser window for the Google sign-in.
+To open the config file quickly, in Claude Desktop go to **Settings → Developer → Edit Config**.
 
 For more details, see the [Claude Desktop documentation](https://support.anthropic.com/en/articles/9487310-desktop-app).
 


### PR DESCRIPTION
The section on Claude desktop was incorrect for Windows machine. I have updated it with the resolution Claude gave, which worked for me. 

Reason: 
Claude Desktop does not support "type": "http" in claude_desktop_config.json. You can use a local proxy package called mcp-remote that bridges Claude Desktop (stdio) to the remote HTTP server (requires Node.js).

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

