### PR TITLE
runtime v2 flag for new captures and derivations

### DIFF
--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -185,6 +185,7 @@ pub struct TestHarness {
     pub alert_sender: self::alerts::TestSender,
     pub runtime_v2_new_captures: bool,
     pub runtime_v2_new_materializations: bool,
+    pub runtime_v2_new_derivations: bool,
     // Control plane API app instance for GraphQL queries
     control_plane_app: Option<Arc<control_plane_api::App>>,
 }
@@ -288,6 +289,7 @@ impl HarnessBuilder {
             alert_sender: alerts::TestSender::new(),
             runtime_v2_new_captures: false,
             runtime_v2_new_materializations: false,
+            runtime_v2_new_derivations: false,
         };
         harness.truncate_tables().await;
         harness.setup_test_connectors().await;
@@ -1130,6 +1132,7 @@ impl TestHarness {
                 pg_pool: self.pool.clone(),
                 runtime_v2_new_captures: self.runtime_v2_new_captures,
                 runtime_v2_new_materializations: self.runtime_v2_new_materializations,
+                runtime_v2_new_derivations: self.runtime_v2_new_derivations,
             }),
             task_types::DISCOVERS => Server::new().register(DiscoverExecutor {
                 handler: self.discover_handler.clone(),

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -184,6 +184,7 @@ pub struct TestHarness {
     pub directive_exec: crate::directives::DirectiveHandler,
     pub alert_sender: self::alerts::TestSender,
     pub runtime_v2_new_captures: bool,
+    pub runtime_v2_new_materializations: bool,
     // Control plane API app instance for GraphQL queries
     control_plane_app: Option<Arc<control_plane_api::App>>,
 }
@@ -286,6 +287,7 @@ impl HarnessBuilder {
             control_plane_app: None,
             alert_sender: alerts::TestSender::new(),
             runtime_v2_new_captures: false,
+            runtime_v2_new_materializations: false,
         };
         harness.truncate_tables().await;
         harness.setup_test_connectors().await;
@@ -1127,6 +1129,7 @@ impl TestHarness {
                 publisher: self.publisher.clone(),
                 pg_pool: self.pool.clone(),
                 runtime_v2_new_captures: self.runtime_v2_new_captures,
+                runtime_v2_new_materializations: self.runtime_v2_new_materializations,
             }),
             task_types::DISCOVERS => Server::new().register(DiscoverExecutor {
                 handler: self.discover_handler.clone(),

--- a/crates/agent/src/integration_tests/user_publications.rs
+++ b/crates/agent/src/integration_tests/user_publications.rs
@@ -596,3 +596,139 @@ async fn test_runtime_v2_new_captures() {
         "an existing capture must stay unflagged on republish"
     );
 }
+
+/// The runtime-v2 materialization rollout (`RuntimeV2Rollout` initializer) stamps
+/// `enable-runtime-v2: true` into the model of a *newly-created* materialization
+/// when enabled. Covers: a materialization created while it's off is untouched; a
+/// new materialization created while it's on is enabled in both the committed
+/// model and the built-spec shard label; an explicit flag is preserved; and an
+/// existing materialization is never retroactively enabled on republish.
+#[tokio::test]
+async fn test_runtime_v2_new_materializations() {
+    let mut harness = TestHarness::init("test_runtime_v2_new_materializations").await;
+    let user = harness.setup_tenant("cats").await;
+
+    let collection = || {
+        serde_json::json!({
+            "schema": { "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] },
+            "key": ["/id"]
+        })
+    };
+    let materialization = |source: &str, table: &str| {
+        serde_json::json!({
+            "endpoint": { "connector": {
+                "image": "materialize/test:test",
+                "config": {}
+            }},
+            "bindings": [ {
+                "resource": { "table": table },
+                "source": source
+            } ]
+        })
+    };
+    // The `enable-runtime-v2` value in a materialization's committed model, if any.
+    async fn model_flag(harness: &mut TestHarness, name: &str) -> Option<String> {
+        let state = harness.get_controller_state(name).await;
+        let models::AnySpec::Materialization(model) = state.live_spec.as_ref().unwrap() else {
+            panic!("expected a materialization model");
+        };
+        model
+            .shards
+            .flags
+            .get(&models::Token::new(models::ENABLE_RUNTIME_V2))
+            .map(|v| v.as_str().to_string())
+    }
+    // The `enable-runtime-v2` value on a built materialization's shard template, if any.
+    fn built_materialization_v2_label(spec: &proto_flow::AnyBuiltSpec) -> Option<String> {
+        let proto_flow::AnyBuiltSpec::Materialization(materialization) = spec else {
+            return None;
+        };
+        let set = materialization.shard_template.as_ref()?.labels.as_ref()?;
+        labels::values(set, labels::RUNTIME_V2_FLAG)
+            .first()
+            .map(|l| l.value.clone())
+    }
+
+    // Rollout disabled: a materialization created now is left on v1.
+    harness.runtime_v2_new_materializations = false;
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/early-src": collection() },
+        "materializations": { "cats/early": materialization("cats/early-src", "early") },
+    }));
+    let result = harness
+        .user_publication(user, "rollout disabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "a materialization created while the rollout is off must be unflagged"
+    );
+
+    // Rollout enabled from here on.
+    harness.runtime_v2_new_materializations = true;
+
+    // A newly-created materialization is enabled onto v2; one that pins itself to
+    // v1 is left alone.
+    let mut pinned = materialization("cats/pinned-src", "pinned");
+    pinned["shards"] = serde_json::json!({ "flags": { "enable-runtime-v2": "false" } });
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/auto-src": collection(), "cats/pinned-src": collection() },
+        "materializations": {
+            "cats/auto": materialization("cats/auto-src", "auto"),
+            "cats/pinned": pinned,
+        },
+    }));
+    let result = harness
+        .user_publication(user, "rollout enabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+
+    // cats/auto: enabled in the committed model AND emitted as the built-spec label.
+    assert_eq!(
+        model_flag(&mut harness, "cats/auto").await.as_deref(),
+        Some("true"),
+        "a new materialization is enabled in the model"
+    );
+    let state = harness.get_controller_state("cats/auto").await;
+    assert_eq!(
+        built_materialization_v2_label(state.built_spec.as_ref().unwrap()).as_deref(),
+        Some("true"),
+        "the flag is emitted as the built-spec shard label"
+    );
+
+    // cats/pinned: an explicit flag is never changed.
+    assert_eq!(
+        model_flag(&mut harness, "cats/pinned").await.as_deref(),
+        Some("false"),
+        "an explicit `false` is preserved"
+    );
+
+    // Republishing `cats/early` (created while the rollout was off) with a real
+    // edit does NOT retroactively enable it: only new materializations are stamped.
+    let draft = draft_catalog(serde_json::json!({
+        "collections": { "cats/early-src": collection() },
+        "materializations": { "cats/early": materialization("cats/early-src", "early-v2") },
+    }));
+    let result = harness
+        .user_publication(user, "republish existing", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "an existing materialization must stay unflagged on republish"
+    );
+}

