### PR TITLE
docs: document materialize-s3-iceberg nanosecond_timestamps option

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -66,6 +66,7 @@ Estuary collections to your tables.
 | **`/region`**                     | Region                | AWS Region.                                                                                                                                         | string | Required         |
 | **`/namespace`**                  | Namespace             | Namespace for bound collection tables (unless overridden within the binding resource configuration).                                                | string | Required         |
 | `/upload_interval`                | Upload Interval       | Frequency at which files will be uploaded. Must be a valid ISO8601 duration string no greater than 4 hours.                                         | string | PT5M             |
+| `/advanced/nanosecond_timestamps` | Nanosecond Timestamps | Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2).                                    | bool   | false            |
 | **`/catalog/catalog_type`**       | Catalog Type          | Either "Iceberg REST Server" or "AWS Glue".                                                                                                         | string | Required         |
 | `/catalog/glue_id`                | Glue Catalog ID       | Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials. This enables cross-account Glue catalog access. | string |                  |
 | **`/catalog/uri`**                | URI                   | URI identifying the REST catalog, in the format of 'https://yourserver.com/catalog'.                                                                | string | Required         |
@@ -129,6 +130,13 @@ Estuary collection fields with `{type: string, format: time}` and `{type: string
 materialized as **string** columns rather than **time** and **uuid** columns for compatibility with
 Apache Spark. **[Nested types](https://iceberg.apache.org/spec/#nested-types)** are not currently
 supported.
+
+With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
+instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
+using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
+Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
+existing materialization requires a backfill of its bindings, because Iceberg has no in-place
+promotion between the two timestamp encodings.
 
 ## Table Maintenance
 

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -136,9 +136,11 @@ instead materialized as **timestamptz_ns** columns with nanosecond precision, an
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
 Make sure your query engine supports format v3 tables before enabling this option.
 
-Toggling the option on an existing materialization applies to data going forward: Iceberg has no
-in-place conversion between the two timestamp encodings, so each timestamp column is re-created
-under the new type, and existing rows read as **null** for those columns. Prior values remain
+Toggling the option in either direction on an existing materialization applies to data going
+forward: Iceberg has no in-place conversion between the two timestamp encodings, so each timestamp
+column is re-created under the new type, and existing rows read as **null** for those columns.
+Enabling the option on an existing format v2 table also upgrades the table to format v3 in place.
+Prior values remain
 readable in the table's earlier snapshots via time travel. To repopulate history under the new
 type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -134,9 +134,13 @@ supported.
 With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
 instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
-Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
-existing materialization requires a backfill of its bindings, because Iceberg has no in-place
-promotion between the two timestamp encodings.
+Make sure your query engine supports format v3 tables before enabling this option.
+
+Toggling the option on an existing materialization applies to data going forward: Iceberg has no
+in-place conversion between the two timestamp encodings, so each timestamp column is re-created
+under the new type, and existing rows read as **null** for those columns. Prior values remain
+readable in the table's earlier snapshots via time travel. To repopulate history under the new
+type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 
 ## Table Maintenance
 


### PR DESCRIPTION
**Description:**

Documents the new `nanosecond_timestamps` advanced option of `materialize-s3-iceberg`: date-time fields materialize as `timestamptz_ns` columns and tables are created as Iceberg format v3.

Companion to estuary/connectors#4483, where the option is implemented; adding it here was requested in that PR's review.

**Workflow steps:**

No behavior change; docs only.

**Documentation links affected:**

[Amazon S3 Iceberg](https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-iceberg/) — adds the `/advanced/nanosecond_timestamps` endpoint property and a column-types note (format v3, query-engine support caution, backfill required on toggle).

**Notes for reviewers:**

Mirrors the same page's update in the connectors repo (estuary/connectors#4483).
