### PR TITLE
docs: fix allow_existing_tables_for_new_bindings backfill claim, add binding migration steps

### DIFF
--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -122,19 +122,7 @@ Allows materializations to write to tables that already exist in the destination
   - This flag alone does **not** prevent backfill of the source collection. A binding that's new to a materialization always starts reading its source collection from the beginning, the same as any other backfill. To avoid replaying data that's already in the existing table, also configure [`notBefore`](/reference/time-travel) on the binding.
   - This flag does not truncate or drop the existing table. A new binding whose destination table already exists is reconciled the same way an existing binding is when its schema changes: new columns are added and existing columns are widened as needed, but no data is removed.
 - **Applies to:** All SQL and warehouse materialization connectors (PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, etc.)
-
-#### Moving a binding to a new materialization
-
-A common use for this flag is moving a binding from one materialization to another, for example when consolidating several materializations into one, or splitting a large one apart, without dropping or reprocessing the destination table's existing data.
-
-To do this without duplicating or losing data:
-
-1. Pause writes to the source (or disable the capture) and let the current materialization fully drain its backlog for that binding.
-2. Disable the binding on the original materialization.
-3. Add the binding to the new materialization:
-   - Set the `allow_existing_tables_for_new_bindings` feature flag under **Endpoint Config → Advanced** on the new materialization.
-   - Set [`notBefore`](/reference/time-travel) under **Binding → Advanced** on the new binding, to a timestamp within the pause window from step 1, or to just after the last `flow_published_at` already written to the destination table.
-4. Resume writes to the source (or re-enable the capture). New data flows through the new binding only; `notBefore` causes the runtime to skip re-reading everything published before it.
+- **Task guide:** [Moving a binding to a new materialization](/guides/move-binding-to-new-materialization)
 
 ### retain_existing_data_on_backfill
 

--- a/site/docs/guides/advanced-usage/feature-flags.md
+++ b/site/docs/guides/advanced-usage/feature-flags.md
@@ -119,8 +119,22 @@ Allows materializations to write to tables that already exist in the destination
 - **Caveats:**
   - Enabling this flag makes the connector load existing keys from the destination before merging, instead of skipping that lookup for keys it expects to be new. It is slightly slower but ensures merges and updates work correctly against rows that already exist in the table.
   - The connector cannot verify that existing table schemas are compatible.
-  - This flag alone does **not** prevent backfill of the source collection. To avoid backfilling data into the existing table, also configure [`notBefore`](/reference/time-travel) or use "Only Changes" mode on the binding.
+  - This flag alone does **not** prevent backfill of the source collection. A binding that's new to a materialization always starts reading its source collection from the beginning, the same as any other backfill. To avoid replaying data that's already in the existing table, also configure [`notBefore`](/reference/time-travel) on the binding.
+  - This flag does not truncate or drop the existing table. A new binding whose destination table already exists is reconciled the same way an existing binding is when its schema changes: new columns are added and existing columns are widened as needed, but no data is removed.
 - **Applies to:** All SQL and warehouse materialization connectors (PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, etc.)
+
+#### Moving a binding to a new materialization
+
+A common use for this flag is moving a binding from one materialization to another, for example when consolidating several materializations into one, or splitting a large one apart, without dropping or reprocessing the destination table's existing data.
+
+To do this without duplicating or losing data:
+
+1. Pause writes to the source (or disable the capture) and let the current materialization fully drain its backlog for that binding.
+2. Disable the binding on the original materialization.
+3. Add the binding to the new materialization:
+   - Set the `allow_existing_tables_for_new_bindings` feature flag under **Endpoint Config → Advanced** on the new materialization.
+   - Set [`notBefore`](/reference/time-travel) under **Binding → Advanced** on the new binding, to a timestamp within the pause window from step 1, or to just after the last `flow_published_at` already written to the destination table.
+4. Resume writes to the source (or re-enable the capture). New data flows through the new binding only; `notBefore` causes the runtime to skip re-reading everything published before it.
 
 ### retain_existing_data_on_backfill
 

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -243,6 +243,8 @@ To keep existing rows when a backfill is triggered, either:
 
 Both options skip the truncate step, but neither prevents the drop-and-recreate path: if the schema change requires a different table structure, the table is still dropped.
 
