### PR TITLE
local: compact a stack's etcd hourly

### DIFF
--- a/mise/tasks/local/etcd
+++ b/mise/tasks/local/etcd
@@ -12,6 +12,20 @@ NAME="${FLOW_STACK_NAME}"
 # All ETCD_* config lives in the env file so the unit stays parameter-free.
 # etcd advertises on this stack's client/peer ports; a single-node cluster with
 # a per-stack data dir keeps stacks fully independent.
+#
+# Auto-compaction is not optional here. Etcd keeps every revision until told otherwise,
+# and a stack left running accumulates them from ordinary shard and journal churn. On
+# reaching the default two-gigabyte quota it arms a NOSPACE alarm and refuses writes — at
+# which point the reactor can no longer advertise shard status, and every task fails to
+# reach primary with nothing in its own logs to explain why. One stack hit exactly that
+# after a day of use; compacting took it from 2.1 GB to 3.3 MB, so essentially all of it
+# was revisions nobody could read. An hour is far more history than a local stack has any
+# use for: nothing here reads a revision older than the session that wrote it.
+#
+# Compaction bounds the live revision set, so the backend stops growing and the quota
+# stays out of reach. It does not shrink the file — freed pages are reused rather than
+# returned — so a stack that has already ballooned wants a one-off `etcdctl defrag` to
+# hand the space back to the filesystem.
 ENV_FILE="${FLOW_ENV_DIR}/etcd-${NAME}.env"
 {
     emit_common_vars
@@ -20,6 +34,8 @@ ENV_FILE="${FLOW_ENV_DIR}/etcd-${NAME}.env"
 # Etcd configuration for stack ${NAME}.
 ETCD_DATA_DIR="${FLOW_STACK_DIR}/etcd/"
 ETCD_LOG_LEVEL=info
+ETCD_AUTO_COMPACTION_MODE=periodic
+ETCD_AUTO_COMPACTION_RETENTION=1h
 ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:${FLOW_PORT_ETCD}
 ETCD_ADVERTISE_CLIENT_URLS=http://etcd.flow.localhost:${FLOW_PORT_ETCD}
 ETCD_LISTEN_PEER_URLS=http://0.0.0.0:${FLOW_PORT_ETCD_PEER}


### PR DESCRIPTION
**Description:**

A local stack's etcd had no compaction configured, so it kept every revision indefinitely
and grew from ordinary shard and journal churn until it reached etcd's default
two-gigabyte quota, armed a `NOSPACE` alarm, and stopped accepting writes.

This sets `ETCD_AUTO_COMPACTION_MODE=periodic` and
`ETCD_AUTO_COMPACTION_RETENTION=1h` in the per-stack env file. One hour is far more
history than a local stack has any use for — nothing here reads a revision older than the
session that wrote it.

**Workflow steps:**

No change to how a stack is used. `mise run local:stack` and `mise run local:etcd` pick the
setting up; an already-running etcd needs `systemctl --user restart flow-etcd@<stack>` to
apply it.

Compaction bounds the live revision set, so the backend stops growing and the quota stays
out of reach. It does **not** shrink the file — freed pages are reused rather than returned
to the filesystem — so a stack that has already ballooned wants a one-off defrag to reclaim
the disk:

```bash
etcdctl --endpoints=localhost:$FLOW_PORT_ETCD --command-timeout=600s defrag
etcdctl --endpoints=localhost:$FLOW_PORT_ETCD alarm disarm   # if NOSPACE was armed
```

**Documentation links affected:**

None.

**Notes for reviewers:**

The failure mode is worth knowing because it is unpleasant to diagnose from the symptoms.
Once the alarm is armed the reactor can no longer advertise shard status, so every task
fails to reach primary — and it reports that with *no shard error to explain it*, because
the shard never got far enough to have one. It presents as tasks that publish successfully
and then do nothing, which looks like a task or connector problem rather than a full
database. The only clue is in the reactor's own log:

```
failed to advertise Etcd shard status (will retry) attempt=1820
err="etcdserver: mvcc: database space exceeded"
```

On a stack that had reached the quota, compacting took the backend from **2.1 GB to
3.3 MB** — essentially all of it revisions nobody could read.

Verified against a running stack — etcd reports the setting at startup:

```
"auto-compaction-mode":"periodic","auto-compaction-retention":"1h0m0s"
```

`quota-backend-bytes` is left at etcd's 2 GiB default deliberately: raising it would delay
this rather than prevent it, and compaction is what actually bounds growth.
