### PR TITLE
build: cross-compile flow-connector-init for linux/amd64, bump CONNECTOR_INIT_IMAGE

### DIFF
--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -19,8 +19,13 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
+//
+// Bump this pin whenever a field is added to a task spec or the connector protocol:
+// this binary decodes and re-encodes every request passing between the runtime and
+// the connector, so a copy older than the field silently drops it and connectors see
+// a spec without it.
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-37-g4cb160dc000";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -24,6 +24,11 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
+//
+// Bump this pin whenever a field is added to a task spec or the connector protocol:
+// this binary decodes and re-encodes every request passing between the runtime and
+// the connector, so a copy older than the field silently drops it and connectors see
+// a spec without it.
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
 const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-69-gb7eb6426711";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -19,8 +19,13 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
+//
+// Bump this pin whenever a field is added to a task spec or the connector protocol:
+// this binary decodes and re-encodes every request passing between the runtime and
+// the connector, so a copy older than the field silently drops it and connectors see
+// a spec without it.
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-37-g4cb160dc000";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -24,6 +24,11 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
+//
+// Bump this pin whenever a field is added to a task spec or the connector protocol:
+// this binary decodes and re-encodes every request passing between the runtime and
+// the connector, so a copy older than the field silently drops it and connectors see
+// a spec without it.
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
 const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-69-gb7eb6426711";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,11 @@ go = { version = "1.25" }
 # `rust` is required, but installation via mise is incompatible with Swatim/rust-cache
 
 "github:wasm-bindgen/wasm-pack" = { version = "0.13.1" }
+
+# zig is used only as a cross C compiler, so that build:connector-init can
+# produce a linux/amd64 flow-connector-init (the platform connector containers
+# run as) from a non-x86_64 host.
+zig = { version = "0.16.0" }
 "github:etcd-io/etcd" = { version = "3.5.24" }
 "github:getsops/sops" = { version = "3.11.0", bin = "sops" }
 "github:jdx/usage" = { version = "3.5.4" }

--- a/mise/tasks/bootstrap/apt-packages-ci-extra
+++ b/mise/tasks/bootstrap/apt-packages-ci-extra
@@ -12,7 +12,9 @@ set -euo pipefail
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   age \
   g++-14 \
+  g++-x86-64-linux-gnu \
   gcc-14 \
+  gcc-x86-64-linux-gnu \
   libjemalloc-dev \
   libsnappy-dev \
   musl-tools \

--- a/mise/tasks/bootstrap/ide-settings
+++ b/mise/tasks/bootstrap/ide-settings
@@ -15,7 +15,7 @@ cat > ${VSCODE_SETTINGS} << EOF
         "CGO_CFLAGS": "${CGO_CFLAGS}",
         "CGO_CPPFLAGS": "${CGO_CPPFLAGS}",
         "GOBIN": "${GOBIN}",
-        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
+        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
     },
     "rust-analyzer.cargo.extraEnv": {
         "CARGO_TARGET_DIR": "${CARGO_TARGET_DIR}",
@@ -37,7 +37,7 @@ cat > ${VSCODE_SETTINGS} << EOF
         "CARGO_TARGET_DIR": "${CARGO_TARGET_DIR}",
         "GOBIN": "${GOBIN}",
         "JEMALLOC_OVERRIDE": "${JEMALLOC_OVERRIDE}",
-        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
+        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
         "ROCKSDB_INCLUDE_DIR": "${ROCKSDB_INCLUDE_DIR}",
         "ROCKSDB_LIB_DIR": "${ROCKSDB_LIB_DIR}",
         "ROCKSDB_VERSION": "${ROCKSDB_VERSION}",
@@ -58,7 +58,7 @@ cat > ${VSCODE_SETTINGS} << EOF
         "FLOW_STACK_NAME": "${FLOW_STACK_NAME}",
         "FLOW_PORT_BIGTABLE": "${FLOW_PORT_BIGTABLE}",
         "GOBIN": "${GOBIN}",
-        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
+        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
         "SOPS_AGE_KEY": "AGE-SECRET-KEY-1UX6ZHA36JJZCFCV9U7FVHZZECHCCKA8NCFT27L68HV0NPRQ2V5ZSRKJJPU"
     },
 
