### PR TITLE
Extend `PrefixFilter` with `in` and add storage mapping query as a consumer

### DIFF
--- a/.sqlx/query-1502c669a9da19e787fb037e534ff2119db6bf56d0af3a2d6d6ef970506130aa.json
+++ b/.sqlx/query-1502c669a9da19e787fb037e534ff2119db6bf56d0af3a2d6d6ef970506130aa.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    il.token,\n                    il.catalog_prefix AS \"catalog_prefix!: String\",\n                    il.capability AS \"capability!: models::Capability\",\n                    il.single_use AS \"single_use!: bool\",\n                    il.detail,\n                    il.created_at AS \"created_at!: chrono::DateTime<chrono::Utc>\",\n                    t.sso_provider_id\n                FROM internal.invite_links il\n                LEFT JOIN tenants t ON il.catalog_prefix::text ^@ t.tenant\n                WHERE il.catalog_prefix::text ^@ ANY($1)\n                  AND ($5::text IS NULL OR il.catalog_prefix::text ^@ $5)\n                  AND ($4::bool IS NULL OR il.single_use = $4)\n                  AND ($2::timestamptz IS NULL OR il.created_at < $2)\n                ORDER BY il.created_at DESC\n                LIMIT $3 + 1\n                ",
+  "query": "\n                SELECT\n                    il.token,\n                    il.catalog_prefix AS \"catalog_prefix!: String\",\n                    il.capability AS \"capability!: models::Capability\",\n                    il.single_use AS \"single_use!: bool\",\n                    il.detail,\n                    il.created_at AS \"created_at!: chrono::DateTime<chrono::Utc>\",\n                    t.sso_provider_id\n                FROM internal.invite_links il\n                LEFT JOIN tenants t ON il.catalog_prefix::text ^@ t.tenant\n                WHERE il.catalog_prefix::text ^@ ANY($1)\n                  AND ($5::text IS NULL OR il.catalog_prefix::text ^@ $5)\n                  AND ($6::text[] IS NULL OR il.catalog_prefix::text = ANY($6))\n                  AND ($4::bool IS NULL OR il.single_use = $4)\n                  AND ($2::timestamptz IS NULL OR il.created_at < $2)\n                ORDER BY il.created_at DESC\n                LIMIT $3 + 1\n                ",
   "describe": {
     "columns": [
       {
@@ -84,7 +84,8 @@
         "Timestamptz",
         "Int4",
         "Bool",
-        "Text"
+        "Text",
+        "TextArray"
       ]
     },
     "nullable": [
@@ -97,5 +98,5 @@
       true
     ]
   },
-  "hash": "6b980602f82b52e0f186d532fd5f93141c03a7f704c461194f45047636867855"
+  "hash": "1502c669a9da19e787fb037e534ff2119db6bf56d0af3a2d6d6ef970506130aa"
 }

--- a/.sqlx/query-303bbbc4f06f38018d8fa287ddbb46204c178c20c2c96d9c1b50af081cdb6d82.json
+++ b/.sqlx/query-303bbbc4f06f38018d8fa287ddbb46204c178c20c2c96d9c1b50af081cdb6d82.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    SELECT\n                        id as \"id!: models::Id\",\n                        catalog_prefix_or_name::text as \"catalog_prefix_or_name!: String\",\n                        config as \"config!: crate::TextJson<models::AlertConfig>\",\n                        detail,\n                        created_at,\n                        updated_at,\n                        last_modified_by\n                    FROM alert_configs\n                    WHERE catalog_prefix_or_name::text ^@ ANY($1)\n                      AND ($2::text IS NULL OR catalog_prefix_or_name::text > $2)\n                      AND ($3::text IS NULL OR catalog_prefix_or_name::text ^@ $3)\n                    ORDER BY catalog_prefix_or_name ASC\n                    LIMIT $4 + 1\n                    ",
+  "query": "\n                    SELECT\n                        id as \"id!: models::Id\",\n                        catalog_prefix_or_name::text as \"catalog_prefix_or_name!: String\",\n                        config as \"config!: crate::TextJson<models::AlertConfig>\",\n                        detail,\n                        created_at,\n                        updated_at,\n                        last_modified_by\n                    FROM alert_configs\n                    WHERE catalog_prefix_or_name::text ^@ ANY($1)\n                      AND ($2::text IS NULL OR catalog_prefix_or_name::text > $2)\n                      AND ($3::text IS NULL OR catalog_prefix_or_name::text ^@ $3)\n                      AND ($5::text[] IS NULL OR catalog_prefix_or_name::text = ANY($5))\n                    ORDER BY catalog_prefix_or_name ASC\n                    LIMIT $4 + 1\n                    ",
   "describe": {
     "columns": [
       {
@@ -44,7 +44,8 @@
         "TextArray",
         "Text",
         "Text",
-        "Int4"
+        "Int4",
+        "TextArray"
       ]
     },
     "nullable": [
@@ -57,5 +58,5 @@
       true
     ]
   },
-  "hash": "ae6e575019bed8166d1c586a666a4bcece2d493a0b579e9da04d58fe62ef764a"
+  "hash": "303bbbc4f06f38018d8fa287ddbb46204c178c20c2c96d9c1b50af081cdb6d82"
 }

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -15,7 +15,9 @@ const DEFAULT_PAGE_SIZE: usize = 50;
 const MAX_PREFIXES: usize = 20;
 
 /// Optional filter for the `alertConfigs` query. When omitted, all accessible
