### PR TITLE
docs: document connector-managed schemas and auto-discover behavior

### DIFF
--- a/site/docs/concepts/captures.md
+++ b/site/docs/concepts/captures.md
@@ -83,6 +83,14 @@ There are several options for controlling the behavior of `autoDiscover`:
 
 * The `evolveIncompatibleCollections` option determines how to respond when the discovered updates would cause a breaking change to the collection. If `true`, it will trigger an [evolution](./advanced/evolutions.md) of the incompatible collection(s) to prevent failures.
 
+* Auto-discover only updates collections whose schema is *connector-managed*, meaning the schema has a `flow://connector-schema` entry in its `$defs`. Collections with a hand-authored schema are left untouched, and a discover on a capture that includes one fails until that schema is opted in. See [Connector-managed schemas](./schemas.md#connector-managed-schemas-and-auto-discover).
+
+When the source changes, auto-discover reconciles bindings by resource path:
+
+- A **new table** is added as a new binding when `addNewBindings` is `true` (added disabled when `false`).
+- A **dropped table** has its binding removed, so capture of that table stops. The collection and any data already captured are retained, not deleted.
+- A **renamed table** is treated as a dropped table plus a new one: the old binding is removed, and a new binding and collection are created under the new name with their own backfill. Data is not carried across from the old collection to the new one, so a rename is not a transparent migration.
+
 In Estuary's web app, you can set these properties when you create or edit a capture.
 
 ![Capture auto-discovery in the UI](./concept-images/captures-auto-discover-ui.png)

--- a/site/docs/concepts/schemas.md
+++ b/site/docs/concepts/schemas.md
@@ -273,6 +273,77 @@ collections:
     key: [/id]
 ```
 
+### Connector-managed schemas and auto-discover
+
+For collections produced by a capture connector, Estuary manages the collection's schema through a
+reserved definition, `flow://connector-schema`, in the schema's `$defs`. Each time
+[`autoDiscover`](./captures.md#automatically-update-captures) runs, it overwrites that definition
+with the schema the connector reports for the source table or stream. A connector-managed collection
+looks like this:
+
+```yaml
+collections:
+  acmeCo/orders:
+    schema:
+      $defs:
+        "flow://connector-schema": {}   # populated and kept up to date by auto-discover
+      $ref: flow://connector-schema
+    key: [/id]
+```
+
+The `$defs` entry marks the collection as connector-managed, and the top-level `$ref` makes that
+managed schema the one documents are validated against.
+
+If a collection's schema does not contain a `flow://connector-schema` entry in `$defs`,
+auto-discover treats the schema as user-owned and will not modify it. Refreshing bindings (running a
+discover) on a capture that includes such a collection fails with an error like:
+
+```
+collection acmeCo/orders has a schema that is not managed by auto-discover (it has no $defs
+entry for 'flow://connector-schema'). To opt in, add {"$defs": {"flow://connector-schema": {}}}
+to the collection schema
+```
+
+This is deliberate, so that auto-discover never overwrites a schema you wrote by hand. It most
+commonly appears when collections were authored directly (for example, built and published from a
+local `flowctl` project with inline schemas) rather than created through Estuary's discovery flow.
+
+#### Opting a hand-authored collection into management
+
+Adding only the empty `$defs` entry stops the error, but it is not sufficient on its own:
+auto-discover will populate the definition, but your existing top-level schema still validates
+documents unless it references that definition. To fully hand the collection over, structure the
+schema so the connector schema is both defined and referenced:
+
+```yaml
+schema:
+  $defs:
+    "flow://connector-schema": {}
+  $ref: flow://connector-schema
+key: [/id]
+```
+
+On the next discover, auto-discover fills `flow://connector-schema` with the live source schema, and
+documents validate against it from then on. If the connector supports
+[continuous schema inference](#continuous-schema-inference), auto-discover also splits the single
+schema into separate write and read schemas, so that the read schema can widen automatically as the
+source changes. The resulting shape is:
+
+```yaml
+writeSchema:
+  $defs:
+    "flow://connector-schema": {}
+  $ref: flow://connector-schema
+readSchema:
+  allOf:
+    - $ref: flow://write-schema
+    - $ref: flow://inferred-schema
+key: [/id]
+```
+
+You do not need to build this split by hand for connector collections; auto-discover creates it the
+first time it runs against a connector-managed collection.
+
 ## Reductions
 
 Estuary's collections have keys, and multiple documents

--- a/site/docs/concepts/schemas.md
+++ b/site/docs/concepts/schemas.md
@@ -223,10 +223,13 @@ but you can also use absolute URLs to a third-party schema like
 
 ## Write and read schemas
 
-In some cases, you may want to impose different constraints to data that is being added (_written_) to the collection
-and data that is exiting (_read from_) the collection.
+Most collections benefit from separate write and read schemas, and it's the pattern Estuary recommends
+by default rather than a special case. The write schema validates documents as they're captured; the read
+schema validates documents as they're consumed by derivations and materializations. Keeping them separate
+lets the read schema evolve safely over time, for example as [continuous schema inference](#continuous-schema-inference)
+learns more about your data, without ever risking a rejected document at capture time.
 
-For example, you may need to start capturing data _now_ from a source system; say, a pub-sub system with short-lived
+One common example: you may need to start capturing data _now_ from a source system; say, a pub-sub system with short-lived
 historical data support or an HTTP endpoint, but don't know or don't control the endpoint's schema.
 You can capture the data with a permissive write schema, and impose a stricter read schema on the data
 as you need to perform a derivation or materialization.
@@ -238,15 +241,15 @@ Make sure that the field used as the collection key is defined in both schemas.
 You can either perform this manually, or use Estuary's **Schema Inference** tool to infer a read schema.
 Schema Inference is available in the web app when you [edit a capture or materialization](/guides/edit-data-flows) and [create a materialization](../guides/create-dataflow.md#create-a-materialization).
 
-**Before separating your write and read schemas, have the following in mind:**
+**Keep the following in mind when working with write and read schemas:**
 
 * The write schema comes from the capture connector that produced the collection and shouldn't be modified.
   Always apply your schema changes to the _read_ schema.
 
-* Separate read and write schemas are typically useful for collections that come from a source system with a flat or loosely
-  defined data structure, such as cloud storage or pub-sub systems.
-  Collections sourced from databases and most SaaS systems come with an explicitly defined data structure and shouldn't
-  need a different read schema.
+* Even collections sourced from databases and SaaS systems with a well-defined structure benefit from the split:
+  it's what lets [continuous schema inference](#continuous-schema-inference) and
+  [`autoDiscover`](./captures.md#automatically-update-captures) evolve the read schema automatically as the
+  source changes, rather than failing captures or requiring manual schema edits.
 
 * If you're using standard [projections](./advanced/projections.md), you must only define them in the read schema.
   However, if your projections are [logical partitions](./advanced/projections.md#logical-partitions), you must define them in both schemas.

--- a/site/docs/guides/flowctl/ci-cd.md
+++ b/site/docs/guides/flowctl/ci-cd.md
@@ -44,6 +44,18 @@ To create a [capture](../../concepts/captures.md), start with a local `flow.yaml
 You will need to use the capture connector's [reference](../../reference/Connectors/capture-connectors/README.md) for details on the available settings, authorization methods, and required fields for the configuration.
 The connector's reference page will include an example specification you can use to get started.
 
+:::tip Recommended: generate bindings and collections with `flowctl discover`
+Rather than hand-writing every binding and its collection, start from a minimal capture spec with an empty `bindings: []` list, then run [`flowctl discover`](../../concepts/captures.md#discovery-through-flowctl):
+
+```bash
+flowctl discover --source flow.yaml
+```
+
+This invokes the connector from your data plane, enumerates the source's resources, and writes the `bindings` and their target `collections` back into your local files. The generated collections are **connector-managed** and inference-ready, so [`autoDiscover`](../../concepts/captures.md#automatically-update-captures) can keep their schemas in sync and the read schema evolves automatically. This is the recommended starting point for most captures.
+
+Hand-authoring the capture and collections (as shown below) is best reserved for when you already have a fixed, known schema and deliberately want to own it. See [Connector-managed schemas](../../concepts/schemas.md#connector-managed-schemas-and-auto-discover) for the trade-offs.
+:::
+
 At a minimum, the configuration will need to specify:
 * The capture name
 * The connector image for the capture
@@ -104,18 +116,38 @@ captures:
 
 Note that you will not be able to successfully publish a capture by itself. You will also need to define the collections that relate to the capture's bindings.
 
+:::note `autoDiscover` and version-controlled specs
+If you enable [`autoDiscover`](../../concepts/captures.md#automatically-update-captures) on a capture whose specs live in Git, note that it republishes the capture and its collections out-of-band whenever the source changes, so the live specs can drift from your repository. Either re-run `flowctl catalog pull-specs` after it fires to bring your repo back in sync, or leave `autoDiscover` off and rely on schema inference (below) for read-schema evolution.
+:::
+
 ### Collection Configuration
 
 When you create a capture configuration, you will also need to create associated [collection](../../concepts/collections.md) configurations. Your resource streams will flow into these collections as a staging area before final materialization.
 
 Collections provide an opportunity to enforce schemas and transform data with [derivations](#derivation-configuration).
-When using the UI, Estuary will intelligently infer these schemas for you. When you're creating your own specifications from scratch, however, you will need to be very aware of your source system's schema in order to replicate it accurately.
 
-Create a collection specification for each **target** you identified in your capture bindings. The collection specification should, at a minimum, include:
-* The schema, with its properties and their types
-* Any required fields in the schema, including the key field
-* The key field used to identify and order documents
-    * Since the key can be a composite, JSON pointers are used to identify relevant fields, so field names should begin with `/`
+If you generated your bindings with `flowctl discover` (recommended above), the target collections were written for you with connector-managed, inference-ready schemas, and you can skip ahead to [publishing](#publishing-resources).
+
+When hand-authoring collections instead, create a specification for each **target** you identified in your capture bindings. At a minimum, each collection needs a schema and a key (the key field identifies and orders documents; since it can be composite, fields are given as JSON pointers beginning with `/`).
+
+You do **not** need to replicate every source column by hand, and it is usually a mistake to try. A fully-specified schema is *frozen*: when the source later adds a column or emits a value that doesn't match (for example a `null` in a field you typed as a required string), the capture fails validation. Instead, define a permissive `writeSchema` (typically just the key) and let [continuous schema inference](../../concepts/schemas.md#continuous-schema-inference) fill in the rest via the `readSchema`:
+
+```yaml
+collections:
+  Artificial-Industries/ci-cd/postgres_shipments:
+    writeSchema:
+      type: object
+      required: [id]
+      properties:
+        id: { type: integer }
+    readSchema:
+      allOf:
+        - $ref: flow://write-schema
+        - $ref: flow://inferred-schema
+    key: [/id]
+```
+
+Schema inference works well with a version-controlled catalog: publishing with `flowctl` never reverts the inferred read schema, and Estuary keeps it up to date as new data arrives, whether or not `autoDiscover` is enabled. The fully-specified schemas shown below are appropriate only when you want to enforce an exact shape and will maintain it by hand.
 
 Consider these example specifications:
 


### PR DESCRIPTION
## What

Documents how auto-discover interacts with collection schemas, which is currently undocumented (`flow://connector-schema` appears only incidentally on the redaction page).

- **`concepts/schemas.md`** — new subsection "Connector-managed schemas and auto-discover": the `flow://connector-schema` `$defs` marker that makes a collection connector-managed, why a hand-authored/inline schema is left untouched (the `not managed by auto-discover` error), and how to opt one in. Notes that the read/write split for inference is created automatically once a collection is managed.
- **`concepts/captures.md`** — extends the `autoDiscover` options with the management prerequisite and how new / dropped / renamed source tables are reconciled.

## Why

A customer hit repeated auto-discover failures because their collections were published from a local `flowctl` project with inline schemas and so were never connector-managed. Nothing in the docs explained the requirement or the fix.

## Verification

Behavior confirmed against source: `crates/control-plane-api/src/discovers/specs.rs` (management check + binding reconcile) and `crates/models/src/schemas.rs` (the `flow://` reference constants).
