### PR TITLE
flowctl: preview-next appends a final drain session

### DIFF
--- a/crates/flowctl/src/raw/preview_next/driver.rs
+++ b/crates/flowctl/src/raw/preview_next/driver.rs
@@ -213,8 +213,14 @@ async fn drive_one_shard(
             }))
             .map_err(|_| anyhow::anyhow!("serve task closed before Task"))?;
 
-        drive_session_responses(&request_tx, &mut response_rx, session_index, &stop_token, drain)
-            .await?;
+        drive_session_responses(
+            &request_tx,
+            &mut response_rx,
+            session_index,
+            &stop_token,
+            drain,
+        )
+        .await?;
     }
 
     drop(request_tx);

--- a/crates/flowctl/src/raw/preview_next/driver.rs
+++ b/crates/flowctl/src/raw/preview_next/driver.rs
@@ -153,11 +153,23 @@ async fn drive_one_shard(
         }))
         .map_err(|_| anyhow::anyhow!("serve task closed before SessionLoop"))?;
 
-    for (idx, target_txns) in session_targets.into_iter().enumerate() {
+    // Every run ends with one additional empty "drain" session (represented
+    // as `None`): the runtime halts a session after its final commit without
+    // running its post-commit work, so the drain session's startup recovery
+    // performs the last transaction's Acknowledge before the preview exits.
+    // A run aborted by timeout or Ctrl-C skips it, like any other session.
+    let sessions = session_targets
+        .into_iter()
+        .map(Some)
+        .chain(std::iter::once(None));
+
+    for (idx, target_txns) in sessions.enumerate() {
         if stop_token.is_cancelled() {
             break;
         }
         let session_index = idx + 1;
+        let drain = target_txns.is_none();
+        let target_txns = target_txns.unwrap_or(0);
 
         // A fixture preview reads each session from its own directory (fresh
         // segments from segment one); live preview shares the run's directory.
@@ -185,6 +197,7 @@ async fn drive_one_shard(
             session = session_index,
             shard_index,
             target_txns,
+            drain,
             "starting preview session",
         );
 
@@ -200,7 +213,8 @@ async fn drive_one_shard(
             }))
             .map_err(|_| anyhow::anyhow!("serve task closed before Task"))?;
 
-        drive_session_responses(&request_tx, &mut response_rx, session_index, &stop_token).await?;
+        drive_session_responses(&request_tx, &mut response_rx, session_index, &stop_token, drain)
+            .await?;
     }
 
     drop(request_tx);
@@ -216,6 +230,7 @@ async fn drive_session_responses(
     response_rx: &mut mpsc::UnboundedReceiver<tonic::Result<proto::Materialize>>,
     session_index: usize,
     stop_token: &CancellationToken,
+    drain: bool,
 ) -> anyhow::Result<()> {
     let verify = runtime_next::verify("Materialize", "Joined, Opened, or Stopped", "shard");
 
@@ -239,6 +254,18 @@ async fn drive_session_responses(
                     tracing::debug!(session_index, max_etcd_revision, "session joined");
                 } else if let Some(proto::materialize::Opened { container, .. }) = &msg.opened {
                     tracing::debug!(session_index, ?container, "session opened");
+
+                    // A drain session runs no transactions: request a graceful
+                    // stop as soon as it opens. The leader completes its
+                    // startup tail — which acknowledges the prior session's
+                    // final committed transaction — before honoring the stop.
+                    if drain && !requested_stop {
+                        requested_stop = true;
+                        _ = request_tx.send(Ok(proto::Materialize {
+                            stop: Some(proto::Stop {}),
+                            ..Default::default()
+                        }));
+                    }
                 } else if let Some(proto::Stopped {}) = msg.stopped {
                     tracing::debug!(session_index, "session stopped");
                     return Ok(());

--- a/crates/flowctl/src/raw/preview_next/mod.rs
+++ b/crates/flowctl/src/raw/preview_next/mod.rs
@@ -56,6 +56,12 @@ pub struct Preview {
     /// of transactions, or upon a timeout, or if the connector exits.
     ///
     /// The default is a single session with an unbounded number of transactions.
+    ///
+    /// Materialization previews always append one final empty drain session:
+    /// a session halts after its final commit without running the post-commit
+    /// Acknowledge, so the drain session's startup recovery acknowledges the
+    /// last committed transaction before the preview exits. A run aborted by
+    /// timeout skips it.
     #[clap(long, value_parser, value_delimiter = ',')]
     sessions: Option<Vec<isize>>,
     /// Path to a transactions fixture to feed in place of live collection data.


### PR DESCRIPTION
A materialization session under runtime-v2 halts after its final commit without running its post-commit Acknowledge. Without an additional session, `flowctl raw preview-next` exits reporting the final transaction as committed while its `Acknowledge` has not been run, and for post-commit apply connectors, it means their transactions are not actually applied to the destination.

Every materialization preview now appends one final **empty drain session**: so `--sessions 2` actually ends up running 3 sessions, but it matches the expectation of having two sessions, driven up to their `Acknowledge`.

## Test plan

- [x] `cargo test -p flowctl`
- [x] E2E from the connectors repo, whose test harness dropped its appended-drain-transaction workaround in favor of this: `materialize-postgres` (1 shard, `--output-apply`/`--output-state`) passes deterministically — the drain session contributes exactly one no-op `["applied.actionDescription", ""]` line and, no longer committing a transaction, drops the previous workaround's `["connectorState",{}]` filler. `materialize-databricks` (2 shards, scale-out) passes with an unchanged snapshot, its final staged MERGE now applied by the drain session's recovery.