### PR TITLE
dekaf: opt-in `allow_empty_topics` for never-written collections

### DIFF
--- a/crates/dekaf-connector/src/lib.rs
+++ b/crates/dekaf-connector/src/lib.rs
@@ -46,6 +46,15 @@ pub struct DekafConfig {
     #[serde(default)]
     #[schemars(title = "Strict Topic Names")]
     pub strict_topic_names: bool,
+    /// Whether to expose bound collections which have never been written as
+    /// valid, empty topics holding a single partition at offset 0. Off by
+    /// default, in which case such a topic reports the retryable error
+    /// `LeaderNotAvailable` until its first document is written — which
+    /// prevents a consumer group from stabilizing across the whole
+    /// subscription, not just the empty topic.
+    #[serde(default)]
+    #[schemars(title = "Allow Empty Topics")]
+    pub allow_empty_topics: bool,
 }
 
 /// Configures a particular binding in a Dekaf-type materialization

--- a/crates/dekaf/src/lib.rs
+++ b/crates/dekaf/src/lib.rs
@@ -122,6 +122,13 @@ impl SessionAuthentication {
             SessionAuthentication::Redirect { config, .. } => config.deletions,
         }
     }
+
+    pub fn allow_empty_topics(&self) -> bool {
+        match self {
+            SessionAuthentication::Task(task_auth) => task_auth.config.allow_empty_topics,
+            SessionAuthentication::Redirect { config, .. } => config.allow_empty_topics,
+        }
+    }
 }
 
 impl TaskAuth {

--- a/crates/dekaf/src/session.rs
+++ b/crates/dekaf/src/session.rs
@@ -2,7 +2,8 @@ use super::{App, Collection, CollectionStatus, CollectionUnavailable, Read};
 use crate::{
     DekafError, KafkaApiClient, KafkaClientAuth, SessionAuthentication, TaskState,
     from_downstream_topic_name, from_upstream_topic_name, logging::propagate_task_forwarder,
-    read::BatchResult, to_downstream_topic_name, to_upstream_topic_name, topology::PartitionOffset,
+    read::BatchResult, to_downstream_topic_name, to_upstream_topic_name, topology,
+    topology::PartitionOffset,
 };
 use anyhow::{Context, bail};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -896,6 +897,20 @@ impl Session {
                     }
                 }
 
+                // An empty topic has no journal to read; its sentinel partition is
+                // answered with an empty batch during the poll phase below.
+                if collection.empty_topic {
+                    metrics::counter!(
+                        "dekaf_fetch_requests",
+                        "topic_name" => key.0.to_string(),
+                        "partition_index" => key.1.to_string(),
+                        "task_name" => task_name.to_string(),
+                        "state" => "empty_topic"
+                    )
+                    .increment(1);
+                    continue;
+                }
+
                 let Some(partition) = collection
                     .partitions
                     .get(partition_request.partition as usize)
@@ -1061,6 +1076,29 @@ impl Session {
                                     );
                                     continue;
                                 }
+                            }
+                            // An empty topic's sentinel partition has no journal to
+                            // read: answer with an empty batch at offset 0 so the
+                            // consumer idles on it instead of erroring.
+                            if collection.empty_topic
+                                && partition_request.partition
+                                    == topology::SENTINEL_PARTITION_INDEX as i32
+                            {
+                                partition_responses.push(
+                                    PartitionData::default()
+                                        .with_partition_index(partition_request.partition)
+                                        .with_high_watermark(0)
+                                        .with_last_stable_offset(0)
+                                        .with_records(Some(Bytes::new()))
+                                        .with_current_leader(
+                                            messages::fetch_response::LeaderIdAndEpoch::default()
+                                                .with_leader_id(messages::BrokerId(1))
+                                                .with_leader_epoch(
+                                                    collection.binding_backfill_counter as i32,
+                                                ),
+                                        ),
+                                );
+                                continue;
                             }
                             // Fall through to UnknownTopicOrPartition
                         }
@@ -1795,7 +1833,7 @@ impl Session {
                             topic_name.clone(),
                             Some(collection.binding_backfill_counter),
                         )
-                        .map(|encrypted_name| (encrypted_name, collection.partitions.len())),
+                        .map(|encrypted_name| (encrypted_name, collection.partition_count())),
                     ),
                     CollectionStatus::Unavailable(_) => None,
                 })
