### PR TITLE
control-plane-api: add billingAdjustments query and createBillingAdjustment mutation

### DIFF
--- a/.sqlx/query-07182f87013ae554a79d327e694e36a2db9096775201a50d89881e99cfccf81e.json
+++ b/.sqlx/query-07182f87013ae554a79d327e694e36a2db9096775201a50d89881e99cfccf81e.json
@@ -1,0 +1,75 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO internal.billing_adjustments (id, tenant, billed_month, usd_cents, authorizer, detail)\n        VALUES (internal.id_generator(), $1::catalog_tenant, $2, $3, $4, $5)\n        RETURNING\n            id as \"id!: models::Id\",\n            created_at as \"created_at!: DateTime<Utc>\",\n            updated_at as \"updated_at!: DateTime<Utc>\",\n            tenant as \"tenant!: String\",\n            billed_month as \"billed_month!: DateTime<Utc>\",\n            usd_cents as \"usd_cents!\",\n            authorizer as \"authorizer!\",\n            detail as \"detail: String\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: models::Id",
+        "type_info": "Macaddr8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "tenant!: String",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "billed_month!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "usd_cents!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "authorizer!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "detail: String",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "catalog_tenant",
+            "kind": {
+              "Domain": "Text"
+            }
+          }
+        },
+        "Timestamptz",
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "07182f87013ae554a79d327e694e36a2db9096775201a50d89881e99cfccf81e"
+}

--- a/.sqlx/query-58b51c4e33d039815f1676defe3dc416988d821f3d2e0f80d90df3f43ab0bfd5.json
+++ b/.sqlx/query-58b51c4e33d039815f1676defe3dc416988d821f3d2e0f80d90df3f43ab0bfd5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT email FROM auth.users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "email",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "58b51c4e33d039815f1676defe3dc416988d821f3d2e0f80d90df3f43ab0bfd5"
+}

--- a/.sqlx/query-b51fa53720a823315d2395d95a4912fdad71cbf632af1f913a627362664b4c3f.json
+++ b/.sqlx/query-b51fa53720a823315d2395d95a4912fdad71cbf632af1f913a627362664b4c3f.json
@@ -1,0 +1,73 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id as \"id!: models::Id\",\n            created_at as \"created_at!: DateTime<Utc>\",\n            updated_at as \"updated_at!: DateTime<Utc>\",\n            tenant as \"tenant!: String\",\n            billed_month as \"billed_month!: DateTime<Utc>\",\n            usd_cents as \"usd_cents!\",\n            authorizer as \"authorizer!\",\n            detail as \"detail: String\"\n        FROM internal.billing_adjustments\n        WHERE tenant = $1::catalog_tenant\n          AND ($2::timestamptz IS NULL OR created_at < $2)\n        ORDER BY created_at DESC\n        LIMIT $3\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: models::Id",
+        "type_info": "Macaddr8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "tenant!: String",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "billed_month!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "usd_cents!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "authorizer!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "detail: String",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "catalog_tenant",
+            "kind": {
+              "Domain": "Text"
+            }
+          }
+        },
+        "Timestamptz",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b51fa53720a823315d2395d95a4912fdad71cbf632af1f913a627362664b4c3f"
+}

