### PR TITLE
runtime-v2: bind task terms to ShardSpec bytes and restart gracefully from Join-wait

### DIFF
--- a/go/runtime/derive_v2.go
+++ b/go/runtime/derive_v2.go
@@ -198,8 +198,11 @@ func (m *deriveAppV2) StartReadingMessages(shard consumer.Shard, _ pc.Checkpoint
 // materializeAppV2.runOneSession: build & send Join until topology consensus,
 // send Task and await Opened (which carries the connector Container), then run
 // the steady-state select loop until term cancellation, shard cancellation, or
-// a stream error. On term cancellation (spec update) we send Stop and await
-// Stopped, then return nil so the framework loops back through RestoreCheckpoint.
+// a stream error. Term cancellation (a spec update, per the term contract in
+// task.go) is always a graceful in-process restart, never a shard failure, both
+// before and after Opened: pre-Opened we return nil directly, and post-Opened
+// we first send Stop and await Stopped. Either way the framework loops back
+// through RestoreCheckpoint with a fresh term.
 func (m *deriveAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.EnvelopeOrError) (err error) {
 	defer func() {
 		if err != nil {
@@ -221,6 +224,15 @@ func (m *deriveAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.Env
 		err = ks.WaitForRevision(m.term.ctx, waitForRevision)
 		ks.Mu.RUnlock()
 		if err != nil {
+			// A term cancellation is a spec update, not a failure. The Rust
+			// session loop is still parked awaiting a Join, so returning nil
+			// restarts the session in-process. Only a shard-context
+			// cancellation is a genuine shutdown.
+			if shard.Context().Err() == nil {
+				logrus.WithField("shardId", shard.Spec().Id).
+					Info("task term ended during Join-wait; restarting session")
+				return nil
+			}
 			return fmt.Errorf("awaiting Etcd revision %d: %w", waitForRevision, err)
 		}
 

--- a/go/runtime/materialize_v2.go
+++ b/go/runtime/materialize_v2.go
@@ -165,10 +165,12 @@ func (m *materializeAppV2) StartReadingMessages(shard consumer.Shard, _ pc.Check
 //  4. Run the steady-state select loop until term cancellation, shard
 //     cancellation, or a stream error.
 //
-// On term cancellation (spec update) we send Stop and wait for Stopped, then
-// return nil so the framework loops back through RestoreCheckpoint. Any
-// non-nil return is forwarded onto `ch` by the deferred sentinel before
-// the channel is closed.
+// Term cancellation (a spec update, per the term contract in task.go) is always
+// a graceful in-process restart, never a shard failure, both before and after
+// Opened: pre-Opened we return nil directly, and post-Opened we first send Stop
+// and wait for Stopped. Either way the framework loops back through
+// RestoreCheckpoint with a fresh term. Any non-nil return is forwarded onto
+// `ch` by the deferred sentinel before the channel is closed.
 func (m *materializeAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.EnvelopeOrError) (err error) {
 	defer func() {
 		if err != nil {
@@ -190,6 +192,15 @@ func (m *materializeAppV2) runOneSession(shard consumer.Shard, ch chan<- consume
 		err = ks.WaitForRevision(m.term.ctx, waitForRevision)
 		ks.Mu.RUnlock()
 		if err != nil {
+			// A term cancellation is a spec update, not a failure. The Rust
+			// session loop is still parked awaiting a Join, so returning nil
+			// restarts the session in-process. Only a shard-context
+			// cancellation is a genuine shutdown.
+			if shard.Context().Err() == nil {
+				logrus.WithField("shardId", shard.Spec().Id).
+					Info("task term ended during Join-wait; restarting session")
+				return nil
+			}
 			return fmt.Errorf("awaiting Etcd revision %d: %w", waitForRevision, err)
 		}
 

--- a/go/runtime/task.go
+++ b/go/runtime/task.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -62,7 +63,10 @@ type taskTerm[TaskSpec pf.Task] struct {
 	ctx       context.Context    // Context for the task term.
 	labels    ops.ShardLabeling  // Shard labels of this task term.
 	shardSpec *pf.ShardSpec      // Term ShardSpec of the task.
-	taskSpec  TaskSpec           // Term TaskSpec of the task.
+	// Raw etcd value of shardSpec, which defines this term: it ends when these
+	// bytes change or the key is deleted, but not on a byte-identical re-PUT.
+	specBytes []byte
+	taskSpec  TaskSpec // Term TaskSpec of the task.
 }
 
 type taskReader[TaskSpec pf.Task] struct {
@@ -211,15 +215,34 @@ func newTaskTerm[TaskSpec pf.Task](
 	publisher *OpsPublisher,
 	shard consumer.Shard,
 ) (*taskTerm[TaskSpec], error) {
-	var shardSpec = shard.Spec()
+	var ks = host.service.State.KS
+	var key = shard.FQN()
+
+	// Read the decoded ShardSpec and its raw value from the same KeyValue under
+	// one lock, so a watch update can't tear them across revisions. Retaining
+	// Raw.Value without copying is safe: KeySpace replaces KeyValues wholesale
+	// rather than mutating value bytes in place.
+	var shardSpec *pf.ShardSpec
+	var specBytes []byte
+	ks.Mu.RLock()
+	if ind, ok := ks.Search(key); ok {
+		var kv = ks.KeyValues[ind]
+		shardSpec = kv.Decoded.(allocator.Item).ItemValue.(*pf.ShardSpec)
+		specBytes = kv.Raw.Value
+	}
+	ks.Mu.RUnlock()
+
+	if shardSpec == nil {
+		return nil, fmt.Errorf("shard %s is not present in the KeySpace (it's being deleted)", key)
+	}
 
 	// Create a term Context which is cancelled if:
 	// - The shard's Context is cancelled, or
-	// - The ShardSpec is updated.
+	// - The ShardSpec's etcd value bytes change (or the key is deleted).
 	// A cancellation of the term's Context doesn't invalidate the shard,
 	// but does mean the current task term is done and a new one should be started.
 	var termCtx, termCancel = context.WithCancel(shard.Context())
-	go signalOnSpecUpdate(termCtx, termCancel, host.service.State.KS, shard, shardSpec)
+	go signalOnSpecUpdate(termCtx, termCancel, ks, key, specBytes)
 
 	var labels, err = labels.ParseShardLabels(shardSpec.LabelSet)
 	if err != nil {
@@ -228,7 +251,10 @@ func newTaskTerm[TaskSpec pf.Task](
 
 	var taskSpec TaskSpec
 
-	if prev != nil && shardSpec == prev.shardSpec {
+	// Reuse the prior term's TaskSpec if the ShardSpec value is unchanged.
+	// Compare bytes rather than decoded-pointer identity: a no-op re-PUT
+	// re-mints the pointer mid-term, and would needlessly re-open the build DB.
+	if prev != nil && bytes.Equal(prev.specBytes, specBytes) {
 		taskSpec = prev.taskSpec
 	} else {
 		// The ShardSpec has changed. Pull its build and extract its TaskSpec.
@@ -254,6 +280,7 @@ func newTaskTerm[TaskSpec pf.Task](
 		ctx:       termCtx,
 		labels:    labels,
 		shardSpec: shardSpec,
+		specBytes: specBytes,
 		taskSpec:  taskSpec,
 	}, nil
 }
@@ -376,7 +403,7 @@ func (t *taskBase[TaskSpec]) heartbeatLoop(shard consumer.Shard) {
 // loop that periodically writes FSM hints between transactions. The consumer
 // transaction loop is bypassed in Runtime V2 shards, so this is currently
 // needed for hints to be written at any time other than graceful restarts.
-// 
+//
 // The loop body transcribes gazette's `<-hintsCh` handler of
 // consumer.runTransactions (consumer/transaction.go) and the unexported
 // consumer.storeRecordedHints it calls (consumer/recovery.go), rebuilt from
@@ -474,29 +501,29 @@ func intervalJitter(period time.Duration, name string) time.Duration {
 	return time.Duration(w.Sum32()%uint32(period.Seconds())) * time.Second
 }
 
+// signalOnSpecUpdate cancels a task term (via the deferred cb) when the shard's
+// ShardSpec value changes or its key is deleted. The term is bound to specBytes
+// rather than to a decoded pointer, which any re-decode re-mints: a re-PUT of
+// identical bytes -- as the control plane's activation path can emit -- must not
+// cancel an otherwise-healthy term.
 func signalOnSpecUpdate(
 	ctx context.Context,
 	cb func(),
 	ks *keyspace.KeySpace,
-	shard consumer.Shard,
-	spec *pf.ShardSpec,
+	key string,
+	specBytes []byte,
 ) {
 	defer cb()
-	var key = shard.FQN()
 
 	ks.Mu.RLock()
 	defer ks.Mu.RUnlock()
 
 	for {
-		// Pluck the ShardSpec out of the KeySpace, rather than using shard.Spec(),
-		// to avoid a re-entrant read lock.
-		var next *pf.ShardSpec
-		if ind, ok := ks.Search(key); ok {
-			next = ks.KeyValues[ind].Decoded.(allocator.Item).ItemValue.(*pf.ShardSpec)
-		}
-
-		if next != spec {
-			return
+		// Pluck the current raw value out of the KeySpace, rather than using
+		// shard.Spec(), to avoid a re-entrant read lock.
+		var ind, ok = ks.Search(key)
+		if !ok || !bytes.Equal(ks.KeyValues[ind].Raw.Value, specBytes) {
+			return // Key deleted, or its value changed.
 		} else if err := ks.WaitForRevision(ctx, ks.Header.Revision+1); err != nil {
 			return
 		}

--- a/go/runtime/task_signal_test.go
+++ b/go/runtime/task_signal_test.go
@@ -1,0 +1,143 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.gazette.dev/core/allocator"
+	"go.gazette.dev/core/consumer"
+	"go.gazette.dev/core/etcdtest"
+	"go.gazette.dev/core/keyspace"
+)
+
+func TestMain(m *testing.M) { etcdtest.TestMainWithEtcd(m) }
+
+// TestSignalOnSpecUpdateIdentityRePut is the regression test for issue #3247:
+// a byte-identical re-PUT of the ShardSpec (as the control plane's activation
+// path can emit) must NOT cancel a live task term.
+func TestSignalOnSpecUpdateIdentityRePut(t *testing.T) {
+	var etcd = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
+
+	var ctx, ks, key, specBytes = startWatchedShard(t, etcd)
+
+	var termCtx, termCancel = context.WithCancel(ctx)
+	go signalOnSpecUpdate(termCtx, termCancel, ks, key, specBytes)
+
+	// Re-PUT identical value bytes twice. Awaiting a revision proves the
+	// KeySpace applied it but not that the signal goroutine re-checked it; the
+	// second awaited round-trip gives the goroutine a full etcd RPC of
+	// scheduling grace to (wrongly) react to the first.
+	putAndAwait(t, ctx, etcd, ks, key, string(specBytes))
+	putAndAwait(t, ctx, etcd, ks, key, string(specBytes))
+
+	// The term must still be live: identical bytes are not a spec change.
+	require.NoError(t, termCtx.Err())
+
+	// Then PUT different bytes and require the term end, proving the goroutine
+	// was watching throughout and not parked on a revision it never received.
+	var next = makeSignalShardSpec(2 * time.Millisecond)
+	var nextBytes, err = next.Marshal()
+	require.NoError(t, err)
+	_, err = etcd.Put(ctx, key, string(nextBytes))
+	require.NoError(t, err)
+
+	requireDone(t, termCtx, "changed spec bytes did not cancel the term")
+}
+
+// TestSignalOnSpecUpdateChangedBytes asserts a genuine spec change ends the term.
+func TestSignalOnSpecUpdateChangedBytes(t *testing.T) {
+	var etcd = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
+
+	var ctx, ks, key, specBytes = startWatchedShard(t, etcd)
+
+	var termCtx, termCancel = context.WithCancel(ctx)
+	go signalOnSpecUpdate(termCtx, termCancel, ks, key, specBytes)
+
+	// PUT a materially different ShardSpec value.
+	var next = makeSignalShardSpec(2 * time.Millisecond)
+	var nextBytes, err = next.Marshal()
+	require.NoError(t, err)
+	_, err = etcd.Put(ctx, key, string(nextBytes))
+	require.NoError(t, err)
+
+	requireDone(t, termCtx, "changed spec bytes did not cancel the term")
+}
+
+// TestSignalOnSpecUpdateDeletion asserts deleting the key ends the term.
+func TestSignalOnSpecUpdateDeletion(t *testing.T) {
+	var etcd = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
+
+	var ctx, ks, key, specBytes = startWatchedShard(t, etcd)
+
+	var termCtx, termCancel = context.WithCancel(ctx)
+	go signalOnSpecUpdate(termCtx, termCancel, ks, key, specBytes)
+
+	var _, err = etcd.Delete(ctx, key)
+	require.NoError(t, err)
+
+	requireDone(t, termCtx, "deleting the shard spec did not cancel the term")
+}
+
+// startWatchedShard writes a fresh ShardSpec into Etcd, loads and watches a
+// consumer KeySpace over it, and returns a cancelable context, the KeySpace,
+// the shard's item key, and the raw value bytes which bind a term.
+func startWatchedShard(t *testing.T, etcd *clientv3.Client) (context.Context, *keyspace.KeySpace, string, []byte) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var ks = consumer.NewKeySpace("/signal/test")
+	var spec = makeSignalShardSpec(1 * time.Millisecond)
+	var key = allocator.ItemKey(ks, spec.Id.String())
+
+	var value, err = spec.Marshal()
+	require.NoError(t, err)
+	_, err = etcd.Put(ctx, key, string(value))
+	require.NoError(t, err)
+
+	require.NoError(t, ks.Load(ctx, etcd, 0))
+	go func() { _ = ks.Watch(ctx, etcd) }()
+
+	// Capture the value bytes under read lock, exactly as newTaskTerm does.
+	var specBytes []byte
+	ks.Mu.RLock()
+	var ind, ok = ks.Search(key)
+	require.True(t, ok)
+	specBytes = ks.KeyValues[ind].Raw.Value
+	ks.Mu.RUnlock()
+
+	return ctx, ks, key, specBytes
+}
+
+// putAndAwait writes value to key, blocking until the KeySpace watch has
+// applied the resulting revision. This synchronizes without sleeps.
+func putAndAwait(t *testing.T, ctx context.Context, etcd *clientv3.Client, ks *keyspace.KeySpace, key, value string) {
+	var resp, err = etcd.Put(ctx, key, value)
+	require.NoError(t, err)
+
+	ks.Mu.RLock()
+	err = ks.WaitForRevision(ctx, resp.Header.Revision)
+	ks.Mu.RUnlock()
+	require.NoError(t, err)
+}
+
+func requireDone(t *testing.T, ctx context.Context, msg string) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal(msg)
+	}
+}
+
+func makeSignalShardSpec(maxTxn time.Duration) *pf.ShardSpec {
+	return &pf.ShardSpec{
+		Id:             "acmeCo/test-task/00000000-00000000",
+		MaxTxnDuration: maxTxn,
+	}
+}


### PR DESCRIPTION
**Description:**

Fixes #3247 by addressing causes (1) and (2). In brief:

1. A term was bound to the decoded `*pf.ShardSpec` pointer, which any re-decode re-mints. Terms are now bound to the raw etcd value bytes: `newTaskTerm` captures the decoded spec and its `Raw.Value` coherently from one `KeyValue` under a single read lock, and `signalOnSpecUpdate` compares `bytes.Equal` on each wakeup, so only a real value change or a deletion ends a term. The `taskSpec`-reuse optimization compares bytes as well, so a no-op re-PUT no longer re-opens the build DB.

2. Term cancellation was fatal during Join-wait but graceful post-`Opened`, contradicting the term contract in `task.go`. A Join-wait cancellation with a still-live shard context now logs at INFO and returns nil, so the framework loops back through `RestoreCheckpoint` with a fresh term. This is safe pre-consensus: the Rust session loop is parked awaiting a Join and re-Joins on the same long-lived stream. Applied identically to materialize and derive.

Root cause (3), the `apply_changes` upsert-before-`Unassign` ordering, is not addressed. With (1) fixed those upserts no longer manufacture a failed set, and the race evaporates.

**Workflow steps:**

No user-facing change. The surviving shards of a multi-shard V2 task now stay parked in Join-wait across an activation's spec re-PUT instead of failing, so all N reach consensus together.

**Documentation links affected:**

None.

**Notes for reviewers:**

- The first commit affects V1 shards too, since `newTaskTerm` / `signalOnSpecUpdate` are shared. The pointer-identity bug was equally wrong there; V1 just tolerated the spurious term restart.
- Retaining `kv.Raw.Value` uncopied is safe: `KeySpace.Apply` rebuilds `KeyValues` wholesale on each watch update and never mutates value bytes in place.
- `newTaskTerm` now reads the ShardSpec from the KeySpace rather than `shard.Spec()`, and errors if the key is absent — where before the term was instead cancelled immediately by the signal goroutine. In that narrow window (STANDBY→PRIMARY as the spec is deleted) a deletion now surfaces as a shard failure. Reading the current spec rather than the transition-time one also means a new term binds to the latest spec, avoiding an immediate self-cancellation.
- `go/runtime/task_signal_test.go` is new, and adds a `TestMain` so `etcdtest` can host an etcd for the package. The identity-re-PUT test double-PUTs and awaits each revision: the second awaited round-trip gives the signal goroutine a full etcd RPC of scheduling grace to wrongly react to the first. It then PUTs different bytes and requires the term to end, proving the goroutine was watching throughout rather than parked on a revision it never received.
