### PR TITLE
data-plane-controller: add GitHub App git auth to replace SSH machine user

### DIFF
--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -58,6 +58,14 @@ jobs:
             DPC_DATABASE_CA=/etc/db-ca.crt
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
             NO_COLOR=1
+            # Git auth for cloning private repos. Leave `ssh` until the GitHub
+            # App is verified, then flip to `github-app` to cut over. See
+            # crates/data-plane-controller/entrypoint.sh.
+            DPC_GIT_AUTH_MODE=ssh
+            # GitHub App identifiers (non-secret). Installation ID is available
+            # once the App is installed on estuary/est-dry-dock.
+            DPC_GITHUB_APP_ID=4126016
+            DPC_GITHUB_INSTALLATION_ID=148554392
 
           secrets: |-
             CONTROL_PLANE_DB_CA_CERT=CONTROL_PLANE_DB_CA_CERT:latest
@@ -66,6 +74,9 @@ jobs:
             DPC_ARM_SUBSCRIPTION_ID=DPC_ARM_SUBSCRIPTION_ID:latest
             DPC_ARM_TENANT_ID=DPC_ARM_TENANT_ID:latest
             DPC_GITHUB_SSH_KEY=DPC_GITHUB_SSH_KEY:latest
+            # GitHub App private key (PEM), stored in estuary-control Secret
+            # Manager alongside DPC_GITHUB_SSH_KEY.
+            DPC_GITHUB_APP_KEY=DPC_GITHUB_APP_KEY:latest
             DPC_IAM_CREDENTIALS=DPC_IAM_CREDENTIALS:latest
             DPC_SERVICE_ACCOUNT=DPC_SERVICE_ACCOUNT:latest
             DPC_VULTR_API_KEY=DPC_VULTR_API_KEY:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "humantime-serde",
  "insta",
  "itertools 0.14.0",
+ "jsonwebtoken",
  "locate-bin",
  "models",
  "ops",

--- a/crates/data-plane-controller/Cargo.toml
+++ b/crates/data-plane-controller/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 itertools = { workspace = true }
+jsonwebtoken = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 rustls = { workspace = true }
 serde = { workspace = true }

--- a/crates/data-plane-controller/entrypoint.sh
+++ b/crates/data-plane-controller/entrypoint.sh
@@ -18,16 +18,29 @@ printf '%s\n' "${DPC_SERVICE_ACCOUNT}" > ${GOOGLE_APPLICATION_CREDENTIALS}
 if [[ "${MODE}" == "service" ]]; then
     # AWS profile to expect in ~/.aws/credentials
     export AWS_PROFILE=data-plane-ops
-    # Disable host-key checks when cloning our git repo.
-    export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
 
     mkdir -p /root/.aws
-    printf '%s\n' "${DPC_GITHUB_SSH_KEY}" > /root/ssh_key
     printf '%s\n' "${DPC_IAM_CREDENTIALS}" > /root/.aws/credentials
 
-    chmod 0400 /root/ssh_key
-    eval "$(ssh-agent -s)"
-    ssh-add /root/ssh_key
+    # Select git authentication for cloning our private repos. This is the
+    # cutover switch from the SSH machine user to a GitHub App: it defaults to
+    # `ssh` so behavior is unchanged until we flip it to `github-app`.
+    if [[ "${DPC_GIT_AUTH_MODE:-ssh}" == "github-app" ]]; then
+        # Rewrite the SSH-style remotes baked into the controller to HTTPS, and
+        # hand git a credential helper that mints and caches short-lived App
+        # installation tokens on demand. Auth stays out of the worker code,
+        # just as ssh-agent did.
+        git config --global url."https://github.com/".insteadOf "git@github.com:"
+        git config --global credential."https://github.com".helper \
+            "!/usr/local/bin/data-plane-controller git-credential"
+    else
+        # SSH machine-user path. Disable host-key checks when cloning our repo.
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
+        printf '%s\n' "${DPC_GITHUB_SSH_KEY}" > /root/ssh_key
+        chmod 0400 /root/ssh_key
+        eval "$(ssh-agent -s)"
+        ssh-add /root/ssh_key
+    fi
 fi
 
 # Log out the IP from which we're running.