--- a/.sqlx/query-f0e483e8d72d270cb8ae9b68d0f340468d3d58edbf46812a37b9f0d4c66d1379.json
+++ b/.sqlx/query-f0e483e8d72d270cb8ae9b68d0f340468d3d58edbf46812a37b9f0d4c66d1379.json
@@ -1,0 +1,73 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id as \"id!: models::Id\",\n            created_at as \"created_at!: DateTime<Utc>\",\n            updated_at as \"updated_at!: DateTime<Utc>\",\n            tenant as \"tenant!: String\",\n            billed_month as \"billed_month!: DateTime<Utc>\",\n            usd_cents as \"usd_cents!\",\n            authorizer as \"authorizer!\",\n            detail as \"detail: String\"\n        FROM internal.billing_adjustments\n        WHERE tenant = $1::catalog_tenant\n          AND ($2::timestamptz IS NULL OR created_at > $2)\n        ORDER BY created_at ASC\n        LIMIT $3\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: models::Id",
+        "type_info": "Macaddr8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "tenant!: String",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "billed_month!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "usd_cents!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "authorizer!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "detail: String",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "catalog_tenant",
+            "kind": {
+              "Domain": "Text"
+            }
+          }
+        },
+        "Timestamptz",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f0e483e8d72d270cb8ae9b68d0f340468d3d58edbf46812a37b9f0d4c66d1379"
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
@@ -1,0 +1,472 @@
+use chrono::{DateTime, Datelike, Timelike, Utc};
+
+/// An authorized adjustment to a tenant's invoice for a particular month,
+/// such as a make-good credit or a negotiated service fee. Adjustments are
+/// created by Estuary support staff and appear as invoice line items.
+#[derive(Debug, Clone, async_graphql::SimpleObject)]
+pub struct BillingAdjustment {
+    /// Unique id of this adjustment.
+    pub id: models::Id,
+    /// Time at which this adjustment was created.
+    pub created_at: DateTime<Utc>,
+    /// Time at which this adjustment was last updated.
+    pub updated_at: DateTime<Utc>,
+    /// Tenant whose invoice is adjusted.
+    pub tenant: String,
+    /// Month of the invoice being adjusted, as the first instant of that
+    /// month in UTC.
+    pub billed_month: DateTime<Utc>,
+    /// Adjustment amount in USD cents. Positive values increase the invoice
+    /// total, and negative values are credits which decrease it.
+    pub usd_cents: i32,
+    /// Email of the Estuary employee who authorized this adjustment.
+    pub authorizer: String,
+    /// Human-readable reason for this adjustment.
+    pub detail: Option<String>,
+}
+
+/// Errors unless `billed_month` is the first instant of a month in UTC,
+/// mirroring the CHECK constraint on internal.billing_adjustments.
+pub fn require_month_boundary(billed_month: DateTime<Utc>) -> async_graphql::Result<()> {
+    if billed_month.day() != 1
+        || billed_month.hour() != 0
+        || billed_month.minute() != 0
+        || billed_month.second() != 0
+        || billed_month.nanosecond() != 0
+    {
+        return Err(async_graphql::Error::new(
+            "billedMonth must be the first instant of a month in UTC, like 2026-07-01T00:00:00Z",
+        ));
+    }
+    Ok(())
+}
+
+pub async fn insert_adjustment(
+    pool: &sqlx::PgPool,
+    tenant: &str,
+    billed_month: DateTime<Utc>,
+    usd_cents: i32,
+    authorizer: &str,
+    detail: &str,
+) -> sqlx::Result<BillingAdjustment> {
+    sqlx::query_as!(
+        BillingAdjustment,
+        r#"
+        INSERT INTO internal.billing_adjustments (id, tenant, billed_month, usd_cents, authorizer, detail)
+        VALUES (internal.id_generator(), $1::catalog_tenant, $2, $3, $4, $5)
+        RETURNING
+            id as "id!: models::Id",
+            created_at as "created_at!: DateTime<Utc>",
+            updated_at as "updated_at!: DateTime<Utc>",
+            tenant as "tenant!: String",
+            billed_month as "billed_month!: DateTime<Utc>",
+            usd_cents as "usd_cents!",
+            authorizer as "authorizer!",
+            detail as "detail: String"
+        "#,
+        tenant as &str,
+        billed_month,
+        usd_cents,
+        authorizer,
+        detail,
+    )
+    .fetch_one(pool)
+    .await
+}
+
+/// Forward pagination: fetch adjustments older than `cursor` (or the newest
+/// adjustments when `cursor` is `None`). Returned rows are ordered newest-first.
+pub async fn fetch_adjustments_forward(
+    pool: &sqlx::PgPool,
+    tenant: &str,
+    cursor: Option<DateTime<Utc>>,
+    limit: Option<usize>,
+) -> sqlx::Result<(Vec<BillingAdjustment>, bool)> {
+    let query_limit = limit.map(|l| l as i64 + 1).unwrap_or(i64::MAX);
+    let mut rows = sqlx::query_as!(
+        BillingAdjustment,
+        r#"
+        SELECT
+            id as "id!: models::Id",
+            created_at as "created_at!: DateTime<Utc>",
+            updated_at as "updated_at!: DateTime<Utc>",
+            tenant as "tenant!: String",
+            billed_month as "billed_month!: DateTime<Utc>",
+            usd_cents as "usd_cents!",
+            authorizer as "authorizer!",
+            detail as "detail: String"
+        FROM internal.billing_adjustments
+        WHERE tenant = $1::catalog_tenant
+          AND ($2::timestamptz IS NULL OR created_at < $2)
+        ORDER BY created_at DESC
+        LIMIT $3
+        "#,
+        tenant as &str,
+        cursor,
+        query_limit,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let has_more = limit.is_some_and(|l| rows.len() > l);
+    if let Some(l) = limit {
+        rows.truncate(l);
+    }
+    Ok((rows, has_more))
+}
+
+/// Backward pagination: fetch adjustments newer than `cursor`. Returned rows
+/// are ordered newest-first (the query selects oldest-first to honor `limit`,
+/// then the result is reversed).
+pub async fn fetch_adjustments_backward(
+    pool: &sqlx::PgPool,
+    tenant: &str,
+    cursor: Option<DateTime<Utc>>,
+    limit: Option<usize>,
+) -> sqlx::Result<(Vec<BillingAdjustment>, bool)> {
+    let query_limit = limit.map(|l| l as i64 + 1).unwrap_or(i64::MAX);
+    let mut rows = sqlx::query_as!(
+        BillingAdjustment,
+        r#"
+        SELECT
+            id as "id!: models::Id",
+            created_at as "created_at!: DateTime<Utc>",
+            updated_at as "updated_at!: DateTime<Utc>",
+            tenant as "tenant!: String",
+            billed_month as "billed_month!: DateTime<Utc>",
+            usd_cents as "usd_cents!",
+            authorizer as "authorizer!",
+            detail as "detail: String"
+        FROM internal.billing_adjustments
+        WHERE tenant = $1::catalog_tenant
+          AND ($2::timestamptz IS NULL OR created_at > $2)
+        ORDER BY created_at ASC
+        LIMIT $3
+        "#,
+        tenant as &str,
+        cursor,
+        query_limit,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let has_more = limit.is_some_and(|l| rows.len() > l);
+    if let Some(l) = limit {
+        rows.truncate(l);
+    }
+    rows.reverse();
+    Ok((rows, has_more))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_util::*;
+    use crate::test_server;
+    use serde_json::json;
+
+    /// Provisions a user who is a member of estuary_support/, and re-creates
+    /// the support role grant on `tenant` which provision_test_tenant removes.
+    async fn provision_support_user(pool: &sqlx::PgPool, email: &str, tenant: &str) -> uuid::Uuid {
+        let user_id = uuid::Uuid::new_v4();
+        sqlx::query("insert into auth.users (id, email) values ($1, $2)")
+            .bind(user_id)
+            .bind(email)
+            .execute(pool)
+            .await
+            .expect("insert support user");
+        sqlx::query(
+            "insert into user_grants (user_id, object_role, capability) values ($1, 'estuary_support/', 'admin')",
+        )
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("grant estuary_support/ membership");
+        sqlx::query(
+            "insert into role_grants (subject_role, object_role, capability) values ('estuary_support/', $1, 'admin')",
+        )
+        .bind(format!("{tenant}/"))
+        .execute(pool)
+        .await
+        .expect("grant estuary_support/ admin on tenant");
+        user_id
+    }
+
+    const CREATE_MUTATION: &str = r#"
+        mutation CreateAdjustment(
+            $tenant: String!
+            $billedMonth: DateTime!
+            $usdCents: Int!
+            $detail: String!
+        ) {
+            createBillingAdjustment(
+                tenant: $tenant
+                billedMonth: $billedMonth
+                usdCents: $usdCents
+                detail: $detail
+            ) {
+                adjustment {
+                    tenant
+                    billedMonth
+                    usdCents
+                    authorizer
+                    detail
+                }
+            }
+        }
+    "#;
+
+    const ADJUSTMENTS_QUERY: &str = r#"
+        query Adjustments($tenant: String!, $first: Int) {
+            tenant(name: $tenant) {
+                billing {
+                    adjustments(first: $first) {
+                        pageInfo { hasNextPage hasPreviousPage }
+                        edges { node { tenant billedMonth usdCents authorizer detail } }
+                    }
+                }
+            }
+        }
+    "#;
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn graphql_billing_adjustments(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+        let tenant = "adjustco";
+        let admin_user_id = provision_test_tenant(&pool, tenant).await;
+        let support_user_id = provision_support_user(&pool, "support@estuary.test", tenant).await;
+
+        let (server, admin_token) =
+            start_server_and_token(&pool, admin_user_id, tenant, mock_provider()).await;
+        let support_token = server.make_access_token(support_user_id, Some("support@estuary.test"));
+
+        // A tenant admin holds EditBilling on their own tenant, but must NOT
+        // be able to create adjustments (credit themselves).
+        let denied: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": CREATE_MUTATION,
+                    "variables": {
+                        "tenant": "adjustco/",
+                        "billedMonth": "2026-07-01T00:00:00Z",
+                        "usdCents": -5000,
+                        "detail": "self-credit attempt",
+                    }
+                }),
+                Some(&admin_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("create_adjustment_denied_tenant_admin", denied);
+
+        // A support user may create an adjustment, and `authorizer` is
+        // derived from their token's email claim.
+        let created: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": CREATE_MUTATION,
+                    "variables": {
+                        "tenant": "adjustco/",
+                        "billedMonth": "2026-07-01T00:00:00Z",
+                        "usdCents": -5000,
+                        "detail": "make-good for incident",
+                    }
+                }),
+                Some(&support_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("create_adjustment_by_support", created);
+
+        // billedMonth which is not a month boundary is rejected.
+        let bad_month: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": CREATE_MUTATION,
+                    "variables": {
+                        "tenant": "adjustco/",
+                        "billedMonth": "2026-07-15T00:00:00Z",
+                        "usdCents": -5000,
+                        "detail": "mid-month",
+                    }
+                }),
+                Some(&support_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("create_adjustment_bad_month", bad_month);
+
+        // Zero-value adjustments are rejected.
+        let zero: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": CREATE_MUTATION,
+                    "variables": {
+                        "tenant": "adjustco/",
+                        "billedMonth": "2026-07-01T00:00:00Z",
+                        "usdCents": 0,
+                        "detail": "zero",
+                    }
+                }),
+                Some(&support_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("create_adjustment_zero_cents", zero);
+
+        // Adjustments for a nonexistent tenant are rejected.
+        let missing: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": CREATE_MUTATION,
+                    "variables": {
+                        "tenant": "nonexistent/",
+                        "billedMonth": "2026-07-01T00:00:00Z",
+                        "usdCents": -5000,
+                        "detail": "no such tenant",
+                    }
+                }),
+                Some(&support_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("create_adjustment_missing_tenant", missing);
+
+        // The tenant admin may view their own adjustments: they already
+        // appear as invoice line items.
+        let listed: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": ADJUSTMENTS_QUERY,
+                    "variables": { "tenant": "adjustco/", "first": 10 }
+                }),
+                Some(&admin_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("adjustments_query_tenant_admin", listed);
+
+        // Another tenant's admin cannot view adjustco's adjustments.
+        let other_tenant = "adjustother";
+        let other_user_id = provision_test_tenant(&pool, other_tenant).await;
+        let other_token =
+            server.make_access_token(other_user_id, Some(&format!("{other_tenant}@example.test")));
+        let cross: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": ADJUSTMENTS_QUERY,
+                    "variables": { "tenant": "adjustco/", "first": 10 }
+                }),
+                Some(&other_token),
+            )
+            .await;
+        insta::assert_json_snapshot!("adjustments_query_cross_tenant_denied", cross);
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn graphql_billing_adjustments_pagination(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+        let tenant = "adjustpage";
+        let admin_user_id = provision_test_tenant(&pool, tenant).await;
+        let support_user_id = provision_support_user(&pool, "support@estuary.test", tenant).await;
+
+        // Insert three adjustments with distinct, increasing created_at values,
+        // so "credit 2" is the newest.
+        for (n, month) in ["2026-05-01", "2026-06-01", "2026-07-01"]
+            .iter()
+            .enumerate()
+        {
+            sqlx::query(
+                r#"
+                insert into internal.billing_adjustments
+                    (id, tenant, billed_month, usd_cents, authorizer, detail, created_at)
+                values
+                    (internal.id_generator(), $1::catalog_tenant, $2::timestamptz, $3,
+                     'support@estuary.test', $4, now() + make_interval(secs => $5))
+                "#,
+            )
+            .bind(format!("{tenant}/"))
+            .bind(format!("{month}T00:00:00Z"))
+            .bind((n as i32 + 1) * -100)
+            .bind(format!("credit {n}"))
+            .bind(n as f64)
+            .execute(&pool)
+            .await
+            .expect("insert adjustment fixture");
+        }
+        let _ = support_user_id;
+
+        let (server, admin_token) =
+            start_server_and_token(&pool, admin_user_id, tenant, mock_provider()).await;
+
+        // Page forward, newest-first, two at a time.
+        let page: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": r#"
+                        query($tenant: String!, $first: Int, $after: String) {
+                            tenant(name: $tenant) {
+                                billing {
+                                    adjustments(first: $first, after: $after) {
+                                        pageInfo { hasNextPage endCursor }
+                                        edges { node { detail usdCents } }
+                                    }
+                                }
+                            }
+                        }
+                    "#,
+                    "variables": { "tenant": "adjustpage/", "first": 2 }
+                }),
+                Some(&admin_token),
+            )
+            .await;
+
+        let edges = page["data"]["tenant"]["billing"]["adjustments"]["edges"]
+            .as_array()
+            .expect("edges array");
+        assert_eq!(edges.len(), 2, "first page should have 2 edges: {page:?}");
+        assert_eq!(
+            edges[0]["node"]["detail"],
+            json!("credit 2"),
+            "newest first"
+        );
+        assert_eq!(
+            page["data"]["tenant"]["billing"]["adjustments"]["pageInfo"]["hasNextPage"],
+            json!(true)
+        );
+
+        let end_cursor = page["data"]["tenant"]["billing"]["adjustments"]["pageInfo"]["endCursor"]
+            .as_str()
+            .expect("end cursor")
+            .to_string();
+
+        let page2: serde_json::Value = server
+            .graphql(
+                &json!({
+                    "query": r#"
+                        query($tenant: String!, $first: Int, $after: String) {
+                            tenant(name: $tenant) {
+                                billing {
+                                    adjustments(first: $first, after: $after) {
+                                        pageInfo { hasNextPage }
+                                        edges { node { detail } }
+                                    }
+                                }
+                            }
+                        }
+                    "#,
+                    "variables": { "tenant": "adjustpage/", "first": 2, "after": end_cursor }
+                }),
+                Some(&admin_token),
+            )
+            .await;
+        let edges2 = page2["data"]["tenant"]["billing"]["adjustments"]["edges"]
+            .as_array()
+            .expect("edges array");
+        assert_eq!(edges2.len(), 1, "second page should have 1 edge: {page2:?}");
+        assert_eq!(edges2[0]["node"]["detail"], json!("credit 0"));
+        assert_eq!(
+            page2["data"]["tenant"]["billing"]["adjustments"]["pageInfo"]["hasNextPage"],
+            json!(false)
+        );
+    }
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
@@ -74,6 +74,19 @@ pub async fn insert_adjustment(
     .await
 }
 
