### PR TITLE
dekaf: fix avro schema when property type is invalid

### DIFF
--- a/crates/avro/src/schema.rs
+++ b/crates/avro/src/schema.rs
@@ -150,6 +150,11 @@ fn object_to_avro(loc: json::Location, obj: doc::shape::ObjShape) -> avro::Schem
             extra = doc::Shape::union(extra, prop.shape);
             continue; // Cannot be represented under Avro's name restrictions.
         }
+
+        if prop.shape.type_ == types::INVALID {
+            continue;
+        }
+
         let default = prop.shape.default.as_ref().map(|d| d.0.clone());
         let schema = shape_to_avro(loc.push_prop(&prop.name), prop.shape, prop.is_required);
 
@@ -318,6 +323,39 @@ mod test {
         }).to_string();
 
         let key = &["/a_bool", "/obj/a_map/a_const"];
+        let key: Vec<_> = key.iter().map(|p| json::Pointer::from(*p)).collect();
+        insta::assert_json_snapshot!(schema_test(&fixture, &key));
+    }
+
+    #[test]
+    fn test_all_of_invalid_field_default() {
+        let fixture = json!({
+          "$defs": {
+            "flow://relaxed-write-schema": {
+              "$id": "flow://relaxed-write-schema",
+              "properties": {
+                "id": {"type": "string"},
+                "value": { "type": "string", "default":"42"},
+              },
+            },
+            "flow://inferred-schema": {
+              "$id": "flow://inferred-schema",
+              "additionalProperties": false,
+              "properties": {
+                "id": {"type": "string"},
+              },
+              "required": ["id"],
+              "type": "object",
+            },
+          },
+          "allOf": [
+            {"$ref": "flow://relaxed-write-schema"},
+            {"$ref": "flow://inferred-schema"},
+          ],
+        })
+        .to_string();
+
+        let key = &["/id"];
         let key: Vec<_> = key.iter().map(|p| json::Pointer::from(*p)).collect();
         insta::assert_json_snapshot!(schema_test(&fixture, &key));
     }

--- a/crates/avro/src/snapshots/avro__schema__test__all_of_invalid_field_default.snap
+++ b/crates/avro/src/snapshots/avro__schema__test__all_of_invalid_field_default.snap
@@ -1,0 +1,37 @@
+---
+source: crates/avro/src/schema.rs
+expression: "schema_test(&fixture, &key)"
+---
+{
+  "key": {
+    "fields": [
+      {
+        "name": "_flow_key",
+        "type": {
+          "fields": [
+            {
+              "name": "p1",
+              "type": "string"
+            }
+          ],
+          "name": "Parts",
+          "namespace": "root.Key",
+          "type": "record"
+        }
+      }
+    ],
+    "name": "Key",
+    "namespace": "root",
+    "type": "record"
+  },
+  "value": {
+    "fields": [
+      {
+        "name": "id",
+        "type": "string"
+      }
+    ],
+    "name": "root",
+    "type": "record"
+  }
+}


### PR DESCRIPTION
**Description:**

Previously, if a property existed on only one side of an allOf combination, it would appear in the output schema as a record.  If the field had a default value it would appear on the record, which could cause the avro schema to be invalid.

Since the property is only on one leg of the allOf, it shouldn't be added to the avro schema at all.

closes: #3286

**Workflow steps:**

None

**Documentation links affected:**

None

**Notes for reviewers:**

This may have become a more likely occurrence since: https://github.com/estuary/connectors/pull/4358