### PR TITLE
2781: Preemptively deploying states for Discovery and Publish

### DIFF
--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -41,6 +41,22 @@ impl JobStatus {
 
 type ProcessResult = Result<tables::DraftCatalog, Vec<models::draft_error::Error>>;
 
+/// Poll state persisted to `internal.tasks` between polls, and therefore
+/// shared with whichever agent instance dequeues the next poll.
+///
+/// This deploy doesn't yet read or write this state: it's carried so that
+/// state persisted by the upcoming stale-snapshot deferral changes remains
+/// decodable by this version during a deploy or rollback.
+#[allow(dead_code)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct DiscoverState {
+    /// The instant a Snapshot must postdate (per `Snapshot::taken_after`)
+    /// before this discover is retried: the queued time its prior attempt
+    /// anchored authorization staleness on.
+    #[serde(default)]
+    pub awaiting_snapshot_after: Option<tokens::DateTime>,
+}
+
 pub struct DiscoverOutcome {
     id: Id,
     draft_id: Id,
@@ -91,7 +107,10 @@ impl<C: DiscoverConnectors> automations::Executor for DiscoverExecutor<C> {
 
     type Receive = serde_json::Value;
 
-    type State = ();
+    /// `None` — the common, never-deferred case — round-trips as the JSON
+    /// `null` that stateless polls have always persisted, keeping in-flight
+    /// tasks readable across a deploy in either direction.
+    type State = Option<DiscoverState>;
 
     type Outcome = DiscoverOutcome;
 

--- a/crates/agent/src/publications.rs
+++ b/crates/agent/src/publications.rs
@@ -23,13 +23,32 @@ pub struct PublicationsExecutor {
     pub runtime_v2_new_derivations: bool,
 }
 
+/// Poll state persisted to `internal.tasks` between polls, and therefore
+/// shared with whichever agent instance dequeues the next poll.
+///
+/// This deploy doesn't yet read or write this state: it's carried so that
+/// state persisted by the upcoming stale-snapshot deferral changes remains
+/// decodable by this version during a deploy or rollback.
+#[allow(dead_code)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct PublicationState {
+    /// The instant a Snapshot must postdate (per `Snapshot::taken_after`)
+    /// before this publication is retried: the queued time its prior attempt
+    /// anchored authorization staleness on.
+    #[serde(default)]
+    pub awaiting_snapshot_after: Option<tokens::DateTime>,
+}
+
 impl automations::Executor for PublicationsExecutor {
     const TASK_TYPE: automations::TaskType = automations::task_types::PUBLICATIONS;
 
     /// We don't do anything with the inbox except log it, so this is just a
     /// generic JSON value.
     type Receive = serde_json::Value;
-    type State = ();
+    /// `None` — the common, never-deferred case — round-trips as the JSON
+    /// `null` that stateless polls have always persisted, keeping in-flight
+    /// tasks readable across a deploy in either direction.
+    type State = Option<PublicationState>;
     type Outcome = automations::Action;
 
     async fn poll<'s>(


### PR DESCRIPTION

**Description:**

control-plane: carry discover/publication poll state for deploy compatibility

Define DiscoverState and PublicationState and wire them as the executors' automations::Executor::State, ahead of the stale-snapshot deferral changes which will actually read and write them. The automations framework decodes persisted task state with serde_json::from_str, and the prior `()` state only accepts JSON `null` — so this intermediate deploy is needed to keep in-flight tasks decodable across a deploy or rollback in either direction.

Nothing reads the state fields yet, hence #[allow(dead_code)].

We are doing this first in order to prevent a deserialization issue when we deploy the next set of changes [from here](https://github.com/estuary/flow/pull/3155)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