--- a/crates/data-plane-controller/src/git_credential.rs
+++ b/crates/data-plane-controller/src/git_credential.rs
@@ -50,7 +50,9 @@ pub async fn run_git_credential(args: GitCredentialArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let token = get_token().await.context("failed to obtain installation token")?;
+    let token = get_token()
+        .await
+        .context("failed to obtain installation token")?;
 
     // Emit the credential to git. The username is fixed for App tokens.
     print!("username=x-access-token\npassword={token}\n\n");
@@ -158,18 +160,15 @@ struct AccessTokenResponse {
 
 /// Sign an App JWT and exchange it for a fresh installation access token.
 async fn mint_token() -> anyhow::Result<CachedToken> {
-    let app_id = std::env::var(ENV_APP_ID)
-        .with_context(|| format!("{ENV_APP_ID} is not set"))?;
+    let app_id = std::env::var(ENV_APP_ID).with_context(|| format!("{ENV_APP_ID} is not set"))?;
     let installation_id = std::env::var(ENV_INSTALLATION_ID)
         .with_context(|| format!("{ENV_INSTALLATION_ID} is not set"))?;
-    let private_key = std::env::var(ENV_APP_KEY)
-        .with_context(|| format!("{ENV_APP_KEY} is not set"))?;
+    let private_key =
+        std::env::var(ENV_APP_KEY).with_context(|| format!("{ENV_APP_KEY} is not set"))?;
 
     let jwt = sign_app_jwt(&app_id, &private_key).context("failed to sign App JWT")?;
 
-    let url = format!(
-        "https://api.github.com/app/installations/{installation_id}/access_tokens"
-    );
+    let url = format!("https://api.github.com/app/installations/{installation_id}/access_tokens");
 
     let response = reqwest::Client::new()
         .post(&url)

--- a/crates/data-plane-controller/src/git_credential.rs
+++ b/crates/data-plane-controller/src/git_credential.rs
@@ -107,15 +107,34 @@ fn read_cache(path: &std::path::Path) -> Option<CachedToken> {
     serde_json::from_slice(&bytes).ok()
 }
 
-/// Atomically write the cache: write to a temp file in the same directory,
-/// then rename over the target so concurrent readers never see a torn file.
+/// Atomically write the cache: write to a per-process temp file in the same
+/// directory, then rename over the target. Concurrent readers never see a torn
+/// file, and the per-process temp name keeps concurrent writers from clobbering
+/// each other's in-progress writes before the rename. The file is created 0600
+/// because it holds a live installation token, mirroring the 0400 treatment of
+/// the SSH key it replaces.
 fn write_cache(path: &std::path::Path, token: &CachedToken) {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
     let Ok(serialized) = serde_json::to_vec(token) else {
         return;
     };
-    let tmp = path.with_extension("json.tmp");
-    if std::fs::write(&tmp, &serialized).is_ok() {
+
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+
+    let write_result = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&tmp)
+        .and_then(|mut f| f.write_all(&serialized));
+
+    if write_result.is_ok() {
         let _ = std::fs::rename(&tmp, path);
+    } else {
+        let _ = std::fs::remove_file(&tmp);
     }
 }
 

--- a/crates/data-plane-controller/src/git_credential.rs
+++ b/crates/data-plane-controller/src/git_credential.rs
@@ -1,0 +1,196 @@
+//! `git-credential` subcommand: a git credential helper that authenticates to
+//! github.com as a GitHub App installation.
+//!
+//! Git invokes a credential helper with a single operation argument (`get`,
+//! `store`, or `erase`), writes the credential context to the helper's stdin,
+//! and reads the answer from its stdout. We only implement `get`: we mint (or
+//! reuse a cached) installation access token and hand it back as the password
+//! for the `x-access-token` user. `store` and `erase` are no-ops.
+//!
+//! This mirrors how the SSH machine-user key was previously loaded into
+//! ssh-agent at container start: authentication stays entirely outside the
+//! controller's worker code. See `entrypoint.sh`, which wires this helper up
+//! via `credential.https://github.com.helper` in `github-app` auth mode.
+//!
+//! The token is never passed on a command line or written into a checkout's
+//! git config, so it cannot leak into the user-visible command logs. It only
+//! ever travels over this stdin/stdout pipe with git.
+
+use anyhow::Context;
+
+/// Environment variable holding the GitHub App ID.
+const ENV_APP_ID: &str = "DPC_GITHUB_APP_ID";
+/// Environment variable holding the App installation ID.
+const ENV_INSTALLATION_ID: &str = "DPC_GITHUB_INSTALLATION_ID";
+/// Environment variable holding the App private key (PEM).
+const ENV_APP_KEY: &str = "DPC_GITHUB_APP_KEY";
+/// Optional override for the token cache file path.
+const ENV_TOKEN_CACHE: &str = "DPC_GITHUB_TOKEN_CACHE";
+
+/// Refresh a cached token once it's within this window of expiring, so that a
+/// git operation never starts with a token that's about to lapse mid-fetch.
+const REFRESH_BEFORE_EXPIRY: chrono::Duration = chrono::Duration::minutes(5);
+
+#[derive(clap::Parser, Debug)]
+pub struct GitCredentialArgs {
+    /// The git credential operation: `get`, `store`, or `erase`.
+    operation: String,
+}
+
+/// Run the git credential helper.
+pub async fn run_git_credential(args: GitCredentialArgs) -> anyhow::Result<()> {
+    // Drain stdin regardless of operation: git writes the credential context
+    // and expects the helper to consume it. We don't need any of the fields
+    // (the helper is already scoped to github.com by git config), but leaving
+    // the pipe unread can cause git to see a broken pipe.
+    drain_stdin().await;
+
+    // Only `get` produces output; `store`/`erase` succeed silently.
+    if args.operation != "get" {
+        return Ok(());
+    }
+
+    let token = get_token().await.context("failed to obtain installation token")?;
+
+    // Emit the credential to git. The username is fixed for App tokens.
+    print!("username=x-access-token\npassword={token}\n\n");
+
+    Ok(())
+}
+
+/// Consume and discard all of stdin.
+async fn drain_stdin() {
+    use tokio::io::AsyncReadExt;
+    let mut buf = Vec::new();
+    let _ = tokio::io::stdin().read_to_end(&mut buf).await;
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CachedToken {
+    token: String,
+    expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Return a valid installation token, reusing the on-disk cache when possible
+/// and otherwise minting a fresh one.
+async fn get_token() -> anyhow::Result<String> {
+    let cache_path = token_cache_path();
+    let now = chrono::Utc::now();
+
+    // Reuse the cached token if it's comfortably in-date.
+    if let Some(cached) = read_cache(&cache_path) {
+        if cached.expires_at - now > REFRESH_BEFORE_EXPIRY {
+            tracing::info!(expires_at = %cached.expires_at, "reusing cached GitHub App token");
+            return Ok(cached.token);
+        }
+    }
+
+    let minted = mint_token().await?;
+    tracing::info!(expires_at = %minted.expires_at, "minted new GitHub App installation token");
+    write_cache(&cache_path, &minted);
+    Ok(minted.token)
+}
+
+/// Path of the token cache file. Overridable via [`ENV_TOKEN_CACHE`]; defaults
+/// to a file in the system temp directory.
+fn token_cache_path() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var(ENV_TOKEN_CACHE) {
+        return std::path::PathBuf::from(path);
+    }
+    std::env::temp_dir().join("dpc-github-token.json")
+}
+
+/// Read and parse the cache file, returning None on any error (a missing,
+/// corrupt, or partially-written cache simply forces a fresh mint).
+fn read_cache(path: &std::path::Path) -> Option<CachedToken> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Atomically write the cache: write to a temp file in the same directory,
+/// then rename over the target so concurrent readers never see a torn file.
+fn write_cache(path: &std::path::Path, token: &CachedToken) {
+    let Ok(serialized) = serde_json::to_vec(token) else {
+        return;
+    };
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, &serialized).is_ok() {
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
+/// Claims of the App authentication JWT.
+#[derive(serde::Serialize)]
+struct Claims {
+    /// Issuer: the GitHub App ID.
+    iss: String,
+    /// Issued-at, backdated slightly to tolerate clock skew.
+    iat: i64,
+    /// Expiry. GitHub rejects App JWTs with a lifetime over 10 minutes.
+    exp: i64,
+}
+
+/// Response from the installation access-token endpoint.
+#[derive(serde::Deserialize)]
+struct AccessTokenResponse {
+    token: String,
+    expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Sign an App JWT and exchange it for a fresh installation access token.
+async fn mint_token() -> anyhow::Result<CachedToken> {
+    let app_id = std::env::var(ENV_APP_ID)
+        .with_context(|| format!("{ENV_APP_ID} is not set"))?;
+    let installation_id = std::env::var(ENV_INSTALLATION_ID)
+        .with_context(|| format!("{ENV_INSTALLATION_ID} is not set"))?;
+    let private_key = std::env::var(ENV_APP_KEY)
+        .with_context(|| format!("{ENV_APP_KEY} is not set"))?;
+
+    let jwt = sign_app_jwt(&app_id, &private_key).context("failed to sign App JWT")?;
+
+    let url = format!(
+        "https://api.github.com/app/installations/{installation_id}/access_tokens"
+    );
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(&jwt)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        // GitHub requires a User-Agent on all API requests.
+        .header(reqwest::header::USER_AGENT, "estuary-data-plane-controller")
+        .send()
+        .await
+        .context("failed to request installation access token")?;
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if !status.is_success() {
+        anyhow::bail!("installation access token request failed ({status}): {body}");
+    }
+
+    let parsed: AccessTokenResponse =
+        serde_json::from_str(&body).context("failed to parse access token response")?;
+
+    Ok(CachedToken {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+    })
+}
+
+/// Build and sign the RS256 App JWT used to authenticate as the App itself.
+fn sign_app_jwt(app_id: &str, private_key: &str) -> anyhow::Result<String> {
+    let now = chrono::Utc::now().timestamp();
+    let claims = Claims {
+        iss: app_id.to_string(),
+        iat: now - 60,  // Backdate for clock skew between us and GitHub.
+        exp: now + 540, // 9 minutes; under GitHub's 10-minute ceiling.
+    };
+
+    let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key.as_bytes())
+        .context("failed to parse App private key as RSA PEM")?;
+
+    jsonwebtoken::encode(&header, &claims, &key).context("failed to encode App JWT")
+}

--- a/crates/data-plane-controller/src/lib.rs
+++ b/crates/data-plane-controller/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod git_credential;
 pub mod job;
 pub mod protocol;
 pub mod service;

--- a/crates/data-plane-controller/src/main.rs
+++ b/crates/data-plane-controller/src/main.rs
@@ -13,6 +13,8 @@ enum Mode {
     Job(data_plane_controller::job::JobArgs),
     /// Run as a service (worker) - receives HTTP requests and executes work
     Service(data_plane_controller::service::ServiceArgs),
+    /// Act as a git credential helper, minting GitHub App installation tokens.
+    GitCredential(data_plane_controller::git_credential::GitCredentialArgs),
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -43,6 +45,9 @@ fn main() -> Result<(), anyhow::Error> {
         match cli.mode {
             Mode::Job(args) => data_plane_controller::job::run_job(args).await,
             Mode::Service(args) => data_plane_controller::service::run_service(args).await,
+            Mode::GitCredential(args) => {
+                data_plane_controller::git_credential::run_git_credential(args).await
+            }
         }
     }));
 

--- a/crates/data-plane-controller/src/main.rs
+++ b/crates/data-plane-controller/src/main.rs
@@ -18,28 +18,41 @@ enum Mode {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    let cli = Cli::parse();
+
     // Required in order for libraries to use `rustls` for TLS.
     // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("failed to install default crypto provider");
 
-    // Use reasonable defaults for printing structured logs to stderr.
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+    // The git-credential helper speaks git's credential protocol over stdout,
+    // so its logs must go to stderr or they corrupt that stream. Other modes
+    // keep logging to stdout.
+    let is_git_credential = matches!(cli.mode, Mode::GitCredential(_));
+    let builder = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_ansi(if matches!(std::env::var("NO_COLOR"), Ok(v) if v == "1") {
-            false
-        } else {
-            true
-        })
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
+        .with_ansi(!is_git_credential && !matches!(std::env::var("NO_COLOR"), Ok(v) if v == "1"));
+    if is_git_credential {
+        tracing::subscriber::set_global_default(builder.with_writer(std::io::stderr).finish())
+            .expect("setting tracing default failed");
+    } else {
+        tracing::subscriber::set_global_default(builder.finish())
+            .expect("setting tracing default failed");
+    }
 
-    let cli = Cli::parse();
-
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?;
+    // The credential helper does trivial work per invocation (git spawns it
+    // afresh each time), so it runs on a single-threaded runtime rather than
+    // paying to spin up a worker pool.
+    let runtime = if is_git_credential {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?
+    };
 
     let result = runtime.block_on(runtime.spawn(async move {
         match cli.mode {


### PR DESCRIPTION
## Why

DPC's service authenticates to GitHub to clone estuary/est-dry-dock at
runtime. Today it does so as the `estuary-dpc` machine user via an SSH key
loaded into ssh-agent by entrypoint.sh. We're enabling SAML SSO enforcement
at the org level, which locks out non-identity-tied accounts like this
machine user. GitHub App identities are exempt from SSO enforcement, so we're
moving DPC's git auth to a GitHub App before the cutover, then retiring the
machine user and reclaiming its Enterprise seat.

## Approach

Keep authentication ambient, exactly where it lives today (entrypoint.sh),
so the controller's worker code does not change. The one real difference from
an SSH key is that App installation tokens expire hourly, so a static
credential loaded once at startup is not enough. Git's built-in answer to
"a credential that needs periodic refresh" is a credential helper, so that's
what this adds.

- New `git-credential` subcommand acts as a git credential helper. On `get`
  it signs an RS256 App JWT, exchanges it for an installation access token,
  caches the token to disk until shortly before expiry, and hands it to git
  as the password for `x-access-token`. The token only ever crosses the
  stdin/stdout pipe with git; it never appears on a command line or in an
  on-disk git config, so it cannot leak into the user-visible command logs.
- entrypoint.sh gains a `DPC_GIT_AUTH_MODE` switch (default `ssh`). In
  `github-app` mode it rewrites the SSH-style remote to HTTPS and registers
  the helper, instead of setting up ssh-agent.
- The deploy workflow (service only; the job does no git) gains the App key
  secret and the App/Installation IDs, with the mode defaulting to `ssh` so
  merging and deploying changes nothing until we deliberately flip it.

worker.rs, the protocol, ControllerConfig, and the tests are untouched.

## Scope

Only estuary/est-dry-dock is affected. An audit-log export over a 3-day
window (~9,500 authenticated events) shows `estuary-dpc` clones/fetches
est-dry-dock and nothing else, all read-only. estuary/flow is a public repo
(no auth needed to clone), and estuary/ops is dead config in DPC (its
checkout was removed in 149b151a27b). So the App needs Contents: Read-only on
est-dry-dock alone.

## Verification

Built and ran the credential helper locally against the real App and the key
in Secret Manager:
- Minted a valid installation token (App ID 4126016, Installation ID
  148554392).
- Performed a real HTTPS clone of est-dry-dock through the helper using the
  same insteadOf rewrite entrypoint.sh applies in github-app mode. Clone
  succeeded.

## Cutover (after merge)

1. Deploy as-is (`ssh` mode). Ships the new binary plus the App key/IDs to the
   service; behavior unchanged.
2. Flip `DPC_GIT_AUTH_MODE=github-app` in the workflow, redeploy the service,
   confirm a clean clone/fetch cycle over HTTPS in the logs.
3. Remove the SSH key from `estuary-dpc` (reversible), wait a full cycle to be
   safe, then delete the user and reclaim the seat.

Note: the deploy action uses `env_vars_update_strategy: overwrite`, so
`DPC_GIT_AUTH_MODE` must be flipped in this workflow file, not in the Cloud
Run console (a console edit would be reverted on the next deploy).

## Rollback

Rollback is a single change: set `DPC_GIT_AUTH_MODE=ssh` in this workflow and
redeploy the service. entrypoint.sh falls back to the existing ssh-agent path,
which is unchanged and still fully wired (the `DPC_GITHUB_SSH_KEY` secret
remains in place throughout cutover). No code revert, no rebuild.

This is why the retire step is deliberately last and ordered as it is: keep the
SSH key and the `estuary-dpc` user until github-app mode has run cleanly for a
full cycle. Do not remove the SSH key until you are ready to give up the
instant rollback, since removing it is what makes the ssh path stop working.

## Prerequisites already done

- GitHub App created, Contents: Read-only, installed on estuary/est-dry-dock.
- Private key stored in estuary-control Secret Manager as `DPC_GITHUB_APP_KEY`.
