### PR TITLE
Docs: Add Snowflake user type

### DIFF
--- a/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
+++ b/site/docs/getting-started/tutorials/dataflow-s3-snowflake.md
@@ -144,6 +144,7 @@ use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
+type = service
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);

--- a/site/docs/getting-started/tutorials/postgresql_cdc_to_snowflake.md
+++ b/site/docs/getting-started/tutorials/postgresql_cdc_to_snowflake.md
@@ -348,6 +348,7 @@ use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
+type = service
 default_role = $estuary_role
 default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);

--- a/site/docs/reference/Connectors/capture-connectors/snowflake.md
+++ b/site/docs/reference/Connectors/capture-connectors/snowflake.md
@@ -23,21 +23,20 @@ See the [script below](#setup) for details.
 
 To set up a user account and warehouse for use with the Snowflake CDC connector,
 copy and paste the following script into the Snowflake SQL editor. Modify the
-variable declarations in the first few lines to set the password and optionally
-customize the names involved.
+variable declarations in the first few lines to optionally customize the names
+involved.
 
 ```sql
 set database_name = 'SOURCE_DB';         -- The database to capture from
 set warehouse_name = 'ESTUARY_WH';       -- The warehouse to execute queries in
 set estuary_user = 'ESTUARY_USER';       -- The name of the capture user
-set estuary_password = 'secret';         -- The password of the capture user
 set estuary_role = 'ESTUARY_ROLE';       -- A role for the capture user's permissions
 
 -- Create a role and user for Estuary
 create role if not exists identifier($estuary_role);
 grant role identifier($estuary_role) to role SYSADMIN;
 create user if not exists identifier($estuary_user)
-  password = $estuary_password
+  type = service
   default_role = $estuary_role
   default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);

--- a/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -60,23 +60,24 @@ use database identifier($database_name);
 create schema if not exists identifier($estuary_schema);
 -- create a user for Estuary
 create user if not exists identifier($estuary_user)
-default_role = $estuary_role
-default_warehouse = $warehouse_name;
+  type = service
+  default_role = $estuary_role
+  default_warehouse = $warehouse_name;
 grant role identifier($estuary_role) to user identifier($estuary_user);
 -- Estuary requires case-sensitive quoted identifiers (e.g. "_meta/op").
 alter user identifier($estuary_user) set QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;
 grant all on schema identifier($estuary_schema) to identifier($estuary_role);
 -- create a warehouse for estuary
 create warehouse if not exists identifier($warehouse_name)
-warehouse_size = xsmall
-warehouse_type = standard
-auto_suspend = 60
-auto_resume = true
-initially_suspended = true;
+  warehouse_size = xsmall
+  warehouse_type = standard
+  auto_suspend = 60
+  auto_resume = true
+  initially_suspended = true;
 -- grant Estuary role access to warehouse
 grant USAGE
-on warehouse identifier($warehouse_name)
-to role identifier($estuary_role);
+  on warehouse identifier($warehouse_name)
+  to role identifier($estuary_role);
 -- grant Estuary access to database
 grant CREATE SCHEMA, MONITOR, USAGE on database identifier($database_name) to role identifier($estuary_role);
 -- change role to ACCOUNTADMIN for STORAGE INTEGRATION support to Estuary (only needed for Snowflake on GCP)


### PR DESCRIPTION
**Description:**

Feedback from Snowflake on a recent blog included that Estuary's SQL setup script should include `TYPE = SERVICE` when creating the database user. No type would treat the user as `TYPE = PERSON` which would require MFA for the user.

This PR adds the service type to the SQL setup script in the connector reference pages and Snowflake tutorials. (Also removed password auth from the capture connector script and added some indentation on the materialization version.)

**Documentation links affected:**

Snowflake connector references and tutorials

**Notes for reviewers:**

Thanks for reviewing!

