### PR TITLE
mise: dev-VM zone configurability (create fallback, zone-agnostic SSH, vm:move-gcp)

### DIFF
--- a/mise/tasks/vm/create-gcp
+++ b/mise/tasks/vm/create-gcp
@@ -4,9 +4,11 @@ set -euo pipefail
 #MISE description="Create a development VM within GCP for a project"
 #USAGE arg "<project_name>" help="Short name of the development project (for example, 'one' or '$feature-name')"
 #USAGE flag "--project <project>" help="GCP project ID" default="estuary-theatre"
-#USAGE flag "--zone <zone>" help="Zone in which to create the VM" default="us-central1-a"
+#USAGE flag "--zone <zone>" help="Zone in which to create the VM, or an ordered comma-separated list tried in turn when zones are out of capacity" default="us-central1-b,us-central1-c,us-east5-a,us-east4-a"
 #USAGE flag "--machine-type <machine_type>" help="GCP machine type" default="c4-highcpu-8"
 #USAGE flag "--image-family <image_family>" help="GCP machine image" default="ubuntu-2404-lts-amd64"
+
+source "$(dirname "$0")/gcp-lib.sh"
 
 ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
 USERNAME="${ACCOUNT%%@*}"
@@ -31,69 +33,53 @@ echo "Using SSH keys from agent:"
 ssh-add -l | sed 's/^/  - /'
 echo ""
 
-gcloud compute instances create ${INSTANCE_NAME} \
-  --project ${usage_project:?} \
-  --zone ${usage_zone:?} \
-  --machine-type ${usage_machine_type:?} \
-  --enable-nested-virtualization \
-  --image-family ${usage_image_family:?} \
-  --image-project ubuntu-os-cloud \
-  --network-interface subnet=default \
-  --metadata ssh-keys="${SSH_KEYS}" \
-  --tags dev-vm \
-  --labels dev-vm=true,owner=${USERNAME},drataexclude=test-equipment \
-  --boot-disk-size 256GB \
-  --boot-disk-type hyperdisk-balanced \
+# Try each zone in order. GCP capacity varies by zone and hour, so a capacity
+# error just means "next zone"; any other error is real and fails immediately.
+# Capacity failures on `instances create` are atomic: nothing is left behind.
+IFS=',' read -ra ZONES <<< "${usage_zone:?}"
+CREATED_ZONE=""
+for ZONE in "${ZONES[@]}"; do
+  echo "Creating ${INSTANCE_NAME} in ${ZONE}..."
 
