### PR TITLE
Local-stack QA quality of life: arm64 connector containers, child-process cleanup, readiness

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,11 @@ default-filter = 'not binary_id(/dekaf::e2e/)'
 [profile.dekaf-e2e]
 # Migration tests excluded due to 8-minute timeout.
 default-filter = 'binary_id(/dekaf::e2e/) and not test(/migration/)'
+# These tests publish specs, wait for shards, and consume through Dekaf, so
+# they're routinely slower than the default 30s/120s. Under CI load the slowest
+# have been observed at ~80s, which is close enough to the inherited 120s
+# terminate-after to become its own source of flakiness.
+slow-timeout = { period = "60s", terminate-after = 5 }
 
 [[profile.default.overrides]]
 filter = 'package(agent) and (test(discovers::) + test(directives::) + test(integration_tests::))'

--- a/.github/workflows/dekaf-test.yaml
+++ b/.github/workflows/dekaf-test.yaml
@@ -62,3 +62,14 @@ jobs:
             - run: mise run build:flowctl-go
             - run: mise run local:stack --dekaf
             - run: mise run ci:dekaf-e2e
+
+            # `ci:dekaf-e2e` dumps logs for the services a test failure implicates,
+            # but a failure while bringing the stack up leaves no diagnostics at
+            # all. Dump every unit's state and journal so those are debuggable
+            # from the run alone.
+            - name: Dump stack diagnostics
+              if: failure()
+              run: |
+                  systemctl --user list-units --all --no-pager 'flow-*' || true
+                  systemctl --user --failed --no-pager || true
+                  journalctl --user -u 'flow-*' --no-pager -n 3000 -o short-precise || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,15 +42,19 @@ mise run ci:catalog-test
 mise run local:supabase
 # Reset with current migrations as needed
 supabase db reset
-# Interact directly with dev DB ($FLOW_PG_URL is ambient inside the checkout)
-psql "$FLOW_PG_URL" -c 'SELECT 1;'
+# Interact directly with dev DB. $FLOW_PG_URL comes from stack-env, so it is set
+# only UNDER mise; in a plain shell it is empty. Single-quote so mise (not your shell) expands it.
+mise exec -- bash -c 'psql "$FLOW_PG_URL" -c "SELECT 1;"'
+# Or make it ambient for the rest of an interactive shell:
+#   eval "$(mise run local:stack-env)"
 
-# Start a complete local stack (see local/README.md)
+# Start a complete local stack (see local/README.md). Blocks until every service
+# accepts connections; `mise run local:stack-wait` re-checks that on demand.
 mise run local:stack
-# CLI for interacting with the platform (FLOWCTL_PROFILE is ambient; no flag).
-cargo run -p flowctl -- --help
+# CLI for interacting with the platform (FLOWCTL_PROFILE is ambient under mise; no --profile flag).
+mise exec -- cargo run -p flowctl -- --help
 # ...or the built binary once the stack is up:
