### PR TITLE
dekaf: only read back when a fetch offset lands inside a document

### DIFF
--- a/crates/dekaf/Cargo.toml
+++ b/crates/dekaf/Cargo.toml
@@ -93,6 +93,7 @@ locate-bin = { path = "../locate-bin" }
 apache-avro = { workspace = true }
 insta = { workspace = true }
 rdkafka = { workspace = true }
+reqwest = { workspace = true }
 schema_registry_converter = { workspace = true }
 serde_yaml = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -19,7 +19,7 @@ pub struct Read {
     /// Journal offset to be served by this Read.
     /// (Actual next offset may be larger if a fragment was removed).
     /// If this offset lands inside a document, the underlying journal read
-    /// restarts up to OFFSET_READBACK bytes earlier, and documents which end
+    /// begins up to OFFSET_READBACK bytes earlier, and documents which end
     /// at-or-before this offset are suppressed rather than served.
     pub(crate) offset: i64,
     /// Most-recent journal write head observed by this Read.
@@ -51,12 +51,6 @@ pub struct Read {
     deletes: DeletionMode,
 
     pub(crate) rewrite_offsets_from: Option<i64>,
-
-    // Whether the current stream's starting position is not yet verified to
-    // be a document boundary. While set, the stream's first parsed document
-    // (or parse failure) decides whether the read landed inside a document,
-    // in which case it restarts with readback. See OFFSET_READBACK.
-    probe_boundary: bool,
 
     // Leader epoch for this partition, used in RecordBatch headers.
     // Must match the epoch reported in OffsetFetch's committed_leader_epoch
@@ -91,12 +85,12 @@ pub enum ReadTarget {
 /// containing document, which a read started at the fetch offset would scan
 /// past and drop. Reading backwards unconditionally is far too expensive,
 /// however: almost all fetches target document boundaries, and each readback
-/// re-reads and discards up to this many bytes from the journal. So reads
-/// begin by probing whether the offset being served is a document boundary
-/// (see `probe_offset`); only when the probe shows a mid-document landing
-/// does the read restart this many bytes earlier, with `next_batch`
-/// suppressing documents which end at-or-before the served offset. It's
-/// sized to be larger than the maximum size of a single document (64MB).
+/// re-reads and discards up to this many bytes from the journal. So
+/// `stream_start_offset` first inspects the byte before the offset being
+/// served to determine whether it's a document boundary; only a mid-document
+/// landing begins this many bytes earlier, with `next_batch` suppressing
+/// documents which end at-or-before the served offset. It's sized to be
+/// larger than the maximum size of a single document (64MB).
 const OFFSET_READBACK: i64 = 1 << 26; // 64MB
 
 /// Map an offset to be served into the journal offset at which its read
@@ -108,22 +102,6 @@ fn readback_offset(offset: i64) -> i64 {
     } else {
         offset
     }
-}
-
-/// Map an offset to be served into the journal offset at which its probe
-/// read begins: one byte earlier. An offset is a document boundary exactly
-/// when the byte before it is a document-separator newline, which the parser
-/// skips as inter-document whitespace, so a boundary probe's first document
-/// verifies with a valid UUID. Starting at the offset itself would mis-verify
-/// fetches which address a document's final byte — its trailing newline, and
-/// precisely the offset Kafka assigns the document as a record — because the
-/// stream would begin at the separator and parse the *next* document cleanly.
-/// From one byte earlier such a fetch reads the document's last content byte
-/// as an unparseable suffix instead, correctly triggering readback.
-/// Non-positive offsets pass through, as does offset 0, which is trivially a
-/// boundary.
-fn probe_offset(offset: i64) -> i64 {
-    if offset > 0 { offset - 1 } else { offset }
 }
 
 impl Read {
@@ -146,9 +124,27 @@ impl Read {
             .name
             .as_str();
 
+        let task_name = match auth {
+            SessionAuthentication::Task(task_auth) => task_auth.task_name.clone(),
+            SessionAuthentication::Redirect { .. } => {
+                bail!("Redirected sessions cannot read data")
+            }
+        };
+
         // Data-preview reads pass a fragment-start offset, which is always a
         // document boundary, and don't require boundary verification.
-        let probe_boundary = rewrite_offsets_from.is_none();
+        let stream_offset = if rewrite_offsets_from.is_none() {
+            Self::stream_start_offset(
+                &task_state_listener,
+                partition_template_name,
+                &partition.spec.name,
+                &task_name,
+                offset,
+            )
+            .await?
+        } else {
+            offset
+        };
 
         let (stream, stream_exp) = Self::new_stream(
             collection.not_before,
@@ -156,11 +152,7 @@ impl Read {
             partition_template_name.to_owned(),
             partition.spec.name.clone(),
             buffer_size,
-            if probe_boundary {
-                probe_offset(offset)
-            } else {
-                offset
-            },
+            stream_offset,
         )
         .await?;
 
@@ -185,60 +177,19 @@ impl Read {
             partition_template_name: partition_template_name.to_owned(),
             journal_name: partition.spec.name.clone(),
             collection_name: collection.name.to_owned(),
-            task_name: match auth {
-                SessionAuthentication::Task(task_auth) => task_auth.task_name.clone(),
-                SessionAuthentication::Redirect { .. } => {
-                    bail!("Redirected sessions cannot read data")
-                }
-            },
+            task_name,
             rewrite_offsets_from,
-            probe_boundary,
             deletes: auth.deletions(),
             partition_leader_epoch: collection.binding_backfill_counter as i32,
         })
     }
 
-    /// Restart the journal stream up to OFFSET_READBACK bytes before the
-    /// offset being served, so that the document containing that offset is
-    /// reached (with its predecessors suppressed) rather than dropped.
-    async fn restart_with_readback(&mut self) -> anyhow::Result<()> {
-        metrics::counter!(
-            "dekaf_readback_restarts",
-            "task_name" => self.task_name.to_owned(),
-            "journal_name" => self.journal_name.to_owned(),
-        )
-        .increment(1);
-        tracing::debug!(
-            offset = self.offset,
-            journal_name = self.journal_name,
-            "offset is not a document boundary; restarting read with readback"
-        );
-
-        (self.stream, self.stream_exp) = Self::new_stream(
-            self.not_before,
-            self.listener.clone(),
-            self.partition_template_name.clone(),
-            self.journal_name.clone(),
-            self.buffer_size,
-            readback_offset(self.offset),
-        )
-        .await?;
-        self.probe_boundary = false;
-        Ok(())
-    }
-
-    async fn new_stream(
-        not_before: Option<Clock>,
-        listener: TaskStateListener,
-        partition_template_name: String,
-        journal_name: String,
-        buffer_size: usize,
-        offset: i64,
-    ) -> anyhow::Result<(ReadJsonLines, std::time::SystemTime)> {
-        let (not_before_sec, _) = not_before
-            .map(|c: Clock| Clock::to_unix(&c))
-            .unwrap_or((0, 0));
-
+    /// Fetch the current journal client and authorization expiry for this
+    /// partition's template from the task state.
+    async fn journal_client(
+        listener: &TaskStateListener,
+        partition_template_name: &str,
+    ) -> anyhow::Result<(gazette::journal::Client, std::time::SystemTime)> {
         let task_state = listener.get().await?;
 
         let partitions = match task_state.as_ref() {
@@ -267,6 +218,126 @@ impl Read {
             ))??;
 
         Ok((
+            client,
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(claims.exp),
+        ))
+    }
+
+    /// Resolve the journal offset at which a stream serving `offset` begins.
+    ///
+    /// Collection journals are newline-delimited JSON: every document is
+    /// written compactly and terminated by exactly one newline, and JSON
+    /// forbids unescaped control characters within strings, so a raw newline
+    /// byte occurs in journal content only as a document terminator. `offset`
+    /// is therefore a document boundary exactly when the preceding byte is a
+    /// newline, which a single-byte point read determines directly.
+    ///
+    /// Any other byte means `offset` lands inside a document — commonly a
+    /// fetch addressing a document's final byte, which is the Kafka offset
+    /// assigned to the document as a record — and the stream must begin up to
+    /// OFFSET_READBACK earlier to serve the containing document, with
+    /// `next_batch` suppressing its predecessors.
+    ///
+    /// If the preceding byte is unavailable — offset zero, at or beyond the
+    /// write head, expired from the journal, or the journal is suspended or
+    /// deleted — then no containing document can be served regardless, and
+    /// the stream begins at `offset`.
+    async fn stream_start_offset(
+        listener: &TaskStateListener,
+        partition_template_name: &str,
+        journal_name: &str,
+        task_name: &str,
+        offset: i64,
+    ) -> anyhow::Result<i64> {
+        if offset <= 0 {
+            return Ok(offset);
+        }
+
+        let (client, _exp) = Self::journal_client(listener, partition_template_name).await?;
+
+        let stream = client.read(broker::ReadRequest {
+            journal: journal_name.to_string(),
+            offset: offset - 1,
+            end_offset: offset,
+            block: false,
+            ..Default::default()
+        });
+        tokio::pin!(stream);
+
+        loop {
+            match stream.next().await {
+                // EOF without content: no byte precedes `offset` to read.
+                None => return Ok(offset),
+                Some(Ok(resp)) => {
+                    if resp.fragment.is_some() || resp.content.is_empty() {
+                        continue; // Metadata-only response.
+                    }
+                    // The broker fast-forwards past deleted fragments, in which
+                    // case the byte (and its containing document) is gone.
+                    let index = (offset - 1) - resp.offset;
+                    if index < 0 {
+                        return Ok(offset);
+                    }
+                    if resp.content[index as usize] == b'\n' {
+                        return Ok(offset);
+                    }
+
+                    metrics::counter!(
+                        "dekaf_readback_reads",
+                        "task_name" => task_name.to_string(),
+                        "journal_name" => journal_name.to_string(),
+                    )
+                    .increment(1);
+                    tracing::debug!(
+                        offset,
+                        journal_name,
+                        "offset is not a document boundary; reading back"
+                    );
+                    return Ok(readback_offset(offset));
+                }
+                Some(Err(gazette::RetryError {
+                    inner: gazette::Error::BrokerStatus(status),
+                    ..
+                })) if matches!(
+                    status,
+                    broker::Status::OffsetNotYetAvailable
+                        | broker::Status::Suspended
+                        | broker::Status::JournalNotFound
+                ) =>
+                {
+                    // No preceding byte to inspect. Begin at `offset` and let
+                    // the stream itself surface any terminal condition.
+                    return Ok(offset);
+                }
+                Some(Err(gazette::RetryError { attempt, inner }))
+                    if inner.is_transient() && attempt < 5 =>
+                {
+                    tracing::warn!(error = ?inner, "retrying transient error of boundary probe read");
+                    continue;
+                }
+                Some(Err(gazette::RetryError { inner, .. })) => {
+                    return Err(anyhow::Error::new(inner)
+                        .context("reading the byte before the fetch offset"));
+                }
+            }
+        }
+    }
+
+    async fn new_stream(
+        not_before: Option<Clock>,
+        listener: TaskStateListener,
+        partition_template_name: String,
+        journal_name: String,
+        buffer_size: usize,
+        offset: i64,
+    ) -> anyhow::Result<(ReadJsonLines, std::time::SystemTime)> {
+        let (not_before_sec, _) = not_before
+            .map(|c: Clock| Clock::to_unix(&c))
+            .unwrap_or((0, 0));
+
+        let (client, exp) = Self::journal_client(&listener, &partition_template_name).await?;
+
+        Ok((
             client.read_json_lines(
                 broker::ReadRequest {
                     offset,
@@ -280,7 +351,7 @@ impl Read {
                 // network delay of the next fetch request.
                 buffer_size,
             ),
-            std::time::UNIX_EPOCH + std::time::Duration::from_secs(claims.exp),
+            exp,
         ))
     }
 
@@ -299,19 +370,29 @@ impl Read {
         if (now + timeout + std::time::Duration::from_secs(30)) > self.stream_exp {
             tracing::debug!("stream auth expired, fetching new token");
             // Once this read has served a document, self.offset is that
-            // document's end and the probe verifies without a restart.
-            self.probe_boundary = self.rewrite_offsets_from.is_none();
+            // document's end — a boundary — and the probe resolves to it
+            // without readback. A refresh during an in-progress readback
+            // instead re-probes the original mid-document offset and resumes
+            // the readback.
+            let stream_offset = if self.rewrite_offsets_from.is_none() {
+                Self::stream_start_offset(
+                    &self.listener,
+                    &self.partition_template_name,
+                    &self.journal_name,
+                    &self.task_name,
+                    self.offset,
+                )
+                .await?
+            } else {
+                self.offset
+            };
             (self.stream, self.stream_exp) = Self::new_stream(
                 self.not_before,
                 self.listener.clone(),
                 self.partition_template_name.clone(),
                 self.journal_name.clone(),
                 self.buffer_size,
-                if self.probe_boundary {
-                    probe_offset(self.offset)
-                } else {
-                    self.offset
-                },
+                stream_offset,
             )
             .await?;
         }
@@ -364,37 +445,19 @@ impl Read {
                 None => bail!("blocking gazette client read never returns EOF"),
                 Some(resp) => match resp {
                     Ok(data @ ReadJsonLine::Meta(_)) => Ok(data),
-                    Ok(ReadJsonLine::Doc { root, next_offset }) => {
-                        if self.probe_boundary {
-                            // A mid-document landing may still parse, when the
-                            // document's suffix happens to be valid JSON, but
-                            // it cannot carry a valid UUID at the collection's
-                            // UUID pointer.
-                            if matches!(
-                                self.uuid_ptr.query(root.get()),
-                                Some(doc::ArchivedNode::String(uuid))
-                                    if gazette::uuid::parse_str(uuid.as_str()).is_ok()
-                            ) {
-                                self.probe_boundary = false;
-                            } else {
-                                self.restart_with_readback().await?;
-                                continue;
-                            }
+                    Ok(ReadJsonLine::Doc { root, next_offset }) => match root.get() {
+                        doc::heap::ArchivedNode::Object(_, _) => {
+                            Ok(ReadJsonLine::Doc { root, next_offset })
                         }
-                        match root.get() {
-                            doc::heap::ArchivedNode::Object(_, _) => {
-                                Ok(ReadJsonLine::Doc { root, next_offset })
-                            }
-                            non_object => {
-                                tracing::warn!(
-                                    "skipping past non-object node at offset {}: {:?}",
-                                    self.offset,
-                                    doc::SerPolicy::debug_value(non_object)
-                                );
-                                continue;
-                            }
+                        non_object => {
+                            tracing::warn!(
+                                "skipping past non-object node at offset {}: {:?}",
+                                self.offset,
+                                doc::SerPolicy::debug_value(non_object)
+                            );
+                            continue;
                         }
-                    }
+                    },
                     Err(gazette::RetryError { attempt, inner })
                         if inner.is_transient() && attempt < 5 =>
                     {
@@ -406,11 +469,7 @@ impl Read {
                         attempt,
                         inner: err @ gazette::Error::Parsing { .. },
                     }) => {
-                        if self.probe_boundary {
-                            tracing::debug!(%err, "fetch offset landed inside a document");
-                            self.restart_with_readback().await?;
-                            continue;
-                        } else if attempt == 0 {
+                        if attempt == 0 {
                             tracing::debug!(%err, "Ignoring first parse error to skip past partial document");
                             continue;
                         } else {

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -92,11 +92,11 @@ pub enum ReadTarget {
 /// past and drop. Reading backwards unconditionally is far too expensive,
 /// however: almost all fetches target document boundaries, and each readback
 /// re-reads and discards up to this many bytes from the journal. So reads
-/// begin exactly at the offset being served and probe whether it is a
-/// document boundary; only when the probe shows a mid-document landing does
-/// the read restart this many bytes earlier, with `next_batch` suppressing
-/// documents which end at-or-before the served offset. It's sized to be
-/// larger than the maximum size of a single document (64MB).
+/// begin by probing whether the offset being served is a document boundary
+/// (see `probe_offset`); only when the probe shows a mid-document landing
+/// does the read restart this many bytes earlier, with `next_batch`
+/// suppressing documents which end at-or-before the served offset. It's
+/// sized to be larger than the maximum size of a single document (64MB).
 const OFFSET_READBACK: i64 = 1 << 26; // 64MB
 
 /// Map an offset to be served into the journal offset at which its read
@@ -108,6 +108,22 @@ fn readback_offset(offset: i64) -> i64 {
     } else {
         offset
     }
+}
+
+/// Map an offset to be served into the journal offset at which its probe
+/// read begins: one byte earlier. An offset is a document boundary exactly
+/// when the byte before it is a document-separator newline, which the parser
+/// skips as inter-document whitespace, so a boundary probe's first document
+/// verifies with a valid UUID. Starting at the offset itself would mis-verify
+/// fetches which address a document's final byte — its trailing newline, and
+/// precisely the offset Kafka assigns the document as a record — because the
+/// stream would begin at the separator and parse the *next* document cleanly.
+/// From one byte earlier such a fetch reads the document's last content byte
+/// as an unparseable suffix instead, correctly triggering readback.
+/// Non-positive offsets pass through, as does offset 0, which is trivially a
+/// boundary.
+fn probe_offset(offset: i64) -> i64 {
+    if offset > 0 { offset - 1 } else { offset }
 }
 
 impl Read {
@@ -140,7 +156,11 @@ impl Read {
             partition_template_name.to_owned(),
             partition.spec.name.clone(),
             buffer_size,
-            offset,
+            if probe_boundary {
+                probe_offset(offset)
+            } else {
+                offset
+            },
         )
         .await?;
 
@@ -278,18 +298,22 @@ impl Read {
 
         if (now + timeout + std::time::Duration::from_secs(30)) > self.stream_exp {
             tracing::debug!("stream auth expired, fetching new token");
+            // Once this read has served a document, self.offset is that
+            // document's end and the probe verifies without a restart.
+            self.probe_boundary = self.rewrite_offsets_from.is_none();
             (self.stream, self.stream_exp) = Self::new_stream(
                 self.not_before,
                 self.listener.clone(),
                 self.partition_template_name.clone(),
                 self.journal_name.clone(),
                 self.buffer_size,
-                self.offset,
+                if self.probe_boundary {
+                    probe_offset(self.offset)
+                } else {
+                    self.offset
+                },
             )
             .await?;
-            // Once this read has served a document, self.offset is that
-            // document's end and the probe verifies without a restart.
-            self.probe_boundary = self.rewrite_offsets_from.is_none();
         }
 
         let mut records: Vec<Record> = Vec::new();

--- a/crates/dekaf/src/read.rs
+++ b/crates/dekaf/src/read.rs
@@ -18,9 +18,9 @@ use lz4_flex::frame::BlockMode;
 pub struct Read {
     /// Journal offset to be served by this Read.
     /// (Actual next offset may be larger if a fragment was removed).
-    /// The underlying journal read begins up to OFFSET_READBACK bytes
-    /// earlier, and documents which end at-or-before this offset are
-    /// suppressed rather than served.
+    /// If this offset lands inside a document, the underlying journal read
+    /// restarts up to OFFSET_READBACK bytes earlier, and documents which end
+    /// at-or-before this offset are suppressed rather than served.
     pub(crate) offset: i64,
     /// Most-recent journal write head observed by this Read.
     pub(crate) last_write_head: i64,
@@ -52,6 +52,12 @@ pub struct Read {
 
     pub(crate) rewrite_offsets_from: Option<i64>,
 
+    // Whether the current stream's starting position is not yet verified to
+    // be a document boundary. While set, the stream's first parsed document
+    // (or parse failure) decides whether the read landed inside a document,
+    // in which case it restarts with readback. See OFFSET_READBACK.
+    probe_boundary: bool,
+
     // Leader epoch for this partition, used in RecordBatch headers.
     // Must match the epoch reported in OffsetFetch's committed_leader_epoch
     // so that librdkafka's epoch-aware commit filtering doesn't silently
@@ -78,14 +84,19 @@ pub enum ReadTarget {
     Docs(usize),
 }
 
-/// Journal reads begin this many bytes before the offset being served, and
-/// `next_batch` suppresses documents which end at-or-before that offset.
 /// Dekaf maps each document to the Kafka offset of its final byte, so a
 /// consumer may fetch at an offset which lands in the middle of a document,
 /// for example when it plans fetches by numerically partitioning the offset
-/// space. Reading backwards lets such a fetch serve its containing document,
-/// which a read started at the fetch offset would scan past and drop.
-/// It's sized to be larger than the maximum size of a single document (64MB).
+/// space. Serving such a fetch requires reading backwards to reach the
+/// containing document, which a read started at the fetch offset would scan
+/// past and drop. Reading backwards unconditionally is far too expensive,
+/// however: almost all fetches target document boundaries, and each readback
+/// re-reads and discards up to this many bytes from the journal. So reads
+/// begin exactly at the offset being served and probe whether it is a
+/// document boundary; only when the probe shows a mid-document landing does
+/// the read restart this many bytes earlier, with `next_batch` suppressing
+/// documents which end at-or-before the served offset. It's sized to be
+/// larger than the maximum size of a single document (64MB).
 const OFFSET_READBACK: i64 = 1 << 26; // 64MB
 
 /// Map an offset to be served into the journal offset at which its read
@@ -120,12 +131,8 @@ impl Read {
             .as_str();
 
         // Data-preview reads pass a fragment-start offset, which is always a
-        // document boundary, and don't require reading backwards.
-        let stream_offset = if rewrite_offsets_from.is_none() {
-            readback_offset(offset)
-        } else {
-            offset
-        };
+        // document boundary, and don't require boundary verification.
+        let probe_boundary = rewrite_offsets_from.is_none();
 
         let (stream, stream_exp) = Self::new_stream(
             collection.not_before,
@@ -133,7 +140,7 @@ impl Read {
             partition_template_name.to_owned(),
             partition.spec.name.clone(),
             buffer_size,
-            stream_offset,
+            offset,
         )
         .await?;
 
@@ -165,9 +172,39 @@ impl Read {
                 }
             },
             rewrite_offsets_from,
+            probe_boundary,
             deletes: auth.deletions(),
             partition_leader_epoch: collection.binding_backfill_counter as i32,
         })
+    }
+
+    /// Restart the journal stream up to OFFSET_READBACK bytes before the
+    /// offset being served, so that the document containing that offset is
+    /// reached (with its predecessors suppressed) rather than dropped.
+    async fn restart_with_readback(&mut self) -> anyhow::Result<()> {
+        metrics::counter!(
+            "dekaf_readback_restarts",
+            "task_name" => self.task_name.to_owned(),
+            "journal_name" => self.journal_name.to_owned(),
+        )
+        .increment(1);
+        tracing::debug!(
+            offset = self.offset,
+            journal_name = self.journal_name,
+            "offset is not a document boundary; restarting read with readback"
+        );
+
+        (self.stream, self.stream_exp) = Self::new_stream(
+            self.not_before,
+            self.listener.clone(),
+            self.partition_template_name.clone(),
+            self.journal_name.clone(),
+            self.buffer_size,
+            readback_offset(self.offset),
+        )
+        .await?;
+        self.probe_boundary = false;
+        Ok(())
     }
 
     async fn new_stream(
@@ -247,9 +284,12 @@ impl Read {
                 self.partition_template_name.clone(),
                 self.journal_name.clone(),
                 self.buffer_size,
-                readback_offset(self.offset),
+                self.offset,
             )
             .await?;
+            // Once this read has served a document, self.offset is that
+            // document's end and the probe verifies without a restart.
+            self.probe_boundary = self.rewrite_offsets_from.is_none();
         }
 
         let mut records: Vec<Record> = Vec::new();
@@ -300,19 +340,37 @@ impl Read {
                 None => bail!("blocking gazette client read never returns EOF"),
                 Some(resp) => match resp {
                     Ok(data @ ReadJsonLine::Meta(_)) => Ok(data),
-                    Ok(ReadJsonLine::Doc { root, next_offset }) => match root.get() {
-                        doc::heap::ArchivedNode::Object(_, _) => {
-                            Ok(ReadJsonLine::Doc { root, next_offset })
+                    Ok(ReadJsonLine::Doc { root, next_offset }) => {
+                        if self.probe_boundary {
+                            // A mid-document landing may still parse, when the
+                            // document's suffix happens to be valid JSON, but
+                            // it cannot carry a valid UUID at the collection's
+                            // UUID pointer.
+                            if matches!(
+                                self.uuid_ptr.query(root.get()),
+                                Some(doc::ArchivedNode::String(uuid))
+                                    if gazette::uuid::parse_str(uuid.as_str()).is_ok()
+                            ) {
+                                self.probe_boundary = false;
+                            } else {
+                                self.restart_with_readback().await?;
+                                continue;
+                            }
                         }
-                        non_object => {
-                            tracing::warn!(
-                                "skipping past non-object node at offset {}: {:?}",
-                                self.offset,
-                                doc::SerPolicy::debug_value(non_object)
-                            );
-                            continue;
+                        match root.get() {
+                            doc::heap::ArchivedNode::Object(_, _) => {
+                                Ok(ReadJsonLine::Doc { root, next_offset })
+                            }
+                            non_object => {
+                                tracing::warn!(
+                                    "skipping past non-object node at offset {}: {:?}",
+                                    self.offset,
+                                    doc::SerPolicy::debug_value(non_object)
+                                );
+                                continue;
+                            }
                         }
-                    },
+                    }
                     Err(gazette::RetryError { attempt, inner })
                         if inner.is_transient() && attempt < 5 =>
                     {
@@ -324,7 +382,11 @@ impl Read {
                         attempt,
                         inner: err @ gazette::Error::Parsing { .. },
                     }) => {
-                        if attempt == 0 {
+                        if self.probe_boundary {
+                            tracing::debug!(%err, "fetch offset landed inside a document");
+                            self.restart_with_readback().await?;
+                            continue;
+                        } else if attempt == 0 {
                             tracing::debug!(%err, "Ignoring first parse error to skip past partial document");
                             continue;
                         } else {

--- a/crates/dekaf/tests/e2e/fetch_offsets.rs
+++ b/crates/dekaf/tests/e2e/fetch_offsets.rs
@@ -113,6 +113,27 @@ fn payload(i: usize) -> serde_json::Value {
     json!({"id": format!("doc-{i:02}"), "value": "x".repeat(64)})
 }
 
+/// Total `dekaf_readback_restarts` recorded for journals of this test's
+/// namespace. Namespaces are unique per test, so concurrent tests sharing the
+/// Dekaf instance cannot contaminate each other's counts.
+async fn readback_restarts_for(namespace: &str) -> anyhow::Result<u64> {
+    let metrics = super::fetch_dekaf_metrics().await?;
+
+    let mut total = 0;
+    for line in metrics.lines() {
+        if !line.starts_with("dekaf_readback_restarts{") || !line.contains(namespace) {
+            continue;
+        }
+        let value = line
+            .rsplit_once(' ')
+            .context("malformed metric line")?
+            .1
+            .parse::<f64>()?;
+        total += value as u64;
+    }
+    Ok(total)
+}
+
 /// A fetch at an offset which lands inside a document must serve that
 /// document, not skip forward to the next one.
 ///
@@ -155,6 +176,71 @@ async fn test_fetch_mid_document_returns_containing_document() -> anyhow::Result
     let records = fetch_records_at_nonempty(&mut client, target_offset).await?;
 
     assert_eq!(records.first().map(|r| r.offset), Some(target_offset));
+
+    // The mid-document fetch is served by probing at the fetch offset and
+    // restarting the read with readback.
+    assert!(
+        readback_restarts_for(&env.namespace).await? >= 1,
+        "expected the mid-document fetch to record a readback restart"
+    );
+
+    Ok(())
+}
+
+/// A fetch at a document-boundary offset must be served without restarting
+/// the read with readback.
+///
+/// Boundary offsets are the overwhelmingly common case: a sequential consumer
+/// always fetches at its last record's offset plus one, which is the next
+/// document's begin. Each readback restart re-reads up to OFFSET_READBACK
+/// (64MB) from the journal only to discard it, so paying it for boundary
+/// fetches regressed Dekaf's broker-side read volume by several orders of
+/// magnitude on read-heavy workloads.
+#[tokio::test]
+async fn test_fetch_at_document_boundary_avoids_readback() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let env = DekafTestEnv::setup("fetch_boundary", FIXTURE).await?;
+    env.inject_documents("data", (0..8).map(payload)).await?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let low = resolve_offset(&mut client, -2).await?;
+    let high = resolve_offset(&mut client, -1).await?;
+    let all = read_all_records(&mut client, low, high).await?;
+
+    // Target the boundary following a data record far enough from the write
+    // head that this cannot be mistaken for a data-preview fetch.
+    let target_index = {
+        let data_indices: Vec<usize> = (0..all.len()).filter(|&i| !all[i].control).collect();
+        data_indices[data_indices.len() / 2]
+    };
+    let boundary_offset = all[target_index].offset + 1;
+
+    assert!(
+        high - boundary_offset >= 13,
+        "fetch offset must be far enough from the write head to avoid data-preview detection"
+    );
+
+    // A record's offset is its document's final byte, so offset + 1 is the
+    // begin of the next document: the position a sequential consumer fetches.
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+    let records = fetch_records_at_nonempty(&mut client, boundary_offset).await?;
+
+    assert_eq!(
+        records.first().map(|r| r.offset),
+        Some(all[target_index + 1].offset)
+    );
+
+    // Every fetch in this test targeted a document boundary (ListOffsets
+    // results and record offsets plus one), so none may pay a readback.
+    assert_eq!(
+        readback_restarts_for(&env.namespace).await?,
+        0,
+        "boundary fetches must not record readback restarts"
+    );
 
     Ok(())
 }

--- a/crates/dekaf/tests/e2e/fetch_offsets.rs
+++ b/crates/dekaf/tests/e2e/fetch_offsets.rs
@@ -113,15 +113,15 @@ fn payload(i: usize) -> serde_json::Value {
     json!({"id": format!("doc-{i:02}"), "value": "x".repeat(64)})
 }
 
-/// Total `dekaf_readback_restarts` recorded for journals of this test's
+/// Total `dekaf_readback_reads` recorded for journals of this test's
 /// namespace. Namespaces are unique per test, so concurrent tests sharing the
 /// Dekaf instance cannot contaminate each other's counts.
-async fn readback_restarts_for(namespace: &str) -> anyhow::Result<u64> {
+async fn readback_reads_for(namespace: &str) -> anyhow::Result<u64> {
     let metrics = super::fetch_dekaf_metrics().await?;
 
     let mut total = 0;
     for line in metrics.lines() {
-        if !line.starts_with("dekaf_readback_restarts{") || !line.contains(namespace) {
+        if !line.starts_with("dekaf_readback_reads{") || !line.contains(namespace) {
             continue;
         }
         let value = line
@@ -177,22 +177,21 @@ async fn test_fetch_mid_document_returns_containing_document() -> anyhow::Result
 
     assert_eq!(records.first().map(|r| r.offset), Some(target_offset));
 
-    // The mid-document fetch is served by probing at the fetch offset and
-    // restarting the read with readback.
+    // The mid-document fetch is detected by inspecting the byte before the
+    // fetch offset, and served by a read which begins with readback.
     assert!(
-        readback_restarts_for(&env.namespace).await? >= 1,
-        "expected the mid-document fetch to record a readback restart"
+        readback_reads_for(&env.namespace).await? >= 1,
+        "expected the mid-document fetch to record a readback read"
     );
 
     Ok(())
 }
 
-/// A fetch at a document-boundary offset must be served without restarting
-/// the read with readback.
+/// A fetch at a document-boundary offset must be served without readback.
 ///
 /// Boundary offsets are the overwhelmingly common case: a sequential consumer
 /// always fetches at its last record's offset plus one, which is the next
-/// document's begin. Each readback restart re-reads up to OFFSET_READBACK
+/// document's begin. Each readback read re-reads up to OFFSET_READBACK
 /// (64MB) from the journal only to discard it, so paying it for boundary
 /// fetches regressed Dekaf's broker-side read volume by several orders of
 /// magnitude on read-heavy workloads.
@@ -237,9 +236,9 @@ async fn test_fetch_at_document_boundary_avoids_readback() -> anyhow::Result<()>
     // Every fetch in this test targeted a document boundary (ListOffsets
     // results and record offsets plus one), so none may pay a readback.
     assert_eq!(
-        readback_restarts_for(&env.namespace).await?,
+        readback_reads_for(&env.namespace).await?,
         0,
-        "boundary fetches must not record readback restarts"
+        "boundary fetches must not record readback reads"
     );
 
     Ok(())

--- a/crates/dekaf/tests/e2e/harness.rs
+++ b/crates/dekaf/tests/e2e/harness.rs
@@ -553,6 +553,26 @@ pub async fn db_pool() -> anyhow::Result<&'static sqlx::PgPool> {
     Ok(DB_POOL.get_or_init(|| pool))
 }
 
+/// Scrape the local Dekaf's Prometheus metrics in exposition text format.
+/// The metrics listener is allocated two ports above the Kafka listener
+/// (see mise/tasks/local/data-plane).
+pub async fn fetch_dekaf_metrics() -> anyhow::Result<String> {
+    let broker = std::env::var("DEKAF_BROKER").context("DEKAF_BROKER must be set")?;
+    let (host, port) = broker
+        .rsplit_once(':')
+        .with_context(|| format!("invalid DEKAF_BROKER address: {broker}"))?;
+    let port: u16 = port.parse().context("invalid DEKAF_BROKER port")?;
+
+    let url = format!("http://{host}:{}/metrics", port + 2);
+    let body = reqwest::get(&url)
+        .await
+        .and_then(|resp| resp.error_for_status())
+        .with_context(|| format!("fetching Dekaf metrics from {url}"))?
+        .text()
+        .await?;
+    Ok(body)
+}
+
 /// Get connection info for a specific dataplane by querying the database.
 ///
 /// Returns the Dekaf broker address and schema registry address for the given dataplane.

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -15,5 +15,6 @@ mod partition_eofs;
 
 pub use harness::{
     ConnectionInfo, DekafTestEnv, cluster_name, cluster_name_2, connection_info_for_dataplane,
-    db_pool, init_tracing, trigger_migration, wait_for_dekaf_redirect, wait_for_migration_complete,
+    db_pool, fetch_dekaf_metrics, init_tracing, trigger_migration, wait_for_dekaf_redirect,
+    wait_for_migration_complete,
 };


### PR DESCRIPTION
**Description:**

#3150 fixed lost documents on mid-document fetch offsets by starting every new journal read up to `OFFSET_READBACK` (64MB) before the requested offset, scanning and discarding documents until reaching it. That cost is paid per read start, and consumers which frequently start new reads (e.g. SingleStore pipelines, which reconnect per batch) pay it on nearly every fetch: Dekaf's broker-side read volume per fetch request jumped from tens of KB to many MB, and delivery stalled behind the suppression scans.

This change makes the readback conditional. Collection journals are newline-delimited JSON — documents are written compactly with exactly one terminating newline, and JSON forbids unescaped control characters — so a raw newline byte occurs in journal content only as a document terminator. An offset is therefore a document boundary exactly when the preceding byte is a newline. Before opening a read, a single-byte non-blocking point read inspects that byte:

* `\n` → boundary: the read begins exactly at the fetch offset. This is the overwhelmingly common case (sequential consumers always fetch at a served document's end).
* Anything else → mid-document landing (commonly a fetch at a document's final byte, which is precisely the Kafka offset assigned to the document as a record): the read begins up to `OFFSET_READBACK` earlier, with predecessors suppressed, as before.
* Byte unavailable (offset zero, at/beyond the write head, expired fragments, journal suspended or deleted) → no containing document can be served regardless; the read begins at the fetch offset.

Stream rebuilds on token refresh run the same check. Each readback increments a new `dekaf_readback_reads{task_name, journal_name}` metric, which is also the signal to watch after deploy.

**Workflow steps:**

No user-facing changes.

**Documentation links affected:**

None.

**Notes for reviewers:**

* An earlier revision probed by parsing (starting the stream one byte early and classifying the first parse outcome, with a UUID check to disambiguate suffixes that parse as valid JSON); review feedback simplified this to inspecting the byte directly, which costs one extra intra-data-plane roundtrip per read start but removes the probe state machine from `next_batch` entirely.
* Testing: `cargo test -p dekaf --lib` passes, and a full local `ci:dekaf-e2e` run is green — 25 passed / 0 failed. That includes #3150's tests (mid-document fetch serves the containing document; write-head fetch serves nothing), a new assertion that the mid-document fetch records a readback read, and a new `test_fetch_at_document_boundary_avoids_readback` asserting a boundary fetch serves the correct next record with zero readbacks.