### PR TITLE
agent-api: Add `STRIPE_WEBHOOK_SECRET` to cloud run config

### DIFF
--- a/.github/workflows/deploy-agent-api.yaml
+++ b/.github/workflows/deploy-agent-api.yaml
@@ -53,6 +53,7 @@ jobs:
             CONTROL_PLANE_DB_CA_CERT=CONTROL_PLANE_DB_CA_CERT:latest
             CONTROL_PLANE_JWT_SECRET=CONTROL_PLANE_JWT_SECRET:latest
             STRIPE_API_KEY=STRIPE_API_KEY:latest
+            STRIPE_WEBHOOK_SECRET=STRIPE_WEBHOOK_SECRET:latest
 
           env_vars_update_strategy: overwrite
           secrets_update_strategy: overwrite


### PR DESCRIPTION
https://github.com/estuary/flow/pull/3174 added `/api/v1/stripe/webhook` which needs `STRIPE_WEBHOOK_SECRET`. We already set up the webhook and configured the secret in GCP secret manager, this just updates the cloud run service definition to inject it.