-flowctl catalog list
+mise exec -- flowctl catalog list
 
 # Run after changing Rust files to ensure consistent formatting
 cargo fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7304,6 +7304,7 @@ dependencies = [
  "proto-gazette",
  "proto-grpc",
  "quickcheck",
+ "rand 0.9.2",
  "reqwest 0.12.23",
  "rocksdb",
  "serde",

--- a/crates/dekaf/src/api_client.rs
+++ b/crates/dekaf/src/api_client.rs
@@ -84,6 +84,57 @@ fn parse_broker_url(broker_url: &str) -> anyhow::Result<(ConnectionScheme, Strin
     Ok((scheme, host, port))
 }
 
+/// Where a `FindCoordinator` response directs us.
+#[derive(Debug)]
+enum CoordinatorTarget {
+    /// The broker we're already connected to should serve this group.
+    Current,
+    /// Connect to this broker URL to serve this group.
+    Broker(String),
+    /// The cluster has no servable coordinator yet, but expects to shortly.
+    Retry(kafka_protocol::ResponseError),
+}
+
+/// Interpret a `FindCoordinator` response into the broker we should talk to.
+fn coordinator_target(
+    scheme: ConnectionScheme,
+    resp: &messages::FindCoordinatorResponse,
+) -> anyhow::Result<CoordinatorTarget> {
+    // v4 moved the result into `coordinators` to allow batching; v0-3 carry a
+    // single result inline. We request v3, but handle both so that bumping the
+    // requested version doesn't silently start reading zeroed inline fields.
+    let (error_code, host, port) = match resp.coordinators.first() {
+        Some(coord) => (coord.error_code, coord.host.as_str(), coord.port),
+        None => (resp.error_code, resp.host.as_str(), resp.port),
+    };
+
+    match error_code.err() {
+        // The coordinator's `__consumer_offsets` partition is being replayed or
+        // created. Notably, a cluster which has no `__consumer_offsets` topic
+        // auto-creates it in response to this very request, so the first group
+        // of a cluster's lifetime reliably sees this at least once.
+        Some(
+            err @ (kafka_protocol::ResponseError::CoordinatorNotAvailable
+            | kafka_protocol::ResponseError::CoordinatorLoadInProgress),
+        ) => return Ok(CoordinatorTarget::Retry(err)),
+        Some(err) => anyhow::bail!("FindCoordinator failed: {err}"),
+        None => {}
+    }
+
+    // Brokers also spell "I have no coordinator for you" as an empty host with
+    // a port of -1, without necessarily setting an error code. This must be
+    // checked *before* building a URL: -1 is not a representable port, so
+    // `broker_url_for_host_port` would reject it as a malformed address rather
+    // than the transient condition it actually is.
+    if host.is_empty() && port == -1 {
+        return Ok(CoordinatorTarget::Current);
+    }
+
+    Ok(CoordinatorTarget::Broker(broker_url_for_host_port(
+        scheme, host, port,
+    )?))
+}
+
 static ROOT_CERT_STORE: tokio::sync::OnceCell<Arc<RootCertStore>> =
     tokio::sync::OnceCell::const_new();
 
@@ -467,37 +518,72 @@ impl KafkaApiClient {
         resp
     }
 
+    /// Resolve the group coordinator for `key`, polling while the cluster
+    /// reports one is still loading.
+    ///
+    /// Every caller is serving a live consumer-group API, and Dekaf has no way
+    /// to hand a client a retryable error mid-session: an error here propagates
+    /// out of `dispatch_request_frame` and closes the connection, which the
+    /// client reports as a transport failure. So a condition the cluster tells
+    /// us to wait on must be waited on here rather than returned.
     #[instrument(skip(self))]
     pub async fn connect_to_group_coordinator(&mut self, key: &str) -> anyhow::Result<&mut Self> {
-        let req = messages::FindCoordinatorRequest::default()
-            .with_key(protocol::StrBytes::from_string(key.to_string()))
-            // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java#L119
-            .with_key_type(0); // 0: consumer, 1: transaction
+        const MAX_ATTEMPTS: u32 = 6;
+        const BASE_DELAY: Duration = Duration::from_millis(250);
 
-        let resp = self
-            .send_request(
-                req,
-                Some(
-                    messages::RequestHeader::default()
-                        .with_request_api_key(messages::FindCoordinatorRequest::KEY)
-                        .with_request_api_version(3),
-                ),
-            )
-            .await?;
+        // `None` once resolved means "keep using the current connection".
+        // Resolving into a local rather than returning `&mut self` from inside
+        // the loop keeps the borrow of `self` confined to a single iteration.
+        let mut target = None;
 
-        let (coord_host, coord_port) = if let Some(coord) = resp.coordinators.first() {
-            (coord.host.as_str(), coord.port)
-        } else {
-            (resp.host.as_str(), resp.port)
-        };
+        for attempt in 1..=MAX_ATTEMPTS {
+            let resp = self
+                .send_request(
+                    messages::FindCoordinatorRequest::default()
+                        .with_key(protocol::StrBytes::from_string(key.to_string()))
+                        // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java#L119
+                        .with_key_type(0), // 0: consumer, 1: transaction
+                    Some(
+                        messages::RequestHeader::default()
+                            .with_request_api_key(messages::FindCoordinatorRequest::KEY)
+                            .with_request_api_version(3),
+                    ),
+                )
+                .await?;
 
-        let coord_url = broker_url_for_host_port(self.scheme, coord_host, coord_port)?;
+            match coordinator_target(self.scheme, &resp)? {
+                CoordinatorTarget::Current => break,
+                CoordinatorTarget::Broker(url) => {
+                    target = Some(url);
+                    break;
+                }
+                CoordinatorTarget::Retry(err) if attempt == MAX_ATTEMPTS => {
+                    anyhow::bail!(
+                        "group coordinator for {key} still unavailable after {attempt} attempts: {err}"
+                    );
+                }
+                CoordinatorTarget::Retry(err) => {
+                    // Exponential backoff of 250ms, 500ms, 1s, 2s, 4s: ~7.75s
+                    // in total, which is comfortably within the request timeout
+                    // a Kafka client allows for group operations.
+                    let delay = BASE_DELAY * 2u32.pow(attempt - 1);
 
-        Ok(if coord_host.len() == 0 && coord_port == -1 {
-            self
-        } else {
-            self.client_for_broker(&coord_url).await?
-        })
+                    tracing::warn!(
+                        %key,
+                        %err,
+                        attempt,
+                        ?delay,
+                        "group coordinator is not yet available; retrying"
+                    );
+                    () = tokio::time::sleep(delay).await;
+                }
+            }
+        }
+
+        match target {
+            Some(url) => self.client_for_broker(&url).await,
+            None => Ok(self),
+        }
     }
 
     /// Some APIs can only be sent to the current cluster controller broker.
@@ -890,7 +976,73 @@ impl rsasl::callback::SessionCallback for MSKCredentialsProvider {
 mod tests {
     use insta::assert_snapshot;
 
-    use super::{ConnectionScheme, broker_url_for_host_port, parse_broker_url};
+    use super::{ConnectionScheme, broker_url_for_host_port, coordinator_target, parse_broker_url};
+    use kafka_protocol::{messages, protocol::StrBytes};
+
+    /// A v0-3 style response, which carries its single result inline.
+    fn inline_response(
+        error_code: i16,
+        host: &str,
+        port: i32,
+    ) -> messages::FindCoordinatorResponse {
+        messages::FindCoordinatorResponse::default()
+            .with_error_code(error_code)
+            .with_host(StrBytes::from_string(host.to_string()))
+            .with_port(port)
+    }
+
+    /// A v4+ style response, which batches results under `coordinators`.
+    fn batched_response(
+        error_code: i16,
+        host: &str,
+        port: i32,
+    ) -> messages::FindCoordinatorResponse {
+        messages::FindCoordinatorResponse::default().with_coordinators(vec![
+            messages::find_coordinator_response::Coordinator::default()
+                .with_error_code(error_code)
+                .with_host(StrBytes::from_string(host.to_string()))
+                .with_port(port),
+        ])
+    }
+
+    #[test]
+    fn test_coordinator_target() {
+        let target = |resp| match coordinator_target(ConnectionScheme::Tls, &resp) {
+            Ok(target) => format!("{target:?}"),
+            Err(err) => format!("Err({err})"),
+        };
+
+        // A resolved coordinator, in both response shapes.
+        assert_snapshot!(
+            target(inline_response(0, "broker.example", 9092)),
+            @r#"Broker("tls://broker.example:9092")"#
+        );
+        assert_snapshot!(
+            target(batched_response(0, "broker.example", 9092)),
+            @r#"Broker("tls://broker.example:9092")"#
+        );
+
+        // The condition that regressed: a coordinator which isn't servable yet
+        // must be retried, not reported as a malformed broker address.
+        assert_snapshot!(
+            target(inline_response(15, "", -1)),
+            @"Retry(CoordinatorNotAvailable)"
+        );
+        assert_snapshot!(
+            target(batched_response(14, "", -1)),
+            @"Retry(CoordinatorLoadInProgress)"
+        );
+
+        // The same sentinel without an accompanying error code leaves us on the
+        // broker we're already connected to.
+        assert_snapshot!(target(inline_response(0, "", -1)), @"Current");
+
+        // Anything else is terminal.
+        assert_snapshot!(
+            target(inline_response(29, "", -1)),
+            @"Err(FindCoordinator failed: TopicAuthorizationFailed)"
+        );
+    }
 
     #[test]
     fn test_parse_broker_url_success_cases() {

--- a/crates/dekaf/tests/e2e/harness.rs
+++ b/crates/dekaf/tests/e2e/harness.rs
@@ -204,15 +204,10 @@ impl DekafTestEnv {
         }
     }
 
-    /// Inject documents into a collection via HTTP ingest.
-    pub async fn inject_documents(
-        &self,
-        path: &str,
-        docs: impl IntoIterator<Item = serde_json::Value>,
-    ) -> anyhow::Result<()> {
+    /// Resolve the HTTP-ingest URL of the fixture's capture shard.
+    async fn ingest_url(&self, path: &str) -> anyhow::Result<String> {
         let capture = self.capture_name().context("no capture in fixture")?;
 
-        // Get shard endpoint from flowctl
         let output = async_process::output(flowctl_command()?.args([
             "raw",
             "list-shards",
@@ -221,6 +216,13 @@ impl DekafTestEnv {
             "-ojson",
         ]))
         .await?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "list-shards for {capture} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
 
         let shard: proto_gazette::consumer::list_response::Shard =
             serde_json::from_slice(&output.stdout)?;
@@ -244,7 +246,27 @@ impl DekafTestEnv {
             .context("no port label")?;
 
         let base = endpoint.replace("https://", "");
-        let url = format!("https://{hostname}-{port}.{base}/{path}");
+        Ok(format!("https://{hostname}-{port}.{base}/{path}"))
+    }
+
+    /// Inject documents into a collection via HTTP ingest.
+    ///
+    /// A shard reports PRIMARY as soon as its store is ready, which is before
+    /// its connector container is necessarily running — so `wait_for_primary`
+    /// returning is not a guarantee that the ingest endpoint accepts requests
+    /// yet. In that window the data-plane proxy fails to dial the container and
+    /// its `ReverseProxy` error handler synthesizes a 503 (see
+    /// `go/network/frontend.go`). That happens before any request bytes are
+    /// forwarded, so a 503 means nothing was ingested and the POST is safe to
+    /// replay — which is why only 503 is retried here, and not, say, a
+    /// transport error that could have cut off mid-body.
+    pub async fn inject_documents(
+        &self,
+        path: &str,
+        docs: impl IntoIterator<Item = serde_json::Value>,
+    ) -> anyhow::Result<()> {
+        const RETRY_TIMEOUT: Duration = Duration::from_secs(60);
+        const RETRY_DELAY: Duration = Duration::from_secs(1);
 
         let client = reqwest::Client::builder()
             .danger_accept_invalid_certs(true)
@@ -253,20 +275,41 @@ impl DekafTestEnv {
         let docs: Vec<_> = docs.into_iter().collect();
         tracing::info!(count = docs.len(), %path, "Injecting documents");
 
-        for doc in docs {
-            let resp = client
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .json(&doc)
-                .send()
-                .await?;
+        // Re-resolved on each retry: a container that isn't running may also
+        // mean the shard is being re-assigned to a different reactor.
+        let mut url = self.ingest_url(path).await?;
 
-            if !resp.status().is_success() {
-                anyhow::bail!(
-                    "inject failed: {} {}",
-                    resp.status(),
-                    resp.text().await.unwrap_or_default()
-                );
+        for doc in docs {
+            let deadline = std::time::Instant::now() + RETRY_TIMEOUT;
+
+            loop {
+                let resp = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .json(&doc)
+                    .send()
+                    .await?;
+
+                let status = resp.status();
+
+                if status.is_success() {
+                    break;
+                }
+
+                let body = resp.text().await.unwrap_or_default();
+
+                if status != reqwest::StatusCode::SERVICE_UNAVAILABLE {
+                    anyhow::bail!("inject failed: {status} {body}");
+                }
+                if std::time::Instant::now() > deadline {
+                    anyhow::bail!("inject still unavailable after {RETRY_TIMEOUT:?}: {body}");
+                }
+
+                // Logged at warn because this used to fail the test outright:
+                // its frequency in CI is worth being able to see.
+                tracing::warn!(%status, %body, "ingest endpoint not ready; retrying");
+                tokio::time::sleep(RETRY_DELAY).await;
+                url = self.ingest_url(path).await?;
             }
         }
 

--- a/crates/dekaf/tests/e2e/kafka.rs
+++ b/crates/dekaf/tests/e2e/kafka.rs
@@ -22,6 +22,38 @@ pub struct DecodedRecord {
     pub value: serde_json::Value,
 }
 
+/// Is this a condition librdkafka recovers from on its own?
+///
+/// librdkafka surfaces such conditions on the consumer stream even though it is
+/// already reconnecting or re-discovering the coordinator underneath. A Dekaf
+/// session that drops — because the task's authorization is being refreshed, or
+/// because the session is torn down and re-established — arrives as
+/// `BrokerTransportFailure`, and the client is usable again a moment later.
+/// Real consumers poll straight through these, so tests must too: treating them
+/// as fatal makes every consuming test flaky for reasons unrelated to what it
+/// asserts. Fatal conditions (bad credentials, unknown topic) are deliberately
+/// excluded so they still fail fast.
+fn is_transient(err: &rdkafka::error::KafkaError) -> bool {
+    use rdkafka::types::RDKafkaErrorCode;
+
+    let rdkafka::error::KafkaError::MessageConsumption(code) = err else {
+        return false;
+    };
+
+    matches!(
+        code,
+        RDKafkaErrorCode::BrokerTransportFailure
+            | RDKafkaErrorCode::AllBrokersDown
+            | RDKafkaErrorCode::RequestTimedOut
+            | RDKafkaErrorCode::LeaderNotAvailable
+            | RDKafkaErrorCode::NotLeaderForPartition
+            | RDKafkaErrorCode::CoordinatorLoadInProgress
+            | RDKafkaErrorCode::CoordinatorNotAvailable
+            | RDKafkaErrorCode::NotCoordinator
+            | RDKafkaErrorCode::RebalanceInProgress
+    )
+}
+
 impl KafkaConsumer {
     pub fn new(broker: &str, registry: &str, username: &str, password: &str) -> Self {
         Self::with_group_id(
@@ -73,7 +105,13 @@ impl KafkaConsumer {
     /// Fetch all available records until no more arrive within the timeout.
     pub async fn fetch(&self) -> anyhow::Result<Vec<DecodedRecord>> {
         const TIMEOUT: Duration = Duration::from_secs(10);
+        // Transient errors reset the idle window, so bound the whole call as
+        // well: if the broker never settles we must fail rather than spin.
+        // Kept well under the profile's terminate-after, since tests call this
+        // more than once.
+        const DEADLINE: Duration = Duration::from_secs(60);
 
+        let deadline = std::time::Instant::now() + DEADLINE;
         let mut records = Vec::new();
         let mut stream = self.consumer.stream();
 
@@ -98,6 +136,12 @@ impl KafkaConsumer {
                         key: apache_avro::from_value(&key.value)?,
                         value: apache_avro::from_value(&value.value)?,
                     });
+                }
+                Ok(Some(Err(e))) if is_transient(&e) => {
+                    if std::time::Instant::now() > deadline {
+                        return Err(e).context("consumer did not recover from transient error");
+                    }
+                    tracing::warn!(error = %e, "transient consumer error; continuing to poll");
                 }
                 Ok(Some(Err(e))) => return Err(e.into()),
                 Ok(None) => break,
@@ -145,6 +189,9 @@ impl KafkaConsumer {
                     self.consumer
                         .commit_message(&msg, rdkafka::consumer::CommitMode::Sync)
                         .context("failed to commit")?;
+                }
+                Ok(Some(Err(e))) if is_transient(&e) => {
+                    tracing::warn!(error = %e, "transient consumer error; continuing to poll");
                 }
                 Ok(Some(Err(e))) => return Err(e.into()),
                 Ok(None) => break,
@@ -195,6 +242,9 @@ impl KafkaConsumer {
                         key: apache_avro::from_value(&key.value)?,
                         value: apache_avro::from_value(&value.value)?,
                     });
+                }
+                Ok(Some(Err(e))) if is_transient(&e) => {
+                    tracing::warn!(error = %e, "transient consumer error; continuing to poll");
                 }
                 Ok(Some(Err(e))) => return Err(e.into()),
                 Ok(None) => break,

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -458,7 +458,12 @@ async fn docker_pull(image: &str, logger: &impl crate::Logger) -> anyhow::Result
         let is_transient = err_str.contains("TLS handshake timeout")
             || err_str.contains("connection reset")
             || err_str.contains("i/o timeout")
-            || err_str.contains("unexpected EOF");
+            || err_str.contains("unexpected EOF")
+            // Docker's registry client gives up on a slow registry with
+            // `request canceled (Client.Timeout exceeded while awaiting
+            // headers)`, which reads as a client-side error but is really the
+            // registry being slow to answer.
+            || err_str.contains("Client.Timeout exceeded");
 
         if is_transient && attempt < MAX_RETRIES {
             logger.event(crate::LogEvent::ImagePullRetry {

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -12,6 +12,11 @@ use tokio::io::AsyncBufReadExt;
 // connectors.
 const CONNECTOR_INIT_PORT: u16 = 49092;
 
+// For now, we support only Linux amd64 connectors. `docker pull` must request
+// it explicitly: under Docker's containerd image store a platform-less pull
+// fetches only the host's variant, which `docker run --platform` cannot use.
+const CONNECTOR_PLATFORM: &str = "linux/amd64";
+
 const RUNTIME_PROTO_LABEL: &str = "FLOW_RUNTIME_PROTOCOL";
 const USAGE_RATE_LABEL: &str = "dev.estuary.usage-rate";
 const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
@@ -39,9 +44,7 @@ pub async fn flow_runtime_protocol(image: &str) -> anyhow::Result<RuntimeProtoco
             .context("pulling image")?;
     }
 
-    let inspect_output = docker_cmd(&["inspect", image])
-        .await
-        .context("inspecting image")?;
+    let inspect_output = inspect_image(image).await.context("inspecting image")?;
 
     let inspection = parse_image_inspection(&inspect_output)?;
     tracing::info!(
@@ -143,8 +146,7 @@ pub async fn start<L: crate::Logger>(
         connector_memory_limit(),
         "--cpus".to_string(),
         connector_cpu_limit(),
-        // For now, we support only Linux amd64 connectors.
-        "--platform=linux/amd64".to_string(),
+        format!("--platform={CONNECTOR_PLATFORM}"),
         // Attach labels that let us group connector resource usage under a few dimensions.
         format!("--label=image={}", image),
         format!("--label=task-name={}", task_name),
@@ -204,18 +206,31 @@ pub async fn start<L: crate::Logger>(
     tokio::spawn(async move {
         let mut stderr = tokio::io::BufReader::new(stderr);
         let mut line = String::new();
-
-        // Wait for a non-empty read of stderr to complete or EOF/error.
-        // Note that `flow-connector-init` writes one whitespace byte on startup.
-        if let Ok(buf) = stderr.fill_buf().await {
-            if buf.first() == Some(&b' ') {
-                stderr.consume(1); // Discard.
-            }
-        }
-        std::mem::drop(ready_tx); // Signal that we're ready.
+        let mut ready_tx = Some(ready_tx);
 
         let decoder = ops::decode::Decoder::new(std::time::SystemTime::now);
         loop {
+            // `flow-connector-init` binds its port and then writes a single
+            // whitespace byte: our only signal that the container is up. Anything
+            // before it is `docker run` talking -- pull progress, or a failure
+            // such as a name conflict -- and mistaking that for readiness races
+            // us into inspecting a container which doesn't exist yet.
+            let first = match stderr.fill_buf().await {
+                Ok([]) => None, // Clean EOF.
+                Ok(buf) => Some(buf[0]),
+                Err(error) => {
+                    tracing::error!(%error, "failed to read from connector stderr");
+                    None
+                }
+            };
+            let Some(first) = first else { break };
+
+            if first == b' ' && ready_tx.is_some() {
+                stderr.consume(1); // Discard.
+                _ = ready_tx.take().unwrap().send(()); // Signal that we're ready.
+                continue;
+            }
+
             line.clear();
 
             match stderr.read_line(&mut line).await {
@@ -232,6 +247,8 @@ pub async fn start<L: crate::Logger>(
             let sanitized = sanitize_event_type(&quoted_task_name, log);
             pump_logger.log(&sanitized);
         }
+        // An un-sent `ready_tx` cancels on drop, telling `start()` that stderr
+        // closed before the container came up.
     });
 
     // Wait for container to become ready, or close its stderr (likely due to a crash),
@@ -240,7 +257,12 @@ pub async fn start<L: crate::Logger>(
         _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
             anyhow::bail!("timeout waiting for the container to become ready");
         }
-        _ = ready_rx => (),
+        ready = ready_rx => if ready.is_err() {
+            anyhow::bail!(
+                "container exited before flow-connector-init started; \
+                 the cause is in the preceding connector logs"
+            );
+        },
     }
 
     // Ask docker for network configuration that it assigned to the container.
@@ -376,13 +398,9 @@ impl<L: crate::Logger> Drop for Guard<L> {
     }
 }
 
+/// Generate a name for a connector container which is unique on this host.
 fn unique_container_name() -> String {
-    let n = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-
-    format!("fc_{:x}", n as u32)
+    format!("fc_{:016x}", rand::random::<u64>())
 }
 
 fn docker_cli() -> String {
@@ -425,7 +443,14 @@ async fn docker_pull(image: &str, logger: &impl crate::Logger) -> anyhow::Result
     const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
     for attempt in 1..=MAX_RETRIES {
-        let Err(err) = docker_cmd(&["pull", image, "--quiet"]).await else {
+        let Err(err) = docker_cmd(&[
+            "pull",
+            image,
+            "--quiet",
+            &format!("--platform={CONNECTOR_PLATFORM}"),
+        ])
+        .await
+        else {
             return Ok(());
         };
 
@@ -669,7 +694,7 @@ async fn find_connector_init_and_copy(tmp_path: &std::path::Path) -> anyhow::Res
     let name = format!("{}_fci", unique_container_name());
     docker_cmd(&[
         "create",
-        "--platform=linux/amd64",
+        &format!("--platform={CONNECTOR_PLATFORM}"),
         &format!("--name={name}"),
         CONNECTOR_INIT_IMAGE,
     ])
@@ -689,6 +714,30 @@ async fn find_connector_init_and_copy(tmp_path: &std::path::Path) -> anyhow::Res
     Ok(())
 }
 
+/// Inspect the `CONNECTOR_PLATFORM` variant of `image`, which must already be
+/// pulled. The result is mounted into the container as `/image-inspect.json`,
+/// from which `flow-connector-init` derives the connector's real entrypoint.
+///
+/// Plain `docker inspect` reports the host platform's variant, which under the
+/// containerd image store may not be present at all -- yielding an empty
+/// `Config` that fails to parse. Only `docker image inspect` takes `--platform`.
+/// `podman image inspect` has no such flag and needs none, as it stores the
+/// concrete image that `--platform` pulled; hence the fallback.
+async fn inspect_image(image: &str) -> anyhow::Result<Vec<u8>> {
+    let platform = format!("--platform={CONNECTOR_PLATFORM}");
+
+    match docker_cmd(&["image", "inspect", &platform, image]).await {
+        Ok(output) => Ok(output),
+        Err(error) => {
+            tracing::debug!(
+                %error,
+                "`image inspect --platform` failed; retrying without it"
+            );
+            docker_cmd(&["image", "inspect", image]).await
+        }
+    }
+}
+
 async fn inspect_image_and_copy(
     image: &str,
     tmp_path: &std::path::Path,
@@ -698,9 +747,7 @@ async fn inspect_image_and_copy(
         docker_pull(image, logger).await.context("pulling image")?;
     }
 
-    let inspect_content = docker_cmd(&["inspect", image])
-        .await
-        .context("inspecting image")?;
+    let inspect_content = inspect_image(image).await.context("inspecting image")?;
 
     tokio::fs::write(tmp_path, &inspect_content)
         .await

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -53,6 +53,7 @@ jsonwebtoken = { workspace = true }
 librocksdb-sys = { workspace = true }
 pbjson-types = { workspace = true }
 prost = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
 rocksdb = { workspace = true }
 serde = { workspace = true }

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -425,7 +425,12 @@ async fn docker_pull(image: &str) -> anyhow::Result<()> {
         let is_transient = err_str.contains("TLS handshake timeout")
             || err_str.contains("connection reset")
             || err_str.contains("i/o timeout")
-            || err_str.contains("unexpected EOF");
+            || err_str.contains("unexpected EOF")
+            // Docker's registry client gives up on a slow registry with
+            // `request canceled (Client.Timeout exceeded while awaiting
+            // headers)`, which reads as a client-side error but is really the
+            // registry being slow to answer.
+            || err_str.contains("Client.Timeout exceeded");
 
         if is_transient && attempt < MAX_RETRIES {
             tracing::warn!(

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -12,6 +12,11 @@ use tokio::io::AsyncBufReadExt;
 // connectors.
 const CONNECTOR_INIT_PORT: u16 = 49092;
 
+// For now, we support only Linux amd64 connectors. `docker pull` must request
+// it explicitly: under Docker's containerd image store a platform-less pull
+// fetches only the host's variant, which `docker run --platform` cannot use.
+const CONNECTOR_PLATFORM: &str = "linux/amd64";
+
 const RUNTIME_PROTO_LABEL: &str = "FLOW_RUNTIME_PROTOCOL";
 const USAGE_RATE_LABEL: &str = "dev.estuary.usage-rate";
 const PORT_PUBLIC_LABEL_PREFIX: &str = "dev.estuary.port-public.";
@@ -35,9 +40,7 @@ pub async fn flow_runtime_protocol(image: &str) -> anyhow::Result<RuntimeProtoco
         docker_pull(image).await.context("pulling image")?;
     }
 
-    let inspect_output = docker_cmd(&["inspect", image])
-        .await
-        .context("inspecting image")?;
+    let inspect_output = inspect_image(image).await.context("inspecting image")?;
 
     let inspection = parse_image_inspection(&inspect_output)?;
     tracing::info!(
@@ -133,8 +136,7 @@ pub async fn start(
         connector_memory_limit(),
         "--cpus".to_string(),
         connector_cpu_limit(),
-        // For now, we support only Linux amd64 connectors.
-        "--platform=linux/amd64".to_string(),
+        format!("--platform={CONNECTOR_PLATFORM}"),
         // Attach labels that let us group connector resource usage under a few dimensions.
         format!("--label=image={}", image),
         format!("--label=task-name={}", task_name),
@@ -193,18 +195,31 @@ pub async fn start(
     tokio::spawn(async move {
         let mut stderr = tokio::io::BufReader::new(stderr);
         let mut line = String::new();
-
-        // Wait for a non-empty read of stderr to complete or EOF/error.
-        // Note that `flow-connector-init` writes one whitespace byte on startup.
-        if let Ok(buf) = stderr.fill_buf().await {
-            if buf.first() == Some(&b' ') {
-                stderr.consume(1); // Discard.
-            }
-        }
-        std::mem::drop(ready_tx); // Signal that we're ready.
+        let mut ready_tx = Some(ready_tx);
 
         let decoder = ops::decode::Decoder::new(std::time::SystemTime::now);
         loop {
+            // `flow-connector-init` binds its port and then writes a single
+            // whitespace byte: our only signal that the container is up. Anything
+            // before it is `docker run` talking -- pull progress, or a failure
+            // such as a name conflict -- and mistaking that for readiness races
+            // us into inspecting a container which doesn't exist yet.
+            let first = match stderr.fill_buf().await {
+                Ok([]) => None, // Clean EOF.
+                Ok(buf) => Some(buf[0]),
+                Err(error) => {
+                    tracing::error!(%error, "failed to read from connector stderr");
+                    None
+                }
+            };
+            let Some(first) = first else { break };
+
+            if first == b' ' && ready_tx.is_some() {
+                stderr.consume(1); // Discard.
+                _ = ready_tx.take().unwrap().send(()); // Signal that we're ready.
+                continue;
+            }
+
             line.clear();
 
             match stderr.read_line(&mut line).await {
@@ -221,6 +236,8 @@ pub async fn start(
             let sanitized = sanitize_event_type(&quoted_task_name, log);
             log_handler.log(&sanitized);
         }
+        // An un-sent `ready_tx` cancels on drop, telling `start()` that stderr
+        // closed before the container came up.
     });
 
     // Wait for container to become ready, or close its stderr (likely due to a crash),
@@ -229,7 +246,12 @@ pub async fn start(
         _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
             anyhow::bail!("timeout waiting for the container to become ready");
         }
-        _ = ready_rx => (),
+        ready = ready_rx => if ready.is_err() {
+            anyhow::bail!(
+                "container exited before flow-connector-init started; \
+                 the cause is in the preceding connector logs"
+            );
+        },
     }
 
     // Ask docker for network configuration that it assigned to the container.
@@ -343,13 +365,9 @@ pub struct Guard {
     _process: async_process::Child,
 }
 
+/// Generate a name for a connector container which is unique on this host.
 fn unique_container_name() -> String {
-    let n = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-
-    format!("fc_{:x}", n as u32)
+    format!("fc_{:016x}", rand::random::<u64>())
 }
 
 fn docker_cli() -> String {
@@ -392,7 +410,14 @@ async fn docker_pull(image: &str) -> anyhow::Result<()> {
     const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
     for attempt in 1..=MAX_RETRIES {
-        let Err(err) = docker_cmd(&["pull", image, "--quiet"]).await else {
+        let Err(err) = docker_cmd(&[
+            "pull",
+            image,
+            "--quiet",
+            &format!("--platform={CONNECTOR_PLATFORM}"),
+        ])
+        .await
+        else {
             return Ok(());
         };
 
@@ -638,7 +663,7 @@ async fn find_connector_init_and_copy(tmp_path: &std::path::Path) -> anyhow::Res
     let name = format!("{}_fci", unique_container_name());
     docker_cmd(&[
         "create",
-        "--platform=linux/amd64",
+        &format!("--platform={CONNECTOR_PLATFORM}"),
         &format!("--name={name}"),
         CONNECTOR_INIT_IMAGE,
     ])
@@ -658,6 +683,30 @@ async fn find_connector_init_and_copy(tmp_path: &std::path::Path) -> anyhow::Res
     Ok(())
 }
 
+/// Inspect the `CONNECTOR_PLATFORM` variant of `image`, which must already be
+/// pulled. The result is mounted into the container as `/image-inspect.json`,
+/// from which `flow-connector-init` derives the connector's real entrypoint.
+///
+/// Plain `docker inspect` reports the host platform's variant, which under the
+/// containerd image store may not be present at all -- yielding an empty
+/// `Config` that fails to parse. Only `docker image inspect` takes `--platform`.
+/// `podman image inspect` has no such flag and needs none, as it stores the
+/// concrete image that `--platform` pulled; hence the fallback.
+async fn inspect_image(image: &str) -> anyhow::Result<Vec<u8>> {
+    let platform = format!("--platform={CONNECTOR_PLATFORM}");
+
+    match docker_cmd(&["image", "inspect", &platform, image]).await {
+        Ok(output) => Ok(output),
+        Err(error) => {
+            tracing::debug!(
+                %error,
+                "`image inspect --platform` failed; retrying without it"
+            );
+            docker_cmd(&["image", "inspect", image]).await
+        }
+    }
+}
+
 async fn inspect_image_and_copy(
     image: &str,
     tmp_path: &std::path::Path,
@@ -666,9 +715,7 @@ async fn inspect_image_and_copy(
         docker_pull(image).await.context("pulling image")?;
     }
 
-    let inspect_content = docker_cmd(&["inspect", image])
-        .await
-        .context("inspecting image")?;
+    let inspect_content = inspect_image(image).await.context("inspecting image")?;
 
     tokio::fs::write(tmp_path, &inspect_content)
         .await

--- a/crates/shuffle/tests/scenario_fixtures.rs
+++ b/crates/shuffle/tests/scenario_fixtures.rs
@@ -175,7 +175,11 @@ fn collect_read_entries(
 #[tokio::test]
 async fn shuffle_scenarios() {
     // Build the catalog fixture.
-    let source = build::arg_source_to_url("./tests/shuffle.flow.yaml", false).unwrap();
+    let source = build::arg_source_to_url(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/shuffle.flow.yaml"),
+        false,
+    )
+    .unwrap();
     let build_output = Arc::new(
         build::for_local_test(&source, true)
             .await

--- a/crates/shuffle/tests/scenario_fuzz.rs
+++ b/crates/shuffle/tests/scenario_fuzz.rs
@@ -207,8 +207,11 @@ fn get_harness() -> &'static SharedHarness {
 
         let (data_plane, service, materialization_spec, capture_spec, log_dir, server_handle) =
             runtime.block_on(async {
-                let source =
-                    build::arg_source_to_url("./tests/shuffle_fuzz.flow.yaml", false).unwrap();
+                let source = build::arg_source_to_url(
+                    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/shuffle_fuzz.flow.yaml"),
+                    false,
+                )
+                .unwrap();
                 let build_output = Arc::new(
                     build::for_local_test(&source, true)
                         .await

--- a/local/README.md
+++ b/local/README.md
@@ -167,8 +167,30 @@ flow-plane@<dp>.target                     one per data plane (dp = local-<stack
 
 `local:stack` boots the control plane plus a `local-<stack>-cluster` data plane
 at `FLOW_PLANE_BASE` with 4 brokers, 1 reactor, and link, then publishes
-`ops-catalog/local-view.bundle.json` and prints the stack card. Add `--dekaf`
-for the Kafka shim.
+`ops-catalog/local-view.bundle.json`, waits for the stack to actually serve
+(next section), and prints the stack card. Add `--dekaf` for the Kafka shim.
+
+### Unit state is NOT a readiness signal
+
+Every `flow-*@.service` is `Type=simple` and builds in `ExecStartPre` (cargo/go).
+Two consequences that will mislead you if you script against systemd state:
+
+- A unit reports `active` the moment `ExecStart` **forks** — before it binds its
+  port. `active` means "launched", not "serving".
+- `flow-plane@<dp>.target` aggregates its members with `Wants=`, so the target
+  reports `active` even while a member is still in `activating (start-pre)`
+  compiling. On a cold checkout that takes *minutes*.
+
+`local:stack-wait` is a readiness check - it enumerates this stack's
+loaded units, maps each to its port, and blocks until all accept connections:
+
+```bash
+mise run local:stack-wait                 # default 900s budget
+mise run local:stack-wait --timeout 120
+```
+
+`local:stack` runs and blocks on `local:stack-wait` before returning.
+Run it directly after restarting individual units.
 
 Useful incantations (stack `flow`, index 0, shown; `local:stack-info` prints the
 exact names/ports for your stack):
@@ -337,6 +359,41 @@ inside the checkout targets this stack** — no `--profile` needed.
 You must `export SSL_CERT_FILE=~/flow-local/ca.crt` (per command) or you'll see
 TLS violations on broker/reactor calls.
 
+## Connectors must be registered before you can publish them
+
+A stack can only publish specs whose connector image is in its `connectors`
+table, and `supabase/seed.sql` seeds only a handful. **Having the image locally
+in `docker images` is not enough**: image presence and DB registration are independent.
+
+Publishing an unregistered image fails with a message written for production:
+
+```
+connector image 'ghcr.io/estuary/materialize-sqlite:dev' is unknown to Estuary,
+so the endpoint configuration cannot be encrypted. Use a different connector or
+reach out to Estuary support for help
+```
+
+Locally, that means "register it first". See what this stack knows, then add what it doesn't:
+
+```bash
+# Make this stack's vars ambient first.
+eval "$(mise run local:stack-env)"
+
+# What's registered (and whether its tag job has run):
+psql "$FLOW_PG_URL" -c "SELECT c.image_name, t.image_tag,
+  t.job_status->>'type' FROM connectors c JOIN connector_tags t
+  ON t.connector_id = c.id ORDER BY 1;"
+
+# Register one. NOTE: the image name is passed WITHOUT its tag; the tag is a
+# separate second argument and defaults to 'local', NOT 'dev'.
+mise exec -- ./local/install-connector.sh ghcr.io/estuary/materialize-sqlite dev
+```
+
+Registering queues a `connector_tags` job; the agent runs the image to fill in
+its protocol and endpoint/resource spec schemas, which validation needs. Wait
+for that row to reach `success` (a few seconds) before publishing — until then
+the schemas are absent and a publish can still fail.
+
 ## Connectors run on the Supabase Docker network
 
 The **reactor** sets `FLOW_NETWORK=supabase_network_<stack>` (per stack), and the
@@ -413,5 +470,8 @@ collide; the classic remap set belongs to one stack).
 
 `local/ops-publication.sh <bundle>` emits the SQL that `local:stack` uses to
 publish an ops bundle (targets `ops/dp/public/${FLOW_CLUSTER}`).
-`local/install-connector.sh <image> [tag]` adds a connector to this stack's DB.
+`local/install-connector.sh <image> [tag]` adds a connector to this stack's DB —
+a **precondition** for publishing a spec that uses it, not an optional extra; see
+"Connectors must be registered before you can publish them" above for the failure
+it prevents and the tag-argument gotcha.
 Both require the ambient `FLOW_*` vars (run inside a mise context).

--- a/mise/tasks/local/lib.sh
+++ b/mise/tasks/local/lib.sh
@@ -89,8 +89,12 @@ EOF
 # when nothing is running; callers announce state themselves.
 print_stack_card() {
     echo "Stack '${FLOW_STACK_NAME}' — index ${FLOW_STACK_INDEX}, ports ${FLOW_STACK_BASE}-$((FLOW_STACK_BASE + 999))."
-    echo "  flowctl catalog list          # FLOWCTL_PROFILE=${FLOW_STACK_NAME} is ambient in this checkout"
-    echo "  psql \"\$FLOW_PG_URL\"           # Supabase Postgres  localhost:${FLOW_PORT_SUPABASE_DB}"
-    echo "  mise run local:stack-info     # full port map, units, and commands"
-    echo "  mise run local:test-tenant    # provision tenant credentials"
+    # `mise exec --` is not decoration: FLOWCTL_PROFILE comes from stack-env,
+    # which applies only under mise (see local/README.md). psql's URL is printed
+    # literally because $FLOW_PG_URL would be expanded — to empty — by the
+    # reader's own shell before mise could set it.
+    echo "  mise exec -- flowctl catalog list   # FLOWCTL_PROFILE=${FLOW_STACK_NAME} is ambient under mise"
+    echo "  psql ${FLOW_PG_URL}"
+    echo "  mise run local:stack-info          # full port map, units, and commands"
+    echo "  mise run local:test-tenant         # provision tenant credentials"
 }

--- a/mise/tasks/local/stack
+++ b/mise/tasks/local/stack
@@ -82,5 +82,11 @@ commit;
 EOF
 
 echo ""
+# Don't claim the stack is up until it actually serves. The units build in
+# ExecStartPre and are `Type=simple`, so systemd reports them active long
+# before they listen; on a cold checkout that gap is minutes of compiling.
+mise run local:stack-wait
+
+echo ""
 echo "Stack '${FLOW_STACK_NAME}' is up."
 print_stack_card

--- a/mise/tasks/local/stack-info
+++ b/mise/tasks/local/stack-info
@@ -32,14 +32,18 @@ printf '  %-22s %s\n' "plane 0 base" "${PB} (brokers ${PB}+, reactors ${PB}+99 d
 echo ""
 
 echo "Units for this stack:"
-UNITS="$(systemctl --user list-units --all --no-legend --no-pager \
+# `--plain` suppresses the `●` marker systemctl prefixes onto failed/not-found
+# units. Without it those rows gain a leading column, so $1 is the marker and the
+# unit NAME is dropped from the output entirely. The LOAD column ($2) carries
+# what the marker was signalling, so surface it when it isn't the boring `loaded`.
+UNITS="$(systemctl --user list-units --all --no-legend --no-pager --plain \
     "flow-*@${FLOW_STACK_NAME}.service" \
     "flow-*@${FLOW_STACK_NAME}.target" \
     "flow-*@${FLOW_CLUSTER}.service" \
     "flow-*@${FLOW_CLUSTER}.target" \
     "flow-*@${FLOW_CLUSTER}-*.service" \
     "flow-*@${FLOW_CLUSTER}-*.target" 2>/dev/null \
-    | awk '{printf "  %-52s %s %s\n", $1, $3, $4}')"
+    | awk '{load = ($2 == "loaded" ? "" : " [" $2 "]"); printf "  %-52s %s %s%s\n", $1, $3, $4, load}')"
 if [ -n "${UNITS}" ]; then
     printf '%s\n' "${UNITS}"
 else
@@ -48,9 +52,16 @@ fi
 echo ""
 
 REACTOR_PORT=$((PB + 99))
+# Print psql's URL literally rather than as $FLOW_PG_URL: that variable comes
+# from stack-env and exists only under mise, so a pasted `psql "$FLOW_PG_URL"`
+# expands to empty in the user's shell and fails against the default libpq socket.
+# (Note `mise exec -- psql "$FLOW_PG_URL"` is no fix: the OUTER shell expands the
+# argument before mise sets anything.) flowctl needs only FLOWCTL_PROFILE from
+# the environment, so for it `mise exec --` is sufficient.
 echo "Ready-to-paste commands:"
-echo "  psql \"\$FLOW_PG_URL\"                       # Supabase Postgres  localhost:${FLOW_PORT_SUPABASE_DB}"
-echo "  flowctl catalog list                       # FLOWCTL_PROFILE=${FLOW_STACK_NAME} is ambient here"
+echo "  psql ${FLOW_PG_URL}"
+echo "  mise exec -- flowctl catalog list          # FLOWCTL_PROFILE=${FLOW_STACK_NAME} is ambient under mise"
+echo "  mise run local:stack-wait                  # block until all services accept connections"
 echo "  export SSL_CERT_FILE=${FLOW_LOCAL}/ca.crt   # per-command; needed for broker/reactor TLS calls"
 echo "  journalctl --user -u flow-reactor@${FLOW_CLUSTER}-${REACTOR_PORT} -f"
 echo "  mise run local:test-tenant && source ${FLOW_STACK_DIR}/test-tenant-test.env"

--- a/mise/tasks/local/stack-wait
+++ b/mise/tasks/local/stack-wait
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#MISE description="Block until this stack's services are accepting connections"
+#USAGE flag "--timeout <timeout>" help="Seconds to wait before giving up (default 900)"
+
+# Why this exists: every flow-*@.service is `Type=simple`, so systemd marks a
+# unit `active` the moment ExecStart forks -- and the units build before they
+# serve (ExecStartPre runs cargo/go). Neither `is-active` nor
+# `flow-plane@<dp>.target` being active therefore implies "usable": the target
+# aggregates its members with `Wants=`, so it reports active even while a member
+# is still in start-pre compiling. The only honest readiness signal is a
+# connection to the port each service listens on, which is what this does.
+
+source "$(dirname "$0")/lib.sh"
+ensure_stack_env
+
+TIMEOUT="${usage_timeout:-900}"
+
+# Systemd instance names for data-plane units are `<data-plane>-<port>` for
+# brokers and reactors, but a bare `<data-plane>` for the sidecar and Dekaf.
+# Recover the latter's port block from the former: brokers count up from
+# base+0 and reactors down from base+99, so the lowest port seen for a data
+# plane, rounded down to a multiple of 100, is that plane's base.
+plane_base_for() {
+    local dp="$1" lowest="" port
+    # `--plain` is load-bearing: without it systemctl prefixes not-found/failed
+    # units with a `●` marker, shifting every column and silently turning the
+    # unit name into `●`.
+    for port in $(systemctl --user list-units --all --no-legend --no-pager --plain \
+        "flow-gazette@${dp}-*.service" "flow-reactor@${dp}-*.service" 2>/dev/null \
+        | awk '{print $1}' | sed -E 's/^.*-([0-9]+)\.service$/\1/'); do
+        if [ -z "${lowest}" ] || [ "${port}" -lt "${lowest}" ]; then
+            lowest="${port}"
+        fi
+    done
+    if [ -z "${lowest}" ]; then
+        echo "${FLOW_PLANE_BASE}" # No brokers/reactors found; assume plane 0.
+        return
+    fi
+    echo "$((lowest - lowest % 100))"
+}
+
+# Echo the TCP port `unit` listens on, or nothing when it has none to probe
+# (`flow-plane-link@` is a oneshot that exits, and unknown units are skipped
+# rather than guessed at).
+port_for_unit() {
+    local unit="$1" tmpl inst
+    tmpl="${unit%@*}"
+    inst="${unit#*@}"
+    inst="${inst%.service}"
+
+    case "${tmpl}" in
+    flow-etcd) echo "${FLOW_PORT_ETCD}" ;;
+    flow-supabase) echo "${FLOW_PORT_SUPABASE_DB}" ;;
+    flow-control-agent) echo "${FLOW_PORT_AGENT}" ;;
+    flow-config-encryption) echo "${FLOW_PORT_CONFIG_ENC}" ;;
+    flow-bigtable) echo "${FLOW_PORT_BIGTABLE}" ;;
+    flow-dekaf-kafka) echo "${FLOW_PORT_KAFKA}" ;;
+    flow-gazette | flow-reactor) echo "${inst##*-}" ;;
+    flow-runtime-sidecar) echo "$(($(plane_base_for "${inst}") + 60))" ;;
+    flow-dekaf) echo "$(($(plane_base_for "${inst}") + 50))" ;;
+    *) echo "" ;;
+    esac
+}
+
+# `--plain` suppresses the `●` marker systemctl puts on failed/not-found units;
+# without it those lines shift a column and the unit name reads as `●`, which
+# would drop exactly the broken units this check exists to catch.
+UNITS="$(systemctl --user list-units --all --no-legend --no-pager --plain \
+    "flow-*@${FLOW_STACK_NAME}.service" \
+    "flow-*@${FLOW_CLUSTER}.service" \
+    "flow-*@${FLOW_CLUSTER}-*.service" 2>/dev/null | awk '{print $1}')"
+
+if [ -z "${UNITS}" ]; then
+    echo "error: no units loaded for stack '${FLOW_STACK_NAME}' — start it with: mise run local:stack" >&2
+    exit 1
+fi
+
+# Pair each probe-able unit with its port once, up front.
+TARGETS=""
+for unit in ${UNITS}; do
+    port="$(port_for_unit "${unit}")"
+    [ -n "${port}" ] && TARGETS="${TARGETS}${TARGETS:+ }${unit}:${port}"
+done
+
+echo "Waiting up to ${TIMEOUT}s for $(echo "${TARGETS}" | wc -w) service(s) of stack '${FLOW_STACK_NAME}'..."
+
+ELAPSED=0
+LAST_REPORT=""
+while true; do
+    PENDING=""
+    for target in ${TARGETS}; do
+        unit="${target%:*}"
+        port="${target##*:}"
+
+        # Fail fast rather than burning the whole timeout on a dead unit.
+        if systemctl --user is-failed --quiet "${unit}"; then
+            echo "error: ${unit} failed to start. Logs:" >&2
+            journalctl --user -u "${unit}" --no-pager -n 40 >&2
+            exit 1
+        fi
+        if ! nc -z localhost "${port}" 2>/dev/null; then
+            # Distinguish "still compiling" from "started but not yet listening":
+            # the units build in ExecStartPre, which can dominate a cold start.
+            if systemctl --user is-active --quiet "${unit}"; then
+                PENDING="${PENDING}${PENDING:+ }${unit%@*}:${port}"
+            else
+                PENDING="${PENDING}${PENDING:+ }${unit%@*}:${port}(building)"
+            fi
+        fi
+    done
+
+    [ -z "${PENDING}" ] && break
+
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+        echo "error: stack '${FLOW_STACK_NAME}' not ready after ${TIMEOUT}s; still waiting on: ${PENDING}" >&2
+        exit 1
+    fi
+    # Report only on change, so a long cold-start build stays quiet but visible.
+    if [ "${PENDING}" != "${LAST_REPORT}" ]; then
+        echo "  waiting on: ${PENDING}"
+        LAST_REPORT="${PENDING}"
+    fi
+    sleep 2
+    ELAPSED=$((ELAPSED + 2))
+done
+
+echo "All services of stack '${FLOW_STACK_NAME}' are accepting connections."


### PR DESCRIPTION
Quality-of-life work that resolves sharp edges hit while doing QA against a local stack.

**arm64 connector containers.** The `docker --platform` changes are **required** for MacBook arm64 hosts running arm64 VMs under Lima with Rosetta. Without them, connector startup fails with a misleading `no such object` / "did it crash?" error whose real cause is that a platform-less `docker pull` fetches only the host variant under Docker's containerd image store. Also fixes a bogus-readiness race (docker's inline-pull chatter was accepted as the container's ready signal) and container-name collisions from truncated `SystemTime` nanos, which back-to-back reads return identical on ARM's 24MHz timer.

**Child-process cleanup.** `PR_SET_PDEATHSIG` so a hard-killed parent takes its children with it. `Child::drop` only covers paths that unwind; a SIGKILL or OOM kill left etcd and gazette clusters re-parented to init, serving and holding temp dirs indefinitely, and `local:stop` will never reap them since these are from tests and not systemd units.

**Local-stack readiness and paste-ability.** Nothing surfaces when a stack is actually useable: units are `Type=simple` and build in `ExecStartPre`, so both `is-active` and `flow-plane@<dp>.target` report active well before anything binds a port. Adds `local:stack-wait` (TCP probes, fails fast on a failed unit) which `local:stack` now blocks on. Also fixes "ready-to-paste" commands that were not paste-able, a unit listing that dropped the name of any unit with a problem, and documents that connector registration is a publish precondition that a present image does not imply.

**Verification.** QA'd end to end on an aarch64 host with the containerd image store: capture → TypeScript derivation → materialization all publishing and flowing, with each defect's mechanism reproduced independently first. `kill -9` orphan behavior confirmed against a negative control. Touched crates' test suites pass; `cargo fmt --all --check` clean.

_Branch name is a worktree artifact — this is unrelated to #3246._