### PR TITLE
graphql: separate prefix authorization from user filters

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -5,14 +5,13 @@
 //! Updating a row requires admin access to its governing prefix. For exact
 //! catalog names, the governing prefix is the parent prefix.
 
-use super::filters;
+use super::{authorized_prefixes::MAX_PREFIXES, filters};
 use async_graphql::{
     Context,
     types::connection::{self, Connection},
 };
 
 const DEFAULT_PAGE_SIZE: usize = 50;
-const MAX_PREFIXES: usize = 20;
 
 /// Optional filter for the `alertConfigs` query. When omitted, all accessible
 /// rows are returned. A filter only narrows those results; the caller's
@@ -138,9 +137,9 @@ impl AlertConfigsQuery {
             return Ok(PaginatedAlertConfigs::new(false, false));
         }
         if read_prefixes.len() > MAX_PREFIXES {
-            return Err(async_graphql::Error::new(
-                "Too many accessible prefixes; narrow results with a filter",
-            ));
+            return Err(async_graphql::Error::new(format!(
+                "Too many accessible prefixes to list; this query supports at most {MAX_PREFIXES}"
+            )));
         }
 
         connection::query_with::<String, _, _, _, async_graphql::Error>(
@@ -790,20 +789,19 @@ mod test {
         );
     }
 
-    // Regression coverage for the reason `narrow_to_exact_set` runs before the
-    // `MAX_PREFIXES` guard: a caller who can read more than `MAX_PREFIXES`
-    // prefixes is refused an unfiltered listing, but an `in` filter narrows the
-    // authorized set back under the cap so the same caller succeeds.
+    // `MAX_PREFIXES` caps the caller's authorized set, which is derived from
+    // grants alone. A filter scopes rows in SQL and leaves that set untouched,
+    // so a caller over the cap is refused whether or not they filter.
     #[sqlx::test(
         migrations = "../../supabase/migrations",
         fixtures(path = "../../../fixtures", scripts("data_planes"))
     )]
