### PR TITLE
docs: document the ClickHouse partition_by materialization option

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/ClickHouse.md
+++ b/site/docs/reference/Connectors/materialization-connectors/ClickHouse.md
@@ -1,5 +1,5 @@
 ---
-description: Materialize data collections directly into ClickHouse using the native protocol. Handles hard and soft deletes, merge and delta updates, and sync schedules.
+description: Materialize data collections directly into ClickHouse using the native protocol. Handles hard and soft deletes, merge and delta updates, custom partitioning, and sync schedules.
 ---
 
 # ClickHouse
@@ -84,6 +84,7 @@ Use the below properties to configure a ClickHouse materialization, which will d
 |---|---|---|---|---|
 | **`/table`** | Table | Name of the database table to materialize to. The connector will create the table if it doesn't already exist. | string | Required |
 | `/delta_updates` | Delta Update | Should updates to this table be done via delta updates. | boolean | `false` |
+| `/partition_by` | Partition By | Optional expression to use as the table's `PARTITION BY` clause, for example `toYYYYMM(flow_published_at)`. Changing this value requires backfilling the binding. See [custom partitioning](#custom-partitioning). | string | |
 
 ### Sample
 
@@ -143,3 +144,28 @@ Removing tombstoned rows is a background task in the ClickHouse server, configur
 ## Delta updates
 
 This connector supports [delta updates](/concepts/materialization/#delta-updates) on a per-binding basis. When `delta_updates` is enabled for a binding, the table uses the `MergeTree` engine instead of `ReplacingMergeTree`. Every store operation is appended as-is with no deduplication — rows accumulate and are never removed.
+
+## Custom partitioning
+
+By default, tables created by the connector are not partitioned.
+To set a custom [partitioning key](https://clickhouse.com/docs/engines/table-engines/mergetree-family/custom-partitioning-key), specify the `partition_by` property on a binding.
+The value is a ClickHouse SQL expression over the table's columns, used verbatim as the table's `PARTITION BY` clause:
+
+```yaml
+bindings:
+  - resource:
+      table: my_table
+      partition_by: toYYYYMM(flow_published_at)
+    source: ${PREFIX}/${source_collection}
+```
+
+Partitioning applies to both standard and delta updates bindings.
+The expression is verified against your ClickHouse server when the materialization is published, so mistakes such as a typo or a reference to a field that isn't part of the materialization are caught before the table is created.
+
+Keep the expression low-cardinality: ClickHouse recommends keeping the total number of partitions well under 1,000, and by default rejects inserts that span more than 100 partitions in a single block.
+A hash-bucket expression such as `cityHash64(my_field) % 64` is a good fit for high-cardinality fields.
+
+ClickHouse only accepts a partitioning key when a table is created; it cannot be changed with `ALTER TABLE`. As a result:
+
+- Changing `partition_by` on an existing binding requires backfilling the binding, which drops and re-creates the table with the new partitioning key.
+- A column referenced by the partitioning key cannot change its type in place. If the collection's schema evolves such a column to a new type, backfill the binding to re-create the table.

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -66,6 +66,7 @@ Estuary collections to your tables.
 | **`/region`**                     | Region                | AWS Region.                                                                                                                                         | string | Required         |
 | **`/namespace`**                  | Namespace             | Namespace for bound collection tables (unless overridden within the binding resource configuration).                                                | string | Required         |
 | `/upload_interval`                | Upload Interval       | Frequency at which files will be uploaded. Must be a valid ISO8601 duration string no greater than 4 hours.                                         | string | PT5M             |
+| `/advanced/nanosecond_timestamps` | Nanosecond Timestamps | Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2).                                    | bool   | false            |
 | **`/catalog/catalog_type`**       | Catalog Type          | Either "Iceberg REST Server" or "AWS Glue".                                                                                                         | string | Required         |
 | `/catalog/glue_id`                | Glue Catalog ID       | Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials. This enables cross-account Glue catalog access. | string |                  |
 | **`/catalog/uri`**                | URI                   | URI identifying the REST catalog, in the format of 'https://yourserver.com/catalog'.                                                                | string | Required         |
@@ -129,6 +130,13 @@ Estuary collection fields with `{type: string, format: time}` and `{type: string
 materialized as **string** columns rather than **time** and **uuid** columns for compatibility with
 Apache Spark. **[Nested types](https://iceberg.apache.org/spec/#nested-types)** are not currently
 supported.
+
+With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
+instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
+using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
+Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
+existing materialization requires a backfill of its bindings, because Iceberg has no in-place
+promotion between the two timestamp encodings.
 
 ## Table Maintenance
 

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -136,9 +136,11 @@ instead materialized as **timestamptz_ns** columns with nanosecond precision, an
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
 Make sure your query engine supports format v3 tables before enabling this option.
 
-Toggling the option on an existing materialization applies to data going forward: Iceberg has no
-in-place conversion between the two timestamp encodings, so each timestamp column is re-created
-under the new type, and existing rows read as **null** for those columns. Prior values remain
+Toggling the option in either direction on an existing materialization applies to data going
+forward: Iceberg has no in-place conversion between the two timestamp encodings, so each timestamp
+column is re-created under the new type, and existing rows read as **null** for those columns.
+Enabling the option on an existing format v2 table also upgrades the table to format v3 in place.
+Prior values remain
 readable in the table's earlier snapshots via time travel. To repopulate history under the new
 type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 

--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -134,9 +134,13 @@ supported.
 With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
 instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
-Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
-existing materialization requires a backfill of its bindings, because Iceberg has no in-place
-promotion between the two timestamp encodings.
+Make sure your query engine supports format v3 tables before enabling this option.
+
+Toggling the option on an existing materialization applies to data going forward: Iceberg has no
+in-place conversion between the two timestamp encodings, so each timestamp column is re-created
+under the new type, and existing rows read as **null** for those columns. Prior values remain
+readable in the table's earlier snapshots via time travel. To repopulate history under the new
+type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 
 ## Table Maintenance
 


### PR DESCRIPTION
**Description:**

Documents the new `partition_by` binding option of materialize-clickhouse (estuary/connectors#4836): adds the property to the bindings table and a "Custom partitioning" section covering the expression format, publish-time verification, low-cardinality guidance, and the create-only nature of ClickHouse partition keys (changes require backfilling the binding; partition-key columns can't change type in place).

**Workflow steps:**

Docs only; the feature itself shipped in estuary/connectors#4836.

**Documentation links affected:**

- `reference/Connectors/materialization-connectors/ClickHouse` — new `/partition_by` row and `#custom-partitioning` section.

**Notes for reviewers:**

Guidance numbers (≲1,000 partitions total, 100-partition insert-block default) mirror ClickHouse's own documentation and the connector's field description.