### PR TITLE
standardize GraphQL authorization errors

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/authorization.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorization.rs
@@ -127,6 +127,71 @@ impl<'a> AuthorizationRequirement<'a> {
     }
 }
 
+/// Authorization for a resource selected by an opaque identifier.
+///
+/// The resource's catalog prefix is used for enforcement but is never included
+/// in a client-facing denial. Missing and terminally unauthorized resources
+/// instead share the same not-found response and disclose only the capability
+/// required by the operation.
+#[derive(Clone, Copy)]
+pub(super) struct OpaqueResourceAuthorization {
+    all_of: RequiredCapabilities,
+    not_found_message: &'static str,
+}
+
+impl OpaqueResourceAuthorization {
+    pub(super) fn new(all_of: impl Into<CapabilitySet>, not_found_message: &'static str) -> Self {
+        Self {
+            all_of: RequiredCapabilities::new(all_of),
+            not_found_message,
+        }
+    }
+
+    pub(super) async fn verify(
+        self,
+        env: &crate::Envelope,
+        catalog_prefix: &str,
+    ) -> async_graphql::Result<()> {
+        let policy_result = crate::server::evaluate_names_authorization(
+            env.snapshot(),
+            env.claims()?,
+            self.all_of,
+            [catalog_prefix],
+        );
+
+        match env.authorization_outcome(policy_result).await {
+            Ok((_expiry, ())) => Ok(()),
+            Err(api_error) if is_terminal_permission_denial(&api_error) => {
+                Err(self.not_found_error_with_source(api_error))
+            }
+            Err(api_error) => Err(api_error.into()),
+        }
+    }
+
+    pub(super) fn not_found_error(self) -> async_graphql::Error {
+        let authorization = async_graphql::Value::from_json(serde_json::json!({
+            "requirements": [{
+                "allOf": self.all_of.names(),
+            }]
+        }))
+        .expect("authorization requirements are valid GraphQL values");
+
+        async_graphql::Error::new(self.not_found_message).extend_with(|_, extensions| {
+            extensions.set("code", "NOT_FOUND");
+            extensions.set("authorization", authorization);
+        })
+    }
+
+    fn not_found_error_with_source(self, api_error: crate::ApiError) -> async_graphql::Error {
+        let mut error = self.not_found_error();
+        // Retain the terminal ApiError for existing downcast-based handling.
+        // GraphQL doesn't serialize the source, so the client-visible error is
+        // still identical to the missing-resource case.
+        error.source = Some(Arc::new(api_error));
+        error
+    }
+}
+
 fn is_terminal_permission_denial(error: &crate::ApiError) -> bool {
     matches!(
         error,
@@ -174,7 +239,9 @@ pub(super) fn effective_catalog_prefixes(
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthorizationRequirement, effective_catalog_prefixes};
+    use super::{
+        AuthorizationRequirement, OpaqueResourceAuthorization, effective_catalog_prefixes,
+    };
 
     #[test]
     fn effective_prefixes_intersect_authorization_with_filter() {
@@ -236,5 +303,38 @@ mod tests {
                 .unwrap()
             )
         );
+    }
+
+    #[test]
+    fn opaque_resource_missing_and_denied_errors_are_indistinguishable() {
+        let requirement = OpaqueResourceAuthorization::new(
+            models::authz::Capability::DeleteInviteLink,
+            "invite link not found",
+        );
+        let missing = requirement.not_found_error();
+        let denied = requirement.not_found_error_with_source(crate::ApiError::Status(
+            tonic::Status::permission_denied("not authorized for sensitiveCo/secret-prefix/"),
+        ));
+
+        // Error equality compares the client-visible message and extensions,
+        // while deliberately ignoring the internal source.
+        assert_eq!(missing, denied);
+        assert!(denied.source.is_some());
+        let serialized = serde_json::to_value(denied).unwrap();
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "message": "invite link not found",
+                "extensions": {
+                    "code": "NOT_FOUND",
+                    "authorization": {
+                        "requirements": [{
+                            "allOf": ["DeleteInviteLink"],
+                        }]
+                    }
+                }
+            })
+        );
+        assert!(!serialized.to_string().contains("sensitiveCo"));
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/authorization.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorization.rs
@@ -1,4 +1,6 @@
+use async_graphql::ErrorExtensions;
 use models::authz::{Capability, CapabilitySet};
+use std::{fmt, sync::Arc};
 
 /// Capabilities that must all be held to satisfy an authorization requirement.
 #[derive(Clone, Copy, Debug)]