-    async fn test_alert_configs_in_narrows_past_max_prefixes(pool: sqlx::PgPool) {
+    async fn test_alert_configs_max_prefixes_guard(pool: sqlx::PgPool) {
         let _guard = test_server::init();
 
-        // Grant Bob read on `MAX_PREFIXES + 5` non-overlapping prefixes, each
-        // with a config row. None is a prefix of another, so parent-pruning
-        // leaves the full set and the count exceeds the guard.
+        // Grant Bob read on `MAX_PREFIXES + 5` non-overlapping prefixes. None
+        // is a prefix of another, so parent-pruning leaves the full set and the
+        // count exceeds the guard.
         let bob_uid = uuid::Uuid::from_bytes([0x22; 16]);
         sqlx::query("INSERT INTO auth.users (id, email) VALUES ($1, 'bob@example.test')")
             .bind(bob_uid)
@@ -811,20 +809,14 @@ mod test {
             .await
             .unwrap();
         for n in 0..(MAX_PREFIXES + 5) {
-            let prefix = format!("tenant{n:02}/");
             sqlx::query(
                 "INSERT INTO public.user_grants (user_id, object_role, capability) VALUES ($1, $2, 'read')",
             )
             .bind(bob_uid)
-            .bind(&prefix)
+            .bind(format!("tenant{n:03}/"))
             .execute(&pool)
             .await
             .unwrap();
-            sqlx::query("INSERT INTO alert_configs (catalog_prefix_or_name, config) VALUES ($1, '{}'::jsonb)")
-                .bind(&prefix)
-                .execute(&pool)
-                .await
-                .unwrap();
         }
 
         let server = test_server::TestServer::start(
@@ -854,14 +846,14 @@ mod test {
             "unfiltered query over MAX_PREFIXES should be rejected: {unfiltered}"
         );
 
-        // `in` narrows the authorized set below the cap, so the same caller now
-        // gets a successful, exact-set result.
-        let narrowed: serde_json::Value = server
+        // Filtered: the cap is on the authorized set, which the filter does not
+        // reduce, so the same caller is refused here too.
+        let filtered: serde_json::Value = server
             .graphql(
                 &serde_json::json!({
                     "query": r#"
                     query {
-                        alertConfigs(filter: { catalogPrefixOrName: { in: ["tenant00/", "tenant01/", "tenant02/"] } }) {
+                        alertConfigs(filter: { catalogPrefixOrName: { in: ["tenant000/", "tenant001/"] } }) {
                             edges { node { catalogPrefixOrName } }
                         }
                     }"#
@@ -870,21 +862,11 @@ mod test {
             )
             .await;
         assert!(
-            narrowed.get("errors").is_none(),
-            "narrowed query should succeed: {narrowed}"
+            filtered["errors"]
+                .as_array()
+                .is_some_and(|errors| !errors.is_empty()),
+            "filtered query over MAX_PREFIXES should also be rejected: {filtered}"
         );
-        let names: Vec<String> = narrowed["data"]["alertConfigs"]["edges"]
-            .as_array()
-            .expect("edges array")
-            .iter()
-            .map(|edge| {
-                edge["node"]["catalogPrefixOrName"]
-                    .as_str()
-                    .unwrap()
-                    .to_string()
-            })
-            .collect();
-        assert_eq!(names, vec!["tenant00/", "tenant01/", "tenant02/"]);
     }
 
     #[sqlx::test(

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -1,10 +1,22 @@
+/// Largest authorized-prefix set a prefix-scoped list query will serve.
+///
+/// The caller's prefixes are resolved in memory from the request's
+/// authorization Snapshot and bound into SQL as a `text[]` for a
+/// `^@ ANY($1)` scope check, so the array has to be bounded somewhere. A
+/// caller over this many prefixes is refused rather than served a query with
+/// an unbounded scope array.
+///
+/// Shared by every prefix-scoped list query so the ceiling is uniform across
+/// the API.
+pub(super) const MAX_PREFIXES: usize = 100;
+
 /// Returns catalog prefixes where the authenticated user holds all
 /// `required_capabilities`.
 ///
 /// Intended for use by GraphQL queries that list resources scoped to the
-/// caller's authorized prefixes. User-supplied filters are applied as
-/// narrowing post-passes over this set (see `filtered_authorized_prefixes`),
-/// never here: this function answers only the authorization question.
+/// caller's authorized prefixes. This function answers only the authorization
+/// question: user-supplied filters are never applied here, and instead go to
+/// the resolver's SQL alongside this set (see `filtered_authorized_prefixes`).
 pub(super) fn authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
@@ -41,16 +53,16 @@ fn prune_covered(sorted: impl IntoIterator<Item = String>) -> Vec<String> {
     pruned
 }
 
-/// Resolves the caller's prefixes for `required_capabilities`, narrowed by an
-/// optional `PrefixFilter`, and returns them with the filter's decomposed
-/// `startsWith`/`in` parts (which callers bind into their own SQL). `field`
-/// names the GraphQL input field for the mutual-exclusion error.
+/// Resolves the caller's prefixes for `required_capabilities` and returns them
+/// with the optional `PrefixFilter` decomposed into its `startsWith`/`in`
+/// parts, which callers bind into their own SQL. `field` names the GraphQL
+/// input field for the mutual-exclusion error.
 ///
-/// This chains the steps every prefix-scoped list query repeats —
-/// `PrefixFilter::into_parts`, `authorized_prefixes`, and the filter's
-/// narrowing post-passes (`narrow_to_overlap` / `narrow_to_exact_set`) — so
-/// the narrow-only invariant (a filter can only remove authorized prefixes,
-/// never add them) has a single owner.
+/// The two outputs stay separate all the way into SQL, where the resolver ANDs
+/// an unconditional `^@ ANY($authorized)` scope check against the filter's own
+/// clause. Authorization is therefore built from grants alone and never from
+/// caller input, so a bug in filter handling can only return too few rows,
+/// never widen visibility.
 pub(super) fn filtered_authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
@@ -63,14 +75,7 @@ pub(super) fn filtered_authorized_prefixes(
         Some(cp) => cp.into_parts(field)?,
         None => (None, None),
     };
-    let mut prefixes =
-        authorized_prefixes(role_grants, user_grants, user_id, required_capabilities);
-    if let Some(sw) = starts_with.as_deref() {
-        super::filters::PrefixFilter::narrow_to_overlap(&mut prefixes, sw);
-    }
-    if let Some(exact) = r#in.as_deref() {
-        super::filters::PrefixFilter::narrow_to_exact_set(&mut prefixes, exact);
-    }
+    let prefixes = authorized_prefixes(role_grants, user_grants, user_id, required_capabilities);
     Ok((prefixes, starts_with, r#in))
 }
 
@@ -301,48 +306,41 @@ mod tests {
     }
 
     #[test]
-    fn filtered_starts_with_narrows_by_subtree_and_returns_part() {
+    fn filtered_passes_the_filter_through_without_touching_the_authorized_set() {
+        // A filter narrows rows in SQL, not the authorized set: both grants
+        // come back either way, and the filter is returned verbatim for the
+        // resolver to bind alongside them.
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
 
-        let filter = PrefixFilter {
-            starts_with: Some("acmeCo/".to_string()),
-            r#in: None,
-        };
         let (prefixes, starts_with, r#in) = filtered_authorized_prefixes(
             &rg,
             &ug,
             ALICE,
             Admin,
-            Some(filter),
+            Some(PrefixFilter {
+                starts_with: Some("acmeCo/".to_string()),
+                r#in: None,
+            }),
             "filter.catalogPrefix",
         )
         .unwrap();
-        assert_eq!(prefixes, vec!["acmeCo/"]);
+        assert_eq!(prefixes, vec!["acmeCo/", "beta/"]);
         assert_eq!(starts_with.as_deref(), Some("acmeCo/"));
         assert_eq!(r#in, None);
-    }
 
-    #[test]
-    fn filtered_in_narrows_to_exact_set_and_returns_part() {
-        // `authorized_prefixes` runs with no subtree filter (startsWith is None
-        // when `in` is set), so both grants come back; `narrow_to_exact_set`
-        // then drops everything not overlapping the `in` set.
-        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
-
-        let filter = PrefixFilter {
-            starts_with: None,
-            r#in: Some(vec!["acmeCo/".to_string()]),
-        };
         let (prefixes, starts_with, r#in) = filtered_authorized_prefixes(
             &rg,
             &ug,
             ALICE,
             Admin,
-            Some(filter),
+            Some(PrefixFilter {
+                starts_with: None,
+                r#in: Some(vec!["acmeCo/".to_string()]),
+            }),
             "filter.catalogPrefix",
         )
         .unwrap();
-        assert_eq!(prefixes, vec!["acmeCo/"]);
+        assert_eq!(prefixes, vec!["acmeCo/", "beta/"]);
         assert_eq!(starts_with, None);
         assert_eq!(r#in, Some(vec!["acmeCo/".to_string()]));
     }

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -1,34 +1,36 @@
-/// Returns catalog prefixes where the authenticated user has at least
-/// `min_capability`, optionally narrowed to those overlapping `prefix_filter`.
+/// Returns catalog prefixes where the authenticated user holds all
+/// `required_capabilities`.
 ///
 /// Intended for use by GraphQL queries that list resources scoped to the
-/// caller's authorized prefixes, with an optional prefix filter.
-///
-/// When `prefix_filter` is provided, a prefix is included if the filter is a
-/// sub-prefix of the grant OR the grant is a sub-prefix of the filter. This
-/// bidirectional check lets callers query with a filter that is either broader
-/// or narrower than their grants.
+/// caller's authorized prefixes. User-supplied filters are applied as
+/// narrowing post-passes over this set (see `filtered_authorized_prefixes`),
+/// never here: this function answers only the authorization question.
 pub(super) fn authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
     user_id: uuid::Uuid,
-    min_capability: impl Into<models::authz::CapabilitySet>,
-    prefix_filter: Option<&str>,
+    required_capabilities: impl Into<models::authz::CapabilitySet>,
 ) -> Vec<String> {
-    let min_bits: models::authz::CapabilitySet = min_capability.into();
+    let required_bits: models::authz::CapabilitySet = required_capabilities.into();
 
     // BTreeMap iteration from reachable_prefixes is already prefix-sorted,
     // so the parent-prune step below can run directly on it.
     let prefixes = tables::UserGrant::reachable_prefixes(role_grants, user_grants, user_id)
         .into_iter()
-        .filter(|(prefix, _)| {
-            prefix_filter.is_none_or(|pf| prefix.starts_with(pf) || pf.starts_with(*prefix))
-        })
-        .filter(|(_, (bits, _))| bits.is_superset(min_bits))
+        .filter(|(_, (bits, _))| bits.is_superset(required_bits))
         .map(|(prefix, _)| prefix.to_string());
 
+    prune_covered(prefixes)
+}
+
+/// Drops prefixes already covered by a shorter prefix in the same set, so
+/// `["acmeCo/", "acmeCo/data/"]` collapses to `["acmeCo/"]`.
+///
+/// Input must be sorted, which puts a covering parent immediately before the
+/// run of children it covers.
+fn prune_covered(sorted: impl IntoIterator<Item = String>) -> Vec<String> {
     let mut pruned: Vec<String> = Vec::new();
-    for p in prefixes {
+    for p in sorted {
         if pruned
             .last()
             .is_none_or(|parent| !p.starts_with(parent.as_str()))
@@ -36,24 +38,24 @@ pub(super) fn authorized_prefixes(
             pruned.push(p);
         }
     }
-
     pruned
 }
 
-/// Resolves the caller's prefixes for `min_capability`, narrowed by an optional
-/// `PrefixFilter`, and returns them with the filter's decomposed
+/// Resolves the caller's prefixes for `required_capabilities`, narrowed by an
+/// optional `PrefixFilter`, and returns them with the filter's decomposed
 /// `startsWith`/`in` parts (which callers bind into their own SQL). `field`
 /// names the GraphQL input field for the mutual-exclusion error.
 ///
-/// This chains the three steps every prefix-scoped list query repeats —
-/// `PrefixFilter::into_parts`, `authorized_prefixes`, and
-/// `PrefixFilter::narrow_to_exact_set` — so the narrow-only invariant (a filter
-/// can only remove authorized prefixes, never add them) has a single owner.
+/// This chains the steps every prefix-scoped list query repeats —
+/// `PrefixFilter::into_parts`, `authorized_prefixes`, and the filter's
+/// narrowing post-passes (`narrow_to_overlap` / `narrow_to_exact_set`) — so
+/// the narrow-only invariant (a filter can only remove authorized prefixes,
+/// never add them) has a single owner.
 pub(super) fn filtered_authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
     user_id: uuid::Uuid,
-    min_capability: impl Into<models::authz::CapabilitySet>,
+    required_capabilities: impl Into<models::authz::CapabilitySet>,
     filter: Option<super::filters::PrefixFilter>,
     field: &str,
 ) -> async_graphql::Result<(Vec<String>, Option<String>, Option<Vec<String>>)> {
@@ -61,13 +63,11 @@ pub(super) fn filtered_authorized_prefixes(
         Some(cp) => cp.into_parts(field)?,
         None => (None, None),
     };
-    let mut prefixes = authorized_prefixes(
-        role_grants,
-        user_grants,
-        user_id,
-        min_capability,
-        starts_with.as_deref(),
-    );
+    let mut prefixes =
+        authorized_prefixes(role_grants, user_grants, user_id, required_capabilities);
+    if let Some(sw) = starts_with.as_deref() {
+        super::filters::PrefixFilter::narrow_to_overlap(&mut prefixes, sw);
+    }
     if let Some(exact) = r#in.as_deref() {
         super::filters::PrefixFilter::narrow_to_exact_set(&mut prefixes, exact);
     }
@@ -106,7 +106,7 @@ mod tests {
     const ALICE: uuid::Uuid = uuid::Uuid::from_bytes([0x11; 16]);
 
     #[test]
-    fn no_filter_returns_all_at_or_above_capability() {
+    fn returns_all_at_or_above_capability() {
         let (ug, rg) = make_grants(
             &[
                 (ALICE, "acmeCo/", Admin),
@@ -116,49 +116,21 @@ mod tests {
             &[],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Admin);
         assert_eq!(result, vec!["acmeCo/"]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Write);
         assert_eq!(result, vec!["acmeCo/", "widgets/"]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Read, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Read);
         assert_eq!(result, vec!["acmeCo/", "readonly/", "widgets/"]);
-    }
-
-    #[test]
-    fn filter_narrower_than_grant() {
-        // Grant is on "acmeCo/", filter is "acmeCo/data/" — the grant covers
-        // the filter, so "acmeCo/" is included.
-        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin)], &[]);
-
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/data/"));
-        assert_eq!(result, vec!["acmeCo/"]);
-    }
-
-    #[test]
-    fn filter_broader_than_grant() {
-        // Grant is on "acmeCo/data/", filter is "acmeCo/" — the grant starts
-        // with the filter, so "acmeCo/data/" is included.
-        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/data/", Admin)], &[]);
-
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/"));
-        assert_eq!(result, vec!["acmeCo/data/"]);
-    }
-
-    #[test]
-    fn filter_excludes_non_overlapping() {
-        let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "other/", Admin)], &[]);
-
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/"));
-        assert_eq!(result, vec!["acmeCo/"]);
     }
 
     #[test]
     fn no_grants_returns_empty() {
         let (ug, rg) = make_grants(&[], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Admin);
         assert!(result.is_empty());
     }
 
@@ -170,11 +142,11 @@ mod tests {
             &[("acmeCo/", "shared/", Write)],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Write);
         assert_eq!(result, vec!["acmeCo/", "shared/"]);
 
         // Admin threshold excludes the transitive Write grant.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Admin);
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -187,7 +159,7 @@ mod tests {
             &[],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Admin);
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -200,7 +172,7 @@ mod tests {
             &[("acmeCo/", "acmeCo/team/", Write)],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Write);
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -209,7 +181,7 @@ mod tests {
         let bob = uuid::Uuid::from_bytes([0x22; 16]);
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin)], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, bob, Read, None);
+        let result = authorized_prefixes(&rg, &ug, bob, Read);
         assert!(result.is_empty());
     }
 
@@ -308,11 +280,11 @@ mod tests {
         // child of the qualifying parent. If the union were across
         // ancestors, acmeCo/data/ would qualify on its own (Writer +
         // inherited Admin bits) — it does not.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Admin);
         assert_eq!(result, vec!["acmeCo/"]);
 
         // min=Write: both qualify on their own bits; parent prunes child.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(&rg, &ug, ALICE, Write);
         assert_eq!(result, vec!["acmeCo/"]);
     }
 

--- a/crates/control-plane-api/src/server/public/graphql/filters.rs
+++ b/crates/control-plane-api/src/server/public/graphql/filters.rs
@@ -20,8 +20,7 @@ pub struct PrefixFilter {
     /// between 1 and 100 entries: an empty `in` is rejected during input
     /// validation rather than silently matching nothing (or everything), and
     /// the upper bound keeps this caller-controlled set from driving unbounded
-    /// work — every entry is narrowed against the caller's authorized prefixes
-    /// in memory and bound into a SQL `= ANY(...)` on each request.
+    /// work — every entry is bound into a SQL `= ANY(...)` on each request.
     /// `startsWith` and `in` are mutually exclusive: a resolver rejects a
     /// filter that sets both, so a prefix scope is always either a subtree
     /// (`startsWith`) or an exact set (`in`), never a mix.
@@ -44,34 +43,6 @@ impl PrefixFilter {
             )));
         }
         Ok((self.starts_with, self.r#in))
-    }
-
-    /// Narrows a caller's `authorized` prefixes to those that overlap the
-    /// `startsWith` filter, so a `MAX_PREFIXES` guard stays meaningful for
-    /// callers who can access many prefixes. The overlap is bidirectional (the
-    /// filter may be an ancestor or a descendant of an authorized prefix) and
-    /// deliberately approximate: it can only remove entries, never add them,
-    /// so it cannot widen visibility. Exact subtree scoping is still enforced
-    /// by the resolver's SQL (`^@ $startsWith`) against these authorized
-    /// prefixes.
-    pub fn narrow_to_overlap(authorized: &mut Vec<String>, starts_with: &str) {
-        authorized.retain(|a| a.starts_with(starts_with) || starts_with.starts_with(a.as_str()));
-    }
-
-    /// Narrows a caller's `authorized` prefixes to those that overlap the exact
-    /// `in` set, so a `MAX_PREFIXES` guard stays meaningful for callers who can
-    /// access many prefixes. The overlap is bidirectional (an `in` entry may be
-    /// an ancestor or a descendant of an authorized prefix) and deliberately
-    /// approximate: it can only remove entries, never add them, so it cannot
-    /// widen visibility. Exact membership is still enforced by the resolver's
-    /// SQL (`= ANY($in)`) against these authorized prefixes.
-    pub fn narrow_to_exact_set<S: AsRef<str>>(authorized: &mut Vec<String>, exact: &[S]) {
-        authorized.retain(|a| {
-            exact.iter().any(|e| {
-                let e = e.as_ref();
-                e.starts_with(a.as_str()) || a.as_str().starts_with(e)
-            })
-        });
     }
 }
 
@@ -121,70 +92,5 @@ mod test {
             err.message,
             "`filter.catalogPrefix.startsWith` and `.in` are mutually exclusive; provide only one"
         );
-    }
-
-    #[test]
-    fn narrow_to_overlap_retains_only_overlapping_prefixes() {
-        // Overlap is bidirectional: the filter keeps an authorized prefix that
-        // it equals, descends from, or is an ancestor of. Retained entries
-        // keep their original order.
-        let cases: &[(&[&str], &str, &[&str])] = &[
-            // Equal.
-            (&["acmeCo/"], "acmeCo/", &["acmeCo/"]),
-            // Filter descends from the authorized prefix: the grant covers the
-            // filter, so the prefix stays (SQL narrows rows to the subtree).
-            (&["acmeCo/"], "acmeCo/data/", &["acmeCo/"]),
-            // Filter is an ancestor of the authorized prefix.
-            (&["acmeCo/data/"], "acmeCo/", &["acmeCo/data/"]),
-            // Disjoint.
-            (&["acmeCo/"], "betaCo/", &[]),
-            // Mixed: only overlapping authorized prefixes survive.
-            (
-                &["acmeCo/", "acmeCo/team/", "betaCo/"],
-                "acmeCo/",
-                &["acmeCo/", "acmeCo/team/"],
-            ),
-        ];
-        for &(authorized, starts_with, expected) in cases {
-            let mut got: Vec<String> = authorized.iter().map(|s| s.to_string()).collect();
-            PrefixFilter::narrow_to_overlap(&mut got, starts_with);
-            let want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-            assert_eq!(
-                got, want,
-                "authorized={authorized:?} starts_with={starts_with}"
-            );
-        }
-    }
-
-    #[test]
-    fn narrow_to_exact_set_retains_only_overlapping_prefixes() {
-        // Overlap is bidirectional: an exact entry keeps an authorized prefix
-        // when it equals, descends from, or is an ancestor of it. Disjoint
-        // entries drop it, and an empty exact set drops everything. Retained
-        // entries keep their original order.
-        let cases: &[(&[&str], &[&str], &[&str])] = &[
-            // Equal.
-            (&["acmeCo/"], &["acmeCo/"], &["acmeCo/"]),
-            // Exact entry descends from the authorized prefix.
-            (&["acmeCo/"], &["acmeCo/team/"], &["acmeCo/"]),
-            // Exact entry is an ancestor of the authorized prefix.
-            (&["acmeCo/team/"], &["acmeCo/"], &["acmeCo/team/"]),
-            // Disjoint.
-            (&["acmeCo/"], &["betaCo/"], &[]),
-            // Mixed: only overlapping authorized prefixes survive.
-            (
-                &["acmeCo/", "acmeCo/team/", "betaCo/"],
-                &["acmeCo/", "ghostCo/"],
-                &["acmeCo/", "acmeCo/team/"],
-            ),
-            // Empty exact set overlaps nothing.
-            (&["acmeCo/"], &[], &[]),
-        ];
-        for &(authorized, exact, expected) in cases {
-            let mut got: Vec<String> = authorized.iter().map(|s| s.to_string()).collect();
-            PrefixFilter::narrow_to_exact_set(&mut got, exact);
-            let want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-            assert_eq!(got, want, "authorized={authorized:?} exact={exact:?}");
-        }
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/filters.rs
+++ b/crates/control-plane-api/src/server/public/graphql/filters.rs
@@ -46,6 +46,18 @@ impl PrefixFilter {
         Ok((self.starts_with, self.r#in))
     }
 
+    /// Narrows a caller's `authorized` prefixes to those that overlap the
+    /// `startsWith` filter, so a `MAX_PREFIXES` guard stays meaningful for
+    /// callers who can access many prefixes. The overlap is bidirectional (the
+    /// filter may be an ancestor or a descendant of an authorized prefix) and
+    /// deliberately approximate: it can only remove entries, never add them,
+    /// so it cannot widen visibility. Exact subtree scoping is still enforced
+    /// by the resolver's SQL (`^@ $startsWith`) against these authorized
+    /// prefixes.
+    pub fn narrow_to_overlap(authorized: &mut Vec<String>, starts_with: &str) {
+        authorized.retain(|a| a.starts_with(starts_with) || starts_with.starts_with(a.as_str()));
+    }
+
     /// Narrows a caller's `authorized` prefixes to those that overlap the exact
     /// `in` set, so a `MAX_PREFIXES` guard stays meaningful for callers who can
     /// access many prefixes. The overlap is bidirectional (an `in` entry may be
@@ -109,6 +121,39 @@ mod test {
             err.message,
             "`filter.catalogPrefix.startsWith` and `.in` are mutually exclusive; provide only one"
         );
+    }
+
+    #[test]
+    fn narrow_to_overlap_retains_only_overlapping_prefixes() {
+        // Overlap is bidirectional: the filter keeps an authorized prefix that
+        // it equals, descends from, or is an ancestor of. Retained entries
+        // keep their original order.
+        let cases: &[(&[&str], &str, &[&str])] = &[
+            // Equal.
+            (&["acmeCo/"], "acmeCo/", &["acmeCo/"]),
+            // Filter descends from the authorized prefix: the grant covers the
+            // filter, so the prefix stays (SQL narrows rows to the subtree).
+            (&["acmeCo/"], "acmeCo/data/", &["acmeCo/"]),
+            // Filter is an ancestor of the authorized prefix.
+            (&["acmeCo/data/"], "acmeCo/", &["acmeCo/data/"]),
+            // Disjoint.
+            (&["acmeCo/"], "betaCo/", &[]),
+            // Mixed: only overlapping authorized prefixes survive.
+            (
+                &["acmeCo/", "acmeCo/team/", "betaCo/"],
+                "acmeCo/",
+                &["acmeCo/", "acmeCo/team/"],
+            ),
+        ];
+        for &(authorized, starts_with, expected) in cases {
+            let mut got: Vec<String> = authorized.iter().map(|s| s.to_string()).collect();
+            PrefixFilter::narrow_to_overlap(&mut got, starts_with);
+            let want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+            assert_eq!(
+                got, want,
+                "authorized={authorized:?} starts_with={starts_with}"
+            );
+        }
     }
 
     #[test]

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -1,4 +1,4 @@
-use super::{TimestampCursor, filters};
+use super::{TimestampCursor, authorized_prefixes::MAX_PREFIXES, filters};
 use async_graphql::{Context, types::connection};
 
 /// An invite link that grants access to a catalog prefix.
@@ -54,7 +54,6 @@ pub struct InviteLinksFilter {
 pub struct InviteLinksQuery;
 
 const DEFAULT_PAGE_SIZE: usize = 25;
-const MAX_PREFIXES: usize = 20;
 
 #[async_graphql::Object]
 impl InviteLinksQuery {
@@ -91,9 +90,9 @@ impl InviteLinksQuery {
             return Ok(PaginatedInviteLinks::new(false, false));
         }
         if admin_prefixes.len() > MAX_PREFIXES {
-            return Err(async_graphql::Error::new(
-                "Too many admin prefixes; narrow results with a prefix filter",
-            ));
+            return Err(async_graphql::Error::new(format!(
+                "Too many admin prefixes to list; this query supports at most {MAX_PREFIXES}"
+            )));
         }
 
         connection::query_with::<TimestampCursor, _, _, _, async_graphql::Error>(

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -1,4 +1,4 @@
-use super::{Sensitive, TimestampCursor};
+use super::{Sensitive, TimestampCursor, authorized_prefixes::MAX_PREFIXES};
 use async_graphql::{Context, types::connection};
 
 #[derive(Debug, Clone, async_graphql::SimpleObject)]
@@ -72,7 +72,6 @@ pub type PaginatedServiceAccounts = connection::Connection<
 pub struct ServiceAccountsQuery;
 
 const DEFAULT_PAGE_SIZE: usize = 25;
-const MAX_PREFIXES: usize = 20;
 
 #[async_graphql::Object]
 impl ServiceAccountsQuery {
@@ -98,7 +97,9 @@ impl ServiceAccountsQuery {
             return Ok(PaginatedServiceAccounts::new(false, false));
         }
         if user_accessible_prefixes.len() > MAX_PREFIXES {
-            return Err(async_graphql::Error::new("Too many accessible prefixes"));
+            return Err(async_graphql::Error::new(format!(
+                "Too many accessible prefixes to list; this query supports at most {MAX_PREFIXES}"
+            )));
         }
 
         connection::query_with::<TimestampCursor, _, _, _, async_graphql::Error>(

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -92,7 +92,6 @@ impl ServiceAccountsQuery {
             &snapshot.user_grants,
             env.claims()?.sub,
             models::authz::Capability::QueryServiceAccounts,
-            None,
         );
 
         if user_accessible_prefixes.is_empty() {

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -1,4 +1,4 @@
-use super::filters;
+use super::{authorized_prefixes::MAX_PREFIXES, filters};
 use crate::directives::storage_mappings::{
     collection_and_recovery_spec_from, insert_storage_mapping, strip_collection_data_suffix,
     update_storage_mapping, upsert_storage_mapping,
@@ -656,8 +656,6 @@ pub type PaginatedStorageMappings = Connection<
 #[derive(Debug, Default)]
 pub struct StorageMappingsQuery;
 
-const MAX_PREFIXES: usize = 20;
-
 #[async_graphql::Object]
 impl StorageMappingsQuery {
     /// Returns storage mappings accessible to the current user.
@@ -719,9 +717,9 @@ impl StorageMappingsQuery {
             return Ok(PaginatedStorageMappings::new(false, false));
         }
         if read_prefixes.len() > MAX_PREFIXES {
-            return Err(async_graphql::Error::new(
-                "Too many accessible prefixes; narrow results with a filter",
-            ));
+            return Err(async_graphql::Error::new(format!(
+                "Too many accessible prefixes to list; this query supports at most {MAX_PREFIXES}"
+            )));
         }
 
         let (rows, has_prev, has_next) =
@@ -1210,8 +1208,7 @@ mod test {
 
         // A cross-tenant `in` entry is dropped rather than widening scope; an
         // unknown prefix simply matches nothing. This also confirms several
-        // `in` entries return every authorized exact match (`filters::test`
-        // covers the multi-entry narrowing logic directly).
+        // `in` entries return every authorized exact match.
         let exact_cross_tenant = prefixes(
             &server,
             &alice_token,

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -1540,8 +1540,7 @@ input PrefixFilter {
 	between 1 and 100 entries: an empty `in` is rejected during input
 	validation rather than silently matching nothing (or everything), and
 	the upper bound keeps this caller-controlled set from driving unbounded
-	work — every entry is narrowed against the caller's authorized prefixes
-	in memory and bound into a SQL `= ANY(...)` on each request.
+	work — every entry is bound into a SQL `= ANY(...)` on each request.
 	`startsWith` and `in` are mutually exclusive: a resolver rejects a
 	filter that sets both, so a prefix scope is always either a subtree
 	(`startsWith`) or an exact set (`in`), never a mix.

--- a/crates/tables/src/behaviors.rs
+++ b/crates/tables/src/behaviors.rs
@@ -160,6 +160,13 @@ impl super::UserGrant {
             (authz::CapabilitySet, models::Capability),
         > = Default::default();
         for node in Self::reachable_nodes(role_grants, user_grants, user_id) {
+            // A role edge can be visited yet confer no authority when its
+            // capabilities are fully removed by delegation attenuation. Such
+            // a destination is not reachable by the user in the authorization
+            // sense and must not appear in the returned prefix closure.
+            if node.capabilities.is_empty() {
+                continue;
+            }
             let entry = out
                 .entry(node.object_role)
                 .or_insert((authz::CapabilitySet::empty(), models::Capability::None));
@@ -782,6 +789,23 @@ mod test {
                 ),
                 ("daveCo/sink/", CapabilityBundle::Viewer.capabilities()),
             ],
+        );
+    }
+
+    #[test]
+    fn test_reachable_prefixes_omits_fully_attenuated_destinations() {
+        let (role_grants, user_grants, user_id) = build_scenario(
+            vec![("sourceCo/", vec![CapabilityBundle::Editor])],
+            vec![("sourceCo/", "hiddenCo/", vec![CapabilityBundle::TeamAdmin])],
+        );
+
+        // Editor carries Delegate, so the role edge is considered. Editor and
+        // TeamAdmin share no capability bits, though, so nothing survives the
+        // path to hiddenCo/ and it is not reachable by the user.
+        let reachable = UserGrant::reachable_prefixes(&role_grants, &user_grants, user_id);
+        assert_eq!(
+            reachable.keys().copied().collect::<Vec<_>>(),
+            vec!["sourceCo/"]
         );
     }
 


### PR DESCRIPTION
Prefix-scoped GraphQL list queries resolved the caller's authorized prefixes and applied the caller's `PrefixFilter` in the same pass, so the set handed to SQL was partly a function of caller input. This separates the two.

### Authorization from grants alone

`authorized_prefixes` now answers only the authorization question. It takes `required_capabilities` — a `CapabilitySet` whose bits must all be held, replacing the ordered `min_capability` threshold — and no longer accepts a prefix filter. Parent-pruning is extracted as `prune_covered`.

`filtered_authorized_prefixes` returns the grant-derived set alongside the filter's decomposed `startsWith`/`in` parts. The two stay separate all the way into SQL, where each resolver ANDs an unconditional `^@ ANY($authorized)` scope check against the filter's own clause. A bug in filter handling can therefore only return too few rows, never widen visibility. `PrefixFilter::narrow_to_overlap` and `narrow_to_exact_set` are removed.

### One shared prefix cap

The four per-resolver `MAX_PREFIXES` constants (`alert_configs`, `invite_links`, `service_accounts`, `storage_mappings`) collapse into a single `MAX_PREFIXES: usize = 100` in `authorized_prefixes`. The bound exists because the authorized set is bound into SQL as a `text[]`, and 100 matches the ceiling already enforced on `in`.

Without an in-memory narrowing pass, the cap applies to the grant-derived set whether or not a filter is present, so the alert-configs regression test now asserts that a caller over the cap is refused both with and without a filter. Error messages name the limit.

### Fully attenuated prefixes

`UserGrant::reachable_prefixes` recorded every reachable node, including ones where delegation attenuation removed all capability bits along the path. Those destinations landed in the prefix closure with an empty capability set. They are now omitted, with a regression test covering an Editor grant that delegates across a TeamAdmin role edge — Editor carries Delegate so the edge is walked, but the two bundles share no bits, so nothing survives the path.

Base of #3292.