-# Add additional ssh configuration if not already present.
-if ! grep -q gcp-vms ~/.ssh/config; then
-    # Prepend to ssh config file, as it's sensitive to Host or Match directives.
-    # We use a temp file for portability across macOS and Linux.
-    TMP_SSH_CONFIG=$(mktemp)
-    cat > "${TMP_SSH_CONFIG}" <<EOF
-# Include GCP VM SSH configurations.
-Include ~/.ssh/gcp-vms/*.config
-
-EOF
-    cat ~/.ssh/config >> "${TMP_SSH_CONFIG}"
-    mv "${TMP_SSH_CONFIG}" ~/.ssh/config
-fi
-
-# Write an ssh config file to ~/.ssh/gcp-vms/${INSTANCE_NAME}.config
-mkdir -p ~/.ssh/gcp-vms/
-cat > ~/.ssh/gcp-vms/${INSTANCE_NAME}.config <<EOF
-Host ${INSTANCE_NAME}
-  ControlMaster auto
-  ControlPath ~/.ssh/mux-${INSTANCE_NAME}.sock
-  ControlPersist 20m
-  ForwardAgent true
-  HostName ${INSTANCE_NAME}
-  ServerAliveCountMax 3
-  ServerAliveInterval 30
-  User ${USERNAME}
-  UserKnownHostsFile ~/.ssh/gcp-vms/hosts
-  StrictHostKeyChecking accept-new
-  CheckHostIP no
-  ProxyCommand bash -c 'gcloud compute instances start ${INSTANCE_NAME} --project=${usage_project:?} --zone=${usage_zone:?} 2>/dev/null; gcloud compute start-iap-tunnel ${INSTANCE_NAME} %p --listen-on-stdin --project=${usage_project:?} --zone=${usage_zone:?}'
-EOF
-
-MAX_ATTEMPTS=36  # 36 * 5 seconds = 3 minutes
-ATTEMPT=0
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  ATTEMPT=$((ATTEMPT + 1))
-  echo "Connecting to ${INSTANCE_NAME} (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
-
-  if ssh -o BatchMode=yes ${INSTANCE_NAME} exit; then
+  # `if !` capture keeps set -e from exiting before we can classify the error.
+  if OUT=$(gcloud compute instances create ${INSTANCE_NAME} \
+    --project ${usage_project:?} \
+    --zone ${ZONE} \
+    --machine-type ${usage_machine_type:?} \
+    --enable-nested-virtualization \
+    --image-family ${usage_image_family:?} \
+    --image-project ubuntu-os-cloud \
+    --network-interface subnet=default \
+    --metadata ssh-keys="${SSH_KEYS}" \
+    --tags dev-vm \
+    --labels dev-vm=true,owner=${USERNAME},drataexclude=test-equipment \
+    --boot-disk-size 256GB \
+    --boot-disk-type hyperdisk-balanced 2>&1); then
+    echo "${OUT}"
+    CREATED_ZONE="${ZONE}"
     break
-  else
-    sleep 5
   fi
+
+  echo "${OUT}" >&2
+  if grep -qiE "${GCP_CAPACITY_ERROR_RE}" <<< "${OUT}"; then
+    echo "Zone ${ZONE} is out of capacity for ${usage_machine_type}; trying the next zone..."
+    continue
+  fi
+  exit 1
 done
 
-if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-  echo "ERROR: Failed to connect to ${INSTANCE_NAME} after $MAX_ATTEMPTS attempts" >&2
+if [ -z "${CREATED_ZONE}" ]; then
+  echo "ERROR: every zone in '${usage_zone}' is out of capacity for ${usage_machine_type}." >&2
+  echo "Try again later, or pass --zone with other zones that offer this machine type:" >&2
+  echo "  gcloud compute machine-types list --project ${usage_project} --filter=\"name=${usage_machine_type}\" --format=\"value(zone)\"" >&2
   exit 1
 fi
+
+# The generated config discovers the VM's zone at connect time, so it stays
+# valid if the VM is later moved with `mise run vm:move-gcp`.
+gcp_write_ssh_config "${usage_project}" "${INSTANCE_NAME}" "${USERNAME}"
+
+gcp_wait_for_ssh "${INSTANCE_NAME}"
 
 # Copy GCP-only idle shutdown files before the shared bootstrap runs create-post.
 ssh ${INSTANCE_NAME} mkdir -p /tmp/idle-shutdown
@@ -107,7 +93,7 @@ ssh ${INSTANCE_NAME} bash -s \
 ssh -O exit ${INSTANCE_NAME} 2>/dev/null || true
 
 cat <<EOF
-Your VM ${INSTANCE_NAME} is ready.
+Your VM ${INSTANCE_NAME} is ready in ${CREATED_ZONE}.
 
 Connect:
     ssh ${INSTANCE_NAME}

--- a/mise/tasks/vm/create-gcp
+++ b/mise/tasks/vm/create-gcp
@@ -39,6 +39,9 @@ echo ""
 IFS=',' read -ra ZONES <<< "${usage_zone:?}"
 CREATED_ZONE=""
 for ZONE in "${ZONES[@]}"; do
+  # Tolerate "a, b" style lists: zone names never contain spaces.
+  ZONE="${ZONE// /}"
+  [ -n "${ZONE}" ] || continue
   echo "Creating ${INSTANCE_NAME} in ${ZONE}..."
 
   # `if !` capture keeps set -e from exiting before we can classify the error.

--- a/mise/tasks/vm/create-gcp
+++ b/mise/tasks/vm/create-gcp
@@ -79,6 +79,10 @@ fi
 # valid if the VM is later moved with `mise run vm:move-gcp`.
 gcp_write_ssh_config "${usage_project}" "${INSTANCE_NAME}" "${USERNAME}"
 
+# A prior VM may have used this name; its recorded host key would fail
+# strict checking against the new VM's key.
+gcp_forget_host_key "${INSTANCE_NAME}"
+
 gcp_wait_for_ssh "${INSTANCE_NAME}"
 
 # Copy GCP-only idle shutdown files before the shared bootstrap runs create-post.

--- a/mise/tasks/vm/gcp-lib.sh
+++ b/mise/tasks/vm/gcp-lib.sh
@@ -77,6 +77,18 @@ Host ${instance}
 EOF
 }
 
+# gcp_forget_host_key <instance>
+# Drops the instance's entry from the known-hosts file used by the generated
+# SSH configs. Cloud-init regenerates host keys whenever the instance-id
+# changes (zone moves, or recreating a VM under a reused name), and the
+# configs use strict checking, so the stale key must go before the first
+# connection. `accept-new` then records the fresh key.
+gcp_forget_host_key() {
+    if [ -f ~/.ssh/gcp-vms/hosts ]; then
+        ssh-keygen -R "$1" -f ~/.ssh/gcp-vms/hosts >/dev/null 2>&1 || true
+    fi
+}
+
 # gcp_wait_for_ssh <instance> [max_attempts]
 # Polls until an SSH connection to the instance succeeds. Attempts are 5s
 # apart; the default 36 gives the VM 3 minutes to boot.

--- a/mise/tasks/vm/gcp-lib.sh
+++ b/mise/tasks/vm/gcp-lib.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#MISE hide=true
+#MISE description="(library) shared GCP dev-VM helpers, not runnable"
+#
+# Sourced by mise/tasks/vm/create-gcp and mise/tasks/vm/move-gcp via
+# `source "$(dirname "$0")/gcp-lib.sh"`. Not executable, so mise does not
+# offer it as a task.
+
+# Matches GCP capacity-exhaustion errors and ONLY those. gcloud prints the
+# human-readable message rather than the ZONE_RESOURCE_POOL_EXHAUSTED code,
+# so we match the documented message variants too:
+#   "The zone '...' does not have enough resources available to fulfill
+#    the request. Try a different zone, or try again later."
+#   "A <type> VM instance ... is currently unavailable in the <zone> zone."
+# Callers grep case-insensitively against combined stdout+stderr, and fall
+# through to another zone only on a match. Quota errors and not-found errors
+# deliberately do NOT match: quota is project-wide (zone-hopping won't help)
+# and not-found is a typo (every retry would fail identically).
+# shellcheck disable=SC2034 # consumed by sourcing scripts
+GCP_CAPACITY_ERROR_RE='ZONE_RESOURCE_POOL_EXHAUSTED|does not have enough resources available to fulfill the request|is currently unavailable in the [a-z0-9-]+ zone'
+
+# gcp_instance_zone <project> <instance>
+# Prints the zone basename of every instance with this name, one per line.
+# More than one line means the name exists in multiple zones.
+gcp_instance_zone() {
+    gcloud compute instances list \
+        --project="$1" \
+        --filter="name=($2)" \
+        --format="value(zone.basename())"
+}
+
+# gcp_write_ssh_config <project> <instance> <username>
+# Writes ~/.ssh/gcp-vms/<instance>.config and ensures ~/.ssh/config includes
+# the gcp-vms directory. Idempotent, so move-gcp calls it to heal older,
+# zone-pinned configs.
+#
+# The ProxyCommand discovers the instance's zone at connect time instead of
+# baking it in, so the config survives zone moves. %h/%p are ssh tokens
+# substituted at connect time; the \$-escapes below keep zone discovery out
+# of this (unquoted) heredoc's write-time expansion.
+gcp_write_ssh_config() {
+    local project="$1"
+    local instance="$2"
+    local username="$3"
+
+    # Ensure the Include exists, prepending because ssh_config is sensitive
+    # to Host/Match directive ordering. -s: a missing ~/.ssh/config is simply
+    # "no match". We use a temp file for portability across macOS and Linux.
+    if ! grep -qs gcp-vms ~/.ssh/config; then
+        local tmp_config
+        tmp_config=$(mktemp)
+        cat > "${tmp_config}" <<EOF
+# Include GCP VM SSH configurations.
+Include ~/.ssh/gcp-vms/*.config
+
+EOF
+        cat ~/.ssh/config >> "${tmp_config}" 2>/dev/null || true
+        mkdir -p ~/.ssh
+        mv "${tmp_config}" ~/.ssh/config
+    fi
+
+    mkdir -p ~/.ssh/gcp-vms/
+    cat > ~/.ssh/gcp-vms/"${instance}".config <<EOF
+Host ${instance}
+  ControlMaster auto
+  ControlPath ~/.ssh/mux-${instance}.sock
+  ControlPersist 20m
+  ForwardAgent true
+  HostName ${instance}
+  ServerAliveCountMax 3
+  ServerAliveInterval 30
+  User ${username}
+  UserKnownHostsFile ~/.ssh/gcp-vms/hosts
+  StrictHostKeyChecking accept-new
+  CheckHostIP no
+  ProxyCommand bash -c 'zone=\$(gcloud compute instances list --project=${project} --filter="name=(%h)" --format="value(zone.basename())"); [ -n "\$zone" ] || { echo "instance %h not found in project ${project}" >&2; exit 1; }; gcloud compute instances start %h --project=${project} --zone="\$zone" 2>/dev/null; exec gcloud compute start-iap-tunnel %h %p --listen-on-stdin --project=${project} --zone="\$zone"'
+EOF
+}
+
+# gcp_wait_for_ssh <instance> [max_attempts]
+# Polls until an SSH connection to the instance succeeds. Attempts are 5s
+# apart; the default 36 gives the VM 3 minutes to boot.
+gcp_wait_for_ssh() {
+    local instance="$1"
+    local max_attempts="${2:-36}"
+    local attempt=0
+
+    while [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt + 1))
+        echo "Connecting to ${instance} (attempt ${attempt}/${max_attempts})..."
+
+        if ssh -o BatchMode=yes "${instance}" exit; then
+            return 0
+        fi
+        sleep 5
+    done
+
+    echo "ERROR: Failed to connect to ${instance} after ${max_attempts} attempts" >&2
+    return 1
+}

--- a/mise/tasks/vm/move-gcp
+++ b/mise/tasks/vm/move-gcp
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#MISE description="Move a GCP development VM to a different zone, preserving its disk contents"
+#USAGE arg "<project_name>" help="Short name of the development project (matches vm:create-gcp)"
+#USAGE flag "--project <project>" help="GCP project ID" default="estuary-theatre"
+#USAGE flag "--zone <zone>" help="Target zone, or an ordered comma-separated list tried in turn when zones are out of capacity" default="us-central1-b,us-central1-c,us-east5-a,us-east4-a"
+#USAGE flag "--keep-snapshot" help="Keep the migration snapshot instead of deleting it on success"
+
+# Machine images would be simpler, but they don't support Hyperdisk volumes
+# and C4 machines attach nothing else. So this follows GCP's documented
+# zone-move procedure: snapshot the boot disk (snapshots are global), restore
+# it as a disk in the target zone, and recreate the instance around it.
+#
+# The original instance is RENAMED to <name>-old rather than deleted, and is
+# only destroyed after the replacement passes an SSH check. If every target
+# zone is also out of capacity, the rollback renames it back and nothing is
+# lost. Renaming (vs. keeping the name) matters because instance names may be
+# project-unique, and a duplicate name would break the zone discovery in the
+# generated SSH config.
+
+source "$(dirname "$0")/gcp-lib.sh"
+
+PROJECT="${usage_project:?}"
+
+ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+USERNAME="${ACCOUNT%%@*}"
+
+# Same derivation as vm:create-gcp: dev-<user>-<project-name>
+NAME="dev-${USERNAME}-${usage_project_name:?}"
+OLD="${NAME}-old"
+
+# GCE resource names are capped at 63 characters (RFC1035); "-old" must fit.
+if [ "${#NAME}" -gt 59 ]; then
+    echo "ERROR: instance name '${NAME}' is too long to rename during a move." >&2
+    exit 1
+fi
+
+### Phase 0: resolve and validate. No mutations happen in this phase.
+
+if [ -n "$(gcp_instance_zone "${PROJECT}" "${OLD}")" ]; then
+    echo "ERROR: an instance named '${OLD}' already exists." >&2
+    echo "A previous move likely failed partway. Inspect it (and any '${NAME}'" >&2
+    echo "instance, disks named '${NAME}', and 'move-*-${NAME}' snapshots)," >&2
+    echo "then delete or rename it before moving again." >&2
+    exit 1
+fi
+
+SRC_ZONE="$(gcp_instance_zone "${PROJECT}" "${NAME}")"
+if [ -z "${SRC_ZONE}" ]; then
+    echo "ERROR: no instance named '${NAME}' in project ${PROJECT}." >&2
+    exit 1
+fi
+if [[ "${SRC_ZONE}" == *$'\n'* ]]; then
+    echo "ERROR: multiple instances named '${NAME}' exist (zones: ${SRC_ZONE//$'\n'/, })." >&2
+    echo "Delete the stale one(s) first; zone discovery cannot disambiguate them." >&2
+    exit 1
+fi
+
+DESC=$(gcloud compute instances describe "${NAME}" --project="${PROJECT}" --zone="${SRC_ZONE}" --format=json)
+STATUS=$(jq -r '.status' <<< "${DESC}")
+MACHINE_TYPE=$(jq -r '.machineType | split("/") | last' <<< "${DESC}")
+BOOT_DISK=$(jq -r '[.disks[] | select(.boot)][0].source | split("/") | last' <<< "${DESC}")
+NESTED=$(jq -r '.advancedMachineFeatures.enableNestedVirtualization // false' <<< "${DESC}")
+TAGS=$(jq -r '.tags.items // [] | join(",")' <<< "${DESC}")
+LABELS=$(jq -r '.labels // {} | to_entries | map("\(.key)=\(.value)") | join(",")' <<< "${DESC}")
+SSH_KEYS=$(jq -r '[.metadata.items // [] | .[] | select(.key == "ssh-keys")][0].value // ""' <<< "${DESC}")
+
+# Filter the target list: drop the source zone, then drop zones that don't
+# offer the machine type. This distinguishes typos and rollout gaps (fail or
+# warn now) from capacity exhaustion (discovered per-zone in the move loop).
+IFS=',' read -ra RAW_ZONES <<< "${usage_zone:?}"
+CANDIDATES=()
+for Z in "${RAW_ZONES[@]}"; do
+    if [ "${Z}" != "${SRC_ZONE}" ]; then
+        CANDIDATES+=("${Z}")
+    fi
+done
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+    echo "${NAME} is already in ${SRC_ZONE}; nothing to do." >&2
+    exit 1
+fi
+
+OFFERED="$(gcloud compute machine-types list --project="${PROJECT}" \
+    --filter="name=${MACHINE_TYPE} AND zone:( ${CANDIDATES[*]} )" \
+    --format="value(zone)")"
+ZONES=()
+for Z in "${CANDIDATES[@]}"; do
+    if grep -qx "${Z}" <<< "${OFFERED}"; then
+        ZONES+=("${Z}")
+    else
+        echo "WARNING: ${MACHINE_TYPE} is not offered in ${Z}; skipping it." >&2
+    fi
+done
+if [ "${#ZONES[@]}" -eq 0 ]; then
+    echo "ERROR: none of the requested zones offer ${MACHINE_TYPE}. Find zones with:" >&2
+    echo "  gcloud compute machine-types list --project ${PROJECT} --filter=\"name=${MACHINE_TYPE}\" --format=\"value(zone)\"" >&2
+    exit 1
+fi
+
+echo "Moving ${NAME} (${MACHINE_TYPE}, boot disk ${BOOT_DISK}) from ${SRC_ZONE} to: ${ZONES[*]}"
+
+### Rollback: keyed on how far we got. Nothing is destroyed until the
+### replacement instance has passed an SSH check, so every failure path
+### either restores the original state or leaves both copies in place.
+
+SNAP="move-$(date +%Y%m%d%H%M%S)-${NAME:0:40}"
+PHASE="init"
+
+rollback() {
+    local code=$?
+    [ "${code}" -eq 0 ] && return 0
+
+    case "${PHASE}" in
+    init)
+        # Nothing mutated yet.
+        ;;
+    quiesced | backed-up)
+        echo "Rolling back: restoring ${NAME} in ${SRC_ZONE}..." >&2
+        gcloud compute instances set-disk-auto-delete "${NAME}" --project="${PROJECT}" \
+            --zone="${SRC_ZONE}" --disk="${BOOT_DISK}" --auto-delete || true
+        if [ "${PHASE}" = "backed-up" ]; then
+            gcloud compute snapshots delete "${SNAP}" --project="${PROJECT}" --quiet || true
+        fi
+        echo "Your VM is unchanged in ${SRC_ZONE} (stopped)." >&2
+        ;;
+    renamed)
+        echo "Rolling back: renaming ${OLD} back to ${NAME} in ${SRC_ZONE}..." >&2
+        if gcloud compute instances set-name "${OLD}" --project="${PROJECT}" \
+            --zone="${SRC_ZONE}" --new-name="${NAME}"; then
+            gcloud compute instances set-disk-auto-delete "${NAME}" --project="${PROJECT}" \
+                --zone="${SRC_ZONE}" --disk="${BOOT_DISK}" --auto-delete || true
+            echo "Your VM is unchanged in ${SRC_ZONE} (stopped)." >&2
+        else
+            echo "ERROR: rename-back failed. Your VM is intact but named '${OLD}'; rename it with:" >&2
+            echo "  gcloud compute instances set-name ${OLD} --project ${PROJECT} --zone ${SRC_ZONE} --new-name ${NAME}" >&2
+        fi
+        gcloud compute snapshots delete "${SNAP}" --project="${PROJECT}" --quiet || true
+        ;;
+    verify | cleanup)
+        # The replacement exists; destroying either copy automatically here
+        # could throw away the good one. Leave everything and explain.
+        echo "" >&2
+        echo "Move interrupted after the new instance was created. Current state:" >&2
+        echo "  - New instance '${NAME}' in ${NEW_ZONE:-unknown} (verify with: ssh ${NAME})" >&2
+        echo "  - Old instance '${OLD}' in ${SRC_ZONE}, stopped, with boot disk '${BOOT_DISK}'" >&2
+        echo "  - Snapshot '${SNAP}'" >&2
+        echo "If the new instance works, finish the move with:" >&2
+        echo "  gcloud compute instances delete ${OLD} --project ${PROJECT} --zone ${SRC_ZONE}" >&2
+        echo "  gcloud compute disks delete ${BOOT_DISK} --project ${PROJECT} --zone ${SRC_ZONE}" >&2
+        echo "  gcloud compute snapshots delete ${SNAP} --project ${PROJECT}" >&2
+        echo "(the old boot disk has auto-delete disabled: deleting ${OLD} does NOT delete it)" >&2
+        ;;
+    esac
+}
+trap rollback EXIT
+
+### Phase 1: quiesce and back up. Fully reversible.
+
+if [ "${STATUS}" != "TERMINATED" ]; then
+    echo "Stopping ${NAME}..."
+    ssh -O exit "${NAME}" 2>/dev/null || true
+    gcloud compute instances stop "${NAME}" --project="${PROJECT}" --zone="${SRC_ZONE}"
+fi
+
+# Keep the boot disk alive independently of the instance, so a later
+# `instances delete ${OLD}` cannot take the last copy of the data with it.
+gcloud compute instances set-disk-auto-delete "${NAME}" --project="${PROJECT}" \
+    --zone="${SRC_ZONE}" --disk="${BOOT_DISK}" --no-auto-delete
+PHASE="quiesced"
+
+echo "Snapshotting ${BOOT_DISK} as ${SNAP}..."
+gcloud compute disks snapshot "${BOOT_DISK}" --project="${PROJECT}" \
+    --zone="${SRC_ZONE}" --snapshot-names="${SNAP}"
+PHASE="backed-up"
+
+### Phase 2: free the name. Reversible by renaming back.
+
+# Everything from here on is discoverable by name; if this terminal dies
+# mid-move, this line is the recovery manifest.
+echo "Renaming ${NAME} to ${OLD} (artifacts: instance ${OLD} in ${SRC_ZONE}, snapshot ${SNAP}, new disks/instances named ${NAME})"
+gcloud compute instances set-name "${NAME}" --project="${PROJECT}" \
+    --zone="${SRC_ZONE}" --new-name="${OLD}"
+PHASE="renamed"
+
+### Phase 3: create the replacement, falling through zones on capacity errors.
+
+NEW_ZONE=""
+for Z in "${ZONES[@]}"; do
+    echo "Creating disk ${NAME} in ${Z} from ${SNAP}..."
+    # The type must be explicit: `disks create` defaults to a Persistent Disk
+    # type, which C4 machines cannot attach.
+    if ! OUT=$(gcloud compute disks create "${NAME}" --project="${PROJECT}" --zone="${Z}" \
+        --type=hyperdisk-balanced --source-snapshot="${SNAP}" 2>&1); then
+        echo "${OUT}" >&2
+        if grep -qiE "${GCP_CAPACITY_ERROR_RE}" <<< "${OUT}"; then
+            echo "Zone ${Z} is out of disk capacity; trying the next zone..."
+            continue
+        fi
+        exit 1
+    fi
+
+    # Mirror vm:create-gcp's instance shape. A snapshot carries only disk
+    # contents, so every instance property is re-applied from the describe.
+    CREATE_ARGS=(
+        --project="${PROJECT}"
+        --zone="${Z}"
+        --machine-type="${MACHINE_TYPE}"
+        --disk="name=${NAME},boot=yes,auto-delete=yes"
+        --network-interface subnet=default
+    )
+    if [ "${NESTED}" = "true" ]; then
+        CREATE_ARGS+=(--enable-nested-virtualization)
+    fi
+    if [ -n "${SSH_KEYS}" ]; then
+        CREATE_ARGS+=(--metadata "ssh-keys=${SSH_KEYS}")
+    fi
+    if [ -n "${TAGS}" ]; then
+        CREATE_ARGS+=(--tags="${TAGS}")
+    fi
+    if [ -n "${LABELS}" ]; then
+        CREATE_ARGS+=(--labels="${LABELS}")
+    fi
+
+    echo "Creating instance ${NAME} in ${Z}..."
+    if OUT=$(gcloud compute instances create "${NAME}" "${CREATE_ARGS[@]}" 2>&1); then
+        echo "${OUT}"
+        NEW_ZONE="${Z}"
+        break
+    fi
+
+    echo "${OUT}" >&2
+    gcloud compute disks delete "${NAME}" --project="${PROJECT}" --zone="${Z}" --quiet
+    if grep -qiE "${GCP_CAPACITY_ERROR_RE}" <<< "${OUT}"; then
+        echo "Zone ${Z} is out of capacity for ${MACHINE_TYPE}; trying the next zone..."
+        continue
+    fi
+    exit 1
+done
+
+if [ -z "${NEW_ZONE}" ]; then
+    echo "ERROR: no target zone had capacity for ${MACHINE_TYPE}. Rolling back." >&2
+    exit 1
+fi
+
+### Phase 4: verify over SSH, and only then destroy the old copy.
+
+PHASE="verify"
+
+# Regenerate the SSH config (healing older, zone-pinned configs) and drop any
+# stale control socket from the pre-move instance.
+gcp_write_ssh_config "${PROJECT}" "${NAME}" "${USERNAME}"
+rm -f ~/.ssh/mux-"${NAME}".sock
+
+gcp_wait_for_ssh "${NAME}"
+
+PHASE="cleanup"
+echo "Verified. Deleting the old instance, its boot disk, and the snapshot..."
+gcloud compute instances delete "${OLD}" --project="${PROJECT}" --zone="${SRC_ZONE}" --quiet
+gcloud compute disks delete "${BOOT_DISK}" --project="${PROJECT}" --zone="${SRC_ZONE}" --quiet
+if [ "${usage_keep_snapshot:-false}" = "true" ]; then
+    echo "Keeping snapshot ${SNAP} (--keep-snapshot)."
+else
+    gcloud compute snapshots delete "${SNAP}" --project="${PROJECT}" --quiet
+fi
+PHASE="done"
+
+cat <<EOF
+
+${NAME} now lives in ${NEW_ZONE}. Its disk contents (repo checkout,
+idle-shutdown units, host keys) moved with it; no re-bootstrap is needed.
+
+Connect:
+    ssh ${NAME}
+
+EOF

--- a/mise/tasks/vm/move-gcp
+++ b/mise/tasks/vm/move-gcp
@@ -61,6 +61,8 @@ DESC=$(gcloud compute instances describe "${NAME}" --project="${PROJECT}" --zone
 STATUS=$(jq -r '.status' <<< "${DESC}")
 MACHINE_TYPE=$(jq -r '.machineType | split("/") | last' <<< "${DESC}")
 BOOT_DISK=$(jq -r '[.disks[] | select(.boot)][0].source | split("/") | last' <<< "${DESC}")
+BOOT_DISK_TYPE=$(gcloud compute disks describe "${BOOT_DISK}" --project="${PROJECT}" \
+    --zone="${SRC_ZONE}" --format="value(type.basename())")
 NESTED=$(jq -r '.advancedMachineFeatures.enableNestedVirtualization // false' <<< "${DESC}")
 TAGS=$(jq -r '.tags.items // [] | join(",")' <<< "${DESC}")
 LABELS=$(jq -r '.labels // {} | to_entries | map("\(.key)=\(.value)") | join(",")' <<< "${DESC}")
@@ -72,7 +74,9 @@ SSH_KEYS=$(jq -r '[.metadata.items // [] | .[] | select(.key == "ssh-keys")][0].
 IFS=',' read -ra RAW_ZONES <<< "${usage_zone:?}"
 CANDIDATES=()
 for Z in "${RAW_ZONES[@]}"; do
-    if [ "${Z}" != "${SRC_ZONE}" ]; then
+    # Tolerate "a, b" style lists: zone names never contain spaces.
+    Z="${Z// /}"
+    if [ -n "${Z}" ] && [ "${Z}" != "${SRC_ZONE}" ]; then
         CANDIDATES+=("${Z}")
     fi
 done
@@ -188,10 +192,10 @@ PHASE="renamed"
 NEW_ZONE=""
 for Z in "${ZONES[@]}"; do
     echo "Creating disk ${NAME} in ${Z} from ${SNAP}..."
-    # The type must be explicit: `disks create` defaults to a Persistent Disk
-    # type, which C4 machines cannot attach.
+    # The type must be explicit and mirror the source disk: `disks create`
+    # defaults to a Persistent Disk type, which C4 machines cannot attach.
     if ! OUT=$(gcloud compute disks create "${NAME}" --project="${PROJECT}" --zone="${Z}" \
-        --type=hyperdisk-balanced --source-snapshot="${SNAP}" 2>&1); then
+        --type="${BOOT_DISK_TYPE}" --source-snapshot="${SNAP}" 2>&1); then
         echo "${OUT}" >&2
         if grep -qiE "${GCP_CAPACITY_ERROR_RE}" <<< "${OUT}"; then
             echo "Zone ${Z} is out of disk capacity; trying the next zone..."

--- a/mise/tasks/vm/move-gcp
+++ b/mise/tasks/vm/move-gcp
@@ -247,10 +247,12 @@ fi
 
 PHASE="verify"
 
-# Regenerate the SSH config (healing older, zone-pinned configs) and drop any
-# stale control socket from the pre-move instance.
+# Regenerate the SSH config (healing older, zone-pinned configs) and drop
+# leftovers from the pre-move instance: its control socket, and its recorded
+# host key, which cloud-init regenerates on first boot of the new instance.
 gcp_write_ssh_config "${PROJECT}" "${NAME}" "${USERNAME}"
 rm -f ~/.ssh/mux-"${NAME}".sock
+gcp_forget_host_key "${NAME}"
 
 gcp_wait_for_ssh "${NAME}"
 
@@ -268,7 +270,7 @@ PHASE="done"
 cat <<EOF
 
 ${NAME} now lives in ${NEW_ZONE}. Its disk contents (repo checkout,
-idle-shutdown units, host keys) moved with it; no re-bootstrap is needed.
+idle-shutdown units) moved with it; no re-bootstrap is needed.
 
 Connect:
     ssh ${NAME}


### PR DESCRIPTION
## Description

Dev VMs are pinned to a single GCP zone twice over: `vm:create-gcp` defaults to `us-central1-a`, and each VM's generated SSH `ProxyCommand` hardcodes that zone for the restart-on-connect path. When that zone runs out of `c4-highcpu-8` capacity (`ZONE_RESOURCE_POOL_EXHAUSTED`), idle-stopped VMs can't start again and their owners are stranded, as several folks hit this week.

Three changes:

1. **`vm:create-gcp --zone` takes an ordered comma-separated list** (default `us-central1-b,us-central1-c,us-east5-a,us-east4-a`, all verified to offer c4) and falls through to the next zone on capacity errors only. Typos, quota errors, and everything else still fail fast.
2. **The generated SSH `ProxyCommand` discovers the VM's zone at connect time** instead of baking it in, so configs never go stale when a VM moves. Costs one ~1s `gcloud instances list` per connection, amortized by the existing 20m ControlPersist.
3. **New `vm:move-gcp <name> --zone <target>`** relocates an existing VM, preserving its disk (repo checkout, bootstrap state). Machine images don't support Hyperdisk (all C4 can attach), so it follows GCP's documented snapshot -> disk -> recreate procedure. The original instance is *renamed*, not deleted, until the replacement passes an SSH check; every failure path either restores the original state or leaves both copies with printed recovery steps. Someone stuck on an exhausted zone today runs `mise run vm:move-gcp <name> --zone us-east4-a` and their existing VM (regenerated config included) follows them out.

Shared helpers live in `mise/tasks/vm/gcp-lib.sh`, sourced by both tasks (same pattern as `mise/tasks/local/reap-lib.sh`).

## Testing

Live end-to-end in `estuary-theatre` with a scratch VM (all resources deleted afterwards):

- `vm:create-gcp scratch` landed in `us-central1-b` (first zone in the new default), SSH'd via the zone-discovering ProxyCommand, full bootstrap completed.
- Rollback: planted a colliding disk in the target zone to force a mid-move failure *after* the rename; the trap renamed the instance back, restored the boot disk's auto-delete flag, deleted the snapshot, and exited non-zero with the VM intact.
- Full move `us-central1-b -> us-east4-a -> us-central1-b`; second leg completed hands-off in ~5 minutes with contents verified after each leg.
- The first move leg caught a real bug, fixed in the second commit: cloud-init regenerates SSH host keys on instance-id change, so the strict known-hosts check rejected the moved VM. Both tasks now drop the stale known-hosts entry before first connect (`accept-new` re-records over the IAP tunnel). The failure also proved the phase-4 safety: nothing was deleted, and the printed recovery manifest was followed verbatim to finish that move by hand.
- Unit-level: capacity-error regex checked against the documented GCP message variants plus quota/not-found/auth negatives; jq property extraction checked against full and sparse `instances describe` payloads; config writer checked for idempotency and write-time escaping.

Existing VMs keep working untouched; their configs heal to the zone-agnostic form on first `vm:move-gcp`.