-/// rows are returned.
+/// rows are returned. A filter only narrows those results; the caller's
+/// catalog-read scope is enforced independently, so it can never widen what a
+/// caller may see.
 #[derive(Debug, Clone, Default, async_graphql::InputObject)]
 pub struct AlertConfigsFilter {
     /// Filter on the `catalog_prefix_or_name` column.
@@ -108,9 +110,9 @@ impl AlertConfigsQuery {
     /// Lists alert-config rows visible to the caller.
     ///
     /// Results are limited to readable prefixes and sorted by
-    /// `catalog_prefix_or_name`. `filter.catalogPrefixOrName.startsWith` can
-    /// narrow the results further. Passing a full catalog name returns at
-    /// most one exact-name row.
+    /// `catalog_prefix_or_name`. `filter.catalogPrefixOrName` narrows further,
+    /// by subtree (`startsWith`) or an exact set (`in`) — not both. Passing a
+    /// full catalog name returns at most one exact-name row.
     pub async fn alert_configs(
         &self,
         ctx: &Context<'_>,
@@ -121,17 +123,16 @@ impl AlertConfigsQuery {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
 
-        let prefix_starts_with = filter
-            .and_then(|f| f.catalog_prefix_or_name)
-            .and_then(|f| f.starts_with);
-
-        let read_prefixes = super::authorized_prefixes::authorized_prefixes(
-            &env.snapshot().role_grants,
-            &env.snapshot().user_grants,
-            claims.sub,
-            models::Capability::Read,
-            prefix_starts_with.as_deref(),
-        );
+        let snapshot = env.snapshot();
+        let (read_prefixes, prefix_starts_with, prefix_in) =
+            super::authorized_prefixes::filtered_authorized_prefixes(
+                &snapshot.role_grants,
+                &snapshot.user_grants,
+                claims.sub,
+                models::Capability::Read,
+                filter.and_then(|f| f.catalog_prefix_or_name),
+                "filter.catalogPrefixOrName",
+            )?;
 
         if read_prefixes.is_empty() {
             return Ok(PaginatedAlertConfigs::new(false, false));
@@ -164,6 +165,7 @@ impl AlertConfigsQuery {
                     WHERE catalog_prefix_or_name::text ^@ ANY($1)
                       AND ($2::text IS NULL OR catalog_prefix_or_name::text > $2)
                       AND ($3::text IS NULL OR catalog_prefix_or_name::text ^@ $3)
+                      AND ($5::text[] IS NULL OR catalog_prefix_or_name::text = ANY($5))
                     ORDER BY catalog_prefix_or_name ASC
                     LIMIT $4 + 1
                     "#,
@@ -171,6 +173,7 @@ impl AlertConfigsQuery {
                     after.as_deref(),
                     prefix_starts_with.as_deref(),
                     limit as i64,
+                    prefix_in.as_deref(),
                 )
                 .fetch_all(&env.pg_pool)
                 .await
@@ -577,5 +580,152 @@ mod test {
             )
             .await;
         insta::assert_json_snapshot!("effective_defaults_plus_prefix_override", response);
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_alert_configs_filter(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        // Alice can read `aliceCo/` (admin grant) and `ops/dp/public/` (role
+        // grant), but not `otherCo/`. Seed one config row per prefix.
+        for name in ["aliceCo/", "aliceCo/team/", "otherCo/"] {
+            sqlx::query("INSERT INTO alert_configs (catalog_prefix_or_name, config) VALUES ($1, '{}'::jsonb)")
+                .bind(name)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        // `gate: false` serves the real authorization snapshot immediately.
+        // Unlike the invite-link tests, this test seeds rows with raw SQL and
+        // never runs an authorized mutation first, so nothing would otherwise
+        // advance a gated snapshot past its initial empty state.
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), false).await,
+        )
+        .await;
+        let alice_token = server.make_access_token(
+            uuid::Uuid::from_bytes([0x11; 16]),
+            Some("alice@example.test"),
+        );
+
+        // Helper: run a filter and return the returned catalog_prefix_or_name
+        // values (already sorted ascending by the query), asserting no errors.
+        async fn names(
+            server: &test_server::TestServer,
+            token: &str,
+            filter: serde_json::Value,
+        ) -> Vec<String> {
+            let response: serde_json::Value = server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                            query($filter: AlertConfigsFilter) {
+                                alertConfigs(filter: $filter) {
+                                    edges { node { catalogPrefixOrName } }
+                                }
+                            }
+                        "#,
+                        "variables": { "filter": filter },
+                    }),
+                    Some(token),
+                )
+                .await;
+            assert!(
+                response.get("errors").is_none(),
+                "unexpected errors: {response}"
+            );
+            response["data"]["alertConfigs"]["edges"]
+                .as_array()
+                .expect("edges array")
+                .iter()
+                .map(|edge| {
+                    edge["node"]["catalogPrefixOrName"]
+                        .as_str()
+                        .unwrap()
+                        .to_string()
+                })
+                .collect()
+        }
+
+        // No filter returns every readable row and never `otherCo/`.
+        let all = names(&server, &alice_token, serde_json::json!({})).await;
+        assert_eq!(all, vec!["aliceCo/", "aliceCo/team/"]);
+
+        // `startsWith` narrows by subtree.
+        let subtree = names(
+            &server,
+            &alice_token,
+            serde_json::json!({ "catalogPrefixOrName": { "startsWith": "aliceCo/team/" } }),
+        )
+        .await;
+        assert_eq!(subtree, vec!["aliceCo/team/"]);
+
+        // `in` matches an exact set. Alice can read two prefixes, so this also
+        // exercises the retain() that narrows the authorized set down before
+        // the MAX_PREFIXES guard.
+        let exact_one = names(
+            &server,
+            &alice_token,
+            serde_json::json!({ "catalogPrefixOrName": { "in": ["aliceCo/"] } }),
+        )
+        .await;
+        assert_eq!(exact_one, vec!["aliceCo/"]);
+
+        // `startsWith` and `in` are mutually exclusive prefix-scoping modes;
+        // providing both is rejected rather than intersected.
+        let both: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        alertConfigs(filter: { catalogPrefixOrName: { startsWith: "aliceCo/", in: ["aliceCo/team/"] } }) {
+                            edges { node { catalogPrefixOrName } }
+                        }
+                    }"#
+                }),
+                Some(&alice_token),
+            )
+            .await;
+        assert!(
+            both["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "combining `startsWith` and `in` should be rejected: {both}"
+        );
+
+        // A cross-tenant `in` entry Alice cannot read is dropped, not honored.
+        let cross_tenant = names(
+            &server,
+            &alice_token,
+            serde_json::json!({ "catalogPrefixOrName": { "in": ["otherCo/"] } }),
+        )
+        .await;
+        assert!(cross_tenant.is_empty());
+
+        // An empty `in` set is rejected at input validation.
+        let empty_in: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        alertConfigs(filter: { catalogPrefixOrName: { in: [] } }) {
+                            edges { node { catalogPrefixOrName } }
+                        }
+                    }"#
+                }),
+                Some(&alice_token),
+            )
+            .await;
+        assert!(
+            empty_in["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "empty `in` should be rejected: {empty_in}"
+        );
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -665,9 +665,8 @@ mod test {
         .await;
         assert_eq!(subtree, vec!["aliceCo/team/"]);
 
-        // `in` matches an exact set. Alice can read two prefixes, so this also
-        // exercises the retain() that narrows the authorized set down before
-        // the MAX_PREFIXES guard.
+        // `in` matches an exact set: only the requested prefix is returned,
+        // even though Alice can also read `aliceCo/team/`.
         let exact_one = names(
             &server,
             &alice_token,
@@ -727,5 +726,126 @@ mod test {
                 .is_some_and(|errors| !errors.is_empty()),
             "empty `in` should be rejected: {empty_in}"
         );
+
+        // An `in` set larger than the 100-entry cap is rejected at input
+        // validation, bounding the caller-controlled side of the work.
+        let over_cap: Vec<String> = (0..101).map(|n| format!("aliceCo/{n}/")).collect();
+        let too_many: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query($in: [String!]) {
+                        alertConfigs(filter: { catalogPrefixOrName: { in: $in } }) {
+                            edges { node { catalogPrefixOrName } }
+                        }
+                    }"#,
+                    "variables": { "in": over_cap },
+                }),
+                Some(&alice_token),
+            )
+            .await;
+        assert!(
+            too_many["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "`in` over the 100-entry cap should be rejected: {too_many}"
+        );
+    }
+
+    // Regression coverage for the reason `narrow_to_exact_set` runs before the
+    // `MAX_PREFIXES` guard: a caller who can read more than `MAX_PREFIXES`
+    // prefixes is refused an unfiltered listing, but an `in` filter narrows the
+    // authorized set back under the cap so the same caller succeeds.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes"))
+    )]
+    async fn test_alert_configs_in_narrows_past_max_prefixes(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        // Grant Bob read on `MAX_PREFIXES + 5` non-overlapping prefixes, each
+        // with a config row. None is a prefix of another, so parent-pruning
+        // leaves the full set and the count exceeds the guard.
+        let bob_uid = uuid::Uuid::from_bytes([0x22; 16]);
+        sqlx::query("INSERT INTO auth.users (id, email) VALUES ($1, 'bob@example.test')")
+            .bind(bob_uid)
+            .execute(&pool)
+            .await
+            .unwrap();
+        for n in 0..(MAX_PREFIXES + 5) {
+            let prefix = format!("tenant{n:02}/");
+            sqlx::query(
+                "INSERT INTO public.user_grants (user_id, object_role, capability) VALUES ($1, $2, 'read')",
+            )
+            .bind(bob_uid)
+            .bind(&prefix)
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query("INSERT INTO alert_configs (catalog_prefix_or_name, config) VALUES ($1, '{}'::jsonb)")
+                .bind(&prefix)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), false).await,
+        )
+        .await;
+        let bob_token = server.make_access_token(bob_uid, Some("bob@example.test"));
+
+        // Unfiltered: the readable set exceeds `MAX_PREFIXES`, so the resolver
+        // refuses rather than scanning all of them.
+        let unfiltered: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        alertConfigs { edges { node { catalogPrefixOrName } } }
+                    }"#
+                }),
+                Some(&bob_token),
+            )
+            .await;
+        assert!(
+            unfiltered["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "unfiltered query over MAX_PREFIXES should be rejected: {unfiltered}"
+        );
+
+        // `in` narrows the authorized set below the cap, so the same caller now
+        // gets a successful, exact-set result.
+        let narrowed: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        alertConfigs(filter: { catalogPrefixOrName: { in: ["tenant00/", "tenant01/", "tenant02/"] } }) {
+                            edges { node { catalogPrefixOrName } }
+                        }
+                    }"#
+                }),
+                Some(&bob_token),
+            )
+            .await;
+        assert!(
+            narrowed.get("errors").is_none(),
+            "narrowed query should succeed: {narrowed}"
+        );
+        let names: Vec<String> = narrowed["data"]["alertConfigs"]["edges"]
+            .as_array()
+            .expect("edges array")
+            .iter()
+            .map(|edge| {
+                edge["node"]["catalogPrefixOrName"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(names, vec!["tenant00/", "tenant01/", "tenant02/"]);
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -40,9 +40,44 @@ pub(super) fn authorized_prefixes(
     pruned
 }
 
+/// Resolves the caller's prefixes for `min_capability`, narrowed by an optional
+/// `PrefixFilter`, and returns them with the filter's decomposed
+/// `startsWith`/`in` parts (which callers bind into their own SQL). `field`
+/// names the GraphQL input field for the mutual-exclusion error.
+///
+/// This chains the three steps every prefix-scoped list query repeats —
+/// `PrefixFilter::into_parts`, `authorized_prefixes`, and
+/// `PrefixFilter::narrow_to_exact_set` — so the narrow-only invariant (a filter
+/// can only remove authorized prefixes, never add them) has a single owner.
+pub(super) fn filtered_authorized_prefixes(
+    role_grants: &tables::RoleGrants,
+    user_grants: &tables::UserGrants,
+    user_id: uuid::Uuid,
+    min_capability: impl Into<models::authz::CapabilitySet>,
+    filter: Option<super::filters::PrefixFilter>,
+    field: &str,
+) -> async_graphql::Result<(Vec<String>, Option<String>, Option<Vec<String>>)> {
+    let (starts_with, r#in) = match filter {
+        Some(cp) => cp.into_parts(field)?,
+        None => (None, None),
+    };
+    let mut prefixes = authorized_prefixes(
+        role_grants,
+        user_grants,
+        user_id,
+        min_capability,
+        starts_with.as_deref(),
+    );
+    if let Some(exact) = r#in.as_deref() {
+        super::filters::PrefixFilter::narrow_to_exact_set(&mut prefixes, exact);
+    }
+    Ok((prefixes, starts_with, r#in))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::authorized_prefixes;
+    use super::super::filters::PrefixFilter;
+    use super::{authorized_prefixes, filtered_authorized_prefixes};
     use models::Capability::{Admin, Read, Write};
 
     fn make_grants(
@@ -279,5 +314,87 @@ mod tests {
         // min=Write: both qualify on their own bits; parent prunes child.
         let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
         assert_eq!(result, vec!["acmeCo/"]);
+    }
+
+    #[test]
+    fn filtered_no_filter_returns_all_prefixes_and_no_parts() {
+        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
+
+        let (prefixes, starts_with, r#in) =
+            filtered_authorized_prefixes(&rg, &ug, ALICE, Admin, None, "filter.catalogPrefix")
+                .unwrap();
+        assert_eq!(prefixes, vec!["acmeCo/", "beta/"]);
+        assert_eq!(starts_with, None);
+        assert_eq!(r#in, None);
+    }
+
+    #[test]
+    fn filtered_starts_with_narrows_by_subtree_and_returns_part() {
+        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
+
+        let filter = PrefixFilter {
+            starts_with: Some("acmeCo/".to_string()),
+            r#in: None,
+        };
+        let (prefixes, starts_with, r#in) = filtered_authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            Admin,
+            Some(filter),
+            "filter.catalogPrefix",
+        )
+        .unwrap();
+        assert_eq!(prefixes, vec!["acmeCo/"]);
+        assert_eq!(starts_with.as_deref(), Some("acmeCo/"));
+        assert_eq!(r#in, None);
+    }
+
+    #[test]
+    fn filtered_in_narrows_to_exact_set_and_returns_part() {
+        // `authorized_prefixes` runs with no subtree filter (startsWith is None
+        // when `in` is set), so both grants come back; `narrow_to_exact_set`
+        // then drops everything not overlapping the `in` set.
+        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
+
+        let filter = PrefixFilter {
+            starts_with: None,
+            r#in: Some(vec!["acmeCo/".to_string()]),
+        };
+        let (prefixes, starts_with, r#in) = filtered_authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            Admin,
+            Some(filter),
+            "filter.catalogPrefix",
+        )
+        .unwrap();
+        assert_eq!(prefixes, vec!["acmeCo/"]);
+        assert_eq!(starts_with, None);
+        assert_eq!(r#in, Some(vec!["acmeCo/".to_string()]));
+    }
+
+    #[test]
+    fn filtered_propagates_mutual_exclusion_error() {
+        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin)], &[]);
+
+        let filter = PrefixFilter {
+            starts_with: Some("acmeCo/".to_string()),
+            r#in: Some(vec!["acmeCo/".to_string()]),
+        };
+        let err = filtered_authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            Admin,
+            Some(filter),
+            "filter.catalogPrefix",
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "`filter.catalogPrefix.startsWith` and `.in` are mutually exclusive; provide only one"
+        );
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/filters.rs
+++ b/crates/control-plane-api/src/server/public/graphql/filters.rs
@@ -13,5 +13,130 @@ pub struct DateFilter {
 
 #[derive(Debug, Clone, Default, async_graphql::InputObject)]
 pub struct PrefixFilter {
+    /// Match values that start with this prefix — a subtree match, e.g.
+    /// `acmeCo/` matches `acmeCo/`, `acmeCo/team/`, and so on.
     pub starts_with: Option<String>,
+    /// Match values exactly equal to any entry in this set. When provided the
+    /// set must be non-empty; an empty `in` is rejected during input
+    /// validation rather than silently matching nothing (or everything).
+    /// `startsWith` and `in` are mutually exclusive: a resolver rejects a
+    /// filter that sets both, so a prefix scope is always either a subtree
+    /// (`startsWith`) or an exact set (`in`), never a mix.
+    #[graphql(validator(min_items = 1))]
+    pub r#in: Option<Vec<String>>,
+}
+
+impl PrefixFilter {
+    /// Enforces that `startsWith` and `in` are not both set — they are mutually
+    /// exclusive prefix-scoping modes — and returns `(startsWith, in)`. `field`
+    /// names the enclosing GraphQL input field for the error message, e.g.
+    /// `filter.catalogPrefix`.
+    pub fn into_parts(
+        self,
+        field: &str,
+    ) -> async_graphql::Result<(Option<String>, Option<Vec<String>>)> {
+        if self.starts_with.is_some() && self.r#in.is_some() {
+            return Err(async_graphql::Error::new(format!(
+                "`{field}.startsWith` and `.in` are mutually exclusive; provide only one"
+            )));
+        }
+        Ok((self.starts_with, self.r#in))
+    }
+
+    /// Narrows a caller's `authorized` prefixes to those that overlap the exact
+    /// `in` set, so a `MAX_PREFIXES` guard stays meaningful for callers who can
+    /// access many prefixes. The overlap is bidirectional (an `in` entry may be
+    /// an ancestor or a descendant of an authorized prefix) and deliberately
+    /// approximate: it can only remove entries, never add them, so it cannot
+    /// widen visibility. Exact membership is still enforced by the resolver's
+    /// SQL (`= ANY($in)`) against these authorized prefixes.
+    pub fn narrow_to_exact_set<S: AsRef<str>>(authorized: &mut Vec<String>, exact: &[S]) {
+        authorized.retain(|a| {
+            exact.iter().any(|e| {
+                let e = e.as_ref();
+                e.starts_with(a.as_str()) || a.as_str().starts_with(e)
+            })
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PrefixFilter;
+
+    #[test]
+    fn into_parts_passes_through_at_most_one_mode() {
+        // Neither mode set.
+        let (starts_with, r#in) = PrefixFilter::default()
+            .into_parts("filter.catalogPrefix")
+            .unwrap();
+        assert_eq!(starts_with, None);
+        assert_eq!(r#in, None);
+
+        // `startsWith` alone.
+        let (starts_with, r#in) = PrefixFilter {
+            starts_with: Some("acmeCo/".to_string()),
+            r#in: None,
+        }
+        .into_parts("filter.catalogPrefix")
+        .unwrap();
+        assert_eq!(starts_with.as_deref(), Some("acmeCo/"));
+        assert_eq!(r#in, None);
+
+        // `in` alone.
+        let (starts_with, r#in) = PrefixFilter {
+            starts_with: None,
+            r#in: Some(vec!["acmeCo/".to_string()]),
+        }
+        .into_parts("filter.catalogPrefix")
+        .unwrap();
+        assert_eq!(starts_with, None);
+        assert_eq!(r#in, Some(vec!["acmeCo/".to_string()]));
+    }
+
+    #[test]
+    fn into_parts_rejects_both_modes_and_names_the_field() {
+        let err = PrefixFilter {
+            starts_with: Some("acmeCo/".to_string()),
+            r#in: Some(vec!["acmeCo/".to_string()]),
+        }
+        .into_parts("filter.catalogPrefix")
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "`filter.catalogPrefix.startsWith` and `.in` are mutually exclusive; provide only one"
+        );
+    }
+
+    #[test]
+    fn narrow_to_exact_set_retains_only_overlapping_prefixes() {
+        // Overlap is bidirectional: an exact entry keeps an authorized prefix
+        // when it equals, descends from, or is an ancestor of it. Disjoint
+        // entries drop it, and an empty exact set drops everything. Retained
+        // entries keep their original order.
+        let cases: &[(&[&str], &[&str], &[&str])] = &[
+            // Equal.
+            (&["acmeCo/"], &["acmeCo/"], &["acmeCo/"]),
+            // Exact entry descends from the authorized prefix.
+            (&["acmeCo/"], &["acmeCo/team/"], &["acmeCo/"]),
+            // Exact entry is an ancestor of the authorized prefix.
+            (&["acmeCo/team/"], &["acmeCo/"], &["acmeCo/team/"]),
+            // Disjoint.
+            (&["acmeCo/"], &["betaCo/"], &[]),
+            // Mixed: only overlapping authorized prefixes survive.
+            (
+                &["acmeCo/", "acmeCo/team/", "betaCo/"],
+                &["acmeCo/", "ghostCo/"],
+                &["acmeCo/", "acmeCo/team/"],
+            ),
+            // Empty exact set overlaps nothing.
+            (&["acmeCo/"], &[], &[]),
+        ];
+        for &(authorized, exact, expected) in cases {
+            let mut got: Vec<String> = authorized.iter().map(|s| s.to_string()).collect();
+            PrefixFilter::narrow_to_exact_set(&mut got, exact);
+            let want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+            assert_eq!(got, want, "authorized={authorized:?} exact={exact:?}");
+        }
+    }
 }

--- a/crates/control-plane-api/src/server/public/graphql/filters.rs
+++ b/crates/control-plane-api/src/server/public/graphql/filters.rs
@@ -16,13 +16,16 @@ pub struct PrefixFilter {
     /// Match values that start with this prefix — a subtree match, e.g.
     /// `acmeCo/` matches `acmeCo/`, `acmeCo/team/`, and so on.
     pub starts_with: Option<String>,
-    /// Match values exactly equal to any entry in this set. When provided the
-    /// set must be non-empty; an empty `in` is rejected during input
-    /// validation rather than silently matching nothing (or everything).
+    /// Match values exactly equal to any entry in this set. The set must hold
+    /// between 1 and 100 entries: an empty `in` is rejected during input
+    /// validation rather than silently matching nothing (or everything), and
+    /// the upper bound keeps this caller-controlled set from driving unbounded
+    /// work — every entry is narrowed against the caller's authorized prefixes
+    /// in memory and bound into a SQL `= ANY(...)` on each request.
     /// `startsWith` and `in` are mutually exclusive: a resolver rejects a
     /// filter that sets both, so a prefix scope is always either a subtree
     /// (`startsWith`) or an exact set (`in`), never a mix.
-    #[graphql(validator(min_items = 1))]
+    #[graphql(validator(min_items = 1, max_items = 100))]
     pub r#in: Option<Vec<String>>,
 }
 

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -41,6 +41,9 @@ pub type PaginatedInviteLinks = connection::Connection<
     connection::DisableNodesField,
 >;
 
+/// Composable filter for the `inviteLinks` query. Every field is optional and
+/// only narrows the result set; the caller's admin scope is enforced
+/// independently, so a filter can never widen what a caller may see.
 #[derive(Debug, Clone, Default, async_graphql::InputObject)]
 pub struct InviteLinksFilter {
     pub single_use: Option<filters::BoolFilter>,
@@ -58,7 +61,8 @@ impl InviteLinksQuery {
     /// List invite links the caller has admin access to.
     ///
     /// Returns invite links under all prefixes where the caller has admin
-    /// capability, optionally narrowed by a prefix filter.
+    /// capability, optionally narrowed by a prefix filter — a subtree
+    /// (`startsWith`) or an exact set (`in`), not both.
     async fn invite_links(
         &self,
         ctx: &Context<'_>,
@@ -72,17 +76,16 @@ impl InviteLinksQuery {
             .as_ref()
             .and_then(|f| f.single_use.as_ref())
             .and_then(|f| f.eq);
-        let prefix_starts_with = filter
-            .and_then(|f| f.catalog_prefix)
-            .and_then(|f| f.starts_with);
-
-        let admin_prefixes = super::authorized_prefixes::authorized_prefixes(
-            &env.snapshot().role_grants,
-            &env.snapshot().user_grants,
-            env.claims()?.sub,
-            models::Capability::Admin,
-            prefix_starts_with.as_deref(),
-        );
+        let snapshot = env.snapshot();
+        let (admin_prefixes, prefix_starts_with, prefix_in) =
+            super::authorized_prefixes::filtered_authorized_prefixes(
+                &snapshot.role_grants,
+                &snapshot.user_grants,
+                env.claims()?.sub,
+                models::Capability::Admin,
+                filter.and_then(|f| f.catalog_prefix),
+                "filter.catalogPrefix",
+            )?;
 
         if admin_prefixes.is_empty() {
             return Ok(PaginatedInviteLinks::new(false, false));
@@ -116,6 +119,7 @@ impl InviteLinksQuery {
                 LEFT JOIN tenants t ON il.catalog_prefix::text ^@ t.tenant
                 WHERE il.catalog_prefix::text ^@ ANY($1)
                   AND ($5::text IS NULL OR il.catalog_prefix::text ^@ $5)
+                  AND ($6::text[] IS NULL OR il.catalog_prefix::text = ANY($6))
                   AND ($4::bool IS NULL OR il.single_use = $4)
                   AND ($2::timestamptz IS NULL OR il.created_at < $2)
                 ORDER BY il.created_at DESC
@@ -126,6 +130,7 @@ impl InviteLinksQuery {
                     limit as i64,
                     single_use_eq,
                     prefix_starts_with.as_deref(),
+                    prefix_in.as_deref(),
                 )
                 .fetch_all(&env.pg_pool)
                 .await?;
@@ -1512,6 +1517,111 @@ mod test {
             parent_filter_edges.len(),
             4,
             "parent prefix filter returns all invite links under the grant"
+        );
+
+        // `in` matches an exact set of prefixes. Helper: run an `in` filter and
+        // return the count of returned links, asserting no GraphQL errors.
+        async fn in_filter_count(
+            server: &test_server::TestServer,
+            token: &str,
+            prefixes: serde_json::Value,
+        ) -> usize {
+            let response: serde_json::Value = server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                        query($in: [String!]) {
+                            inviteLinks(filter: { catalogPrefix: { in: $in } }) {
+                                edges { node { catalogPrefix } }
+                            }
+                        }"#,
+                        "variables": { "in": prefixes },
+                    }),
+                    Some(token),
+                )
+                .await;
+            assert!(
+                response.get("errors").is_none(),
+                "unexpected errors: {response}"
+            );
+            response["data"]["inviteLinks"]["edges"]
+                .as_array()
+                .expect("should have edges")
+                .len()
+        }
+
+        // An exact `in` entry matches only links at exactly that prefix, not the
+        // whole subtree — the three links created at "aliceCo/", but not the one
+        // under "aliceCo/data/invite/".
+        assert_eq!(
+            in_filter_count(&server, &alice_token, serde_json::json!(["aliceCo/"])).await,
+            3,
+            "`in: [aliceCo/]` returns only the exact-prefix links"
+        );
+
+        // The sub-prefix entry is authorized because it descends from Alice's
+        // "aliceCo/" admin grant (the retain keeps that grant), and the SQL
+        // exact-match then selects just the one link under it.
+        assert_eq!(
+            in_filter_count(
+                &server,
+                &alice_token,
+                serde_json::json!(["aliceCo/data/invite/"])
+            )
+            .await,
+            1,
+            "`in` narrows to an exact sub-prefix authorized via a broader grant"
+        );
+
+        // A cross-tenant entry Alice cannot admin is dropped rather than
+        // widening scope, leaving no authorized prefixes and an empty result.
+        assert_eq!(
+            in_filter_count(&server, &alice_token, serde_json::json!(["otherCo/"])).await,
+            0,
+            "an unauthorized `in` entry is dropped, not honored"
+        );
+
+        // `startsWith` and `in` are mutually exclusive prefix-scoping modes;
+        // providing both is rejected rather than intersected.
+        let both: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        inviteLinks(filter: { catalogPrefix: { startsWith: "aliceCo/", in: ["aliceCo/"] } }) {
+                            edges { node { catalogPrefix } }
+                        }
+                    }"#
+                }),
+                Some(&alice_token),
+            )
+            .await;
+        assert!(
+            both["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "combining `startsWith` and `in` should be rejected: {both}"
+        );
+
+        // An empty `in` set is rejected at input validation.
+        let empty_in: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        inviteLinks(filter: { catalogPrefix: { in: [] } }) {
+                            edges { node { catalogPrefix } }
+                        }
+                    }"#
+                }),
+                Some(&alice_token),
+            )
+            .await;
+        assert!(
+            empty_in["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "empty `in` should be rejected: {empty_in}"
         );
     }
 

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -1,3 +1,4 @@
+use super::filters;
 use crate::directives::storage_mappings::{
     collection_and_recovery_spec_from, insert_storage_mapping, strip_collection_data_suffix,
     update_storage_mapping, upsert_storage_mapping,
@@ -589,6 +590,46 @@ pub struct StorageMappingsBy {
     pub under_prefix: Option<models::Prefix>,
 }
 
+impl StorageMappingsBy {
+    /// Maps the deprecated `by` selection onto the equivalent `PrefixFilter`:
+    /// `underPrefix` is a `startsWith` subtree and `exactPrefixes` is an `in`
+    /// exact set, so `by` and `filter` resolve through one shared path. Enforces
+    /// that exactly one mode is set, naming `by`'s own fields in the error.
+    fn into_prefix_filter(self) -> async_graphql::Result<filters::PrefixFilter> {
+        let exact_prefixes = self.exact_prefixes.unwrap_or_default();
+        match (exact_prefixes.is_empty(), self.under_prefix.is_none()) {
+            (true, true) => Err(async_graphql::Error::new(
+                "provide exactly one of `exactPrefixes` or `underPrefix`, or omit `by` entirely",
+            )),
+            (false, false) => Err(async_graphql::Error::new(
+                "`exactPrefixes` and `underPrefix` are mutually exclusive; provide only one",
+            )),
+            (false, true) => Ok(filters::PrefixFilter {
+                starts_with: None,
+                r#in: Some(exact_prefixes.iter().map(|p| p.to_string()).collect()),
+            }),
+            (true, false) => Ok(filters::PrefixFilter {
+                starts_with: self.under_prefix.map(|p| p.to_string()),
+                r#in: None,
+            }),
+        }
+    }
+}
+
+/// Composable filter for the `storageMappings` query. Every field is optional
+/// and only narrows the result set; the caller's catalog-read scope is enforced
+/// independently, so a filter can never widen what a caller may see.
+#[derive(Debug, Clone, Default, async_graphql::InputObject)]
+pub struct StorageMappingsFilter {
+    /// Narrow by catalog prefix. `startsWith` matches a whole subtree —
+    /// mappings for `acmeCo/`, `acmeCo/team-a/`, etc. — like the deprecated
+    /// `by: { underPrefix }`. `in` matches an exact set of prefixes, like
+    /// `by: { exactPrefixes }`. The two are alternative query modes and are
+    /// mutually exclusive. Either way, results compose with (never widen past)
+    /// the caller's authorized read prefixes.
+    pub catalog_prefix: Option<filters::PrefixFilter>,
+}
+
 /// A storage mapping that defines where collection data is stored.
 #[derive(Debug, Clone, async_graphql::SimpleObject)]
 pub struct StorageMapping {
@@ -622,13 +663,18 @@ impl StorageMappingsQuery {
     /// Returns storage mappings accessible to the current user.
     ///
     /// Returns mappings under every prefix where the caller has catalog-read
-    /// capability. The optional `by` filter narrows those authorized results.
+    /// capability. The optional `filter` narrows those authorized results.
     /// Results are paginated and sorted by catalog_prefix.
     pub async fn storage_mappings(
         &self,
         ctx: &Context<'_>,
-        #[graphql(deprecation = "Omit this argument to return all accessible storage mappings.")]
+        #[graphql(
+            deprecation = "Prefer `filter: { catalogPrefix }`: `startsWith` replaces `underPrefix` \
+                                 and `in` replaces `exactPrefixes`. `by` is retained only for \
+                                 existing clients."
+        )]
         by: Option<StorageMappingsBy>,
+        filter: Option<StorageMappingsFilter>,
         after: Option<String>,
         before: Option<String>,
         first: Option<i32>,
@@ -636,47 +682,38 @@ impl StorageMappingsQuery {
     ) -> async_graphql::Result<PaginatedStorageMappings> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let (exact_prefixes, under_prefix) = match by {
-            None => (Vec::new(), None),
-            Some(StorageMappingsBy {
-                exact_prefixes,
-                under_prefix,
-            }) => {
-                let exact_prefixes = exact_prefixes.unwrap_or_default();
-                match (exact_prefixes.is_empty(), under_prefix.is_none()) {
-                    (true, true) => {
-                        return Err(
-                            "provide exactly one of `exactPrefixes` or `underPrefix`, or omit `by` entirely".into(),
-                        );
-                    }
-                    (false, false) => {
-                        return Err(
-                            "`exactPrefixes` and `underPrefix` are mutually exclusive; provide only one"
-                                .into(),
-                        );
-                    }
-                    _ => (exact_prefixes, under_prefix),
+        // `filter` is the going-forward replacement for `by`. Map the
+        // deprecated `by` onto the same `PrefixFilter` shape — `underPrefix` is
+        // a `startsWith` subtree, `exactPrefixes` is an `in` exact set — so both
+        // resolve through the shared `filtered_authorized_prefixes`. `by` and
+        // `filter` are mutually exclusive.
+        let prefix_filter = match (by, filter.and_then(|f| f.catalog_prefix)) {
+            (Some(by), filter_catalog_prefix) => {
+                if filter_catalog_prefix
+                    .is_some_and(|cp| cp.starts_with.is_some() || cp.r#in.is_some())
+                {
+                    return Err(
+                        "provide either `by` or `filter`, not both; `by` is deprecated".into(),
+                    );
                 }
+                Some(by.into_prefix_filter()?)
             }
+            (None, filter_catalog_prefix) => filter_catalog_prefix,
         };
 
         let snapshot = env.snapshot();
-        let mut read_prefixes = super::authorized_prefixes::authorized_prefixes(
-            &snapshot.role_grants,
-            &snapshot.user_grants,
-            env.claims()?.sub,
-            models::authz::Capability::CatalogRead,
-            under_prefix.as_ref().map(|prefix| prefix.as_str()),
-        );
-
-        if !exact_prefixes.is_empty() {
-            read_prefixes.retain(|authorized| {
-                exact_prefixes.iter().any(|exact| {
-                    exact.as_str().starts_with(authorized.as_str())
-                        || authorized.starts_with(exact.as_str())
-                })
-            });
-        }
+        let (read_prefixes, under_prefix, exact_prefixes) =
+            super::authorized_prefixes::filtered_authorized_prefixes(
+                &snapshot.role_grants,
+                &snapshot.user_grants,
+                env.claims()?.sub,
+                models::authz::Capability::CatalogRead,
+                prefix_filter,
+                "filter.catalogPrefix",
+            )
+            .map(|(prefixes, starts_with, r#in)| {
+                (prefixes, starts_with, r#in.unwrap_or_default())
+            })?;
 
         if read_prefixes.is_empty() {
             return Ok(PaginatedStorageMappings::new(false, false));
@@ -704,7 +741,7 @@ impl StorageMappingsQuery {
                             &env.pg_pool,
                             &read_prefixes,
                             &exact_prefixes,
-                            under_prefix.as_ref(),
+                            under_prefix.as_deref(),
                             before.as_deref(),
                             limit as i64,
                         )
@@ -717,7 +754,7 @@ impl StorageMappingsQuery {
                             &env.pg_pool,
                             &read_prefixes,
                             &exact_prefixes,
-                            under_prefix.as_ref(),
+                            under_prefix.as_deref(),
                             after.as_deref(),
                             limit as i64,
                         )
@@ -780,15 +817,13 @@ struct StorageMappingRow {
 async fn fetch_storage_mappings_after(
     db: &sqlx::PgPool,
     read_prefixes: &[String],
-    exact_prefixes: &[models::Prefix],
-    under_prefix: Option<&models::Prefix>,
+    exact_prefixes: &[String],
+    under_prefix: Option<&str>,
     after: Option<&str>,
     limit: i64,
 ) -> anyhow::Result<Vec<StorageMappingRow>> {
-    // Convert to plain strings to avoid sqlx encoding as `_catalog_name` domain array,
-    // which would trigger domain constraint validation on bind.
-    let exact_prefixes: Vec<String> = exact_prefixes.iter().map(|p| p.to_string()).collect();
-    let under_prefix = under_prefix.map(|p| p.as_str());
+    // Prefixes bind as `text[]`/`text` rather than the `_catalog_name` domain
+    // array, so sqlx does not run domain-constraint validation on bind.
     let filter_all = exact_prefixes.is_empty() && under_prefix.is_none();
 
     let rows = sqlx::query!(
@@ -811,7 +846,7 @@ async fn fetch_storage_mappings_after(
         "#,
         read_prefixes,
         filter_all,
-        &exact_prefixes,
+        exact_prefixes,
         under_prefix,
         after,
         limit,
@@ -832,15 +867,13 @@ async fn fetch_storage_mappings_after(
 async fn fetch_storage_mappings_before(
     db: &sqlx::PgPool,
     read_prefixes: &[String],
-    exact_prefixes: &[models::Prefix],
-    under_prefix: Option<&models::Prefix>,
+    exact_prefixes: &[String],
+    under_prefix: Option<&str>,
     before: Option<&str>,
     limit: i64,
 ) -> anyhow::Result<Vec<StorageMappingRow>> {
-    // Convert to plain strings to avoid sqlx encoding as `_catalog_name` domain array,
-    // which would trigger domain constraint validation on bind.
-    let exact_prefixes: Vec<String> = exact_prefixes.iter().map(|p| p.to_string()).collect();
-    let under_prefix = under_prefix.map(|p| p.as_str());
+    // Prefixes bind as `text[]`/`text` rather than the `_catalog_name` domain
+    // array, so sqlx does not run domain-constraint validation on bind.
     let filter_all = exact_prefixes.is_empty() && under_prefix.is_none();
 
     let mut rows = sqlx::query!(
@@ -863,7 +896,7 @@ async fn fetch_storage_mappings_before(
         "#,
         read_prefixes,
         filter_all,
-        &exact_prefixes,
+        exact_prefixes,
         under_prefix,
         before,
         limit,
@@ -887,6 +920,66 @@ async fn fetch_storage_mappings_before(
 #[cfg(test)]
 mod test {
     use crate::test_server;
+
+    #[test]
+    fn by_under_prefix_maps_to_starts_with() {
+        let filter = super::StorageMappingsBy {
+            exact_prefixes: None,
+            under_prefix: Some(models::Prefix::new("acmeCo/")),
+        }
+        .into_prefix_filter()
+        .unwrap();
+        assert_eq!(filter.starts_with.as_deref(), Some("acmeCo/"));
+        assert_eq!(filter.r#in, None);
+    }
+
+    #[test]
+    fn by_exact_prefixes_maps_to_in() {
+        let filter = super::StorageMappingsBy {
+            exact_prefixes: Some(vec![
+                models::Prefix::new("acmeCo/"),
+                models::Prefix::new("betaCo/"),
+            ]),
+            under_prefix: None,
+        }
+        .into_prefix_filter()
+        .unwrap();
+        assert_eq!(filter.starts_with, None);
+        assert_eq!(
+            filter.r#in,
+            Some(vec!["acmeCo/".to_string(), "betaCo/".to_string()])
+        );
+    }
+
+    #[test]
+    fn by_rejects_both_modes() {
+        let err = super::StorageMappingsBy {
+            exact_prefixes: Some(vec![models::Prefix::new("acmeCo/")]),
+            under_prefix: Some(models::Prefix::new("acmeCo/")),
+        }
+        .into_prefix_filter()
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "`exactPrefixes` and `underPrefix` are mutually exclusive; provide only one"
+        );
+    }
+
+    #[test]
+    fn by_rejects_neither_mode() {
+        // Empty `exactPrefixes` counts as absent, so this is the "neither" case
+        // — legacy `by` errors rather than treating it as "match everything".
+        let err = super::StorageMappingsBy {
+            exact_prefixes: Some(vec![]),
+            under_prefix: None,
+        }
+        .into_prefix_filter()
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "provide exactly one of `exactPrefixes` or `underPrefix`, or omit `by` entirely"
+        );
+    }
 
     #[sqlx::test(
         migrations = "../../supabase/migrations",
@@ -995,5 +1088,215 @@ mod test {
           }
         }
         "###);
+    }
+
+    // The `filter` argument scopes by catalog-prefix subtree exactly like the
+    // deprecated `by: { underPrefix }`, and composes with the caller's read
+    // scope. Providing both `by` and `filter` is rejected.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn storage_mappings_filter_scopes_by_prefix(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let spec = crate::TextJson(models::StorageDef {
+            data_planes: Vec::new(),
+            stores: vec![models::Store::example()],
+        });
+        for prefix in ["aliceCo/", "aliceCo/team/", "otherCo/"] {
+            sqlx::query("INSERT INTO storage_mappings (catalog_prefix, spec) VALUES ($1, $2)")
+                .bind(prefix)
+                .bind(&spec)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let snapshot = test_server::snapshot(pool.clone(), false).await;
+        let server = test_server::TestServer::start(pool.clone(), snapshot).await;
+        let alice_token = server.make_access_token(uuid::Uuid::from_bytes([0x11; 16]), None);
+
+        // Helper: run the query with the given variables and return the sorted
+        // list of returned catalog prefixes, asserting no GraphQL errors.
+        async fn prefixes(
+            server: &test_server::TestServer,
+            token: &str,
+            variables: serde_json::Value,
+        ) -> Vec<String> {
+            let response: serde_json::Value = server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                            query($by: StorageMappingsBy, $filter: StorageMappingsFilter) {
+                                storageMappings(by: $by, filter: $filter) {
+                                    edges { node { catalogPrefix } }
+                                }
+                            }
+                        "#,
+                        "variables": variables,
+                    }),
+                    Some(token),
+                )
+                .await;
+            assert!(
+                response.get("errors").is_none(),
+                "unexpected errors: {response}"
+            );
+            response["data"]["storageMappings"]["edges"]
+                .as_array()
+                .expect("edges array")
+                .iter()
+                .map(|edge| edge["node"]["catalogPrefix"].as_str().unwrap().to_string())
+                .collect()
+        }
+
+        // A prefix filter narrows to the matching subtree, the same result the
+        // deprecated `by: { underPrefix }` produces.
+        let narrowed = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({ "filter": { "catalogPrefix": { "startsWith": "aliceCo/team/" } } }),
+        )
+        .await;
+        assert_eq!(narrowed, vec!["aliceCo/team/"]);
+
+        // A broader prefix returns the whole authorized subtree.
+        let subtree = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({ "filter": { "catalogPrefix": { "startsWith": "aliceCo/" } } }),
+        )
+        .await;
+        assert_eq!(subtree, vec!["aliceCo/", "aliceCo/team/"]);
+
+        // The filter can never widen scope past the caller's grants.
+        let cross_tenant = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({ "filter": { "catalogPrefix": { "startsWith": "otherCo/" } } }),
+        )
+        .await;
+        assert!(cross_tenant.is_empty());
+
+        // Omitting the filter returns every accessible mapping. This is the
+        // baseline the present-but-empty filter forms must match.
+        let no_filter = prefixes(&server, &alice_token, serde_json::json!({})).await;
+        assert_eq!(no_filter, vec!["aliceCo/", "aliceCo/team/"]);
+
+        // An empty filter — and an empty `catalogPrefix` within it — behave
+        // like omitting the filter: neither narrows anything.
+        let empty_filter =
+            prefixes(&server, &alice_token, serde_json::json!({ "filter": {} })).await;
+        assert_eq!(empty_filter, no_filter);
+        let empty_catalog_prefix = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({ "filter": { "catalogPrefix": {} } }),
+        )
+        .await;
+        assert_eq!(empty_catalog_prefix, no_filter);
+
+        // `in` matches an exact set of prefixes (unlike `startsWith`, it does
+        // not descend into the subtree), the same result `by: { exactPrefixes }`
+        // produces.
+        let exact_one = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({ "filter": { "catalogPrefix": { "in": ["aliceCo/"] } } }),
+        )
+        .await;
+        assert_eq!(exact_one, vec!["aliceCo/"]);
+
+        // A cross-tenant `in` entry is dropped rather than widening scope; an
+        // unknown prefix simply matches nothing. This also confirms several
+        // `in` entries return every authorized exact match (`filters::test`
+        // covers the multi-entry narrowing logic directly).
+        let exact_cross_tenant = prefixes(
+            &server,
+            &alice_token,
+            serde_json::json!({
+                "filter": { "catalogPrefix": { "in": ["aliceCo/", "otherCo/", "ghostCo/"] } }
+            }),
+        )
+        .await;
+        assert_eq!(exact_cross_tenant, vec!["aliceCo/"]);
+
+        // Helper: assert a set of variables is rejected with a GraphQL error.
+        // When `expected_message` is given it must appear in the first error, so
+        // that distinct rejection branches are told apart rather than any error
+        // counting as a pass.
+        async fn expect_error(
+            server: &test_server::TestServer,
+            token: &str,
+            variables: serde_json::Value,
+            expected_message: Option<&str>,
+        ) {
+            let response: serde_json::Value = server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                            query($by: StorageMappingsBy, $filter: StorageMappingsFilter) {
+                                storageMappings(by: $by, filter: $filter) {
+                                    edges { node { catalogPrefix } }
+                                }
+                            }
+                        "#,
+                        "variables": variables,
+                    }),
+                    Some(token),
+                )
+                .await;
+            assert!(
+                response["errors"]
+                    .as_array()
+                    .is_some_and(|errors| !errors.is_empty()),
+                "expected an error for variables {variables}: {response}"
+            );
+            if let Some(expected) = expected_message {
+                let message = response["errors"][0]["message"]
+                    .as_str()
+                    .unwrap_or_default();
+                assert!(
+                    message.contains(expected),
+                    "expected error containing {expected:?}, got {message:?} for variables {variables}"
+                );
+            }
+        }
+
+        // `by` and `filter` are mutually exclusive.
+        expect_error(
+            &server,
+            &alice_token,
+            serde_json::json!({
+                "by": { "underPrefix": "aliceCo/" },
+                "filter": { "catalogPrefix": { "startsWith": "aliceCo/" } },
+            }),
+            Some("provide either `by` or `filter`"),
+        )
+        .await;
+
+        // Within a filter, `startsWith` and `in` are mutually exclusive.
+        expect_error(
+            &server,
+            &alice_token,
+            serde_json::json!({
+                "filter": { "catalogPrefix": { "startsWith": "aliceCo/", "in": ["aliceCo/"] } },
+            }),
+            Some("mutually exclusive; provide only one"),
+        )
+        .await;
+
+        // An empty `in` set is rejected at input validation, rather than
+        // ambiguously meaning "match nothing" or "match everything".
+        expect_error(
+            &server,
+            &alice_token,
+            serde_json::json!({
+                "filter": { "catalogPrefix": { "in": [] } },
+            }),
+            None,
+        )
+        .await;
     }
 }

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -139,7 +139,9 @@ type AlertConfigEntryEdge {
 
 """
 Optional filter for the `alertConfigs` query. When omitted, all accessible
-rows are returned.
+rows are returned. A filter only narrows those results; the caller's
+catalog-read scope is enforced independently, so it can never widen what a
+caller may see.
 """
 input AlertConfigsFilter {
 	"""
@@ -988,6 +990,11 @@ type InviteLinkEdge {
 	cursor: String!
 }
 
+"""
+Composable filter for the `inviteLinks` query. Every field is optional and
+only narrows the result set; the caller's admin scope is enforced
+independently, so a filter can never widen what a caller may see.
+"""
 input InviteLinksFilter {
 	singleUse: BoolFilter
 	catalogPrefix: PrefixFilter
@@ -1523,7 +1530,20 @@ type PendingConfigUpdateStatus {
 scalar Prefix
 
 input PrefixFilter {
+	"""
+	Match values that start with this prefix — a subtree match, e.g.
+	`acmeCo/` matches `acmeCo/`, `acmeCo/team/`, and so on.
+	"""
 	startsWith: String
+	"""
+	Match values exactly equal to any entry in this set. When provided the
+	set must be non-empty; an empty `in` is rejected during input
+	validation rather than silently matching nothing (or everything).
+	`startsWith` and `in` are mutually exclusive: a resolver rejects a
+	filter that sets both, so a prefix scope is always either a subtree
+	(`startsWith`) or an exact set (`in`), never a mix.
+	"""
+	in: [String!]
 }
 
 """
@@ -1798,9 +1818,9 @@ type QueryRoot {
 	Lists alert-config rows visible to the caller.
 	
 	Results are limited to readable prefixes and sorted by
-	`catalog_prefix_or_name`. `filter.catalogPrefixOrName.startsWith` can
-	narrow the results further. Passing a full catalog name returns at
-	most one exact-name row.
+	`catalog_prefix_or_name`. `filter.catalogPrefixOrName` narrows further,
+	by subtree (`startsWith`) or an exact set (`in`) — not both. Passing a
+	full catalog name returns at most one exact-name row.
 	"""
 	alertConfigs(filter: AlertConfigsFilter, after: String, first: Int): AlertConfigEntryConnection!
 	"""
@@ -1816,10 +1836,10 @@ type QueryRoot {
 	Returns storage mappings accessible to the current user.
 	
 	Returns mappings under every prefix where the caller has catalog-read
-	capability. The optional `by` filter narrows those authorized results.
+	capability. The optional `filter` narrows those authorized results.
 	Results are paginated and sorted by catalog_prefix.
 	"""
-	storageMappings(by: StorageMappingsBy @deprecated(reason: "Omit this argument to return all accessible storage mappings."), after: String, before: String, first: Int, last: Int): StorageMappingConnection!
+	storageMappings(by: StorageMappingsBy @deprecated(reason: "Prefer `filter: { catalogPrefix }`: `startsWith` replaces `underPrefix` and `in` replaces `exactPrefixes`. `by` is retained only for existing clients."), filter: StorageMappingsFilter, after: String, before: String, first: Int, last: Int): StorageMappingConnection!
 	"""
 	Returns data planes accessible to the current user.
 	
@@ -1846,7 +1866,8 @@ type QueryRoot {
 	List invite links the caller has admin access to.
 	
 	Returns invite links under all prefixes where the caller has admin
-	capability, optionally narrowed by a prefix filter.
+	capability, optionally narrowed by a prefix filter — a subtree
+	(`startsWith`) or an exact set (`in`), not both.
 	"""
 	inviteLinks(filter: InviteLinksFilter, after: String, first: Int): InviteLinkConnection!
 	"""
@@ -2369,6 +2390,23 @@ input StorageMappingsBy {
 	Exactly one of `exactPrefixes` or `underPrefix` must be provided.
 	"""
 	underPrefix: Prefix
+}
+
+"""
+Composable filter for the `storageMappings` query. Every field is optional
+and only narrows the result set; the caller's catalog-read scope is enforced
+independently, so a filter can never widen what a caller may see.
+"""
+input StorageMappingsFilter {
+	"""
+	Narrow by catalog prefix. `startsWith` matches a whole subtree —
+	mappings for `acmeCo/`, `acmeCo/team-a/`, etc. — like the deprecated
+	`by: { underPrefix }`. `in` matches an exact set of prefixes, like
+	`by: { exactPrefixes }`. The two are alternative query modes and are
+	mutually exclusive. Either way, results compose with (never widen past)
+	the caller's authorized read prefixes.
+	"""
+	catalogPrefix: PrefixFilter
 }
 
 type Tenant {

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -1536,9 +1536,12 @@ input PrefixFilter {
 	"""
 	startsWith: String
 	"""
-	Match values exactly equal to any entry in this set. When provided the
-	set must be non-empty; an empty `in` is rejected during input
-	validation rather than silently matching nothing (or everything).
+	Match values exactly equal to any entry in this set. The set must hold
+	between 1 and 100 entries: an empty `in` is rejected during input
+	validation rather than silently matching nothing (or everything), and
+	the upper bound keeps this caller-controlled set from driving unbounded
+	work — every entry is narrowed against the caller's authorized prefixes
+	in memory and bound into a SQL `= ANY(...)` on each request.
 	`startsWith` and `in` are mutually exclusive: a resolver rejects a
 	filter that sets both, so a prefix scope is always either a subtree
 	(`startsWith`) or an exact set (`in`), never a mix.

--- a/crates/flowctl/src/alerts/configs/mod.rs
+++ b/crates/flowctl/src/alerts/configs/mod.rs
@@ -122,6 +122,7 @@ async fn do_list(args: &ListArgs, ctx: &mut crate::CliContext) -> anyhow::Result
         .map(|p| list_alert_configs::AlertConfigsFilter {
             catalog_prefix_or_name: Some(list_alert_configs::PrefixFilter {
                 starts_with: Some(p.clone()),
+                in_: None,
             }),
         });
     let rows = fetch_all(ctx, filter).await?;
@@ -198,6 +199,7 @@ async fn fetch_existing(
     let filter = Some(list_alert_configs::AlertConfigsFilter {
         catalog_prefix_or_name: Some(list_alert_configs::PrefixFilter {
             starts_with: Some(prefix_or_name.to_string()),
+            in_: None,
         }),
     });
     let rows = fetch_all(ctx, filter).await?;


### PR DESCRIPTION
## Summary

Extends the shared `PrefixFilter` GraphQL input with an exact-set `in` predicate — an alternative to the existing `startsWith` subtree match (the two are mutually exclusive), letting prefix-scoped queries filter by an explicit set of prefixes. `storageMappings` gains a composable `filter` argument built on it, matching the pattern already used by `inviteLinks` (and the in-flight `dataPlanes` filter).

Groundwork for moving the UI's storage-mappings table (estuary/ui#2031) and flowctl onto the shared filter pattern.

## `PrefixFilter`

Two scoping modes, mutually exclusive across every consumer:

```graphql
input PrefixFilter {
  startsWith: String     # subtree match: acmeCo/ matches acmeCo/, acmeCo/team/, ...
  in: [String!]          # exact-set match: only the listed prefixes
}
```

For example, scope a query to an explicit set of prefixes (intersected with what the caller can read):

```graphql
storageMappings(filter: { catalogPrefix: { in: ["acmeCo/", "betaCo/"] } })
```

- A prefix scope is always either a subtree (`startsWith`) or an exact set (`in`), never a mix; supplying both is a request error.
- An empty `in: []` is rejected at input validation, rather than ambiguously meaning "nothing" or "everything".
- All three consumers — `storageMappings`, `alertConfigs`, `inviteLinks` — resolve their scope through one combinator, `filtered_authorized_prefixes`, which chains the mutual-exclusion check (`PrefixFilter::into_parts`), the authorized-prefix lookup, and the exact-set narrowing (`PrefixFilter::narrow_to_exact_set`). The narrow-only invariant — a filter can only remove authorized prefixes, never add them — has a single owner.

## Deprecating `storageMappings(by:)`

`storageMappings` gains `filter: { catalogPrefix }`, deprecating `by` in its favor (`underPrefix → startsWith`, `exactPrefixes → in`). `by` maps onto the same `PrefixFilter` internally and stays until flowctl migrates (#3238).

## Stack / follow-ups

- flowctl (#3238): replace `by: { exactPrefixes }` with `filter: { catalogPrefix: { in } }`, stacked on this PR.
- UI (estuary/ui#2031): switch the storage-mappings table to `filter: { catalogPrefix: { startsWith } }` after a codegen refresh.
