### PR TITLE
control-plane-api: add a root effectiveAlertConfig(catalogPrefixOrName:) query

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -207,6 +207,32 @@ impl AlertConfigsQuery {
         )
         .await
     }
+
+    /// Resolves the effective alert config at a single prefix or catalog name.
+    pub async fn effective_alert_config(
+        &self,
+        ctx: &Context<'_>,
+        catalog_prefix_or_name: String,
+    ) -> async_graphql::Result<EffectiveAlertConfig> {
+        let env = ctx.data::<crate::Envelope>()?;
+        let claims = env.claims()?;
+
+        validate_prefix_or_name(&catalog_prefix_or_name)?;
+
+        // Reading a scope's effective config requires catalog-read access at
+        // that scope. Ancestor layers merged into the result are visible to
+        // anyone who can read the scope, matching the `effective` field on
+        // AlertConfigEntry and `effectiveAlertConfig` on liveSpec.
+        let policy_result = crate::server::evaluate_names_authorization(
+            env.snapshot(),
+            claims,
+            models::authz::Capability::CatalogRead,
+            [catalog_prefix_or_name.as_str()],
+        );
+        env.authorization_outcome(policy_result).await?;
+
+        resolve_effective_alert_config(ctx, &catalog_prefix_or_name).await
+    }
 }
 
 #[derive(Debug, Default)]
@@ -317,14 +343,26 @@ fn validate_prefix_or_name(catalog_prefix_or_name: &str) -> async_graphql::Resul
     use validator::Validate;
 
     if catalog_prefix_or_name.ends_with('/') {
-        models::Prefix::new(catalog_prefix_or_name)
+        return models::Prefix::new(catalog_prefix_or_name)
             .validate()
-            .map_err(|e| async_graphql::Error::new(format!("invalid catalog prefix: {e}")))
-    } else {
-        models::Name::new(catalog_prefix_or_name)
-            .validate()
-            .map_err(|e| async_graphql::Error::new(format!("invalid catalog name: {e}")))
+            .map_err(|e| async_graphql::Error::new(format!("invalid catalog prefix: {e}")));
     }
+
+    // A bare name targets a single task. Every real catalog name is
+    // hierarchical (`tenant/.../name`) and so contains at least one `/`; a
+    // slash-less token is neither a prefix nor a task name. Rejecting it here
+    // returns a clear validation error rather than a confusing
+    // `PermissionDenied` from an authorization check no grant can ever satisfy
+    // (a grant at `aliceCo/` does not cover the bare string `aliceCo`).
+    if !catalog_prefix_or_name.contains('/') {
+        return Err(async_graphql::Error::new(format!(
+            "invalid catalog name '{catalog_prefix_or_name}': must contain at least one '/' (did you mean the prefix '{catalog_prefix_or_name}/'?)"
+        )));
+    }
+
+    models::Name::new(catalog_prefix_or_name)
+        .validate()
+        .map_err(|e| async_graphql::Error::new(format!("invalid catalog name: {e}")))
 }
 
 /// Returns the prefix used for authorization checks on
