### PR TITLE
data-plane-controller: fix broken deploy (comments in env/secrets block scalars)

### DIFF
--- a/.github/workflows/deploy-data-plane-controller.yaml
+++ b/.github/workflows/deploy-data-plane-controller.yaml
@@ -54,16 +54,16 @@ jobs:
           # Declare the VPC egress (previously set out-of-band) in code so it survives a full replace.
           flags: '--args=service --no-allow-unauthenticated --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com --network=data-plane-controller --subnet=data-plane-controller-sn1 --vpc-egress=all-traffic'
 
+          # NOTE: env_vars and secrets are literal block scalars (|-); every
+          # line is passed verbatim to deploy-cloudrun as KEY=VALUE /
+          # KEY=SECRET:version. Do NOT put `#` comments inside them.
+          # DPC_GIT_AUTH_MODE selects git auth (ssh | github-app); see
+          # crates/data-plane-controller/entrypoint.sh.
           env_vars: |-
             DPC_DATABASE_CA=/etc/db-ca.crt
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
             NO_COLOR=1
-            # Git auth for cloning private repos. Leave `ssh` until the GitHub
-            # App is verified, then flip to `github-app` to cut over. See
-            # crates/data-plane-controller/entrypoint.sh.
             DPC_GIT_AUTH_MODE=ssh
-            # GitHub App identifiers (non-secret). Installation ID is available
-            # once the App is installed on estuary/est-dry-dock.
             DPC_GITHUB_APP_ID=4126016
             DPC_GITHUB_INSTALLATION_ID=148554392
 
@@ -74,8 +74,6 @@ jobs:
             DPC_ARM_SUBSCRIPTION_ID=DPC_ARM_SUBSCRIPTION_ID:latest
             DPC_ARM_TENANT_ID=DPC_ARM_TENANT_ID:latest
             DPC_GITHUB_SSH_KEY=DPC_GITHUB_SSH_KEY:latest
-            # GitHub App private key (PEM), stored in estuary-control Secret
-            # Manager alongside DPC_GITHUB_SSH_KEY.
             DPC_GITHUB_APP_KEY=DPC_GITHUB_APP_KEY:latest
             DPC_IAM_CREDENTIALS=DPC_IAM_CREDENTIALS:latest
             DPC_SERVICE_ACCOUNT=DPC_SERVICE_ACCOUNT:latest


### PR DESCRIPTION
## Problem

The data-plane-controller deploy is failing on master (first failure: https://github.com/estuary/flow/actions/runs/30048846203). `env_vars` and `secrets` for `deploy-cloudrun` are literal YAML block scalars (`|-`), so the explanatory `#` comment lines added in #3243 were passed verbatim to the action, which tried to parse a comment as a secret mapping:

```
ERROR: (gcloud.run.deploy) No secret version specified for
# GitHub App private key (PEM). Use # GitHub App private key (PEM):latest ...
```

No outage: a failed Cloud Run deploy leaves the previous revision serving, so DPC keeps running on its prior revision. But the deploy pipeline is broken until this lands, and the new binary is not rolled out.

## Fix

Remove the inline `#` comments from both block scalars in the deploy-service step and move the operational note to real YAML comments above `env_vars:`. No functional change: `DPC_GIT_AUTH_MODE` stays `ssh`, and the App key/IDs remain wired for the later cutover.

## Follow-up

#3249 (the github-app cutover flip) branched before this fix and carries the same bad comments; it needs a rebase on top of this before it can deploy.