### PR TITLE
runtime-next: gate task-log stream by configured log level

### DIFF
--- a/crates/runtime-next/src/logger.rs
+++ b/crates/runtime-next/src/logger.rs
@@ -46,6 +46,8 @@
 //! [`ShuffleSession`]: crate::ShuffleSession
 
 use crate::proto;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI32, Ordering};
 
 /// Per-session logger: the sink for the task's log and event stream. The
 /// leader and shards obtain one from a [`LoggerFactory`] at the start of
@@ -243,12 +245,21 @@ pub trait LoggerFactory: Clone + Send + Sync + 'static {
 /// `Fn`. The production shard install: the `Fn` is the task's encoded-JSON
 /// log writer, so connector logs and runtime events both reach the task-log
 /// file.
+///
+/// Records more verbose than the shared `log_level` are dropped: this seam
+/// bypasses `tracing`, so it re-applies the same threshold (from the same
+/// atomic) as [`TokioContext`](crate::TokioContext)'s tracing filter.
 #[derive(Clone)]
-pub struct FnLogger<F>(F);
+pub struct FnLogger<F> {
+    log_handler: F,
+    log_level: Arc<AtomicI32>,
+}
 
 impl<F: Fn(&ops::Log) + Clone + Send + Sync + 'static> Logger for FnLogger<F> {
     fn log(&self, log: &ops::Log) {
-        (self.0)(log)
+        if log.level <= self.log_level.load(Ordering::Relaxed) {
+            (self.log_handler)(log)
+        }
     }
 }
 
@@ -256,11 +267,17 @@ impl<F: Fn(&ops::Log) + Clone + Send + Sync + 'static> Logger for FnLogger<F> {
 /// clone of the wrapped log handler; the handler is shared, the per-session
 /// logger is a cheap clone.
 #[derive(Clone)]
-pub struct FnLoggerFactory<F>(F);
+pub struct FnLoggerFactory<F> {
+    log_handler: F,
+    log_level: Arc<AtomicI32>,
+}
 
 impl<F: Fn(&ops::Log) + Clone + Send + Sync + 'static> FnLoggerFactory<F> {
-    pub fn new(log_handler: F) -> Self {
-        Self(log_handler)
+    pub fn new(log_handler: F, log_level: Arc<AtomicI32>) -> Self {
+        Self {
+            log_handler,
+            log_level,
+        }
     }
 }
 
@@ -268,7 +285,10 @@ impl<F: Fn(&ops::Log) + Clone + Send + Sync + 'static> LoggerFactory for FnLogge
     type Logger = FnLogger<F>;
 
     fn open(&self, _task_name: &str) -> FnLogger<F> {
-        FnLogger(self.0.clone())
+        FnLogger {
+            log_handler: self.log_handler.clone(),
+            log_level: self.log_level.clone(),
+        }
     }
 }
 
@@ -433,5 +453,60 @@ mod test {
           }
         ]
         "#);
+    }
+
+    #[test]
+    fn fn_logger_filters_by_level() {
+        let sink = Arc::new(std::sync::Mutex::new(Vec::<(i32, String)>::new()));
+        let level = Arc::new(AtomicI32::new(ops::LogLevel::Info as i32));
+
+        let factory = {
+            let sink = sink.clone();
+            FnLoggerFactory::new(
+                move |log: &ops::Log| sink.lock().unwrap().push((log.level, log.message.clone())),
+                level.clone(),
+            )
+        };
+        let logger = factory.open("acmeCo/task");
+
+        let record = |lvl: ops::LogLevel, msg: &str| ops::Log {
+            meta: None,
+            shard: None,
+            timestamp: None,
+            level: lvl as i32,
+            message: msg.to_string(),
+            fields_json_map: Default::default(),
+            spans: Vec::new(),
+        };
+
+        // At Info: Warn and Info surface; Debug and Trace are dropped.
+        logger.log(&record(ops::LogLevel::Warn, "warn"));
+        logger.log(&record(ops::LogLevel::Info, "info"));
+        logger.log(&record(ops::LogLevel::Debug, "debug"));
+        logger.log(&record(ops::LogLevel::Trace, "trace"));
+
+        // A Debug Persist event flows through `event()`, likewise dropped at Info.
+        let persist = proto::Persist {
+            connector_patches_json: b"[{\"cursor\":\"abc\"}\t]".as_slice().into(),
+            ..Default::default()
+        };
+        logger.event(LogEvent::Persist { persist: &persist });
+
+        // Lowering the level to Debug surfaces the same Persist event.
+        level.store(ops::LogLevel::Debug as i32, Ordering::Relaxed);
+        logger.event(LogEvent::Persist { persist: &persist });
+
+        let got = sink.lock().unwrap().clone();
+        assert_eq!(
+            got,
+            vec![
+                (ops::LogLevel::Warn as i32, "warn".to_string()),
+                (ops::LogLevel::Info as i32, "info".to_string()),
+                (
+                    ops::LogLevel::Debug as i32,
+                    "persisted connector-state delta".to_string()
+                ),
+            ]
+        );
     }
 }