@@ -847,5 +885,149 @@ mod test {
             })
             .collect();
         assert_eq!(names, vec!["tenant00/", "tenant01/", "tenant02/"]);
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_effective_alert_config_query(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let defaults = models::AlertConfig {
+            data_movement_stalled: None,
+            shard_failed: Some(models::ShardFailedConfig {
+                enabled: Some(true),
+                condition: Some(models::ShardFailedCondition {
+                    failures: Some(3),
+                    per: Some(std::time::Duration::from_secs(8 * 3600)),
+                }),
+            }),
+            task_chronically_failing: None,
+            task_idle: None,
+        };
+
+        let server = test_server::TestServer::start_with_alert_defaults(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+            defaults,
+        )
+        .await;
+
+        let token = server.make_access_token(
+            uuid::Uuid::from_bytes([0x11; 16]),
+            Some("alice@example.test"),
+        );
+
+        // A prefix with no explicit alert_configs row is absent from the
+        // alertConfigs listing but still resolves an effective config here,
+        // sourced entirely from controller defaults (provenance source null).
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        effectiveAlertConfig(catalogPrefixOrName: "aliceCo/nested/deep/") {
+                            config
+                            provenance { path source }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("query_effective_defaults_only", response);
+
+        // Insert a prefix override at aliceCo/.
+        let _: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    mutation {
+                        updateAlertConfig(
+                            catalogPrefixOrName: "aliceCo/"
+                            config: { shardFailed: { condition: { failures: 5 } } }
+                        ) { id }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+
+        // The nested prefix inherits the aliceCo/ override merged over defaults,
+        // with provenance attributing the overridden field to aliceCo/.
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        effectiveAlertConfig(catalogPrefixOrName: "aliceCo/nested/deep/") {
+                            config
+                            provenance { path source }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("query_effective_inherited_override", response);
+
+        // An exact catalog name (not a prefix) resolves through the exact-name
+        // layer of ancestor_prefixes_and_name, inheriting the aliceCo/ override.
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        effectiveAlertConfig(catalogPrefixOrName: "aliceCo/in/capture-foo") {
+                            config
+                            provenance { path source }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("query_effective_exact_name", response);
+
+        // A slash-less token is neither a prefix nor a real catalog name, and is
+        // rejected at input validation rather than surfacing as PermissionDenied.
+        let invalid: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        effectiveAlertConfig(catalogPrefixOrName: "aliceCo") {
+                            config
+                            provenance { path source }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        assert!(
+            invalid["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "a slash-less catalogPrefixOrName should be rejected at validation: {invalid}"
+        );
+
+        // A prefix the caller cannot read is denied.
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        effectiveAlertConfig(catalogPrefixOrName: "notAliceCo/") {
+                            config
+                            provenance { path source }
+                        }
+                    }"#
+                }),
+                Some(&token),
+            )
+            .await;
+        insta::assert_json_snapshot!("query_effective_denied", response);
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_defaults_only.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_defaults_only.snap
@@ -1,0 +1,33 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+expression: response
+---
+{
+  "data": {
+    "effectiveAlertConfig": {
+      "config": {
+        "shardFailed": {
+          "condition": {
+            "failures": 3,
+            "per": "8h"
+          },
+          "enabled": true
+        }
+      },
+      "provenance": [
+        {
+          "path": "shardFailed.condition.failures",
+          "source": null
+        },
+        {
+          "path": "shardFailed.condition.per",
+          "source": null
+        },
+        {
+          "path": "shardFailed.enabled",
+          "source": null
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_denied.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_denied.snap
@@ -1,0 +1,22 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+assertion_line: 729
+expression: response
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 25,
+          "line": 3
+        }
+      ],
+      "message": "PermissionDenied: alice@example.test is not authorized to access prefix or name 'notAliceCo/' with required capability CatalogRead",
+      "path": [
+        "effectiveAlertConfig"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_exact_name.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_exact_name.snap
@@ -1,0 +1,33 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+expression: response
+---
+{
+  "data": {
+    "effectiveAlertConfig": {
+      "config": {
+        "shardFailed": {
+          "condition": {
+            "failures": 5,
+            "per": "8h"
+          },
+          "enabled": true
+        }
+      },
+      "provenance": [
+        {
+          "path": "shardFailed.condition.failures",
+          "source": "aliceCo/"
+        },
+        {
+          "path": "shardFailed.condition.per",
+          "source": null
+        },
+        {
+          "path": "shardFailed.enabled",
+          "source": null
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_inherited_override.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__alert_configs__test__query_effective_inherited_override.snap
@@ -1,0 +1,33 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+expression: response
+---
+{
+  "data": {
+    "effectiveAlertConfig": {
+      "config": {
+        "shardFailed": {
+          "condition": {
+            "failures": 5,
+            "per": "8h"
+          },
+          "enabled": true
+        }
+      },
+      "provenance": [
+        {
+          "path": "shardFailed.condition.failures",
+          "source": "aliceCo/"
+        },
+        {
+          "path": "shardFailed.condition.per",
+          "source": null
+        },
+        {
+          "path": "shardFailed.enabled",
+          "source": null
+        }
+      ]
+    }
+  }
+}

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -1827,6 +1827,10 @@ type QueryRoot {
 	"""
 	alertConfigs(filter: AlertConfigsFilter, after: String, first: Int): AlertConfigEntryConnection!
 	"""
+	Resolves the effective alert config at a single prefix or catalog name.
+	"""
+	effectiveAlertConfig(catalogPrefixOrName: String!): EffectiveAlertConfig!
+	"""
 	Returns all possible alert types with their user-facing metadata.
 	"""
 	alertTypes: [AlertTypeInfo!]!


### PR DESCRIPTION
## Summary

Adds a top-level `effectiveAlertConfig(catalogPrefixOrName:)` GraphQL query that resolves the effective alert config at a single prefix or catalog name — merging all ancestor prefix layers and controller defaults, with per-field provenance.

## Why a root query

Master already exposes effective config as *fields* (`AlertConfigEntry.effective`, `LiveSpec.effectiveAlertConfig`), which only answer for scopes that have an entry or a live spec. This root query takes an **arbitrary** `catalogPrefixOrName` and does not require an `alert_configs` row to exist there, so it answers for prefixes and names that carry no explicit config and are therefore absent from the `alertConfigs` listing.

It reuses the existing `resolve_effective_alert_config` helper and its provenance output; auth requires `CatalogRead` on the scope, matching the field-level accessors.

## Input validation

`validate_prefix_or_name` now rejects a slash-less token like `aliceCo`. Such a token is neither a prefix (no trailing `/`) nor a real catalog name (names are always hierarchical), so it previously validated as a bare `Name` and then failed authorization with a confusing `PermissionDenied` — a grant at `aliceCo/` never covers the bare string `aliceCo`. It now returns a validation error pointing at the trailing-slash prefix form, matching the slash requirement the mutation path already enforces via `governing_prefix`.

## Testing

`test_effective_alert_config_query` covers:
- defaults-only resolution (no row present; provenance `source: null`)
- an inherited prefix override with provenance attribution
- the exact-catalog-name layer (`aliceCo/in/capture-foo`)
- the slash-less validation rejection
- read-denied

SDL regenerated.
