### PR TITLE
control-plane: verify delete permission for user storage mappings

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -89,6 +89,8 @@ async fn check_store_health(
 ) -> Option<String> {
     let fut = client.fragment_store_health(broker::FragmentStoreHealthRequest {
         fragment_store: fragment_store.to_string(),
+        check_delete: true,
+        check_delete_prefix: "recovery/".to_string(),
     });
 
     match tokio::time::timeout(HEALTH_CHECK_TIMEOUT, fut).await {

--- a/crates/proto-gazette/src/protocol.rs
+++ b/crates/proto-gazette/src/protocol.rs
@@ -875,6 +875,14 @@ pub struct FragmentStoreHealthRequest {
     /// Fragment store to check the health of.
     #[prost(string, tag = "1")]
     pub fragment_store: ::prost::alloc::string::String,
+    /// If true, also verify delete permission with a throwaway probe object under
+    /// check_delete_prefix. Defaults to false (delete is not exercised).
+    #[prost(bool, tag = "2")]
+    pub check_delete: bool,
+    /// Prefix under which the delete probe is written (e.g. "recovery/"); empty
+    /// probes the store root. Only used when check_delete is true.
+    #[prost(string, tag = "3")]
+    pub check_delete_prefix: ::prost::alloc::string::String,
 }
 /// FragmentStoreHealthResponse is the unary response message of the broker FragmentStoreHealth RPC.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto-gazette/src/protocol.serde.rs
+++ b/crates/proto-gazette/src/protocol.serde.rs
@@ -1357,9 +1357,21 @@ impl serde::Serialize for FragmentStoreHealthRequest {
         if !self.fragment_store.is_empty() {
             len += 1;
         }
+        if self.check_delete {
+            len += 1;
+        }
+        if !self.check_delete_prefix.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("protocol.FragmentStoreHealthRequest", len)?;
         if !self.fragment_store.is_empty() {
             struct_ser.serialize_field("fragmentStore", &self.fragment_store)?;
+        }
+        if self.check_delete {
+            struct_ser.serialize_field("checkDelete", &self.check_delete)?;
+        }
+        if !self.check_delete_prefix.is_empty() {
+            struct_ser.serialize_field("checkDeletePrefix", &self.check_delete_prefix)?;
         }
         struct_ser.end()
     }
@@ -1373,11 +1385,17 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
         const FIELDS: &[&str] = &[
             "fragment_store",
             "fragmentStore",
+            "check_delete",
+            "checkDelete",
+            "check_delete_prefix",
+            "checkDeletePrefix",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             FragmentStore,
+            CheckDelete,
+            CheckDeletePrefix,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -1401,6 +1419,8 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                     {
                         match value {
                             "fragmentStore" | "fragment_store" => Ok(GeneratedField::FragmentStore),
+                            "checkDelete" | "check_delete" => Ok(GeneratedField::CheckDelete),
+                            "checkDeletePrefix" | "check_delete_prefix" => Ok(GeneratedField::CheckDeletePrefix),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -1421,6 +1441,8 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut fragment_store__ = None;
+                let mut check_delete__ = None;
+                let mut check_delete_prefix__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::FragmentStore => {
@@ -1429,6 +1451,18 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                             }
                             fragment_store__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::CheckDelete => {
+                            if check_delete__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("checkDelete"));
+                            }
+                            check_delete__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::CheckDeletePrefix => {
+                            if check_delete_prefix__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("checkDeletePrefix"));
+                            }
+                            check_delete_prefix__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -1436,6 +1470,8 @@ impl<'de> serde::Deserialize<'de> for FragmentStoreHealthRequest {
                 }
                 Ok(FragmentStoreHealthRequest {
                     fragment_store: fragment_store__.unwrap_or_default(),
+                    check_delete: check_delete__.unwrap_or_default(),
+                    check_delete_prefix: check_delete_prefix__.unwrap_or_default(),
                 })
             }
         }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
-	go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c
+	go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64
 	golang.org/x/net v0.55.0
 	google.golang.org/api v0.251.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c h1:6oRaNmlNhFD4IaAkXSfOgXUxayPskHBTndhuNG7VSyw=
-go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
+go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64 h1:YX2MhHISLxvz1xoS+YQntf4FMZ24Q02+97nmTHImrYI=
+go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=


### PR DESCRIPTION
**Description:**

Historically storage-mapping health checks have only exercised read/connect, so a bucket lacking the delete permission on its `recovery/` path was allowed in, but later would cause problems with the shard pruner service that needs to delete objects from this location.

gazette/core#489 adds an optional check for deleting from `recovery/`, which is intended to be used for this case. It is optional so that it does not run on during the broker's normal on-going health checks, since a failure to delete would not necessarily impact an otherwise functioning data flow, and because there are pre-existing working configurations like this that we don't necessarily want to stop. The deletion check is only used for user-initiated changes to storage mappings, as a gate to ensure that the permissions exist for the shard pruner to work correctly.

Separately but related, https://github.com/gazette/core/pull/488 downgrades the shard pruner failure to delete due to permissions from a fatal error to a log, as this is an expected condition for pre-existing configurations.

This PR wires up the delete validation in the control plane API's `check_store_health`.

The gazette pin points to the merged gazette/core#489 (commit e54beb5c6e6452a94fe0c0bbe21a1695fa9fddd6). It is fine to merge this before new brokers are deployed with the new code, since pre-existing brokers will just ignore the extra parameters.

Closes https://github.com/estuary/flow/issues/3073

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)


