### PR TITLE
docs: reference gcloud storage instead of gsutil for GCS bucket IAM

### DIFF
--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -97,7 +97,7 @@ For a [GCS bucket](https://cloud.google.com/storage/docs/creating-buckets), upda
 * [`roles/storage.admin`](https://cloud.google.com/storage/docs/access-control/iam-roles) as the **role**
 
 You can configure this through the [Cloud Console](https://console.cloud.google.com/) or
-the `gsutil` CLI.
+the `gcloud storage` CLI.
 
 ### Amazon S3
 


### PR DESCRIPTION
The GCS bucket setup step in the storage docs points users at the `gsutil` CLI. Google is removing `gsutil` from the default gcloud CLI bundle after March 2027 and recommends `gcloud storage` as the supported replacement, so the docs should name the current tool.

Change: one line in `site/docs/getting-started/installation.md` (GCS section), `gsutil` -> `gcloud storage`.

The Cloud Console path in the same sentence is unchanged.