@@ -90,7 +90,7 @@ cat > ${ZED_SETTINGS} << EOF
                     "CGO_CFLAGS": "${CGO_CFLAGS}",
                     "CGO_CPPFLAGS": "${CGO_CPPFLAGS}",
                     "GOBIN": "${GOBIN}",
-                    "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}"
+                    "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}"
                 }
             }
         },
@@ -115,7 +115,7 @@ cat > ${ZED_SETTINGS} << EOF
                         "CARGO_TARGET_DIR": "${CARGO_TARGET_DIR}",
                         "GOBIN": "${GOBIN}",
                         "JEMALLOC_OVERRIDE": "${JEMALLOC_OVERRIDE}",
-                        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
+                        "PATH": "${PATH}:${CARGO_TARGET_DIR}/debug/:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${GOBIN}",
                         "ROCKSDB_INCLUDE_DIR": "${ROCKSDB_INCLUDE_DIR}",
                         "ROCKSDB_LIB_DIR": "${ROCKSDB_LIB_DIR}",
                         "ROCKSDB_VERSION": "${ROCKSDB_VERSION}",

--- a/mise/tasks/build/connector-init
+++ b/mise/tasks/build/connector-init
@@ -1,10 +1,53 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-#MISE description="Build musl binaries (debug)"
+#MISE description="Build flow-connector-init for the connector container platform (linux/amd64)"
 #MISE depends=["bootstrap:apt-packages-ci-extra"]
 
-rustup target add $(uname -m)-unknown-linux-musl
+# `flow-connector-init` is bind-mounted into every connector container and is that
+# container's entrypoint, and connector containers always run linux/amd64 (see the
+# hard-coded `--platform=linux/amd64` in crates/runtime/src/container.rs). So it must
+# be an x86_64 binary even when the host is aarch64: otherwise the entrypoint cannot
+# exec and *every* connector container dies before starting, which surfaces only as
+# "failed to inspect a started docker container (did it crash?)".
+TARGET=x86_64-unknown-linux-musl
+
+rustup target add "${TARGET}"
+
+if [[ "$(uname -m)" != "x86_64" ]]; then
+    # Cross-compiling. `ring` and `aws-lc-sys` build C, and their objects have to be
+    # compiled against musl headers — a glibc cross-gcc leaves glibc-only symbols
+    # (`__isoc23_sscanf`, `__fprintf_chk`) that the musl link cannot resolve. `zig cc`
+    # ships headers and libc for every target, so use it as the C compiler and let
+    # rustc's bundled lld link against the target's musl.
+    #
+    # Two wrapper quirks: cc-rs passes an LLVM triple via `--target=`, which zig does
+    # not accept (it gets `-target` below), and `zig cc` enables UBSan by default
+    # while we do not link its runtime.
+    WRAPPER_DIR="${CARGO_TARGET_DIR:-target}/cross"
+    mkdir -p "${WRAPPER_DIR}"
+
+    for KIND in cc c++; do
+        SUFFIX="${KIND/c++/cxx}"
+        cat > "${WRAPPER_DIR}/zig-${SUFFIX}" <<EOF
+#!/usr/bin/env bash
+args=()
+for a in "\$@"; do
+  case "\$a" in --target=*) continue ;; esac
+  args+=("\$a")
+done
+exec zig ${KIND} -target x86_64-linux-musl -fno-sanitize=undefined "\${args[@]}"
+EOF
+        chmod +x "${WRAPPER_DIR}/zig-${SUFFIX}"
+    done
+
+    export CC_x86_64_unknown_linux_musl="${WRAPPER_DIR}/zig-cc"
+    export CXX_x86_64_unknown_linux_musl="${WRAPPER_DIR}/zig-cxx"
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld
+    # Drop the host's mold linker from RUSTFLAGS: it only emits host-arch objects.
+    export RUSTFLAGS="-D warnings"
+fi
 
 cargo build \
-    --target $(uname -m)-unknown-linux-musl \
+    --target "${TARGET}" \
     -p connector-init

--- a/mise/tasks/local/lib.sh
+++ b/mise/tasks/local/lib.sh
@@ -72,7 +72,9 @@ CGO_LDFLAGS="${CGO_LDFLAGS}"
 FLOW_ROOT="${_root}"
 GOBIN="${GOBIN}"
 JEMALLOC_OVERRIDE="${JEMALLOC_OVERRIDE}"
