### PR TITLE
data-plane-controller: cut git auth over to the GitHub App

### DIFF
--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -63,7 +63,7 @@ jobs:
             DPC_DATABASE_CA=/etc/db-ca.crt
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
             NO_COLOR=1
-            DPC_GIT_AUTH_MODE=ssh
+            DPC_GIT_AUTH_MODE=github-app
             DPC_GITHUB_APP_ID=4126016
             DPC_GITHUB_INSTALLATION_ID=148554392
 


### PR DESCRIPTION
## What

Flip `DPC_GIT_AUTH_MODE` from `ssh` to `github-app` on the data-plane-controller
service deploy. The controller now clones estuary/est-dry-dock over HTTPS using
GitHub App installation tokens (minted by the `git-credential` helper added in
#3243), instead of authenticating as the `estuary-dpc` SSH machine user.

This is the cutover ahead of org SAML SSO enforcement, which would lock out the
non-identity machine user. GitHub App identities are exempt.

## Verification

The github-app path was verified end to end locally before #3243 merged: the
helper mints a valid installation token (App ID 4126016, Installation ID
148554392, key in estuary-control Secret Manager as DPC_GITHUB_APP_KEY) and a
real HTTPS clone of est-dry-dock succeeds through it, including under the
container's RUST_LOG=info condition.

After this deploys, confirm in the service logs a clean clone/fetch cycle over
HTTPS and the `minted new GitHub App installation token` log line.

## Rollback

Revert this change (back to `DPC_GIT_AUTH_MODE=ssh`) and redeploy. The
`DPC_GITHUB_SSH_KEY` secret is still present, so the ssh-agent path is fully
wired and rollback needs no code change or rebuild.

## After a clean cycle

Only once github-app mode has run cleanly for a full cycle should the SSH key be
removed from the estuary-dpc account, then the user deleted and its seat
reclaimed. Removing the SSH key is the point of no return for the instant
rollback above.
