### PR TITLE
runtime-next: force txn close at any usage ceiling, bypassing min duration

### DIFF
--- a/crates/runtime-next/src/leader/close_policy.rs
+++ b/crates/runtime-next/src/leader/close_policy.rs
@@ -56,22 +56,32 @@ impl Policy {
         }
     }
 
-    /// Evaluate whether an open transaction may extend, close, or hold.
+    /// Decide whether an open transaction may extend, may close, or must hold —
+    /// the batching heuristic at the heart of a V2 task.
     ///
-    /// Threshold policy with a hysteresis band per dimension:
-    /// - `policy_extend` while every measure is below its `range.end`.
-    /// - `policy_close` once every measure is above its `range.start`.
-    ///   Usage-based measures saturate below `start` once `policy_extend` is false
-    ///   (otherwise we'd live-lock because the threshold cannot be reached).
+    /// Bigger transactions amortize the fixed cost of a commit, but must be
+    /// bounded: too large risks memory and disk pressure, too long hurts latency,
+    /// and too small or too frequent wastes overhead. Each measure carries a
+    /// `start..end` band naming the transaction sizes we're content with:
     ///
-    /// Overrides:
-    /// - `close_requested`, or `idempotent_replay && !unresolved_hints`: force close.
-    /// - `unresolved_hints`: forces extend; suppresses close until hints resolve.
-    /// - `idempotent_replay`: suppresses extend (replay is one-shot).
-    /// - `close_requested` or `stopping` with `may_close=true`: suppresses extend so
-    ///   the current txn closes promptly (and Head can stop after the next commit).
-    ///   With Tail still draining, extend is permitted to keep the pipeline full.
-    /// - `!tail_done`: suppresses close (must hold open while Tail finishes).
+    /// - Under every floor we're too small: extend only.
+    /// - Inside the bands we're content either way, so both flags are set and the
+    ///   caller extends if more input is ready and otherwise closes. The gap
+    ///   between floor and ceiling is what keeps us from flapping at a threshold.
+    /// - At any ceiling we're done: close now, even if other measures sit below
+    ///   their floor. A saturated measure means no further useful progress is
+    ///   possible, so honoring the minimum would only idle a doomed transaction.
+    ///
+    /// Lifecycle flags override the size heuristic:
+    /// - `unresolved_hints` pins us open: we may close only on a coherent boundary.
+    /// - `idempotent_replay` is one-shot: never extend, and close once hints clear.
+    /// - `close_requested` forces a close, and with `stopping` also stops extending
+    ///   once we can actually close, so the shard stops promptly — though we keep
+    ///   extending while Tail drains, to leave the pipeline full.
+    /// - `tail_done` gates close: hold open until Tail finishes the prior txn.
+    ///
+    /// `wake_after` reports when the nearest time threshold would next change this
+    /// decision, so an idle caller knows when to re-evaluate.
     pub fn evaluate(&self, inputs: Inputs) -> Decision {
         let Inputs {
             open_age,
@@ -86,29 +96,44 @@ impl Policy {
             tail_done,
         } = inputs;
 
-        let policy_extend = open_age < self.open_duration.end
-            && last_age < self.last_close_age.end
-            && combiner_bytes < self.combiner_usage_bytes.end
-            && read_bytes < self.read_bytes.end
-            && read_docs < self.read_docs.end;
+        // Are all time-based measures above their minimum?
+        let time_above_min =
+            open_age >= self.open_duration.start && last_age >= self.last_close_age.start;
+        // Are any time-based measures above their maximum?
+        let time_above_max =
+            open_age >= self.open_duration.end || last_age >= self.last_close_age.end;
 
-        let mut policy_close = open_age >= self.open_duration.start
-            && last_age >= self.last_close_age.start
-            && (!policy_extend || combiner_bytes >= self.combiner_usage_bytes.start)
-            && (!policy_extend || read_bytes >= self.read_bytes.start)
-            && (!policy_extend || read_docs >= self.read_docs.start);
+        // Are all usage-based measures above their minimum?
+        let usage_above_min = combiner_bytes >= self.combiner_usage_bytes.start
+            && read_bytes >= self.read_bytes.start
+            && read_docs >= self.read_docs.start;
+        // Are any usage-based measures above their maximum?
+        let usage_above_max = combiner_bytes >= self.combiner_usage_bytes.end
+            || read_bytes >= self.read_bytes.end
+            || read_docs >= self.read_docs.end;
+
+        // Are we trying to close quickly due to user request or graceful stop?
+        let finishing = close_requested || stopping;
+
+        // We want to extend while neither time-max nor usage-max is breached.
+        let policy_extend = !time_above_max && !usage_above_max;
+        // We want to close if we're not extending, or time-min and usage-min is reached.
+        let mut policy_close = !policy_extend || (usage_above_min && time_above_min);
+
+        // Overrides: also close if we've completed an idempotent replay.
         policy_close |= idempotent_replay && !unresolved_hints;
-        policy_close |= close_requested;
+        policy_close |= close_requested; // Or if requested.
 
+        // Structurally, we cannot close if there are unresolved hints (we must
+        // only close at a coherent transaction boundary), or if the Tail FSM
+        // is still processing.
         let may_close = policy_close && !unresolved_hints && tail_done;
 
-        // A requested or stopping close stops extending the current txn once
-        // we're actually able to close it, so the txn finishes promptly. While
-        // we cannot yet close (Tail still draining, or unresolved hints), we
-        // keep extending if policy allows — maximizing parallelism as Tail works.
-        let finishing = close_requested || stopping;
+        // Structurally, we must cease extending an idempotent replay having
+        // no unresolved hints, or if we're trying to close and are allowed to do so.
+        // However we must extend if unresolved hints remain.
         let may_extend =
-            (!idempotent_replay && policy_extend && (!finishing || !may_close)) || unresolved_hints;
+            (policy_extend && !idempotent_replay && (!finishing || !may_close)) || unresolved_hints;
 
         let wake_after = [
             self.open_duration.start.checked_sub(open_age),
@@ -134,6 +159,7 @@ mod tests {
 
     /// Table-driven coverage of `Policy::evaluate`. The policy's hysteresis
     /// bands are 1..5 (s/bytes/docs); `mid` sits in-band on every dimension.
+    /// A ceiling is any value >= 5, a below-floor value is 0.
     #[test]
     fn close_policy_table() {
         let policy = Policy {
@@ -174,7 +200,7 @@ mod tests {
                 want: (true, true),
             },
             Case {
-                name: "below all minima: extend only",
+                name: "below every floor: extend only",
                 inputs: Inputs {
                     open_age: Duration::ZERO,
                     last_age: Duration::ZERO,
@@ -186,37 +212,93 @@ mod tests {
                 want: (true, false),
             },
             Case {
-                name: "saturated combiner: close only",
+                // In-band usage but below the minimum transaction duration: hold
+                // open to keep batching. Pins that the min-duration floor gates
+                // close even when every usage measure is already above its floor.
+                name: "below min duration only: hold for min_txn_duration",
                 inputs: Inputs {
-                    combiner_bytes: 10,
+                    open_age: Duration::ZERO,
+                    last_age: Duration::ZERO,
+                    ..mid.clone()
+                },
+                want: (true, false),
+            },
+            Case {
+                // The last-close age is a distinct time floor from open duration.
+                name: "below last-close floor: hold",
+                inputs: Inputs {
+                    last_age: Duration::ZERO,
+                    ..mid.clone()
+                },
+                want: (true, false),
+            },
+            // Each usage ceiling independently forces close, even in-band on time.
+            Case {
+                name: "combiner at ceiling: close only",
+                inputs: Inputs {
+                    combiner_bytes: 9,
                     ..mid.clone()
                 },
                 want: (false, true),
             },
             Case {
-                name: "saturated combiner but open_age below min: hold",
+                name: "read_bytes at ceiling: close only",
+                inputs: Inputs {
+                    read_bytes: 9,
+                    ..mid.clone()
+                },
+                want: (false, true),
+            },
+            Case {
+                name: "read_docs at ceiling: close only",
+                inputs: Inputs {
+                    read_docs: 9,
+                    ..mid.clone()
+                },
+                want: (false, true),
+            },
+            Case {
+                // A usage ceiling closes even below the min-duration floor.
+                name: "usage ceiling below min duration: bypass floor, close",
                 inputs: Inputs {
                     open_age: Duration::ZERO,
-                    combiner_bytes: 10,
+                    combiner_bytes: 9,
+                    ..mid.clone()
+                },
+                want: (false, true),
+            },
+            Case {
+                // The max-duration ceiling likewise closes with usage below floor.
+                name: "max duration reached, usage below floor: close",
+                inputs: Inputs {
+                    open_age: Duration::from_secs(9),
+                    combiner_bytes: 0,
+                    read_bytes: 0,
+                    read_docs: 0,
+                    ..mid.clone()
+                },
+                want: (false, true),
+            },
+            Case {
+                // ...but no ceiling may close while Tail still drains.
+                name: "usage ceiling but Tail busy: hold",
+                inputs: Inputs {
+                    combiner_bytes: 9,
+                    tail_done: false,
                     ..mid.clone()
                 },
                 want: (false, false),
             },
             Case {
-                name: "close_requested with may_close: extend suppressed, close",
+                name: "close_requested, able to close: extend suppressed, close",
                 inputs: Inputs {
-                    open_age: Duration::ZERO,
-                    last_age: Duration::ZERO,
-                    read_bytes: 0,
-                    read_docs: 0,
-                    combiner_bytes: 0,
                     close_requested: true,
                     ..mid.clone()
                 },
                 want: (false, true),
             },
             Case {
-                name: "close_requested but tail still busy: hold open",
+                name: "close_requested but Tail busy: keep pipeline full",
                 inputs: Inputs {
                     close_requested: true,
                     tail_done: false,
@@ -234,38 +316,37 @@ mod tests {
                 want: (true, false),
             },
             Case {
-                name: "idempotent_replay with hints resolved: close only",
+                name: "stopping, able to close: extend suppressed",
                 inputs: Inputs {
-                    open_age: Duration::ZERO,
-                    idempotent_replay: true,
+                    stopping: true,
                     ..mid.clone()
                 },
                 want: (false, true),
             },
             Case {
-                name: "idempotent_replay with unresolved hints: extend forced",
+                name: "stopping but Tail busy: keep pipeline full",
                 inputs: Inputs {
-                    open_age: Duration::ZERO,
-                    idempotent_replay: true,
-                    unresolved_hints: true,
+                    stopping: true,
+                    tail_done: false,
                     ..mid.clone()
                 },
                 want: (true, false),
             },
             Case {
-                name: "stopping with may_close: extend suppressed",
+                name: "idempotent_replay, hints resolved: close only",
                 inputs: Inputs {
-                    close_requested: true,
-                    stopping: true,
+                    open_age: Duration::ZERO,
+                    idempotent_replay: true,
                     ..mid.clone()
                 },
                 want: (false, true),
             },
             Case {
-                name: "stopping with tail busy: keep pipeline full",
+                name: "idempotent_replay, unresolved hints: extend forced",
                 inputs: Inputs {
-                    stopping: true,
-                    tail_done: false,
+                    open_age: Duration::ZERO,
+                    idempotent_replay: true,
+                    unresolved_hints: true,
                     ..mid.clone()
                 },
                 want: (true, false),
@@ -290,5 +371,17 @@ mod tests {
                 case.inputs,
             );
         }
+
+        // `wake_after` targets the nearest future time threshold — here the min
+        // duration and last-close floors, both 1s out from a fresh transaction.
+        let fresh = Inputs {
+            open_age: Duration::ZERO,
+            last_age: Duration::ZERO,
+            ..mid.clone()
+        };
+        assert_eq!(
+            policy.evaluate(fresh).wake_after,
+            Some(Duration::from_secs(1))
+        );
     }
 }


### PR DESCRIPTION
## What

Reworks the V2 close policy (`crates/runtime-next/src/leader/close_policy.rs`) so that breaching **any** usage ceiling forces the open transaction to close immediately, even when the minimum transaction duration has not yet elapsed.

## Why

A saturated usage measure — e.g. combiner disk usage, which captures cap at 64 MiB to favor small transactions — means an open transaction can make no further useful progress. Previously, a usage-max breach still respected the time floor (`open_duration.start`), so the transaction would idle up to `min_txn_duration` while holding its full combiner. That's a doomed transaction we've already decided to end; closing promptly reduces peak resource residency and latency.

## How

`evaluate()` is restructured around symmetric time/usage min/max predicates. The rule is now uniform: **any `.end` breach forces close and waives all `.start` floors** (both time and usage). Previously that waiver only applied when a *time* max was breached; a *usage* max still gated on the time floor. `policy_extend`, `may_close`, and `may_extend` are otherwise logically unchanged.

Note on scope: `min_txn_duration` becomes a soft batching target rather than a hard floor — a resource ceiling can now produce sub-`min_txn_duration` transactions under load. This is the intended priority (resource protection > batching preference).

## Tests

- Rewrote the `evaluate()` doc comment to explain batching intent rather than restate the logic.
- Extended the table: per-dimension usage ceilings, the last-close time floor, the max-duration ceiling with usage below floor, and a `wake_after` assertion — all previously uncovered.
- Verified capture FSM tests (the real consumer) still pass.