--- a/crates/runtime-next/src/task_service.rs
+++ b/crates/runtime-next/src/task_service.rs
@@ -68,7 +68,7 @@ impl TaskService {
             // logs and flattened runtime Events alike — to the task-log file
             // (the same encoded-JSON handler the runtime's own tracing uses),
             // which the Go runtime forwards to the task's ops-log journal.
-            crate::FnLoggerFactory::new(log_handler),
+            crate::FnLoggerFactory::new(log_handler, tokio_context.log_level_handle()),
             // Inert registry: TaskService is the CGO entry point and does not
             // serve an admin surface; event! tracks still capture per-handler.
             service_kit::Registry::default(),

--- a/crates/runtime-next/src/tokio_context.rs
+++ b/crates/runtime-next/src/tokio_context.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::prelude::*;
 pub struct TokioContext {
     runtime: Option<tokio::runtime::Runtime>,
     set_log_level_fn: Arc<dyn Fn(ops::log::Level) + Send + Sync>,
+    log_level: Arc<AtomicI32>,
 }
 
 impl TokioContext {
@@ -44,6 +45,7 @@ impl TokioContext {
         });
 
         // Build a tracing_subscriber::Filter which uses our dynamic log level.
+        let log_level_filter = log_level.clone();
         let log_filter = tracing_subscriber::filter::DynFilterFn::new(move |metadata, _cx| {
             let cur_level = match metadata.level().as_str() {
                 "TRACE" => ops::log::Level::Trace as i32,
@@ -61,7 +63,7 @@ impl TokioContext {
                 }
             }
 
-            cur_level <= log_level.load(Ordering::Relaxed)
+            cur_level <= log_level_filter.load(Ordering::Relaxed)
         });
 
         // Configure a tracing::Dispatch, which is a type-erased form of a tracing::Subscriber,
@@ -90,12 +92,20 @@ impl TokioContext {
         Self {
             runtime: Some(runtime),
             set_log_level_fn: set_log_level,
+            log_level,
         }
     }
 
     /// Return a function closure which dynamically updates the configured log level for tracing events.
     pub fn set_log_level_fn(&self) -> Arc<dyn Fn(ops::log::Level) + Send + Sync> {
         self.set_log_level_fn.clone()
+    }
+
+    /// The same atomic [`set_log_level_fn`](Self::set_log_level_fn) updates and
+    /// the tracing filter reads, exposed so task-log seams that bypass `tracing`
+    /// (the shard's [`FnLoggerFactory`](crate::FnLoggerFactory)) gate identically.
+    pub fn log_level_handle(&self) -> Arc<AtomicI32> {
+        self.log_level.clone()
     }
 
     thread_local!(static DISPATCH_GUARD: std::cell::Cell<Option<tracing::dispatcher::DefaultGuard>> = std::cell::Cell::new(None));


### PR DESCRIPTION
**Description:**

The shard's FnLogger seam wrote every record to the task ops-log unconditionally, so Debug runtime LogEvents — e.g. "persisted connector-state delta" — surfaced in Info-level capture logs, because this seam bypasses the level-filtered tracing layer.

Share TokioContext's dynamic log-level atomic with FnLogger and drop records more verbose than the threshold — the task-stream analogue of the tracing filter, reading the same atomic so the two never disagree on what a level surfaces.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

