### PR TITLE
shuffle: fix open-phase deadlock via EOF-cascade teardown

### DIFF
--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -91,6 +91,32 @@ consumed, a coordinator does it only once it will request no further checkpoints
 then calls `SessionClient::close()` (which blocks until the Session→Slice→Log
 topology has fully drained).
 
+#### Teardown during the opening phase
+
+The opening phase participates in the same EOF cascade. Each handler opens its
+downstream peers and races that fan-out against its own request stream. It
+short-circuits if any downstream open errors — dropping the sibling open futures,
+which drops their request channels and cascades EOF down to those peers and
+their peers in turn. Racing the request stream catches the *upstream* going
+away mid-open.
+
+The Log rendezvous is the subtle case. `M` Slices connect to each Log shard; the
+invocation that connects last runs the `LogActor`, while the earlier `M-1` park.
+A parked invocation must remain cancel-observant, so it selects its own
+completion signal against `response_tx.closed()` (fired when its Slice
+client drops its receiver) and reaps *only its own* slot under the `log_joins`
+mutex (dropping the whole entry when it removed the last live slot),
+so a stale partial rendezvous can't wedge the map or poison
+a retry.
+
+#### No deadlines, by design
+
+There are deliberately **no** open-phase deadlines. Every transient failure
+surfaces as an error that self-heals via `try_join_all` and the Go retry loop,
+so a timeout would add flapping that would only paper over a true regression,
+and makes the ensemble more difficult to debug (a stable wedge is far easier
+to inspect).
+
 ### Authorization
 
 When the `Service` is built with a `proto_grpc::Signer` (the sidecar; `None` in

--- a/crates/shuffle/src/lib.rs
+++ b/crates/shuffle/src/lib.rs
@@ -119,6 +119,27 @@ fn verify_send<T>(tx: &mpsc::Sender<T>, value: T) -> anyhow::Result<()> {
     }
 }
 
