### PR TITLE
Allow localhost:3000 origin for the local control-plane agent

### DIFF
--- a/local/systemd/flow-control-agent@.service
+++ b/local/systemd/flow-control-agent@.service
@@ -14,7 +14,7 @@ TimeoutStartSec=600
 EnvironmentFile=%h/flow-local/env/agent-%i.env
 
 ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p agent'
-ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/agent --allow-origin http://localhost:${FLOW_PORT_DASHBOARD}'
+ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/agent --allow-origin http://localhost:${FLOW_PORT_DASHBOARD} --allow-origin http://localhost:3000'
 
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
Restore `http://localhost:3000` as an allowed CORS origin for the local control-plane agent. The multi-stack refactor (d1ebe24) swapped it for the per-stack `${FLOW_PORT_DASHBOARD}`, which blocks GraphQL from a UI served on the conventional port 3000. Deployed still allows 3000; the dashboard-port origin is kept too.
