### PR TITLE
add invite-link authorization capabilities

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/authorization.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorization.rs
@@ -1,0 +1,115 @@
+use models::authz::{Capability, CapabilitySet};
+
+/// Capabilities that must all be held to satisfy an authorization requirement.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct RequiredCapabilities(CapabilitySet);
+
+impl RequiredCapabilities {
+    pub(super) fn new(capabilities: impl Into<CapabilitySet>) -> Self {
+        Self(capabilities.into())
+    }
+
+    pub(super) fn capabilities(self) -> CapabilitySet {
+        self.0
+    }
+}
+
+/// The effective authorization scope applied to a scoped GraphQL list.
+///
+/// The listed prefixes are the same values used to filter the backing query,
+/// allowing clients to distinguish "authorized, but empty" from "no scope".
+#[derive(Clone, Debug, async_graphql::SimpleObject)]
+pub(super) struct AuthorizationScope {
+    all_of: Vec<Capability>,
+    effective_catalog_prefixes: Vec<models::Prefix>,
+}
+
+impl AuthorizationScope {
+    pub(super) fn new(
+        required: RequiredCapabilities,
+        effective_catalog_prefixes: &[String],
+    ) -> Self {
+        Self {
+            all_of: required.capabilities().iter().collect(),
+            effective_catalog_prefixes: effective_catalog_prefixes
+                .iter()
+                .map(models::Prefix::new)
+                .collect(),
+        }
+    }
+}
+
+/// Intersects already-authorized prefixes with a prefix filter so one exact
+/// vector can both filter SQL and describe the effective client scope.
+pub(super) fn effective_catalog_prefixes(
+    authorized_prefixes: Vec<String>,
+    starts_with: Option<&str>,
+    exact: Option<&[String]>,
+) -> Vec<String> {
+    if let Some(exact) = exact {
+        let mut effective: Vec<_> = exact
+            .iter()
+            .filter(|requested| {
+                authorized_prefixes
+                    .iter()
+                    .any(|authorized| requested.starts_with(authorized))
+            })
+            .cloned()
+            .collect();
+        effective.sort();
+        effective.dedup();
+        return effective;
+    }
+
+    let Some(starts_with) = starts_with else {
+        return authorized_prefixes;
+    };
+
+    authorized_prefixes
+        .into_iter()
+        .map(|prefix| {
+            if starts_with.starts_with(&prefix) {
+                starts_with.to_string()
+            } else {
+                prefix
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_catalog_prefixes;
+
+    #[test]
+    fn effective_prefixes_intersect_authorization_with_filter() {
+        assert_eq!(
+            effective_catalog_prefixes(vec!["acmeCo/".to_string()], Some("acmeCo/widgets/"), None,),
+            vec!["acmeCo/widgets/"]
+        );
+        assert_eq!(
+            effective_catalog_prefixes(vec!["acmeCo/widgets/".to_string()], Some("acmeCo/"), None,),
+            vec!["acmeCo/widgets/"]
+        );
+        assert_eq!(
+            effective_catalog_prefixes(vec!["acmeCo/".to_string()], None, None),
+            vec!["acmeCo/"]
+        );
+        assert_eq!(
+            effective_catalog_prefixes(
+                vec!["acmeCo/".to_string()],
+                None,
+                Some(&["acmeCo/one".to_string(), "other/two".to_string()]),
+            ),
+            vec!["acmeCo/one"]
+        );
+        assert_eq!(
+            effective_catalog_prefixes(
+                vec!["acmeCo/team/".to_string()],
+                None,
+                Some(&["acmeCo/".to_string()]),
+            ),
+            Vec::<String>::new()
+        );
+    }
+}

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -1,4 +1,8 @@
-use super::{TimestampCursor, filters};
+use super::{
+    TimestampCursor,
+    authorization::{AuthorizationScope, RequiredCapabilities, effective_catalog_prefixes},
+    filters,
+};
 use async_graphql::{Context, types::connection};
 
 /// An invite link that grants access to a catalog prefix.
@@ -31,10 +35,16 @@ pub struct RedeemInviteLinkResult {
     pub capability: models::Capability,
 }
 
+#[derive(Debug, Clone, async_graphql::SimpleObject)]
+pub struct InviteLinksConnectionFields {
+    /// The authorization requirement and effective prefixes used to filter this result.
+    authorization_scope: AuthorizationScope,
+}
+
 pub type PaginatedInviteLinks = connection::Connection<
     TimestampCursor,
     InviteLink,
-    connection::EmptyFields,
+    InviteLinksConnectionFields,
     connection::EmptyFields,
     connection::DefaultConnectionName,
     connection::DefaultEdgeName,
@@ -42,7 +52,7 @@ pub type PaginatedInviteLinks = connection::Connection<
 >;
 
 /// Composable filter for the `inviteLinks` query. Every field is optional and
-/// only narrows the result set; the caller's admin scope is enforced
+/// only narrows the result set; the caller's authorization scope is enforced
 /// independently, so a filter can never widen what a caller may see.
 #[derive(Debug, Clone, Default, async_graphql::InputObject)]
 pub struct InviteLinksFilter {
@@ -58,10 +68,10 @@ const MAX_PREFIXES: usize = 20;
 
 #[async_graphql::Object]
 impl InviteLinksQuery {
-    /// List invite links the caller has admin access to.
+    /// List invite links the caller is authorized to query.
     ///
-    /// Returns invite links under all prefixes where the caller has admin
-    /// capability, optionally narrowed by a prefix filter — a subtree
+    /// Returns invite links under all authorized prefixes, optionally narrowed
+    /// by a prefix filter — a subtree
     /// (`startsWith`) or an exact set (`in`), not both.
     async fn invite_links(
         &self,
@@ -76,23 +86,38 @@ impl InviteLinksQuery {
             .as_ref()
             .and_then(|f| f.single_use.as_ref())
             .and_then(|f| f.eq);
+        let required = RequiredCapabilities::new(models::authz::Capability::QueryInviteLinks);
         let snapshot = env.snapshot();
-        let (admin_prefixes, prefix_starts_with, prefix_in) =
+        let (authorized_prefixes, prefix_starts_with, prefix_in) =
             super::authorized_prefixes::filtered_authorized_prefixes(
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
-                models::Capability::Admin,
+                required.capabilities(),
                 filter.and_then(|f| f.catalog_prefix),
                 "filter.catalogPrefix",
             )?;
+        let effective_prefixes = effective_catalog_prefixes(
+            authorized_prefixes,
+            prefix_starts_with.as_deref(),
+            prefix_in.as_deref(),
+        );
+        // Bind only the authorized intersection for exact filters.
+        let prefix_in = prefix_in.map(|_| effective_prefixes.clone());
+        let connection_fields = InviteLinksConnectionFields {
+            authorization_scope: AuthorizationScope::new(required, &effective_prefixes),
+        };
 
-        if admin_prefixes.is_empty() {
-            return Ok(PaginatedInviteLinks::new(false, false));
+        if effective_prefixes.is_empty() {
+            return Ok(PaginatedInviteLinks::with_additional_fields(
+                false,
+                false,
+                connection_fields,
+            ));
         }
-        if admin_prefixes.len() > MAX_PREFIXES {
+        if effective_prefixes.len() > MAX_PREFIXES {
             return Err(async_graphql::Error::new(
-                "Too many admin prefixes; narrow results with a prefix filter",
+                "Too many authorized prefixes; narrow results with a prefix filter",
             ));
         }
 
@@ -125,7 +150,7 @@ impl InviteLinksQuery {
                 ORDER BY il.created_at DESC
                 LIMIT $3 + 1
                 "#,
-                    &admin_prefixes,
+                    &effective_prefixes,
                     after_created_at,
                     limit as i64,
                     single_use_eq,
@@ -156,7 +181,11 @@ impl InviteLinksQuery {
                     })
                     .collect();
 
-                let mut conn = connection::Connection::new(after_created_at.is_some(), has_next);
+                let mut conn = connection::Connection::with_additional_fields(
+                    after_created_at.is_some(),
+                    has_next,
+                    connection_fields,
+                );
                 conn.edges = edges;
                 Ok(conn)
             },
@@ -172,7 +201,7 @@ pub struct InviteLinksMutation;
 impl InviteLinksMutation {
     /// Create an invite link that grants access to a catalog prefix.
     ///
-    /// The caller must have admin capability on the catalog prefix.
+    /// The caller must be authorized to create invite links on the catalog prefix.
     /// Share the returned token with the intended recipient out-of-band.
     pub async fn create_invite_link(
         &self,
@@ -197,7 +226,12 @@ impl InviteLinksMutation {
             )));
         }
 
-        super::verify_authorization(env, &catalog_prefix, models::Capability::Admin).await?;
+        super::verify_authorization(
+            env,
+            &catalog_prefix,
+            models::authz::Capability::CreateInviteLink,
+        )
+        .await?;
 
         let row = sqlx::query!(
             r#"
@@ -357,7 +391,7 @@ impl InviteLinksMutation {
 
     /// Delete an invite link, revoking it so it can no longer be redeemed.
     ///
-    /// The caller must have admin capability on the invite link's catalog prefix.
+    /// The caller must be authorized to delete invite links on the catalog prefix.
     pub async fn delete_invite_link(
         &self,
         ctx: &Context<'_>,
@@ -386,7 +420,12 @@ impl InviteLinksMutation {
             None => return Err(async_graphql::Error::new("Invalid invite link")),
         };
 
-        super::verify_authorization(env, &invite.catalog_prefix, models::Capability::Admin).await?;
+        super::verify_authorization(
+            env,
+            &invite.catalog_prefix,
+            models::authz::Capability::DeleteInviteLink,
+        )
+        .await?;
 
         sqlx::query!("DELETE FROM internal.invite_links WHERE token = $1", token,)
             .execute(&mut *txn)

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -25,6 +25,7 @@ mod alert_configs;
 mod alert_subscriptions;
 mod alert_types;
 mod alerts;
+mod authorization;
 mod authorized_prefixes;
 pub(crate) mod billing;
 mod data_planes;

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -258,6 +258,17 @@ input AlertsBy {
 	active: Boolean
 }
 
+"""
+The effective authorization scope applied to a scoped GraphQL list.
+
+The listed prefixes are the same values used to filter the backing query,
+allowing clients to distinguish "authorized, but empty" from "no scope".
+"""
+type AuthorizationScope {
+	allOf: [CapabilityBit!]!
+	effectiveCatalogPrefixes: [Prefix!]!
+}
+
 type AutoDiscoverFailure {
 	"""
 	The number of consecutive failures that have been observed.
@@ -406,6 +417,8 @@ enum CapabilityBit {
 	RevokeApiKey
 	Delegate
 	Assume
+	QueryInviteLinks
+	DeleteInviteLink
 }
 
 type CardPaymentMethodDetails {
@@ -974,6 +987,10 @@ type InviteLinkConnection {
 	A list of edges.
 	"""
 	edges: [InviteLinkEdge!]!
+	"""
+	The authorization requirement and effective prefixes used to filter this result.
+	"""
+	authorizationScope: AuthorizationScope!
 }
 
 """
@@ -992,7 +1009,7 @@ type InviteLinkEdge {
 
 """
 Composable filter for the `inviteLinks` query. Every field is optional and
-only narrows the result set; the caller's admin scope is enforced
+only narrows the result set; the caller's authorization scope is enforced
 independently, so a filter can never widen what a caller may see.
 """
 input InviteLinksFilter {
@@ -1312,7 +1329,7 @@ type MutationRoot {
 	"""
 	Create an invite link that grants access to a catalog prefix.
 	
-	The caller must have admin capability on the catalog prefix.
+	The caller must be authorized to create invite links on the catalog prefix.
 	Share the returned token with the intended recipient out-of-band.
 	"""
 	createInviteLink(catalogPrefix: Prefix!, capability: Capability!, singleUse: Boolean! = true, detail: String): InviteLink!
@@ -1324,7 +1341,7 @@ type MutationRoot {
 	"""
 	Delete an invite link, revoking it so it can no longer be redeemed.
 	
-	The caller must have admin capability on the invite link's catalog prefix.
+	The caller must be authorized to delete invite links on the catalog prefix.
 	"""
 	deleteInviteLink(token: UUID!): Boolean!
 	"""
@@ -1870,10 +1887,10 @@ type QueryRoot {
 	"""
 	publicDataPlanes(after: String, before: String, first: Int, last: Int): PublicDataPlaneConnection!
 	"""
-	List invite links the caller has admin access to.
+	List invite links the caller is authorized to query.
 	
-	Returns invite links under all prefixes where the caller has admin
-	capability, optionally narrowed by a prefix filter — a subtree
+	Returns invite links under all authorized prefixes, optionally narrowed
+	by a prefix filter — a subtree
 	(`startsWith`) or an exact set (`in`), not both.
 	"""
 	inviteLinks(filter: InviteLinksFilter, after: String, first: Int): InviteLinkConnection!

--- a/crates/models/src/authz.rs
+++ b/crates/models/src/authz.rs
@@ -37,6 +37,8 @@ pub enum Capability {
     RevokeApiKey,
     Delegate,
     Assume,
+    QueryInviteLinks,
+    DeleteInviteLink,
 }
 
 impl std::fmt::Display for Capability {
@@ -124,7 +126,9 @@ impl CapabilityBundle {
             Self::TeamAdmin => {
                 CreateGrant
                     | DeleteGrant
+                    | QueryInviteLinks
                     | CreateInviteLink
+                    | DeleteInviteLink
                     | Self::ManageServiceAccounts.capabilities()
             }
             Self::ManageDataPlane => {


### PR DESCRIPTION
**Description:**

Adds fine-grained authorization for invite-link operations:

- Introduces `QueryInviteLinks` and `DeleteInviteLink` capability bits and includes them, together with the existing `CreateInviteLink` bit, in `TeamAdmin`.
- Gates invite-link list, create, and delete operations with their corresponding bits.
- Adds a typed `authorizationScope` to the invite-link connection. Its effective prefixes are the same values bound into the SQL query, so clients can distinguish an authorized empty result from no authorized scope.
- Regenerates the checked-in GraphQL SDL.

**Workflow steps:**

GraphQL clients can request:

```graphql
inviteLinks {
  authorizationScope {
    allOf
    effectiveCatalogPrefixes
  }
  edges {
    node {
      token
    }
  }
}
```

Legacy admin grants continue to work because the `Admin` bundle includes `TeamAdmin`.

**Documentation links affected:**

None.

**Notes for reviewers:**

This is the base PR in a two-PR stack. The child PR standardizes structured authorization-denial errors.

Validation:

- `cargo check -p control-plane-api`
- `cargo test -p tables` (37 passed)
- `cargo test -p flow-client`
- `cargo build -p flow-client --features generate`
- `git diff --check`