@@ -11,6 +13,31 @@ impl RequiredCapabilities {
 
     pub(super) fn capabilities(self) -> CapabilitySet {
         self.0
+    }
+
+    fn names(self) -> Vec<String> {
+        self.0
+            .iter()
+            .map(|capability| capability.to_string())
+            .collect()
+    }
+}
+
+impl fmt::Display for RequiredCapabilities {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, capability) in self.0.iter().enumerate() {
+            if index != 0 {
+                f.write_str(" & ")?;
+            }
+            capability.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<RequiredCapabilities> for CapabilitySet {
+    fn from(required: RequiredCapabilities) -> Self {
+        required.capabilities()
     }
 }
 
@@ -37,6 +64,74 @@ impl AuthorizationScope {
                 .collect(),
         }
     }
+}
+
+/// A runtime authorization requirement used both to evaluate access and to
+/// describe a terminal denial to GraphQL clients.
+pub(super) struct AuthorizationRequirement<'a> {
+    all_of: RequiredCapabilities,
+    catalog_prefixes: Vec<&'a str>,
+}
+
+impl<'a> AuthorizationRequirement<'a> {
+    pub(super) fn for_catalog_prefix(
+        all_of: impl Into<CapabilitySet>,
+        catalog_prefix: &'a str,
+    ) -> Self {
+        Self {
+            all_of: RequiredCapabilities::new(all_of),
+            catalog_prefixes: vec![catalog_prefix],
+        }
+    }
+
+    pub(super) async fn verify(self, env: &crate::Envelope) -> async_graphql::Result<()> {
+        let policy_result = crate::server::evaluate_names_authorization(
+            env.snapshot(),
+            env.claims()?,
+            self.all_of,
+            self.catalog_prefixes.iter().copied(),
+        );
+
+        match env.authorization_outcome(policy_result).await {
+            Ok((_expiry, ())) => Ok(()),
+            Err(api_error) if is_terminal_permission_denial(&api_error) => {
+                Err(self.permission_denied_error(api_error))
+            }
+            Err(api_error) => Err(api_error.into()),
+        }
+    }
+
+    fn permission_denied_error(self, api_error: crate::ApiError) -> async_graphql::Error {
+        let message = match &api_error {
+            crate::ApiError::Status(status) => {
+                format!("{:?}: {}", status.code(), status.message())
+            }
+            crate::ApiError::AuthZRetry(_) => unreachable!("a retry is not a terminal denial"),
+        };
+        let authorization = async_graphql::Value::from_json(serde_json::json!({
+            "requirements": [{
+                "allOf": self.all_of.names(),
+                "catalogPrefixes": self.catalog_prefixes,
+            }]
+        }))
+        .expect("authorization requirements are valid GraphQL values");
+
+        let mut error = async_graphql::Error::new(message).extend_with(|_, extensions| {
+            extensions.set("code", "PERMISSION_DENIED");
+            extensions.set("authorization", authorization);
+        });
+        // The handler identifies authorization retries through this source, and
+        // other resolvers downcast ApiError to selectively hide denials.
+        error.source = Some(Arc::new(api_error));
+        error
+    }
+}
+
+fn is_terminal_permission_denial(error: &crate::ApiError) -> bool {
+    matches!(
+        error,
+        crate::ApiError::Status(status) if status.code() == tonic::Code::PermissionDenied
+    )
 }
 
 /// Intersects already-authorized prefixes with a prefix filter so one exact
