### PR TITLE
docs: document _meta field selection and depth behavior

### DIFF
--- a/site/docs/guides/customize-dataflows/customize-materialization-fields.md
+++ b/site/docs/guides/customize-dataflows/customize-materialization-fields.md
@@ -194,7 +194,7 @@ Two metadata fields are the exception, and are selected automatically whenever a
 * `_meta/op`: the change operation type (create, update, or delete).
 * `flow_published_at`: the time at which Estuary published the document.
 
-To materialize any other `_meta` field, add it explicitly to the binding's `require` list (or click **Require** for that field in the Field Selection table). There is no wildcard or global setting that includes all `_meta` fields at once; each field must be named individually, per binding:
+To materialize any other [`_meta` field](/guides/advanced-usage/metadata-fields), add it explicitly to the binding's `require` list (or click **Require** for that field in the Field Selection table). There is no wildcard or global setting that includes all `_meta` fields at once; each field must be named individually, per binding:
 
 ```yaml
 bindings:

--- a/site/docs/guides/customize-dataflows/customize-materialization-fields.md
+++ b/site/docs/guides/customize-dataflows/customize-materialization-fields.md
@@ -185,6 +185,28 @@ Regardless of user selections, the connector will always require certain basic f
 
 The dashboard will provide a full list of fields that will be materialized, including required fields, along with their selection reasons.
 
+### Metadata (`_meta`) fields and depth selection
+
+Document metadata fields under `_meta` (such as `_meta/source/ts_ms`, `_meta/source/txid`, and `_meta/before/*`) are treated as a special case: they are **not** selected by the depth-based **modes** (Depth One, Depth Two, or Unlimited Depth). Even Unlimited Depth does not pull in `_meta` subfields automatically.
+
+Two metadata fields are the exception, and are selected automatically whenever any depth mode is active:
+
+* `_meta/op`: the change operation type (create, update, or delete).
+* `flow_published_at`: the time at which Estuary published the document.
+
+To materialize any other `_meta` field, add it explicitly to the binding's `require` list (or click **Require** for that field in the Field Selection table). There is no wildcard or global setting that includes all `_meta` fields at once; each field must be named individually, per binding:
+
+```yaml
+bindings:
+  - source: acmeCo/example/collection
+    resource: { table: example_table }
+    fields:
+      recommended: true
+      require:
+        _meta/source/ts_ms: {}
+        _meta/source/txid: {}
+```
+
 ### Group-By Keys
 
 In addition to selecting fields to materialize, you can also specify which of those fields should be used as group-by keys.


### PR DESCRIPTION
## What

Adds a "Metadata (`_meta`) fields and depth selection" subsection to the Customize Materialized Fields guide, documenting that:

- `_meta` fields are excluded from depth-based field selection modes (Depth One / Two / Unlimited).
- `_meta/op` and `flow_published_at` are the only metadata fields auto-selected (whenever any depth mode is active).
- Any other `_meta` field must be added explicitly via `fields.require`, per binding. There is no wildcard or global mechanism.

## Why

This behavior is intentional and enforced in the field-selection logic, but it is not documented anywhere. The docs only mention `_meta/op` in passing under "Required Fields." It is a recurring source of support questions (users toggle a new table and expect the `_meta` columns to come along with the depth setting).

## Code references (behavior is intentional, not incidental)

All in `crates/validation/src/field_selection.rs` on `master`:

- `_meta` excluded from depth selection, with intent comment:
  ```rust
  let desired = if desired_depth == 0 {
      false
  } else if p.ptr.starts_with("/_meta") {
      false // _meta is ignored by DesiredDepth.
  } else if depth == desired_depth {
  ```
  (field_selection.rs:243-247) — any projection whose pointer starts with `/_meta` is short-circuited before any depth comparison, for all depth values including `recommended: true` (unlimited).

- `_meta/op` and `flow_published_at` force-selected as `CoreMetadata`:
  ```rust
  // Certain metadata fields have special treatment if there's _any_ desired selection:
  // - flow_published_at is /_meta/uuid but mapped to extract a date-time
  // - _meta/op is core.
  if desired_depth > 0 && ["flow_published_at", "_meta/op"].contains(&p.field.as_str()) {
      selects.push((p.field.as_str(), Select::CoreMetadata));
  }
  ```
  (field_selection.rs:233-238)

- No wildcard mechanism: `require` is a `BTreeMap<Field, RawValue>` of exact field names (`crates/models/src/materializations.rs:217`); no glob support. `recommended` (depth) is the only automatic control and it skips `/_meta` by the above.

## Reviewer

Suggest Emily (docs). No behavior change; docs only.
