### PR TITLE
docs: source-mailchimp-native

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/README.md
+++ b/site/docs/reference/Connectors/capture-connectors/README.md
@@ -198,6 +198,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Looker
   - [Configuration](./looker.md)
   - Package - ghcr.io/estuary/source-looker:v1
+- Mailchimp
+  - [Configuration](./mailchimp-native.md)
+  - Package - ghcr.io/estuary/source-mailchimp-native:v1
 - MariaDB
   - [Configuration](./MariaDB/)
   - Package - ghcr.io/estuary/source-mariadb:v3
@@ -390,7 +393,7 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - LinkedIn Ads
   - [Configuration](./linkedin-ads.md)
   - Package - ghcr.io/estuary/source-linkedin-ads:v2
-- Mailchimp
+- Mailchimp (deprecated)
   - [Configuration](./mailchimp.md)
   - Package - ghcr.io/estuary/source-mailchimp:v3
 - Marketo

--- a/site/docs/reference/Connectors/capture-connectors/mailchimp-native.md
+++ b/site/docs/reference/Connectors/capture-connectors/mailchimp-native.md
@@ -1,0 +1,90 @@
+---
+description: Capture Mailchimp lists, members, campaigns, and email activity with Estuary's native Mailchimp connector, using OAuth2 or a Mailchimp API key.
+---
+
+# Mailchimp
+
+This connector captures data from Mailchimp into Estuary collections.
+It authenticates with OAuth2 or a Mailchimp [API key](https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key) and reads data through the [Mailchimp Marketing API](https://mailchimp.com/developer/marketing/api/).
+
+## Supported data resources
+
+The following data resources are supported:
+
+| Resource                                                                                                           | Replication Mode |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| [automation_emails](https://mailchimp.com/developer/marketing/api/automation-email/list-automated-emails/)         | Full Refresh     |
+| [automations](https://mailchimp.com/developer/marketing/api/automation/list-automations/)                          | Full Refresh     |
+| [campaigns](https://mailchimp.com/developer/marketing/api/campaigns/list-campaigns/)                               | Incremental      |
+| [email_activity](https://mailchimp.com/developer/marketing/api/email-activity-reports/list-email-activity/)        | Incremental      |
+| [interest_categories](https://mailchimp.com/developer/marketing/api/interest-categories/list-interest-categories/) | Full Refresh     |
+| [interests](https://mailchimp.com/developer/marketing/api/interests/list-interests-in-category/)                   | Full Refresh     |
+| [list_members](https://mailchimp.com/developer/marketing/api/list-members/list-members-info/)                      | Incremental      |
+| [lists](https://mailchimp.com/developer/marketing/api/lists/get-lists-info/)                                       | Full Refresh     |
+| [segment_members](https://mailchimp.com/developer/marketing/api/list-segment-members/list-members-in-segment/)     | Full Refresh     |
+| [segments](https://mailchimp.com/developer/marketing/api/list-segments/list-segments/)                             | Incremental      |
+| [tags](https://mailchimp.com/developer/marketing/api/list-tag-search/search-for-tags-on-a-list-by-name/)           | Full Refresh     |
+
+By default, each resource is mapped to an Estuary collection through a separate binding.
+
+:::tip
+The `campaigns` stream re-captures existing campaigns with periodic backfills, since Mailchimp's `/campaigns` endpoint only supports filtering by creation time while campaign records keep changing after creation (status transitions, report statistics). These backfills can be scheduled with the `schedule` resource config setting. By default, `campaigns`'s schedule is `0 0 * * *`, which means the stream attempts to backfill every day at midnight UTC. Campaign deletions are not captured.
+:::
+
+## Prerequisites
+
+To set up the Mailchimp source connector, you'll need a Mailchimp [API key](https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key), including its data center suffix (for example, a key ending in `-us21`). The connector uses the suffix to resolve your account's data-center-specific API endpoint automatically.
+
+Alternatively, you can authenticate by signing in to Mailchimp with OAuth2 in the Estuary web app; the connector then resolves your API endpoint from Mailchimp's OAuth metadata endpoint.
+
+## Configuration
+
+You configure connectors either in the Estuary web app, or by directly editing the catalog specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Mailchimp source connector.
+
+### Properties
+
+#### Endpoint
+
+The properties below reflect the manual, API key authentication method.
+
+| Property                             | Title                 | Description                                                                                                                                                                                       | Type   | Required/Default |
+| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
+| **`/credentials/api_key`**           | API Key               | Your Mailchimp API key, including the data center suffix (e.g. ends in `-us21`).                                                                                                                  | string | Required         |
+| **`/credentials/credentials_title`** | Authentication Method | Name of the credentials set. Set to `API Key`.                                                                                                                                                    | string | Required         |
+| `/start_date`                        | Start Date            | UTC date and time in the format `YYYY-MM-DDTHH:MM:SSZ`. Any data generated before this date will not be replicated. If left blank, the start date will be set to 30 days before the present date. | string |                  |
+
+#### Bindings
+
+| Property    | Title             | Description                                                                                                                                                                                                                                                     | Type   | Required/Default |
+| ----------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
+| **`/name`** | Data resource     | Name of the data resource.                                                                                                                                                                                                                                      | string | Required         |
+| `/interval` | Interval          | Interval between data syncs.                                                                                                                                                                                                                                    | string |                  |
+| `/schedule` | Backfill schedule | The schedule for automatically backfilling this binding. Accepts a cron expression. For example, a schedule of `55 23 * * *` means the binding will initiate a new backfill at 23:55 UTC every day. If left empty, the binding will not automatically backfill. | string |                  |
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-mailchimp-native:v1
+        config:
+          credentials:
+            credentials_title: API Key
+            api_key: <secret>
+          start_date: 2025-01-01T00:00:00Z
+    bindings:
+      - resource:
+          name: lists
+        target: ${PREFIX}/lists
+      - resource:
+          name: list_members
+        target: ${PREFIX}/list_members
+      - resource:
+          name: campaigns
+          schedule: 0 0 * * *
+        target: ${PREFIX}/campaigns
+      {...}
+```

--- a/site/docs/reference/Connectors/capture-connectors/mailchimp.md
+++ b/site/docs/reference/Connectors/capture-connectors/mailchimp.md
@@ -2,9 +2,13 @@
 description: Sync Mailchimp data with Estuary's connector, including lists, campaigns, and email activity, using a Mailchimp API key.
 ---
 
-# Mailchimp
+# Mailchimp (Deprecated)
 
 This connector captures data from a Mailchimp account.
+
+:::warning
+This connector is deprecated. For the best experience, we recommend using our native [Mailchimp connector](./mailchimp-native.md) instead.
+:::
 
 Three data resources are supported, each of which is mapped to an Estuary collection: lists, campaigns, and email activity.
 


### PR DESCRIPTION
Documentation for https://github.com/estuary/connectors/pull/4895.

Mirrors `docs/reference/Connectors/capture-connectors/mailchimp-native.md` from the connectors repo verbatim, and adds the connector to the capture-connectors index.