### PR TITLE
graphql: add capability, tenant, and prefix filters to the prefixes query

### DIFF
--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -1,3 +1,9 @@
+/// Each prefix a user reaches, mapped to the union of capability bits granted
+/// there and the legacy `capability` column value: the output of
+/// `tables::UserGrant::reachable_prefixes`.
+pub(super) type ReachablePrefixMap<'a> =
+    std::collections::BTreeMap<&'a str, (models::authz::CapabilitySet, models::Capability)>;
+
 /// Returns catalog prefixes where the authenticated user holds all
 /// `required_capabilities`.
 ///
@@ -11,12 +17,29 @@ pub(super) fn authorized_prefixes(
     user_id: uuid::Uuid,
     required_capabilities: impl Into<models::authz::CapabilitySet>,
 ) -> Vec<String> {
+    authorized_from_reachable(
+        &tables::UserGrant::reachable_prefixes(role_grants, user_grants, user_id),
+        required_capabilities,
+    )
+}
+
+/// Reduces an already-walked `reachable` map to the prefixes holding all
+/// `required_capabilities`, pruned of children covered by a qualifying parent.
+///
+/// `authorized_prefixes` is this composed with the grant-graph walk. A caller
+/// that already holds the map — because it lists the prefixes themselves rather
+/// than SQL rows scoped by them — uses this instead, so the walk runs once per
+/// request rather than once per consumer.
+pub(super) fn authorized_from_reachable(
+    reachable: &ReachablePrefixMap<'_>,
+    required_capabilities: impl Into<models::authz::CapabilitySet>,
+) -> Vec<String> {
     let required_bits: models::authz::CapabilitySet = required_capabilities.into();
 
-    // BTreeMap iteration from reachable_prefixes is already prefix-sorted,
-    // so the parent-prune step below can run directly on it.
-    let prefixes = tables::UserGrant::reachable_prefixes(role_grants, user_grants, user_id)
-        .into_iter()
+    // BTreeMap iteration is already prefix-sorted, so the parent-prune step
+    // below can run directly on it.
+    let prefixes = reachable
+        .iter()
         .filter(|(_, (bits, _))| bits.is_superset(required_bits))
         .map(|(prefix, _)| prefix.to_string());
 

--- a/crates/control-plane-api/src/server/public/graphql/prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/prefixes.rs
@@ -25,6 +25,49 @@ pub struct PrefixesBy {
     pub min_capability: models::Capability,
 }
 
+/// Composable filter for the `prefixes` query. Every field is optional and only
+/// narrows the result set; the caller's reach is resolved independently, so a
+/// filter can never widen what they see.
+#[derive(Debug, Clone, Default, async_graphql::InputObject)]
+pub struct PrefixesFilter {
+    /// Keep only prefixes where the caller holds *every* listed capability.
+    /// Bits are conjunctive, so `[CatalogRead, SpecEdit]` answers "where may I
+    /// both read and publish", not "where may I do either". Omit the field to
+    /// list every reachable prefix whatever the caller holds there; an empty
+    /// list is rejected during input validation rather than silently matching
+    /// nothing.
+    ///
+    /// This replaces the deprecated `by.minCapability`, which selects a point on
+    /// the legacy read/write/admin ladder rather than naming bits. The two are
+    /// alternative spellings of one constraint and are mutually exclusive;
+    /// `by` does compose with this filter's other fields, which scope by
+    /// namespace rather than capability.
+    ///
+    /// These capabilities also arm `tenant`: when both are given, a prefix must
+    /// be one the caller holds them all at *and* one the tenant reaches with
+    /// them all.
+    #[graphql(validator(min_items = 1))]
+    pub with_capabilities: Option<Vec<models::authz::Capability>>,
+    /// Keep only prefixes that this tenant reaches through the role-grant
+    /// graph — the tenant's own namespace, plus any namespace a qualifying
+    /// chain of role grants projects it into. A chain qualifies when it carries
+    /// every required capability, so with no capability filter at all any
+    /// delegatable chain qualifies.
+    ///
+    /// The walk starts from the caller's own footholds within the tenant, and
+    /// the reachable set is intersected with the caller's authorized prefixes.
+    /// The filter therefore narrows a listing to one organization's namespace,
+    /// never surfaces a prefix the caller could not already see, and shows only
+    /// reach flowing from namespace the caller occupies. Naming a tenant
+    /// requires at least one foothold within (or covering) its namespace,
+    /// holding the required capabilities there.
+    pub tenant: Option<models::Prefix>,
+    /// Narrow to a subtree or an exact set of prefixes. The match is against
+    /// the returned prefix itself, so `startsWith: "acmeCo/"` keeps `acmeCo/`
+    /// and its descendants, and `in` keeps only exact members of the set.
+    pub prefix: Option<super::filters::PrefixFilter>,
+}
+
 pub type PaginatedPrefixes = connection::Connection<
     String,
     PrefixRef,
@@ -40,26 +83,89 @@ pub struct PrefixesQuery;
 
 #[async_graphql::Object]
 impl PrefixesQuery {
+    /// Every prefix the caller reaches through the grant graph, with the
+    /// capability bits they hold at each.
+    ///
+    /// Unfiltered, this is the caller's whole access surface: a prefix is listed
+    /// whatever the caller holds there, and each entry's `capabilities` carry
+    /// the bits a client gates features on. `filter.withCapabilities` inverts
+    /// that read, answering "which prefixes may I do X at" instead.
+    ///
+    /// Ordered lexically, which walks the prefix tree depth-first: a parent
+    /// immediately precedes its own descendants. The cursor is the prefix
+    /// itself.
     pub async fn prefixes(
         &self,
         ctx: &Context<'_>,
-        by: PrefixesBy,
+        #[graphql(
+            deprecation = "Prefer `filter: { withCapabilities }`, which names capability bits \
+                                 directly instead of a point on the legacy read/write/admin \
+                                 ladder. `by` is retained only for existing clients and is \
+                                 mutually exclusive with it."
+        )]
+        by: Option<PrefixesBy>,
+        filter: Option<PrefixesFilter>,
         after: Option<String>,
         first: Option<i32>,
     ) -> async_graphql::Result<PaginatedPrefixes> {
         let env = ctx.data::<crate::Envelope>()?;
 
+        let filter = filter.unwrap_or_default();
+        // `filter` is the going-forward replacement for `by`. Both name the same
+        // capability constraint — `by.minCapability` as a point on the legacy
+        // read/write/admin ladder, `filter.withCapabilities` as bits — so they
+        // are alternative spellings and mutually exclusive. `by` composes freely
+        // with the filter's other fields, which scope by namespace rather than
+        // capability.
+        //
+        // With neither supplied the required set is empty, which every
+        // capability set is a superset of, so the same `is_superset` test that
+        // narrows a filtered query admits everything for an unfiltered one.
+        let required: models::authz::CapabilitySet = match (by, filter.with_capabilities) {
+            (Some(_), Some(_)) => {
+                return Err(
+                    "provide either `by` or `filter.withCapabilities`, not both; `by` is deprecated"
+                        .into(),
+                );
+            }
+            (Some(by), None) => by.min_capability.into(),
+            (None, Some(bits)) => bits.into_iter().collect(),
+            (None, None) => models::authz::CapabilitySet::empty(),
+        };
+
+        let tenant = match filter.tenant {
+            Some(tenant) => Some(super::tenant::validate_tenant_name(tenant.as_str())?),
+            None => None,
+        };
+        let (starts_with, r#in) = match filter.prefix {
+            Some(prefix) => prefix.into_parts("filter.prefix")?,
+            None => (None, None),
+        };
+
         connection::query(after, None, first, None, |after, _, first, _| async move {
             let snapshot = env.snapshot();
             let user_id = env.claims()?.sub;
 
-            let min_bits: models::authz::CapabilitySet = by.min_capability.into();
-
+            // The single grant-graph walk this request performs. Both the
+            // listing and the tenant scope are derived from it, and it is pure
+            // in-memory work over the authorization Snapshot — this resolver
+            // never touches the database.
             let reachable = tables::UserGrant::reachable_prefixes(
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 user_id,
             );
+
+            let tenant_scope = match &tenant {
+                Some(tenant) => Some(tenant_scope(
+                    &snapshot.role_grants,
+                    &reachable,
+                    tenant.as_str(),
+                    required,
+                )?),
+                None => None,
+            };
+
             // Cursor pagination: BTreeMap::range jumps directly to the
             // first key strictly greater than the previous page's last
             // prefix, rather than iterating from the start and filtering
@@ -69,7 +175,18 @@ impl PrefixesQuery {
                 .map_or(std::ops::Bound::Unbounded, std::ops::Bound::Excluded);
             let all_roles: Vec<PrefixRef> = reachable
                 .range::<str, _>((start, std::ops::Bound::Unbounded))
-                .filter(|(_, (bits, _))| bits.is_superset(min_bits))
+                .filter(|(prefix, (bits, _))| {
+                    bits.is_superset(required)
+                        && tenant_scope.as_ref().is_none_or(|scope| {
+                            scope.iter().any(|s| prefix.starts_with(s.as_str()))
+                        })
+                        && starts_with
+                            .as_deref()
+                            .is_none_or(|sw| prefix.starts_with(sw))
+                        && r#in
+                            .as_deref()
+                            .is_none_or(|exact| exact.iter().any(|e| e.as_str() == **prefix))
+                })
                 .map(|(prefix, (bits, legacy))| PrefixRef {
                     prefix: models::Prefix::new(*prefix),
                     user_capability: *legacy,
@@ -95,6 +212,46 @@ impl PrefixesQuery {
         })
         .await
     }
+}
+
+/// Resolves the prefix scope that `filter.tenant` narrows to: the prefixes the
+/// tenant reaches with `required`, intersected with the caller's own authorized
+/// prefixes so the filter can only ever remove entries. An empty `required`
+/// admits any chain the graph can delegate along.
+///
+/// The walk starts from the caller's footholds within the tenant — their
+/// authorized prefixes clamped into its subtree — so the caller witnesses only
+/// reach flowing from namespace they occupy. Naming a tenant requires at least
+/// one foothold. A tenant's reachable set is derived from `role_grants`, which
+/// are not otherwise readable here: without that gate, filtering by a tenant the
+/// caller knows nothing about and observing whether prefixes come back in some
+/// *other* namespace would reveal that a role grant connects the two. The check
+/// is a function of the caller's own grants and the tenant string alone, so the
+/// denial itself reveals nothing about the tenant — including whether it exists.
+fn tenant_scope(
+    role_grants: &tables::RoleGrants,
+    reachable: &super::authorized_prefixes::ReachablePrefixMap<'_>,
+    tenant: &str,
+    required: models::authz::CapabilitySet,
+) -> async_graphql::Result<Vec<String>> {
+    let caller = super::authorized_prefixes::authorized_from_reachable(reachable, required);
+
+    let seeds = super::authorized_prefixes::intersect_prefixes(&caller, &[tenant.to_string()]);
+    if seeds.is_empty() {
+        return Err(async_graphql::Error::new(format!(
+            "not authorized to filter by tenant '{tenant}'"
+        )));
+    }
+
+    // The walk starts from the footholds rather than the tenant root, so the
+    // caller witnesses only reach flowing from namespace they occupy: edges
+    // granted to sibling branches of their footholds contribute nothing.
+    let reached =
+        super::authorized_prefixes::tenant_reachable_prefixes(role_grants, &seeds, required);
+
+    Ok(super::authorized_prefixes::intersect_prefixes(
+        &caller, &reached,
+    ))
 }
 
 #[cfg(test)]
@@ -207,5 +364,223 @@ mod tests {
           ]
         }
         "#);
+    }
+
+    /// Runs `query` as alice and returns the JSON response.
+    async fn run(server: &test_server::TestServer, query: &str) -> serde_json::Value {
+        let token = server.make_access_token(uuid::Uuid::from_bytes([0x11; 16]), None);
+        server
+            .graphql(&serde_json::json!({ "query": query }), Some(&token))
+            .await
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_graphql_prefixes_filters(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        // The alice fixture grants admin on aliceCo/, plus role grants reaching
+        // aliceCo/data/ and ops/dp/public/. zebraCo/ adds a second root, which
+        // sorts last under the lexical ordering this query preserves.
+        sqlx::query(
+            "INSERT INTO public.user_grants (user_id, object_role, capability)
+             VALUES ($1, 'zebraCo/', 'admin')",
+        )
+        .bind(uuid::Uuid::from_bytes([0x11; 16]))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let server =
+            test_server::TestServer::start(pool.clone(), test_server::snapshot(pool, false).await)
+                .await;
+
+        // `by` is now optional. Omitting every argument lists the caller's whole
+        // access surface, in lexical order, whatever they hold at each prefix.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes {
+                    edges { cursor node { prefix userCapability capabilities } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `withCapabilities` is conjunctive. Alice admins aliceCo/ and zebraCo/,
+        // so she holds both bits only there; aliceCo/data/ reaches her with
+        // write (no SpecEdit) and ops/dp/public/ with read.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { withCapabilities: [CatalogRead, SpecEdit] }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `by` and `withCapabilities` are alternative spellings of one
+        // constraint, so supplying both is rejected.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(
+                    by: { minCapability: read }
+                    filter: { withCapabilities: [SpecEdit] }
+                ) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // The exclusion is narrow: `by` composes with the filter's other fields,
+        // which scope by namespace rather than capability. `admin` alone admits
+        // the two prefixes she admins, and the aliceCo/ tenant scope excludes
+        // zebraCo/, so a result of just aliceCo/ proves both were applied.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(by: { minCapability: admin }, filter: { tenant: "aliceCo/" }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // A bit no grant carries anywhere yields an empty listing rather than
+        // falling back to the unfiltered set.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { withCapabilities: [Assume] }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `startsWith` drills into one subtree, matching the returned prefix
+        // itself, so the ops/dp/public/ and zebraCo/ roots drop out.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { prefix: { startsWith: "aliceCo/" } }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `in` matches exactly, selecting aliceCo/data/ without its parent.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { prefix: { in: ["aliceCo/data/", "ghostCo/"] } }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `tenant` keeps what aliceCo/ reaches with the required capabilities —
+        // its own namespace plus ops/dp/public/ through the role grant — and
+        // drops zebraCo/, which alice sees but aliceCo/ does not reach.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { tenant: "aliceCo/" }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // The capabilities also arm the tenant walk: the aliceCo/ ->
+        // ops/dp/public/ edge carries only read, so requiring SpecEdit drops it
+        // where the unfiltered tenant query keeps it.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { tenant: "aliceCo/", withCapabilities: [SpecEdit] }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // Naming a tenant alice has no foothold in is denied. The denial turns
+        // only on her own grants, so it reveals nothing about the tenant —
+        // including whether it exists.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { tenant: "ghostCo/" }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // `startsWith` and `in` are mutually exclusive.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { prefix: { startsWith: "aliceCo/", in: ["aliceCo/"] } }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
+
+        // An empty capability list is rejected during input validation.
+        let response = run(
+            &server,
+            r#"
+            query {
+                prefixes(filter: { withCapabilities: [] }) {
+                    edges { node { prefix } }
+                }
+            }
+            "#,
+        )
+        .await;
+        insta::assert_json_snapshot!(response);
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-10.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-10.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 17,
+          "line": 3
+        }
+      ],
+      "message": "not authorized to filter by tenant 'ghostCo/'",
+      "path": [
+        "prefixes"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-11.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-11.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 17,
+          "line": 3
+        }
+      ],
+      "message": "`filter.prefix.startsWith` and `.in` are mutually exclusive; provide only one",
+      "path": [
+        "prefixes"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-12.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-12.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 34,
+          "line": 3
+        }
+      ],
+      "message": "Failed to parse \"[CapabilityBit!]\": the value length is 0, must be greater than or equal to 1 (occurred while parsing \"PrefixesFilter\")",
+      "path": [
+        "prefixes"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-2.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-2.snap
@@ -1,0 +1,22 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/"
+          }
+        },
+        {
+          "node": {
+            "prefix": "zebraCo/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-3.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-3.snap
@@ -1,0 +1,21 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 17,
+          "line": 3
+        }
+      ],
+      "message": "provide either `by` or `filter.withCapabilities`, not both; `by` is deprecated",
+      "path": [
+        "prefixes"
+      ]
+    }
+  ]
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-4.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-4.snap
@@ -1,0 +1,17 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-5.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-5.snap
@@ -1,0 +1,11 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": []
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-6.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-6.snap
@@ -1,0 +1,22 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/"
+          }
+        },
+        {
+          "node": {
+            "prefix": "aliceCo/data/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-7.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-7.snap
@@ -1,0 +1,17 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/data/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-8.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-8.snap
@@ -1,0 +1,27 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/"
+          }
+        },
+        {
+          "node": {
+            "prefix": "aliceCo/data/"
+          }
+        },
+        {
+          "node": {
+            "prefix": "ops/dp/public/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-9.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters-9.snap
@@ -1,0 +1,17 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "node": {
+            "prefix": "aliceCo/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__prefixes__tests__graphql_prefixes_filters.snap
@@ -1,0 +1,87 @@
+---
+source: crates/control-plane-api/src/server/public/graphql/prefixes.rs
+expression: response
+---
+{
+  "data": {
+    "prefixes": {
+      "edges": [
+        {
+          "cursor": "aliceCo/",
+          "node": {
+            "capabilities": [
+              "CatalogRead",
+              "JournalRead",
+              "JournalAppend",
+              "SpecEdit",
+              "CreateGrant",
+              "DeleteGrant",
+              "CreateInviteLink",
+              "ViewDataPlanePrivateNetworking",
+              "ModifyDataPlanePrivateNetworking",
+              "ViewBilling",
+              "EditBilling",
+              "QueryServiceAccounts",
+              "CreateServiceAccount",
+              "CreateApiKey",
+              "RevokeApiKey",
+              "Delegate"
+            ],
+            "prefix": "aliceCo/",
+            "userCapability": "admin"
+          }
+        },
+        {
+          "cursor": "aliceCo/data/",
+          "node": {
+            "capabilities": [
+              "CatalogRead",
+              "JournalRead",
+              "JournalAppend",
+              "ViewDataPlanePrivateNetworking"
+            ],
+            "prefix": "aliceCo/data/",
+            "userCapability": "write"
+          }
+        },
+        {
+          "cursor": "ops/dp/public/",
+          "node": {
+            "capabilities": [
+              "CatalogRead",
+              "JournalRead",
+              "ViewDataPlanePrivateNetworking"
+            ],
+            "prefix": "ops/dp/public/",
+            "userCapability": "read"
+          }
+        },
+        {
+          "cursor": "zebraCo/",
+          "node": {
+            "capabilities": [
+              "CatalogRead",
+              "JournalRead",
+              "JournalAppend",
+              "SpecEdit",
+              "CreateGrant",
+              "DeleteGrant",
+              "CreateInviteLink",
+              "ViewDataPlanePrivateNetworking",
+              "ModifyDataPlanePrivateNetworking",
+              "ViewBilling",
+              "EditBilling",
+              "QueryServiceAccounts",
+              "CreateServiceAccount",
+              "CreateApiKey",
+              "RevokeApiKey",
+              "Delegate"
+            ],
+            "prefix": "zebraCo/",
+            "userCapability": "admin"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -1608,6 +1608,55 @@ input PrefixesBy {
 }
 
 """
+Composable filter for the `prefixes` query. Every field is optional and only
+narrows the result set; the caller's reach is resolved independently, so a
+filter can never widen what they see.
+"""
+input PrefixesFilter {
+	"""
+	Keep only prefixes where the caller holds *every* listed capability.
+	Bits are conjunctive, so `[CatalogRead, SpecEdit]` answers "where may I
+	both read and publish", not "where may I do either". Omit the field to
+	list every reachable prefix whatever the caller holds there; an empty
+	list is rejected during input validation rather than silently matching
+	nothing.
+	
+	This replaces the deprecated `by.minCapability`, which selects a point on
+	the legacy read/write/admin ladder rather than naming bits. The two are
+	alternative spellings of one constraint and are mutually exclusive;
+	`by` does compose with this filter's other fields, which scope by
+	namespace rather than capability.
+	
+	These capabilities also arm `tenant`: when both are given, a prefix must
+	be one the caller holds them all at *and* one the tenant reaches with
+	them all.
+	"""
+	withCapabilities: [CapabilityBit!]
+	"""
+	Keep only prefixes that this tenant reaches through the role-grant
+	graph — the tenant's own namespace, plus any namespace a qualifying
+	chain of role grants projects it into. A chain qualifies when it carries
+	every required capability, so with no capability filter at all any
+	delegatable chain qualifies.
+	
+	The walk starts from the caller's own footholds within the tenant, and
+	the reachable set is intersected with the caller's authorized prefixes.
+	The filter therefore narrows a listing to one organization's namespace,
+	never surfaces a prefix the caller could not already see, and shows only
+	reach flowing from namespace the caller occupies. Naming a tenant
+	requires at least one foothold within (or covering) its namespace,
+	holding the required capabilities there.
+	"""
+	tenant: Prefix
+	"""
+	Narrow to a subtree or an exact set of prefixes. The match is against
+	the returned prefix itself, so `startsWith: "acmeCo/"` keeps `acmeCo/`
+	and its descendants, and `in` keeps only exact members of the set.
+	"""
+	prefix: PrefixFilter
+}
+
+"""
 A configured private link and its controller-observed provisioning status.
 """
 type PrivateLink {
@@ -1834,7 +1883,20 @@ type QueryRoot {
 	Returns all possible alert types with their user-facing metadata.
 	"""
 	alertTypes: [AlertTypeInfo!]!
-	prefixes(by: PrefixesBy!, after: String, first: Int): PrefixRefConnection!
+	"""
+	Every prefix the caller reaches through the grant graph, with the
+	capability bits they hold at each.
+	
+	Unfiltered, this is the caller's whole access surface: a prefix is listed
+	whatever the caller holds there, and each entry's `capabilities` carry
+	the bits a client gates features on. `filter.withCapabilities` inverts
+	that read, answering "which prefixes may I do X at" instead.
+	
+	Ordered lexically, which walks the prefix tree depth-first: a parent
+	immediately precedes its own descendants. The cursor is the prefix
+	itself.
+	"""
+	prefixes(by: PrefixesBy @deprecated(reason: "Prefer `filter: { withCapabilities }`, which names capability bits directly instead of a point on the legacy read/write/admin ladder. `by` is retained only for existing clients and is mutually exclusive with it."), filter: PrefixesFilter, after: String, first: Int): PrefixRefConnection!
 	"""
 	Returns a complete list of alert subscriptions.
 	"""


### PR DESCRIPTION
**Description:**

The `prefixes` query answers "which prefixes do I reach, and what may I do at each" — but it required a `by.minCapability` argument naming a point on the legacy read/write/admin ladder, and offered no way to narrow the result at all. Different capability bits map to different product features, so which bit makes a prefix interesting is the client's question rather than the resolver's; and a caller browsing a large namespace needs to drill down rather than page through everything they can see.

`by` becomes **optional and deprecated**. A new `filter` argument carries three narrowing fields, all optional:

- **`withCapabilities: [CapabilityBit!]`** keeps prefixes where the caller holds *every* listed bit. Conjunctive: `[CatalogRead, SpecEdit]` means read *and* publish. Omitting it lists each reachable prefix whatever the caller holds there — the shape a client wants when it reads per-prefix `capabilities` to gate features. An omitted filter collapses to the empty capability set, which every set is a superset of, so one `is_superset` test serves both the filtered and unfiltered paths; a literal `[]` is rejected by the input validator.
- **`tenant: Prefix`** narrows to what one organization reaches through the role-grant graph, reusing `tenant_reachable_prefixes` and `intersect_prefixes` from the parent PR. The walk starts from the caller's own footholds within the tenant, and the reachable set is intersected with the caller's authorized prefixes, so the filter only ever removes entries and shows only reach flowing from namespace the caller occupies. Naming a tenant requires at least one foothold; the denial turns on the caller's own grants and the tenant string alone, so it reveals nothing about the tenant — including whether it exists. The required capabilities arm this walk too.
- **`prefix: PrefixFilter`** is the shared filter, drilling into a subtree (`startsWith`) or selecting an exact set (`in`), matching the returned prefix itself.

`by` and `filter.withCapabilities` are alternative spellings of one capability constraint, so **supplying both is rejected** — the same narrow exclusion `storageMappings` applies to its own deprecated `by`. Narrow because `by` still composes with `tenant` and `prefix`, which scope by namespace rather than capability.

**Backward compatibility.** Lexical ordering and the prefix cursor are unchanged, so this is observationally compatible for existing callers — relaxing `by` from required to optional does not invalidate any query that passes it. `flowctl`'s `ListAuthorizedPrefixes` passes `by` as an inline object literal, so its generated variable stays `$min_capability: Capability!`; verified `cargo check -p flowctl` is clean.

**Workflow steps:**

```graphql
# The caller's whole access surface. No arguments required any more.
query {
  prefixes(first: 50) {
    pageInfo { hasNextPage }
    edges { cursor node { prefix capabilities } }
  }
}

# Which prefixes may I publish specs and edit billing at?
query {
  prefixes(filter: { withCapabilities: [SpecEdit, EditBilling] }) {
    edges { node { prefix } }
  }
}

# Drill into one subtree of a large hierarchy.
query {
  prefixes(filter: { prefix: { startsWith: "acmeCo/" } }) {
    edges { node { prefix capabilities } }
  }
}

# Scope to one organization's reach.
query {
  prefixes(filter: { tenant: "acmeCo/" }) {
    edges { node { prefix capabilities } }
  }
}
```

**Documentation links affected:**

None.

**Notes for reviewers:**

Stacked on #3292 (`filter.tenant` on `serviceAccounts`), which introduced the `tenant_reachable_prefixes` / `intersect_prefixes` helpers this reuses. Review that one first.

Note the branch name (`greg/gql-reachable-prefixes`) is stale: this started as a separate `reachablePrefixes` query and was redirected into extending `prefixes` instead, since the two would have been near-duplicate surfaces over the same closure. The branch was force-pushed with clean history; there is no `reachablePrefixes` in the diff.

Worth a look:

- **`by` / `withCapabilities` exclusion follows `storageMappings`, and is deliberately narrow.** Both name the same capability constraint, so supplying both is an error with the same wording that query uses. But the exclusion checks only the *overlapping* field: `by` combined with `tenant` or `prefix` is allowed, since those scope by namespace. A test pins that allowed combination and is discriminating — `admin` alone returns two prefixes, `tenant: "aliceCo/"` alone returns three, and together they return one, so neither constraint can be silently dropped.
- **Empty `withCapabilities` means "no narrowing", not "nothing".** `is_superset(empty)` is universally true. That is what makes the unfiltered query list a prefix where the caller holds only, say, `ViewBilling` — a `CatalogRead`-gated listing would have hidden it, which matters because the UI gates per-feature off these bits.
- **One grant-graph walk per request.** `authorized_prefixes` is itself the walk plus a reduction, so calling it for the tenant scope would have walked the caller's graph twice. The first commit splits that reduction out as `authorized_from_reachable`, and the resolver derives both the listing and the tenant scope from a single walk. Behavior-preserving; existing callers untouched.
- **`prefix` filtering matches the returned prefix, not a SQL row.** Unlike the SQL-backed listings there is no second predicate to re-narrow, so `startsWith` here is exact rather than the deliberately-approximate bidirectional overlap `narrow_to_overlap` performs.
- **Still no `MAX_PREFIXES` guard.** There is no predicate array to bound — the closure is enumerated in memory from the authorization Snapshot with no database access — and pagination bounds the response.
- **`userCapability` is untouched.** It stays on `PrefixRef` for the dashboard's read/write/admin bucket store, and `flowctl` reads it too. Retiring it (and `by` with it) is the follow-up once both migrate to `capabilities`.