--- a/crates/agent/src/integration_tests/user_publications.rs
+++ b/crates/agent/src/integration_tests/user_publications.rs
@@ -732,3 +732,165 @@ async fn test_runtime_v2_new_materializations() {
         "an existing materialization must stay unflagged on republish"
     );
 }
+
+/// The runtime-v2 derivation rollout (`RuntimeV2Rollout` initializer) stamps
+/// `enable-runtime-v2: true` into the model of a *newly-created* derivation when
+/// enabled. A derivation is a collection carrying a `derive` block, so the flag
+/// lives at `derive.shards.flags` (not `shards.flags`), and plain collections are
+/// never candidates. Covers: a derivation created while it's off is untouched; a
+/// new derivation created while it's on is enabled in both the committed model
+/// and the built-spec shard label; an explicit flag is preserved; and an existing
+/// derivation is never retroactively enabled on republish.
+#[tokio::test]
+async fn test_runtime_v2_new_derivations() {
+    let mut harness = TestHarness::init("test_runtime_v2_new_derivations").await;
+    let user = harness.setup_tenant("cats").await;
+
+    let collection = || {
+        serde_json::json!({
+            "schema": { "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] },
+            "key": ["/id"]
+        })
+    };
+    let derivation = |source: &str, lambda: &str| {
+        serde_json::json!({
+            "schema": { "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] },
+            "key": ["/id"],
+            "derive": {
+                "using": { "sqlite": { "migrations": [] } },
+                "transforms": [
+                    { "name": "fromSource", "source": source, "shuffle": "any", "lambda": lambda }
+                ]
+            }
+        })
+    };
+    // The `enable-runtime-v2` value in a derivation's committed model, if any.
+    async fn model_flag(harness: &mut TestHarness, name: &str) -> Option<String> {
+        let state = harness.get_controller_state(name).await;
+        let models::AnySpec::Collection(model) = state.live_spec.as_ref().unwrap() else {
+            panic!("expected a collection model");
+        };
+        model
+            .derive
+            .as_ref()
+            .expect("expected a derived collection")
+            .shards
+            .flags
+            .get(&models::Token::new(models::ENABLE_RUNTIME_V2))
+            .map(|v| v.as_str().to_string())
+    }
+    // The `enable-runtime-v2` value on a built derivation's shard template, if any.
+    fn built_derivation_v2_label(spec: &proto_flow::AnyBuiltSpec) -> Option<String> {
+        let proto_flow::AnyBuiltSpec::Collection(collection) = spec else {
+            return None;
+        };
+        let set = collection
+            .derivation
+            .as_ref()?
+            .shard_template
+            .as_ref()?
+            .labels
+            .as_ref()?;
+        labels::values(set, labels::RUNTIME_V2_FLAG)
+            .first()
+            .map(|l| l.value.clone())
+    }
+
+    // Rollout disabled: a derivation created now is left on v1.
+    harness.runtime_v2_new_derivations = false;
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "cats/source": collection(),
+            "cats/early": derivation("cats/source", "select $id;"),
+        },
+    }));
+    let result = harness
+        .user_publication(user, "rollout disabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "a derivation created while the rollout is off must be unflagged"
+    );
+
+    // Rollout enabled from here on.
+    harness.runtime_v2_new_derivations = true;
+
+    // A newly-created derivation is enabled onto v2; one that pins itself to v1 is
+    // left alone. The plain source collection is never a candidate.
+    let mut pinned = derivation("cats/source", "select $id;");
+    pinned["derive"]["shards"] = serde_json::json!({ "flags": { "enable-runtime-v2": "false" } });
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "cats/source": collection(),
+            "cats/auto": derivation("cats/source", "select $id;"),
+            "cats/pinned": pinned,
+        },
+    }));
+    let result = harness
+        .user_publication(user, "rollout enabled", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+
+    // cats/auto: enabled in the committed model AND emitted as the built-spec label.
+    assert_eq!(
+        model_flag(&mut harness, "cats/auto").await.as_deref(),
+        Some("true"),
+        "a new derivation is enabled in the model"
+    );
+    let state = harness.get_controller_state("cats/auto").await;
+    assert_eq!(
+        built_derivation_v2_label(state.built_spec.as_ref().unwrap()).as_deref(),
+        Some("true"),
+        "the flag is emitted as the built-spec shard label"
+    );
+
+    // cats/pinned: an explicit flag is never changed.
+    assert_eq!(
+        model_flag(&mut harness, "cats/pinned").await.as_deref(),
+        Some("false"),
+        "an explicit `false` is preserved"
+    );
+
+    // cats/source: a plain (non-derived) collection has no derivation to stamp,
+    // and never gains one.
+    let source = harness.get_controller_state("cats/source").await;
+    let models::AnySpec::Collection(source_model) = source.live_spec.as_ref().unwrap() else {
+        panic!("expected a collection model");
+    };
+    assert!(
+        source_model.derive.is_none(),
+        "a plain collection must not gain a derivation"
+    );
+
+    // Republishing `cats/early` (created while the rollout was off) with a real
+    // edit does NOT retroactively enable it: only new derivations are stamped.
+    let draft = draft_catalog(serde_json::json!({
+        "collections": {
+            "cats/source": collection(),
+            "cats/early": derivation("cats/source", "select $id, $id as also_id;"),
+        },
+    }));
+    let result = harness
+        .user_publication(user, "republish existing", draft)
+        .await;
+    assert!(
+        result.status.is_success(),
+        "publication failed: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model_flag(&mut harness, "cats/early").await,
+        None,
+        "an existing derivation must stay unflagged on republish"
+    );
+}

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -167,6 +167,13 @@ struct Args {
     #[clap(long, env = "RUNTIME_V2_NEW_CAPTURES", default_value = "false")]
     runtime_v2_new_captures: bool,
 
+    /// When `true`, any *newly-created* materialization without an explicit
+    /// `enable-runtime-v2` shard flag is published onto runtime v2. Existing
+    /// materializations are unaffected, and an explicit per-task flag always
+    /// takes precedence.
+    #[clap(long, env = "RUNTIME_V2_NEW_MATERIALIZATIONS", default_value = "false")]
+    runtime_v2_new_materializations: bool,
+
     #[command(flatten)]
     controller_config: agent::controllers::ControllerConfig,
 }
