### PR TITLE
Docs: Update dashboard instructions for alert configs

### DIFF
--- a/site/docs/guides/notifications/customize-alerts.md
+++ b/site/docs/guides/notifications/customize-alerts.md
@@ -1,12 +1,15 @@
+---
+description: Customize alert settings to subscribe to notifications based on environment, finetune error thresholds, or disable alert types by prefix.
+---
 
 # Customizing Alerts
 
 You can configure alert thresholds and scope subscriptions to customize when and how you receive notifications.
-You may manage these customization options using [`flowctl`](/guides/get-started-with-flowctl), Estuary's CLI tool.
+You may manage these customization options within the dashboard or by using [`flowctl`](/guides/get-started-with-flowctl), Estuary's CLI tool.
 
 ## Scope notifications per environment
 
-Subscriptions are scoped by catalog prefix, and a subscription can target a sub-prefix such as a single environment (for example `acmeCo/prod/`). Subscriptions are additive: an alert notifies every subscription whose prefix is a parent of the failing task. To route environments differently, create a separate subscription for each prefix.
+Subscriptions are scoped by catalog prefix, and a subscription can target a sub-prefix such as a single environment (for example `acmeCo/prod/`). Subscriptions are additive: an alert notifies every subscription whose prefix is a parent of the failing task. To route environments differently, create a separate [subscription](/reference/notifications) for each prefix.
 
 For example, you can page an on-call address for `acmeCo/prod/` but send `acmeCo/dev/` alerts to a team list.
 
@@ -25,13 +28,18 @@ Catalog prefixes must end in `/`.
 
 ## Alert configurations
 
-Alert conditions can be tuned per prefix or per task with `flowctl alerts configs`.
+Alert conditions can be tuned per prefix or per task.
 Configure alerts to reduce noise, or to apply different sensitivity to different environments.
 
 A more specific prefix overrides a broader one, field by field; any value you don't set inherits the default.
 This lets you set tenant-wide behavior with per-subprefix or per-task exceptions.
 
-Alerts that can be configured include:
+Alert conditions that can be configured using the dashboard include:
+* [Data Movement Stalled](/reference/notifications/#data-movement-alerts)
+   * Set a default interval value for the chosen prefix when creating or editing a notification subscription
+   * Set interval values on a per-task basis from the task's **Alerts** tab
+
+Alerts that can be configured using `flowctl alerts configs` include:
 * [`shardFailed`](/reference/notifications/#task-failure-alerts) (for task failures)
    * `taskChronicallyFailing`
 * [`dataMovementStalled`](/reference/notifications/#data-movement-alerts)

--- a/site/docs/guides/notifications/notifications.md
+++ b/site/docs/guides/notifications/notifications.md
@@ -20,8 +20,10 @@ To configure alert subscriptions:
 2. Select the [**Settings**](https://dashboard.estuary.dev/admin/settings) tab
 3. If you have access to more than one prefix, select your desired tenant from the **Prefix** dropdown
 4. Under the **Organization Notifications** section, click **Configure Notifications** to create a new subscription or **Edit** an existing one
-5. Enter your desired prefix, email, and [alert types](#alert-types)
-6. Save your alert subscription
+5. In the alert configuration screen, specify a subprefix if desired or use the base prefix to apply the subscription to the whole tenant
+6. Under **Global Settings**, optionally choose default values for alert settings
+7. Add one or more **Recipients**, each of which should specify an email and the [alert types](#alert-types) to send to that email
+8. Save your alert subscription
 
 </TabItem>
 <TabItem value="Using flowctl">
@@ -71,9 +73,11 @@ One email may subscribe to multiple alert types.
 
 ### Data Movement Alerts
 
-A user can select an interval for tracking zero data movement for a specific capture or materialization.
+A user can select an interval for tracking zero data movement for a specific capture or materialization or apply a default interval for tasks within a specific prefix.
 
-On the capture or materialization details page, select the **Alerts** tab. Under the **Notification Settings** card, select a time interval from the **Interval** dropdown. You must have already configured notifications in order for the alert to take effect. If you are not yet subscribed to notifications, an info box will appear prompting you to set up a subscription by clicking on `CLICK HERE`.
+Default settings can be managed when creating or editing an alert subscription.
+
+To select an interval for a specific task, select the **Alerts** tab on the capture or materialization details page. Under the **Notification Settings** card, select a time interval from the **Interval** dropdown. You must have already configured notifications in order for the alert to take effect. If you are not yet subscribed to notifications, an info box will appear prompting you to set up a subscription by clicking on `CLICK HERE`.
 
 If your task does not receive any new documents with the selected timeframe, an email will be sent to any email addresses that are subscribed to the "Data Movement Stalled" alert type.
 


### PR DESCRIPTION
**Description:**

Updates docs to note new alert configuration options in the dashboard and specifies which functionality is available through the dashboard vs. flowctl on the customization page, which previously was solely focused on flowctl instructions.

**Documentation links affected:**

Pages on notifications and customizing alerts.

**Notes for reviewers:**

Thanks for reviewing! Updates are fairly minimal; open to further changes if needed, though the dashboard instructions feel pretty self-explanatory.