+/// Page size used when the caller does not pass `first`/`last`, so an
+/// unbounded connection request can't fetch a tenant's entire adjustment
+/// history in one shot.
+const DEFAULT_PAGE_SIZE: usize = 100;
+
+/// Drops the extra sentinel row fetched to detect a further page, returning
+/// the page rows and whether more exist beyond it.
+fn trim_page(mut rows: Vec<BillingAdjustment>, page_size: usize) -> (Vec<BillingAdjustment>, bool) {
+    let has_more = rows.len() > page_size;
+    rows.truncate(page_size);
+    (rows, has_more)
+}
+
 /// Forward pagination: fetch adjustments older than `cursor` (or the newest
 /// adjustments when `cursor` is `None`). Returned rows are ordered newest-first.
 pub async fn fetch_adjustments_forward(
@@ -82,8 +95,9 @@ pub async fn fetch_adjustments_forward(
     cursor: Option<DateTime<Utc>>,
     limit: Option<usize>,
 ) -> sqlx::Result<(Vec<BillingAdjustment>, bool)> {
-    let query_limit = limit.map(|l| l as i64 + 1).unwrap_or(i64::MAX);
-    let mut rows = sqlx::query_as!(
+    let page_size = limit.unwrap_or(DEFAULT_PAGE_SIZE);
+    let query_limit = page_size as i64 + 1;
+    let rows = sqlx::query_as!(
         BillingAdjustment,
         r#"
         SELECT
@@ -108,11 +122,7 @@ pub async fn fetch_adjustments_forward(
     .fetch_all(pool)
     .await?;
 
-    let has_more = limit.is_some_and(|l| rows.len() > l);
-    if let Some(l) = limit {
-        rows.truncate(l);
-    }
-    Ok((rows, has_more))
+    Ok(trim_page(rows, page_size))
 }
 
 /// Backward pagination: fetch adjustments newer than `cursor`. Returned rows
@@ -124,8 +134,9 @@ pub async fn fetch_adjustments_backward(
     cursor: Option<DateTime<Utc>>,
     limit: Option<usize>,
 ) -> sqlx::Result<(Vec<BillingAdjustment>, bool)> {
-    let query_limit = limit.map(|l| l as i64 + 1).unwrap_or(i64::MAX);
-    let mut rows = sqlx::query_as!(
+    let page_size = limit.unwrap_or(DEFAULT_PAGE_SIZE);
+    let query_limit = page_size as i64 + 1;
+    let rows = sqlx::query_as!(
         BillingAdjustment,
         r#"
         SELECT
@@ -150,10 +161,7 @@ pub async fn fetch_adjustments_backward(
     .fetch_all(pool)
     .await?;
 
-    let has_more = limit.is_some_and(|l| rows.len() > l);
-    if let Some(l) = limit {
-        rows.truncate(l);
-    }
+    let (mut rows, has_more) = trim_page(rows, page_size);
     rows.reverse();
     Ok((rows, has_more))
 }
@@ -367,7 +375,10 @@ mod tests {
         let _guard = test_server::init();
         let tenant = "adjustpage";
         let admin_user_id = provision_test_tenant(&pool, tenant).await;
-        let support_user_id = provision_support_user(&pool, "support@estuary.test", tenant).await;
+        // Seeds the estuary_support/ grants so the fixture inserts below have a
+        // valid authorizer; the returned user id isn't needed (the test reads
+        // as the tenant admin).
+        provision_support_user(&pool, "support@estuary.test", tenant).await;
 
         // Insert three adjustments with distinct, increasing created_at values,
         // so "credit 2" is the newest.
@@ -393,7 +404,6 @@ mod tests {
             .await
             .expect("insert adjustment fixture");
         }
-        let _ = support_user_id;
 
         let (server, admin_token) =
             start_server_and_token(&pool, admin_user_id, tenant, mock_provider()).await;

--- a/crates/control-plane-api/src/server/public/graphql/billing/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::billing::BillingProvider;
 use async_graphql::Context;
 
+mod adjustments;
 pub(super) mod contact;
 mod invoices;
 mod loaders;

--- a/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
@@ -1,5 +1,6 @@
 use super::super::tenant::validate_tenant_name;
 use super::super::verify_authorization;
+use super::adjustments::{self, BillingAdjustment};
 use super::billing_provider;
 use super::contact::{self, BillingAddress, BillingAddressInput, BillingContact};
 use super::payment_methods::PaymentMethod;
@@ -85,6 +86,77 @@ impl BillingMutation {
         Ok(CreateBillingSetupIntentPayload {
             client_secret: super::super::Sensitive::new(client_secret),
         })
+    }
+
+    /// Create a billing adjustment (a credit or fee) against a tenant's
+    /// invoice for a given month. Adjustments are Estuary-internal: the
+    /// caller must be a member of estuary_support/, so that a tenant admin
+    /// cannot credit their own account. The adjustment's `authorizer` is
+    /// derived from the caller's authenticated email and is never
+    /// client-supplied.
+    async fn create_billing_adjustment(
+        &self,
+        ctx: &Context<'_>,
+        tenant: String,
+        billed_month: chrono::DateTime<chrono::Utc>,
+        usd_cents: i32,
+        detail: String,
+    ) -> Result<CreateBillingAdjustmentPayload> {
+        let env = ctx.data::<crate::Envelope>()?;
+        let tenant = validate_tenant_name(&tenant)?;
+
+        verify_authorization(env, "estuary_support/", models::Capability::Admin).await?;
+        verify_authorization(env, tenant.as_str(), models::authz::Capability::EditBilling).await?;
+
+        // The authorizer is the caller's email: from the token's email claim
+        // when present, and otherwise from auth.users (access tokens minted
+        // via refresh-token exchange carry no email claim).
+        let claims = env.claims()?;
+        let authorizer = match claims.email.clone() {
+            Some(email) => email,
+            None => {
+                sqlx::query_scalar!(r#"SELECT email FROM auth.users WHERE id = $1"#, claims.sub,)
+                    .fetch_optional(&env.pg_pool)
+                    .await?
+                    .flatten()
+                    .context("authenticated user has no email address")?
+            }
+        };
+
+        adjustments::require_month_boundary(billed_month)?;
+        if usd_cents == 0 {
+            return Err(async_graphql::Error::new("usdCents must be non-zero"));
+        }
+        if detail.trim().is_empty() || detail.len() > 4096 {
+            return Err(async_graphql::Error::new(
+                "detail must be non-empty and at most 4096 characters",
+            ));
+        }
+
+        let exists: bool = sqlx::query_scalar!(
+            r#"SELECT EXISTS(SELECT 1 FROM tenants WHERE tenant = $1) AS "exists!""#,
+            tenant.as_str(),
+        )
+        .fetch_one(&env.pg_pool)
+        .await?;
+        if !exists {
+            return Err(async_graphql::Error::new(format!(
+                "tenant {tenant} does not exist"
+            )));
+        }
+
+        let adjustment = adjustments::insert_adjustment(
+            &env.pg_pool,
+            tenant.as_str(),
+            billed_month,
+            usd_cents,
+            &authorizer,
+            &detail,
+        )
+        .await
+        .map_err(|err| async_graphql::Error::new(err.to_string()))?;
+
+        Ok(CreateBillingAdjustmentPayload { adjustment })
     }
 
     async fn set_billing_payment_method(
@@ -231,6 +303,11 @@ pub struct BillingPaymentMethodPayload {
 #[derive(Debug, Clone, SimpleObject)]
 pub struct SetBillingContactPayload {
     contact: BillingContact,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct CreateBillingAdjustmentPayload {
+    adjustment: BillingAdjustment,
 }
 
 #[cfg(test)]

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__adjustments_query_cross_tenant_denied.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__adjustments_query_cross_tenant_denied.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: cross
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 13,
+          "line": 3
+        }
+      ],
+      "message": "PermissionDenied: adjustother@example.test is not authorized to access prefix or name 'adjustco/' with required capability read",
+      "path": [
+        "tenant"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__adjustments_query_tenant_admin.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__adjustments_query_tenant_admin.snap
@@ -1,0 +1,29 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: listed
+---
+{
+  "data": {
+    "tenant": {
+      "billing": {
+        "adjustments": {
+          "edges": [
+            {
+              "node": {
+                "authorizer": "support@estuary.test",
+                "billedMonth": "2026-07-01T00:00:00+00:00",
+                "detail": "make-good for incident",
+                "tenant": "adjustco/",
+                "usdCents": -5000
+              }
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_bad_month.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_bad_month.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: bad_month
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 13,
+          "line": 8
+        }
+      ],
+      "message": "billedMonth must be the first instant of a month in UTC, like 2026-07-01T00:00:00Z",
+      "path": [
+        "createBillingAdjustment"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_by_support.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_by_support.snap
@@ -1,0 +1,17 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: created
+---
+{
+  "data": {
+    "createBillingAdjustment": {
+      "adjustment": {
+        "authorizer": "support@estuary.test",
+        "billedMonth": "2026-07-01T00:00:00+00:00",
+        "detail": "make-good for incident",
+        "tenant": "adjustco/",
+        "usdCents": -5000
+      }
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_denied_tenant_admin.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_denied_tenant_admin.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: denied
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 13,
+          "line": 8
+        }
+      ],
+      "message": "PermissionDenied: adjustco@example.test is not authorized to access prefix or name 'estuary_support/' with required capability admin",
+      "path": [
+        "createBillingAdjustment"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_missing_tenant.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_missing_tenant.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: missing
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 13,
+          "line": 8
+        }
+      ],
+      "message": "PermissionDenied: support@estuary.test is not authorized to access prefix or name 'nonexistent/' with required capability EditBilling",
+      "path": [
+        "createBillingAdjustment"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_zero_cents.snap
+++ b/crates/control-plane-api/src/server/public/graphql/billing/snapshots/control_plane_api__server__public__graphql__billing__adjustments__tests__create_adjustment_zero_cents.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/billing/adjustments.rs
+expression: zero
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 13,
+          "line": 8
+        }
+      ],
+      "message": "usdCents must be non-zero",
+      "path": [
+        "createBillingAdjustment"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::super::tenant::Tenant;
 use super::super::verify_authorization;
 use super::billing_provider;
@@ -7,7 +5,7 @@ use super::contact::{self, BillingContact};
 use super::invoices::{Invoice, InvoiceFilter};
 use super::loaders::CustomerDataLoader;
 use super::payment_methods::PaymentMethod;
-use crate::billing::{self, BillingProvider, InvoiceCursor};
+use crate::billing::{self, InvoiceCursor};
 use async_graphql::{
     ComplexObject, Context, Result,
     connection::{self, Connection},
@@ -19,21 +17,19 @@ impl Tenant {
     async fn billing(&self, ctx: &Context<'_>) -> Result<TenantBilling> {
         let env = ctx.data::<crate::Envelope>()?;
         verify_authorization(env, &self.name, models::authz::Capability::ViewBilling).await?;
-        let provider = billing_provider(ctx)?;
-        Ok(TenantBilling::new(self.name.clone(), provider))
+        Ok(TenantBilling {
+            tenant: self.name.clone(),
+        })
     }
 }
 
+/// The billing provider is resolved lazily by the fields which actually
+/// require it (payment methods), so that database-backed fields like
+/// `contact` and `invoices` work on deployments where billing is not
+/// configured.
 #[derive(Debug, Clone)]
 pub struct TenantBilling {
     tenant: String,
-    provider: Arc<dyn BillingProvider>,
-}
-
-impl TenantBilling {
-    fn new(tenant: String, provider: Arc<dyn BillingProvider>) -> Self {
-        Self { tenant, provider }
-    }
 }
 
 #[async_graphql::Object]
@@ -46,12 +42,12 @@ impl TenantBilling {
     }
 
     async fn payment_methods(&self, ctx: &Context<'_>) -> Result<Vec<PaymentMethod>> {
+        let provider = billing_provider(ctx)?;
         let loader = ctx.data::<DataLoader<CustomerDataLoader>>()?;
         let Some(customer) = loader.load_one(self.tenant.clone()).await? else {
             return Ok(Vec::new());
         };
-        let methods = self
-            .provider
+        let methods = provider
             .list_payment_methods(&customer.id)
             .await
             .map_err(|err| async_graphql::Error::new(err.to_string()))?;
@@ -59,6 +55,7 @@ impl TenantBilling {
     }
 
     async fn primary_payment_method(&self, ctx: &Context<'_>) -> Result<Option<PaymentMethod>> {
+        let provider = billing_provider(ctx)?;
         let loader = ctx.data::<DataLoader<CustomerDataLoader>>()?;
         let Some(customer) = loader.load_one(self.tenant.clone()).await? else {
             return Ok(None);
@@ -66,8 +63,7 @@ impl TenantBilling {
         let Some(primary_id) = billing::default_payment_method_id(&customer) else {
             return Ok(None);
         };
-        let pm = self
-            .provider
+        let pm = provider
             .get_payment_method(&primary_id.parse().map_err(|_| {
                 async_graphql::Error::new("invalid payment method ID in customer default")
             })?)

--- a/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
@@ -1,5 +1,9 @@
+use super::super::TimestampCursor;
 use super::super::tenant::Tenant;
 use super::super::verify_authorization;
+use super::adjustments::{
+    BillingAdjustment, fetch_adjustments_backward, fetch_adjustments_forward,
+};
 use super::billing_provider;
 use super::contact::{self, BillingContact};
 use super::invoices::{Invoice, InvoiceFilter};
@@ -25,8 +29,8 @@ impl Tenant {
 
 /// The billing provider is resolved lazily by the fields which actually
 /// require it (payment methods), so that database-backed fields like
-/// `contact` and `invoices` work on deployments where billing is not
-/// configured.
+/// `contact`, `invoices`, and `adjustments` work on deployments where
+/// billing is not configured.
 #[derive(Debug, Clone)]
 pub struct TenantBilling {
     tenant: String,
@@ -120,6 +124,56 @@ impl TenantBilling {
                     let cursor = InvoiceCursor::from_row(&row);
                     let invoice = Invoice::from_row(row);
                     connection::Edge::new(cursor, invoice)
+                }));
+                Ok(connection)
+            },
+        )
+        .await
+    }
+
+    /// Billing adjustments (credits and fees) applied to this tenant's
+    /// invoices, ordered newest-first.
+    async fn adjustments(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Connection<TimestampCursor, BillingAdjustment>> {
+        let env = ctx.data::<crate::Envelope>()?;
+        let tenant = self.tenant.clone();
+
+        connection::query_with::<TimestampCursor, _, _, _, async_graphql::Error>(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                let has_before = before.is_some();
+                let has_after = after.is_some();
+                let (rows, has_prev, has_next) = if has_before || last.is_some() {
+                    let (rows, has_prev) = fetch_adjustments_backward(
+                        &env.pg_pool,
+                        &tenant,
+                        before.map(|c| c.0),
+                        last,
+                    )
+                    .await
+                    .map_err(async_graphql::Error::from)?;
+                    (rows, has_prev, has_before)
+                } else {
+                    let (rows, has_next) =
+                        fetch_adjustments_forward(&env.pg_pool, &tenant, after.map(|c| c.0), first)
+                            .await
+                            .map_err(async_graphql::Error::from)?;
+                    (rows, has_after, has_next)
+                };
+
+                let mut connection = Connection::new(has_prev, has_next);
+                connection.edges.extend(rows.into_iter().map(|row| {
+                    let cursor = TimestampCursor(row.created_at);
+                    connection::Edge::new(cursor, row)
                 }));
                 Ok(connection)
             },

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -358,6 +358,77 @@ input BillingAddressInput {
 	country: String
 }
 
+"""
+An authorized adjustment to a tenant's invoice for a particular month,
+such as a make-good credit or a negotiated service fee. Adjustments are
+created by Estuary support staff and appear as invoice line items.
+"""
+type BillingAdjustment {
+	"""
+	Unique id of this adjustment.
+	"""
+	id: Id!
+	"""
+	Time at which this adjustment was created.
+	"""
+	createdAt: DateTime!
+	"""
+	Time at which this adjustment was last updated.
+	"""
+	updatedAt: DateTime!
+	"""
+	Tenant whose invoice is adjusted.
+	"""
+	tenant: String!
+	"""
+	Month of the invoice being adjusted, as the first instant of that
+	month in UTC.
+	"""
+	billedMonth: DateTime!
+	"""
+	Adjustment amount in USD cents. Positive values increase the invoice
+	total, and negative values are credits which decrease it.
+	"""
+	usdCents: Int!
+	"""
+	Email of the Estuary employee who authorized this adjustment.
+	"""
+	authorizer: String!
+	"""
+	Human-readable reason for this adjustment.
+	"""
+	detail: String
+}
+
+type BillingAdjustmentConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [BillingAdjustmentEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [BillingAdjustment!]!
+}
+
+"""
+An edge in a connection.
+"""
+type BillingAdjustmentEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: BillingAdjustment!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type BillingContact {
 	email: String
 	name: String
@@ -675,6 +746,10 @@ type CreateApiKeyResult {
 	client caches without a follow-up query.
 	"""
 	serviceAccount: ServiceAccount!
+}
+
+type CreateBillingAdjustmentPayload {
+	adjustment: BillingAdjustment!
 }
 
 type CreateBillingSetupIntentPayload {
@@ -1218,6 +1293,15 @@ type LockFailure {
 
 type MutationRoot {
 	createBillingSetupIntent(tenant: String!): CreateBillingSetupIntentPayload!
+	"""
+	Create a billing adjustment (a credit or fee) against a tenant's
+	invoice for a given month. Adjustments are Estuary-internal: the
+	caller must be a member of estuary_support/, so that a tenant admin
+	cannot credit their own account. The adjustment's `authorizer` is
+	derived from the caller's authenticated email and is never
+	client-supplied.
+	"""
+	createBillingAdjustment(tenant: String!, billedMonth: DateTime!, usdCents: Int!, detail: String!): CreateBillingAdjustmentPayload!
 	setBillingPaymentMethod(tenant: String!, paymentMethodId: String!): BillingPaymentMethodPayload!
 	setBillingContact(tenant: String!, email: String!, name: String!, address: BillingAddressInput!): SetBillingContactPayload!
 	deleteBillingPaymentMethod(tenant: String!, paymentMethodId: String!): BillingPaymentMethodPayload!
@@ -2356,6 +2440,11 @@ type TenantBilling {
 	paymentMethods: [PaymentMethod!]!
 	primaryPaymentMethod: PaymentMethod
 	invoices(filter: InvoiceFilter, after: String, before: String, first: Int, last: Int): InvoiceConnection!
+	"""
+	Billing adjustments (credits and fees) applied to this tenant's
+	invoices, ordered newest-first.
+	"""
+	adjustments(after: String, before: String, first: Int, last: Int): BillingAdjustmentConnection!
 }
 
 """


### PR DESCRIPTION
## Motivation

Billing adjustments (make-good credits and negotiated service fees) live in `internal.billing_adjustments` and land on invoices as line items, but the only way to create one today is manual SQL against the production database. Hand-written INSERTs are easy to get wrong: the month-boundary CHECK and id generation are both left to whoever is typing, and there's no consistent authorization path. Nothing can build on it either. Support tooling that computes a credit, like backfill make-goods, still ends with a human pasting SQL.

Exposing adjustments through the GraphQL API gives tooling and the dashboard a proper path. Authorization is enforced centrally, and the audit trail (`authorizer`) can't be forged by the caller.

## Description

**`Tenant.billing.adjustments`** is a paginated connection under the existing billing surface, gated by `ViewBilling` like its siblings. Customers may read their own adjustments: they already appear as line items on their invoices. Results are newest-first, cursored on `created_at`:

```graphql
query {
  tenant(name: "acmeCo/") {
    billing {
      adjustments(first: 10) {
        edges { node { id billedMonth usdCents authorizer detail createdAt } }
        pageInfo { hasNextPage endCursor }
      }
    }
  }
}
```

**`createBillingAdjustment`** is Estuary-internal. The caller must hold a transitive Admin grant on `estuary_support/` (the same staff-membership convention `authorize_user_prefix` enforces for Admin capability), in addition to `EditBilling` on the target tenant. A tenant admin holds `EditBilling` on their own tenant but is not support staff, so they cannot credit their own account.

```graphql
mutation {
  createBillingAdjustment(
    tenant: "acmeCo/"
    billedMonth: "2026-07-01T00:00:00Z"
    usdCents: -5000            # negative = credit
    detail: "make-good for incident X"
  ) {
    adjustment { id authorizer createdAt }
  }
}
```

The `authorizer` column records the caller's authenticated identity and is never client-supplied. It comes from the token's email claim when present, and otherwise from `auth.users` by user id (access tokens minted via refresh-token exchange carry no email claim). Input validation mirrors the table's constraints before the INSERT: `billedMonth` must be the first instant of a month in UTC (the table CHECK), `usdCents` must be non-zero, `detail` is required (non-empty, at most 4096 characters), and the tenant must exist. ids are minted with `internal.id_generator()`.

Also included: `Tenant.billing` previously required a configured billing provider up front, so the whole surface errored with `Billing is not configured` when none is set. Only the payment-method fields actually need Stripe. The provider is now resolved lazily per field, and the database-backed fields (`contact`, `invoices`, and `adjustments`) work on deployments without billing configured (first commit).

## Implementation notes

- `billing/adjustments.rs` holds the type, validation, insert, and the invoice-style forward/backward fetch pair; the connection field and mutation delegate to it from `tenant.rs` / `mutations.rs`.
- Pagination uses the shared TimestampCursor on created_at, newest-first, with a limit+1 row to detect hasNextPage. Unlike the invoices query, an argument-less request is capped at a default page size (100) rather than returning the full history.
- The `estuary_support/` gate uses `verify_authorization` (not the fail-closed `may_access`) so a stale snapshot follows the standard refresh-and-retry path and denials are explicit errors.
- No new PostgREST exposure: the table stays internal; sqlx queries with offline cache (`.sqlx`) committed, SDL regenerated.

## Testing

- `sqlx::test` coverage: the full authorization matrix (support user creates; tenant admin denied create; tenant admin reads own; other tenant denied read), validation errors (mid-month, zero cents, nonexistent tenant), and two-page cursor pagination with newest-first ordering. Insta snapshots committed.
- Verified end-to-end against a live agent + Postgres stack: support user created a credit and a fee (correct authorizer via the auth.users fallback, real flowids in the table); tenant admin denied create; read-only user denied `ViewBilling`; cursors paged correctly; validation errors clean.