@@ -79,7 +174,7 @@ pub(super) fn effective_catalog_prefixes(
 
 #[cfg(test)]
 mod tests {
-    use super::effective_catalog_prefixes;
+    use super::{AuthorizationRequirement, effective_catalog_prefixes};
 
     #[test]
     fn effective_prefixes_intersect_authorization_with_filter() {
@@ -110,6 +205,36 @@ mod tests {
                 Some(&["acmeCo/".to_string()]),
             ),
             Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn terminal_denial_has_a_machine_readable_requirement() {
+        let error = AuthorizationRequirement::for_catalog_prefix(
+            models::authz::Capability::CreateInviteLink,
+            "acmeCo/",
+        )
+        .permission_denied_error(crate::ApiError::Status(
+            tonic::Status::permission_denied("not authorized"),
+        ));
+        assert!(error.source.is_some());
+        let extensions = error.extensions.expect("extensions");
+
+        assert_eq!(
+            extensions.get("code"),
+            Some(&async_graphql::Value::from("PERMISSION_DENIED"))
+        );
+        assert_eq!(
+            extensions.get("authorization"),
+            Some(
+                &async_graphql::Value::from_json(serde_json::json!({
+                    "requirements": [{
+                        "allOf": ["CreateInviteLink"],
+                        "catalogPrefixes": ["acmeCo/"],
+                    }]
+                }))
+                .unwrap()
+            )
         );
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -1,6 +1,9 @@
 use super::{
     TimestampCursor,
-    authorization::{AuthorizationScope, RequiredCapabilities, effective_catalog_prefixes},
+    authorization::{
+        AuthorizationScope, OpaqueResourceAuthorization, RequiredCapabilities,
+        effective_catalog_prefixes,
+    },
     filters,
 };
 use async_graphql::{Context, types::connection};
@@ -399,6 +402,10 @@ impl InviteLinksMutation {
     ) -> async_graphql::Result<bool> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
+        let authorization = OpaqueResourceAuthorization::new(
+            models::authz::Capability::DeleteInviteLink,
+            "invite link not found",
+        );
 
         let mut txn = env.pg_pool.begin().await?;
 
@@ -417,15 +424,10 @@ impl InviteLinksMutation {
 
         let invite = match invite {
             Some(row) => row,
-            None => return Err(async_graphql::Error::new("Invalid invite link")),
+            None => return Err(authorization.not_found_error()),
         };
 
-        super::verify_authorization(
-            env,
-            &invite.catalog_prefix,
-            models::authz::Capability::DeleteInviteLink,
-        )
-        .await?;
+        authorization.verify(env, &invite.catalog_prefix).await?;
 
         sqlx::query!("DELETE FROM internal.invite_links WHERE token = $1", token,)
             .execute(&mut *txn)

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -86,16 +86,11 @@ fn may_access(
 async fn verify_authorization(
     env: &crate::Envelope,
     prefix: &str,
-    capability: impl Into<models::authz::CapabilitySet> + std::fmt::Display + Copy,
+    capability: impl Into<models::authz::CapabilitySet>,
 ) -> async_graphql::Result<()> {
-    let policy_result = crate::server::evaluate_names_authorization(
-        env.snapshot(),
-        env.claims()?,
-        capability,
-        [prefix],
-    );
-    let (_expiry, ()) = env.authorization_outcome(policy_result).await?;
-    Ok(())
+    authorization::AuthorizationRequirement::for_catalog_prefix(capability, prefix)
+        .verify(env)
+        .await
 }
 
 /// A JSON object, the shape of which is opaque to the graphql schema

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__delete_bad_token.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__delete_bad_token.snap
@@ -12,10 +12,22 @@ expression: bad_delete
           "line": 3
         }
       ],
-      "message": "Invalid invite link",
+      "message": "invite link not found",
       "path": [
         "deleteInviteLink"
-      ]
+      ],
+      "extensions": {
+        "authorization": {
+          "requirements": [
+            {
+              "allOf": [
+                "DeleteInviteLink"
+              ]
+            }
+          ]
+        },
+        "code": "NOT_FOUND"
+      }
     }
   ]
 }

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__delete_unauthorized.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__invite_links__test__delete_unauthorized.snap
@@ -12,10 +12,22 @@ expression: unauthorized_delete
           "line": 3
         }
       ],
-      "message": "PermissionDenied: bob@example.test is not authorized to access prefix or name 'aliceCo/' with required capability admin",
+      "message": "invite link not found",
       "path": [
         "deleteInviteLink"
-      ]
+      ],
+      "extensions": {
+        "authorization": {
+          "requirements": [
+            {
+              "allOf": [
+                "DeleteInviteLink"
+              ]
+            }
+          ]
+        },
+        "code": "NOT_FOUND"
+      }
     }
   ]
 }


### PR DESCRIPTION
**Description:**

Standardizes terminal GraphQL authorization failures around runtime authorization requirements.

For caller-known scopes, the same requirement object is passed to the authorization evaluator and serialized into the GraphQL error, preventing the machine-readable contract from drifting from enforcement. Terminal denials include both the required capabilities and catalog prefixes:

```json
{
  "code": "PERMISSION_DENIED",
  "authorization": {
    "requirements": [
      {
        "allOf": ["CreateInviteLink"],
        "catalogPrefixes": ["acmeCo/"]
      }
    ]
  }
}
```

For resources selected by opaque identifiers, the prefix remains internal. `deleteInviteLink` now returns the same client-visible response for a missing token and a terminal authorization denial, while still communicating the capability required by the operation:

```json
{
  "code": "NOT_FOUND",
  "authorization": {
    "requirements": [
      {
        "allOf": ["DeleteInviteLink"]
      }
    ]
  }
}
```

The underlying `ApiError` remains attached as the non-serialized GraphQL error source. This preserves the existing stale-snapshot `307` refresh-and-retry flow and resolver behavior that intentionally downcasts selected permission denials.

**Workflow steps:**

Clients make the operation normally and inspect `errors[].extensions` after a terminal denial. Provisional denials continue through the existing retry response instead of returning a structured terminal error. For opaque resources, clients must not infer existence from the terminal `NOT_FOUND` response.

**Documentation links affected:**

None.

**Notes for reviewers:**

This PR is stacked on the invite-link capability PR. The opaque-resource test asserts that missing and denied errors are client-visible equivalents and that a sensitive internal prefix is absent from serialized output.

Validation:

- `cargo check -p control-plane-api`
- `git diff --check`

The focused control-plane unit-test target is currently blocked by five unrelated missing SQLx offline cache entries in `service_accounts.rs`.
