### PR TITLE
config-encryption: fix broken image and deploy from CI

### DIFF
--- a/.github/workflows/deploy-config-encryption.yaml
+++ b/.github/workflows/deploy-config-encryption.yaml
@@ -1,0 +1,71 @@
+name: Deploy config-encryption
+
+on:
+  workflow_run:
+    workflows: ["Platform Build"]
+    types:
+      - completed
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Get image tag
+        id: image-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="dev-next"
+          else
+            TAG=$(git describe --tags --always)
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "image=us-central1-docker.pkg.dev/estuary-control/ghcr/estuary/config-encryption:${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Authenticate with GCP Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: cd-github-actions@estuary-control.iam.gserviceaccount.com
+          workload_identity_provider: projects/1084703453822/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
+
+      - name: Deploy Cloud Run service `config-encryption`
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: config-encryption
+          project_id: estuary-control
+          region: us-central1
+          image: ${{ steps.image-tag.outputs.image }}
+          # The service reads its listen port from API_PORT (default 8765) and ignores
+          # Cloud Run's injected PORT, so the container port is stated explicitly.
+          port: 8765
+
+          # The service predates this workflow and was last deployed by hand in 2023 with
+          # a since-removed CLI (`--log.format`, `--gcp-kms`). Clearing command/args hands
+          # configuration back to the image ENTRYPOINT plus the env vars below; leaving the
+          # stale args in place would make the container exit on unrecognized arguments.
+          # The `config-encryption` runtime service account already holds
+          # roles/cloudkms.cryptoKeyEncrypter on the KMS key's project.
+          flags: >-
+            --command=""
+            --args=""
+            --service-account=config-encryption@estuary-control.iam.gserviceaccount.com
+
+          env_vars: |-
+            KMS_TYPE=gcp
+            KMS_KEY=projects/helpful-kingdom-273219/locations/us-central1/keyRings/catalog-sops/cryptoKeys/config-encryptor
+            NO_COLOR=1
+            RUST_LOG=info
+
+          env_vars_update_strategy: overwrite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,6 @@ dependencies = [
 name = "config-encryption"
 version = "0.1.0"
 dependencies = [
- "aide",
  "anyhow",
  "async-process",
  "axum",

--- a/crates/config-encryption/Cargo.toml
+++ b/crates/config-encryption/Cargo.toml
@@ -12,7 +12,6 @@ doc = { path = "../doc" }
 json = { path = "../json" }
 async-process = { path = "../async-process" }
 
-aide = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }

--- a/crates/config-encryption/src/lib.rs
+++ b/crates/config-encryption/src/lib.rs
@@ -22,7 +22,7 @@ pub struct Request {
     /// have a suffix added to its name (e.g. "api_key" -> "api_key_sops").
     pub schema: serde_json::Value,
     /// The plain text configuration to encrypt. This must validate against the provided JSON
-    /// schema. If provided in YAML format, then all comments will be stripped.
+    /// schema.
     pub config: serde_json::Value,
     /// Keychain to use for this encryption request.
     #[serde(default)]

--- a/docker/config-encryption.Dockerfile
+++ b/docker/config-encryption.Dockerfile
@@ -6,6 +6,11 @@ RUN apt-get update \
 
 ARG TARGETARCH
 COPY ${TARGETARCH}/flow-config-encryption /usr/local/bin/
+# The service shells out to `sops` to perform the actual encryption.
+COPY ${TARGETARCH}/sops /usr/local/bin/
 
 ENV RUST_LOG=info
+
+EXPOSE 8765
+
 ENTRYPOINT ["flow-config-encryption"]


### PR DESCRIPTION
## What

Fixes the `config-encryption` image, which cannot currently serve a request, and adds a deploy workflow so the service tracks master like our other Cloud Run services.

## The image is broken

The service shells out to `sops` to do the actual encryption ([`lib.rs:141`](https://github.com/estuary/flow/blob/master/crates/config-encryption/src/lib.rs#L141)), but `docker/config-encryption.Dockerfile` only ever copied in `flow-config-encryption`. Every `/v1/encrypt-config` call in that image fails with ``failed to run `sops` ``. The `reactor`, `dekaf`, `control-plane-agent`, and `data-plane-controller` images all copy `sops`; this one didn't. `ci:package` already stages the binary, so it's a one-line fix.

## Deployment

The image was **already** being built and pushed on every master push — `ci:docker-images` globs every `docker/*.Dockerfile`, and `ci:package` already links `flow-config-encryption`. `ghcr.io/estuary/config-encryption` has 249 tags. So this PR only wires up *deployment*, pulling through the `estuary-control/ghcr` Artifact Registry remote repository exactly as `deploy-agent-api`, `deploy-oidc-discovery-server`, and `deploy-data-plane-controller` do.

The running service is revision `config-encryption-00012-yox` from **2023-06-02**, deployed by hand from the pre-migration micro-repo. Its args reference a CLI that no longer exists (`--log.format`, `--gcp-kms`), so the workflow clears `command`/`args` and moves configuration to env vars — otherwise the new container would exit on unrecognized arguments.

## Verifying the cutover is safe

Since this jumps production forward ~2.5 years, I checked compatibility rather than assuming it.

Encrypting an identical (fictitious) input against the **same production KMS key**, via the live service and via current master + sops 3.11.0. Both returned `200 application/json`. Structural diff of the two documents:

```
23c23
<   "sops_version": "3.7.3"
---
>   "sops_version": "3.11.0"
```

Same key paths, same `_sops` suffixes, same `encrypted_suffix`, same `gcp_kms` stanza, same plaintext preservation. Round-trip decryption with sops 3.11.0, as `crates/unseal` invokes it:

```
old.json (3.7.3-encrypted) -> DECRYPT OK
new.json (3.11.0-encrypted) -> DECRYPT OK
*** identical plaintext ***
```

Pre-existing stored configs keep working — and that was already true, since the reactor ships sops 3.11.0 from `mise.toml` today and already decrypts 3.7.3-era documents.

One behavioral difference: sops 3.7.3 emits explicit `null`s for unused backends (`age`, `azure_kv`, `hc_vault`, `kms`, `pgp`); 3.11.0 omits those keys. Inert, because `unseal` deserializes only `encrypted_suffix`, with `#[serde(default)]` and no `deny_unknown_fields`. The only other references to those names are stored fixtures.

**Callers** — all three send the same `{config, schema}` JSON and none sends the optional `keychain`:
- `crates/flow-client/src/client.rs:177`
- `crates/flowctl/src/draft/encrypt.rs:152`
- `supabase/functions/oauth/encrypt-config.ts:73`

**Dropped features are unreachable.** The micro-repo migration (`6d4fc972b07`) removed YAML support and the OpenAPI schema. No caller sends YAML, and the live service already 404s on `/v1/openapi.json`, `/openapi.json`, `/docs`, `/v1/docs`, and `/` — `POST /v1/encrypt-config` is the only route that has ever existed in production.

**IAM** needs no change: `config-encryption@estuary-control.iam.gserviceaccount.com` already holds `roles/cloudkms.cryptoKeyEncrypter` on the key's project.

## Also

Drops the now-unused `aide` dependency (unreferenced in `src/` since the OpenAPI removal; still used by `agent` and `control-plane-api`, so the workspace dep stays) and a stale doc comment referencing the removed YAML support.

`cargo test -p config-encryption`: 5 passed, 0 failed.

## Reviewer note

Deploy is **automatic** on master push, so merging cuts production forward unattended on the next Platform Build. Ordering is correct — Platform Build rebuilds from the merge commit, so the deployed image contains the `sops` fix — but if you'd rather do the first cutover by hand, say so and I'll gate it to `workflow_dispatch` with an explicit tag input (the `deploy-agent-api` pattern) and flip it on afterward.