@@ -1880,6 +1918,9 @@ impl Session {
                         decrypted_name
                     ))?
                 {
+                    // An empty topic has no journal to attribute the commit to; the
+                    // upstream commit above still happened, there's just nothing to log.
+                    (_, CollectionStatus::Ready(c)) if c.empty_topic => continue,
                     (_, CollectionStatus::Ready(c)) => &c.partitions,
                     (_, CollectionStatus::Unavailable(_)) => {
                         // For unavailable topics, skip partition processing since we have no journals
@@ -2616,14 +2657,21 @@ impl Session {
     ) -> anyhow::Result<MetadataResponseTopic> {
         let leader_epoch = collection.binding_backfill_counter as i32;
 
-        // Collections with empty partitions should be handled as NotReady before
-        // reaching this function, so we can safely iterate over partitions here
-        let partitions = collection
-            .partitions
-            .iter()
-            .enumerate()
-            .map(|(index, _)| Self::build_partition(index as i32, leader_epoch))
-            .collect();
+        // A collection with no journals is either handled as NotReady before reaching
+        // this function, or (with `allow_empty_topics`) presents one sentinel partition.
+        let partitions = if collection.empty_topic {
+            vec![Self::build_partition(
+                topology::SENTINEL_PARTITION_INDEX as i32,
+                leader_epoch,
+            )]
+        } else {
+            collection
+                .partitions
+                .iter()
+                .enumerate()
+                .map(|(index, _)| Self::build_partition(index as i32, leader_epoch))
+                .collect()
+        };
 
         Ok(MetadataResponseTopic::default()
             .with_name(Some(name))

--- a/crates/dekaf/src/topology.rs
+++ b/crates/dekaf/src/topology.rs
@@ -60,6 +60,10 @@ pub struct Collection {
     pub value_schema: avro::Schema,
     pub extractors: Vec<(avro::Schema, utils::CustomizableExtractor)>,
     pub binding_backfill_counter: u32,
+    /// The collection has no journals, and the task opted into serving it as an
+    /// empty topic (`allow_empty_topics`) rather than as `NotReady`. `partitions`
+    /// is empty; the topic presents one sentinel partition sitting at offset 0.
+    pub empty_topic: bool,
 }
 
 /// Represents why a collection is unavailable.
@@ -135,6 +139,11 @@ pub struct PartitionOffset {
 
 const OFFSET_REQUEST_EARLIEST: i64 = -2;
 const OFFSET_REQUEST_LATEST: i64 = -1;
+
+/// Index of the single partition presented for an empty topic (see
+/// [`Collection::empty_topic`]). Kafka clients require at least one partition
+/// per topic to complete a group assignment.
+pub const SENTINEL_PARTITION_INDEX: usize = 0;
 
 impl Collection {
     /// Build a Collection by fetching its spec, an authenticated data-plane access token, and its partitions.
@@ -296,7 +305,14 @@ impl Collection {
         // If there are no partitions/journals, the collection exists but isn't ready to serve.
         // This happens when a collection was reset and journals haven't been created yet,
         // or when a collection exists but no data has ever been written.
-        if partitions.is_empty() {
+        //
+        // `LeaderNotAvailable` (the `NotReady` mapping) is retryable, which suits a
+        // reset that's about to complete, but a never-written collection stays that
+        // way indefinitely and blocks consumer-group rebalance for every topic in the
+        // subscription. Tasks which prefer an idle-but-valid topic opt into
+        // `allow_empty_topics`.
+        let empty_topic = partitions.is_empty();
+        if empty_topic && !auth.allow_empty_topics() {
             tracing::debug!(
                 collection_name,
                 "Collection binding exists but has no journals available"
@@ -325,6 +341,7 @@ impl Collection {
             // TODO(jshearer): While this is a simple fix, it's not clear why exactly consumers behaves this way.
             // It would be good to understand this better and see if there's a more principled fix.
             binding_backfill_counter: binding.backfill + 1,
+            empty_topic,
         }))
     }
 
@@ -342,6 +359,16 @@ impl Collection {
         Ok((key_id, value_id))
     }
 
+    /// Number of partitions this collection presents to Kafka clients: its
+    /// journals, or the lone sentinel partition of an empty topic.
+    pub fn partition_count(&self) -> usize {
+        if self.empty_topic {
+            1
+        } else {
+            self.partitions.len()
+        }
+    }
+
     /// Map a partition and timestamp into the newest covering fragment offset.
     /// Request latest offset
     ///     - `suspend::Level::Full | suspend::Level::Partial`: `suspend.offset`
@@ -355,6 +382,15 @@ impl Collection {
         timestamp_millis: i64,
     ) -> anyhow::Result<Option<PartitionOffset>> {
         let Some(partition) = self.partitions.get(partition_index) else {
+            // The sentinel partition of an empty topic has no journal to query:
+            // it always sits at offset 0 with nothing to read.
+            if self.empty_topic && partition_index == SENTINEL_PARTITION_INDEX {
+                return Ok(Some(PartitionOffset {
+                    fragment_start: 0,
+                    offset: 0,
+                    mod_time: -1, // UNKNOWN_TIMESTAMP
+                }));
+            }
             return Ok(None);
         };
 

--- a/crates/dekaf/tests/e2e/empty_binding_group.rs
+++ b/crates/dekaf/tests/e2e/empty_binding_group.rs
@@ -1,0 +1,204 @@
+use super::DekafTestEnv;
+use crate::raw_kafka::{TestKafkaClient, fetch_partition_error, list_offsets_partition_error};
+use anyhow::Context;
+use futures::StreamExt;
+use kafka_protocol::ResponseError;
+use rdkafka::consumer::Consumer;
+use serde_json::json;
+use std::time::Duration;
+
+const TWO_TOPICS_FIXTURE: &str = include_str!("fixtures/two_topics.flow.yaml");
+const ALLOW_EMPTY_FIXTURE: &str = include_str!("fixtures/two_topics_allow_empty.flow.yaml");
+const METADATA_TIMEOUT: Duration = Duration::from_secs(30);
+const CONSUME_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Publish the fixture, write two documents to `test_data_a`, and leave
+/// `test_data_b` journal-less. Returns the environment once `topic_a`'s
+/// metadata is serving, along with `topic_b`'s metadata error code.
+async fn setup_one_populated_one_empty(
+    test_name: &str,
+    fixture: &str,
+) -> anyhow::Result<(DekafTestEnv, i16)> {
+    let env = DekafTestEnv::setup(test_name, fixture).await?;
+
+    // A shard can briefly report primary before its proxy listener accepts, so retry.
+    let docs = vec![
+        json!({"id": "a1", "value": "1"}),
+        json!({"id": "a2", "value": "2"}),
+    ];
+    let mut injected = Err(anyhow::anyhow!("not attempted"));
+    for _ in 0..10 {
+        injected = env.inject_documents("data_a", docs.clone()).await;
+        if injected.is_ok() {
+            break;
+        }
+        tracing::warn!(error = ?injected, "inject failed; retrying");
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+    injected?;
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let deadline = std::time::Instant::now() + METADATA_TIMEOUT;
+    let (err_a, err_b) = loop {
+        let metadata = client.metadata(&["topic_a", "topic_b"]).await?;
+        let code = |name: &str| {
+            metadata
+                .topics
+                .iter()
+                .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some(name))
+                .map(|t| t.error_code)
+        };
+        let (a, b) = (
+            code("topic_a").context("topic_a missing from metadata")?,
+            code("topic_b").context("topic_b missing from metadata")?,
+        );
+        if a == 0 || std::time::Instant::now() > deadline {
+            break (a, b);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    };
+    assert_eq!(err_a, 0, "topic_a has data, so its metadata should be OK");
+
+    Ok((env, err_b))
+}
+
+/// Consume from a fresh group subscribed to both topics, polling through
+/// client-side error events rather than failing on the first one. Returns the
+/// number of records read and the count of assigned partitions.
+async fn consume_both_topics(env: &DekafTestEnv) -> anyhow::Result<(usize, usize, Vec<String>)> {
+    let group = format!("mixed-{}", uuid::Uuid::new_v4());
+    let consumer = env.kafka_consumer_with_group_id(&group).await?;
+    consumer.subscribe(&["topic_a", "topic_b"])?;
+
+    let deadline = std::time::Instant::now() + CONSUME_TIMEOUT;
+    let (mut count, mut errors) = (0, Vec::new());
+    let mut stream = consumer.inner().stream();
+    while std::time::Instant::now() < deadline && count < 2 {
+        match tokio::time::timeout(Duration::from_secs(2), stream.next()).await {
+            Ok(Some(Ok(_))) => count += 1,
+            Ok(Some(Err(e))) => errors.push(e.to_string()),
+            Ok(None) => break,
+            Err(_) => continue,
+        }
+    }
+    drop(stream);
+
+    let assigned = consumer
+        .inner()
+        .assignment()
+        .map(|tpl| tpl.count())
+        .unwrap_or(0);
+
+    Ok((count, assigned, errors))
+}
+
+/// https://github.com/estuary/flow/issues/3064: by default, a binding whose
+/// collection has never been written has no journals, so dekaf reports the
+/// retryable `LeaderNotAvailable` for its topic. A subscription mixing such a
+/// topic with a populated one is assigned nothing and consumes nothing — not
+/// even from the populated topic.
+#[tokio::test]
+async fn test_empty_binding_blocks_consumer_group() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let (env, err_b) =
+        setup_one_populated_one_empty("empty_binding_group", TWO_TOPICS_FIXTURE).await?;
+    assert_eq!(
+        err_b,
+        ResponseError::LeaderNotAvailable.code(),
+        "without allow_empty_topics, an unwritten collection reports LeaderNotAvailable"
+    );
+
+    // Control: a group subscribed only to the populated topic consumes fine.
+    let group = format!("populated-only-{}", uuid::Uuid::new_v4());
+    let consumer = env.kafka_consumer_with_group_id(&group).await?;
+    consumer.subscribe(&["topic_a"])?;
+    assert_eq!(
+        consumer.fetch().await?.len(),
+        2,
+        "subscription to the populated topic alone should consume both documents"
+    );
+
+    let (count, assigned, errors) = consume_both_topics(&env).await?;
+    tracing::info!(count, assigned, ?errors, "mixed subscription");
+    assert_eq!(
+        count, 0,
+        "the empty topic starves the whole subscription (assigned: {assigned}, errors: {errors:?})"
+    );
+
+    Ok(())
+}
+
+/// With `allow_empty_topics`, the same unwritten collection is served as a
+/// valid topic with one partition sitting at offset 0: the group stabilizes and
+/// the populated topic in the subscription is consumed normally.
+#[tokio::test]
+async fn test_allow_empty_topics_unblocks_consumer_group() -> anyhow::Result<()> {
+    super::init_tracing();
+
+    let (env, err_b) =
+        setup_one_populated_one_empty("allow_empty_topics", ALLOW_EMPTY_FIXTURE).await?;
+    assert_eq!(
+        err_b, 0,
+        "with allow_empty_topics, an unwritten collection is a valid topic"
+    );
+
+    let info = env.connection_info().await?;
+    let token = env.dekaf_token()?;
+    let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
+
+    let metadata = client.metadata(&["topic_b"]).await?;
+    let topic_b = metadata
+        .topics
+        .iter()
+        .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some("topic_b"))
+        .context("topic_b missing from metadata")?;
+    assert_eq!(
+        topic_b.partitions.len(),
+        1,
+        "an empty topic presents a single sentinel partition"
+    );
+
+    for timestamp in [-1 /* latest */, -2 /* earliest */] {
+        let resp = client
+            .list_offsets_with_epoch("topic_b", 0, timestamp, -1)
+            .await?;
+        assert_eq!(
+            list_offsets_partition_error(&resp, "topic_b", 0),
+            Some(0),
+            "ListOffsets({timestamp}) should succeed for an empty topic"
+        );
+        let offset = resp
+            .topics
+            .iter()
+            .find(|t| t.name.as_str() == "topic_b")
+            .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
+            .context("topic_b partition 0 missing from ListOffsets response")?
+            .offset;
+        assert_eq!(offset, 0, "an empty topic sits at offset 0");
+    }
+
+    let fetch_resp = client.fetch_with_epoch("topic_b", 0, 0, -1).await?;
+    assert_eq!(
+        fetch_partition_error(&fetch_resp, "topic_b", 0),
+        Some(0),
+        "Fetch from an empty topic should return an empty batch, not an error"
+    );
+
+    let (count, assigned, errors) = consume_both_topics(&env).await?;
+    tracing::info!(count, assigned, ?errors, "mixed subscription");
+    assert_eq!(
+        count, 2,
+        "the populated topic is consumable alongside the empty one \
+         (assigned: {assigned}, errors: {errors:?})"
+    );
+    assert_eq!(
+        assigned, 2,
+        "both topics' partitions are assigned (errors: {errors:?})"
+    );
+
+    Ok(())
+}

--- a/crates/dekaf/tests/e2e/empty_binding_group.rs
+++ b/crates/dekaf/tests/e2e/empty_binding_group.rs
@@ -8,17 +8,18 @@ use serde_json::json;
 use std::time::Duration;
 
 const TWO_TOPICS_FIXTURE: &str = include_str!("fixtures/two_topics.flow.yaml");
-const ALLOW_EMPTY_FIXTURE: &str = include_str!("fixtures/two_topics_allow_empty.flow.yaml");
+const ALLOW_EMPTY_FIXTURE: &str = include_str!("fixtures/multi_topics_allow_empty.flow.yaml");
 const METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const CONSUME_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Publish the fixture, write two documents to `test_data_a`, and leave
-/// `test_data_b` journal-less. Returns the environment once `topic_a`'s
-/// metadata is serving, along with `topic_b`'s metadata error code.
-async fn setup_one_populated_one_empty(
+/// Publish the fixture and write two documents to `test_data_a`, leaving every
+/// other collection journal-less. Returns the environment once `topic_a`'s
+/// metadata is serving, along with each empty topic's metadata error code.
+async fn setup_populated_and_empty(
     test_name: &str,
     fixture: &str,
-) -> anyhow::Result<(DekafTestEnv, i16)> {
+    empty_topics: &[&str],
+) -> anyhow::Result<(DekafTestEnv, Vec<i16>)> {
     let env = DekafTestEnv::setup(test_name, fixture).await?;
 
     // A shard can briefly report primary before its proxy listener accepts, so retry.
@@ -41,37 +42,48 @@ async fn setup_one_populated_one_empty(
     let token = env.dekaf_token()?;
     let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
 
+    let requested: Vec<&str> = std::iter::once("topic_a")
+        .chain(empty_topics.iter().copied())
+        .collect();
+
     let deadline = std::time::Instant::now() + METADATA_TIMEOUT;
-    let (err_a, err_b) = loop {
-        let metadata = client.metadata(&["topic_a", "topic_b"]).await?;
-        let code = |name: &str| {
-            metadata
-                .topics
-                .iter()
-                .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some(name))
-                .map(|t| t.error_code)
-        };
-        let (a, b) = (
-            code("topic_a").context("topic_a missing from metadata")?,
-            code("topic_b").context("topic_b missing from metadata")?,
-        );
-        if a == 0 || std::time::Instant::now() > deadline {
-            break (a, b);
+    let codes = loop {
+        let metadata = client.metadata(&requested).await?;
+        let codes: Vec<i16> = requested
+            .iter()
+            .map(|name| {
+                metadata
+                    .topics
+                    .iter()
+                    .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some(*name))
+                    .map(|t| t.error_code)
+                    .with_context(|| format!("{name} missing from metadata"))
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        if codes[0] == 0 || std::time::Instant::now() > deadline {
+            break codes;
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     };
-    assert_eq!(err_a, 0, "topic_a has data, so its metadata should be OK");
+    assert_eq!(
+        codes[0], 0,
+        "topic_a has data, so its metadata should be OK"
+    );
 
-    Ok((env, err_b))
+    Ok((env, codes[1..].to_vec()))
 }
 
-/// Consume from a fresh group subscribed to both topics, polling through
+/// Consume from a fresh group subscribed to all of `topics`, polling through
 /// client-side error events rather than failing on the first one. Returns the
-/// number of records read and the count of assigned partitions.
-async fn consume_both_topics(env: &DekafTestEnv) -> anyhow::Result<(usize, usize, Vec<String>)> {
+/// number of records read, the count of assigned partitions, and any errors.
+async fn consume_topics(
+    env: &DekafTestEnv,
+    topics: &[&str],
+) -> anyhow::Result<(usize, usize, Vec<String>)> {
     let group = format!("mixed-{}", uuid::Uuid::new_v4());
     let consumer = env.kafka_consumer_with_group_id(&group).await?;
-    consumer.subscribe(&["topic_a", "topic_b"])?;
+    consumer.subscribe(topics)?;
 
     let deadline = std::time::Instant::now() + CONSUME_TIMEOUT;
     let (mut count, mut errors) = (0, Vec::new());
@@ -104,11 +116,11 @@ async fn consume_both_topics(env: &DekafTestEnv) -> anyhow::Result<(usize, usize
 async fn test_empty_binding_blocks_consumer_group() -> anyhow::Result<()> {
     super::init_tracing();
 
-    let (env, err_b) =
-        setup_one_populated_one_empty("empty_binding_group", TWO_TOPICS_FIXTURE).await?;
+    let (env, empty_codes) =
+        setup_populated_and_empty("empty_binding_group", TWO_TOPICS_FIXTURE, &["topic_b"]).await?;
     assert_eq!(
-        err_b,
-        ResponseError::LeaderNotAvailable.code(),
+        empty_codes,
+        vec![ResponseError::LeaderNotAvailable.code()],
         "without allow_empty_topics, an unwritten collection reports LeaderNotAvailable"
     );
 
@@ -122,7 +134,7 @@ async fn test_empty_binding_blocks_consumer_group() -> anyhow::Result<()> {
         "subscription to the populated topic alone should consume both documents"
     );
 
-    let (count, assigned, errors) = consume_both_topics(&env).await?;
+    let (count, assigned, errors) = consume_topics(&env, &["topic_a", "topic_b"]).await?;
     tracing::info!(count, assigned, ?errors, "mixed subscription");
     assert_eq!(
         count, 0,
@@ -132,72 +144,79 @@ async fn test_empty_binding_blocks_consumer_group() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// With `allow_empty_topics`, the same unwritten collection is served as a
-/// valid topic with one partition sitting at offset 0: the group stabilizes and
-/// the populated topic in the subscription is consumed normally.
+/// With `allow_empty_topics`, unwritten collections are served as valid topics
+/// with one partition sitting at offset 0. Several of them in one subscription
+/// must all resolve, so the group stabilizes and the populated topic alongside
+/// them is consumed normally.
 #[tokio::test]
 async fn test_allow_empty_topics_unblocks_consumer_group() -> anyhow::Result<()> {
     super::init_tracing();
 
-    let (env, err_b) =
-        setup_one_populated_one_empty("allow_empty_topics", ALLOW_EMPTY_FIXTURE).await?;
+    let empty_topics = ["topic_b", "topic_c"];
+    let (env, empty_codes) =
+        setup_populated_and_empty("allow_empty_topics", ALLOW_EMPTY_FIXTURE, &empty_topics).await?;
     assert_eq!(
-        err_b, 0,
-        "with allow_empty_topics, an unwritten collection is a valid topic"
+        empty_codes,
+        vec![0; empty_topics.len()],
+        "with allow_empty_topics, every unwritten collection is a valid topic"
     );
 
     let info = env.connection_info().await?;
     let token = env.dekaf_token()?;
     let mut client = TestKafkaClient::connect(&info.broker, &info.username, &token).await?;
 
-    let metadata = client.metadata(&["topic_b"]).await?;
-    let topic_b = metadata
-        .topics
-        .iter()
-        .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some("topic_b"))
-        .context("topic_b missing from metadata")?;
-    assert_eq!(
-        topic_b.partitions.len(),
-        1,
-        "an empty topic presents a single sentinel partition"
-    );
-
-    for timestamp in [-1 /* latest */, -2 /* earliest */] {
-        let resp = client
-            .list_offsets_with_epoch("topic_b", 0, timestamp, -1)
-            .await?;
-        assert_eq!(
-            list_offsets_partition_error(&resp, "topic_b", 0),
-            Some(0),
-            "ListOffsets({timestamp}) should succeed for an empty topic"
-        );
-        let offset = resp
+    let metadata = client.metadata(&empty_topics).await?;
+    for name in empty_topics {
+        let topic = metadata
             .topics
             .iter()
-            .find(|t| t.name.as_str() == "topic_b")
-            .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
-            .context("topic_b partition 0 missing from ListOffsets response")?
-            .offset;
-        assert_eq!(offset, 0, "an empty topic sits at offset 0");
+            .find(|t| t.name.as_ref().map(|n| n.as_str()) == Some(name))
+            .with_context(|| format!("{name} missing from metadata"))?;
+        assert_eq!(
+            topic.partitions.len(),
+            1,
+            "empty topic {name} presents a single sentinel partition"
+        );
+
+        for timestamp in [-1 /* latest */, -2 /* earliest */] {
+            let resp = client
+                .list_offsets_with_epoch(name, 0, timestamp, -1)
+                .await?;
+            assert_eq!(
+                list_offsets_partition_error(&resp, name, 0),
+                Some(0),
+                "ListOffsets({timestamp}) should succeed for empty topic {name}"
+            );
+            let offset = resp
+                .topics
+                .iter()
+                .find(|t| t.name.as_str() == name)
+                .and_then(|t| t.partitions.iter().find(|p| p.partition_index == 0))
+                .with_context(|| format!("{name} partition 0 missing from ListOffsets response"))?
+                .offset;
+            assert_eq!(offset, 0, "empty topic {name} sits at offset 0");
+        }
+
+        let fetch_resp = client.fetch_with_epoch(name, 0, 0, -1).await?;
+        assert_eq!(
+            fetch_partition_error(&fetch_resp, name, 0),
+            Some(0),
+            "Fetch from empty topic {name} should return an empty batch, not an error"
+        );
     }
 
-    let fetch_resp = client.fetch_with_epoch("topic_b", 0, 0, -1).await?;
-    assert_eq!(
-        fetch_partition_error(&fetch_resp, "topic_b", 0),
-        Some(0),
-        "Fetch from an empty topic should return an empty batch, not an error"
-    );
-
-    let (count, assigned, errors) = consume_both_topics(&env).await?;
+    let subscription = ["topic_a", "topic_b", "topic_c"];
+    let (count, assigned, errors) = consume_topics(&env, &subscription).await?;
     tracing::info!(count, assigned, ?errors, "mixed subscription");
     assert_eq!(
         count, 2,
-        "the populated topic is consumable alongside the empty one \
+        "the populated topic is consumable alongside two empty ones \
          (assigned: {assigned}, errors: {errors:?})"
     );
     assert_eq!(
-        assigned, 2,
-        "both topics' partitions are assigned (errors: {errors:?})"
+        assigned,
+        subscription.len(),
+        "every topic's partition is assigned (errors: {errors:?})"
     );
 
     Ok(())

--- a/crates/dekaf/tests/e2e/fixtures/multi_topics_allow_empty.flow.yaml
+++ b/crates/dekaf/tests/e2e/fixtures/multi_topics_allow_empty.flow.yaml
@@ -17,18 +17,29 @@ collections:
             required: [id]
         key: [/id]
 
+    test_data_c:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+                value: { type: string }
+            required: [id]
+        key: [/id]
+
 captures:
     source_ingest:
         endpoint:
             connector:
                 image: ghcr.io/estuary/source-http-ingest:dev
                 config:
-                    paths: ["/data_a", "/data_b"]
+                    paths: ["/data_a", "/data_b", "/data_c"]
         bindings:
             - resource: { path: "/data_a", stream: "/data_a" }
               target: test_data_a
             - resource: { path: "/data_b", stream: "/data_b" }
               target: test_data_b
+            - resource: { path: "/data_c", stream: "/data_c" }
+              target: test_data_c
 
 materializations:
     dekaf_test:
@@ -47,6 +58,11 @@ materializations:
                 exclude: [flow_published_at]
             - source: test_data_b
               resource: { topic_name: topic_b }
+              fields:
+                recommended: true
+                exclude: [flow_published_at]
+            - source: test_data_c
+              resource: { topic_name: topic_c }
               fields:
                 recommended: true
                 exclude: [flow_published_at]

--- a/crates/dekaf/tests/e2e/fixtures/two_topics_allow_empty.flow.yaml
+++ b/crates/dekaf/tests/e2e/fixtures/two_topics_allow_empty.flow.yaml
@@ -1,0 +1,52 @@
+collections:
+    test_data_a:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+                value: { type: string }
+            required: [id]
+        key: [/id]
+
+    test_data_b:
+        schema:
+            type: object
+            properties:
+                id: { type: string }
+                value: { type: string }
+            required: [id]
+        key: [/id]
+
+captures:
+    source_ingest:
+        endpoint:
+            connector:
+                image: ghcr.io/estuary/source-http-ingest:dev
+                config:
+                    paths: ["/data_a", "/data_b"]
+        bindings:
+            - resource: { path: "/data_a", stream: "/data_a" }
+              target: test_data_a
+            - resource: { path: "/data_b", stream: "/data_b" }
+              target: test_data_b
+
+materializations:
+    dekaf_test:
+        endpoint:
+            dekaf:
+                variant: testing
+                config:
+                    token: "test-token-12345"
+                    strict_topic_names: false
+                    allow_empty_topics: true
+        bindings:
+            - source: test_data_a
+              resource: { topic_name: topic_a }
+              fields:
+                recommended: true
+                exclude: [flow_published_at]
+            - source: test_data_b
+              resource: { topic_name: topic_b }
+              fields:
+                recommended: true
+                exclude: [flow_published_at]

--- a/crates/dekaf/tests/e2e/main.rs
+++ b/crates/dekaf/tests/e2e/main.rs
@@ -6,6 +6,7 @@ mod auth;
 mod basic;
 mod collection_reset;
 mod consumer_group;
+mod empty_binding_group;
 mod empty_fetch;
 mod fetch_offsets;
 mod list_offsets;

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
@@ -93,6 +93,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
@@ -64,6 +64,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/dekaf.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/dekaf.md
@@ -66,6 +66,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --------------------- | ------------------ | -------------------------------------------------------------------------- | ------- | ---------------- |
 | `/token`              | Auth Token         | The password that Kafka consumers can use to authenticate to this task.    | string  | Required         |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false`          |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions`          | Deletion Mode      | Can choose between `kafka` or `cdc` deletion modes.                        | string  | `kafka`          |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
@@ -68,6 +68,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
@@ -88,6 +88,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/risingwave.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/risingwave.md
@@ -67,6 +67,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --------------------- | ------------------ | -------------------------------------------------------------------------- | ------- | ---------------- |
 | `/token`              | Auth Token         | The password that Kafka consumers can use to authenticate to this task.    | string  | Required         |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false`          |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions`          | Deletion Mode      | Can choose between `kafka` or `cdc` deletion modes.                        | string  | `kafka`          |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
@@ -70,6 +70,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
@@ -59,6 +59,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings

--- a/site/docs/reference/Connectors/materialization-connectors/Dekaf/tinybird.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Dekaf/tinybird.md
@@ -131,6 +131,7 @@ Use the below properties to configure a Dekaf materialization, which will direct
 | --- | --- | --- | --- | --- |
 | `/token` | Auth Token | The password that Kafka consumers can use to authenticate to this task. | string | Required |
 | `/strict_topic_names` | Strict Topic Names | Whether or not to expose topic names in a strictly Kafka-compliant format. | boolean | `false` |
+| `/allow_empty_topics` | Allow Empty Topics | Whether to expose bound collections that have never been written as valid, empty topics with a single partition at offset 0. When off, such a topic reports a retryable `LeaderNotAvailable` error, which prevents a consumer group from stabilizing across the whole subscription. | boolean | `false` |
 | `/deletions` | Deletion Mode | Can choose between `kafka` or `cdc` deletion modes. | string | `kafka` |
 
 #### Bindings


### PR DESCRIPTION
Fixes #3064.

## Problem

A materialization binding whose collection has no journals is reported as `CollectionStatus::NotReady`, which maps to the retryable `LeaderNotAvailable`. That's right for a collection reset that's about to complete, but a collection which has simply never been written stays that way indefinitely.

The issue frames this as a metadata problem, but the sharper blocker is group management: `join_group` (`session.rs:1360-1376`) and `sync_group` (`session.rs:1573-1586`) fail the **entire request** with the first non-`Ready` topic's error code. So one empty binding makes every JoinGroup return `LeaderNotAvailable` and the group never forms — the consumer is assigned nothing and reads nothing, including from the populated topics in the same subscription. `offset_commit` is all-or-nothing in the same way; metadata / ListOffsets / Fetch / OffsetFetch are per-topic.

Reproduced against a local stack with a subscription mixing one populated and one never-written collection:

| subscription | assigned partitions | records read |
| --- | --- | --- |
| `topic_a` (populated) alone | 1 | 2 |
| `topic_a` + `topic_b` (empty) | 0 | 0 |

## Change

New endpoint option `allow_empty_topics`, **off by default**. When set, a collection with no journals is served as a valid topic with one sentinel partition sitting at offset 0:

- `topology.rs` — `Collection::empty_topic`, `partition_count()`, and `fetch_partition_offset` answering offset 0 for the sentinel (which also covers ListOffsets and OffsetForLeaderEpoch).
- `session.rs` — sentinel partition in metadata; an empty successful batch in Fetch; `partition_count()` when creating the upstream offsets topic; skip the journal-name lookup when logging commits.
- Group management needs no change: the collection is `Ready`, so JoinGroup/SyncGroup pass through and the group stabilizes.
- Side effect worth noting: the schema registry (`registry.rs:102`) also stops rejecting empty collections, since Avro schemas come from the spec rather than from journals.

Once the collection is first written, its real journals take over at the same leader epoch, so partition 0's committed offset stays valid.

This "single partition at offset 0" shape is what dekaf presented before 58f0f0da54 introduced `CollectionStatus` — the flag restores it without touching reset semantics on the default path. Dekaf behavior changes are historically high-risk, hence opt-in.

## Testing

`mise run ci:dekaf-e2e` — 27 passed (3 flaky-retried, all the pre-existing `SHARD_STOPPED` injection race, unrelated to this change). Two new e2e tests:

- `test_empty_binding_blocks_consumer_group` pins the default behavior (`LeaderNotAvailable`, nothing assigned, nothing consumed).
- `test_allow_empty_topics_unblocks_consumer_group` subscribes to one populated and **two** empty topics: it asserts metadata / ListOffsets / Fetch on each empty topic, then that all three partitions are assigned and both documents are consumed from the populated topic.

## Note for review

Separate pre-existing bug found while testing, left alone as out of scope: `KafkaApiClient::connect_to_group_coordinator` (`api_client.rs:494-500`) builds the coordinator URL *before* checking the `port == -1` sentinel, so a `FindCoordinator` response with port -1 (coordinator not yet elected) fails with "invalid broker port" and drops the client connection — the sentinel branch below it is unreachable. It's a one-line reorder if we want it.

cc @jshearer as SME on dekaf.