+To move a binding to a different materialization while keeping the destination table's existing data (for example, consolidating or splitting materializations), see [Moving a binding to a new materialization](/guides/advanced-usage/feature-flags#moving-a-binding-to-a-new-materialization).
+
 ### Backfill Selection
 
 Backfills can be a powerful tool to recover data, but can also result in unnecessary data costs if used incorrectly. This section will help you choose when to backfill and which backfill option to use.

--- a/site/docs/guides/backfilling-data.md
+++ b/site/docs/guides/backfilling-data.md
@@ -243,7 +243,7 @@ To keep existing rows when a backfill is triggered, either:
 
 Both options skip the truncate step, but neither prevents the drop-and-recreate path: if the schema change requires a different table structure, the table is still dropped.
 
-To move a binding to a different materialization while keeping the destination table's existing data (for example, consolidating or splitting materializations), see [Moving a binding to a new materialization](/guides/advanced-usage/feature-flags#moving-a-binding-to-a-new-materialization).
+To move a binding to a different materialization while keeping the destination table's existing data (for example, consolidating or splitting materializations), see [Moving a binding to a new materialization](/guides/move-binding-to-new-materialization).
 
 ### Backfill Selection
 

--- a/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
+++ b/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
@@ -19,20 +19,30 @@ You need:
 
 :::warning
 The connector cannot verify that the existing table's schema is compatible with the new binding. Confirm the destination table matches the collection you are materializing before you begin.
+
+If a column's type differs in a way the connector cannot migrate in place, the publication fails and the remedy offered is a backfill, which drops and recreates the table. That defeats the purpose of this procedure, so check the destination schema first.
 :::
 
 ## Steps
 
 1. **Pause writes to the source.** Disable the capture, or otherwise stop new documents from arriving in the source collection. Let the original materialization fully drain its backlog for the binding, so everything captured so far is written to the destination table.
 