@@ -404,6 +411,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
                 publisher,
                 pg_pool: pg_pool.clone(),
                 runtime_v2_new_captures: args.runtime_v2_new_captures,
+                runtime_v2_new_materializations: args.runtime_v2_new_materializations,
             })
             .register(agent::DiscoverExecutor {
                 handler: discover_handler,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -174,6 +174,13 @@ struct Args {
     #[clap(long, env = "RUNTIME_V2_NEW_MATERIALIZATIONS", default_value = "false")]
     runtime_v2_new_materializations: bool,
 
+    /// When `true`, any *newly-created* derivation without an explicit
+    /// `enable-runtime-v2` shard flag is published onto runtime v2. Existing
+    /// derivations are unaffected, and an explicit per-task flag always takes
+    /// precedence.
+    #[clap(long, env = "RUNTIME_V2_NEW_DERIVATIONS", default_value = "false")]
+    runtime_v2_new_derivations: bool,
+
     #[command(flatten)]
     controller_config: agent::controllers::ControllerConfig,
 }
@@ -412,6 +419,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
                 pg_pool: pg_pool.clone(),
                 runtime_v2_new_captures: args.runtime_v2_new_captures,
                 runtime_v2_new_materializations: args.runtime_v2_new_materializations,
+                runtime_v2_new_derivations: args.runtime_v2_new_derivations,
             })
             .register(agent::DiscoverExecutor {
                 handler: discover_handler,

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -17,6 +17,8 @@ pub struct PublicationsExecutor {
     pub pg_pool: sqlx::PgPool,
     /// When true, newly-created captures are published onto runtime v2; see [`RuntimeV2Rollout`].
     pub runtime_v2_new_captures: bool,
+    /// When true, newly-created materializations are published onto runtime v2; see [`RuntimeV2Rollout`].
+    pub runtime_v2_new_materializations: bool,
 }
 
 impl automations::Executor for PublicationsExecutor {
@@ -174,6 +176,7 @@ impl PublicationsExecutor {
             initialize: (
                 RuntimeV2Rollout {
                     new_captures: self.runtime_v2_new_captures,
+                    new_materializations: self.runtime_v2_new_materializations,
                 },
                 ExpandDraft {
                     filter_user_has_admin: true,

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -19,6 +19,8 @@ pub struct PublicationsExecutor {
     pub runtime_v2_new_captures: bool,
     /// When true, newly-created materializations are published onto runtime v2; see [`RuntimeV2Rollout`].
     pub runtime_v2_new_materializations: bool,
+    /// When true, newly-created derivations are published onto runtime v2; see [`RuntimeV2Rollout`].
+    pub runtime_v2_new_derivations: bool,
 }
 
 impl automations::Executor for PublicationsExecutor {
@@ -177,6 +179,7 @@ impl PublicationsExecutor {
                 RuntimeV2Rollout {
                     new_captures: self.runtime_v2_new_captures,
                     new_materializations: self.runtime_v2_new_materializations,
+                    new_derivations: self.runtime_v2_new_derivations,
                 },
                 ExpandDraft {
                     filter_user_has_admin: true,

--- a/crates/control-plane-api/src/publications/initialize.rs
+++ b/crates/control-plane-api/src/publications/initialize.rs
@@ -105,6 +105,8 @@ pub struct RuntimeV2Rollout {
     pub new_captures: bool,
     /// When true, newly-created materializations without an explicit flag run runtime v2.
     pub new_materializations: bool,
+    /// When true, newly-created derivations without an explicit flag run runtime v2.
+    pub new_derivations: bool,
 }
 
 impl Initialize for RuntimeV2Rollout {
@@ -124,8 +126,9 @@ impl Initialize for RuntimeV2Rollout {
         };
 
         // Gather candidate names across the task types whose rollout is enabled.
-        // Catalog names are globally unique, so captures and materializations
-        // share the single existence query below.
+        // Catalog names are globally unique, so all task types share the single
+        // existence query below. Derivations are collections carrying a `derive`
+        // block, and their shards live at `derive.shards` rather than `shards`.
         let mut candidates = Vec::new();
         if self.new_captures {
             candidates.extend(
@@ -151,6 +154,20 @@ impl Initialize for RuntimeV2Rollout {
                             .is_some_and(|model| is_candidate(row.is_touch, &model.shards))
                     })
                     .map(|row| row.materialization.to_string()),
+            );
+        }
+        if self.new_derivations {
+            candidates.extend(
+                draft
+                    .collections
+                    .iter()
+                    .filter(|row| {
+                        row.model
+                            .as_ref()
+                            .and_then(|model| model.derive.as_ref())
+                            .is_some_and(|derive| is_candidate(row.is_touch, &derive.shards))
+                    })
+                    .map(|row| row.collection.to_string()),
             );
         }
         if candidates.is_empty() {
@@ -198,6 +215,22 @@ impl Initialize for RuntimeV2Rollout {
                     && !existing.contains(row.materialization.as_str())
                 {
                     model
+                        .shards
+                        .flags
+                        .insert(flag.clone(), models::Token::new("true"));
+                }
+            }
+        }
+        if self.new_derivations {
+            for row in draft.collections.iter_mut() {
+                let Some(derive) = row.model.as_mut().and_then(|model| model.derive.as_mut())
+                else {
+                    continue;
+                };
+                if is_candidate(row.is_touch, &derive.shards)
+                    && !existing.contains(row.collection.as_str())
+                {
+                    derive
                         .shards
                         .flags
                         .insert(flag.clone(), models::Token::new("true"));

--- a/crates/control-plane-api/src/publications/initialize.rs
+++ b/crates/control-plane-api/src/publications/initialize.rs
@@ -103,6 +103,8 @@ impl Initialize for ExpandDraft {
 pub struct RuntimeV2Rollout {
     /// When true, newly-created captures without an explicit flag run runtime v2.
     pub new_captures: bool,
+    /// When true, newly-created materializations without an explicit flag run runtime v2.
+    pub new_materializations: bool,
 }
 
 impl Initialize for RuntimeV2Rollout {
@@ -113,34 +115,52 @@ impl Initialize for RuntimeV2Rollout {
         _user_id: Uuid,
         draft: &mut tables::DraftCatalog,
     ) -> anyhow::Result<()> {
-        if !self.new_captures {
-            return Ok(());
-        }
         let flag = models::Token::new(models::ENABLE_RUNTIME_V2);
 
-        // Candidate captures: drafted, not a touch or deletion, whose model
-        // hasn't set the flag explicitly.
-        let is_candidate = |row: &tables::DraftCapture| {
-            !row.is_touch
-                && row
-                    .model
-                    .as_ref()
-                    .is_some_and(|model| !model.shards.flags.contains_key(&flag))
+        // A drafted task is a candidate for stamping when it's a real upsert
+        // (not a touch or deletion) whose model hasn't set the flag explicitly.
+        let is_candidate = |is_touch: bool, shards: &models::ShardTemplate| {
+            !is_touch && !shards.flags.contains_key(&flag)
         };
-        let candidates = draft
-            .captures
-            .iter()
-            .filter(|row| is_candidate(row))
-            .map(|row| row.capture.to_string())
-            .collect::<Vec<_>>();
+
+        // Gather candidate names across the task types whose rollout is enabled.
+        // Catalog names are globally unique, so captures and materializations
+        // share the single existence query below.
+        let mut candidates = Vec::new();
+        if self.new_captures {
+            candidates.extend(
+                draft
+                    .captures
+                    .iter()
+                    .filter(|row| {
+                        row.model
+                            .as_ref()
+                            .is_some_and(|model| is_candidate(row.is_touch, &model.shards))
+                    })
+                    .map(|row| row.capture.to_string()),
+            );
+        }
+        if self.new_materializations {
+            candidates.extend(
+                draft
+                    .materializations
+                    .iter()
+                    .filter(|row| {
+                        row.model
+                            .as_ref()
+                            .is_some_and(|model| is_candidate(row.is_touch, &model.shards))
+                    })
+                    .map(|row| row.materialization.to_string()),
+            );
+        }
         if candidates.is_empty() {
             return Ok(());
         }
 
-        // Only *new* captures are enabled. A candidate that already has a
+        // Only *new* tasks are enabled. A candidate that already has a
         // non-tombstone live spec is an update, so it's left as-is. A tombstone
         // (`spec is null`, a deleted spec a controller hasn't yet reaped) is
-        // excluded by `spec is not null`, so re-creating a capture counts as new.
+        // excluded by `spec is not null`, so re-creating a task counts as new.
         let existing: std::collections::HashSet<String> = sqlx::query!(
             r#"select catalog_name
                from live_specs
@@ -149,19 +169,39 @@ impl Initialize for RuntimeV2Rollout {
         )
         .fetch_all(db)
         .await
-        .context("fetching existing capture names")?
+        .context("fetching existing task names")?
         .into_iter()
         .map(|row| row.catalog_name)
         .collect();
 
-        for row in draft.captures.iter_mut() {
-            if is_candidate(row) && !existing.contains(row.capture.as_str()) {
-                row.model
-                    .as_mut()
-                    .unwrap()
-                    .shards
-                    .flags
-                    .insert(flag.clone(), models::Token::new("true"));
+        if self.new_captures {
+            for row in draft.captures.iter_mut() {
+                let Some(model) = row.model.as_mut() else {
+                    continue;
+                };
+                if is_candidate(row.is_touch, &model.shards)
+                    && !existing.contains(row.capture.as_str())
+                {
+                    model
+                        .shards
+                        .flags
+                        .insert(flag.clone(), models::Token::new("true"));
+                }
+            }
+        }
+        if self.new_materializations {
+            for row in draft.materializations.iter_mut() {
+                let Some(model) = row.model.as_mut() else {
+                    continue;
+                };
+                if is_candidate(row.is_touch, &model.shards)
+                    && !existing.contains(row.materialization.as_str())
+                {
+                    model
+                        .shards
+                        .flags
+                        .insert(flag.clone(), models::Token::new("true"));
+                }
             }
         }
 

--- a/mise/tasks/local/control-plane
+++ b/mise/tasks/local/control-plane
@@ -34,6 +34,14 @@ SERVE_HANDLERS=true
 SKIP_CONNECTOR_TABLE_CHECK=true
 SSL_CERT_FILE=${FLOW_LOCAL}/ca.crt
 
+# Local stacks run the V2 task runtime for every newly-created task: the agent
+# stamps enable-runtime-v2 onto new captures, derivations, and materializations
+# at publication time. Existing tasks and explicit per-task flags are unaffected.
+# See RuntimeV2Rollout in crates/control-plane-api.
+RUNTIME_V2_NEW_CAPTURES=true
+RUNTIME_V2_NEW_DERIVATIONS=true
+RUNTIME_V2_NEW_MATERIALIZATIONS=true
+
 BIGTABLE_PROJECT=estuary-local
 BIGTABLE_INSTANCE=estuary-local
 BIGTABLE_EMULATOR_HOST=localhost:${FLOW_PORT_BIGTABLE}


### PR DESCRIPTION
**Description:**

Rolls newly-created materializations and derivations onto runtime-v2, mirroring the existing captures flag (b98d27ceaba). Adds `RUNTIME_V2_NEW_MATERIALIZATIONS` and `RUNTIME_V2_NEW_DERIVATIONS` agent flags, each an independent per-task-type toggle on `RuntimeV2Rollout`. New tasks get `enable-runtime-v2` stamped at publish; existing tasks and explicit flags are untouched. Defaults off (deploy-inert); the last commit turns all three on for local stacks.

Tested: integration tests for both types + end-to-end on a local stack (new task gets the flag in model + built shard label and actually runs on the v2 sidecar).

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

