### PR TITLE
vm: fix Lima development VMs on Linux hosts

### DIFF
--- a/local/systemd/flow-bigtable@.service
+++ b/local/systemd/flow-bigtable@.service
@@ -7,6 +7,13 @@ Type=simple
 
 EnvironmentFile=%h/flow-local/env/bigtable-%i.env
 
+# Clear a container left holding this name. `--rm` cleans up on a normal exit, but
+# not when the unit loses track of a still-running container (a `systemd --user`
+# restart, for example): `docker run` then fails with a name conflict, and because
+# `Restart=on-failure` retries forever the unit never recovers on its own.
+# flow-dekaf-kafka@.service does the same thing for the same reason.
+ExecStartPre=-/usr/bin/docker rm -f flow-bigtable-%i
+
 # The emulator listens on the fixed container-internal 8086; the host-published
 # port is per-stack (FLOW_PORT_BIGTABLE), and the container name embeds %i so
 # stacks don't collide.

--- a/mise/tasks/vm/create-lima
+++ b/mise/tasks/vm/create-lima
@@ -34,29 +34,49 @@ else
 fi
 MEMORY="${usage_memory:-16}"
 
-# make sure .ssh/config exists before we check to see if it needs modification
+# Point ssh(1) at Lima's generated per-VM configs, so `ssh lima-<name>` resolves.
+#
+# The Include MUST precede the first Host or Match line. ssh scopes every
+# directive after a Host stanza to that stanza, so an Include further down applies
+# only when connecting to that one host, and `ssh lima-<name>` then fails with a
+# resolve error. Blank lines and comments do NOT close a stanza.
+#
+# The guard here used to be `grep -q lima`, which matches that string anywhere in
+# the file. Once a copy existed in the wrong position, the guard passed forever and
+# this block never repaired it. It only ever prepended when absent, so it could not
+# move one that had ended up mis-scoped (which happens as soon as anything is added
+# above it). Instead: strip any copy we previously wrote, wherever it sits, then
+# prepend. That converges from any prior state and cannot duplicate.
+# We use a temp file for portability across macOS and Linux.
+TMP_SSH_CONFIG=$(mktemp)
+cat > "${TMP_SSH_CONFIG}" <<EOF
+# Include Lima VM SSH configurations.
+Include ~/.lima/*/ssh.config
+
+EOF
 if [[ -f ~/.ssh/config ]]; then
-  # Add additional ssh configuration if not already present.
-  if ! grep -q lima ~/.ssh/config; then
-      # Prepend to ssh config file, as it's sensitive to Host or Match directives.
-      # We use a temp file for portability across macOS and Linux.
-      TMP_SSH_CONFIG=$(mktemp)
-      cat > "${TMP_SSH_CONFIG}" <<EOF
-# Include Lima VM SSH configurations.
-Include ~/.lima/*/ssh.config
-
-EOF
-      cat ~/.ssh/config >> "${TMP_SSH_CONFIG}"
-      mv "${TMP_SSH_CONFIG}" ~/.ssh/config
-  fi
-else
-  # if config doesn't exist yet, create it with our default content
-  cat > ~/.ssh/config <<EOF
-# Include Lima VM SSH configurations.
-Include ~/.lima/*/ssh.config
-
-EOF
+    # `|| true` because `grep -v` exits 1 when it selects nothing, which happens for
+    # an empty config or one holding only this block. Under `set -o pipefail` that
+    # status aborts the task before the config is written, so no VM is created and
+    # nothing is reported. `sed '/./,$!d'` drops leading blank lines from what
+    # remains, so the blank line written above does not accumulate one per run.
+    { grep -vxE '# Include Lima VM SSH configurations\.|[[:space:]]*Include[[:space:]]+~/\.lima/\*/ssh\.config[[:space:]]*' \
+        ~/.ssh/config || true; } | sed '/./,$!d' >> "${TMP_SSH_CONFIG}"
 fi
+
+# Write only when the content actually changes, and write *through* the existing
+# file rather than moving one in over it. Now that the old `grep -q lima` guard is
+# gone this runs on every invocation, and `mv` from /tmp would each time: relabel
+# the file under SELinux (mktemp gives it `user_tmp_t`, policy wants `ssh_home_t`),
+# replace a dotfile-managed symlink with a regular file, reset its mode, and make
+# two concurrent runs last-writer-wins. Converged content means there is nothing
+# to do at all, which is the overwhelmingly common case.
+if [[ ! -f ~/.ssh/config ]] || ! cmp -s "${TMP_SSH_CONFIG}" ~/.ssh/config; then
+    mkdir -p ~/.ssh
+    cat "${TMP_SSH_CONFIG}" > ~/.ssh/config
+    chmod 600 ~/.ssh/config
+fi
+rm -f "${TMP_SSH_CONFIG}"
 
 TEMP_CONFIG=$(mktemp /tmp/lima-config-yaml-XXXXXX)
 
