### PR TITLE
shuffle: gate the causal-hint stall timeout on a requested checkpoint

### DIFF
--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -476,7 +476,9 @@ producer's `last_commit` advancing — since the last emission.
 
 The same "did `unresolved` make progress?" signal disarms the `on_tick`
 stall timeout: it fires only when no progress at all occurs between
-two consecutive ticks.
+two consecutive ticks, and only while a coordinator request is
+outstanding — with nobody waiting on a checkpoint, zero progress is
+routine.
 
 A peek also carries `latest_backfill_begin` eagerly (cloned from
 `unresolved`, which retains it for the eventual resolved `ready`), as

--- a/crates/shuffle/src/session/state.rs
+++ b/crates/shuffle/src/session/state.rs
@@ -271,14 +271,14 @@ pub struct CheckpointPipeline {
     /// `unresolved.unresolved_hints` is the count of producers awaiting resolution.
     unresolved: crate::Frontier,
     /// Mark-and-sweep counter for detecting stalled causal hint resolution.
-    /// Incremented on each tick where `unresolved.unresolved_hints > 0` and no
-    /// progress has been made in `unresolved` since the prior tick. Reset to
-    /// zero on any progress in `unresolved` (any producer's `last_commit`
-    /// advancing) — the same underlying signal that drives
-    /// `unresolved_peek_progress`. When the accumulated stall
-    /// (`unresolved_stalled_ticks * ACTOR_TICKER_INTERVAL`) reaches
-    /// [`crate::CAUSAL_HINT_RESOLUTION_TIMEOUT`], hint resolution has stalled and
-    /// we return an error to tear down the session.
+    /// Incremented on each tick where a checkpoint is requested,
+    /// `unresolved.unresolved_hints > 0`, and no progress has been made in
+    /// `unresolved` since the prior tick. Reset to zero on any progress in
+    /// `unresolved` (any producer's `last_commit` advancing) — the same
+    /// underlying signal that drives `unresolved_peek_progress`. When the
+    /// accumulated stall (`unresolved_stalled_ticks * ACTOR_TICKER_INTERVAL`)
+    /// reaches [`crate::CAUSAL_HINT_RESOLUTION_TIMEOUT`], hint resolution has
+    /// stalled and we return an error to tear down the session.
     unresolved_stalled_ticks: u32,
     /// Set true whenever `unresolved` advances via `resolve_hints`,
     /// or `progressed` is promoted into `unresolved`. `take_ready()` clears.
@@ -605,15 +605,16 @@ impl CheckpointPipeline {
 
     /// Called on each actor tick to detect stalled causal hint resolution.
     ///
-    /// Uses mark-and-sweep: each tick with unresolved hints increments a stall
-    /// counter. Any progress in `unresolved` between ticks (handled in
+    /// Uses mark-and-sweep: each tick with a requested checkpoint and
+    /// unresolved hints increments a stall counter. Any progress in
+    /// `unresolved` between ticks (handled in
     /// `on_progressed_chunk`/`try_promote`) resets it. Once the accumulated
     /// stall (counter × `ACTOR_TICKER_INTERVAL`) reaches
     /// [`crate::CAUSAL_HINT_RESOLUTION_TIMEOUT`] — i.e. no progress at all across
     /// that span — return an error with details about which producers and
     /// journals are stuck.
     pub fn on_tick(&mut self) -> anyhow::Result<()> {
-        if self.unresolved.unresolved_hints == 0 {
+        if !self.requested || self.unresolved.unresolved_hints == 0 {
             self.unresolved_stalled_ticks = 0;
             return Ok(());
         }
@@ -1296,6 +1297,9 @@ mod test {
         assert_eq!(pipeline.unresolved.unresolved_hints, 2);
         assert_eq!(pipeline.unresolved_stalled_ticks, 0);
 
+        // A client blocks on the next checkpoint: only now do ticks count.
+        pipeline.request().unwrap();
+
         // Ticks accumulate the stall counter without erroring until the horizon.
         for expect in 1..ticks_to_timeout {
             pipeline.on_tick().unwrap();
@@ -1314,6 +1318,7 @@ mod test {
             vec![jf("journal/A", 0, vec![pf(0x01, 10, 100, -50)])],
             vec![],
         );
+        pipeline.request().unwrap();
         pipeline.on_tick().unwrap();
         assert_eq!(pipeline.unresolved_stalled_ticks, 1);
 
@@ -1343,7 +1348,9 @@ mod test {
             vec![jf("journal/A", 0, vec![pf(0x01, 10, 50, -100)])],
             vec![],
         );
+        pipeline.request().unwrap();
         pipeline.on_tick().unwrap();
+        assert_eq!(pipeline.unresolved_stalled_ticks, 1);
         ingest_progressed(
             &mut pipeline,
             vec![jf("journal/A", 0, vec![pf(0x01, 60, 0, -500)])],
@@ -1353,6 +1360,26 @@ mod test {
         assert_eq!(pipeline.unresolved_stalled_ticks, 0);
         pipeline.on_tick().unwrap();
         assert_eq!(pipeline.unresolved_stalled_ticks, 0);
+    }
+
+    #[test]
+    fn test_on_tick_not_counted_without_an_outstanding_request() {
+        let mut pipeline = test_pipeline();
+        ingest_progressed(
+            &mut pipeline,
+            vec![jf("journal/A", 0, vec![pf(0x01, 10, 100, -50)])],
+            vec![],
+        );
+        assert_eq!(pipeline.unresolved.unresolved_hints, 1);
+
+        // Well past the horizon, with no request outstanding, nothing accrues.
+        let ticks_to_timeout = (crate::CAUSAL_HINT_RESOLUTION_TIMEOUT.as_secs()
+            / crate::ACTOR_TICKER_INTERVAL.as_secs()) as u32;
+
+        for _ in 0..ticks_to_timeout + 5 {
+            pipeline.on_tick().unwrap();
+            assert_eq!(pipeline.unresolved_stalled_ticks, 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Description:**

Zero progress is routine while the coordinator is busy and reads are parked under disk back-pressure, so the timeout could tear down a healthy session whose connector transaction simply took a long time to store. Count stalled ticks only while a checkpoint request is outstanding; an unresolvable hint yields neither a `ready` nor a peek, so its request stays outstanding and the horizon is still reached.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

