### PR TITLE
docs: AWS IAM auth cross-account guidance, correct Identity Provider ARN wording

### DIFF
--- a/site/docs/guides/iam-auth/aws.md
+++ b/site/docs/guides/iam-auth/aws.md
@@ -43,12 +43,12 @@ For example, these are the issuer values for a few common public data planes:
 
 ![Add Identity Provider](../guide-images/aws-iam-1.png)
 
-# Trust Relationship in Role
+## Trust Relationship in Role
 
 Finally, return to the details page of your role, head to "Trust relationships" tab and add the following trust policy, replacing:
 
 * The OpenID URL with the correct issuer value for your data plane
-* The principal with the ARN of the Identity Provider depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value) you use
+* The principal with the ARN of the Identity Provider you created in the previous step. This provider lives in your own AWS account, so copy its ARN from the IAM console rather than writing it by hand
 * The `:sub` condition with your tenant name so only tasks from your tenant are allowed to assume this role
 
 :::tip
@@ -77,3 +77,13 @@ Make sure the `:aud` and `:sub` values use the correct issuer. Minor discrepanci
     ]
 }
 ```
+
+## Resources in a Different AWS Account
+
+Estuary makes a single `sts:AssumeRoleWithWebIdentity` call. There is no second, chained `AssumeRole`, so a role in one account cannot be used as a stepping stone to a role in another.
+
+An IAM OIDC identity provider is a per-account resource, and a role's trust policy can only name a provider in the same account as the role. If the resource you want to connect to lives in a different AWS account from one you have already set up, create both the identity provider and the role in the account that owns the resource, then use that role's ARN in your endpoint configuration. Nothing needs to change in your original account.
+
+A task's endpoint configuration holds a single role ARN, so resources spread across several accounts need one task per account.
+
+Granting your existing role cross-account access through a resource-based policy is not a substitute. Connectors often call account-level APIs during discovery, such as `dynamodb:ListTables`, which a resource-based policy on an individual resource cannot grant.


### PR DESCRIPTION
Two fixes to the AWS IAM auth guide, both surfaced by a customer question about connecting to a resource in a second AWS account.

**1. The Identity Provider ARN wording was wrong.**

The trust-relationship section said the principal is "the ARN of the Identity Provider depending on the data plane (if you use a private deployment or BYOC, we will provide you with this value)". The IAM OIDC provider is a resource the user creates in their own AWS account, so its ARN is theirs, not ours. What we supply is the issuer, and the preceding section already explains how to find it in the dashboard. Reworded to point at the provider they just created and to copy the ARN from the console.

**2. No guidance on resources in another AWS account.**

`crates/iam-auth/src/providers/aws.rs` makes a single `sts:AssumeRoleWithWebIdentity` call with no chained `AssumeRole`. Combined with an IAM OIDC provider being account-scoped, that means both the provider and the role have to live in the account owning the resource. AWS documents the same fork for EKS IRSA ([cross-account access](https://docs.aws.amazon.com/eks/latest/userguide/cross-account-access.html)): create an IdP in the target account, or chain two `AssumeRole` calls. Only the first option is available to us, and the guide didn't say so.

The new section also notes why a resource-based policy on the target resource is not a substitute: connectors call account-level APIs during discovery, `dynamodb:ListTables` being the concrete case, which a resource policy on an individual resource cannot grant.

Also promotes a stray `#` mid-page to `##`. The anchor is derived from the heading text, so `#trust-relationship-in-role` is unchanged.

No code changes.
