### PR TITLE
docs: use :::deprecated admonition for deprecated connector notices

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/HubSpot.md
+++ b/site/docs/reference/Connectors/capture-connectors/HubSpot.md
@@ -3,7 +3,7 @@
 
 This connector captures data from a Hubspot account.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [HubSpot connector](/reference/Connectors/capture-connectors/HubSpot-real-time) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-historical-data.md
+++ b/site/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-historical-data.md
@@ -6,7 +6,7 @@ It uses batch processing and is ideal for syncing your historical Salesforce dat
 [A separate connector is available for real-time Salesforce data capture](./salesforce-real-time.md).
 For help using both connectors in parallel, [contact your Estuary account manager](mailto:info@estuary.dev).
 
-:::warning
+:::deprecated
 This connector is deprecated. Consider using the new [native Salesforce connector](./salesforce-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-real-time.md
+++ b/site/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-real-time.md
@@ -5,7 +5,7 @@ This connector captures data from Salesforce objects into Estuary collections in
 [A separate connector is available for syncing historical Salesforce data](./salesforce-historical-data.md).
 For help using both connectors in parallel, [contact your Estuary account manager](mailto:info@estuary.dev).
 
-:::warning
+:::deprecated
 This connector is deprecated. Consider using the new [native Salesforce connector](./salesforce-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/airtable.md
+++ b/site/docs/reference/Connectors/capture-connectors/airtable.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Airtable into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Airtable connector](./airtable-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/amazon-redshift.md
+++ b/site/docs/reference/Connectors/capture-connectors/amazon-redshift.md
@@ -2,7 +2,7 @@
 
 This connector captures data from your Amazon Redshift cluster into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Redshift batch connector](./redshift-batch.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/chargebee.md
+++ b/site/docs/reference/Connectors/capture-connectors/chargebee.md
@@ -4,7 +4,7 @@ This connector captures data from Chargebee into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Chargebee connector](./chargebee-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
+++ b/site/docs/reference/Connectors/capture-connectors/facebook-marketing.md
@@ -3,7 +3,7 @@
 
 This connector captures data from the Facebook Marketing API into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Facebook Ads connector](./facebook-marketing-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/site/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -3,7 +3,7 @@
 
 This connector previously captured data from a view in Google Universal Analytics.
 
-:::danger
+:::deprecated
 
 This connector and Universal Analytics are now **deprecated** along with the Google Analytics Universal Analytics API - ([see Google announcement](https://support.google.com/analytics/answer/11583528?hl=en)).
 

--- a/site/docs/reference/Connectors/capture-connectors/greenhouse.md
+++ b/site/docs/reference/Connectors/capture-connectors/greenhouse.md
@@ -5,7 +5,7 @@ This connector captures data from Greenhouse into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [Greenhouse connector](./greenhouse-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/intercom.md
+++ b/site/docs/reference/Connectors/capture-connectors/intercom.md
@@ -5,7 +5,7 @@ This connector captures data from Intercom into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Intercom connector](./intercom-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/iterable.md
+++ b/site/docs/reference/Connectors/capture-connectors/iterable.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Iterable into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Iterable connector](./iterable-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/jira-legacy.md
+++ b/site/docs/reference/Connectors/capture-connectors/jira-legacy.md
@@ -3,7 +3,7 @@
 
 This connector captures data from [Jira's REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/) into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [Jira connector](./jira-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/jira.md
+++ b/site/docs/reference/Connectors/capture-connectors/jira.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Jira into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. See the new [Jira connector](./jira-native.md) for the latest integration.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/klaviyo.md
+++ b/site/docs/reference/Connectors/capture-connectors/klaviyo.md
@@ -5,7 +5,7 @@ This connector captures data from Klaviyo into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Klaviyo connector](./klaviyo-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/stripe.md
+++ b/site/docs/reference/Connectors/capture-connectors/stripe.md
@@ -2,7 +2,7 @@
 
 This connector captures data from Stripe into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. See the [Stripe Real-time](./stripe-realtime.md) connector for the latest Stripe integration.
 :::
 

--- a/site/docs/reference/Connectors/materialization-connectors/Rockset.md
+++ b/site/docs/reference/Connectors/materialization-connectors/Rockset.md
@@ -3,7 +3,7 @@
 
 This connector materializes [delta updates](/concepts/materialization/#delta-updates) of your Estuary collections into Rockset collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using one of our other [materialization connectors](/reference/Connectors/materialization-connectors).
 :::
 

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -194,6 +194,12 @@ const config = {
           editUrl: 'https://github.com/estuary/flow/edit/master/site/',
           routeBasePath: '/',
           remarkPlugins: [codeImport],
+          admonitions: {
+            // 'deprecated' renders like `:::warning` (see src/theme/Admonition)
+            // but carries its own `theme-admonition-deprecated` CSS class, so
+            // Kapa's crawler can exclude deprecated connector pages from search.
+            keywords: ['deprecated'],
+          },
           async sidebarItemsGenerator({ defaultSidebarItemsGenerator, ...args }) {
             const sidebarItems = await defaultSidebarItemsGenerator(args);
             return sortSidebarAlphabetically(sidebarItems);

--- a/site/src/theme/Admonition/Type/Deprecated.js
+++ b/site/src/theme/Admonition/Type/Deprecated.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import IconWarning from '@theme/Admonition/Icon/Warning';
+
+// Renders identically to `:::warning`, but under its own admonition type
+// (`theme-admonition-deprecated`, applied automatically by AdmonitionLayout)
+// so it can be targeted independently — e.g. by Kapa's search crawler to
+// exclude deprecated connector pages from search results.
+const infimaClassName = 'alert alert--warning';
+const defaultProps = {
+  icon: <IconWarning />,
+  title: (
+    <Translate
+      id="theme.admonition.deprecated"
+      description="The default label used for the Deprecated admonition (:::deprecated)">
+      deprecated
+    </Translate>
+  ),
+};
+
+export default function AdmonitionTypeDeprecated(props) {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/site/src/theme/Admonition/Types.js
+++ b/site/src/theme/Admonition/Types.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import AdmonitionTypeNote from '@theme/Admonition/Type/Note';
+import AdmonitionTypeTip from '@theme/Admonition/Type/Tip';
+import AdmonitionTypeInfo from '@theme/Admonition/Type/Info';
+import AdmonitionTypeWarning from '@theme/Admonition/Type/Warning';
+import AdmonitionTypeDanger from '@theme/Admonition/Type/Danger';
+import AdmonitionTypeCaution from '@theme/Admonition/Type/Caution';
+import AdmonitionTypeDeprecated from '@theme/Admonition/Type/Deprecated';
+
+const admonitionTypes = {
+  note: AdmonitionTypeNote,
+  tip: AdmonitionTypeTip,
+  info: AdmonitionTypeInfo,
+  warning: AdmonitionTypeWarning,
+  danger: AdmonitionTypeDanger,
+  deprecated: AdmonitionTypeDeprecated,
+};
+
+// Undocumented legacy admonition type aliases
+// Provide hardcoded/untranslated retrocompatible label
+// See also https://github.com/facebook/docusaurus/issues/7767
+const admonitionAliases = {
+  secondary: (props) => <AdmonitionTypeNote title="secondary" {...props} />,
+  important: (props) => <AdmonitionTypeInfo title="important" {...props} />,
+  success: (props) => <AdmonitionTypeTip title="success" {...props} />,
+  caution: AdmonitionTypeCaution,
+};
+
+export default {
+  ...admonitionTypes,
+  ...admonitionAliases,
+};


### PR DESCRIPTION
**Description:**

Registers a custom `deprecated` admonition type and switches the 16 deprecated connector pages to `:::deprecated`, so they can be distinguished from ordinary warnings.

**Workflow steps:**

No end-user workflow change. This gives Kapa's docs-search crawler a stable `theme-admonition-deprecated` CSS class to exclude deprecated connector pages from search results. Neither alternative works: Kapa can't match on page title text, and no URL/filename convention separates deprecated from current pages (Jira has 4 pages, only 2 deprecated). Excluding on `:::warning`'s class would drop the 35 unrelated warnings elsewhere on the site.

The component is ported verbatim from `estuary/docs`, which already implements it, keeping the two repos consistent.

**Documentation links affected:**

None beyond the 16 connector pages. Reader-facing appearance is unchanged, since `Deprecated.js` reuses `:::warning`'s icon and `alert--warning` styling. The exception is `google-analytics.md`, previously the lone `:::danger` page, which now matches the other 15.

**Notes for reviewers:**

- Equivalent changes already merged in `estuary/connectors` and `estuary/docs` don't reach production, because `docs.estuary.dev` builds only from `site/**` in this repo.
- **Swizzle safety:** `Types.js` is purely additive over the bundled 3.9.2 copy (one import, one map entry) and preserves all 6 built-in types plus the 4 legacy aliases. Verified by diffing a full local build against unmodified `master`: **275 admonitions in both**, with `warning` 50 → 35, `danger` 1 → 0, `deprecated` 0 → 16, and `note`/`tip`/`info`/`caution`/`important` identical. Nothing hit Docusaurus's unknown-type fallback.
- **Pre-existing local build failure, unrelated to this PR:** `npm run build` also fails on unmodified `master` on case-insensitive filesystems, where the `hubspot-real-time` → `HubSpot-real-time` redirect collides. Linux CI is unaffected.
- **After merge:** the selector for Kapa to exclude is `.theme-admonition-deprecated`. Nothing needed in `estuary/docs`, whose deploy runs `git submodule update --remote` hourly and picks up the matching content automatically.