### PR TITLE
docs: clarify sync schedule connector scope and backfill heuristic

### DIFF
--- a/site/docs/guides/customize-dataflows/materialization-sync-schedule.md
+++ b/site/docs/guides/customize-dataflows/materialization-sync-schedule.md
@@ -18,7 +18,12 @@ reduce the costs incurred in the destination from the actions the connector
 takes to load data to it.
 :::
 
-Most warehouse materialization connectors (such as [Snowflake](/reference/Connectors/materialization-connectors/Snowflake), [Databricks](/reference/Connectors/materialization-connectors/databricks), and [BigQuery](/reference/Connectors/materialization-connectors/BigQuery)) support configuring a sync schedule.
+Sync schedules are supported by two kinds of materialization connectors:
+
+- Warehouse connectors, such as [Snowflake](/reference/Connectors/materialization-connectors/Snowflake), [Databricks](/reference/Connectors/materialization-connectors/databricks), and [BigQuery](/reference/Connectors/materialization-connectors/BigQuery), as well as Amazon Redshift, MotherDuck, ClickHouse, and Azure Fabric Warehouse.
+- File and object-store connectors that write data in batches, such as the Amazon S3, Google Cloud Storage, and Azure Blob Storage file materializations, and the Apache Iceberg materializations. For these connectors the batching interval (for example, an upload interval) is the sync frequency.
+
+Transactional database materializations (such as PostgreSQL, MySQL, and SQL Server) and streaming or API destinations (such as Elasticsearch, MongoDB, DynamoDB, and Pinecone) do _not_ use a sync schedule; they apply updates as they arrive.
 Check the connector reference docs to determine if a specific connector supports sync schedules.
 
 ## How transactions are used to sync data to a destination
@@ -42,6 +47,16 @@ amount of time. This extra delay is only applied when the materialization is
 fully caught up - backfills always run as fast as possible. And while a
 transaction is delayed, Estuary will continue batching and combining new
 documents so that the next transaction contains all of the latest data.
+
+The connector decides whether it is caught up or still backfilling by looking at
+the sizes of its recent transactions. If any of the last several transactions
+stored a large number of documents (on the order of a million), the
+materialization is assumed to still be backfilling, and the sync schedule delay
+is skipped so that it can catch up as fast as possible. Once several consecutive
+transactions are all below that size, the materialization is treated as caught
+up and the sync schedule delay applies. This behavior is the same for every
+connector that supports a sync schedule, including the file and object-store
+connectors.
 
 You can read about [how continuous materialization
 works](/concepts/materialization/#how-continuous-materialization-works) for

--- a/site/docs/guides/customize-dataflows/materialization-sync-schedule.md
+++ b/site/docs/guides/customize-dataflows/materialization-sync-schedule.md
@@ -18,13 +18,18 @@ reduce the costs incurred in the destination from the actions the connector
 takes to load data to it.
 :::
 
-Sync schedules are supported by two kinds of materialization connectors:
+Sync schedules are supported by **warehouse** materialization connectors, such as [Snowflake](/reference/Connectors/materialization-connectors/Snowflake), [Databricks](/reference/Connectors/materialization-connectors/databricks), [BigQuery](/reference/Connectors/materialization-connectors/BigQuery), Amazon Redshift, MotherDuck, ClickHouse, and Azure Fabric Warehouse.
 
-- Warehouse connectors, such as [Snowflake](/reference/Connectors/materialization-connectors/Snowflake), [Databricks](/reference/Connectors/materialization-connectors/databricks), and [BigQuery](/reference/Connectors/materialization-connectors/BigQuery), as well as Amazon Redshift, MotherDuck, ClickHouse, and Azure Fabric Warehouse.
-- File and object-store connectors that write data in batches, such as the Amazon S3, Google Cloud Storage, and Azure Blob Storage file materializations, and the Apache Iceberg materializations. For these connectors the batching interval (for example, an upload interval) is the sync frequency.
+In contrast, transactional database materializations (such as PostgreSQL, MySQL, and SQL Server) and streaming or API destinations (such as Elasticsearch, MongoDB, DynamoDB, and Pinecone) do _not_ use a sync schedule; they apply updates as they arrive.
 
-Transactional database materializations (such as PostgreSQL, MySQL, and SQL Server) and streaming or API destinations (such as Elasticsearch, MongoDB, DynamoDB, and Pinecone) do _not_ use a sync schedule; they apply updates as they arrive.
-Check the connector reference docs to determine if a specific connector supports sync schedules.
+The connector reference docs will note whether a specific connector supports sync schedules.
+
+:::note
+File and object-store connectors support a similar concept to sync schedules.
+These connectors (such as the Amazon S3, Google Cloud Storage, and Azure Blob Storage file materializations) use an `uploadInterval` property or similar to manage data load frequency.
+
+They do not support other sync schedule functionality like fast sync times.
+:::
 
 ## How transactions are used to sync data to a destination
 
@@ -55,8 +60,7 @@ materialization is assumed to still be backfilling, and the sync schedule delay
 is skipped so that it can catch up as fast as possible. Once several consecutive
 transactions are all below that size, the materialization is treated as caught
 up and the sync schedule delay applies. This behavior is the same for every
-connector that supports a sync schedule, including the file and object-store
-connectors.
+connector that supports a sync schedule or upload interval.
 
 You can read about [how continuous materialization
 works](/concepts/materialization/#how-continuous-materialization-works) for


### PR DESCRIPTION
## What

Clarifies the [Materialization Sync Schedule](https://docs.estuary.dev/reference/materialization-sync-schedule/) page on two points that currently cause confusion:

1. **Which connectors support a sync schedule.** The page previously implied this is a warehouse-only feature. In fact the same acknowledgement-delay mechanism is also used by the file and object-store connectors (S3/GCS/Azure Blob file materializations and Iceberg), which route their batching/upload interval through the same `syncFrequency`. Transactional-database materializations (Postgres, MySQL, SQL Server) and streaming/API destinations do **not** use it. The page now lists all three groups.

2. **How the "backfills always run as fast as possible" behavior actually works.** Added a short paragraph describing the heuristic: if any of the last several transactions stored a large number of documents (on the order of a million), the connector treats itself as still backfilling and skips the sync-schedule delay; once several consecutive transactions are all below that size it is treated as caught up. This is the same across every connector that supports a sync schedule.

## Why

A support question asked whether the "1M record skip" applies to all materializations or only database/warehouse ones. The docs didn't answer it, and an inference from the current wording is that file-based materializations use a separate mechanism, which is wrong: file sinks share the exact same code path.

## Source of truth

`go/materialize/transactions_stream.go` in `estuary/connectors` (`storeBackfillThreshold = 1_000_000`, `storedHistorySize = 5`), and the `AckSchedule` wiring in each connector's driver. The connectors that set `AckSchedule` are exactly: Snowflake, BigQuery, Databricks, Redshift, ClickHouse, MotherDuck, Azure Fabric Warehouse, filesink (S3/GCS file sinks), S3 Iceberg, and Iceberg.

Docs owner: Emily (@aeluce).