-2. **Disable the binding on the original materialization.** Disable it rather than deleting it, so you can re-enable it if the move needs to be reverted. Deleting the binding does not drop the destination table, but it does discard the binding's state.
+2. **Confirm the drain finished.** Wait for the original materialization to report no remaining lag for the binding, then note the highest [`flow_published_at`](/guides/advanced-usage/metadata-fields#_metauuid-and-flow_published_at) value in the destination table:
 
-3. **Add the binding to the new materialization.** Configure two settings on it:
+   ```sql
+   SELECT MAX(flow_published_at) FROM your_destination_table;
+   ```
+
+   This value anchors the `notBefore` timestamp you set in step 4. Do not skip this check: `notBefore` discards documents rather than deferring them, so anything the original materialization had not yet written when you cut over is lost from the destination unless you backfill.
+
+3. **Disable the binding on the original materialization.** Disable it rather than deleting it, so you can re-enable it if the move needs to be reverted. Deleting the binding does not drop the destination table, but it does discard the binding's state.
+
+4. **Add the binding to the new materialization.** Configure two settings on it:
 
    * Set the `allow_existing_tables_for_new_bindings` [feature flag](/guides/advanced-usage/feature-flags#allow_existing_tables_for_new_bindings) under **Endpoint Config → Advanced**. This lets the new binding write to the table that already exists.
-   * Set [`notBefore`](/reference/time-travel) under **Binding → Advanced**. Use a timestamp inside the pause window from step 1, or just after the last [`flow_published_at`](/guides/advanced-usage/metadata-fields#_metauuid-and-flow_published_at) value already written to the destination table.
+   * Set [`notBefore`](/reference/time-travel) under **Binding → Advanced**, in the **Time Travel** section. Use the timestamp you recorded in step 2, or any point inside the pause window from step 1.
 
-4. **Resume writes to the source.** Re-enable the capture. New data flows through the new binding only. `notBefore` causes the runtime to skip everything published before that timestamp, so the binding does not replay data the table already holds.
+5. **Resume writes to the source.** Re-enable the capture. New data flows through the new binding only. `notBefore` causes the runtime to skip everything published before that timestamp, so the binding does not replay data the table already holds.
 
 ## Why notBefore is required
 
@@ -43,6 +53,18 @@ The feature flag and `notBefore` solve two different problems, and you need both
 The flag also does not truncate or drop the existing table. A new binding whose destination table already exists is reconciled the same way an existing binding is when its schema changes: new columns are added and existing columns are widened as needed, but no data is removed.
 
 `notBefore` is what limits the read. Without it, the new binding re-reads the full collection history and re-merges every document into the destination table.
+
+## Leave the feature flag enabled
+
+Keep `allow_existing_tables_for_new_bindings` set for as long as the binding materializes the adopted table. Do not remove it once the move is complete.
+
+The flag does two separate things. It permits a new binding to write to a table that already exists, which only matters at the moment you add the binding. It also disables the runtime's load optimization, which matters permanently.
+
+That optimization normally lets a materialization skip looking up keys it believes are new, based on the highest key the binding itself has stored. In an adopted table, rows the binding never wrote can sit above that high-water mark. With the optimization active, updates to those rows are treated as new keys and are inserted rather than merged.
+
+Because the flag is only *required* while the binding is new, removing it later still publishes successfully. Nothing fails and no error is logged; merges quietly become inserts.
+
+Note that this flag is set on the endpoint, so disabling the load optimization applies to every binding on the materialization, not only the one you moved.
 
 ## Related
 

--- a/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
+++ b/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
@@ -9,13 +9,13 @@ You may want to move a binding from one materialization to another: to consolida
 
 By default, a binding that is new to a materialization fails if its destination table already exists. This guide covers how to point a new binding at the existing table instead, so you keep the data already in it and avoid replaying history you have already materialized.
 
-## Before you start
+## Prerequisites
 
 You need:
 
 * An existing materialization with the binding you want to move.
 * The target materialization the binding will move to. It can be an existing materialization or a new one.
-* A SQL or warehouse materialization connector (PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, and similar). See [`allow_existing_tables_for_new_bindings`](/guides/advanced-usage/feature-flags#allow_existing_tables_for_new_bindings) for connector support.
+* A materialization connector that supports the [`allow_existing_tables_for_new_bindings`](/guides/advanced-usage/feature-flags#allow_existing_tables_for_new_bindings) feature flag. This includes SQL and warehouse connectors (PostgreSQL, MySQL, Snowflake, BigQuery, Redshift) as well as MongoDB, DynamoDB, and Elasticsearch.
 
 :::warning
 The connector cannot verify that the existing table's schema is compatible with the new binding. Confirm the destination table matches the collection you are materializing before you begin.
@@ -25,7 +25,7 @@ The connector cannot verify that the existing table's schema is compatible with 
 
 1. **Pause writes to the source.** Disable the capture, or otherwise stop new documents from arriving in the source collection. Let the original materialization fully drain its backlog for the binding, so everything captured so far is written to the destination table.
 
-2. **Disable the binding on the original materialization.** Do not delete the materialization or the binding while the table still needs to be written to by the new binding.
+2. **Disable the binding on the original materialization.** Disable it rather than deleting it, so you can re-enable it if the move needs to be reverted. Deleting the binding does not drop the destination table, but it does discard the binding's state.
 
 3. **Add the binding to the new materialization.** Configure two settings on it:
 

--- a/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
+++ b/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
@@ -40,9 +40,9 @@ The feature flag and `notBefore` solve two different problems, and you need both
 
 `allow_existing_tables_for_new_bindings` only controls whether the connector will write to a table it did not create. It does not change where the binding starts reading. A binding that is new to a materialization always starts reading its source collection from the beginning, the same as any other backfill.
 
-`notBefore` is what limits the read. Without it, the new binding re-reads the full collection history and re-merges every document into the destination table.
-
 The flag also does not truncate or drop the existing table. A new binding whose destination table already exists is reconciled the same way an existing binding is when its schema changes: new columns are added and existing columns are widened as needed, but no data is removed.
+
+`notBefore` is what limits the read. Without it, the new binding re-reads the full collection history and re-merges every document into the destination table.
 
 ## Related
 

--- a/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
+++ b/site/docs/guides/customize-dataflows/move-binding-to-new-materialization.md
@@ -1,0 +1,51 @@
+---
+description: Move a binding from one Estuary materialization to another without dropping the destination table or replaying data, using the allow_existing_tables_for_new_bindings feature flag and notBefore.
+slug: /guides/move-binding-to-new-materialization/
+---
+
+# Moving a Binding to a New Materialization
+
+You may want to move a binding from one materialization to another: to consolidate several materializations into one, to split a large materialization apart, or to move a table onto a materialization with different settings.
+
+By default, a binding that is new to a materialization fails if its destination table already exists. This guide covers how to point a new binding at the existing table instead, so you keep the data already in it and avoid replaying history you have already materialized.
+
+## Before you start
+
+You need:
+
+* An existing materialization with the binding you want to move.
+* The target materialization the binding will move to. It can be an existing materialization or a new one.
+* A SQL or warehouse materialization connector (PostgreSQL, MySQL, Snowflake, BigQuery, Redshift, and similar). See [`allow_existing_tables_for_new_bindings`](/guides/advanced-usage/feature-flags#allow_existing_tables_for_new_bindings) for connector support.
+
+:::warning
+The connector cannot verify that the existing table's schema is compatible with the new binding. Confirm the destination table matches the collection you are materializing before you begin.
+:::
+
+## Steps
+
+1. **Pause writes to the source.** Disable the capture, or otherwise stop new documents from arriving in the source collection. Let the original materialization fully drain its backlog for the binding, so everything captured so far is written to the destination table.
+
+2. **Disable the binding on the original materialization.** Do not delete the materialization or the binding while the table still needs to be written to by the new binding.
+
+3. **Add the binding to the new materialization.** Configure two settings on it:
+
+   * Set the `allow_existing_tables_for_new_bindings` [feature flag](/guides/advanced-usage/feature-flags#allow_existing_tables_for_new_bindings) under **Endpoint Config → Advanced**. This lets the new binding write to the table that already exists.
+   * Set [`notBefore`](/reference/time-travel) under **Binding → Advanced**. Use a timestamp inside the pause window from step 1, or just after the last [`flow_published_at`](/guides/advanced-usage/metadata-fields#_metauuid-and-flow_published_at) value already written to the destination table.
+
+4. **Resume writes to the source.** Re-enable the capture. New data flows through the new binding only. `notBefore` causes the runtime to skip everything published before that timestamp, so the binding does not replay data the table already holds.
+
+## Why notBefore is required
+
+The feature flag and `notBefore` solve two different problems, and you need both.
+
+`allow_existing_tables_for_new_bindings` only controls whether the connector will write to a table it did not create. It does not change where the binding starts reading. A binding that is new to a materialization always starts reading its source collection from the beginning, the same as any other backfill.
+
+`notBefore` is what limits the read. Without it, the new binding re-reads the full collection history and re-merges every document into the destination table.
+
+The flag also does not truncate or drop the existing table. A new binding whose destination table already exists is reconciled the same way an existing binding is when its schema changes: new columns are added and existing columns are widened as needed, but no data is removed.
+
+## Related
+
+* [Feature flags](/guides/advanced-usage/feature-flags) for the full list of available flags and their caveats.
+* [Backfilling data](/reference/backfilling-data) for how backfills interact with existing destination data.
+* [Time travel](/reference/time-travel) for `notBefore` and `notAfter` details.


### PR DESCRIPTION
**Description:**

Fixes an inaccurate caveat on the `allow_existing_tables_for_new_bindings` materialization feature flag, and adds a step-by-step for its most common real use case.

**Workflow steps:**

- Removed "Only Changes" backfill mode as a suggested alternative to `notBefore`. It's a capture-side setting (skips the initial table scan for future captures) and isn't retroactive, so it can't stop a materialization binding from replaying collection data that's already been captured. Confirmed against `sqlcapture/capture.go` and the shuffle/broker read-range code (`crates/shuffle`, `go/shuffle`, Gazette's `fragment/index.go`): a new binding's read range is governed entirely by `notBefore`, nothing about the capture's backfill mode reaches it.
- Added "Moving a binding to a new materialization" under the flag's section: pause writes, drain and disable the old binding, add the new binding with the flag plus `notBefore` set from the pause window, resume writes. This is the standard pattern for consolidating or splitting materializations without dropping or replaying existing destination data.
- Added a caveat clarifying the flag never truncates or drops the existing table (confirmed in `materialize-boilerplate/apply.go` + `materializer.go`: a new binding whose destination table already exists is reconciled additively, new columns added / widened, never recreated).
- Cross-linked from `backfilling-data.md`'s "Preserving existing data during a backfill" section.

**Documentation links affected:**

- [Feature Flags](https://docs.estuary.dev/guides/advanced-usage/feature-flags/#allow_existing_tables_for_new_bindings)
- [Backfilling Data](https://docs.estuary.dev/guides/backfilling-data/#preserving-existing-data-during-a-backfill)

**Notes for reviewers:**

Several Kapa-indexed community threads repeat the same "Only Changes" suggestion in this exact context; flagging those separately for correction, not in scope for this PR.