@@ -92,11 +112,13 @@ EOF
 fi
 
 if [[ "$OS" == "linux" ]]; then
+    # No `networks:` entry. The only option on Linux is `lima: user-v2`, which
+    # *replaces* Lima's built-in NIC rather than adding to it, and buys only
+    # VM-to-VM connectivity that the vz branch above forgoes as well. Keeping the
+    # two at parity is deliberate. Enabling it has also caused QEMU to abort under
+    # sustained transfer; check git log before reaching for it.
     cat >> "${TEMP_CONFIG}" << EOF
 vmType: qemu
-
-networks:
-  - lima: user-v2  # User-space proxy, allows VM <=> VM
 
 EOF
 fi

--- a/mise/tasks/vm/create-post
+++ b/mise/tasks/vm/create-post
@@ -23,6 +23,44 @@ echo "${USER}:admin" | sudo chpasswd
 sudo usermod -aG docker ${USER}
 sudo usermod -aG systemd-journal ${USER}
 
+# `usermod` only edits /etc/group; running processes keep the groups they started
+# with. `systemd --user` is already up, so every unit it later spawns inherits the
+# old set and the local stack's units fail with EACCES on the docker socket, while
+# an interactive shell looks correct. Restarting the manager from the *system*
+# manager re-resolves credentials in a fresh process, so it gains the new groups.
+#
+# `loginctl terminate-user` also recycles it, but destroys the session it arrives
+# on along with /run/user/$UID, leaving logind wedged and `systemctl --user`
+# unusable. This restarts only the manager and leaves the session intact.
+# Only recycle it when the manager is actually missing one of the groups added
+# above, so re-running create-post on a healthy VM does not tear down a running
+# stack along with the manager.
+#
+# The pattern deliberately does not pin systemd's install path: matching
+# `-x /usr/lib/systemd/systemd --user` finds nothing wherever it lives elsewhere
+# (Debian's /lib/systemd), and an empty PID here means an empty group list, which
+# reads as "stale" and restarts unconditionally. That is the teardown this guard
+# exists to avoid, so the failure has to not be silent.
+MANAGER_PID="$(pgrep -u "$(id -u)" -f 'systemd --user' | head -1 || true)"
+MANAGER_GIDS=""
+if [ -n "${MANAGER_PID}" ]; then
+    MANAGER_GIDS="$(sed -n 's/^Groups:[[:space:]]*//p' "/proc/${MANAGER_PID}/status" 2>/dev/null || true)"
+fi
+
+NEEDS_RESTART=false
+for group in docker systemd-journal; do
+    gid="$(getent group "${group}" 2>/dev/null | cut -d: -f3 || true)"
+    [ -n "${gid}" ] || continue
+    case " ${MANAGER_GIDS} " in
+        *" ${gid} "*) ;; # already present
+        *) NEEDS_RESTART=true ;;
+    esac
+done
+
+if [ "${NEEDS_RESTART}" = true ]; then
+    sudo systemctl restart "user@$(id -u).service"
+fi
+
 # Add additional .bashrc configuration if not already present.
 if ! grep -q "mise" "${HOME}/.bashrc"; then
     cat >> "${HOME}/.bashrc" << EOF
@@ -34,10 +72,22 @@ EOF
 fi
 
 # Create and enable a swapfile.
-sudo fallocate -l 8G /swapfile.img
-sudo chmod 600 /swapfile.img
-sudo mkswap /swapfile.img
-sudo swapon /swapfile.img
+#
+# Guarded so create-post survives a second run. On an already-provisioned VM the
+# swapfile is active, and `fallocate` then fails with "Text file busy" (ETXTBSY),
+# aborting the whole task under `set -e`. `mkswap` and `swapon` would likewise
+# refuse an in-use device. Re-running create-post is the documented way to
+# diagnose a bad first boot, so it has to be re-runnable.
+# No pipe into `grep -q`: it exits on its first match, the writer can then die of
+# SIGPIPE, and `set -o pipefail` turns that into a non-zero pipeline that `if !`
+# inverts, running `fallocate` on the active swapfile after all. `-F` because the
+# `.` in the name is otherwise a regex metacharacter.
+if ! grep -qxF /swapfile.img <<<"$(swapon --show=NAME --noheadings)"; then
+    sudo fallocate -l 8G /swapfile.img
+    sudo chmod 600 /swapfile.img
+    sudo mkswap /swapfile.img
+    sudo swapon /swapfile.img
+fi
 
 # Add swapfile to fstab for persistence across reboots.
 if ! grep -q "/swapfile.img" /etc/fstab; then


### PR DESCRIPTION
**Description:**

`mise run vm:create-lima` did not work on a Linux host. Three unrelated defects there, plus two more that affect any dev VM: `vm:create-post` could not be run twice, and the bigtable unit could loop forever.

