### PR TITLE
Reactor Mem Usage Profiling Results Cleanup

### DIFF
--- a/go/protocols/catalog/build_load.go
+++ b/go/protocols/catalog/build_load.go
@@ -115,6 +115,28 @@ func LoadMaterialization(db *sql.DB, name string) (*pf.MaterializationSpec, erro
 	return out, loadOneSpec(db, `SELECT spec FROM built_materializations WHERE materialization = ?;`, out, name)
 }
 
+// LoadCollectionBytes, LoadCaptureBytes, and LoadMaterializationBytes return
+// the raw protobuf encoding of a named built spec, without decoding it.
+// The V2 runtime forwards the built encoding verbatim to the Rust runtime,
+// which is its sole consumer: loading bytes avoids materializing (and then
+// retaining) the decoded spec, which is large for tasks with many bindings
+// or wide collection schemas.
+
+// LoadCollectionBytes returns the raw encoding of the named CollectionSpec.
+func LoadCollectionBytes(db *sql.DB, name string) ([]byte, error) {
+	return loadOneSpecBytes(db, `SELECT spec FROM built_collections WHERE collection = ?;`, name)
+}
+
+// LoadCaptureBytes returns the raw encoding of the named CaptureSpec.
+func LoadCaptureBytes(db *sql.DB, name string) ([]byte, error) {
+	return loadOneSpecBytes(db, `SELECT spec FROM built_captures WHERE capture = ?;`, name)
+}
+
+// LoadMaterializationBytes returns the raw encoding of the named MaterializationSpec.
+func LoadMaterializationBytes(db *sql.DB, name string) ([]byte, error) {
+	return loadOneSpecBytes(db, `SELECT spec FROM built_materializations WHERE materialization = ?;`, name)
+}
+
 // LoadAllTests loads all tests.
 func LoadAllTests(db *sql.DB) ([]*pf.TestSpec, error) {
 	var out []*pf.TestSpec
@@ -182,6 +204,21 @@ func loadOneSpec(
 		return fmt.Errorf("validating spec %s: %w", spec.String(), err)
 	}
 	return nil
+}
+
+func loadOneSpecBytes(
+	db *sql.DB,
+	query string,
+	args ...interface{},
+) ([]byte, error) {
+	var b []byte
+	if err := db.QueryRow(query, args...).Scan(&b); err != nil {
+		if err != sql.ErrNoRows {
+			err = fmt.Errorf("query(%q): %w", query, err)
+		}
+		return nil, err
+	}
+	return b, nil
 }
 
 func loadRows(

--- a/go/runtime/capture_v2.go
+++ b/go/runtime/capture_v2.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/protocols/catalog"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
@@ -22,7 +23,7 @@ import (
 // Rust owns connector polling, document publishing, stats, and local RocksDB
 // recovery-log persistence for the shard.
 type captureAppV2 struct {
-	*taskBase[*pf.CaptureSpec]
+	*taskBase[[]byte]
 
 	client pr.Shard_CaptureClient
 	respCh <-chan captureRecvResult
@@ -38,7 +39,7 @@ type captureRecvResult struct {
 var _ application = (*captureAppV2)(nil)
 
 func newCaptureAppV2(host *FlowConsumer, shard consumer.Shard, recorder *recoverylog.Recorder) (*captureAppV2, error) {
-	var base, err = newTaskBaseV2[*pf.CaptureSpec](host, shard, recorder, extractCaptureSpec)
+	var base, err = newTaskBaseV2(host, shard, recorder, catalog.LoadCaptureBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -122,11 +123,6 @@ func (c *captureAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.En
 		close(ch)
 	}()
 
-	var specBytes []byte
-	if specBytes, err = c.term.taskSpec.Marshal(); err != nil {
-		return fmt.Errorf("marshaling CaptureSpec: %w", err)
-	}
-
 	// Build Join from this current shard topology, and send.
 	var join *pr.Join
 	if join, err = c.buildJoin(); err != nil {
@@ -147,7 +143,7 @@ func (c *captureAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.En
 	// Send task.
 	_ = c.client.Send(&pr.Capture{
 		Task: &pr.Task{
-			Spec:            specBytes,
+			Spec:            c.term.taskSpec,
 			MaxTransactions: 0,
 		},
 	})

--- a/go/runtime/derive_v2.go
+++ b/go/runtime/derive_v2.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/protocols/catalog"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
@@ -33,7 +34,7 @@ import (
 // is ephemeral. The leader recovers the authoritative checkpoint from the
 // connector at Open, so the empty RocksDB scan is harmless.
 type deriveAppV2 struct {
-	*taskBase[*pf.CollectionSpec]
+	*taskBase[[]byte]
 
 	client pr.Shard_DeriveClient
 	// shuffleDir hosts per-shard shuffle files for this assignment.
@@ -65,20 +66,29 @@ func newDeriveAppV2(host *FlowConsumer, shard consumer.Shard, recorder *recovery
 		return nil, fmt.Errorf("creating runtime-v2 shuffle tempdir: %w", err)
 	}
 
-	var base *taskBase[*pf.CollectionSpec]
-	base, err = newTaskBaseV2[*pf.CollectionSpec](host, shard, recorder, extractCollectionSpec)
+	var base *taskBase[[]byte]
+	base, err = newTaskBaseV2(host, shard, recorder, catalog.LoadCollectionBytes)
 	if err != nil {
 		_ = os.RemoveAll(shuffleDir)
 		return nil, err
 	}
 	go base.heartbeatLoop(shard)
 
+	// The term holds the raw spec encoding; decode a transient copy for the
+	// one property Go reads.
+	var collection pf.CollectionSpec
+	if err = collection.Unmarshal(base.term.taskSpec); err != nil {
+		base.drop()
+		_ = os.RemoveAll(shuffleDir)
+		return nil, fmt.Errorf("unmarshaling CollectionSpec: %w", err)
+	}
+
 	// derive-sqlite tasks thread a recorded SQLite VFS to the connector. Only
 	// shard zero (which hosts the recovery log) builds it; non-zero shards have
 	// a nil recorder. Register the VFS, create the `gazette_checkpoints` table,
 	// then close the Go-side DB so Rust can reopen it through the registered VFS.
-	var isSqlite = base.term.taskSpec.Derivation != nil &&
-		base.term.taskSpec.Derivation.ConnectorType == pf.CollectionSpec_Derivation_SQLITE
+	var isSqlite = collection.Derivation != nil &&
+		collection.Derivation.ConnectorType == pf.CollectionSpec_Derivation_SQLITE
 
 	var sqlite *store_sqlite.Store
 	if isSqlite && recorder != nil {
@@ -211,11 +221,6 @@ func (m *deriveAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.Env
 		close(ch)
 	}()
 
-	var specBytes []byte
-	if specBytes, err = m.term.taskSpec.Marshal(); err != nil {
-		return fmt.Errorf("marshaling CollectionSpec: %w", err)
-	}
-
 	// Run the Join/Joined protocol loop until consensus is met.
 	var waitForRevision int64
 	for {
@@ -269,7 +274,7 @@ func (m *deriveAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.Env
 	}
 	_ = m.client.Send(&pr.Derive{
 		Task: &pr.Task{
-			Spec:            specBytes,
+			Spec:            m.term.taskSpec,
 			MaxTransactions: 0,
 			SqliteVfsUri:    sqliteVfsUri,
 		},

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -269,6 +269,15 @@ func (f *FlowConsumer) tickTimepoint(wallTime time.Time) {
 
 // InitApplication starts shared services of the flow-consumer.
 func (f *FlowConsumer) InitApplication(args runconsumer.InitArgs) error {
+	// Gazette's InitDiagnosticsAndRecover enables grpc.EnableTracing, under
+	// which every gRPC stream pins its sent and received messages in
+	// golang.org/x/net/trace event logs until the stream completes. Runtime
+	// session streams live for the length of a shard session, and their Task
+	// message embeds the complete marshalled task spec: on busy reactors,
+	// tracing pinned hundreds of MB of otherwise-dead spec bytes. We prefer
+	// the memory over the /debug/requests diagnostic.
+	grpc.EnableTracing = false
+
 	bindings.RegisterPrometheusCollector()
 	var config = *args.Config.(*FlowConsumerConfig)
 

--- a/go/runtime/materialize_v2.go
+++ b/go/runtime/materialize_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
 	"github.com/estuary/flow/go/labels"
+	"github.com/estuary/flow/go/protocols/catalog"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
@@ -30,7 +31,7 @@ import (
 // only manages session startup (Join → Joined → Task → Opened) and
 // teardown (Stop → Stopped) per term.
 type materializeAppV2 struct {
-	*taskBase[*pf.MaterializationSpec]
+	*taskBase[[]byte]
 
 	client pr.Shard_MaterializeClient
 	// shuffleDir hosts per-shard shuffle files for this assignment.
@@ -59,8 +60,8 @@ func newMaterializeAppV2(host *FlowConsumer, shard consumer.Shard, recorder *rec
 		return nil, fmt.Errorf("creating runtime-v2 shuffle tempdir: %w", err)
 	}
 
-	var base *taskBase[*pf.MaterializationSpec]
-	base, err = newTaskBaseV2[*pf.MaterializationSpec](host, shard, recorder, extractMaterializationSpec)
+	var base *taskBase[[]byte]
+	base, err = newTaskBaseV2(host, shard, recorder, catalog.LoadMaterializationBytes)
 	if err != nil {
 		_ = os.RemoveAll(shuffleDir)
 		return nil, err
@@ -179,11 +180,6 @@ func (m *materializeAppV2) runOneSession(shard consumer.Shard, ch chan<- consume
 		close(ch)
 	}()
 
-	var specBytes []byte
-	if specBytes, err = m.term.taskSpec.Marshal(); err != nil {
-		return fmt.Errorf("marshaling MaterializationSpec: %w", err)
-	}
-
 	// Run the Join/Joined protocol loop until consensus is met.
 	var waitForRevision int64
 	for {
@@ -231,7 +227,7 @@ func (m *materializeAppV2) runOneSession(shard consumer.Shard, ch chan<- consume
 	// Send Task.
 	_ = m.client.Send(&pr.Materialize{
 		Task: &pr.Task{
-			Spec:            specBytes,
+			Spec:            m.term.taskSpec,
 			MaxTransactions: 0,
 		},
 	})

--- a/go/runtime/task.go
+++ b/go/runtime/task.go
@@ -46,7 +46,15 @@ type taskService interface {
 	Drop()
 }
 
-type taskBase[TaskSpec pf.Task] struct {
+// taskBase hosts the state shared by all task applications. Its TaskSpec
+// parameter is the decoded *pf.CaptureSpec / *pf.CollectionSpec /
+// *pf.MaterializationSpec for V1 applications, which consume the spec
+// throughout their transaction loops. V2 applications instead use the raw
+// []byte encoding of the built spec: their only consumer is the Rust runtime,
+// which receives the encoding verbatim, and holding the decoded form would
+// retain a large object graph (per-binding CollectionSpecs, projections,
+// inference) that the Go side never reads.
+type taskBase[TaskSpec any] struct {
 	container    atomic.Pointer[pr.Container]            // Current Container of this shard, or nil.
 	extractFn    func(*sql.DB, string) (TaskSpec, error) // Extracts a TaskSpec from a build DB.
 	host         *FlowConsumer                           // Host Consumer application of the shard.
@@ -58,7 +66,7 @@ type taskBase[TaskSpec pf.Task] struct {
 	termCount    int                                     // Number of initialized task terms.
 }
 
-type taskTerm[TaskSpec pf.Task] struct {
+type taskTerm[TaskSpec any] struct {
 	cancel    context.CancelFunc // Cancel the task term.
 	ctx       context.Context    // Context for the task term.
 	labels    ops.ShardLabeling  // Shard labels of this task term.
@@ -66,7 +74,7 @@ type taskTerm[TaskSpec pf.Task] struct {
 	// Raw etcd value of shardSpec, which defines this term: it ends when these
 	// bytes change or the key is deleted, but not on a byte-identical re-PUT.
 	specBytes []byte
-	taskSpec  TaskSpec // Term TaskSpec of the task.
+	taskSpec  TaskSpec // Term TaskSpec of the task (see taskBase).
 }
 
 type taskReader[TaskSpec pf.Task] struct {
@@ -125,12 +133,13 @@ func newTaskBase[TaskSpec pf.Task](
 // newTaskBaseV2 mirrors newTaskBase but instantiates the runtime-next
 // (V2) TaskService. The legacy and V2 services are independently linked
 // CGO services with distinct gRPC surfaces; only the constructor differs.
-func newTaskBaseV2[TaskSpec pf.Task](
+// V2 terms carry the raw built-spec encoding rather than a decoded spec.
+func newTaskBaseV2(
 	host *FlowConsumer,
 	shard consumer.Shard,
 	recorder *recoverylog.Recorder,
-	extractFn func(*sql.DB, string) (TaskSpec, error),
-) (*taskBase[TaskSpec], error) {
+	extractFn func(*sql.DB, string) ([]byte, error),
+) (*taskBase[[]byte], error) {
 
 	var opsCtx, opsCancel = context.WithCancel(host.opsContext)
 	opsCtx = pprof.WithLabels(opsCtx, pprof.Labels(
@@ -139,7 +148,7 @@ func newTaskBaseV2[TaskSpec pf.Task](
 	var opsPublisher = NewOpsPublisher(message.NewPublisher(
 		client.NewAppendService(opsCtx, host.service.Journals), nil))
 
-	term, err := newTaskTerm[TaskSpec](nil, extractFn, host, opsPublisher, shard)
+	term, err := newTaskTerm[[]byte](nil, extractFn, host, opsPublisher, shard)
 	if err != nil {
 		opsCancel()
 		return nil, err
@@ -158,7 +167,7 @@ func newTaskBaseV2[TaskSpec pf.Task](
 		return nil, fmt.Errorf("creating V2 task service: %w", err)
 	}
 
-	var base = &taskBase[TaskSpec]{
+	var base = &taskBase[[]byte]{
 		container:    atomic.Pointer[pr.Container]{},
 		extractFn:    extractFn,
 		host:         host,
@@ -208,7 +217,7 @@ func (t *taskBase[TaskSpec]) drop() {
 	t.svc.Drop()
 }
 
-func newTaskTerm[TaskSpec pf.Task](
+func newTaskTerm[TaskSpec any](
 	prev *taskTerm[TaskSpec],
 	extractFn func(*sql.DB, string) (TaskSpec, error),
 	host *FlowConsumer,
@@ -361,7 +370,7 @@ func (t *taskBase[TaskSpec]) heartbeatLoop(shard consumer.Shard) {
 		jitter = intervalJitter(period, shard.FQN())
 		// Op notified when the shard fails.
 		op       = shard.PrimaryLoop()
-		taskName = t.term.taskSpec.TaskName()
+		taskName = t.term.labels.TaskName
 	)
 	for {
 		select {


### PR DESCRIPTION
## Description

A heap profile from a busy production reactor showed ~70% of its 1.9GB live Go
heap was retained task-spec data. Two commits, one per cause:

**runtime: disable grpc.EnableTracing in the reactor**

Gazette's diagnostics boilerplate enables grpc.EnableTracing, and x/net/trace
pins every logged message until its trace finishes. V2 session streams live for
days and never hit trace compaction, so the sent Task message (embedding the
full marshalled spec) stayed pinned: ~365MB. The reactor now turns tracing off,
trading /debug/requests for the memory. 

**runtime: V2 task terms hold raw spec bytes, not decoded specs**

Go reads almost nothing from a V2 task's decoded spec; it existed to produce
Task message bytes for Rust (~1.0GB retained). Terms now hold the raw built
spec encoding straight from the build DB and forward it verbatim, so V2 shard
startup no longer decodes or re-marshals specs at all. V1 apps are unchanged.
Note two edge behavior changes: Rust receives the control plane's encoding
verbatim (the old gogo re-encode dropped unknown fields), and a corrupt spec
blob now errors in Rust at session start rather than in Go at term init.

## Notes for reviewers

Verified on a local stack with runtime-v2 captures using wide synthetic
schemas, plus V2 materializations and derivations. Before: heap shows Marshal
bytes 100% retained under runOneSession and decoded specs under binding
Unmarshal, matching the production profile. After: both attributions are gone,
leaving only the raw bytes by design. Sessions commit continuously, heartbeat
stats publish, and spec-update term transitions drain and restart cleanly.
`mise run ci:gotest` passes. No protocol or Rust-side changes.
