### PR TITLE
config-encryption: fix Cloud Run startup probe port

### DIFF
--- a/.github/workflows/deploy-config-encryption.yaml
+++ b/.github/workflows/deploy-config-encryption.yaml
@@ -47,9 +47,6 @@ jobs:
           project_id: estuary-control
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
-          # The service reads its listen port from API_PORT (default 8765) and ignores
-          # Cloud Run's injected PORT, so the container port is stated explicitly.
-          port: 8765
 
           # The service predates this workflow and was last deployed by hand in 2023 with
           # a since-removed CLI (`--log.format`, `--gcp-kms`). Clearing command/args hands
@@ -57,12 +54,19 @@ jobs:
           # stale args in place would make the container exit on unrecognized arguments.
           # The `config-encryption` runtime service account already holds
           # roles/cloudkms.cryptoKeyEncrypter on the KMS key's project.
+          #
+          # `--port` must go here rather than in a `port:` input: deploy-cloudrun@v2 has no
+          # such input and silently ignores one, which leaves the container port at Cloud
+          # Run's 8080 default while the service listens on API_PORT, failing the startup
+          # probe. API_PORT below is set to the same value so neither side is implicit.
           flags: >-
             --command=""
             --args=""
+            --port=8765
             --service-account=config-encryption@estuary-control.iam.gserviceaccount.com
 
           env_vars: |-
+            API_PORT=8765
             KMS_TYPE=gcp
             KMS_KEY=projects/helpful-kingdom-273219/locations/us-central1/keyRings/catalog-sops/cryptoKeys/config-encryptor
             NO_COLOR=1


### PR DESCRIPTION
Follow-up to #3308, which merged and then failed its first automated deploy.

## What went wrong

`google-github-actions/deploy-cloudrun@v2` has **no `port` input**. From its `action.yml`:

```
service, job, metadata, image, source, suffix, env_vars, env_vars_file,
env_vars_update_strategy, secrets, secrets_update_strategy, labels,
skip_default_labels, tag, timeout, flags, no_traffic, wait, revision_traffic,
tag_traffic, update_traffic_flags, project_id, region, gcloud_version, gcloud_component
```

So the `port: 8765` in #3308 was silently ignored. The container port stayed at Cloud Run's 8080 default while the service bound `API_PORT`'s 8765 default, and the startup probe hit the wrong port:

```
Default STARTUP TCP probe failed 1 time consecutively for container
"config-encryption-1" on port 8080. The instance was not started.
Connection failed with status DEADLINE_EXCEEDED.
```

## Everything else in #3308 worked

From revision `config-encryption-00013-78t`:

```
{"message":"started!","fields":{"args":"Args { api_port: 8765, kms_type: Gcp,
  kms_key: \"projects/helpful-kingdom-273219/.../config-encryptor\" }"}}
```

The container started, the `sops` fix is in the image, clap parsed `KMS_TYPE`/`KMS_KEY` from env, and `command`/`args` are both `null` — so clearing the stale 2023 CLI worked. Only the probe port was wrong.

Traffic never shifted to the failed revision (`latestReady` remained `config-encryption-00012-yox`), so the service kept serving normally throughout.

## The fix

```diff
-          port: 8765
           flags: >-
             --command=""
             --args=""
+            --port=8765
             --service-account=config-encryption@estuary-control.iam.gserviceaccount.com
 
           env_vars: |-
+            API_PORT=8765
             KMS_TYPE=gcp
```

`--port` in `flags` reaches `gcloud run deploy`, where it is a real flag. `API_PORT` is set explicitly alongside it so neither side of the match depends on a default — if the app's default ever changes, the deploy won't silently break.

## Caveat for the reviewer

**This is not verified against live Cloud Run.** I tried to confirm the flag combination with a manual `gcloud run deploy` before opening this, but that action was blocked in my environment. The reasoning is sound and `--port` is a documented `gcloud run deploy` flag, but the next Platform Build is what actually proves it. If it fails again, traffic stays on the current healthy revision as it did this time.

## Note on a latent copy of the same bug

`deploy-oidc-discovery-server.yaml:48` passes the same dead `port: 8080` input. It is inert there — 8080 is both Cloud Run's default and that service's listen port — but it is exactly what misled me here. Left alone to keep this PR focused; happy to remove it here or separately.