1. **The VM died partway through setup.** The Linux branch requested Lima's `user-v2` network. On Linux that *replaces* Lima's built-in NIC rather than adding to it, so all guest traffic crossed a single socket-backed interface served by Lima's embedded gvisor-tap-vsock. Under any sustained transfer (the first-boot `apt` upgrade, the repo clone, later `cargo fetch`) that stream desynchronizes and QEMU aborts:

   ```
   qemu-system-x86_64: ../net/net.c:2172:
     net_fill_rstate: Assertion `size == 0' failed.
   ```

   The underlying defect is in gvisor-tap-vsock and is unfixed upstream. Removing the entry costs only VM-to-VM connectivity, which the macOS branch already forgoes, so this brings the two to parity rather than taking a capability away from anyone.

2. **`ssh lima-<name>` failed to resolve.** The `~/.ssh/config` edit was guarded by `grep -q lima`, which matches that string anywhere in the file, and only ever prepended when absent. Once the `Include` line ended up below a `Host` stanza (which happens as soon as anything is added above it), ssh scoped it to that single host, and the guard then passed forever so nothing repaired it.

3. **The first `mise run local:stack` on a new VM always failed.** `usermod -aG docker` only edits `/etc/group`, and `systemd --user` was already running with the old group set, so every unit it spawned inherited it. The stack's units failed with `EACCES` on the docker socket while `id -nG` in a shell looked correct.

4. **`vm:create-post` could not be re-run.** Its swapfile step called `fallocate` on an already-active swapfile, failing with `ETXTBSY` and aborting the task under `set -e`, so every later step was skipped. Re-running `create-post` is the standard way to diagnose a bad first boot, so it needs to survive a second run.

5. **The bigtable emulator unit could loop forever.** `ExecStart` runs `docker run --rm --name flow-bigtable-<stack>`, and `--rm` only cleans up on a normal exit. When the unit loses track of a container that is still running (a `systemd --user` restart, for example) the container survives and keeps the name, `docker run` fails with a name conflict, and `Restart=on-failure` retries every 5s indefinitely. Seen at a restart counter of 1206 while the emulator itself was up and serving the whole time, so the stack read as broken in `systemctl` but worked. `flow-dekaf-kafka@.service` already carries the `ExecStartPre=-docker rm -f` that prevents this; bigtable now does too.

Fixes (3), (4) and (5) are not Lima-specific. (3) and (4) live in `create-post`, which `create-gcp` runs through the same `bootstrap-flow.sh`, so GCP VMs get both as well: a fresh GCP VM had the same failing first `mise run local:stack` and the same non-re-runnable `create-post`. (5) is in a shared unit template.

**Workflow steps:**

Unchanged for macOS users. For a Linux host, `mise run vm:create-lima <name>` now works end to end, and `mise run local:stack` inside the VM succeeds on the first attempt with no restart.

One behavioral note for Linux hosts: with Lima's default network, Lima automatically forwards the guest's listening ports to the host loopback, so `mise run vm:port-forward` is unnecessary and will report `Address already in use` for every port. The stack is reachable directly, e.g. `psql -h 127.0.0.1 -p <base+11>`. Making `port-forward` detect that is left for a follow-up.

Linux hosts do not get VM-to-VM connectivity between Lima VMs. Neither do macOS hosts.

**Documentation links affected:**

None in product docs. Separately, `mise/README.md` has only a macOS host-prerequisites section (`brew install lima`) with no Linux equivalent, which this PR does not address.

**Notes for reviewers:**

**The `create-post` changes cannot be validated from this branch.** `bootstrap-flow.sh` clones the repo from GitHub inside the VM and runs `create-post` from *that* copy, so edits in a local checkout never reach a newly created VM. I verified them by copying the file into a running VM and re-running the task. The `create-lima` changes run host-side and were verified from scratch.

What was verified on a Linux host (Fedora 44, QEMU 10.2.2, Lima 2.1.1):

- `vm:create-lima` from scratch, exit 0, including the 3.2GB clone that previously killed the VM
- `local:stack` first try, exit 0, 14 units active, 0 failed
- 624MB download at 22MB/s inside the VM, concurrently with a cargo build, no crash
- `local:test-tenant` and `flowctl` against the local control plane
- Postgres, agent, API and Studio all reachable from the host
- `create-post` re-run on a healthy VM: exit 0, user manager not restarted, running stack left intact

Two details worth a look:

- The user-manager restart is conditional on a group actually being absent, so re-running `create-post` does not tear down a running stack. `loginctl terminate-user` also recycles the manager but destroys the session and `/run/user/$UID` with it, leaving logind unresponsive and `systemctl --user` unusable, so it is deliberately not used.
- The ssh config rewrite is now unconditional, so it writes only when content actually changes and writes through the existing file. Otherwise every run would relabel it under SELinux, replace a dotfile-managed symlink with a regular file, reset its mode, and make concurrent runs last-writer-wins.