+/// Build the error for a request stream that closed or spoke out of turn while
+/// a handler was still opening. No legitimate request arrives before a handler
+/// emits its `Opened` (the coordinator sends `resume_checkpoint`, and the
+/// Session sends `Start`, only after observing `Opened`). So EOF, an error, or
+/// any message means the client (or its RPC) went away: the handler aborts,
+/// dropping its downstream open fan-out so that EOF teardown cascades to peers.
+/// Deliberately involves no deadline — see the crate README "Shutdown" notes.
+fn opening_aborted<T>(source: &str, peer: &str, msg: Option<tonic::Result<T>>) -> anyhow::Error {
+    match msg {
+        None => {
+            anyhow::format_err!("{source} request stream from {peer} reached EOF during opening")
+        }
+        Some(Err(status)) => status_to_anyhow(status).context(format!(
+            "{source} request stream from {peer} errored during opening"
+        )),
+        Some(Ok(_)) => anyhow::format_err!(
+            "{source} received an unexpected request from {peer} during opening (before Opened was sent)"
+        ),
+    }
+}
+
 // Map an anyhow::Error into a tonic::Status.
 #[inline]
 fn anyhow_to_status(err: anyhow::Error) -> tonic::Status {

--- a/crates/shuffle/src/lib.rs
+++ b/crates/shuffle/src/lib.rs
@@ -54,6 +54,8 @@ mod session;
 pub mod slice;
 
 #[cfg(test)]
+mod open_deadlock_tests;
+#[cfg(test)]
 pub(crate) mod testing;
 
 /// Document passed JSON Schema validation.

--- a/crates/shuffle/src/log/handler.rs
+++ b/crates/shuffle/src/log/handler.rs
@@ -1,9 +1,23 @@
-use super::{LogJoin, state, writer::Writer};
+use super::{LogJoin, LogJoinSlot, state, writer::Writer};
 use anyhow::Context;
 use futures::StreamExt;
 use proto_flow::shuffle;
 use tokio::sync::mpsc;
 use tracing::Instrument;
+
+/// Outcome of registering a Slice connection into a Log rendezvous.
+enum Rendezvous {
+    /// This invocation completed the rendezvous: it owns every slot and runs
+    /// the LogActor.
+    Complete(Vec<Option<LogJoinSlot>>),
+    /// This invocation registered its slot and must park until the rendezvous
+    /// completes (released via `complete_rx`) or its Slice client goes away
+    /// (`response_tx.closed()`), in which case it reaps its own slot.
+    Park {
+        complete_rx: tokio::sync::oneshot::Receiver<()>,
+        response_tx: mpsc::Sender<tonic::Result<shuffle::LogResponse>>,
+    },
+}
 
 pub(crate) async fn serve_log<R>(
     service: crate::Service,
@@ -83,10 +97,14 @@ where
         directory = directory.clone(),
         "received Open from Slice",
     );
-    let join_key = (directory.clone(), log_shard_index);
+    let join_key = (directory.clone(), session_id, log_shard_index);
 
-    // Scope `guard` to prove it's not held across await points.
-    let connections = {
+    // Register this Slice's connection into the rendezvous. Either we complete
+    // it (own all slots and run the LogActor) or we must park until released —
+    // scope `guard` so the std Mutex is never held across the await that
+    // follows. The clone of `response_tx` lets a parked handler observe its
+    // Slice client going away (`closed()`) without moving the slot's own sender.
+    let rendezvous = {
         let mut guard = service.log_joins.lock().unwrap();
 
         let join = guard.entry(join_key.clone()).or_insert_with(|| LogJoin {
@@ -110,7 +128,14 @@ where
                 "Log shard_index {log_shard_index} directory {directory} in session {session_id} received duplicate Slice connection from {slice_shard_index}",
             );
         }
-        join.shards[slice_shard_index as usize] = Some((request_rx.boxed(), response_tx));
+
+        let (complete_tx, complete_rx) = tokio::sync::oneshot::channel();
+        let response_tx_clone = response_tx.clone();
+        join.shards[slice_shard_index as usize] = Some(LogJoinSlot {
+            request_rx: request_rx.boxed(),
+            response_tx,
+            complete_tx,
+        });
 
         let connected = join.shards.iter().filter(|s| s.is_some()).count();
 
@@ -125,24 +150,71 @@ where
 
         // Are there still more Slices that need to connect?
         if connected != shards.len() as usize {
-            // This invocation only contributed its streams to the rendezvous;
-            // the invocation that completes it runs the LogActor.
-            handler.finish_ok();
-            return Ok(());
+            Rendezvous::Park {
+                complete_rx,
+                response_tx: response_tx_clone,
+            }
+        } else {
+            // All Slices have connected to this Log.
+            Rendezvous::Complete(guard.remove(&join_key).unwrap().shards)
         }
-        // All Slices have connected to this Log.
-        let LogJoin { shards } = guard.remove(&join_key).unwrap();
-        shards
     };
 
-    // Walk `connections` and partition into Senders and receiver Streams.
+    let connections = match rendezvous {
+        Rendezvous::Park {
+            complete_rx,
+            response_tx,
+        } => {
+            // We only contributed our streams to the rendezvous; the invocation
+            // that completes it runs the LogActor. Park until either happens:
+            tokio::select! {
+                // Released by the completing invocation.
+                _ = complete_rx => {
+                    handler.finish_ok();
+                    return Ok(());
+                }
+                // Our Slice client's response receiver dropped: it aborted its
+                // open (Session/Slice EOF cascade), or the remote disconnected
+                // (tonic surfaces both as `closed()`). Reap our own slot so a
+                // stale partial rendezvous can't poison a retry, resolving the
+                // race with a concurrent completer under the mutex: if the entry
+                // or our slot is already gone, the rendezvous completed and we
+                // just exit. Drop the whole entry only when we removed its last
+                // live slot — each sibling reaps its own slot as its abort lands.
+                _ = response_tx.closed() => {
+                    let mut guard = service.log_joins.lock().unwrap();
+                    if let Some(join) = guard.get_mut(&join_key) {
+                        join.shards[slice_shard_index as usize] = None;
+                        if join.shards.iter().all(Option::is_none) {
+                            guard.remove(&join_key);
+                        }
+                    }
+                    handler.finish_ok();
+                    return Ok(());
+                }
+            }
+        }
+        Rendezvous::Complete(connections) => connections,
+    };
+
+    // Walk `connections` and partition into Senders and receiver Streams,
+    // releasing each slot's parked sibling as we take ownership.
     let mut log_response_tx = Vec::with_capacity(shards.len());
     let mut log_request_rx = Vec::with_capacity(shards.len());
 
     for connection in connections {
-        let (rx, tx) = connection.unwrap();
-        log_response_tx.push(tx);
-        log_request_rx.push(rx);
+        let LogJoinSlot {
+            request_rx,
+            response_tx,
+            complete_tx,
+        } = connection.unwrap();
+
+        // Release the parked sibling holding this slot. Its receiver may already
+        // be gone (it aborted, or this is our own unused slot) — ignore that.
+        let _ = complete_tx.send(());
+
+        log_response_tx.push(response_tx);
+        log_request_rx.push(request_rx);
     }
 
     // Send Opened response to all Slices.

--- a/crates/shuffle/src/log/mod.rs
+++ b/crates/shuffle/src/log/mod.rs
@@ -178,13 +178,31 @@ pub const BLOCK_HEADER_LEN: usize = 8;
 
 /// LogJoin coordinates multiple Slice streams connecting to the same Log.
 /// Each Log shard receives connections from all Slices (M connections total).
+///
+/// The map is keyed by `(directory, session_id, log_shard_index)` in
+/// [`crate::Service`]. Including `session_id` makes retries collision-free by
+/// construction: a fresh session never reuses a prior session's slots even if
+/// it reuses the same `directory`. `directory` stays in the key because
+/// `session_id` is a u32 of time-nanos and can collide across concurrent tasks
+/// on one sidecar.
 pub(crate) struct LogJoin {
-    shards: Vec<
-        Option<(
-            BoxStream<'static, tonic::Result<shuffle::LogRequest>>,
-            mpsc::Sender<tonic::Result<shuffle::LogResponse>>,
-        )>,
-    >,
+    /// One slot per Slice, indexed by `slice_shard_index`. `None` until that
+    /// Slice connects (or after its slot is reaped on abort).
+    shards: Vec<Option<LogJoinSlot>>,
+}
+
+/// A single Slice's connection to a Log rendezvous.
+pub(crate) struct LogJoinSlot {
+    /// The Slice's request stream and the response sender back to it, handed to
+    /// the [`super::actor::LogActor`] once the rendezvous completes.
+    request_rx: BoxStream<'static, tonic::Result<shuffle::LogRequest>>,
+    response_tx: mpsc::Sender<tonic::Result<shuffle::LogResponse>>,
+    /// Fired by the invocation that completes the rendezvous to release this
+    /// slot's parked, non-completing handler so it exits `Ok`. A per-slot
+    /// `oneshot` (rather than a shared `watch`) keeps the release edge-triggered
+    /// and lets a completing invocation hand off ownership per slot without a
+    /// broadcast the parked handlers would have to filter.
+    complete_tx: tokio::sync::oneshot::Sender<()>,
 }
 
 #[derive(Clone)]

--- a/crates/shuffle/src/open_deadlock_tests.rs
+++ b/crates/shuffle/src/open_deadlock_tests.rs
@@ -1,0 +1,286 @@
+//! Regression tests for issue #3245: "runtime-v2: multi-shard shuffle open
+//! deadlocks when a peer sidecar is briefly unreachable".
+//!
+//! These exercise the Session→Slice→Log open fan-out across two in-process
+//! `Service` instances with distinct `peer_endpoint`s, one of which runs a real
+//! tonic server over `http://127.0.0.1:<port>` loopback. They assert that a
+//! transient open failure of any peer promptly errors the whole `open` (rather
+//! than wedging forever) and leaves no partial rendezvous state behind in the
+//! process-global `Service::log_joins` map.
+//!
+//! Against the unfixed code these tests fail by exhausting their `tokio::time`
+//! timeout: `join_all` traps the peer's error while sibling in-process opens
+//! park on a Log rendezvous that can never complete.
+
+use proto_flow::{flow, shuffle};
+
+/// A journal-client factory that is never dialed by these tests: `open`
+/// aborts (or is torn down) before any Slice actor begins reading journals.
+/// It builds a client pointed at an unroutable endpoint so that, in the one
+/// test where `open` succeeds, the post-open listing simply errors and tears
+/// the session down instead of panicking.
+fn dummy_journal_factory() -> gazette::journal::ClientFactory {
+    std::sync::Arc::new(|_authz_sub: String, _authz_obj: String| {
+        gazette::journal::Client::new(
+            "http://127.0.0.1:1".to_string(),
+            gazette::journal::Client::new_fragment_client(),
+            proto_grpc::Metadata::new(),
+            gazette::Router::new("local"),
+        )
+    })
+}
+
+/// Build a Service with the given `peer_endpoint`, unauthenticated (no signer),
+/// matching how tests run the shuffle fan-out.
+fn build_service(peer_endpoint: &str) -> crate::Service {
+    crate::Service::new(
+        peer_endpoint.to_string(),
+        dummy_journal_factory(),
+        crate::DEFAULT_SHUFFLE_DISK_LIMIT_BYTES,
+        service_kit::Registry::new(),
+        None,
+    )
+}
+
+/// Bind a loopback listener and return it alongside its `http://` endpoint.
+async fn bind_endpoint() -> (tokio::net::TcpListener, String) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    (listener, endpoint)
+}
+
+/// Reserve then release a loopback port, yielding an endpoint that will refuse
+/// connections instantly (nothing is listening).
+async fn unbound_endpoint() -> String {
+    let (listener, endpoint) = bind_endpoint().await;
+    drop(listener);
+    endpoint
+}
+
+/// Serve `service` on `listener` until the returned handle is aborted.
+fn serve(
+    service: crate::Service,
+    listener: tokio::net::TcpListener,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        let _ = service
+            .build_tonic_server()
+            .serve_with_incoming(incoming)
+            .await;
+    })
+}
+
+/// Build an N-shard topology, one endpoint per shard, with each shard's log
+/// directory rooted under `dir` (created so a completing Log can open a Writer).
+fn build_shards(endpoints: &[&str], dir: &std::path::Path) -> Vec<shuffle::Shard> {
+    let count = endpoints.len() as u32;
+    endpoints
+        .iter()
+        .enumerate()
+        .map(|(i, endpoint)| {
+            let i = i as u32;
+            let key_begin = if i == 0 {
+                0
+            } else {
+                ((i as u64 * (u32::MAX as u64 + 1)) / count as u64) as u32
+            };
+            let key_end = if i == count - 1 {
+                u32::MAX
+            } else {
+                (((i + 1) as u64 * (u32::MAX as u64 + 1)) / count as u64 - 1) as u32
+            };
+            let directory = dir.join(format!("shard-{i:03}"));
+            std::fs::create_dir_all(&directory).unwrap();
+
+            shuffle::Shard {
+                id: format!("open-deadlock/shard-{i:03}"),
+                range: Some(flow::RangeSpec {
+                    key_begin,
+                    key_end,
+                    r_clock_begin: 0,
+                    r_clock_end: u32::MAX,
+                }),
+                endpoint: endpoint.to_string(),
+                directory: directory.to_str().unwrap().to_string(),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+fn build_task(spec: &flow::MaterializationSpec) -> shuffle::Task {
+    shuffle::Task {
+        task: Some(shuffle::task::Task::Materialization(spec.clone())),
+    }
+}
+
+/// Build the shuffle task from the shared catalog fixture (offline; no
+/// data-plane). Only the open path is exercised, so the bindings' shuffle
+/// configuration is all that matters.
+async fn fixture_task() -> shuffle::Task {
+    let source = build::arg_source_to_url("./tests/shuffle.flow.yaml", false).unwrap();
+    let output = build::for_local_test(&source, true)
+        .await
+        .into_result()
+        .expect("build of catalog fixture should succeed");
+
+    let spec = output
+        .built
+        .built_materializations
+        .get_by_key(&models::Materialization::new("testing/materialization"))
+        .expect("should have built materialization")
+        .spec
+        .as_ref()
+        .expect("built materialization should have a spec")
+        .clone();
+
+    build_task(&spec)
+}
+
+/// Poll `service.log_joins` until it drains to empty, or panic after the bound.
+async fn await_log_joins_empty(service: &crate::Service, label: &str) {
+    for _ in 0..200 {
+        if service.log_joins.lock().unwrap().is_empty() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!(
+        "{label}: log_joins did not drain: {} entries remain",
+        service.log_joins.lock().unwrap().len(),
+    );
+}
+
+/// Guards against a hang: `open` must resolve (Ok or Err) well within this
+/// bound. Against the unfixed code it never resolves, so the timeout fires.
+const OPEN_GUARD: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// (a) Trapped-error repro: a 2-shard session whose peer endpoint refuses
+/// connections instantly must fail `open` promptly rather than deadlocking.
+#[tokio::test]
+async fn open_errors_when_peer_dial_refused() {
+    let task = fixture_task().await;
+
+    // Shard 0 is in-process; shard 1 points at an unbound port (instant refuse).
+    let endpoint_a = "http://127.0.0.1:1".to_string();
+    let service = build_service(&endpoint_a);
+    let unbound = unbound_endpoint().await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let shards = build_shards(&[&endpoint_a, &unbound], dir.path());
+
+    let result = tokio::time::timeout(
+        OPEN_GUARD,
+        crate::SessionClient::open(&service, task, shards, Default::default()),
+    )
+    .await
+    .expect("open must not hang when a peer is unreachable (issue #3245)");
+
+    let Err(err) = result else {
+        panic!("open must fail when a peer dial is refused");
+    };
+    tracing::info!(%err, "open failed as expected");
+
+    await_log_joins_empty(&service, "dial-refused").await;
+}
+
+/// (b) Reachable-peer open failure: the peer sidecar is reachable, but its
+/// Slice open is rejected (endpoint-identity mismatch). `open` must error and
+/// both Services' `log_joins` maps must drain to empty.
+#[tokio::test]
+async fn open_errors_when_reachable_peer_rejects() {
+    let task = fixture_task().await;
+
+    // Coordinator (shard 0, in-process). It makes remote hops to the peer for
+    // both the Slice RPC and its in-process Slice's Log RPC, but needs no
+    // server of its own: the peer's Slice open fails before it dials back.
+    let endpoint_a = "http://127.0.0.1:1".to_string();
+    let service_a = build_service(&endpoint_a);
+
+    // Reachable peer (shard 1). Its `peer_endpoint` deliberately mismatches the
+    // address shard 1 is dialed at, so its Slice open rejects with an
+    // endpoint-identity error — a reachable-peer open failure, not a dial error.
+    let (listener_b, endpoint_b) = bind_endpoint().await;
+    let service_b = build_service("http://127.0.0.1:9");
+    let handle_b = serve(service_b.clone(), listener_b);
+
+    let dir = tempfile::tempdir().unwrap();
+    let shards = build_shards(&[&endpoint_a, &endpoint_b], dir.path());
+
+    let result = tokio::time::timeout(
+        OPEN_GUARD,
+        crate::SessionClient::open(&service_a, task, shards, Default::default()),
+    )
+    .await
+    .expect("open must not hang when a reachable peer rejects (issue #3245)");
+
+    let Err(err) = result else {
+        panic!("open must fail when a reachable peer rejects the Slice open");
+    };
+    tracing::info!(%err, "open failed as expected");
+
+    // Both the coordinator's in-process Log and the peer's remote Log
+    // registered partial rendezvous state that must be reaped on abort.
+    await_log_joins_empty(&service_a, "reachable-reject coordinator").await;
+    await_log_joins_empty(&service_b, "reachable-reject peer").await;
+
+    handle_b.abort();
+}
+
+/// (c) Abort-then-retry: a partial rendezvous that aborts must not poison a
+/// subsequent session reusing the same shard directories. The stale slot is
+/// reaped, and the retry opens cleanly (no "duplicate Slice connection").
+#[tokio::test]
+async fn retry_after_abort_reuses_directory() {
+    let task = fixture_task().await;
+
+    // Two fully-functional peers, each serving loopback. The retry needs both
+    // (the peer's Slice dials back to the coordinator's Log).
+    let (listener_a, endpoint_a) = bind_endpoint().await;
+    let service_a = build_service(&endpoint_a);
+    let handle_a = serve(service_a.clone(), listener_a);
+
+    let (listener_b, endpoint_b) = bind_endpoint().await;
+    let service_b = build_service(&endpoint_b);
+    let handle_b = serve(service_b.clone(), listener_b);
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // Attempt 1: shard 1 points at an unbound port, aborting a partial
+    // rendezvous on the coordinator's in-process Log.
+    let unbound = unbound_endpoint().await;
+    let shards1 = build_shards(&[&endpoint_a, &unbound], dir.path());
+
+    let result = tokio::time::timeout(
+        OPEN_GUARD,
+        crate::SessionClient::open(&service_a, task.clone(), shards1, Default::default()),
+    )
+    .await
+    .expect("first open must not hang (issue #3245)");
+    assert!(
+        result.is_err(),
+        "first open must fail with shard 1 unreachable",
+    );
+
+    // The stale slot must be reaped before the retry reuses the directory.
+    await_log_joins_empty(&service_a, "retry attempt-1 coordinator").await;
+
+    // Attempt 2: shard 1 now points at the reachable peer, reusing the same
+    // shard directories. This must open cleanly.
+    let shards2 = build_shards(&[&endpoint_a, &endpoint_b], dir.path());
+
+    let session = tokio::time::timeout(
+        OPEN_GUARD,
+        crate::SessionClient::open(&service_a, task, shards2, Default::default()),
+    )
+    .await
+    .expect("retry open must not hang")
+    .expect("retry open must succeed (no duplicate Slice connection)");
+
+    // Drop the session to tear down; the dummy factory would error a real read.
+    drop(session);
+
+    handle_a.abort();
+    handle_b.abort();
+}

--- a/crates/shuffle/src/service.rs
+++ b/crates/shuffle/src/service.rs
@@ -28,8 +28,10 @@ pub struct ServiceImpl {
     /// Transport channels to dialed peers.
     pub(crate) channels: std::sync::Mutex<HashMap<String, tonic::transport::Channel>>,
     /// Shared state for coordinating Log RPCs from multiple Slices into a single LogActor.
-    /// Keyed by (directory, log_shard_index).
-    pub(crate) log_joins: std::sync::Mutex<HashMap<(String, u32), log::LogJoin>>,
+    /// Keyed by (directory, session_id, log_shard_index). `session_id` scopes
+    /// each rendezvous to its session so retries can't collide with a prior
+    /// session's leftover slots; see [`log::LogJoin`].
+    pub(crate) log_joins: std::sync::Mutex<HashMap<(String, u32, u32), log::LogJoin>>,
     /// Registry of in-flight Session/Slice/Log handlers, for the admin surface.
     pub(crate) registry: service_kit::Registry,
     /// Signs `SHUFFLE` bearer tokens for every outbound shuffle hop.

--- a/crates/shuffle/src/session/handler.rs
+++ b/crates/shuffle/src/session/handler.rs
@@ -76,22 +76,23 @@ where
         "received Open from Coordinator"
     );
 
-    // Concurrently Open a Slice RPC with every shard.
-    let open_results =
-        futures::future::join_all((0..shards.len()).into_iter().map(|shard_index| {
+    // Concurrently Open a Slice RPC with every shard, racing the fan-out
+    // against the coordinator's request stream. `try_join_all` short-circuits
+    // the instant any Slice open errors, dropping the sibling open futures —
+    // which drops their per-Slice request channels and cascades EOF teardown
+    // down to those Slices and their Logs. Racing the request stream catches
+    // the coordinator (or its RPC) going away mid-open, which we treat the same
+    // way. This is the open-phase counterpart to the running-phase EOF cascade
+    // (see the crate README "Shutdown" notes).
+    let (slice_request_tx, response_rx): (Vec<_>, Vec<_>) = tokio::select! {
+        result = futures::future::try_join_all((0..shards.len()).map(|shard_index| {
             open_slice_rpc(&service, session_id, &task, &shards, shard_index as u32)
-        }))
-        .await;
+        })) => result?.into_iter().unzip(),
 
-    // Walk results and partition into Senders and receiver Streams.
-    let mut slice_request_tx = Vec::with_capacity(shards.len());
-    let mut response_rx = Vec::with_capacity(shards.len());
-
-    for result in open_results {
-        let (tx, rx) = result?;
-        slice_request_tx.push(tx);
-        response_rx.push(rx);
-    }
+        msg = request_rx.next() => {
+            return Err(crate::opening_aborted("Session", "coordinator", msg));
+        }
+    };
 
     tracing::info!(
         session_id,

--- a/crates/shuffle/src/slice/handler.rs
+++ b/crates/shuffle/src/slice/handler.rs
@@ -81,9 +81,14 @@ where
         "received Open from Session",
     );
 
-    // Concurrently Open a Log RPC with every shard.
-    let open_results =
-        futures::future::join_all((0..shards.len()).into_iter().map(|log_shard_index| {
+    // Concurrently Open a Log RPC with every shard, racing the fan-out against
+    // our Slice request stream. `try_join_all` short-circuits on the first Log
+    // open error, dropping the sibling opens (and their Log request channels)
+    // so teardown cascades. `Start` arrives only after we send `Opened`, so any
+    // message here means the Session (or its RPC) went away: we abort likewise.
+    // This mirrors the Session handler's open-phase EOF cascade.
+    let (log_request_tx, log_response_rx): (Vec<_>, Vec<_>) = tokio::select! {
+        result = futures::future::try_join_all((0..shards.len()).map(|log_shard_index| {
             open_log_rpc(
                 &service,
                 session_id,
@@ -91,18 +96,12 @@ where
                 &shards,
                 log_shard_index as u32,
             )
-        }))
-        .await;
+        })) => result?.into_iter().unzip(),
 
-    // Walk results and partition into Senders and receiver Streams.
-    let mut log_request_tx = Vec::with_capacity(shards.len());
-    let mut log_response_rx = Vec::with_capacity(shards.len());
-
-    for result in open_results {
-        let (tx, rx) = result?;
-        log_request_tx.push(tx);
-        log_response_rx.push(rx);
-    }
+        msg = slice_request_rx.next() => {
+            return Err(crate::opening_aborted("Slice", "session", msg));
+        }
+    };
 
     tracing::info!(
         session_id,


### PR DESCRIPTION
**Description:**

Fixes #3245: a multi-shard V2 task wedged forever at startup whenever one shard's runtime-sidecar was briefly unreachable while another shard's shuffle Session was opening — a routine cold-start / rolling-restart race.

The Session→Slice→Log open fan-outs used `futures::future::join_all`, which does not short-circuit on `Err`: a peer's connection-refused error resolved but was trapped while sibling in-process opens parked forever on the Log rendezvous (which completes only once ALL Slices connect). The parked handlers are detached tasks not yet polling their request streams, so teardown was never observed, and partial rendezvous state in the process-global `Service::log_joins` map poisoned in-tenure retries with `received duplicate Slice connection`.

The fix is structural and entirely within `crates/shuffle`: the opening phase now participates in the same request-stream-EOF teardown cascade the running phase already uses (per the crate README's shutdown model).

- **Session & Slice handlers**: `join_all` → `try_join_all`, raced via `tokio::select!` against the handler's own request stream. The first downstream open error short-circuits, dropping sibling open futures and cascading EOF teardown downward. Any EOF/error/message on the request stream during opening (all illegal before `Opened`) likewise aborts.
- **Log rendezvous is abort-safe**: a non-completing invocation no longer returns immediately after registering. It parks on a per-slot `oneshot` completion signal raced against `response_tx.closed()`, and on abort reaps its own slot under the `log_joins` mutex (removing the entry when its last slot goes). Aborted partial rendezvous neither poison retries nor leak.
- **`LogJoin` key is session-scoped**: `(directory, log_shard_index)` → `(directory, session_id, log_shard_index)`, making retries collision-free by construction; abort cleanup is then leak-prevention rather than correctness-critical. The duplicate-slice check remains as an intra-session protocol assertion.

**Deliberately no deadlines or stall watchdogs.** Every transient failure now errors and self-heals through error propagation plus the Go retry loop. The remaining non-erroring wedge classes are rare and likely persistent — a stable wedge is far easier to debug than one flapping through teardown/retry. Rationale is recorded in the crate README so it isn't "fixed" later.

**Workflow steps:**

None — internal runtime bug fix with no user-facing surface. Multi-shard V2 tasks now recover from a briefly-unreachable peer sidecar instead of hanging.

**Documentation links affected:**

None (internal `crates/shuffle/README.md` updated in-repo).

**Notes for reviewers:**

- Two commits, TDD: the first adds three red regression tests (`crates/shuffle/src/open_deadlock_tests.rs`, each with a 30s hang guard) verified failing — hanging — against the unfixed code; the second lands the fix and README update, turning them green in <0.1s.
- No Go, protocol, or runtime-next changes; `session_id` already rides in every Open. `log_joins` is process-local, so there is no mixed-version concern. Derivations get the fix alongside materializations.
- Full `cargo test -p shuffle` passes (99 lib tests + scenario fixture/fuzz tests).