-PATH="${PATH}:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/debug/:${GOBIN}"
+# flow-connector-init is built for x86_64 (the platform connector containers
+# run as), so search that directory ahead of the host-arch musl one.
+PATH="${PATH}:${CARGO_TARGET_DIR}/x86_64-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/$(uname -m)-unknown-linux-musl/debug/:${CARGO_TARGET_DIR}/debug/:${GOBIN}"
 ROCKSDB_INCLUDE_DIR="${ROCKSDB_INCLUDE_DIR}"
 ROCKSDB_LIB_DIR="${ROCKSDB_LIB_DIR}"
 ROCKSDB_VERSION="${ROCKSDB_VERSION}"


### PR DESCRIPTION
**Description:**

Two fixes so that a locally built stack can actually run connectors, and so that connectors see the spec fields the runtime sends them.

**`build:connector-init` now builds for linux/amd64.** `flow-connector-init` is bind-mounted into every connector container as its entrypoint, and connector containers always run `linux/amd64` (hard-coded in `crates/runtime/src/container.rs`). The task built for `$(uname -m)`, so on an aarch64 host it produced an aarch64 binary those containers cannot exec — **every** connector container dies before starting. The only symptom is:

```
publication failed with status: JobStatus { type: BuildFailed }
  detail: "failed to inspect a started docker container (did it crash?)
      docker command ["inspect", …, "fc_8535aae"] failed: error: no such object: fc_8535aae"
```

with `docker ps -a --filter name=fc_` showing the container stuck in `Created`. On Apple Silicon this makes a locally built stack unable to run any connector at all.

The target is now `x86_64-unknown-linux-musl` unconditionally, cross-compiling when the host differs. `ring` and `aws-lc-sys` compile C, and those objects must be compiled against musl headers: a glibc cross-gcc (`x86_64-linux-gnu-gcc`) leaves glibc-only symbols (`__isoc23_sscanf`, `__fprintf_chk`) that the musl link cannot resolve. So `zig cc` is used as the cross C compiler — it ships headers and libc for every target — while rustc's bundled lld links against the target's musl. Two zig quirks are handled by generated wrappers: `cc-rs` passes an LLVM triple via `--target=` that zig rejects, and `zig cc` enables UBSan by default without linking its runtime.

`locate_bin()` searches `PATH`, so `mise/tasks/local/lib.sh` and `bootstrap/ide-settings` now include the x86_64 musl directory. Without that the runtime silently falls back to `CONNECTOR_INIT_IMAGE`.

**`CONNECTOR_INIT_IMAGE` bumped** from `reactor:v0.6.10-62-g8b6aeec1cd3` to `reactor:v0.6.12-37-g4cb160dc000` (the newest published tag). The old pin was **67 commits older** than 4d66c8db, which added `created_at` to task specs. Because that binary decodes and re-encodes every request between runtime and connector, a copy older than a protocol field drops it silently — connectors observed specs with no `created_at` at Validate, Apply *and* Open even though the build database and `live_specs` both carried it. The comment now says the pin must be bumped whenever a spec/protocol field is added.

**Workflow steps:**

`mise run build:connector-init` now produces an x86_64 binary on any host (~40s cross-compiling on an 8-CPU aarch64 VM). No workflow change beyond that; `mise install` picks up zig.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Verified on an aarch64 Lima VM: the task produces `ELF 64-bit x86-64`, the runtime resolves it from PATH, and the container mounts it (md5 of the mounted `/flow-connector-init` matches the built binary). Connectors then receive the full spec — a materialization reported `createdAt="2026-08-01"` at Validate, Apply and Open, where before all three saw an absent field.
- `zig` is added to `mise.toml` purely as a cross C compiler; on x86_64 hosts (CI) the build path is unchanged and zig is not invoked.
- `gcc-x86-64-linux-gnu` / `g++-x86-64-linux-gnu` are added to `apt-packages-ci-extra`. They are not used by the zig path and can be dropped if you prefer — they were the first approach and are harmless to keep for other cross needs.
- I deliberately did **not** publish a floating `reactor:stable` tag; CI tags images only with `git describe`, and `:stable` exists solely for `derive-python`/`derive-typescript`. Note the newest master commits often have no image at all (docs-only commits skip the platform build), so the newest usable tag lagged master by two commits when I picked it.
