### PR TITLE
runtime-next: stop constructing per-iteration timers in actor loops

### DIFF
--- a/crates/runtime-next/src/leader/derive/actor.rs
+++ b/crates/runtime-next/src/leader/derive/actor.rs
@@ -95,6 +95,9 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
         let mut stopping = false;
         // Transactions completed in this task session, for preview harness limits.
         let mut transactions_completed = 0usize;
+        // Timer for the lowest-priority arm; `sleep_unless_zero` resets it
+        // before each await, so this initial deadline is never observed.
+        let mut wake_sleep = std::pin::pin!(tokio::time::sleep(Duration::ZERO));
 
         while !matches!(head, fsm::Head::Stop) {
             loop_count += 1;
@@ -271,7 +274,7 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                 }
 
                 // Lowest priority.
-                _ = tokio::time::sleep(wake_after) => {}
+                _ = crate::sleep_unless_zero(wake_sleep.as_mut(), wake_after) => {}
             }
 
             if !wake_after.is_zero() {

--- a/crates/runtime-next/src/leader/materialize/actor.rs
+++ b/crates/runtime-next/src/leader/materialize/actor.rs
@@ -117,6 +117,9 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
         let mut stopping = false;
         // Transactions completed in this task session, for preview harness limits.
         let mut transactions_completed = 0usize;
+        // Timer for the lowest-priority arm; `sleep_unless_zero` resets it
+        // before each await, so this initial deadline is never observed.
+        let mut wake_sleep = std::pin::pin!(tokio::time::sleep(Duration::ZERO));
 
         while !matches!(head, fsm::Head::Stop) {
             loop_count += 1;
@@ -312,7 +315,7 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                 }
 
                 // Lowest priority.
-                _ = tokio::time::sleep(wake_after) => {}
+                _ = crate::sleep_unless_zero(wake_sleep.as_mut(), wake_after) => {}
             }
 
             if !wake_after.is_zero() {

--- a/crates/runtime-next/src/lib.rs
+++ b/crates/runtime-next/src/lib.rs
@@ -71,6 +71,34 @@ pub const X_GENERATION_ID: &str = "x-collection-generation-id";
 /// instrumentation fires periodically even when no other events arrive.
 pub(crate) const ACTOR_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Lowest-priority `select!` arm of an actor event loop: park until `wake_after`
+/// elapses, re-using a `Sleep` hoisted out of the caller's loop.
+///
+/// ZERO means the FSMs have synchronous work queued and want to be stepped
+/// again immediately, so return without touching a timer: `deadline_to_tick`
+/// rounds deadlines up to the end of the current millisecond, which would cap
+/// input-free FSM sequences (rotate, drain, persist) near 1000 steps/second.
+///
+/// Non-zero durations must not be collapsed, even far below that 1ms tick.
+/// They're deadline-driven — `leader::close_policy` reports time remaining until
+/// its nearest threshold, shrinking to microseconds as it nears — so returning
+/// early would spin re-evaluating a deadline that hasn't passed.
+///
+/// `reset` to a *later* deadline lands on `extend_expiration`'s lock-free CAS,
+/// so only a loop's first non-zero iteration takes the global timer-wheel mutex.
+pub(crate) async fn sleep_unless_zero(
+    mut sleep: std::pin::Pin<&mut tokio::time::Sleep>,
+    wake_after: std::time::Duration,
+) {
+    if wake_after.is_zero() {
+        return;
+    }
+    sleep
+        .as_mut()
+        .reset(tokio::time::Instant::now() + wake_after);
+    sleep.await
+}
+
 /// Describes the basic type of runtime protocol. Mirrors `runtime::RuntimeProtocol`
 /// so that connector image inspection (Phase F-ported `container::flow_runtime_protocol`)
 /// can return a type that's local to this crate.

--- a/crates/runtime-next/src/lib.rs
+++ b/crates/runtime-next/src/lib.rs
@@ -71,6 +71,15 @@ pub const X_GENERATION_ID: &str = "x-collection-generation-id";
 /// instrumentation fires periodically even when no other events arrive.
 pub(crate) const ACTOR_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// A deadline far enough out to mean "never", for arming a hoisted `Sleep` which
+/// has no deadline or whose deadline was consumed.
+///
+/// Mirrors the private `tokio::time::Instant::far_future`, relying on the same
+/// `instant_to_tick` clamp to `MAX_SAFE_MILLIS_DURATION` (~2.2 years).
+pub(crate) fn far_future() -> tokio::time::Instant {
+    tokio::time::Instant::now() + std::time::Duration::from_secs(86400 * 365 * 30)
+}
+
 /// Lowest-priority `select!` arm of an actor event loop: park until `wake_after`
 /// elapses, re-using a `Sleep` hoisted out of the caller's loop.
 ///

--- a/crates/runtime-next/src/shard/capture/actor.rs
+++ b/crates/runtime-next/src/shard/capture/actor.rs
@@ -183,6 +183,9 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
         let mut stopping = false;
         // Transactions completed in this task session, for preview harness limits.
         let mut transactions_completed = 0usize;
+        // Timer for the lowest-priority arm; `sleep_unless_zero` resets it
+        // before each await, so this initial deadline is never observed.
+        let mut wake_sleep = std::pin::pin!(tokio::time::sleep(Duration::ZERO));
 
         while !matches!(head, fsm::Head::Stop) {
             loop_count += 1;
@@ -372,7 +375,7 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                 }
 
                 // Lowest priority.
-                _ = tokio::time::sleep(wake_after) => {}
+                _ = crate::sleep_unless_zero(wake_sleep.as_mut(), wake_after) => {}
             }
 
             if !wake_after.is_zero() {

--- a/crates/runtime-next/src/shard/capture/actor.rs
+++ b/crates/runtime-next/src/shard/capture/actor.rs
@@ -48,6 +48,7 @@ pub(super) struct Actor<P: crate::Publisher, L: crate::Logger> {
     // Per-session metrics counters.
     metrics: super::Metrics,
     // When Some, a deadline at which we begin a graceful session stop.
+    // Consumed once at `serve` entry into a hoisted timer.
     token_restart_at: Option<tokio::time::Instant>,
     // Logger of task-centric state changes and events.
     logger: L,
@@ -186,6 +187,12 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
         // Timer for the lowest-priority arm; `sleep_unless_zero` resets it
         // before each await, so this initial deadline is never observed.
         let mut wake_sleep = std::pin::pin!(tokio::time::sleep(Duration::ZERO));
+        // IAM token-restart deadline, consumed once at loop entry and hoisted out
+        // of the `select!` (which rebuilds its arms every iteration).
+        // `far_future` stands in for "no injected credentials, never restart".
+        let mut token_restart = std::pin::pin!(tokio::time::sleep_until(
+            self.token_restart_at.unwrap_or_else(crate::far_future)
+        ));
 
         while !matches!(head, fsm::Head::Stop) {
             loop_count += 1;
@@ -364,14 +371,16 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                     self.on_connector_rx(&mut ready_connector_rx, msg)?;
                 }
                 // Next, a graceful session restart ahead of IAM token expiry
-                _ = maybe_deadline(self.token_restart_at) => {
+                _ = token_restart.as_mut() => {
                     service_kit::event!(
                         tracing::Level::INFO,
                         "shard",
                         "injected IAM credentials expire soon; stopping session gracefully",
                     );
                     stopping = true;
-                    self.token_restart_at = None;
+                    // A fired `Sleep` stays Ready, so disarm to keep this arm
+                    // from winning every later iteration.
+                    token_restart.as_mut().reset(crate::far_future());
                 }
 
                 // Lowest priority.
@@ -857,14 +866,6 @@ fn now_clock() -> uuid::Clock {
 async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> Option<T> {
     match opt.as_mut() {
         Some(fut) => Some(fut.await),
-        None => std::future::pending().await,
-    }
-}
-
-/// Sleep until the deadline, or park forever when there isn't one.
-async fn maybe_deadline(deadline: Option<tokio::time::Instant>) {
-    match deadline {
-        Some(deadline) => tokio::time::sleep_until(deadline).await,
         None => std::future::pending().await,
     }
 }

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -64,6 +64,7 @@ pub(super) struct Actor {
     // When Some, a deadline at which we ask the leader for a graceful session
     // stop, ahead of the expiry of IAM credentials injected into the connector
     // config. The session's restart re-runs the connector with fresh tokens.
+    // Consumed once at `serve` entry into a hoisted timer.
     token_restart_at: Option<tokio::time::Instant>,
 }
 
@@ -130,6 +131,13 @@ impl Actor {
 
         let mut ticker = tokio::time::interval(crate::ACTOR_TICK_INTERVAL);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        // IAM token-restart deadline, consumed once at loop entry and hoisted out
+        // of the `select!` (which rebuilds its arms every iteration).
+        // `far_future` stands in for "no injected credentials, never restart".
+        let mut token_restart = std::pin::pin!(tokio::time::sleep_until(
+            self.token_restart_at.unwrap_or_else(crate::far_future)
+        ));
 
         loop {
             loop_count += 1;
@@ -265,7 +273,7 @@ impl Actor {
                 // Next, a graceful session restart ahead of IAM token expiry.
                 // The leader Stops at the next transaction boundary, and the
                 // restarted session mints fresh tokens for the connector.
-                _ = maybe_deadline(self.token_restart_at) => {
+                _ = token_restart.as_mut() => {
                     service_kit::event!(
                         tracing::Level::INFO,
                         "leader",
@@ -275,7 +283,9 @@ impl Actor {
                         stop: Some(proto::Stop {}),
                         ..Default::default()
                     });
-                    self.token_restart_at = None;
+                    // A fired `Sleep` stays Ready, so disarm to keep this arm
+                    // from winning every later iteration.
+                    token_restart.as_mut().reset(crate::far_future());
                 }
                 // Periodic tick ensures the iteration trace fires even when otherwise idle.
                 _ = ticker.tick() => {}
@@ -667,13 +677,6 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> T {
             *opt = None;
             result
         }
-        None => std::future::pending().await,
-    }
-}
-
-async fn maybe_deadline(deadline: Option<tokio::time::Instant>) {
-    match deadline {
-        Some(deadline) => tokio::time::sleep_until(deadline).await,
         None => std::future::pending().await,
     }
 }


### PR DESCRIPTION
`runtime-next`'s actor event loops constructed a fresh `tokio::time::sleep` (or
`sleep_until`) inside their `select!` on *every* iteration, registering a timer
into — and on drop removing it from — the tokio runtime's single global timer
wheel (one wheel per runtime, not sharded per worker).

`wake_after` is also frequently `Duration::ZERO`, meaning the FSMs have
synchronous work queued and want to be stepped again immediately. That was not
free: `TimeSource::deadline_to_tick` adds `999_999ns` before truncating to
milliseconds, rounding every deadline up to the end of the current millisecond.
So the loop parked for up to 1ms per step, capping the input-free FSM sequences
taken at every transaction boundary (rotate → drain → persist → write-intents).

## Measurements

`flowctl raw preview-next` over `tests/soak/capture/flow.yaml` (reconfigured to
`rate: 0` so the connector emits flat-out rather than paced at 20 docs/s),
sampling `runtime_shard_capture_transactions` from `--debug-port /metrics` over a
15s window after a 6s warmup:

| | txn/s | docs/s |
|---|---|---|
| `master` | 1.0, 1.1 | 6382, 6179 |
| + commit 1 | 147.0 | 111052 |
| + commit 2 | 139.0, 141.7, 136.6 | 110412, 106883, 110617 |

**~17x on document throughput** (6.3k → 110k docs/s).

Read the transaction figure carefully. Captures default to `max_txn_duration` of
1s with no minimum (`crates/assemble/src/lib.rs`); on `master` the loop could not
reach a transaction's *usage* ceiling within that second, so every transaction
closed on the time limit — hence a flat 1.0 txn/s. Afterward they close on usage
in ~7ms. So 17x on docs/s is the honest headline; the ~130x on txn/s is that plus
release from the time cap.

Commit 1 delivers the entire measured win. **Commit 2 is unmeasured by this
probe, by construction**: the soak capture has no injected IAM credentials, so
`token_restart_at` is `None` and the `maybe_deadline(None)` it replaces was
already a free `std::future::pending()`. Its benefit applies only to tasks that
*do* carry injected credentials. The 147 → 139 delta between commits is inside
the run-to-run spread (136.6–147.0 at HEAD).

## Commit 1 — `sleep_unless_zero`, with a hoisted `Sleep`

Returns immediately on `ZERO`; otherwise resets a `Sleep` hoisted out of the
caller's loop, which lands on `TimerEntry::extend_expiration`'s lock-free CAS so
only a loop's first non-zero iteration takes the wheel mutex. Applied to the
three `wake_after` loops: `shard/capture`, `leader/materialize`, `leader/derive`.

Two deliberate choices, both documented at the definition:

- **Plain return on `ZERO`, not `yield_now()`.** The mpsc arms polled by every
  iteration consume tokio's cooperative budget, forcing a yield within ~128
  iterations regardless; bursting between those yields is wanted for cache and
  branch behavior.
- **Non-zero durations are never collapsed**, even below the 1ms tick. They are
  deadline-driven — `leader::close_policy` reports time remaining until its
  nearest threshold, shrinking to microseconds as it nears — so a sub-ms
  threshold would spin re-evaluating a deadline that has not passed.

## Commit 2 — hoist the IAM token-restart timers

Same technique for the `token_restart_at` arm in `shard/capture` and
`shard/materialize`, which is ungated and hot (once per FSM step; once per
inbound connector message, respectively). Absent injected credentials there is no
deadline, so the hoisted `Sleep` is armed at `far_future()` rather than keeping an
`Option` — which also supplies the disarm the arm now needs, since a fired `Sleep`
stays `Ready` and would otherwise win on every later iteration.
`token_restart_at` becomes write-once, and both copies of `maybe_deadline` lose
their only caller and are deleted.

## Notes

- Behavior-preserving throughout; no protocol, spec, or persisted-state changes.
- `shard/derive` and `shard/materialize`'s `wake_after`-less loops are untouched:
  they already `continue` past the `select!` for synchronous work and use a
  long-lived `Interval` for the idle tick, which is this same pattern.
- The cold `sleep` sites (`triggers.rs` webhook backoff, `container.rs` readiness
  timeout and image-pull retry) are left alone — none can receive `ZERO` and none
  is in a loop.
- 151 `runtime-next` unit tests pass; both commits build independently.
  `tests/split_e2e.rs` needs `etcd` and `gazette` on PATH and did not run
  locally; it drives its own transaction loop, not the actors'.
