### PR TITLE
runtime-next: build per-collection state once per Target / Source

### DIFF
--- a/crates/doc/src/combine/memtable.rs
+++ b/crates/doc/src/combine/memtable.rs
@@ -96,11 +96,16 @@ impl Entries {
                 return Ok(());
             }
             let rhs = &next[index];
+            let (binding, validator) = (
+                rhs.meta.binding(),
+                self.spec.validator_index[rhs.meta.binding()] as usize,
+            );
 
             let rhs_outcomes = validate_root(
                 &rhs.root,
-                &mut validators[rhs.meta.binding()],
-                &self.spec.names[rhs.meta.binding()],
+                &mut validators[validator],
+                &self.spec.names[validator],
+                binding,
                 validation::reduce_filter,
             )?;
 
@@ -432,10 +437,12 @@ impl MemTable {
             if doc.meta.front() || doc.meta.known_valid() {
                 continue;
             }
+            let validator = spec.validator_index[doc.meta.binding()] as usize;
             let outcomes = validate_root(
                 &doc.root,
-                &mut spec.validators[doc.meta.binding()],
-                &spec.names[doc.meta.binding()],
+                &mut spec.validators[validator],
+                &spec.names[validator],
+                doc.meta.binding(),
                 validation::redact_filter,
             )?;
             doc.meta.set_known_valid(true);
@@ -513,10 +520,13 @@ impl MemDrainer {
             meta.set_front(); // Transfer stale existence onto the fresh output.
         }
 
-        let is_full = self.spec.is_full[meta.binding()];
-        let keys = self.spec.keys[meta.binding()].as_ref();
-        let name = &self.spec.names[meta.binding()];
-        let validator = &mut self.spec.validators[meta.binding()];
+        let binding = meta.binding();
+        let validator = self.spec.validator_index[binding] as usize;
+
+        let is_full = self.spec.is_full[binding];
+        let keys = self.spec.keys[binding].as_ref();
+        let name = &self.spec.names[validator];
+        let validator = &mut self.spec.validators[validator];
 
         // Attempt to reduce additional entries.
         while let Some(next) = self.it.peek() {
@@ -531,8 +541,13 @@ impl MemDrainer {
                 break;
             }
 
-            let rhs_outcomes =
-                validate_root(&next.root, validator, name, validation::reduce_filter)?;
+            let rhs_outcomes = validate_root(
+                &next.root,
+                validator,
+                name,
+                binding,
+                validation::reduce_filter,
+            )?;
 
             match reduce_roots(&root, &next.root, &rhs_outcomes, &self.zz_alloc, is_full) {
                 Ok((node, deleted)) => {
@@ -553,7 +568,7 @@ impl MemDrainer {
             Vec::new() // Skip validation.
         } else {
             meta.set_known_valid(true); // Optimistic.
-            validate_root(&root, validator, name, validation::redact_filter)?
+            validate_root(&root, validator, name, binding, validation::redact_filter)?
         };
 
         // If we don't need to apply redaction outcomes, return the root as-is.
@@ -628,6 +643,7 @@ fn validate_root<'v, F>(
     root: &HeapRoot,
     validator: &'v mut crate::Validator,
     name: &str,
+    binding: usize,
     filter: F,
 ) -> Result<Vec<validation::ScopedOutcome<'v>>, Error>
 where
@@ -637,7 +653,12 @@ where
         Ok(heap_node) => validator.validate(&heap_node, &filter),
         Err(embedded) => validator.validate(embedded.get(), &filter),
     };
-    valid.map_err(|invalid| Error::FailedValidation(name.to_string(), invalid))
+    valid.map_err(|invalid| Error::FailedValidation(failed_name(name, binding), invalid))
+}
+
+/// Name a failed validation: the shared validator's name qualified by its binding.
+pub(super) fn failed_name(name: &str, binding: usize) -> String {
+    format!("{name} (binding {binding})")
 }
 
 /// Reduce two HeapRoot entries, dispatching each through `access()` to
@@ -730,7 +751,7 @@ mod test {
     /// `v` array reduces by append. A closure (not `vec![…; N]`) because
     /// `Validator` isn't `Clone`.
     fn append_merge_spec(n_bindings: usize) -> Spec {
-        let binding = || {
+        let validator = || {
             let schema = build_schema(
                 &url::Url::parse("http://example/schema").unwrap(),
                 &json!({
@@ -739,18 +760,51 @@ mod test {
                 }),
             )
             .unwrap();
-            (
-                true, // Full reduction.
-                vec![Extractor::with_default(
-                    "/key",
-                    &SerPolicy::noop(),
-                    json!("def"),
-                )],
-                "test",
-                Validator::new(schema).unwrap(),
-            )
+            ("test", Validator::new(schema).unwrap())
         };
-        Spec::with_bindings(std::iter::repeat_with(binding).take(n_bindings), Vec::new())
+        let key = || {
+            vec![Extractor::with_default(
+                "/key",
+                &SerPolicy::noop(),
+                json!("def"),
+            )]
+        };
+        // Identity mapping: one validator per binding.
+        Spec::with_bindings(
+            (0..n_bindings).map(|binding| (true, key(), binding as u32)),
+            std::iter::repeat_with(validator).take(n_bindings),
+            Vec::new(),
+        )
+    }
+
+    /// A Spec over three bindings and *two* validators: bindings 0 and 1 share
+    /// validator "shared" (whose `v` items must be strings) while binding 2 has
+    /// validator "solo" (whose `v` items must be integers). The two schemas are
+    /// mutually exclusive, so any leak of one validator onto the other's binding
+    /// surfaces as a validation failure rather than silently passing.
+    fn shared_validator_spec() -> Spec {
+        let validator = |name: &'static str, item_type: &str| {
+            let schema = build_schema(
+                &url::Url::parse("http://example/schema").unwrap(),
+                &json!({
+                    "properties": { "v": {
+                        "type": "array",
+                        "items": { "type": item_type },
+                        "reduce": { "strategy": "append" },
+                    } },
+                    "reduce": { "strategy": "merge" }
+                }),
+            )
+            .unwrap();
+            (name, Validator::new(schema).unwrap())
+        };
+        let key = || vec![Extractor::new("/key", &SerPolicy::noop())];
+
+        Spec::with_bindings(
+            [(true, key(), 0), (true, key(), 0), (true, key(), 1)],
+            [validator("shared", "string"), validator("solo", "integer")],
+            Vec::new(),
+        )
     }
 
     /// Force the Accumulator's current MemTable into a new spill segment,
@@ -771,6 +825,107 @@ mod test {
             serde_json::to_value(SerPolicy::noop().on_owned(&doc.root)).unwrap(),
             doc.meta.front(),
         )
+    }
+
+    #[test]
+    fn test_shared_validators() {
+        // Bindings which share a validator must still combine and drain
+        // separately: `Meta` remains keyed by binding, and only `names` and
+        // `validators` are validator-indexed.
+        assert_eq!(shared_validator_spec().binding_count(), 3);
+        assert_eq!(shared_validator_spec().validator_count(), 2);
+
+        // All three bindings write key "k", so any collapse across bindings
+        // would show up as a reduction that shouldn't have happened.
+        let add_all = |mt: &MemTable| {
+            for (binding, v) in [
+                (0, json!(["a"])),
+                (0, json!(["b"])), // Reduces into binding 0's "a".
+                (1, json!(["c"])),
+                (2, json!([7])),
+            ] {
+                mt.add(
+                    binding,
+                    HeapNode::from_node(&json!({"key": "k", "v": v}), mt.alloc()),
+                    false,
+                )
+                .unwrap();
+            }
+        };
+        let expected = vec![
+            (0, json!({"key": "k", "v": ["a", "b"]}), false),
+            (1, json!({"key": "k", "v": ["c"]}), false),
+            // Validated by validator 1, which alone accepts integer items.
+            (2, json!({"key": "k", "v": [7]}), false),
+        ];
+
+        // In-memory drain.
+        {
+            let memtable = MemTable::new(shared_validator_spec());
+            add_all(&memtable);
+
+            let drained = memtable
+                .try_into_drainer()
+                .unwrap()
+                .map_ok(project)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert_eq!(drained, expected, "in-memory drain");
+        }
+
+        // Spill drain: sharing survives a MemTable→segment→SpillDrainer
+        // round-trip, which carries `Meta` (and thus the binding) through the
+        // spill format while the Spec is moved along with it.
+        {
+            let mut acc = crate::combine::Accumulator::new(
+                shared_validator_spec(),
+                tempfile::tempfile().unwrap(),
+            )
+            .unwrap();
+            add_all(acc.memtable().unwrap());
+            force_spill(&mut acc);
+            add_all(acc.memtable().unwrap());
+
+            let drained = acc
+                .into_drainer()
+                .unwrap()
+                .map_ok(project)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+
+            // Each binding's two rounds reduce together, still per-binding.
+            let expected = vec![
+                (0, json!({"key": "k", "v": ["a", "b", "a", "b"]}), false),
+                (1, json!({"key": "k", "v": ["c", "c"]}), false),
+                (2, json!({"key": "k", "v": [7, 7]}), false),
+            ];
+            assert_eq!(drained, expected, "spill drain");
+        }
+
+        // A failure on binding 1 names its validator *and* its binding, even
+        // though the validator is named "shared" and is reached from two bindings.
+        {
+            let memtable = MemTable::new(shared_validator_spec());
+            memtable
+                .add(
+                    1,
+                    HeapNode::from_node(&json!({"key": "k", "v": [7]}), memtable.alloc()),
+                    false,
+                )
+                .unwrap();
+
+            let err = memtable
+                .try_into_drainer()
+                .unwrap()
+                .map_ok(project)
+                .collect::<Result<Vec<_>, _>>()
+                .expect_err("integer item is invalid for the shared validator");
+
+            assert!(
+                matches!(&err, Error::FailedValidation(n, _) if n == "shared (binding 1)"),
+                "unexpected error: {err:?}",
+            );
+        }
     }
 
     #[test]
@@ -1146,9 +1301,9 @@ mod test {
                     &SerPolicy::noop(),
                     json!("def"),
                 )],
-                "test",
-                Validator::new(schema).unwrap(),
+                0, // Slot.
             )],
+            [("test", Validator::new(schema).unwrap())],
             Vec::new(),
         );
         let mut acc =
@@ -1197,6 +1352,7 @@ mod test {
             json!("def"),
         )];
         let spec = Spec::with_bindings(
+            (0..2).map(|binding| (true /* Full reduction. */, key.clone(), binding as u32)),
             std::iter::repeat_with(|| {
                 let schema = build_schema(
                     &url::Url::parse("http://example/schema").unwrap(),
@@ -1213,12 +1369,7 @@ mod test {
                 )
                 .unwrap();
 
-                (
-                    true, // Full reduction.
-                    key.clone(),
-                    "source-name",
-                    Validator::new(schema).unwrap(),
-                )
+                ("source-name", Validator::new(schema).unwrap())
             })
             .take(2),
             Vec::new(),
@@ -1478,8 +1629,10 @@ mod test {
                 .unwrap(),
             )
         };
+        let [full, associative] = [spec(true), spec(false)];
         let memtable = MemTable::new(Spec::with_bindings(
-            [spec(true), spec(false)].into_iter(),
+            [(full.0, full.1, 0u32), (associative.0, associative.1, 1u32)],
+            [(full.2, full.3), (associative.2, associative.3)],
             Vec::new(),
         ));
 
@@ -1774,7 +1927,9 @@ mod test {
 
         let mut spill = SpillWriter::new(io::Cursor::new(Vec::new())).unwrap();
         let out = memtable.spill(&mut spill, CHUNK_TARGET_SIZE);
-        assert!(matches!(out, Err(Error::FailedValidation(n, _)) if n == "source-name"));
+        assert!(
+            matches!(out, Err(Error::FailedValidation(n, _)) if n == "source-name (binding 0)")
+        );
     }
 
     #[test]

--- a/crates/doc/src/combine/mod.rs
+++ b/crates/doc/src/combine/mod.rs
@@ -19,13 +19,20 @@ pub enum Error {
     SpillIO(#[from] io::Error),
 }
 
-/// Specification of how Combine operations are to be done
-/// over one or more bindings.
+/// Specification of how Combine operations are to be done over one or more
+/// bindings, each mapping to one or more validators.
 pub struct Spec {
+    // Full or partial reduction? (binding-indexed)
     is_full: Vec<bool>,
+    // Key to be combined over (binding-indexed)
     keys: Arc<[Box<[Extractor]>]>,
+    // Name of each validator (validator-indexed)
     names: Vec<String>,
+    // Effective salt to use for redacted values.
     redact_salt: Vec<u8>,
+    // Mapping from binding to validator (binding-indexed)
+    validator_index: Vec<u32>,
+    // JSON schema validators (validator-indexed)
     validators: Vec<Validator>,
 }
 
@@ -50,36 +57,60 @@ impl Spec {
             keys: vec![key.into()].into(),
             names: vec![name.into()],
             redact_salt,
+            validator_index: vec![0],
             validators: vec![validator],
         }
     }
 
-    /// Build a Spec from an Iterator of (is-full-reduction, key, schema, validator).
-    pub fn with_bindings<I, K, N>(bindings: I, redact_salt: Vec<u8>) -> Self
+    /// Build a Spec from a per-binding Iterator of (is-full-reduction, key,
+    /// validator index), and a validator-indexed Iterator of (name, validator).
+    ///
+    /// Panics if a binding names a validator which was not provided.
+    pub fn with_bindings<B, V, K, N>(bindings: B, validators: V, redact_salt: Vec<u8>) -> Self
     where
-        I: IntoIterator<Item = (bool, K, N, Validator)>,
+        B: IntoIterator<Item = (bool, K, u32)>,
+        V: IntoIterator<Item = (N, Validator)>,
         K: Into<Box<[Extractor]>>,
         N: Into<String>,
     {
-        let mut full = Vec::new();
-        let mut keys = Vec::new();
-        let mut names = Vec::new();
-        let mut validators = Vec::new();
+        let (names, validators): (Vec<String>, Vec<Validator>) = validators
+            .into_iter()
+            .map(|(name, validator)| (name.into(), validator))
+            .unzip();
 
-        for (index, (is_full, key, name, validator)) in bindings.into_iter().enumerate() {
-            full.push(is_full);
+        let mut is_full = Vec::new();
+        let mut keys = Vec::new();
+        let mut validator_index = Vec::new();
+
+        for (binding, (full, key, index)) in bindings.into_iter().enumerate() {
+            assert!(
+                (index as usize) < validators.len(),
+                "binding {binding} names validator {index}, but only {} validators were given",
+                validators.len(),
+            );
+            is_full.push(full);
             keys.push(key.into());
-            names.push(format!("{} (binding {index})", name.into()));
-            validators.push(validator);
+            validator_index.push(index);
         }
 
         Self {
-            is_full: full,
+            is_full,
             keys: keys.into(),
             names,
             redact_salt,
+            validator_index,
             validators,
         }
+    }
+
+    /// Number of bindings of this Spec.
+    pub fn binding_count(&self) -> usize {
+        self.validator_index.len()
+    }
+
+    /// Number of validators of this Spec.
+    pub fn validator_count(&self) -> usize {
+        self.validators.len()
     }
 }
 

--- a/crates/doc/src/combine/spill.rs
+++ b/crates/doc/src/combine/spill.rs
@@ -416,9 +416,12 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
             meta.set_front(); // Transfer stale existence onto the fresh output.
         }
 
-        let is_full = self.spec.is_full[meta.binding()];
-        let key = self.spec.keys[meta.binding()].as_ref();
-        let validator = &mut self.spec.validators[meta.binding()];
+        let binding = meta.binding();
+        let validator_index = self.spec.validator_index[binding] as usize;
+
+        let is_full = self.spec.is_full[binding];
+        let key = self.spec.keys[binding].as_ref();
+        let validator = &mut self.spec.validators[validator_index];
 
         // `reduced` root which is updated as reductions occur.
         let mut reduced: Option<HeapNode<'_>> = None;
@@ -441,8 +444,11 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
             let rhs_outcomes = validator
                 .validate(next.head.root.get(), validation::reduce_filter)
                 .map_err(|invalid| {
+                    let rhs_binding = next.head.meta.binding();
+                    let rhs_index = self.spec.validator_index[rhs_binding] as usize;
+
                     Error::FailedValidation(
-                        self.spec.names[next.head.meta.binding()].clone(),
+                        super::memtable::failed_name(&self.spec.names[rhs_index], rhs_binding),
                         invalid,
                     )
                 })?;
@@ -487,7 +493,10 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
                 Some(reduced) => validator.validate(reduced, validation::redact_filter),
             }
             .map_err(|invalid| {
-                Error::FailedValidation(self.spec.names[meta.binding()].clone(), invalid)
+                Error::FailedValidation(
+                    super::memtable::failed_name(&self.spec.names[validator_index], binding),
+                    invalid,
+                )
             })?
         };
 
@@ -681,6 +690,17 @@ mod test {
     #[test]
     fn test_heap_merge() {
         let spec = Spec::with_bindings(
+            (0..3).map(|binding| {
+                (
+                    true, // Full reduction.
+                    vec![Extractor::with_default(
+                        "/key",
+                        &SerPolicy::noop(),
+                        json!("def"),
+                    )],
+                    binding as u32,
+                )
+            }),
             std::iter::repeat_with(|| {
                 let schema = json::schema::build(
                     &url::Url::parse("http://example/schema").unwrap(),
@@ -697,16 +717,7 @@ mod test {
                 )
                 .unwrap();
 
-                (
-                    true, // Full reduction.
-                    vec![Extractor::with_default(
-                        "/key",
-                        &SerPolicy::noop(),
-                        json!("def"),
-                    )],
-                    "source-name",
-                    Validator::new(schema).unwrap(),
-                )
+                ("source-name", Validator::new(schema).unwrap())
             })
             .take(3),
             Vec::new(),
@@ -835,27 +846,24 @@ mod test {
 
     #[test]
     fn test_drain_validation() {
-        let spec = Spec::with_bindings(
-            std::iter::repeat_with(|| {
-                let schema = json::schema::build(
-                    &url::Url::parse("http://example/schema").unwrap(),
-                    &json!({
-                        "properties": {
-                            "key": { "type": "string" },
-                            "v": { "const": "good" },
-                        }
-                    }),
-                )
-                .unwrap();
+        let schema = json::schema::build(
+            &url::Url::parse("http://example/schema").unwrap(),
+            &json!({
+                "properties": {
+                    "key": { "type": "string" },
+                    "v": { "const": "good" },
+                }
+            }),
+        )
+        .unwrap();
 
-                (
-                    true, // Full reduction.
-                    vec![Extractor::new("/key", &SerPolicy::noop())],
-                    "source-name",
-                    Validator::new(schema).unwrap(),
-                )
-            })
-            .take(1),
+        let spec = Spec::with_bindings(
+            [(
+                true, // Full reduction.
+                vec![Extractor::new("/key", &SerPolicy::noop())],
+                0, // Slot.
+            )],
+            [("source-name", Validator::new(schema).unwrap())],
             Vec::new(),
         );
 
@@ -1059,10 +1067,9 @@ mod test {
             [(
                 false, // Associative (not full) reduction.
                 vec![Extractor::new("/key", &SerPolicy::noop())],
-                "source",
-                Validator::new(schema).unwrap(),
-            )]
-            .into_iter(),
+                0, // Slot.
+            )],
+            [("source", Validator::new(schema).unwrap())],
             Vec::new(),
         );
 

--- a/crates/doc/tests/merge_patch_fuzz.rs
+++ b/crates/doc/tests/merge_patch_fuzz.rs
@@ -96,14 +96,21 @@ fn reduce_combiner(input: Vec<ArbitraryValue>) -> bool {
             doc::Validator::new(schema).unwrap(),
         )
     };
-    let memtable_1 = MemTable::new(Spec::with_bindings(
-        [spec(false), spec(true)].into_iter(),
-        Vec::new(),
-    ));
-    let memtable_2 = MemTable::new(Spec::with_bindings(
-        [spec(false), spec(true)].into_iter(),
-        Vec::new(),
-    ));
+    // Identity mapping: one validator per binding.
+    let make_spec = || {
+        let [
+            (full_0, key_0, name_0, validator_0),
+            (full_1, key_1, name_1, validator_1),
+        ] = [spec(false), spec(true)];
+
+        Spec::with_bindings(
+            [(full_0, key_0, 0u32), (full_1, key_1, 1u32)],
+            [(name_0, validator_0), (name_1, validator_1)],
+            Vec::new(),
+        )
+    };
+    let memtable_1 = MemTable::new(make_spec());
+    let memtable_2 = MemTable::new(make_spec());
 
     let seed = json!({"hello": "world", "null": null});
     let mut expect = seed.clone();

--- a/crates/doc/tests/spill_merge_fuzz.rs
+++ b/crates/doc/tests/spill_merge_fuzz.rs
@@ -34,8 +34,19 @@ fn make_spec() -> combine::Spec {
     let ser_policy = doc::SerPolicy::noop();
 
     combine::Spec::with_bindings(
-        // Binding 0: full reduction. Binding 1: associative (non-full) reduction.
-        [true, false].into_iter().map(|is_full| {
+        // Binding 0: full reduction. Binding 1: associative (non-full)
+        // reduction. Identity mapping: one validator per binding.
+        [true, false]
+            .into_iter()
+            .enumerate()
+            .map(|(index, is_full)| {
+                (
+                    is_full,
+                    vec![Extractor::new("/key", &ser_policy)],
+                    index as u32,
+                )
+            }),
+        std::iter::repeat_with(|| {
             let schema = build_schema(
                 &url::Url::parse("http://example/schema").unwrap(),
                 &json!({
@@ -55,13 +66,9 @@ fn make_spec() -> combine::Spec {
             )
             .unwrap();
 
-            (
-                is_full,
-                vec![Extractor::new("/key", &ser_policy)],
-                "source-name",
-                Validator::new(schema).unwrap(),
-            )
-        }),
+            ("source-name", Validator::new(schema).unwrap())
+        })
+        .take(2),
         Vec::new(),
     )
 }

--- a/crates/e2e-support/tests/hello_world.rs
+++ b/crates/e2e-support/tests/hello_world.rs
@@ -53,8 +53,8 @@ async fn hello_world(build: Arc<build::Output>, journal_client: gazette::journal
         .as_ref()
         .expect("built collection should have a spec");
 
-    let binding = publisher::Binding::from_collection_spec(collection_spec)
-        .expect("should build binding from collection spec");
+    let target = publisher::Target::from_collection_spec(collection_spec)
+        .expect("should build target from collection spec");
 
     let factory: gazette::journal::ClientFactory = Arc::new({
         let journal_client = journal_client.clone();
@@ -64,7 +64,7 @@ async fn hello_world(build: Arc<build::Output>, journal_client: gazette::journal
     // Create a Publisher with deterministic identity for reproducible snapshots.
     let mut publisher = publisher::Publisher::new(
         String::new(), // No AuthZ subject.
-        vec![binding],
+        vec![target],
         factory,
         uuid::Producer::from_bytes([0x01, 0x00, 0x00, 0x00, 0x00, 0x01]),
         uuid::Clock::UNIX_EPOCH,
@@ -118,7 +118,7 @@ async fn hello_world(build: Arc<build::Output>, journal_client: gazette::journal
         .expect("ACK write should succeed");
 
     // Snapshot the partition listing from the Publisher's own watch.
-    let (_client, partitions) = publisher.mapped_binding_client(0);
+    let (_client, partitions) = publisher.mapped_target_client(0);
     let partitions_watch = partitions.ready().await;
     let splits = partitions_watch.token();
     let splits = splits.result().expect("partitions should be available");

--- a/crates/flowctl/src/raw/preview_next/fixture.rs
+++ b/crates/flowctl/src/raw/preview_next/fixture.rs
@@ -201,7 +201,7 @@ pub fn build(
     requested_targets: &[u32],
     n_shards: u32,
 ) -> anyhow::Result<FixturePlan> {
-    let (bindings, mut validators, collection_bindings) = task_bindings(task)?;
+    let (bindings, sources, mut validators, collection_bindings) = task_bindings(task)?;
 
     let mut transactions = parse(path)?;
     // A session bounded by `max_transactions` can't run zero transactions, so
@@ -247,6 +247,7 @@ pub fn build(
             frontiers.push(write_transaction(
                 &transaction,
                 &bindings,
+                &sources,
                 &mut validators,
                 &collection_bindings,
                 &shards,
@@ -331,7 +332,7 @@ pub fn start_streaming(
     eof_stop: tokio_util::sync::CancellationToken,
     hold: tokio_util::sync::CancellationToken,
 ) -> anyhow::Result<(String, tokio::task::JoinHandle<anyhow::Result<()>>)> {
-    let (bindings, validators, collection_bindings) = task_bindings(task)?;
+    let (bindings, sources, validators, collection_bindings) = task_bindings(task)?;
 
     // The session reads from its own directory, mirroring the eager per-session
     // layout.
@@ -344,6 +345,7 @@ pub fn start_streaming(
 
     let handle = tokio::spawn(feed_stream(
         bindings,
+        sources,
         validators,
         collection_bindings,
         path,
@@ -358,6 +360,7 @@ pub fn start_streaming(
 
 async fn feed_stream(
     bindings: Vec<shuffle::Binding>,
+    sources: Vec<shuffle::Source>,
     mut validators: Vec<doc::Validator>,
     collection_bindings: HashMap<String, Vec<usize>>,
     path: Option<std::path::PathBuf>,
@@ -370,6 +373,7 @@ async fn feed_stream(
     let mut sealed = Vec::new();
     let result = feed_lines(
         &bindings,
+        &sources,
         &mut validators,
         &collection_bindings,
         path,
@@ -410,6 +414,7 @@ async fn feed_stream(
 /// cancels), or on a stream / fixture error.
 async fn feed_lines(
     bindings: &[shuffle::Binding],
+    sources: &[shuffle::Source],
     validators: &mut [doc::Validator],
     collection_bindings: &HashMap<String, Vec<usize>>,
     path: Option<std::path::PathBuf>,
@@ -464,6 +469,7 @@ async fn feed_lines(
                 let frontier = write_transaction(
                     &std::mem::take(&mut current),
                     bindings,
+                    sources,
                     validators,
                     collection_bindings,
                     shards,
@@ -490,6 +496,7 @@ async fn feed_lines(
         let frontier = write_transaction(
             &current,
             bindings,
+            sources,
             validators,
             collection_bindings,
             shards,
@@ -505,27 +512,28 @@ async fn feed_lines(
     Ok(())
 }
 
-/// Build shuffle bindings and validators for `task`, plus a map from each
-/// source collection name to the binding indices it feeds (a collection may be
-/// read by multiple derivation transforms).
+/// Build shuffle bindings, sources, and per-source validators for `task`, plus
+/// a map from each source collection name to the binding indices it feeds (a
+/// collection may be read by multiple derivation transforms).
 fn task_bindings(
     task: &shuffle::proto::Task,
 ) -> anyhow::Result<(
     Vec<shuffle::Binding>,
+    Vec<shuffle::Source>,
     Vec<doc::Validator>,
     HashMap<String, Vec<usize>>,
 )> {
-    let (bindings, validators) =
+    let (bindings, sources, validators) =
         shuffle::Binding::from_task(task).context("building shuffle bindings from task")?;
 
     let mut collection_bindings: HashMap<String, Vec<usize>> = HashMap::new();
     for (index, binding) in bindings.iter().enumerate() {
         collection_bindings
-            .entry(binding.collection.to_string())
+            .entry(sources[binding.source as usize].collection.to_string())
             .or_default()
             .push(index);
     }
-    Ok((bindings, validators, collection_bindings))
+    Ok((bindings, sources, validators, collection_bindings))
 }
 
 /// Write one transaction as a log block per shard receiving documents, and
@@ -544,6 +552,7 @@ fn task_bindings(
 fn write_transaction(
     transaction: &Transaction,
     bindings: &[shuffle::Binding],
+    sources: &[shuffle::Source],
     validators: &mut [doc::Validator],
     collection_bindings: &HashMap<String, Vec<usize>>,
     shards: &[shuffle::proto::Shard],
@@ -577,12 +586,13 @@ fn write_transaction(
 
         for &bi in binding_indices {
             let binding = &bindings[bi];
-            let journal = fixture_journal(&binding.collection);
+            let source = &sources[binding.source as usize];
+            let journal = fixture_journal(&source.collection);
 
             // Inject a synthetic UUID at the collection's UUID pointer.
             let mut doc = doc.clone();
             let synthetic_uuid = uuid::build(FIXTURE_PRODUCER, doc_clock, uuid::Flags::OUTSIDE_TXN);
-            *json::ptr::create_value(&binding.source_uuid_ptr, &mut doc)
+            *json::ptr::create_value(&source.uuid_ptr, &mut doc)
                 .context("creating fixture UUID location in document")? =
                 serde_json::json!(synthetic_uuid.as_hyphenated().to_string());
 
@@ -595,7 +605,7 @@ fn write_transaction(
             // Mirror the slice: set the schema-valid flag from validation and
             // pack the shuffle key from the archived document.
             let mut flags = uuid::Flags::OUTSIDE_TXN.0;
-            if validators[bi].is_valid(archived) {
+            if validators[binding.source as usize].is_valid(archived) {
                 flags |= shuffle::FLAGS_SCHEMA_VALID;
             }
 

--- a/crates/flowctl/src/raw/preview_next/publish.rs
+++ b/crates/flowctl/src/raw/preview_next/publish.rs
@@ -11,6 +11,7 @@
 //! (`--output-apply`) — flows through the separate
 //! [`Logger`](runtime_next::Logger) seam in [`super::logger`].
 
+use anyhow::Context as _;
 use bytes::Bytes;
 use std::collections::BTreeMap;
 use std::io::Write as _;
@@ -36,9 +37,23 @@ impl runtime_next::PublisherFactory for PreviewPublisherFactory {
         _producer: proto_gazette::uuid::Producer,
         _stats_journal: &str,
         collection_specs: &[&proto_flow::flow::CollectionSpec],
+        binding_targets: &[u32],
     ) -> anyhow::Result<PreviewPublisher> {
+        // Preview frames documents by collection name, so the binding -> target
+        // remap is resolved here rather than carried into `publish_doc`.
+        let collection_names = binding_targets
+            .iter()
+            .enumerate()
+            .map(|(binding, &target)| {
+                let spec = collection_specs.get(target as usize).with_context(|| {
+                    format!("binding {binding} maps to unknown target {target}")
+                })?;
+                Ok(spec.name.clone())
+            })
+            .collect::<anyhow::Result<Vec<String>>>()?;
+
         Ok(PreviewPublisher {
-            collection_names: collection_specs.iter().map(|s| s.name.clone()).collect(),
+            collection_names,
             line_buf: Vec::new(),
         })
     }

--- a/crates/publisher/src/lib.rs
+++ b/crates/publisher/src/lib.rs
@@ -1,16 +1,16 @@
 pub mod appender;
-pub mod binding;
 pub mod intents;
 pub mod mapping;
 pub mod publisher;
+pub mod target;
 pub mod watch;
 
 pub use appender::{Appender, AppenderGroup, ThrottleSample};
-pub use binding::{Binding, FixedBinding, MappedBinding};
 pub use mapping::{MIN_PARTITION_WIDTH, SplitOutcome};
 pub use publisher::Publisher;
+pub use target::{FixedTarget, MappedTarget, Target};
 
-/// Boxed closure for lazy initialization of a Mapped binding's partitions
+/// Boxed closure for lazy initialization of a Mapped target's partitions
 /// watch and journal Client.
 type MappedClientInit = Box<
     dyn FnOnce() -> (
@@ -19,22 +19,22 @@ type MappedClientInit = Box<
         ) + Send,
 >;
 
-/// Boxed closure for lazy initialization of a Fixed binding's journal Client.
+/// Boxed closure for lazy initialization of a Fixed target's journal Client.
 type FixedClientInit = Box<dyn FnOnce() -> gazette::journal::Client + Send>;
 
-/// LazyBindingClient defers initialization of per-binding journal resources
+/// LazyTargetClient defers initialization of per-target journal resources
 /// until first use.
 ///
-/// Mapped bindings need both a journal Client and a long-lived list-watch
-/// stream of partitions. Fixed bindings only need a Client (the journal is
+/// Mapped targets need both a journal Client and a long-lived list-watch
+/// stream of partitions. Fixed targets only need a Client (the journal is
 /// known by name; no listing is required).
 ///
 /// An instantiated client and watch each consume background resources:
 /// periodic token refreshes for the client, and a long-lived list RPC for the
-/// watch. However, many (most?) bindings and collections are infrequently
-/// written and a Publisher instance may never interact with the binding during
-/// its lifetime, so avoid paying this cost until we know it's needed.
-pub(crate) enum LazyBindingClient {
+/// watch. However, many (most?) collections are infrequently written and a
+/// Publisher instance may never interact with the target during its lifetime,
+/// so avoid paying this cost until we know it's needed.
+pub(crate) enum LazyTargetClient {
     Mapped(
         std::sync::LazyLock<
             (
@@ -47,7 +47,7 @@ pub(crate) enum LazyBindingClient {
     Fixed(std::sync::LazyLock<gazette::journal::Client, FixedClientInit>),
 }
 
-impl LazyBindingClient {
+impl LazyTargetClient {
     /// Force initialization and return the underlying journal Client.
     pub(crate) fn client(&self) -> &gazette::journal::Client {
         match self {

--- a/crates/publisher/src/mapping.rs
+++ b/crates/publisher/src/mapping.rs
@@ -14,7 +14,7 @@ use proto_gazette::broker;
 ///
 /// Port of Go's `Mapper.Map` (`go/flow/mapping.go`).
 pub(crate) async fn map_partition<N: json::AsNode>(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     lazy: &std::sync::LazyLock<
         (
             gazette::journal::Client,
@@ -26,9 +26,9 @@ pub(crate) async fn map_partition<N: json::AsNode>(
     prefix: String,
     packed_key: bytes::BytesMut,
 ) -> tonic::Result<(String, bytes::BytesMut)> {
-    let (prefix, packed_key, key_hash) = extract_mapping_context(binding, doc, prefix, packed_key)?;
+    let (prefix, packed_key, key_hash) = extract_mapping_context(target, doc, prefix, packed_key)?;
     let (_doc, journal, packed_key) =
-        map_partition_from_context(binding, lazy, doc, prefix, packed_key, key_hash).await?;
+        map_partition_from_context(target, lazy, doc, prefix, packed_key, key_hash).await?;
     Ok((journal, packed_key))
 }
 
@@ -38,7 +38,7 @@ pub(crate) async fn map_partition<N: json::AsNode>(
 /// through the async mapping loop, rather than holding a borrowed `HeapNode`
 /// across its `.await` points. Returns `doc` alongside the mapped journal.
 pub(crate) async fn map_partition_owned(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     lazy: &std::sync::LazyLock<
         (
             gazette::journal::Client,
@@ -51,12 +51,12 @@ pub(crate) async fn map_partition_owned(
     packed_key: bytes::BytesMut,
 ) -> tonic::Result<(doc::OwnedNode, String, bytes::BytesMut)> {
     let (prefix, packed_key, key_hash) =
-        extract_mapping_context_owned(binding, &doc, prefix, packed_key)?;
-    map_partition_from_context(binding, lazy, doc, prefix, packed_key, key_hash).await
+        extract_mapping_context_owned(target, &doc, prefix, packed_key)?;
+    map_partition_from_context(target, lazy, doc, prefix, packed_key, key_hash).await
 }
 
 async fn map_partition_from_context<D: PartitionDoc>(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     lazy: &std::sync::LazyLock<
         (
             gazette::journal::Client,
@@ -84,18 +84,18 @@ async fn map_partition_from_context<D: PartitionDoc>(
         // Uncommon case: a covering physical partition doesn't exist.
 
         // Have we exhausted the limit of partitions?
-        if partitions.len() >= binding.partitions_limit {
+        if partitions.len() >= target.partitions_limit {
             return Err(tonic::Status::resource_exhausted(format!(
                 "collection {} has too many partitions ({}, limit is {})",
-                binding.collection,
+                target.collection,
                 partitions.len(),
-                binding.partitions_limit
+                target.partitions_limit
             )));
         }
         // Attempt to create a new full-range physical partition of this logical
         // partition. The logical-partition labels are extracted from the document
         // only here, on the uncommon path that actually needs them.
-        let (name, request) = build_partition_apply(binding, &doc)?;
+        let (name, request) = build_partition_apply(target, &doc)?;
         let result = client.apply(request).await;
 
         match result {
@@ -126,26 +126,26 @@ async fn map_partition_from_context<D: PartitionDoc>(
 /// is all that's required to map a document in the common case where its
 /// physical partition already exists.
 fn extract_mapping_context<N: json::AsNode>(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     doc: &N,
     mut prefix: String,
     mut packed_key: bytes::BytesMut,
 ) -> tonic::Result<(String, bytes::BytesMut, u32)> {
     doc::Extractor::extract_all(
         doc,
-        &binding.key_extractors,
+        &target.key_extractors,
         doc::Encoding::Packed,
         &mut packed_key,
         None,
     );
     let key_hash = doc::Extractor::packed_hash(&packed_key);
 
-    prefix.push_str(&binding.partitions_template.name);
+    prefix.push_str(&target.partitions_template.name);
     prefix.push('/');
     prefix = labels::partition::append_extracted_fields_name_suffix(
         prefix,
-        &binding.partition_fields,
-        &binding.partition_extractors,
+        &target.partition_fields,
+        &target.partition_extractors,
         doc,
     )
     .map_err(|err| tonic::Status::internal(format!("failed to encode logical prefix: {err}")))?;
@@ -156,18 +156,18 @@ fn extract_mapping_context<N: json::AsNode>(
 /// Owned-document counterpart of `extract_mapping_context`, which dispatches
 /// `doc` to its inner `json::AsNode` representation.
 fn extract_mapping_context_owned(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     doc: &doc::OwnedNode,
     prefix: String,
     packed_key: bytes::BytesMut,
 ) -> tonic::Result<(String, bytes::BytesMut, u32)> {
     match doc {
         doc::OwnedNode::Heap(root) => match root.access() {
-            Ok(heap_node) => extract_mapping_context(binding, &heap_node, prefix, packed_key),
-            Err(embedded) => extract_mapping_context(binding, embedded.get(), prefix, packed_key),
+            Ok(heap_node) => extract_mapping_context(target, &heap_node, prefix, packed_key),
+            Err(embedded) => extract_mapping_context(target, embedded.get(), prefix, packed_key),
         },
         doc::OwnedNode::Archived(archived) => {
-            extract_mapping_context(binding, archived.get(), prefix, packed_key)
+            extract_mapping_context(target, archived.get(), prefix, packed_key)
         }
     }
 }
@@ -184,7 +184,7 @@ trait PartitionDoc {
     /// `estuary.dev/field/` labels of `labels`, returning the extended set.
     fn encode_logical_partition_labels(
         &self,
-        binding: &super::MappedBinding,
+        target: &super::MappedTarget,
         labels: broker::LabelSet,
     ) -> tonic::Result<broker::LabelSet>;
 }
@@ -192,13 +192,13 @@ trait PartitionDoc {
 impl<N: json::AsNode> PartitionDoc for &N {
     fn encode_logical_partition_labels(
         &self,
-        binding: &super::MappedBinding,
+        target: &super::MappedTarget,
         labels: broker::LabelSet,
     ) -> tonic::Result<broker::LabelSet> {
         labels::partition::encode_extracted_fields_labels(
             labels,
-            &binding.partition_fields,
-            &binding.partition_extractors,
+            &target.partition_fields,
+            &target.partition_extractors,
             *self,
         )
         .map_err(|err| {
@@ -210,20 +210,20 @@ impl<N: json::AsNode> PartitionDoc for &N {
 impl PartitionDoc for doc::OwnedNode {
     fn encode_logical_partition_labels(
         &self,
-        binding: &super::MappedBinding,
+        target: &super::MappedTarget,
         labels: broker::LabelSet,
     ) -> tonic::Result<broker::LabelSet> {
         // Dispatch to the `&N` impl over `doc::OwnedNode`'s inner representation.
         match self {
             doc::OwnedNode::Heap(root) => match root.access() {
-                Ok(heap_node) => (&heap_node).encode_logical_partition_labels(binding, labels),
+                Ok(heap_node) => (&heap_node).encode_logical_partition_labels(target, labels),
                 Err(embedded) => embedded
                     .get()
-                    .encode_logical_partition_labels(binding, labels),
+                    .encode_logical_partition_labels(target, labels),
             },
             doc::OwnedNode::Archived(archived) => archived
                 .get()
-                .encode_logical_partition_labels(binding, labels),
+                .encode_logical_partition_labels(target, labels),
         }
     }
 }
@@ -282,10 +282,10 @@ fn pick_partition(
 // Build an ApplyRequest to create a new full-range physical partition of the
 // logical partition implied by `doc`.
 fn build_partition_apply<D: PartitionDoc>(
-    binding: &super::MappedBinding,
+    target: &super::MappedTarget,
     doc: &D,
 ) -> tonic::Result<(String, broker::ApplyRequest)> {
-    let mut spec = binding.partitions_template.clone();
+    let mut spec = target.partitions_template.clone();
 
     // Encode labels of a single physical partition covering the full key
     // range, then the logical-partition fields extracted from `doc`.
@@ -294,7 +294,7 @@ fn build_partition_apply<D: PartitionDoc>(
         u32::MIN,
         u32::MAX,
     );
-    let labels = doc.encode_logical_partition_labels(binding, labels)?;
+    let labels = doc.encode_logical_partition_labels(target, labels)?;
 
     let name = labels::partition::full_name(&spec.name, &labels).unwrap();
     spec.name = name.clone();
@@ -337,8 +337,8 @@ pub enum SplitOutcome {
 /// Attempt to split partition `journal` at its key-range midpoint.
 ///
 /// `partitions_template` is the owning collection's partition template (the
-/// only thing about the binding a split needs); `client` and `partitions` are
-/// the binding's journal client and live partition watch.
+/// only thing about the target a split needs); `client` and `partitions` are
+/// the target's journal client and live partition watch.
 ///
 /// The journal's width is first checked against the in-memory partition watch
 /// (no RPC): if it's below `2 * MIN_PARTITION_WIDTH` the outcome is `AtFloor`
@@ -547,8 +547,8 @@ mod test {
         assert_eq!(pick_partition(&p, "coll/a=1/", 0), None);
     }
 
-    /// Build a test MappedBinding from a built CollectionSpec.
-    fn test_binding(spec: &flow::CollectionSpec) -> super::super::MappedBinding {
+    /// Build a test MappedTarget from a built CollectionSpec.
+    fn test_target(spec: &flow::CollectionSpec) -> super::super::MappedTarget {
         let flow::CollectionSpec {
             name,
             partition_template,
@@ -566,7 +566,7 @@ mod test {
         let partition_extractors =
             extractors::for_fields(partition_fields, projections, &policy).unwrap();
 
-        super::super::MappedBinding {
+        super::super::MappedTarget {
             collection: models::Collection::new(name),
             key_extractors,
             partition_fields: partition_fields.clone(),
@@ -591,17 +591,17 @@ mod test {
             .unwrap();
 
         let spec = spec.as_ref().unwrap();
-        let binding = test_binding(spec);
+        let target = test_target(spec);
 
         // extract_mapping_context encodes partition field values directly into
         // the logical journal-name prefix.
         let doc_1 = json!({"a_key": "k", "a_bool": true, "a_str": "hello"});
         let (prefix_1, _, _) =
-            extract_mapping_context(&binding, &doc_1, String::new(), bytes::BytesMut::new())
+            extract_mapping_context(&target, &doc_1, String::new(), bytes::BytesMut::new())
                 .unwrap();
 
         let (prefix_2, _, _) = extract_mapping_context(
-            &binding,
+            &target,
             &json!({"a_key": "k", "a_bool": false, "a_str": "world"}),
             String::new(),
             bytes::BytesMut::new(),
@@ -610,7 +610,7 @@ mod test {
 
         // Pre-allocated capacity doesn't affect the output.
         let (prefix_3, _, _) = extract_mapping_context(
-            &binding,
+            &target,
             &json!({"a_key": "k", "a_bool": true, "a_str": "reused"}),
             String::with_capacity(256),
             bytes::BytesMut::new(),
@@ -622,7 +622,7 @@ mod test {
         // build_partition_apply creates a full-key-range partition spec, with
         // the logical-partition field labels extracted from the document only
         // when a new partition must be created.
-        let (name, request) = build_partition_apply(&binding, &&doc_1).unwrap();
+        let (name, request) = build_partition_apply(&target, &&doc_1).unwrap();
 
         insta::assert_json_snapshot!(
             "physical_partition_apply",
@@ -661,7 +661,7 @@ mod test {
         (client, tokens::fixed(Ok(listing)))
     }
 
-    /// Build a parent JournalSplit of `split_test_binding`'s template, having
+    /// Build a parent JournalSplit of `split_test_template`, having
     /// the given key range and one logical-partition field label.
     fn split_test_parent(
         key_begin: u32,

--- a/crates/publisher/src/publisher.rs
+++ b/crates/publisher/src/publisher.rs
@@ -5,15 +5,10 @@ use proto_gazette::{broker, uuid};
 /// Publisher is responsible for transactional publishing of documents to
 /// journal partitions, creating partitions on-demand and as needed.
 pub struct Publisher {
-    // Re-useable Appenders for binding journals.
+    // Re-useable Appenders for target journals.
     appenders: super::AppenderGroup,
     // Subject used to scope journal authorizations.
     authz_subject: String,
-    // Bindings of this Publisher.
-    bindings: Vec<super::Binding>,
-    // Lazily-initialized journal Client (and, for Mapped bindings, partitions
-    // watch) for each `bindings` entry.
-    binding_clients: Vec<super::LazyBindingClient>,
     // Factory for building journal Clients on demand.
     client_factory: gazette::journal::ClientFactory,
     // Clock used to stamp published document UUIDs.
@@ -24,48 +19,53 @@ pub struct Publisher {
     prefix_buf: String,
     // Producer used to stamp published document UUIDs.
     producer: uuid::Producer,
+    // Lazily-initialized journal Client (and, for Mapped targets, partitions
+    // watch) for each `targets` entry.
+    target_clients: Vec<super::LazyTargetClient>,
+    // Journal destinations of this Publisher.
+    targets: Vec<super::Target>,
 }
 
 impl Publisher {
-    /// Create a new Publisher for the given bindings, producer identity, and clock.
+    /// Create a new Publisher for the given targets, producer identity, and clock.
     ///
-    /// `client_factory` is used to build lazy per-binding journal clients
-    /// (one per entry of `bindings`), and to build ephemeral clients inside
-    /// `write_intents` for ACK intents that do not match any current binding.
+    /// `client_factory` is used to build lazy per-target journal clients
+    /// (one per entry of `targets`), and to build ephemeral clients inside
+    /// `write_intents` for ACK intents that do not match any current target.
     /// `authz_subject` is passed through to this factory without modification,
-    /// and a binding's `authz_object()` is the AuthZ object.
+    /// and a target's `authz_object()` is the AuthZ object.
     ///
     /// The `producer` identifies this Publisher as a distinct writer and is
     /// embedded in every UUID it generates. The `clock` provides a monotonic
     /// timestamp for ordering documents within this producer's stream.
     pub fn new(
         authz_subject: String,
-        bindings: Vec<super::Binding>,
+        targets: Vec<super::Target>,
         client_factory: gazette::journal::ClientFactory,
         producer: uuid::Producer,
         clock: uuid::Clock,
     ) -> Self {
-        let binding_clients = bindings
+        let target_clients = targets
             .iter()
-            .map(|b| {
+            .map(|t| {
                 let factory = client_factory.clone();
                 let authz_subject = authz_subject.clone();
-                let authz_object = b.authz_object().to_string();
+                let authz_object = t.authz_object().to_string();
 
-                match b {
-                    super::Binding::Mapped(_) => {
+                match t {
+                    super::Target::Mapped(_) => {
                         let init: crate::MappedClientInit = Box::new(move || {
                             let client = factory(authz_subject, authz_object.clone());
                             let partitions =
                                 crate::watch::watch_partitions(client.clone(), &authz_object);
                             (client, partitions)
                         });
-                        super::LazyBindingClient::Mapped(std::sync::LazyLock::new(init))
+                        super::LazyTargetClient::Mapped(std::sync::LazyLock::new(init))
                     }
-                    super::Binding::Fixed(_) => {
+                    super::Target::Fixed(_) => {
                         let init: crate::FixedClientInit =
                             Box::new(move || factory(authz_subject, authz_object));
-                        super::LazyBindingClient::Fixed(std::sync::LazyLock::new(init))
+                        super::LazyTargetClient::Fixed(std::sync::LazyLock::new(init))
                     }
                 }
             })
@@ -74,13 +74,13 @@ impl Publisher {
         Self {
             appenders: super::AppenderGroup::new(),
             authz_subject,
-            binding_clients,
-            bindings,
             client_factory,
             clock,
             packed_key_buf: bytes::BytesMut::new(),
             prefix_buf: String::new(),
             producer,
+            target_clients,
+            targets,
         }
     }
 
@@ -100,9 +100,9 @@ impl Publisher {
     /// Enqueue a document for publication to the appropriate journal partition.
     ///
     /// Assigns a UUID with the given `flags` and passes it to `doc`, which
-    /// returns `(binding_index, document)`. For Mapped bindings the document
+    /// returns `(target_index, document)`. For Mapped targets the document
     /// is mapped to a physical partition (creating one if needed, which may
-    /// issue an Apply RPC). For Fixed bindings the binding's journal is used
+    /// issue an Apply RPC). For Fixed targets the target's journal is used
     /// directly, with no key extraction or partition mapping. The document is
     /// serialized as newline-delimited JSON into the partition's Appender
     /// buffer, and checkpoint'd. The checkpoint may start a background Append
@@ -118,24 +118,23 @@ impl Publisher {
 
         // Sequence the document.
         let uuid = proto_gazette::uuid::build(self.producer, self.clock.tick(), flags);
-        let (binding_idx, doc) = doc(uuid)?;
+        let (target_idx, doc) = doc(uuid)?;
 
-        let (mut journal, mut packed_key) = match &self.bindings[binding_idx] {
-            super::Binding::Mapped(mapped) => {
-                let super::LazyBindingClient::Mapped(lazy) = &self.binding_clients[binding_idx]
-                else {
-                    unreachable!("Mapped binding has Mapped lazy client");
+        let (mut journal, mut packed_key) = match &self.targets[target_idx] {
+            super::Target::Mapped(mapped) => {
+                let super::LazyTargetClient::Mapped(lazy) = &self.target_clients[target_idx] else {
+                    unreachable!("Mapped target has Mapped lazy client");
                 };
                 super::mapping::map_partition(mapped, lazy, &doc, prefix, packed_key).await?
             }
-            super::Binding::Fixed(fixed) => {
+            super::Target::Fixed(fixed) => {
                 let mut prefix = prefix;
                 prefix.push_str(&fixed.journal);
                 (prefix, packed_key)
             }
         };
 
-        let client = self.binding_clients[binding_idx].client();
+        let client = self.target_clients[target_idx].client();
         let appender = self.appenders.activate(&journal, client);
 
         // Enqueue the serialization to the Appender's buffer, then checkpoint.
@@ -172,24 +171,23 @@ impl Publisher {
 
         // Sequence the document.
         let uuid = proto_gazette::uuid::build(self.producer, self.clock.tick(), flags);
-        let (binding_idx, doc) = doc(uuid)?;
+        let (target_idx, doc) = doc(uuid)?;
 
-        let (doc, mut journal, mut packed_key) = match &self.bindings[binding_idx] {
-            super::Binding::Mapped(mapped) => {
-                let super::LazyBindingClient::Mapped(lazy) = &self.binding_clients[binding_idx]
-                else {
-                    unreachable!("Mapped binding has Mapped lazy client");
+        let (doc, mut journal, mut packed_key) = match &self.targets[target_idx] {
+            super::Target::Mapped(mapped) => {
+                let super::LazyTargetClient::Mapped(lazy) = &self.target_clients[target_idx] else {
+                    unreachable!("Mapped target has Mapped lazy client");
                 };
                 super::mapping::map_partition_owned(mapped, lazy, doc, prefix, packed_key).await?
             }
-            super::Binding::Fixed(fixed) => {
+            super::Target::Fixed(fixed) => {
                 let mut prefix = prefix;
                 prefix.push_str(&fixed.journal);
                 (doc, prefix, packed_key)
             }
         };
 
-        let client = self.binding_clients[binding_idx].client();
+        let client = self.target_clients[target_idx].client();
         let appender = self.appenders.activate(&journal, client);
 
         // Enqueue the serialization to the Appender's buffer, then checkpoint.
@@ -238,20 +236,19 @@ impl Publisher {
     }
 
     /// Snapshot a backfill marker broadcast: every partition journal of a Mapped
-    /// collection binding, plus a ticked commit clock and producer identity. Unlike
+    /// collection target, plus a ticked commit clock and producer identity. Unlike
     /// [`Self::commit_intents`] (only appended journals), a marker must reach *every*
     /// partition so a reader observes it regardless of its selector.
     pub async fn marker_commit(
         &mut self,
-        binding_idx: usize,
+        target_idx: usize,
     ) -> tonic::Result<(uuid::Producer, uuid::Clock, Vec<String>)> {
         // Snapshot the journals to broadcast to, releasing the partitions watch
         // borrow before returning.
-        let journals: Vec<String> = match &self.bindings[binding_idx] {
-            super::Binding::Mapped(_) => {
-                let super::LazyBindingClient::Mapped(lazy) = &self.binding_clients[binding_idx]
-                else {
-                    unreachable!("Mapped binding has Mapped lazy client");
+        let journals: Vec<String> = match &self.targets[target_idx] {
+            super::Target::Mapped(_) => {
+                let super::LazyTargetClient::Mapped(lazy) = &self.target_clients[target_idx] else {
+                    unreachable!("Mapped target has Mapped lazy client");
                 };
                 let (_client, partitions) = &(**lazy);
                 let partitions = partitions.ready().await;
@@ -262,8 +259,8 @@ impl Publisher {
                     .map(|split| split.name.to_string())
                     .collect()
             }
-            super::Binding::Fixed(_) => {
-                unreachable!("backfill markers are only broadcast to Mapped collection bindings")
+            super::Target::Fixed(_) => {
+                unreachable!("backfill markers are only broadcast to Mapped collection targets")
             }
         };
 
@@ -276,9 +273,9 @@ impl Publisher {
     /// Takes the output of `intents::build_transaction_intents()` — per-journal
     /// NDJSON `Bytes` — and appends each to its journal in parallel. For each
     /// journal, this uses a hybrid client strategy:
-    /// - If the journal matches a binding, reuse that binding's client.
-    ///   For Mapped bindings the match is a prefix-match on the binding's
-    ///   partitions prefix; for Fixed bindings it's an exact name match.
+    /// - If the journal matches a target, reuse that target's client.
+    ///   For Mapped targets the match is a prefix-match on the target's
+    ///   partitions prefix; for Fixed targets it's an exact name match.
     /// - Otherwise, build an ephemeral client. This supports recovered ACK
     ///   intents that may reference journals no longer bound to the current
     ///   task (e.g. from a prior published task). For this class of journals,
@@ -296,20 +293,20 @@ impl Publisher {
         for (journal, intents) in journal_intents {
             super::validate_ndjson(&journal, &intents)?;
 
-            // Attempt to find a binding that covers `journal`.
-            // TODO(johnny): We're walking bindings for each ACK intent journal.
+            // Attempt to find a target that covers `journal`.
+            // TODO(johnny): We're walking targets for each ACK intent journal.
             // This is probably fine but _could_ be faster.
-            // We can do this by building a sorted index of partition template name => binding.
-            let binding_client = self
-                .bindings
+            // We can do this by building a sorted index of partition template name => target.
+            let target_client = self
+                .targets
                 .iter()
-                .position(|b| match b {
-                    super::Binding::Mapped(m) => journal.starts_with(&m.partitions_prefix),
-                    super::Binding::Fixed(f) => journal == f.journal,
+                .position(|t| match t {
+                    super::Target::Mapped(m) => journal.starts_with(&m.partitions_prefix),
+                    super::Target::Fixed(f) => journal == f.journal,
                 })
-                .map(|i| self.binding_clients[i].client());
+                .map(|i| self.target_clients[i].client());
 
-            let appender = if let Some(client) = binding_client {
+            let appender = if let Some(client) = target_client {
                 self.appenders.activate(&journal, client)
             } else {
                 let client = (self.client_factory)(self.authz_subject.clone(), journal.clone());
@@ -319,7 +316,7 @@ impl Publisher {
             appender.buffer.extend_from_slice(&intents);
         }
 
-        // Require that binding appenders flush nominally: journals must exist.
+        // Require that target appenders flush nominally: journals must exist.
         self.appenders.flush().await?;
         self.appenders.sweep();
 
@@ -327,7 +324,7 @@ impl Publisher {
         //
         // Only *recovered* intents reach this path: a live transaction's
         // intents are keyed on journals it just wrote, and every such journal
-        // came from a binding. An ephemeral journal is therefore always one
+        // came from a target. An ephemeral journal is therefore always one
         // this task published to under an earlier specification.
         //
         // Fail-open is the only terminating choice for these. Nothing clears an
@@ -371,7 +368,7 @@ impl Publisher {
     /// Build a detached future which attempts to split partition `journal` at
     /// its key-range midpoint (see [`super::mapping::split_partition`]).
     ///
-    /// Returns None when `journal` is not a partition of any Mapped binding
+    /// Returns None when `journal` is not a partition of any Mapped target
     /// (e.g. the fixed ops-stats journal) — such journals can never be split.
     ///
     /// The future owns cloned journal-client and partitions-watch handles, so
@@ -384,22 +381,22 @@ impl Publisher {
     ) -> Option<futures::future::BoxFuture<'static, tonic::Result<super::SplitOutcome>>> {
         use futures::FutureExt;
 
-        let index = self.bindings.iter().position(|b| match b {
-            super::Binding::Mapped(m) => journal.starts_with(&m.partitions_prefix),
-            super::Binding::Fixed(_) => false,
+        let index = self.targets.iter().position(|t| match t {
+            super::Target::Mapped(m) => journal.starts_with(&m.partitions_prefix),
+            super::Target::Fixed(_) => false,
         })?;
-        let super::Binding::Mapped(binding) = &self.bindings[index] else {
-            unreachable!("position matched a Mapped binding");
+        let super::Target::Mapped(target) = &self.targets[index] else {
+            unreachable!("position matched a Mapped target");
         };
-        let super::LazyBindingClient::Mapped(lazy) = &self.binding_clients[index] else {
-            unreachable!("Mapped binding has a Mapped lazy client");
+        let super::LazyTargetClient::Mapped(lazy) = &self.target_clients[index] else {
+            unreachable!("Mapped target has a Mapped lazy client");
         };
 
         // Force the lazy client + watch (warm in practice — `journal` was
-        // appended to through this binding) and clone owned handles into the
-        // detached future, along with the only part of the binding a split
+        // appended to through this target) and clone owned handles into the
+        // detached future, along with the only part of the target a split
         // reads: its partition template.
-        let partitions_template = binding.partitions_template.clone();
+        let partitions_template = target.partitions_template.clone();
         let (client, partitions) = &**lazy;
         let (client, partitions) = (client.clone(), partitions.clone());
         let journal = journal.to_string();
@@ -425,14 +422,14 @@ impl Publisher {
         active_backfills: &std::collections::BTreeMap<usize, u64>,
     ) -> tonic::Result<()> {
         for (&index, &clock) in active_backfills {
-            let target = labels::truncated_at_value(clock);
+            let label_value = labels::truncated_at_value(clock);
 
-            let super::Binding::Mapped(binding) = &self.bindings[index] else {
+            let super::Target::Mapped(target) = &self.targets[index] else {
                 return Err(tonic::Status::internal(format!(
-                    "binding {index} has an active backfill but is not a Mapped collection binding"
+                    "target {index} has an active backfill but is not a Mapped collection target"
                 )));
             };
-            let client = self.binding_clients[index].client();
+            let client = self.target_clients[index].client();
 
             // Watch the partition listing: the watch handles transient-error
             // backoff and restates the journals after every change, so a lost CAS
@@ -442,7 +439,7 @@ impl Publisher {
                 selector: Some(broker::LabelSelector {
                     include: Some(labels::build_set([(
                         "name:prefix",
-                        binding.partitions_prefix.as_str(),
+                        target.partitions_prefix.as_str(),
                     )])),
                     exclude: None,
                 }),
@@ -454,7 +451,7 @@ impl Publisher {
             loop {
                 match watch.next().await {
                     Some(Ok(listing)) => {
-                        if advance_truncated_at_labels(client, listing, &target).await? {
+                        if advance_truncated_at_labels(client, listing, &label_value).await? {
                             break;
                         }
                     }
@@ -470,19 +467,19 @@ impl Publisher {
         Ok(())
     }
 
-    /// Access the lazy Client and partitions watch for the Mapped binding at
-    /// `index`. Panics if the binding is Fixed. Primarily used by tests.
-    pub fn mapped_binding_client(
+    /// Access the lazy Client and partitions watch for the Mapped target at
+    /// `index`. Panics if the target is Fixed. Primarily used by tests.
+    pub fn mapped_target_client(
         &self,
         index: usize,
     ) -> &(
         gazette::journal::Client,
         tokens::PendingWatch<Vec<super::watch::PartitionSplit>>,
     ) {
-        match &self.binding_clients[index] {
-            super::LazyBindingClient::Mapped(lazy) => &**lazy,
-            super::LazyBindingClient::Fixed(_) => {
-                panic!("binding {index} is Fixed, not Mapped")
+        match &self.target_clients[index] {
+            super::LazyTargetClient::Mapped(lazy) => &**lazy,
+            super::LazyTargetClient::Fixed(_) => {
+                panic!("target {index} is Fixed, not Mapped")
             }
         }
     }
@@ -734,10 +731,10 @@ mod test {
         }
     }
 
-    /// Publisher over a single Fixed binding, whose every journal Client denies
+    /// Publisher over a single Fixed target, whose every journal Client denies
     /// authorization. The denial is raised while acquiring the append token, so
     /// no broker is contacted.
-    fn denied_publisher(binding_journal: &str) -> Publisher {
+    fn denied_publisher(target_journal: &str) -> Publisher {
         let factory: gazette::journal::ClientFactory = std::sync::Arc::new(|_sub, obj| {
             gazette::journal::Client::new_with_tokens(
                 |_token: &()| unreachable!("extract is not called for an errored token"),
@@ -751,7 +748,7 @@ mod test {
 
         Publisher::new(
             "shard-id".to_string(),
-            vec![crate::Binding::for_fixed_journal(binding_journal)],
+            vec![crate::Target::for_fixed_journal(target_journal)],
             factory,
             uuid::Producer::from_bytes([0x01, 0, 0, 0, 0, 0x01]),
             uuid::Clock::UNIX_EPOCH,
@@ -761,7 +758,7 @@ mod test {
     // ACK intents are NDJSON, and `write_intents` validates the shape.
     const ACK: &[u8] = b"{\"_meta\":{\"uuid\":\"whatever\"}}\n";
 
-    /// A recovered intent naming a journal outside every binding is discarded
+    /// A recovered intent naming a journal outside every target is discarded
     /// rather than failing the session: nothing but writing it can clear the
     /// intent, so failing here would crash-loop the task forever.
     #[tokio::test]
@@ -779,10 +776,10 @@ mod test {
     }
 
     /// The tolerance is scoped to the ephemeral path. A journal the task still
-    /// binds is a live write, and losing authorization to it must fail loudly:
+    /// targets is a live write, and losing authorization to it must fail loudly:
     /// the task is actively publishing there and cannot make correct progress.
     #[tokio::test]
-    async fn test_write_intents_fails_unauthorized_binding() {
+    async fn test_write_intents_fails_unauthorized_target() {
         let mut publisher = denied_publisher("ops/current/stats/pivot=00");
 
         let status = publisher

--- a/crates/publisher/src/target.rs
+++ b/crates/publisher/src/target.rs
@@ -2,18 +2,18 @@ use anyhow::Context;
 use proto_flow::flow;
 use proto_gazette::broker;
 
-/// Metadata for routing publications to a specific journal.
-pub enum Binding {
-    /// `Mapped` bindings dynamically resolve documents to one of a collection's
+/// Metadata for routing publications to a journal destination.
+pub enum Target {
+    /// `Mapped` targets dynamically resolve documents to one of a collection's
     /// physical partitions, creating partitions on-demand.
-    Mapped(MappedBinding),
-    /// `Fixed` bindings target a single, pre-existing journal by name.
-    Fixed(FixedBinding),
+    Mapped(MappedTarget),
+    /// `Fixed` targets publish to a single, pre-existing journal by name.
+    Fixed(FixedTarget),
 }
 
 /// Routes documents to a collection's physical partitions via key hashing
 /// and partition-field extraction.
-pub struct MappedBinding {
+pub struct MappedTarget {
     /// Target collection name (for logging/debugging).
     pub collection: models::Collection,
     /// Pre-built key extractors for the collection key pointers.
@@ -24,37 +24,22 @@ pub struct MappedBinding {
     pub partition_extractors: Vec<doc::Extractor>,
     /// Template for partitions of this collection.
     pub partitions_template: broker::JournalSpec,
-    /// Maximum number of allowed partitions for this binding.
+    /// Maximum number of allowed partitions for this target.
     pub partitions_limit: usize,
     /// Collection partitions prefix ("{partitions_template.name}/").
     pub partitions_prefix: String,
 }
 
 /// Routes documents to a single named journal that already exists.
-pub struct FixedBinding {
-    /// Journal to which the binding publishes.
+pub struct FixedTarget {
+    /// Journal to which the target publishes.
     pub journal: String,
 }
 
-impl Binding {
-    /// Build Bindings for a CaptureSpec, one per active capture binding.
-    pub fn from_capture_spec(spec: &flow::CaptureSpec) -> anyhow::Result<Vec<Self>> {
-        spec.resolved_bindings()
-            .enumerate()
-            .map(|(index, (_binding, resolved))| {
-                let (collection_spec, _identity) = resolved
-                    .with_context(|| format!("capture binding {index} missing collection"))?;
-
-                Self::from_collection_spec(collection_spec).with_context(|| {
-                    format!("building binding for collection {}", collection_spec.name)
-                })
-            })
-            .collect()
-    }
-
-    /// Build a Mapped Binding from a built CollectionSpec.
+impl Target {
+    /// Build a Mapped Target from a built CollectionSpec.
     ///
-    /// The Binding authorizes to and watches all partitions of the collection.
+    /// The Target authorizes to and watches all partitions of the collection.
     pub fn from_collection_spec(spec: &flow::CollectionSpec) -> anyhow::Result<Self> {
         let flow::CollectionSpec {
             name,
@@ -87,7 +72,7 @@ impl Binding {
             100
         };
 
-        Ok(Self::Mapped(MappedBinding {
+        Ok(Self::Mapped(MappedTarget {
             collection: models::Collection::new(name),
             key_extractors,
             partition_fields: partition_fields.clone(),
@@ -98,20 +83,20 @@ impl Binding {
         }))
     }
 
-    /// Build a Fixed Binding that publishes to a single named journal.
-    /// The binding skips the partitions watch and partition-mapping machinery.
+    /// Build a Fixed Target that publishes to a single named journal.
+    /// The target skips the partitions watch and partition-mapping machinery.
     pub fn for_fixed_journal(journal: impl Into<String>) -> Self {
-        Self::Fixed(FixedBinding {
+        Self::Fixed(FixedTarget {
             journal: journal.into(),
         })
     }
 
-    /// AuthZ object string for this binding's lazy journal Client. For Mapped
-    /// bindings this is the partitions prefix; for Fixed it's the journal name.
+    /// AuthZ object string for this target's lazy journal Client. For Mapped
+    /// targets this is the partitions prefix; for Fixed it's the journal name.
     pub(crate) fn authz_object(&self) -> &str {
         match self {
-            Self::Mapped(b) => &b.partitions_prefix,
-            Self::Fixed(b) => &b.journal,
+            Self::Mapped(t) => &t.partitions_prefix,
+            Self::Fixed(t) => &t.journal,
         }
     }
 }

--- a/crates/runtime-next/README.md
+++ b/crates/runtime-next/README.md
@@ -74,37 +74,67 @@ src/
 ├── leader/            # sidecar Leader service
 │   ├── service.rs       # gRPC entry, per-task Join rendezvous
 │   ├── join.rs          # protocol primitives for joining shards into a session
+│   ├── close_policy.rs  # when a transaction closes (min / max txn duration)
+│   ├── frontier_mapping.rs  # consumer.Checkpoint <-> shuffle::Frontier
 │   ├── shuffle.rs       # ShuffleSession / ShuffleSessionFactory traits + ShuffleServiceFactory
 │   │                     #   (journal-reading Session) impl; leader is monomorphized over the
 │   │                     #   factory (preview installs its own fixture replay from flowctl)
+│   ├── capture/
+│   │   ├── fsm.rs           # head/tail state machines for capture transactions
+│   │   └── task.rs          # Task + Binding + Target: the leader's data model
+│   ├── derive/
+│   │   ├── handler.rs       # gRPC stream handler, dispatches to startup/actor
+│   │   ├── startup.rs       # Recover / Open / Apply / Recovered phase
+│   │   ├── fsm.rs           # pipelined HeadFSM / TailFSM state machines
+│   │   ├── actor.rs         # event loop driving open / commit / acknowledge
+│   │   └── task.rs          # Task: the leader's data model
 │   └── materialize/
 │       ├── handler.rs       # gRPC stream handler, dispatches to startup/actor
 │       ├── startup.rs       # Recover / Open / Apply / Recovered phase
 │       ├── fsm.rs           # pipelined HeadFSM / TailFSM state machines
 │       ├── actor.rs         # event loop driving open / commit / acknowledge / trigger
-│       ├── frontier_mapping.rs  # consumer.Checkpoint <-> shuffle::Frontier
 │       ├── triggers.rs      # webhook trigger delivery
 │       ├── sync_schedule.rs # compiled sync-schedule evaluator (commit pacing)
-│       └── task.rs          # per-task state held by the leader actor
+│       └── task.rs          # Task: the leader's data model
 │
 └── shard/             # per-shard controller-facing service
     ├── service.rs       # gRPC entry, dispatches by task type
     ├── recovery.rs      # Persist <-> RocksDB WriteBatch encode/decode + scan-time FC: pruning
     ├── rocksdb.rs       # single Persist application path
+    ├── split_policy.rs  # append-rate throttling which drives partition splits
     ├── capture/
-    │   ├── handler.rs       # startup, apply/open, recovery scan, publisher setup
+    │   ├── handler.rs       # startup, apply/open, recovery scan, publisher setup;
+    │   │                     #   stows inferred shapes by collection across sessions
     │   ├── connector.rs     # capture connector RPC bridging
     │   ├── actor.rs         # independent per-shard capture transaction loop
-    │   ├── fsm.rs           # head/tail state machines for capture transactions
-    │   └── task.rs          # per-capture task and binding shape
+    │   └── drain.rs         # combiner drain: publish documents, widen inference
+    ├── derive/
+    │   ├── handler.rs       # gRPC stream handler
+    │   ├── startup.rs       # join leader, scan RocksDB, open connector
+    │   ├── scan.rs          # frontier scan: source documents out as C:Read
+    │   ├── connector.rs     # connector RPC bridging
+    │   ├── actor.rs         # per-shard transaction loop
+    │   ├── drain.rs         # output combiner drain: publish derived documents
+    │   └── task.rs          # Task + Transform + Source: the shard's data model
     └── materialize/
         ├── handler.rs       # gRPC stream handler
         ├── startup.rs       # join leader, scan RocksDB, open connector
-        ├── scan.rs          # in-memory state recovery from RocksDB
+        ├── scan.rs          # frontier scan: source documents into the combiner,
+        │                     #   unseen keys out as C:Load
         ├── connector.rs     # connector RPC bridging
         ├── actor.rs         # per-shard transaction loop
-        └── drain.rs         # graceful drain on Stop / CloseNow
+        ├── drain.rs         # combiner drain: C:Store to the connector
+        ├── boundaries.rs    # per-binding backfill-truncation boundaries
+        └── task.rs          # Task + Binding + Source: the shard's data model
 ```
+
+Within a task type, `mod.rs` declares submodules and the session's `Metrics`,
+and `task.rs` owns the task's data model: a `Task`, its per-binding struct
+(`Transform` for a derivation, `Binding` otherwise), and the per-collection
+`Source` / `Target` those bindings group onto. Derive and materialize are
+deliberately parallel at every one of these paths, so a difference between the
+two files at the same path is meant to be a real difference between the task
+types.
 
 ## Key entry points
 
@@ -207,6 +237,51 @@ with differing priorities. The shuffle Session mirrors this split, stopping
 journal reads once they read through hinted spans. This prevents over-read
 from consuming disk quota, and prevents starving lower-priority bindings.
 See `crates/shuffle/README.md` and issue #3246.
+
+## Targets and Sources
+
+Bindings don't carry collection-derived state; they *reference* a per-collection
+struct which does. A capture binding references a `Target` it writes, and a
+materialize binding or derive transform references a `Source` it reads. Schema
+validators, publisher targets, and inferred write-shapes are built once per
+Target / Source, so a task fanning many bindings onto few collections pays
+per collection.
+
+The two key differently:
+
+- **Capture `Target`s key on `partition_template_name`** — journal identity — in
+  both spec forms. `Task::new` requires that bindings sharing a name also carry
+  equal `CollectionSpec` values.
+- **Materialize / derive / shuffle `Source`s key on the declared
+  `collection_index`** — value identity — never on collection name, because a
+  materialization's `group_by` can give two bindings of one named collection
+  differing read schemas. An inline-form binding carries no index and is its
+  own Source.
+
+## Schema inference (capture)
+
+Inference is keyed by *collection*, not binding: every binding of a Target
+widens that Target's one shape, capped and logged once. Any binding's
+`SourcedSchema` therefore ratchets its whole collection to
+`SOURCED_SCHEMA_COMPLEXITY_LIMIT`.
+
+Shapes live only in memory but accumulate across the many connector sessions of
+a shard, so between sessions they're stowed under the Target's
+`partition_template_name` — stable where Target *indices* are not — and restored
+into the next session's layout. A collection's generation is folded into its
+template name, so a collection reset also restarts inference.
+
+## Backfill truncation (capture)
+
+A capture `BackfillBegin` publishes an isolated, document-free marker
+transaction and stamps `estuary.dev/truncated-at` on every partition of the
+target collection — the boundary materializations classify against (below).
+
+When other active bindings of the task also write those journals
+(`Target::fan_in`), the head FSM suppresses the Begin: the message still
+isolates its transaction, but no boundary clock, marker intent, `truncated-at`
+label, or `ActiveBackfillChange::Begin` is built. The backfill itself proceeds
+regardless — the connector re-captures, and documents merge on key.
 
 ## Backfill truncation (materialize)
 

--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -25,7 +25,7 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-69-gb7eb6426711";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/crates/runtime-next/src/leader/capture/fsm.rs
+++ b/crates/runtime-next/src/leader/capture/fsm.rs
@@ -55,6 +55,10 @@ pub enum BackfillMessage {
 /// Per-transaction aggregated state threaded through Head/Tail FSMs.
 #[derive(Debug, Default, Clone)]
 pub struct Extents {
+    // A backfill message observed in this transaction.
+    backfill: Option<BackfillMessage>,
+    // Are the downstream `backfill` truncation-control effects being suppressed?
+    backfill_suppressed: bool,
     // Sparse per-binding map of bindings have changed extents in this transaction.
     bindings: BTreeMap<u32, BindingExtents>,
     // Total number of captured connector document bytes of this transaction.
@@ -72,8 +76,6 @@ pub struct Extents {
     sourced_schemas: BTreeMap<u32, doc::Shape>,
     // Was a synthetic checkpoint injected due to hard-bound violation?
     synthetic_checkpoint: bool,
-    // A backfill message observed in this transaction.
-    backfill: Option<BackfillMessage>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -522,6 +524,7 @@ impl HeadExtend {
                     );
                 }
                 extents.backfill = Some(ctrl);
+                extents.backfill_suppressed = suppress_fan_in(task, ctrl);
                 // Await the terminating Checkpoint of this isolated sequence.
                 (Action::Idle, Head::Extend(self))
             }
@@ -597,9 +600,12 @@ impl TailDrain {
         }
         let stats = build_stats_doc(task, &extents);
 
-        // Lift any backfill message into the WriteStats action: the actor builds
-        // the marker ACK broadcast there, alongside the ordinary commit intents.
-        let backfill = extents.backfill.take();
+        // Lift an unsuppressed backfill message into the WriteStats action:
+        // the actor builds ACK metadata alongside ordinary commit intents.
+        let backfill = match extents.backfill.take() {
+            Some(_) if extents.backfill_suppressed => None,
+            backfill => backfill,
+        };
 
         (
             Action::WriteStats { stats, backfill },
@@ -796,6 +802,51 @@ impl TailApplyLabels {
 #[derive(Debug, Default)]
 pub struct TailDone {}
 
+/// Does this backfill message's truncation get suppressed?
+///
+/// A `BackfillBegin` is suppressed when its binding's target journals are also
+/// written by other active bindings of the task ([`super::task::Target::fan_in`]).
+/// The backfill itself proceeds -- the connector re-captures, documents are
+/// written, and they merge on key into the existing collection -- but we suppress
+/// the control markers that tell downstream consumers of its truncation boundaries
+/// (a `TRUNCATE` of one source table among many does not imply the shared
+/// logical collection should be truncated).
+///
+/// A suppressed Begin is never lifted into `Action::WriteStats`, so no boundary
+/// clock, marker intent, `truncated-at` label, or `ActiveBackfillChange::Begin`
+/// is ever built for it.
+///
+/// `BackfillComplete` is never suppressed: a backfill begun while its binding
+/// was sole must complete even if a later spec update made the binding fan-in
+/// (a suppressed backfill's Complete takes the existing orphaned-complete no-op path).
+fn suppress_fan_in(task: &Task, backfill: BackfillMessage) -> bool {
+    let BackfillMessage::BackfillBegin { binding } = backfill else {
+        return false;
+    };
+    let Some(spec) = task.bindings.get(binding as usize) else {
+        return false;
+    };
+    let target = &task.targets[spec.target as usize];
+    if !target.fan_in {
+        return false;
+    }
+    let bindings = task
+        .bindings
+        .iter()
+        .filter(|peer| peer.target == spec.target)
+        .count();
+
+    service_kit::event!(
+        tracing::Level::INFO,
+        "head",
+        binding,
+        collection = target.collection_name.clone(),
+        bindings,
+        "suppressed truncation of a collection written by multiple task bindings",
+    );
+    true
+}
+
 /// Build an `ops::Stats` document snapshotting this transaction's extents.
 fn build_stats_doc(task: &Task, extents: &Extents) -> ops::proto::Stats {
     let mut capture = BTreeMap::<String, ops::proto::stats::CaptureBinding>::new();
@@ -805,7 +856,13 @@ fn build_stats_doc(task: &Task, extents: &Extents) -> ops::proto::Stats {
         let Some(binding) = task.bindings.get(*binding_index as usize) else {
             continue;
         };
-        let entry = capture.entry(binding.collection_name.clone()).or_default();
+        let entry = capture
+            .entry(
+                task.targets[binding.target as usize]
+                    .collection_name
+                    .clone(),
+            )
+            .or_default();
         entry.last_published_at = last_published_at;
 
         ops::merge_docs_and_bytes(&extents.captured, &mut entry.right);
@@ -832,7 +889,6 @@ fn build_stats_doc(task: &Task, extents: &Extents) -> ops::proto::Stats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::leader::capture::task::Binding;
     use bytes::Bytes;
 
     /// Aggregates the capture Actor's per-iteration locals so `step_head` /
@@ -912,11 +968,17 @@ mod tests {
     }
 
     fn mk_task(explicit_acknowledgements: bool) -> Task {
-        Task {
-            bindings: vec![
-                mk_binding("test/collectionA", "stateA"),
-                mk_binding("test/collectionB", "stateB"),
+        let (bindings, targets) = crate::leader::capture::task::fixture::bindings(
+            &[
+                ("test/collectionA", "stateA", ""),
+                ("test/collectionB", "stateB", ""),
             ],
+            b"{}",
+        );
+
+        Task {
+            bindings,
+            targets,
             // Wide thresholds: `policy_extend` is always true and `policy_close`
             // is always satisfiable, so a close is driven only by
             // `close_requested` / `stopping` or by `ready` going Pending — which
@@ -929,19 +991,6 @@ mod tests {
             restart: uuid::Clock::zero(),
             sequence_bytes_limit: 1024,
             shard_ref: ops::ShardRef::default(),
-        }
-    }
-
-    fn mk_binding(collection_name: &str, state_key: &str) -> Binding {
-        Binding {
-            collection_name: collection_name.to_string(),
-            collection_generation_id: models::Id::zero(),
-            document_uuid_ptr: json::Pointer::empty(),
-            key_extractors: Vec::new(),
-            partition_template_name: collection_name.to_string(),
-            state_key: state_key.to_string(),
-            write_schema_json: Bytes::from_static(b"{}"),
-            write_shape: doc::Shape::nothing(),
         }
     }
 
@@ -1723,6 +1772,60 @@ mod tests {
         tail = t;
         assert!(matches!(action, Action::Idle));
         assert!(matches!(tail, Tail::Done(_)));
+    }
+
+    /// A BackfillBegin of a fan-in binding is admitted and isolated exactly as
+    /// any other, but the Tail suppresses it from WriteStats.
+    #[test]
+    fn fan_in_backfill_lifts_no_marker() {
+        let mut task = mk_task(false);
+        // Both bindings now write the journals of one collection.
+        let (bindings, targets) = crate::leader::capture::task::fixture::bindings(
+            &[
+                ("test/collectionA", "stateA", ""),
+                ("test/collectionA", "stateB", ""),
+            ],
+            b"{}",
+        );
+        (task.bindings, task.targets) = (bindings, targets);
+        assert!(task.targets.iter().all(|target| target.fan_in));
+
+        let mut ctx = mk_ctx(task);
+        let tail = Tail::Done(TailDone::default());
+
+        ctx.ready = ConnectorRx::Backfill(BackfillMessage::BackfillBegin { binding: 1 });
+        let (_action, head) = ctx.step_head(Head::Idle(HeadIdle::default()), &tail);
+        let (_action, head) = ctx.step_head(head, &tail);
+
+        let Head::Extend(extend) = &head else {
+            panic!("expected Extend, got {}", head.kind());
+        };
+        assert!(
+            extend.inner.extents.backfill.is_some() && extend.inner.extents.backfill_suppressed,
+            "the message still isolates its transaction, but is classified as suppressed",
+        );
+
+        // Seal the marker transaction and rotate it into the Tail.
+        ctx.ready = checkpoint();
+        let (_action, head) = ctx.step_head(head, &tail);
+        ctx.close_requested = true;
+        let extents = match ctx.step_head(head, &tail).0 {
+            Action::Rotate { extents } => extents,
+            other => panic!("expected Rotate, got {other:?}"),
+        };
+
+        let (_action, tail) = ctx.step_tail(Tail::Begin(TailBegin { extents }));
+        ctx.drain_finished = Some(DrainedCapture {
+            connector_patches: Bytes::new(),
+            bindings: BTreeMap::new(),
+        });
+        match ctx.step_tail(tail).0 {
+            Action::WriteStats { backfill, .. } => assert!(
+                backfill.is_none(),
+                "a suppressed Begin is never lifted, got {backfill:?}",
+            ),
+            other => panic!("expected WriteStats, got {other:?}"),
+        }
     }
 
     /// A backfill message opens its own transaction immediately, ungated by the

--- a/crates/runtime-next/src/leader/capture/task.rs
+++ b/crates/runtime-next/src/leader/capture/task.rs
@@ -212,16 +212,27 @@ impl Task {
         let state_schema = doc::validation::build_bundle(state_schema.as_bytes()).unwrap();
         let state_validator = doc::Validator::new(state_schema).unwrap();
 
+        // Identity mapping: one validator per binding, plus the
+        // connector-state pseudo-binding at index `bindings.len()`.
+        let (bindings, validators): (Vec<_>, Vec<_>) = self
+            .bindings
+            .iter()
+            .map(|binding| binding.combiner_spec())
+            .chain(std::iter::once((
+                false,
+                Vec::new(),
+                "connector state".to_string(),
+                state_validator,
+            )))
+            .enumerate()
+            .map(|(index, (is_full, key, name, validator))| {
+                ((is_full, key, index as u32), (name, validator))
+            })
+            .unzip();
+
         Ok(doc::combine::Spec::with_bindings(
-            self.bindings
-                .iter()
-                .map(|binding| binding.combiner_spec())
-                .chain(std::iter::once((
-                    false,
-                    Vec::new(),
-                    "connector state".to_string(),
-                    state_validator,
-                ))),
+            bindings,
+            validators,
             self.redact_salt.to_vec(),
         ))
     }

--- a/crates/runtime-next/src/leader/capture/task.rs
+++ b/crates/runtime-next/src/leader/capture/task.rs
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 pub struct Task {
     /// Bindings of this Task.
     pub bindings: Vec<Binding>,
+    /// Target collections written by this Task's bindings.
+    pub targets: Vec<Target>,
     /// Policy for how transactions close.
     pub close_policy: close_policy::Policy,
     /// Does the capture connector want explicit acknowledgements?
@@ -27,24 +29,46 @@ pub struct Task {
     pub shard_ref: ops::ShardRef,
 }
 
+/// One capture binding: a connector resource captured into a target collection.
 #[derive(Debug, Clone)]
 pub struct Binding {
-    // Target collection.
-    pub collection_name: String,
-    // Generation id of the collection, which must be output as part of updating inferred schemas.
-    pub collection_generation_id: models::Id,
-    // JSON pointer at which document UUIDs are added.
-    pub document_uuid_ptr: json::Pointer,
-    // Key components which are extracted from written documents.
-    pub key_extractors: Vec<doc::Extractor>,
-    // Partition template name for journals of the target collection.
-    pub partition_template_name: String,
+    // Index of this binding's target collection within [`Task::targets`].
+    pub target: u32,
     // Encoded resource path + backfill state key of this binding.
     pub state_key: String,
+}
+
+/// A target collection, written by one or more bindings of the Task.
+///
+/// Targets group bindings by `partition_template_name` -- the identity of the
+/// journals they write -- so every structure derived from the collection (a
+/// combiner validator, a publisher target, schema inference) is built once per
+/// collection rather than once per binding.
+#[derive(Debug, Clone)]
+pub struct Target {
+    // Name of the target collection.
+    pub collection_name: String,
+    // Generation id of the collection, output as part of updating inferred schemas.
+    pub collection_generation_id: models::Id,
+    // Partition template name for journals of the collection, which is also the
+    // stable cross-session identity of its inferred shape.
+    pub partition_template_name: String,
+    // JSON pointer at which document UUIDs are added.
+    pub document_uuid_ptr: json::Pointer,
+    // Key components extracted from written documents. One copy per target,
+    // cloned into the combiner's per-binding entries.
+    pub key_extractors: Vec<doc::Extractor>,
     // Write schema of the target collection.
     pub write_schema_json: bytes::Bytes,
-    // Inferred Shape of written documents.
+    // Inferred Shape of the write schema. Built once per target and deep-cloned
+    // only on the rare `apply_sourced_schemas` path.
     pub write_shape: doc::Shape,
+    // First binding which writes this target: a representative for call sites
+    // which resolve a target back to its binding's position in the built spec.
+    pub first_binding: u32,
+    // Do multiple active bindings of the task write this target? Such a
+    // binding's backfill must not truncate journals its peers also write.
+    pub fan_in: bool,
 }
 
 impl Task {
@@ -112,15 +136,62 @@ impl Task {
         }
 
         let ser_policy = doc::SerPolicy::noop();
-        let bindings = spec
-            .resolved_bindings()
-            .enumerate()
-            .map(|(index, (binding, resolved))| {
-                let (collection, _identity) =
-                    resolved.context("missing collection").context(index)?;
-                Binding::new(binding, collection, ser_policy.clone()).context(index)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut bindings = Vec::with_capacity(spec.bindings.len());
+        let mut targets = Vec::<Target>::new();
+        // Linked-table identity and CollectionSpec of each target's first
+        // binding, for the value-equality requirement below.
+        let mut reps: Vec<(Option<u32>, &flow::CollectionSpec)> = Vec::new();
+        let mut targets_by_name = BTreeMap::<&str, u32>::new();
+
+        for (index, (binding, resolved)) in spec.resolved_bindings().enumerate() {
+            let (collection, identity) = resolved.context("missing collection").context(index)?;
+            let template_name = collection
+                .partition_template
+                .as_ref()
+                .context("missing partition template")
+                .context(index)?
+                .name
+                .as_str();
+
+            let target = match targets_by_name.get(template_name) {
+                Some(&target) => {
+                    // Bindings of one target share all of its derived state,
+                    // which is sound only if their `CollectionSpec` values are
+                    // equal. A validation-built spec guarantees this in either
+                    // form; an unvalidated spec which reuses a collection name
+                    // across differing values is a hard error here, rather than
+                    // silent cross-binding contamination downstream.
+                    let (first_identity, first_collection) = reps[target as usize];
+                    match (identity, first_identity) {
+                        // Equal linked-table indices prove equal values.
+                        (Some(a), Some(b)) if a == b => {}
+                        _ => anyhow::ensure!(
+                            collection == first_collection,
+                            "bindings {} and {index} write collection {} with unequal collection specs",
+                            targets[target as usize].first_binding,
+                            collection.name,
+                        ),
+                    }
+                    targets[target as usize].fan_in = true;
+                    target
+                }
+                None => {
+                    let target = targets.len() as u32;
+                    targets.push(
+                        Target::new(collection, index as u32, ser_policy.clone()).context(index)?,
+                    );
+                    reps.push((identity, collection));
+                    targets_by_name.insert(template_name, target);
+                    target
+                }
+            };
+
+            bindings.push(Binding {
+                target,
+                state_key: binding.state_key.clone(),
+            });
+        }
 
         // A Clock one poll `interval` from now, on the same wall-clock base as
         // the actor's monotonic `now`, so the HeadFSM computes the restart wait
@@ -145,6 +216,7 @@ impl Task {
 
         Ok(Self {
             bindings,
+            targets,
             close_policy,
             explicit_acknowledgements,
             max_transactions,
@@ -155,29 +227,23 @@ impl Task {
         })
     }
 
-    pub fn binding_shapes_by_index(
-        &self,
-        mut by_key: BTreeMap<String, doc::Shape>,
-    ) -> Vec<doc::Shape> {
-        let mut by_index = Vec::new();
-        by_index.resize_with(self.bindings.len(), doc::shape::Shape::nothing);
+    /// Restore stowed inferred shapes into this session's target layout, seeding
+    /// annotations for any target which is net-new.
+    pub fn shapes_by_target(&self, mut by_key: BTreeMap<String, doc::Shape>) -> Vec<doc::Shape> {
+        let mut by_target = Vec::new();
+        by_target.resize_with(self.targets.len(), doc::shape::Shape::nothing);
 
-        for (index, binding) in self.bindings.iter().enumerate() {
-            // `partition_template_name` embeds the collection name and generation ID,
-            // while `state_key` is unique if a single target collection is bound
-            // to multiple endpoint resources.
-            let key = format!("{};{}", binding.partition_template_name, binding.state_key);
-
-            // Seed inference annotations only when the binding is net-new.
+        for (index, target) in self.targets.iter().enumerate() {
+            // Seed inference annotations only when the target is net-new.
             // In particular, carry forward an x-complexity-limit that may have
             // been elevated by the presence of a SourcedSchema.
-            if let Some(shape) = by_key.remove(&key) {
-                by_index[index] = shape;
+            if let Some(shape) = by_key.remove(&target.partition_template_name) {
+                by_target[index] = shape;
             } else {
-                let annotations = &mut by_index[index].annotations;
+                let annotations = &mut by_target[index].annotations;
                 annotations.insert(
                     crate::X_GENERATION_ID.to_string(),
-                    serde_json::Value::String(binding.collection_generation_id.to_string()),
+                    serde_json::Value::String(target.collection_generation_id.to_string()),
                 );
                 annotations.insert(
                     doc::shape::X_COMPLEXITY_LIMIT.to_string(),
@@ -185,50 +251,61 @@ impl Task {
                 );
             }
         }
-        by_index
+        by_target
     }
 
-    /// Invert `binding_shapes_by_index`, re-keying inferred shapes by their
-    /// stable `partition_template_name;state_key` identity.
+    /// Invert [`Self::shapes_by_target`], re-keying inferred shapes by their
+    /// stable `partition_template_name` identity.
     ///
     /// Inferred shapes are held only in memory and accumulate across the many
     /// connector sessions of a shard's lifetime (a capture re-Opens every poll
-    /// `interval`). Binding *indices* are not stable across spec updates but the
+    /// `interval`). Target *indices* are not stable across spec updates but the
     /// key is, so the shard stows shapes by key between sessions and
-    /// `binding_shapes_by_index` restores them into the next session's layout.
-    pub fn binding_shapes_by_key(&self, by_index: Vec<doc::Shape>) -> BTreeMap<String, doc::Shape> {
-        let mut by_key = BTreeMap::new();
-
-        for (index, shape) in by_index.into_iter().enumerate() {
-            let binding = &self.bindings[index];
-            let key = format!("{};{}", binding.partition_template_name, binding.state_key);
-            by_key.insert(key, shape);
-        }
-        by_key
+    /// `shapes_by_target` restores them into the next session's layout.
+    pub fn shapes_by_key(&self, by_target: Vec<doc::Shape>) -> BTreeMap<String, doc::Shape> {
+        assert_eq!(
+            by_target.len(),
+            self.targets.len(),
+            "shapes are the session's own target layout",
+        );
+        self.targets
+            .iter()
+            .map(|target| target.partition_template_name.clone())
+            .zip(by_target)
+            .collect()
     }
 
+    /// Build the combiner Spec of this Task: one validator per target
+    /// collection, plus a final validator for the connector-state
+    /// pseudo-binding which rides the same combiner at index `bindings.len()`.
     pub fn combine_spec(&self) -> anyhow::Result<doc::combine::Spec> {
         let state_schema = doc::reduce::merge_patch_schema().to_string();
         let state_schema = doc::validation::build_bundle(state_schema.as_bytes()).unwrap();
         let state_validator = doc::Validator::new(state_schema).unwrap();
 
-        // Identity mapping: one validator per binding, plus the
-        // connector-state pseudo-binding at index `bindings.len()`.
-        let (bindings, validators): (Vec<_>, Vec<_>) = self
+        let mut validators = Vec::with_capacity(self.targets.len() + 1);
+
+        for target in self.targets.iter() {
+            validators.push((
+                format!("captured collection {}", target.collection_name),
+                build_write_validator(&target.write_schema_json)
+                    .with_context(|| format!("collection {}", target.collection_name))?,
+            ));
+        }
+        validators.push(("connector state".to_string(), state_validator));
+
+        let state_validator_index = self.targets.len() as u32;
+        let bindings = self
             .bindings
             .iter()
-            .map(|binding| binding.combiner_spec())
-            .chain(std::iter::once((
-                false,
-                Vec::new(),
-                "connector state".to_string(),
-                state_validator,
-            )))
-            .enumerate()
-            .map(|(index, (is_full, key, name, validator))| {
-                ((is_full, key, index as u32), (name, validator))
+            .map(|binding| {
+                (
+                    false,
+                    self.targets[binding.target as usize].key_extractors.clone(),
+                    binding.target,
+                )
             })
-            .unzip();
+            .chain(std::iter::once((false, Vec::new(), state_validator_index)));
 
         Ok(doc::combine::Spec::with_bindings(
             bindings,
@@ -238,21 +315,12 @@ impl Task {
     }
 }
 
-impl Binding {
+impl Target {
     fn new(
-        spec: &flow::capture_spec::Binding,
         collection: &flow::CollectionSpec,
+        first_binding: u32,
         ser_policy: doc::SerPolicy,
     ) -> anyhow::Result<Self> {
-        let flow::capture_spec::Binding {
-            backfill: _,
-            collection: _,
-            collection_index: _,
-            resource_config_json: _,
-            resource_path: _,
-            state_key,
-        } = spec;
-
         let flow::CollectionSpec {
             ack_template_json: _,
             derivation: _,
@@ -273,47 +341,119 @@ impl Binding {
         let collection_generation_id =
             assemble::extract_generation_id_suffix(&partition_template.name);
 
-        let document_uuid_ptr = json::Pointer::from(uuid_ptr);
         let key_extractors = extractors::for_key(key, projections, &ser_policy)?;
-
-        let built_schema = doc::validation::build_bundle(write_schema_json)
-            .context("collection write_schema_json is not a JSON schema")?;
-        let validator =
-            doc::Validator::new(built_schema).context("could not build a schema validator")?;
-        let write_shape = doc::Shape::infer(&validator.schema(), validator.schema_index());
+        let validator = build_write_validator(write_schema_json)?;
 
         Ok(Self {
             collection_name: name.clone(),
             collection_generation_id,
-            document_uuid_ptr,
-            key_extractors,
             partition_template_name: partition_template.name.clone(),
-            state_key: state_key.clone(),
+            document_uuid_ptr: json::Pointer::from(uuid_ptr),
+            key_extractors,
             write_schema_json: write_schema_json.clone(),
-            write_shape,
+            write_shape: doc::Shape::infer(validator.schema(), validator.schema_index()),
+            first_binding,
+            fan_in: false,
         })
-    }
-
-    fn combiner_spec(&self) -> (bool, Vec<doc::Extractor>, String, doc::Validator) {
-        // These are safe to unwrap() because they were previously run over
-        // `self.write_schema_json` by Binding::new().
-        let built_schema = doc::validation::build_bundle(&self.write_schema_json).unwrap();
-        let validator = doc::Validator::new(built_schema).unwrap();
-
-        (
-            false,
-            self.key_extractors.clone(),
-            format!("captured collection {}", self.collection_name),
-            validator,
-        )
     }
 }
 
+fn build_write_validator(write_schema_json: &[u8]) -> anyhow::Result<doc::Validator> {
+    let built_schema = doc::validation::build_bundle(write_schema_json)
+        .context("collection write_schema_json is not a JSON schema")?;
+
+    doc::Validator::new(built_schema).context("could not build a schema validator")
+}
+
+/// Synthetic capture specs which fan several bindings into one collection,
+/// shared by this module's unit tests and the shard capture actor's tests.
 #[cfg(test)]
-mod tests {
+pub(crate) mod fixture {
     use super::*;
 
-    fn mk_collection(index: usize) -> flow::CollectionSpec {
+    /// Group hand-built test bindings into their Targets by collection name, as
+    /// `Task::new` does over a built spec. Each entry is a binding's
+    /// `(collection_name, state_key, uuid_ptr)`; a collection's `uuid_ptr` is taken
+    /// from its first binding, and all share `write_schema_json`.
+    pub(crate) fn bindings(
+        entries: &[(&str, &str, &str)],
+        write_schema_json: &'static [u8],
+    ) -> (Vec<Binding>, Vec<Target>) {
+        let mut bindings = Vec::new();
+        let mut targets = Vec::<Target>::new();
+
+        for (index, (collection_name, state_key, uuid_ptr)) in entries.iter().enumerate() {
+            let target = match targets
+                .iter()
+                .position(|t| t.collection_name == *collection_name)
+            {
+                Some(target) => {
+                    targets[target].fan_in = true;
+                    target as u32
+                }
+                None => {
+                    let validator = build_write_validator(write_schema_json).unwrap();
+                    targets.push(Target {
+                        collection_name: collection_name.to_string(),
+                        collection_generation_id: models::Id::zero(),
+                        partition_template_name: collection_name.to_string(),
+                        document_uuid_ptr: json::Pointer::from(*uuid_ptr),
+                        key_extractors: Vec::new(),
+                        write_schema_json: bytes::Bytes::from_static(write_schema_json),
+                        write_shape: doc::Shape::infer(
+                            validator.schema(),
+                            validator.schema_index(),
+                        ),
+                        first_binding: index as u32,
+                        fan_in: false,
+                    });
+                    targets.len() as u32 - 1
+                }
+            };
+            bindings.push(Binding {
+                target,
+                state_key: state_key.to_string(),
+            });
+        }
+        (bindings, targets)
+    }
+
+    /// A [`Task`] over hand-built `entries`, as the shard tests want one: wide
+    /// close thresholds, so a transaction closes as soon as the connector idles
+    /// (its checkpoint sequence completes and no further input is ready), free
+    /// of policy-driven close timing.
+    pub(crate) fn task(
+        entries: &[(&str, &str, &str)],
+        write_schema_json: &'static [u8],
+        explicit_acknowledgements: bool,
+    ) -> Task {
+        let (bindings, targets) = self::bindings(entries, write_schema_json);
+
+        Task {
+            bindings,
+            targets,
+            close_policy: close_policy::Policy::new(
+                std::time::Duration::ZERO,
+                std::time::Duration::MAX,
+            ),
+            explicit_acknowledgements,
+            max_transactions: 0,
+            redact_salt: bytes::Bytes::new(),
+            restart: uuid::Clock::zero(),
+            sequence_bytes_limit: 1 << 20,
+            shard_ref: ops::ShardRef::default(),
+        }
+    }
+
+    /// Collection `index` of a synthetic capture: keyed on `/id`, with reduction
+    /// annotations so that documents of one key genuinely combine -- exercising
+    /// the validator a fan-in collection's bindings share, rather than only
+    /// counting it.
+    ///
+    /// Every collection *requires* a property naming itself, so a binding which
+    /// resolved to another collection's validator fails validation outright
+    /// rather than quietly accepting the document.
+    pub(crate) fn collection(index: usize) -> flow::CollectionSpec {
         flow::CollectionSpec {
             name: format!("acmeCo/collection-{index}"),
             key: vec!["/id".to_string()],
@@ -326,34 +466,65 @@ mod tests {
             ]))
             .unwrap(),
             uuid_ptr: "/_meta/uuid".to_string(),
-            write_schema_json: r#"{"type":"object"}"#.into(),
+            write_schema_json: format!(
+                r#"{{
+                    "type": "object",
+                    "properties": {{
+                        "id": {{"type": "string"}},
+                        "value": {{"type": "integer", "reduce": {{"strategy": "sum"}}}},
+                        "from_collection_{index}": {{"const": true}}
+                    }},
+                    "required": ["id", "from_collection_{index}"],
+                    "reduce": {{"strategy": "merge"}}
+                }}"#
+            )
+            .into(),
             ..Default::default()
         }
     }
 
-    /// An indirect-form capture Open / Opened over `collections` linked collections
-    /// and `bindings` bindings, assigned round-robin: any `bindings >
-    /// collections` fans several bindings into one collection.
-    fn mk_open(collections: usize, bindings: usize) -> (Request, Response) {
-        let spec = flow::CaptureSpec {
+    /// An indirect-form `CaptureSpec` over `collections` linked collections, where
+    /// `binding_collections[i]` is the collection which binding `i` writes.
+    /// Repeats fan several bindings into one collection.
+    pub(crate) fn capture_spec(
+        collections: usize,
+        binding_collections: &[usize],
+    ) -> flow::CaptureSpec {
+        flow::CaptureSpec {
             name: "acmeCo/capture".to_string(),
-            bindings: (0..bindings)
-                .map(|index| flow::capture_spec::Binding {
-                    collection_index: (index % collections) as u32,
+            bindings: binding_collections
+                .iter()
+                .enumerate()
+                .map(|(index, collection)| flow::capture_spec::Binding {
+                    collection_index: *collection as u32,
                     resource_path: vec![format!("table-{index}")],
                     state_key: format!("table-{index}"),
                     ..Default::default()
                 })
                 .collect(),
-            linked_collections: (0..collections).map(mk_collection).collect(),
+            linked_collections: (0..collections).map(collection).collect(),
             shard_template: Some(consumer::ShardSpec {
                 min_txn_duration: Some(std::time::Duration::ZERO.into()),
                 max_txn_duration: Some(std::time::Duration::from_secs(1).into()),
                 ..Default::default()
             }),
             ..Default::default()
-        };
+        }
+    }
 
+    /// Inline `spec`: each binding carries its own copy of its collection and the
+    /// linked table is dropped, so no binding has an identity.
+    pub(crate) fn into_inline(spec: &mut flow::CaptureSpec) {
+        let table = std::mem::take(&mut spec.linked_collections);
+
+        for binding in &mut spec.bindings {
+            binding.collection = Some(table[binding.collection_index as usize].clone());
+            binding.collection_index = 0;
+        }
+    }
+
+    /// The Open / Opened pair carrying `spec`, as `Task::new` consumes them.
+    pub(crate) fn open(spec: flow::CaptureSpec) -> (Request, Response) {
         let open = Request {
             open: Some(request::Open {
                 capture: Some(spec),
@@ -376,17 +547,193 @@ mod tests {
         };
         (open, opened)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_open_over(collections: usize, binding_collections: &[usize]) -> (Request, Response) {
+        fixture::open(fixture::capture_spec(collections, binding_collections))
+    }
+
+    fn mk_task(collections: usize, binding_collections: &[usize]) -> Task {
+        let (open, opened) = mk_open_over(collections, binding_collections);
+        Task::new(&open, &opened, 0).unwrap()
+    }
+
+    /// The same task in inline form: each binding carries its own copy of its
+    /// collection and the linked table is dropped, so no binding has an identity.
+    fn mk_inline_task(collections: usize, binding_collections: &[usize]) -> Task {
+        let mut spec = fixture::capture_spec(collections, binding_collections);
+        fixture::into_inline(&mut spec);
+
+        let (open, opened) = fixture::open(spec);
+        Task::new(&open, &opened, 0).unwrap()
+    }
+
+    /// Bindings collapse into one Target per distinct collection -- in either
+    /// spec form -- and a Target written by multiple bindings is fan-in.
+    #[test]
+    fn task_groups_bindings_into_targets() {
+        let targets_and_fan_in = |task: Task| {
+            (
+                task.targets.len(),
+                task.bindings
+                    .iter()
+                    .map(|binding| (binding.target, task.targets[binding.target as usize].fan_in))
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        // Sole binding of its collection.
+        assert_eq!(targets_and_fan_in(mk_task(1, &[0])), (1, vec![(0, false)]),);
+        // Distinct collections don't collapse, and neither is fan-in.
+        assert_eq!(
+            targets_and_fan_in(mk_task(2, &[0, 1])),
+            (2, vec![(0, false), (1, false)]),
+        );
+        // Four bindings over two collections collapse to two targets, all fan-in.
+        assert_eq!(
+            targets_and_fan_in(mk_task(2, &[0, 1, 0, 1])),
+            (2, vec![(0, true), (1, true), (0, true), (1, true)]),
+        );
+        // Targets are ordered by binding scan, not by collection index, and a
+        // collection with one binding is not fan-in even beside one that is.
+        assert_eq!(
+            targets_and_fan_in(mk_task(3, &[2, 1, 2])),
+            (2, vec![(0, true), (1, false), (0, true)]),
+        );
+        // The inline form groups identically: Targets key on the collection's
+        // journal identity, which both forms carry.
+        assert_eq!(
+            targets_and_fan_in(mk_inline_task(2, &[0, 1, 0, 1])),
+            (2, vec![(0, true), (1, true), (0, true), (1, true)]),
+        );
+
+        // Each target names its collection, its first binding, and holds one
+        // inferred write-shape.
+        let task = mk_task(2, &[1, 0, 1]);
+        assert_eq!(
+            task.targets
+                .iter()
+                .map(|target| (target.collection_name.as_str(), target.first_binding))
+                .collect::<Vec<_>>(),
+            [("acmeCo/collection-1", 0), ("acmeCo/collection-0", 1)],
+        );
+    }
+
+    /// Bindings which write one collection share a combiner validator: a parsed
+    /// schema, its index, and its validation scratch are built once per
+    /// collection rather than once per binding. Keys stay per-binding, as does
+    /// the connector-state pseudo-binding riding the same combiner.
+    #[test]
+    fn combine_spec_groups_validators_by_collection() {
+        // Five bindings over two collections, plus connector state.
+        let task = mk_task(2, &[0, 1, 0, 1, 0]);
+        assert_eq!(
+            task.bindings
+                .iter()
+                .map(|binding| binding.target)
+                .collect::<Vec<_>>(),
+            [0, 1, 0, 1, 0],
+        );
+
+        let spec = task.combine_spec().unwrap();
+        assert_eq!(spec.binding_count(), 6);
+        assert_eq!(spec.validator_count(), 3);
+
+        // Targets follow binding-scan order, not collection index.
+        let task = mk_task(3, &[2, 1, 2]);
+        assert_eq!(task.targets.len(), 2);
+        assert_eq!(task.combine_spec().unwrap().validator_count(), 3);
+
+        // The inline form of the same task builds the same combiner.
+        let task = mk_inline_task(2, &[0, 1, 0, 1, 0]);
+        let spec = task.combine_spec().unwrap();
+        assert_eq!(spec.binding_count(), 6);
+        assert_eq!(spec.validator_count(), 3);
+    }
+
+    /// Bindings of one collection must carry equal `CollectionSpec` values:
+    /// a hand-built spec which reuses a collection name across differing values
+    /// is an error rather than silently-shared derived state.
+    #[test]
+    fn task_requires_equal_specs_within_a_collection() {
+        // Inline form: the second binding's copy of collection-0 is tampered.
+        let mut spec = fixture::capture_spec(1, &[0, 0]);
+        fixture::into_inline(&mut spec);
+        spec.bindings[1].collection.as_mut().unwrap().uuid_ptr = "/_meta/other".to_string();
+
+        let (open, opened) = fixture::open(spec);
+        let err = Task::new(&open, &opened, 0).unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "bindings 0 and 1 write collection acmeCo/collection-0 with unequal collection specs"
+            ),
+            "unexpected error: {err}",
+        );
+
+        // Indirect form: two linked-table entries share a name at differing
+        // values, and each is referenced by a binding.
+        let mut spec = fixture::capture_spec(1, &[0, 0]);
+        let mut tampered = spec.linked_collections[0].clone();
+        tampered.uuid_ptr = "/_meta/other".to_string();
+        spec.linked_collections.push(tampered);
+        spec.bindings[1].collection_index = 1;
+
+        let (open, opened) = fixture::open(spec);
+        let err = Task::new(&open, &opened, 0).unwrap_err();
+        assert!(
+            err.to_string().contains("with unequal collection specs"),
+            "unexpected error: {err}",
+        );
+    }
+
+    /// Target indices move when a spec update reorders bindings, so shapes are
+    /// stowed under the collection's stable `partition_template_name` and
+    /// restored into whichever target that collection now occupies.
+    #[test]
+    fn shapes_round_trip_across_a_binding_reorder() {
+        let marker = |shape: &doc::Shape| shape.annotations.get("marker").cloned();
+
+        let task = mk_task(2, &[0, 1]);
+        let mut shapes = task.shapes_by_target(Default::default());
+
+        // Seeded annotations come from the target's collection.
+        assert_eq!(
+            shapes[0].annotations[crate::X_GENERATION_ID],
+            serde_json::json!(task.targets[0].collection_generation_id.to_string()),
+        );
+        shapes[0]
+            .annotations
+            .insert("marker".to_string(), serde_json::json!("collection-0"));
+        let by_key = task.shapes_by_key(shapes);
+
+        // A spec update reverses the bindings, so collection-0 is now target 1.
+        let task = mk_task(2, &[1, 0]);
+        assert_eq!(task.targets[1].collection_name, "acmeCo/collection-0");
+
+        let shapes = task.shapes_by_target(by_key);
+        assert_eq!(marker(&shapes[1]), Some(serde_json::json!("collection-0")));
+        assert_eq!(marker(&shapes[0]), None); // Net-new target, freshly seeded.
+        assert!(shapes[0].annotations.contains_key(crate::X_GENERATION_ID));
+    }
 
     /// The runtime guards `doc::combine`'s u16 binding index independently of
     /// `validation::MAX_BINDINGS`: a spec at the format limit builds, and one
     /// past it is a hard error rather than a wrapped pseudo-binding.
     #[test]
     fn task_guards_the_combiner_format_limit() {
-        let (open, opened) = mk_open(1, u16::MAX as usize);
-        let task = Task::new(&open, &opened, 0).unwrap();
-        assert_eq!(task.bindings.len(), u16::MAX as usize);
+        // All bindings target one collection, so this is also the cheap proof
+        // that per-collection work doesn't scale with binding count.
+        let bindings = vec![0; u16::MAX as usize + 1];
 
-        let (open, opened) = mk_open(1, u16::MAX as usize + 1);
+        let task = mk_task(1, &bindings[..u16::MAX as usize]);
+        assert_eq!(task.bindings.len(), u16::MAX as usize);
+        assert_eq!(task.targets.len(), 1);
+
+        let (open, opened) = mk_open_over(1, &bindings);
         let err = Task::new(&open, &opened, 0).unwrap_err();
         assert!(
             err.to_string()

--- a/crates/runtime-next/src/leader/derive/startup.rs
+++ b/crates/runtime-next/src/leader/derive/startup.rs
@@ -105,6 +105,7 @@ pub(super) async fn run<
             crate::publish::producer_from_bytes(&publisher_id)?,
             &ops_stats_journal,
             &[],
+            &[],
         )
         .context("opening publisher")?;
 

--- a/crates/runtime-next/src/leader/materialize/actor.rs
+++ b/crates/runtime-next/src/leader/materialize/actor.rs
@@ -706,7 +706,7 @@ mod tests {
     fn mk_actor(
         n_shards: usize,
     ) -> (
-        Actor<crate::publish::NoopPublisher, crate::TracingLogger>,
+        Actor<crate::publish::RecordingPublisher, crate::TracingLogger>,
         Vec<mpsc::UnboundedReceiver<tonic::Result<proto::Materialize>>>,
     ) {
         let mut shard_tx = Vec::with_capacity(n_shards);
@@ -736,7 +736,7 @@ mod tests {
             None,
             super::super::Metrics::new("test/task/shard"),
             crate::TracingLogger,
-            crate::publish::NoopPublisher,
+            crate::publish::RecordingPublisher::default(),
             shard_tx,
             task,
         );

--- a/crates/runtime-next/src/leader/materialize/startup.rs
+++ b/crates/runtime-next/src/leader/materialize/startup.rs
@@ -113,6 +113,7 @@ pub(super) async fn run<
             crate::publish::producer_from_bytes(&publisher_id)?,
             &ops_stats_journal,
             &[],
+            &[],
         )
         .context("opening publisher")?;
 

--- a/crates/runtime-next/src/logger.rs
+++ b/crates/runtime-next/src/logger.rs
@@ -97,8 +97,9 @@ pub enum LogEvent<'a> {
     Applied { action_description: &'a str },
 
     /// A collection's inferred write-schema widened this transaction.
-    /// `binding` is the source binding index for captures (multiple bindings
-    /// per task) and `None` for derivations (a single derived collection).
+    /// `binding` is the most-recently-updated binding index for captures
+    /// (multiple bindings may target the same collection, and only the
+    /// latest is retained as a diagnostic). For derivations, it's `None`.
     /// `schema` is the representative JSON Schema of the widened write-shape,
     /// as produced by [`doc::shape::schema::to_schema`].
     #[non_exhaustive]
@@ -315,6 +316,50 @@ impl LoggerFactory for TracingLoggerFactory {
 
     fn open(&self, _task_name: &str) -> TracingLogger {
         TracingLogger
+    }
+}
+
+/// Test [`Logger`] recording the task's stream at both of its layers, so a test
+/// may assert at whichever one it means: every [`ops::Log`] sunk, and each
+/// [`LogEvent::InferredSchema`] intercepted structurally as a widened
+/// collection's `(name, most-recently-updated binding, rendered JSON Schema)`.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct RecordingLogger {
+    pub logs: Arc<std::sync::Mutex<Vec<ops::Log>>>,
+    pub inferences: Arc<std::sync::Mutex<Vec<(String, Option<usize>, String)>>>,
+}
+
+#[cfg(test)]
+impl RecordingLogger {
+    pub fn take_inferences(&self) -> Vec<(String, Option<usize>, String)> {
+        std::mem::take(&mut *self.inferences.lock().unwrap())
+    }
+}
+
+#[cfg(test)]
+impl Logger for RecordingLogger {
+    fn log(&self, log: &ops::Log) {
+        self.logs.lock().unwrap().push(log.clone());
+    }
+
+    fn event(&self, event: LogEvent<'_>) {
+        if let LogEvent::InferredSchema {
+            collection_name,
+            binding,
+            schema,
+            ..
+        } = &event
+        {
+            self.inferences.lock().unwrap().push((
+                collection_name.to_string(),
+                *binding,
+                serde_json::to_string(schema).unwrap(),
+            ));
+        }
+        if let Some(log) = event.to_log() {
+            self.log(&log);
+        }
     }
 }
 

--- a/crates/runtime-next/src/publish.rs
+++ b/crates/runtime-next/src/publish.rs
@@ -110,9 +110,10 @@ pub trait PublisherFactory: Clone + Send + Sync + 'static {
     /// Concrete per-session publisher this factory produces.
     type Publisher: Publisher;
 
-    /// Open a [`Publisher`] for the given task bindings. `collection_specs` are
-    /// the capture / derive collection bindings (empty for a leader's
-    /// stats-only publisher); `stats_journal` is the fixed ops-stats binding.
+    /// Open a [`Publisher`] for the given task targets. `collection_specs`
+    /// are the distinct collections this task writes (empty for a leader's
+    /// stats-only publisher), and `binding_targets` maps each task binding to
+    /// its collection. `stats_journal` is the fixed ops-stats target.
     /// `authz_subject` and `producer` identify the publisher.
     fn open(
         &self,
@@ -120,6 +121,7 @@ pub trait PublisherFactory: Clone + Send + Sync + 'static {
         producer: uuid::Producer,
         stats_journal: &str,
         collection_specs: &[&proto_flow::flow::CollectionSpec],
+        binding_targets: &[u32],
     ) -> anyhow::Result<Self::Publisher>;
 }
 
@@ -145,6 +147,7 @@ impl PublisherFactory for JournalPublisherFactory {
         producer: uuid::Producer,
         stats_journal: &str,
         collection_specs: &[&proto_flow::flow::CollectionSpec],
+        binding_targets: &[u32],
     ) -> anyhow::Result<JournalPublisher> {
         let mut targets = Vec::with_capacity(collection_specs.len() + 1);
 
@@ -155,6 +158,20 @@ impl PublisherFactory for JournalPublisherFactory {
             targets.push(publisher::Target::from_collection_spec(spec)?);
         }
 
+        // Validate `binding_targets` and +1 to account for ops-stats target.
+        let binding_targets = binding_targets
+            .iter()
+            .enumerate()
+            .map(|(binding, &target)| {
+                anyhow::ensure!(
+                    (target as usize) < collection_specs.len(),
+                    "binding {binding} maps to target {target}, but only {} were given",
+                    collection_specs.len(),
+                );
+                Ok(target as usize + 1)
+            })
+            .collect::<anyhow::Result<Vec<usize>>>()?;
+
         let mut publisher = publisher::Publisher::new(
             authz_subject,
             targets,
@@ -164,7 +181,10 @@ impl PublisherFactory for JournalPublisherFactory {
         );
         publisher.update_clock();
 
-        Ok(JournalPublisher(publisher))
+        Ok(JournalPublisher {
+            inner: publisher,
+            binding_targets,
+        })
     }
 }
 
@@ -172,7 +192,10 @@ impl PublisherFactory for JournalPublisherFactory {
 /// Gazette journal IO. The inner `publisher::Publisher` is an implementation
 /// detail; from the leader / shard perspective the operative publisher is the
 /// [`Publisher`] trait.
-pub struct JournalPublisher(publisher::Publisher);
+pub struct JournalPublisher {
+    inner: publisher::Publisher,
+    binding_targets: Vec<usize>,
+}
 
 impl JournalPublisher {
     /// Access the wrapped [`publisher::Publisher`] for low-level enqueues.
@@ -180,17 +203,17 @@ impl JournalPublisher {
     /// against a live broker; not part of the leader / shard hot path.
     #[doc(hidden)]
     pub fn inner_mut(&mut self) -> &mut publisher::Publisher {
-        &mut self.0
+        &mut self.inner
     }
 }
 
 impl Publisher for JournalPublisher {
     fn update_clock(&mut self) {
-        self.0.update_clock()
+        self.inner.update_clock()
     }
 
     async fn publish_stats(&mut self, mut stats: ops::proto::Stats) -> tonic::Result<()> {
-        self.0
+        self.inner
             .enqueue(
                 |uuid| {
                     // Binding index 0 is the fixed ops_stats journal.
@@ -207,7 +230,7 @@ impl Publisher for JournalPublisher {
                 uuid::Flags::CONTINUE_TXN,
             )
             .await?;
-        self.0.flush().await
+        self.inner.flush().await
     }
 
     async fn publish_doc(
@@ -216,10 +239,9 @@ impl Publisher for JournalPublisher {
         mut doc: doc::OwnedNode,
         uuid_ptr: &json::Pointer,
     ) -> tonic::Result<usize> {
-        // Publisher target zero is reserved for the fixed ops stats journal.
-        let publisher_target = binding_index + 1;
+        let publisher_target = self.binding_targets[binding_index];
         let (_, bytes_written) = self
-            .0
+            .inner
             .enqueue_owned(
                 |uuid| {
                     patch_document_uuid(&mut doc, uuid_ptr, uuid)?;
@@ -232,49 +254,60 @@ impl Publisher for JournalPublisher {
     }
 
     async fn flush(&mut self) -> tonic::Result<()> {
-        self.0.flush().await
+        self.inner.flush().await
     }
 
     async fn marker_commit(
         &mut self,
         binding_index: usize,
     ) -> tonic::Result<Option<(uuid::Producer, uuid::Clock, Vec<String>)>> {
-        // Task-binding index `i` maps to publisher target `i + 1` (target 0 is
-        // the fixed ops-stats journal), mirroring `publish_doc`.
-        Ok(Some(self.0.marker_commit(binding_index + 1).await?))
+        let publisher_target = self.binding_targets[binding_index];
+        Ok(Some(self.inner.marker_commit(publisher_target).await?))
     }
 
     async fn apply_truncated_at_labels(
         &mut self,
         active_backfills: &BTreeMap<u32, u64>,
     ) -> tonic::Result<()> {
-        let mapped: BTreeMap<usize, u64> = active_backfills
-            .iter()
-            .map(|(&binding, &clock)| (binding as usize + 1, clock))
-            .collect();
-        self.0.apply_truncated_at_labels(&mapped).await
+        // Multiple bindings' backfills can collapse onto one shared target:
+        // the capture actor suppresses *new* backfills of fan-in bindings, but
+        // `active_backfills` are durable state keyed by resource-path
+        // `state_key`, and a spec update may re-point a mid-backfill binding's
+        // target onto a collection whose own binding is also mid-backfill --
+        // neither changes the state_key, so both recover onto one target.
+        // The `truncated-at` label only ever advances, so the latest boundary
+        // is the one in force: ratchet collapsed entries to it.
+        let mut mapped = BTreeMap::<usize, u64>::new();
+        for (&binding, &clock) in active_backfills {
+            let entry = mapped
+                .entry(self.binding_targets[binding as usize])
+                .or_default();
+            *entry = clock.max(*entry);
+        }
+
+        self.inner.apply_truncated_at_labels(&mapped).await
     }
 
     fn commit_intents(&mut self) -> Option<(uuid::Producer, uuid::Clock, Vec<String>)> {
-        Some(self.0.commit_intents())
+        Some(self.inner.commit_intents())
     }
 
     fn take_throttle_samples(&mut self) -> Vec<publisher::ThrottleSample<'_>> {
-        self.0.take_throttle_samples()
+        self.inner.take_throttle_samples()
     }
 
     fn split_partition(
         &self,
         journal: &str,
     ) -> Option<futures::future::BoxFuture<'static, tonic::Result<publisher::SplitOutcome>>> {
-        self.0.split_partition(journal)
+        self.inner.split_partition(journal)
     }
 
     async fn write_intents(
         &mut self,
         journal_intents: BTreeMap<String, Bytes>,
     ) -> tonic::Result<()> {
-        self.0.write_intents(journal_intents).await
+        self.inner.write_intents(journal_intents).await
     }
 }
 
@@ -299,12 +332,15 @@ impl JournalPublisher {
             });
         let collection_specs: Vec<&proto_flow::flow::CollectionSpec> =
             collection_specs.into_iter().collect();
+        let binding_targets: Vec<u32> = (0..collection_specs.len() as u32).collect();
+
         JournalPublisherFactory::new(factory)
             .open(
                 "test".to_string(),
                 new_producer(),
                 "test/ops/stats",
                 &collection_specs,
+                &binding_targets,
             )
             .unwrap()
     }
@@ -384,26 +420,45 @@ fn missing_uuid_placeholder(uuid_ptr: &json::Pointer) -> tonic::Status {
     ))
 }
 
-/// Test [`Publisher`] performing no journal IO: the in-crate analogue of the
-/// preview harness's publisher, letting actor tests run without Gazette.
+/// Test [`Publisher`] which records what it was asked to publish.
 #[cfg(test)]
-pub(crate) struct NoopPublisher;
+#[derive(Clone, Default)]
+pub(crate) struct RecordingPublisher {
+    /// Each published document as `(task binding index, serialized document)`.
+    pub docs: std::sync::Arc<std::sync::Mutex<Vec<(usize, String)>>>,
+    pub stats: std::sync::Arc<std::sync::Mutex<Vec<ops::proto::Stats>>>,
+}
 
 #[cfg(test)]
-impl Publisher for NoopPublisher {
+impl RecordingPublisher {
+    pub fn take_docs(&self) -> Vec<(usize, String)> {
+        std::mem::take(&mut *self.docs.lock().unwrap())
+    }
+
+    pub fn take_stats(&self) -> Vec<ops::proto::Stats> {
+        std::mem::take(&mut *self.stats.lock().unwrap())
+    }
+}
+
+#[cfg(test)]
+impl Publisher for RecordingPublisher {
     fn update_clock(&mut self) {}
 
-    async fn publish_stats(&mut self, _stats: ops::proto::Stats) -> tonic::Result<()> {
+    async fn publish_stats(&mut self, stats: ops::proto::Stats) -> tonic::Result<()> {
+        self.stats.lock().unwrap().push(stats);
         Ok(())
     }
 
     async fn publish_doc(
         &mut self,
-        _binding_index: usize,
-        _doc: doc::OwnedNode,
+        binding_index: usize,
+        doc: doc::OwnedNode,
         _uuid_ptr: &json::Pointer,
     ) -> tonic::Result<usize> {
-        Ok(0)
+        let doc = serde_json::to_string(&doc::SerPolicy::noop().on_owned(&doc)).unwrap();
+        let bytes = doc.len();
+        self.docs.lock().unwrap().push((binding_index, doc));
+        Ok(bytes)
     }
 
     async fn flush(&mut self) -> tonic::Result<()> {
@@ -452,10 +507,10 @@ mod test {
     use super::*;
 
     #[test]
-    fn noop_take_throttle_samples_is_empty() {
+    fn recording_take_throttle_samples_is_empty() {
         // The auto-split signal path stays inert without journal IO: the
-        // NoopPublisher performs no appends, so there are no throttle samples.
-        let mut publisher = NoopPublisher;
+        // RecordingPublisher performs no appends, so there are no throttle samples.
+        let mut publisher = RecordingPublisher::default();
         assert!(publisher.take_throttle_samples().is_empty());
     }
 

--- a/crates/runtime-next/src/publish.rs
+++ b/crates/runtime-next/src/publish.rs
@@ -146,18 +146,18 @@ impl PublisherFactory for JournalPublisherFactory {
         stats_journal: &str,
         collection_specs: &[&proto_flow::flow::CollectionSpec],
     ) -> anyhow::Result<JournalPublisher> {
-        let mut bindings = Vec::with_capacity(collection_specs.len() + 1);
+        let mut targets = Vec::with_capacity(collection_specs.len() + 1);
 
-        // Binding zero is the fixed ops-stats journal.
-        bindings.push(publisher::Binding::for_fixed_journal(stats_journal));
+        // Target zero is the fixed ops-stats journal.
+        targets.push(publisher::Target::for_fixed_journal(stats_journal));
 
         for spec in collection_specs {
-            bindings.push(publisher::Binding::from_collection_spec(spec)?);
+            targets.push(publisher::Target::from_collection_spec(spec)?);
         }
 
         let mut publisher = publisher::Publisher::new(
             authz_subject,
-            bindings,
+            targets,
             self.client_factory.clone(),
             producer,
             uuid::Clock::zero(),
@@ -216,14 +216,14 @@ impl Publisher for JournalPublisher {
         mut doc: doc::OwnedNode,
         uuid_ptr: &json::Pointer,
     ) -> tonic::Result<usize> {
-        // Publisher binding zero is reserved for the fixed ops stats journal.
-        let publisher_binding = binding_index + 1;
+        // Publisher target zero is reserved for the fixed ops stats journal.
+        let publisher_target = binding_index + 1;
         let (_, bytes_written) = self
             .0
             .enqueue_owned(
                 |uuid| {
                     patch_document_uuid(&mut doc, uuid_ptr, uuid)?;
-                    Ok((publisher_binding, doc))
+                    Ok((publisher_target, doc))
                 },
                 uuid::Flags::CONTINUE_TXN,
             )
@@ -239,7 +239,7 @@ impl Publisher for JournalPublisher {
         &mut self,
         binding_index: usize,
     ) -> tonic::Result<Option<(uuid::Producer, uuid::Clock, Vec<String>)>> {
-        // Task-binding index `i` maps to publisher binding `i + 1` (binding 0 is
+        // Task-binding index `i` maps to publisher target `i + 1` (target 0 is
         // the fixed ops-stats journal), mirroring `publish_doc`.
         Ok(Some(self.0.marker_commit(binding_index + 1).await?))
     }

--- a/crates/runtime-next/src/shard/capture/actor.rs
+++ b/crates/runtime-next/src/shard/capture/actor.rs
@@ -61,7 +61,7 @@ pub(super) struct Actor<P: crate::Publisher, L: crate::Logger> {
     // RocksDB is parked with its per-binding state keys.
     db: Option<(crate::shard::RocksDB, Vec<String>)>,
     publisher: Option<P>,
-    // Inferred per-binding write-shapes. Seeded from prior sessions at
+    // Inferred per-target write-shapes. Seeded from prior sessions at
     // construction, parked into the drain future, handed back at session end.
     shapes: Option<Vec<doc::Shape>>,
     // Long-lived per-journal throttle policy, fed once per transaction once the
@@ -442,16 +442,17 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                     .bindings
                     .get(binding as usize)
                     .with_context(|| format!("invalid captured binding {binding}"))?;
+                let target = &self.task.targets[binding_spec.target as usize];
 
                 let (memtable, alloc, mut doc) =
                     accumulator.parse_json_doc(&doc_json).with_context(|| {
                         format!(
                             "couldn't parse captured document as JSON (target {})",
-                            binding_spec.collection_name
+                            target.collection_name
                         )
                     })?;
 
-                let uuid_ptr = &binding_spec.document_uuid_ptr;
+                let uuid_ptr = &target.document_uuid_ptr;
                 if !uuid_ptr.0.is_empty() {
                     let Ok(_) = doc.try_set(
                         uuid_ptr,
@@ -833,11 +834,11 @@ fn parse_sourced_schema(
         schema_json,
     } = sourced;
 
-    let collection_name = &task
+    let binding_spec = task
         .bindings
         .get(binding as usize)
-        .with_context(|| format!("invalid sourced schema binding {binding}"))?
-        .collection_name;
+        .with_context(|| format!("invalid sourced schema binding {binding}"))?;
+    let collection_name = &task.targets[binding_spec.target as usize].collection_name;
 
     let built_schema = doc::validation::build_bundle(&schema_json).with_context(|| {
         format!("couldn't parse sourced schema as JSON Schema (target {collection_name})")
@@ -873,40 +874,164 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> Option<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::leader::capture::task::Binding;
+    use crate::leader::capture::task::fixture;
+    use crate::logger::RecordingLogger;
+    use crate::publish::RecordingPublisher;
     use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 
-    fn mk_binding(collection_name: &str, state_key: &str, uuid_ptr: &str) -> Binding {
-        Binding {
-            collection_name: collection_name.to_string(),
-            collection_generation_id: models::Id::zero(),
-            document_uuid_ptr: json::Pointer::from(uuid_ptr),
-            key_extractors: Vec::new(),
-            partition_template_name: collection_name.to_string(),
-            state_key: state_key.to_string(),
-            write_schema_json: Bytes::from_static(b"{}"),
-            write_shape: doc::Shape::nothing(),
+    // --- Harness: task fixtures, actor and session drivers, responses. ---
+
+    /// The default Task: two bindings on distinct collections, of which binding
+    /// 0 carries a UUID pointer (exercising placeholder injection).
+    fn mk_task(explicit_acknowledgements: bool) -> Task {
+        fixture::task(
+            &[
+                ("test/collectionA", "stateA", "/_meta/uuid"),
+                ("test/collectionB", "stateB", ""),
+            ],
+            b"{}",
+            explicit_acknowledgements,
+        )
+    }
+
+    /// State keys of `task`'s bindings, under which a shard scans and persists.
+    fn state_keys(task: &Task) -> Vec<String> {
+        task.bindings
+            .iter()
+            .map(|binding| binding.state_key.clone())
+            .collect()
+    }
+
+    /// An [`Actor`] over `task`, with an mpsc channel standing in for the
+    /// connector. Its returned receiver is the mock connector's end: hold it
+    /// even when unread, since dropping it closes the actor's request channel.
+    fn mk_actor<P: crate::Publisher, L: crate::Logger>(
+        task: &std::sync::Arc<Task>,
+        active_backfills: BTreeMap<u32, u64>,
+        db: crate::shard::RocksDB,
+        is_shard_zero: bool,
+        logger: L,
+        publisher: P,
+    ) -> (Actor<P, L>, mpsc::Receiver<Request>) {
+        let (connector_tx, connector_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
+
+        let actor = Actor::new(
+            active_backfills,
+            state_keys(task),
+            connector_tx,
+            db,
+            is_shard_zero,
+            super::super::Metrics::new("test/shard"),
+            logger,
+            publisher,
+            task.shapes_by_target(Default::default()),
+            task.clone(),
+            None, // token_restart_at
+        );
+        (actor, connector_rx)
+    }
+
+    /// What one driven capture session left behind.
+    struct Session {
+        db: crate::shard::RocksDB,
+        /// Inferred write-shapes handed back at session end, one per Target.
+        shapes: Vec<doc::Shape>,
+        acks: Vec<request::Acknowledge>,
+        publisher: RecordingPublisher,
+        task: std::sync::Arc<Task>,
+    }
+
+    impl Session {
+        /// Scan this session's RocksDB, as a next session's recovery does.
+        async fn recover(self) -> (crate::shard::RocksDB, proto::Recover) {
+            self.db.scan(state_keys(&self.task)).await.unwrap()
         }
     }
 
-    fn mk_task(explicit_acknowledgements: bool) -> Task {
-        Task {
-            // Binding 0 carries a UUID pointer (exercising placeholder injection),
-            // binding 1 does not.
-            bindings: vec![
-                mk_binding("test/collectionA", "stateA", "/_meta/uuid"),
-                mk_binding("test/collectionB", "stateB", ""),
-            ],
-            // Wide thresholds: a transaction closes as soon as the connector
-            // idles (its checkpoint sequence completes and no further input is
-            // ready), free of policy-driven close timing.
-            close_policy: crate::leader::close_policy::Policy::new(Duration::ZERO, Duration::MAX),
-            explicit_acknowledgements,
-            max_transactions: 0,
-            redact_salt: Bytes::new(),
-            restart: uuid::Clock::zero(),
-            sequence_bytes_limit: 1 << 20,
-            shard_ref: ops::ShardRef::default(),
+    /// Drive `Actor::serve` end to end over mpsc channels standing in for the
+    /// connector and controller, with a real RocksDB: feed `responses`, drain
+    /// `expect_acks` Acknowledges (one per committed transaction, so each
+    /// commits before Stop), then Stop.
+    ///
+    /// The actor owns its publisher and logger for the session's duration, so
+    /// both record through `Arc` handles: `logger` is the caller's to read back
+    /// once this returns, as is [`Session::publisher`].
+    async fn run_capture_session(
+        task: Task,
+        db: crate::shard::RocksDB,
+        active_backfills: BTreeMap<u32, u64>,
+        logger: impl crate::Logger,
+        responses: Vec<tonic::Result<Response>>,
+        expect_acks: usize,
+    ) -> Session {
+        let (conn_resp_tx, conn_resp_rx) =
+            mpsc::channel::<tonic::Result<Response>>(crate::CHANNEL_BUFFER);
+        let (controller_tx, controller_rx) =
+            mpsc::unbounded_channel::<tonic::Result<proto::Capture>>();
+
+        let task = std::sync::Arc::new(task);
+        let publisher = RecordingPublisher::default();
+        let (actor, mut actor_to_conn_rx) = mk_actor(
+            &task,
+            active_backfills,
+            db,
+            true, // is_shard_zero
+            logger,
+            publisher.clone(),
+        );
+
+        let serve = tokio::spawn(async move {
+            let mut controller_rx = UnboundedReceiverStream::new(controller_rx);
+            actor
+                .serve(
+                    ReceiverStream::new(conn_resp_rx),
+                    &mut controller_rx,
+                    fsm::Head::Idle(fsm::HeadIdle::default()),
+                    fsm::Tail::Recover(fsm::TailRecover {
+                        checkpoints: 0,
+                        ack_intents: BTreeMap::new(),
+                    }),
+                )
+                .await
+        });
+
+        // An actor which errors drops its channels, so unwrapping a send or
+        // receive here would report a closed channel in place of the failure that
+        // actually happened. Break out instead and let the join below re-raise
+        // the actor's own error.
+        for response in responses {
+            if conn_resp_tx.send(response).await.is_err() {
+                break;
+            }
+        }
+        let mut acks = Vec::new();
+        while acks.len() < expect_acks {
+            let Some(request) = actor_to_conn_rx.recv().await else {
+                break;
+            };
+            acks.push(request.acknowledge.expect("actor sent a non-Acknowledge"));
+        }
+        _ = controller_tx.send(Ok(proto::Capture {
+            stop: Some(proto::Stop {}),
+            ..Default::default()
+        }));
+
+        let (db, shapes) = serve
+            .await
+            .unwrap()
+            .unwrap_or_else(|err| panic!("capture session failed: {err:?}"));
+        assert_eq!(
+            acks.len(),
+            expect_acks,
+            "session stopped before acknowledging"
+        );
+
+        Session {
+            db,
+            shapes,
+            acks,
+            publisher,
+            task,
         }
     }
 
@@ -932,98 +1057,375 @@ mod tests {
         })
     }
 
-    /// Drive `Actor::serve` end-to-end over mpsc channels standing in for the
-    /// connector and controller, with a real RocksDB.
+    fn backfill_begin(binding: u32) -> tonic::Result<Response> {
+        Ok(Response {
+            backfill_begin: Some(response::BackfillBegin { binding }),
+            ..Default::default()
+        })
+    }
+
+    fn backfill_complete(binding: u32) -> tonic::Result<Response> {
+        Ok(Response {
+            backfill_complete: Some(response::BackfillComplete { binding }),
+            ..Default::default()
+        })
+    }
+
+    /// Distinct target collections of the fan-in fixture.
+    const M: usize = 3;
+    /// Bindings of the fan-in fixture, fanning evenly onto the M collections:
+    /// binding `i` writes collection `i % M`, so each collection has `N / M`.
+    const N: usize = 12;
+    /// Documents the mock connector captures under one key, per collection.
+    /// Well above the memtable's 32-queued-document compaction threshold, so the
+    /// documents genuinely reduce in memory rather than only at drain.
+    const RUN: i64 = 64;
+
+    /// Everything one fan-in session published and inferred, rendered as strings
+    /// so a mismatch reads as a diff rather than as two proto Debug dumps.
+    type Recording = (
+        Vec<(usize, String)>,
+        Vec<String>,
+        Vec<(String, Option<usize>, String)>,
+    );
+
+    /// Drive one capture session over `spec` with the shared connector script,
+    /// and return what it published and inferred.
     ///
-    /// The connector emits two Captured documents (into distinct bindings) and a
-    /// Checkpoint carrying connector state. The actor accumulates them, closes
-    /// the transaction once the connector idles, and runs the full Tail commit:
-    /// drain+publish, stats, the committing Persist, Acknowledge, and
-    /// WriteIntents. Receiving the connector Acknowledge proves the commit
-    /// reached its post-Persist handoff; a controller Stop then drains the Tail
-    /// and steps Head to Stop. Asserts the connector saw one acknowledged
-    /// checkpoint and that the persisted connector state round-trips from RocksDB.
+    /// The script exercises both hazards of per-collection derived state:
+    /// several bindings of one collection publish documents under the *same*
+    /// key (so a shared validator or a mis-mapped target would cross-contaminate
+    /// rather than merely miscount), repeats within one binding reduce, and a
+    /// `SourcedSchema` folds into the collection's inference alongside the
+    /// documents' widening.
+    async fn run_fan_in_session(spec: flow::CaptureSpec) -> Recording {
+        let (open, opened) = fixture::open(spec);
+        let task = Task::new(&open, &opened, 0).unwrap();
+
+        // Every document uses key "shared", so each collection's documents
+        // collide with the others' on key as well as within a binding.
+        let capture_doc = |binding: usize, value: i64| {
+            Ok(Response {
+                captured: Some(response::Captured {
+                    binding: binding as u32,
+                    doc_json: Bytes::from(format!(
+                        r#"{{"id":"shared","from_collection_{}":true,"value":{value}}}"#,
+                        binding % M,
+                    )),
+                }),
+                ..Default::default()
+            })
+        };
+
+        // One `RUN` per collection, through bindings 0, 1 and 2, so each shared
+        // validator is exercised for its *reduce* annotations and not only for
+        // validation. Then single documents on bindings 3, 6 and 9 -- collection-0
+        // again -- whose outputs must stay separate from binding 0's however much
+        // machinery the four of them share.
+        let responses = (0..RUN)
+            .flat_map(|_| [capture_doc(0, 1), capture_doc(1, 2), capture_doc(2, 3)])
+            .chain([capture_doc(3, 10), capture_doc(6, 100), capture_doc(9, 1000)])
+            .chain([
+                Ok(Response {
+                    sourced_schema: Some(response::SourcedSchema {
+                        binding: 5, // Collection-2, which binding 2 also writes.
+                        schema_json: Bytes::from_static(
+                            br#"{"type":"object","additionalProperties":false,"properties":{"id":{"type":"string"},"from_collection_2":{"const":true},"sourced_only":{"type":"boolean"}},"required":["id","from_collection_2"]}"#,
+                        ),
+                    }),
+                    ..Default::default()
+                }),
+                checkpoint(br#"{"cursor":"lsn-1"}"#),
+            ])
+            .collect();
+
+        let logger = RecordingLogger::default();
+        let session = run_capture_session(
+            task,
+            crate::shard::RocksDB::open(None).await.unwrap(),
+            BTreeMap::new(),
+            logger.clone(),
+            responses,
+            1,
+        )
+        .await;
+
+        let stats = session
+            .publisher
+            .take_stats()
+            .into_iter()
+            .map(normalize_stats)
+            .collect();
+
+        (
+            session.publisher.take_docs(),
+            stats,
+            logger.take_inferences(),
+        )
+    }
+
+    /// Render `stats` for comparison, dropping the fields which are a function of
+    /// when the transaction ran rather than of what it did.
+    fn normalize_stats(mut stats: ops::proto::Stats) -> String {
+        stats.meta = None; // UUID is stamped by the publisher.
+        stats.timestamp = None;
+        stats.open_seconds_total = 0.0;
+
+        for binding in stats.capture.values_mut() {
+            binding.last_published_at = None;
+        }
+        serde_json::to_string_pretty(&stats).unwrap()
+    }
+
+    // --- Tests. ---
+
+    /// One checkpoint sequence end to end: the connector emits two Captured
+    /// documents (into distinct bindings) and a Checkpoint carrying connector
+    /// state. The actor accumulates them, closes the transaction once the
+    /// connector idles, and runs the full Tail commit: drain+publish, stats, the
+    /// committing Persist, Acknowledge, and WriteIntents. Receiving the connector
+    /// Acknowledge proves the commit reached its post-Persist handoff; a
+    /// controller Stop then drains the Tail and steps Head to Stop.
     #[tokio::test]
     async fn serve_transaction_then_stop() {
-        // Actor → connector requests; the test reads as the mock connector.
-        let (connector_tx, mut actor_to_conn_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-        // Mock connector → actor responses.
-        let (conn_resp_tx, conn_resp_rx) =
-            mpsc::channel::<tonic::Result<Response>>(crate::CHANNEL_BUFFER);
-        // Controller → actor signals.
-        let (controller_tx, controller_rx) =
-            mpsc::unbounded_channel::<tonic::Result<proto::Capture>>();
-
-        let task = std::sync::Arc::new(mk_task(true));
-        let shapes = task.binding_shapes_by_index(Default::default());
-
-        let actor = Actor::new(
-            BTreeMap::new(),
-            vec!["stateA".to_string(), "stateB".to_string()],
-            connector_tx,
+        let session = run_capture_session(
+            mk_task(true),
             crate::shard::RocksDB::open(None).await.unwrap(),
-            true,
-            super::super::Metrics::new("test/shard"),
+            BTreeMap::new(),
             crate::TracingLogger,
-            crate::publish::NoopPublisher,
-            shapes,
-            task,
-            None,
+            vec![
+                captured(0, br#"{"id":"a0"}"#),
+                captured(1, br#"{"id":"b0"}"#),
+                checkpoint(br#"{"cursor":"lsn-9"}"#),
+            ],
+            1,
+        )
+        .await;
+
+        assert_eq!(session.acks[0].checkpoints, 1);
+        assert_eq!(session.shapes.len(), 2); // One inferred shape per Target.
+
+        // The drain published each document to the binding which captured it.
+        assert_eq!(
+            session
+                .publisher
+                .take_docs()
+                .into_iter()
+                .map(|(binding, _doc)| binding)
+                .collect::<Vec<_>>(),
+            [0, 1],
         );
 
-        let serve = tokio::spawn(async move {
-            let mut controller_rx = UnboundedReceiverStream::new(controller_rx);
-            actor
-                .serve(
-                    ReceiverStream::new(conn_resp_rx),
-                    &mut controller_rx,
-                    fsm::Head::Idle(fsm::HeadIdle::default()),
-                    fsm::Tail::Recover(fsm::TailRecover {
-                        checkpoints: 0,
-                        ack_intents: BTreeMap::new(),
-                    }),
-                )
-                .await
-        });
-
-        // One checkpoint sequence: two documents, then a connector-state checkpoint.
-        conn_resp_tx
-            .send(captured(0, br#"{"id":"a0"}"#))
-            .await
-            .unwrap();
-        conn_resp_tx
-            .send(captured(1, br#"{"id":"b0"}"#))
-            .await
-            .unwrap();
-        conn_resp_tx
-            .send(checkpoint(br#"{"cursor":"lsn-9"}"#))
-            .await
-            .unwrap();
-
-        // The Acknowledge follows Drain → WriteStats → Persist, so its receipt
-        // proves the transaction committed.
-        let ack = actor_to_conn_rx.recv().await.unwrap();
-        assert_eq!(ack.acknowledge.unwrap().checkpoints, 1);
-
-        // Gracefully stop: the Tail finishes and Head steps to Stop. The connector
-        // response channel stays open (`conn_resp_tx` is held) so the connector
-        // never EOFs out from under the still-running session.
-        controller_tx
-            .send(Ok(proto::Capture {
-                stop: Some(proto::Stop {}),
-                ..Default::default()
-            }))
-            .unwrap();
-
-        let (db, shapes) = serve.await.unwrap().unwrap();
-        assert_eq!(shapes.len(), 2); // One inferred shape handed back per binding.
-
         // The committing Persist durably recorded the connector state.
-        let (_db, recover) = db.scan(Vec::<&str>::new()).await.unwrap();
+        let (_db, recover) = session.recover().await;
         assert_eq!(
             recover.connector_state_json.as_ref(),
             br#"{"cursor":"lsn-9"}"#
         );
+    }
+
+    /// A capture fanning N bindings onto M collections publishes each binding's
+    /// own combined documents and infers one schema per collection -- and does so
+    /// identically whether the spec names its collections indirectly or inline.
+    ///
+    /// Bindings which share a collection share its derived state: one combiner
+    /// validator, one publisher target, one inferred shape. That sharing is the
+    /// point (a task pays per collection, not per binding), and this is the
+    /// strongest statement it can make from outside. If it leaked -- a document
+    /// reduced against the wrong binding's accumulation, a target pointed at the
+    /// wrong collection, a widened shape attributed to the wrong target -- either
+    /// the documents below would be wrong, or the two spec forms would diverge.
+    #[tokio::test]
+    async fn fan_in_capture_publishes_per_binding_and_infers_per_collection() {
+        let indirect = fixture::capture_spec(M, &(0..N).map(|index| index % M).collect::<Vec<_>>());
+        let mut inline = indirect.clone();
+        fixture::into_inline(&mut inline);
+
+        // Targets key on the collection's journal identity, which both forms
+        // carry, so the forms are indistinguishable from outside.
+        let indirect = run_fan_in_session(indirect).await;
+        assert_eq!(indirect, run_fan_in_session(inline).await);
+
+        let (docs, stats, inferences) = indirect;
+
+        // Guard against the recordings agreeing because both are empty, and pin
+        // what each binding published as `(documents, summed value)`.
+        let mut published = BTreeMap::<usize, (usize, i64)>::new();
+
+        for (binding, doc) in &docs {
+            let doc: serde_json::Value = serde_json::from_str(doc).unwrap();
+            let entry = published.entry(*binding).or_default();
+
+            entry.0 += 1;
+            entry.1 += doc["value"].as_i64().unwrap();
+
+            assert_eq!(
+                doc[format!("from_collection_{}", binding % M)],
+                serde_json::json!(true),
+                "binding {binding} published a document of another collection: {doc}",
+            );
+        }
+        assert_eq!(
+            published,
+            BTreeMap::from([
+                // Bindings 0, 1 and 2 each captured `RUN` documents of one key,
+                // valued 1, 2 and 3. A capture combines *associatively*
+                // (`doc::combine`'s `is_full == false`), so a key group drains as
+                // its first document plus the reduction of the rest: two out for
+                // `RUN` in, summing to the binding's own value times the run.
+                (0, (2, RUN)),
+                (1, (2, 2 * RUN)),
+                (2, (2, 3 * RUN)),
+                // Collection-0's other bindings each captured one document, which
+                // stays its own however much machinery the four of them share.
+                (3, (1, 10)),
+                (6, (1, 100)),
+                (9, (1, 1000)),
+            ]),
+        );
+        assert_eq!(stats.len(), 1);
+
+        // One inference event per collection, each naming the last binding to
+        // update it -- including collection-2, whose shape merges binding 5's
+        // sourced schema with binding 2's document, applied in that order.
+        assert_eq!(
+            inferences
+                .iter()
+                .map(|(collection, binding, _schema)| (collection.as_str(), *binding))
+                .collect::<Vec<_>>(),
+            [
+                ("acmeCo/collection-0", Some(9)),
+                ("acmeCo/collection-1", Some(1)),
+                ("acmeCo/collection-2", Some(2)),
+            ],
+        );
+        assert!(
+            inferences[2].2.contains("sourced_only"),
+            "collection-2's inference merged the sourced schema: {}",
+            inferences[2].2,
+        );
+    }
+
+    /// Backfill lifecycle across a restart, for a target written by one binding
+    /// and for one written by two:
+    ///
+    /// - A Begin persists the active backfill -- unless its target is fan-in,
+    ///   where the Begin is suppressed and absence from `active_backfills` *is*
+    ///   the suppression decision, so recovery replays nothing and no
+    ///   `truncated-at` label or marker intent is ever built.
+    /// - A fresh session recovers what was persisted, a Complete removes it, and
+    ///   a Complete for a never-begun binding is an orphaned no-op. A suppressed
+    ///   backfill converges by that same orphaned path.
+    ///
+    /// `truncated_at` is 0 -- the recording publisher's no-op marker clock -- and
+    /// each backfill message is sealed by its own terminating Checkpoint.
+    #[tokio::test]
+    async fn serve_backfill_lifecycle() {
+        // The fan-in task's two bindings target one collection; the default
+        // task's target two, so neither of its targets is fan-in.
+        let mk_fan_in_task = || {
+            fixture::task(
+                &[
+                    ("test/collectionA", "stateA", "/_meta/uuid"),
+                    ("test/collectionA", "stateB", ""),
+                ],
+                b"{}",
+                true,
+            )
+        };
+        let cases: [(&str, fn() -> Task, BTreeMap<u32, u64>); 2] = [
+            (
+                "distinct targets",
+                || mk_task(true),
+                BTreeMap::from([(0, 0)]),
+            ),
+            ("fan-in target", mk_fan_in_task, BTreeMap::new()),
+        ];
+
+        for (case, mk_task, after_begin) in cases {
+            // A Begin persists nothing exactly when its target is fan-in.
+            assert_eq!(
+                mk_task().targets.iter().any(|target| target.fan_in),
+                after_begin.is_empty(),
+                "{case}: fixture",
+            );
+
+            let (db, recover) = run_capture_session(
+                mk_task(),
+                crate::shard::RocksDB::open(None).await.unwrap(),
+                BTreeMap::new(),
+                crate::TracingLogger,
+                vec![backfill_begin(0), checkpoint(br#"{"cursor":"1"}"#)],
+                1,
+            )
+            .await
+            .recover()
+            .await;
+
+            assert_eq!(recover.active_backfills, after_begin, "{case}: after begin");
+
+            // Binding 0's Complete removes what its Begin persisted (or takes the
+            // orphaned path, when the Begin was suppressed). Binding 1 never began
+            // either way, so its Complete is always orphaned.
+            let (_db, recover) = run_capture_session(
+                mk_task(),
+                db,
+                recover.active_backfills,
+                crate::TracingLogger,
+                vec![
+                    backfill_complete(0),
+                    checkpoint(br#"{"cursor":"2"}"#),
+                    backfill_complete(1),
+                    checkpoint(br#"{"cursor":"3"}"#),
+                ],
+                2,
+            )
+            .await
+            .recover()
+            .await;
+
+            assert_eq!(
+                recover.active_backfills,
+                BTreeMap::new(),
+                "{case}: after complete",
+            );
+            assert_eq!(recover.connector_state_json.as_ref(), br#"{"cursor":"3"}"#);
+        }
+    }
+
+    /// Truncated-at labels belong to shard zero alone, and the two shards which
+    /// start a session already holding `active_backfills` part ways on that:
+    ///
+    /// - Shard zero recovered mid-backfill, and must re-apply its labels on the
+    ///   first `ApplyTruncatedLabels` rather than skip -- the restart case a
+    ///   false `labels_dirty` seed would silently break.
+    /// - A non-zero shard inherited the same backfills through a mid-backfill
+    ///   split, and must not apply them at all: it never sees the
+    ///   BackfillComplete which would clear them.
+    #[tokio::test]
+    async fn recovered_backfills_apply_labels_on_shard_zero_only() {
+        for is_shard_zero in [true, false] {
+            let task = std::sync::Arc::new(mk_task(true));
+            let (mut actor, _connector_rx) = mk_actor(
+                &task,
+                BTreeMap::from([(0u32, 5u64)]), // recovered, or split-inherited
+                crate::shard::RocksDB::open(None).await.unwrap(),
+                is_shard_zero,
+                crate::TracingLogger,
+                RecordingPublisher::default(),
+            );
+
+            let mut accumulator = crate::Accumulator::new(task.combine_spec().unwrap()).unwrap();
+            actor
+                .dispatch(fsm::Action::ApplyTruncatedLabels, &mut accumulator)
+                .unwrap();
+
+            assert_eq!(
+                actor.labels_apply_fut.is_some(),
+                is_shard_zero,
+                "labels applied by a shard with is_shard_zero={is_shard_zero}",
+            );
+        }
     }
 
     /// `observe_throttle` parks at most one split for a due journal, never
@@ -1031,9 +1433,6 @@ mod tests {
     /// terminal `ignore` set.
     #[tokio::test]
     async fn observe_throttle_split_dispatch() {
-        let (connector_tx, _actor_to_conn_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-        let task = std::sync::Arc::new(mk_task(true));
-
         let spec = flow::CollectionSpec {
             name: "test/collectionA".to_string(),
             partition_template: Some(proto_gazette::broker::JournalSpec {
@@ -1042,21 +1441,13 @@ mod tests {
             }),
             ..Default::default()
         };
-        let publisher = crate::JournalPublisher::new_test_real([&spec]);
-        let shapes = task.binding_shapes_by_index(Default::default());
-
-        let mut actor = Actor::new(
+        let (mut actor, _connector_rx) = mk_actor(
+            &std::sync::Arc::new(mk_task(true)),
             BTreeMap::new(),
-            vec!["stateA".to_string()],
-            connector_tx,
             crate::shard::RocksDB::open(None).await.unwrap(),
-            true,
-            super::super::Metrics::new("test/shard"),
+            true, // is_shard_zero
             crate::TracingLogger,
-            publisher,
-            shapes,
-            task,
-            None,
+            crate::JournalPublisher::new_test_real([&spec]),
         );
 
         // Seed a policy under which the observed journal is immediately due.
@@ -1115,234 +1506,25 @@ mod tests {
         // `mk_task(true)` has two bindings (indices 0 and 1); index 2 is out of
         // range. An out-of-range binding from the connector must surface as a
         // clean error rather than panicking downstream in publisher indexing.
-        let (connector_tx, _conn_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-        let db = crate::shard::RocksDB::open(None).await.unwrap();
-        let task = std::sync::Arc::new(mk_task(true));
-        let publisher = crate::publish::NoopPublisher;
-        let shapes = task.binding_shapes_by_index(Default::default());
-
-        let actor = Actor::new(
+        let (actor, _connector_rx) = mk_actor(
+            &std::sync::Arc::new(mk_task(true)),
             BTreeMap::new(),
-            vec!["stateA".to_string(), "stateB".to_string()],
-            connector_tx,
-            db,
+            crate::shard::RocksDB::open(None).await.unwrap(),
             true, // is_shard_zero
-            super::super::Metrics::new("test/shard"),
             crate::TracingLogger,
-            publisher,
-            shapes,
-            task,
-            None, // token_restart_at
+            RecordingPublisher::default(),
         );
 
         let mut ready = fsm::ConnectorRx::Eof;
-        for response in [
-            Response {
-                backfill_begin: Some(response::BackfillBegin { binding: 2 }),
-                ..Default::default()
-            },
-            Response {
-                backfill_complete: Some(response::BackfillComplete { binding: 2 }),
-                ..Default::default()
-            },
-        ] {
+        for response in [backfill_begin(2), backfill_complete(2)] {
             let err = actor
-                .on_connector_rx(&mut ready, Some(Ok(response)))
+                .on_connector_rx(&mut ready, Some(response))
                 .unwrap_err();
             assert!(
                 err.to_string().contains("out-of-range binding 2"),
                 "unexpected error: {err}",
             );
         }
-    }
-
-    /// Backfill lifecycle across a restart: a Begin persists the active backfill, a
-    /// fresh session recovers it, a Complete removes it, and an orphaned Complete
-    /// (never-begun binding) is a no-op. `truncated_at` is 0 — the preview
-    /// publisher's no-op marker clock. Each backfill message is sealed by its own
-    /// terminating Checkpoint.
-    #[tokio::test]
-    async fn serve_backfill_lifecycle() {
-        // One capture session over `db`: feed `responses`, drain `expect_acks`
-        // Acknowledges (one per committed marker transaction, so each commits
-        // before Stop), then Stop and return the db.
-        async fn run_capture_session(
-            db: crate::shard::RocksDB,
-            active_backfills: BTreeMap<u32, u64>,
-            responses: Vec<tonic::Result<Response>>,
-            expect_acks: usize,
-        ) -> crate::shard::RocksDB {
-            let (connector_tx, mut actor_to_conn_rx) =
-                mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-            let (conn_resp_tx, conn_resp_rx) =
-                mpsc::channel::<tonic::Result<Response>>(crate::CHANNEL_BUFFER);
-            let (controller_tx, controller_rx) =
-                mpsc::unbounded_channel::<tonic::Result<proto::Capture>>();
-
-            let task = std::sync::Arc::new(mk_task(true));
-            let publisher = crate::publish::NoopPublisher;
-            let shapes = task.binding_shapes_by_index(Default::default());
-
-            let actor = Actor::new(
-                active_backfills,
-                vec!["stateA".to_string(), "stateB".to_string()],
-                connector_tx,
-                db,
-                true,
-                super::super::Metrics::new("test/shard"),
-                crate::TracingLogger,
-                publisher,
-                shapes,
-                task,
-                None, // token_restart_at
-            );
-
-            let serve = tokio::spawn(async move {
-                let mut controller_rx = UnboundedReceiverStream::new(controller_rx);
-                actor
-                    .serve(
-                        ReceiverStream::new(conn_resp_rx),
-                        &mut controller_rx,
-                        fsm::Head::Idle(fsm::HeadIdle::default()),
-                        fsm::Tail::Recover(fsm::TailRecover {
-                            checkpoints: 0,
-                            ack_intents: BTreeMap::new(),
-                        }),
-                    )
-                    .await
-            });
-
-            for response in responses {
-                conn_resp_tx.send(response).await.unwrap();
-            }
-            for _ in 0..expect_acks {
-                assert!(actor_to_conn_rx.recv().await.unwrap().acknowledge.is_some());
-            }
-
-            controller_tx
-                .send(Ok(proto::Capture {
-                    stop: Some(proto::Stop {}),
-                    ..Default::default()
-                }))
-                .unwrap();
-            let (db, _shapes) = serve.await.unwrap().unwrap();
-            db
-        }
-
-        let state_keys = || vec!["stateA".to_string(), "stateB".to_string()];
-
-        let db = run_capture_session(
-            crate::shard::RocksDB::open(None).await.unwrap(),
-            BTreeMap::new(),
-            vec![
-                Ok(Response {
-                    backfill_begin: Some(response::BackfillBegin { binding: 0 }),
-                    ..Default::default()
-                }),
-                checkpoint(br#"{"cursor":"1"}"#),
-            ],
-            1,
-        )
-        .await;
-        let (db, recover) = db.scan(state_keys()).await.unwrap();
-        assert_eq!(
-            recover.active_backfills,
-            BTreeMap::from([(0u32, 0u64)]),
-            "begin persisted the active backfill",
-        );
-
-        let db = run_capture_session(
-            db,
-            recover.active_backfills,
-            vec![
-                Ok(Response {
-                    backfill_complete: Some(response::BackfillComplete { binding: 0 }),
-                    ..Default::default()
-                }),
-                checkpoint(br#"{"cursor":"2"}"#),
-                Ok(Response {
-                    backfill_complete: Some(response::BackfillComplete { binding: 1 }),
-                    ..Default::default()
-                }),
-                checkpoint(br#"{"cursor":"3"}"#),
-            ],
-            2,
-        )
-        .await;
-        let (_db, recover) = db.scan(state_keys()).await.unwrap();
-        assert_eq!(
-            recover.active_backfills,
-            BTreeMap::new(),
-            "complete removed binding 0; orphaned complete for binding 1 was a no-op",
-        );
-    }
-
-    /// A shard recovered mid-backfill (non-empty `active_backfills`) re-applies its
-    /// truncated-at labels on the first `ApplyTruncatedLabels` rather than skipping
-    /// — the restart case a false `labels_dirty` seed would silently break.
-    #[tokio::test]
-    async fn recovered_active_backfills_reapply_labels() {
-        let (connector_tx, _connector_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-        let task = std::sync::Arc::new(mk_task(true));
-        let publisher = crate::publish::NoopPublisher;
-        let shapes = task.binding_shapes_by_index(Default::default());
-
-        let mut actor = Actor::new(
-            BTreeMap::from([(0u32, 5u64)]), // recovered mid-backfill
-            vec!["stateA".to_string(), "stateB".to_string()],
-            connector_tx,
-            crate::shard::RocksDB::open(None).await.unwrap(),
-            true,
-            super::super::Metrics::new("test/shard"),
-            crate::TracingLogger,
-            publisher,
-            shapes,
-            task.clone(),
-            None, // token_restart_at
-        );
-
-        let mut accumulator = crate::Accumulator::new(task.combine_spec().unwrap()).unwrap();
-        actor
-            .dispatch(fsm::Action::ApplyTruncatedLabels, &mut accumulator)
-            .unwrap();
-        assert!(
-            actor.labels_apply_fut.is_some(),
-            "recovered active backfills must re-apply labels, not skip",
-        );
-    }
-
-    /// A non-shard-zero shard that inherited `active_backfills` via a mid-backfill
-    /// split must NOT apply truncated-at labels: it never sees the BackfillComplete
-    /// that would clear them.
-    #[tokio::test]
-    async fn non_shard_zero_skips_label_apply() {
-        let (connector_tx, _connector_rx) = mpsc::channel::<Request>(crate::CHANNEL_BUFFER);
-        let task = std::sync::Arc::new(mk_task(true));
-        let publisher = crate::publish::NoopPublisher;
-        let shapes = task.binding_shapes_by_index(Default::default());
-
-        let mut actor = Actor::new(
-            BTreeMap::from([(0u32, 5u64)]), // inherited mid-backfill via a split
-            vec!["stateA".to_string(), "stateB".to_string()],
-            connector_tx,
-            crate::shard::RocksDB::open(None).await.unwrap(),
-            false, // not shard zero
-            super::super::Metrics::new("test/shard"),
-            crate::TracingLogger,
-            publisher,
-            shapes,
-            task.clone(),
-            None, // token_restart_at
-        );
-
-        let mut accumulator = crate::Accumulator::new(task.combine_spec().unwrap()).unwrap();
-        actor
-            .dispatch(fsm::Action::ApplyTruncatedLabels, &mut accumulator)
-            .unwrap();
-        assert!(
-            actor.labels_apply_fut.is_none(),
-            "a non-shard-zero shard must not apply truncated-at labels",
-        );
     }
 
     /// `parse_sourced_schema` resolves a valid closed schema to its binding and

--- a/crates/runtime-next/src/shard/capture/drain.rs
+++ b/crates/runtime-next/src/shard/capture/drain.rs
@@ -2,7 +2,7 @@
 //!
 //! [`drain_and_publish`] runs as the actor's parked `drain_fut`: it consumes a
 //! rotated combiner, publishes captured documents as `CONTINUE_TXN` journal
-//! appends, folds connector-reported schemas into per-binding inference, and
+//! appends, folds connector-reported schemas into per-target inference, and
 //! assembles the [`fsm::DrainedCapture`] the TailFSM needs to build stats and
 //! the committing Persist.
 //!
@@ -13,14 +13,14 @@
 use crate::leader::capture::{Task, fsm};
 use anyhow::Context;
 use bytes::Bytes;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
-/// Schema-complexity limit for a binding the connector described with a
-/// SourcedSchema. Such a binding has a meaningful source-derived schema, so
-/// inference is trusted with far more leeway than a purely-inferred binding
+/// Schema-complexity limit for a collection the connector described with a
+/// SourcedSchema. Such a collection has a meaningful source-derived schema, so
+/// inference is trusted with far more leeway than a purely-inferred one
 /// (which uses [`doc::shape::limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT`]). The
 /// limit rides in the shape's annotations and so persists across sessions —
-/// see `Task::binding_shapes_by_index`.
+/// see `Task::shapes_by_target`.
 const SOURCED_SCHEMA_COMPLEXITY_LIMIT: usize = 10_000;
 
 /// Resources and results handed back to the actor when a drain completes.
@@ -31,7 +31,7 @@ pub(super) struct Output<P: crate::Publisher> {
     pub(super) drained: fsm::DrainedCapture,
     /// The publisher, borrowed for the drain's journal appends.
     pub(super) publisher: P,
-    /// Per-binding inferred write-shapes, carried across sessions of the shard.
+    /// Per-target inferred write-shapes, carried across sessions of the shard.
     pub(super) shapes: Vec<doc::Shape>,
 }
 
@@ -54,9 +54,10 @@ pub(super) async fn drain_and_publish<P: crate::Publisher, L: crate::Logger>(
     // `Clock::update` is monotonic and never regresses.
     publisher.update_clock();
 
-    // Bindings updated this transaction — by a sourced schema or by widening
-    // an inferred shape — are logged once the drain completes.
-    let mut updated_inferences = BTreeSet::<usize>::new();
+    // Targets whose inference updated this transaction — by a sourced schema or
+    // by widening an inferred shape — are logged once the drain completes, each
+    // naming the last binding which updated it.
+    let mut updated_inferences = BTreeMap::<usize, u32>::new();
 
     apply_sourced_schemas(&mut shapes, &task, sourced_schemas, &mut updated_inferences)?;
 
@@ -92,18 +93,20 @@ pub(super) async fn drain_and_publish<P: crate::Publisher, L: crate::Logger>(
             continue;
         }
 
-        if shapes[binding].widen_owned(&doc) {
-            let limit = complexity_limit(&shapes[binding]);
+        let target = task.bindings[binding].target as usize;
+
+        if shapes[target].widen_owned(&doc) {
+            let limit = complexity_limit(&shapes[target]);
             doc::shape::limits::enforce_shape_complexity_limit(
-                &mut shapes[binding],
+                &mut shapes[target],
                 limit,
                 doc::shape::limits::DEFAULT_SCHEMA_DEPTH_LIMIT,
             );
-            updated_inferences.insert(binding);
+            updated_inferences.insert(target, binding as u32);
         }
 
         let bytes_written = publisher
-            .publish_doc(binding, doc, &task.bindings[binding].document_uuid_ptr)
+            .publish_doc(binding, doc, &task.targets[target].document_uuid_ptr)
             .await
             .context("publishing captured document")?;
 
@@ -122,14 +125,14 @@ pub(super) async fn drain_and_publish<P: crate::Publisher, L: crate::Logger>(
         connector_patches.push(b']');
     }
 
-    for binding in updated_inferences.iter() {
+    for (target, binding) in updated_inferences.iter() {
         // `to_schema` emits the shape's annotations, including the
         // `x-complexity-limit` set by `apply_sourced_schemas` or the
-        // per-session default seeded by `Task::binding_shapes_by_index`.
-        let schema = doc::shape::schema::to_schema(shapes[*binding].clone());
+        // per-session default seeded by `Task::shapes_by_target`.
+        let schema = doc::shape::schema::to_schema(shapes[*target].clone());
         logger.event(crate::LogEvent::InferredSchema {
-            collection_name: &task.bindings[*binding].collection_name,
-            binding: Some(*binding),
+            collection_name: &task.targets[*target].collection_name,
+            binding: Some(*binding as usize), // Diagnostic.
             schema: &schema,
         });
         metrics.inferred_schema_updates.increment(1);
@@ -146,50 +149,54 @@ pub(super) async fn drain_and_publish<P: crate::Publisher, L: crate::Logger>(
     })
 }
 
-/// Fold this transaction's connector-sourced shapes into long-lived per-binding
-/// inference: each is intersected with the binding's write-schema shape, then
-/// unioned into the running inferred shape. A sourced binding is also stamped
-/// with an elevated complexity limit, recorded in the shape's annotations.
+/// Fold this transaction's connector-sourced shapes into long-lived
+/// per-target inference: each is intersected with the target collection's
+/// write-schema shape, then unioned into the running inferred shape. The target
+/// is also stamped with an elevated complexity limit, recorded in the shape's
+/// annotations.
+///
+/// Sourced schemas arrive keyed by binding and are mapped to targets on the
+/// way in, so several bindings' sourced schemas union into one collection
+/// shape.
 fn apply_sourced_schemas(
     shapes: &mut [doc::Shape],
     task: &Task,
     sourced_schemas: BTreeMap<u32, doc::Shape>,
-    updated_inferences: &mut BTreeSet<usize>,
+    updated_inferences: &mut BTreeMap<usize, u32>,
 ) -> anyhow::Result<()> {
     for (binding, sourced_shape) in sourced_schemas {
-        let binding = binding as usize;
-
-        let write_shape = task
+        let target = task
             .bindings
-            .get(binding)
+            .get(binding as usize)
             .with_context(|| format!("invalid sourced schema binding {binding}"))?
-            .write_shape
-            .clone();
+            .target as usize;
 
         // By construction, we cannot capture documents which don't adhere to
         // the write schema. Intersect it to avoid generating incompatible
         // inference updates.
-        let mut sourced_shape = doc::Shape::intersect(sourced_shape, write_shape);
+        let mut sourced_shape =
+            doc::Shape::intersect(sourced_shape, task.targets[target].write_shape.clone());
 
         // Shape::union intersects annotations and retains only those having equal key/values.
         sourced_shape.annotations.insert(
             crate::X_GENERATION_ID.to_string(),
-            shapes[binding].annotations[crate::X_GENERATION_ID].clone(),
+            shapes[target].annotations[crate::X_GENERATION_ID].clone(),
         );
 
-        shapes[binding] = doc::Shape::union(
-            std::mem::replace(&mut shapes[binding], doc::Shape::nothing()),
+        shapes[target] = doc::Shape::union(
+            std::mem::replace(&mut shapes[target], doc::Shape::nothing()),
             sourced_shape,
         );
 
         // Presence of a sourced schema ratchets up the complexity limit for
-        // inferences of this binding. It then rides with the shape: surviving widening,
-        // emitted into the logged schema, and read back by `complexity_limit`.
-        shapes[binding].annotations.insert(
+        // inferences of this target collection. It then rides with the shape:
+        // surviving widening, emitted into the logged schema, and read back by
+        // `complexity_limit`.
+        shapes[target].annotations.insert(
             doc::shape::X_COMPLEXITY_LIMIT.to_string(),
             serde_json::json!(SOURCED_SCHEMA_COMPLEXITY_LIMIT),
         );
-        updated_inferences.insert(binding);
+        updated_inferences.insert(target, binding);
     }
     Ok(())
 }
@@ -204,4 +211,93 @@ fn complexity_limit(shape: &doc::Shape) -> usize {
         .map_or(doc::shape::limits::DEFAULT_SCHEMA_COMPLEXITY_LIMIT, |n| {
             n as usize
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::leader::capture::task::fixture;
+    use crate::logger::RecordingLogger;
+
+    /// Two bindings of one collection widen a single shared shape, and the
+    /// collection is logged exactly once, naming the last binding to update it.
+    /// A third binding on a second collection is the control: it has its own
+    /// target and its own event.
+    #[tokio::test]
+    async fn drain_infers_once_per_collection() {
+        let task = std::sync::Arc::new(fixture::task(
+            &[
+                ("acmeCo/one", "stateA", ""),
+                ("acmeCo/one", "stateB", ""),
+                ("acmeCo/two", "stateC", ""),
+            ],
+            br#"{"type":"object"}"#,
+            false,
+        ));
+        assert_eq!(task.targets.len(), 2);
+
+        // Each binding of `acmeCo/one` contributes a distinct property, so the
+        // shared shape must carry both if -- and only if -- they widen one shape.
+        let mut accumulator = crate::Accumulator::new(task.combine_spec().unwrap()).unwrap();
+        for (binding, doc_json) in [
+            (0u16, br#"{"from_a":1}"#.as_slice()),
+            (1, br#"{"from_b":2}"#.as_slice()),
+            (2, br#"{"from_c":3}"#.as_slice()),
+        ] {
+            let (memtable, _alloc, doc) = accumulator.parse_json_doc(doc_json).unwrap();
+            memtable.add(binding, doc, false).unwrap();
+        }
+        let (drainer, parser) = accumulator.into_drainer().unwrap();
+
+        let logger = RecordingLogger::default();
+        let output = drain_and_publish(
+            drainer,
+            parser,
+            crate::publish::RecordingPublisher::default(),
+            task.clone(),
+            BTreeMap::new(),
+            task.shapes_by_target(Default::default()),
+            super::super::Metrics::new("test/shard"),
+            logger.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output.shapes.len(), 2); // One shape per collection, not per binding.
+        assert_eq!(
+            output.shapes[0]
+                .object
+                .properties
+                .iter()
+                .map(|property| &*property.name)
+                .collect::<Vec<_>>(),
+            ["from_a", "from_b"],
+            "both bindings of acmeCo/one widened its single shape",
+        );
+
+        // One event per collection, naming the last binding which updated it:
+        // binding 1 for `acmeCo/one` (bindings 0 and 1 share its target), and
+        // binding 2 for `acmeCo/two`.
+        let logs = logger.logs.lock().unwrap();
+        let field = |log: &ops::Log, field: &str| {
+            log.fields_json_map
+                .get(field)
+                .map(|value| String::from_utf8_lossy(value).into_owned())
+        };
+        assert_eq!(
+            logs.len(),
+            2,
+            "one inference event per collection: {logs:?}"
+        );
+
+        for (log, (collection, binding)) in logs.iter().zip([("acmeCo/one", 1), ("acmeCo/two", 2)])
+        {
+            assert_eq!(log.message, "inferred schema updated");
+            assert_eq!(
+                field(log, "collection_name"),
+                Some(format!("\"{collection}\"")),
+            );
+            assert_eq!(field(log, "binding"), Some(format!("{binding}")));
+        }
+    }
 }

--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -358,6 +358,9 @@ where
         .resolved_bindings()
         .filter_map(|(_binding, resolved)| resolved.map(|(collection, _identity)| collection))
         .collect();
+    // A capture presently opens one publisher target per binding.
+    let binding_targets: Vec<u32> = (0..collection_specs.len() as u32).collect();
+
     let publisher = service
         .publisher_factory
         .open(
@@ -365,6 +368,7 @@ where
             producer,
             &labeling.stats_journal,
             &collection_specs,
+            &binding_targets,
         )
         .context("opening publisher")?;
 

--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -155,8 +155,9 @@ where
     let verify = crate::verify("Capture", "Join", "controller");
 
     // Inferred document shapes are held only in memory and accumulate across
-    // every session of this Shard stream. They're keyed by stable binding
-    // identity so a spec update that reorders bindings still resumes inference.
+    // every session of this Shard stream. They're keyed by stable collection
+    // identity (`partition_template_name`) so a spec update that reorders or
+    // re-fans bindings still resumes inference of each collection.
     let mut shapes_by_key: BTreeMap<String, doc::Shape> = BTreeMap::new();
 
     // Producer identity for this shard's Publisher, selected once and held
@@ -354,12 +355,23 @@ where
         max_transactions,
     )?);
 
-    let collection_specs: Vec<&flow::CollectionSpec> = spec
-        .resolved_bindings()
-        .filter_map(|(_binding, resolved)| resolved.map(|(collection, _identity)| collection))
-        .collect();
-    // A capture presently opens one publisher target per binding.
-    let binding_targets: Vec<u32> = (0..collection_specs.len() as u32).collect();
+    // Publisher targets follow the Task's targets, so a fan-in capture opens one
+    // journal client and one partitions watch per collection rather than per
+    // binding, and the combiner validator and publisher target of a binding are
+    // grouped identically.
+    let collection_specs: Vec<&flow::CollectionSpec> = task
+        .targets
+        .iter()
+        .map(|target| {
+            let index = target.first_binding as usize;
+            Ok(spec
+                .binding_collection(&spec.bindings[index])
+                .context("missing collection")
+                .context(index)?
+                .0)
+        })
+        .collect::<anyhow::Result<_>>()?;
+    let binding_targets: Vec<u32> = task.bindings.iter().map(|binding| binding.target).collect();
 
     let publisher = service
         .publisher_factory
@@ -390,8 +402,8 @@ where
     });
 
     // Restore inferred shapes accumulated by prior sessions into this session's
-    // binding layout, and stow the session's final shapes back when it ends.
-    let shapes = task.binding_shapes_by_index(std::mem::take(shapes_by_key));
+    // inference-slot layout, and stow the session's final shapes back when it ends.
+    let shapes = task.shapes_by_target(std::mem::take(shapes_by_key));
 
     // Only shard zero drives backfill truncation: it owns the origin of the key
     // and r-clock ranges, so it sees each backfill's full lifecycle even when split.
@@ -413,7 +425,7 @@ where
     .serve(connector_rx, controller_rx, head, tail)
     .await?;
 
-    *shapes_by_key = task.binding_shapes_by_key(shapes);
+    *shapes_by_key = task.shapes_by_key(shapes);
 
     _ = controller_tx.send(Ok(proto::Capture {
         stopped: Some(proto::Stopped {}),

--- a/crates/runtime-next/src/shard/capture/mod.rs
+++ b/crates/runtime-next/src/shard/capture/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use handler::serve;
 pub(crate) struct Metrics {
     /// Transactions completed by this shard session.
     pub(super) transactions: metrics::Counter,
-    /// Per-binding inferred schema updates logged by drain.
+    /// Per-collection inferred schema updates logged by drain.
     pub(super) inferred_schema_updates: metrics::Counter,
 }
 
@@ -25,7 +25,7 @@ impl Metrics {
             metrics::describe_counter!(
                 "runtime_shard_capture_inferred_schema_updates",
                 metrics::Unit::Count,
-                "per-binding inferred schema updates logged by drain",
+                "per-collection inferred schema updates logged by drain",
             );
         });
 

--- a/crates/runtime-next/src/shard/derive/actor.rs
+++ b/crates/runtime-next/src/shard/derive/actor.rs
@@ -1,4 +1,4 @@
-use super::{drain, scan, task::Task};
+use super::{Task, drain, scan};
 use crate::{patches, proto};
 use anyhow::Context;
 use futures::{FutureExt, StreamExt, future, future::BoxFuture};
@@ -156,6 +156,7 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
             } else if let Phase::Scanning(mut scanner) = phase {
                 if scanner.step(
                     &self.task.transforms,
+                    &self.task.sources,
                     &mut source_validators,
                     self.codec,
                     &mut self.connector_pending,
@@ -586,7 +587,7 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> T {
 
 #[cfg(test)]
 mod tests {
-    use super::super::task::Transform;
+    use super::super::{Source, Transform};
     use super::*;
     use proto_flow::derive::response;
     use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
@@ -599,9 +600,12 @@ mod tests {
             redact_salt: bytes::Bytes::new(),
             transforms: vec![Transform {
                 transform: "fromSrc".to_string(),
-                collection: "test/source".to_string(),
-                schema_json: bytes::Bytes::from_static(b"{}"),
+                source: 0,
                 shuffle_key_extractors: Vec::new(),
+            }],
+            sources: vec![Source {
+                collection_name: "test/source".to_string(),
+                read_schema_json: bytes::Bytes::from_static(b"{}"),
             }],
             binding_state_keys: vec!["fromSrc".to_string()],
             write_schema_json: bytes::Bytes::from_static(b"{}"),

--- a/crates/runtime-next/src/shard/derive/actor.rs
+++ b/crates/runtime-next/src/shard/derive/actor.rs
@@ -731,7 +731,7 @@ mod tests {
             actor_to_leader_tx,
             super::super::Metrics::new("test/shard"),
             crate::TracingLogger,
-            crate::publish::NoopPublisher,
+            crate::publish::RecordingPublisher::default(),
             task,
             write_shape,
         );

--- a/crates/runtime-next/src/shard/derive/mod.rs
+++ b/crates/runtime-next/src/shard/derive/mod.rs
@@ -7,7 +7,7 @@ mod startup;
 mod task;
 
 pub(crate) use handler::serve;
-use task::Task;
+use task::{Source, Task, Transform};
 
 #[derive(Clone)]
 pub(crate) struct Metrics {

--- a/crates/runtime-next/src/shard/derive/scan.rs
+++ b/crates/runtime-next/src/shard/derive/scan.rs
@@ -3,7 +3,7 @@ use bytes::BufMut;
 use proto_flow::{derive, flow};
 use std::collections::{HashMap, VecDeque};
 
-use super::task::Transform;
+use super::{Source, Transform};
 use crate::proto::derive::loaded::Binding as LoadedBinding;
 
 /// Scanner is a synchronous state machine that walks a `shuffle::Frontier` one
@@ -47,6 +47,7 @@ impl Scanner {
     pub fn step(
         &mut self,
         transforms: &[Transform],
+        sources: &[Source],
         validators: &mut [doc::Validator],
         codec: connector_init::Codec,
         out: &mut Vec<derive::Request>,
@@ -79,11 +80,12 @@ impl Scanner {
             if meta.flags.to_native() & shuffle::FLAGS_SCHEMA_VALID == 0 {
                 let Transform {
                     transform: name,
-                    collection,
+                    source,
                     ..
                 } = &transforms[transform as usize];
+                let collection = &sources[*source as usize].collection_name;
 
-                validators[transform as usize]
+                validators[*source as usize]
                     .validate(doc.doc.get(), |_| None)
                     .with_context(|| {
                         format!(

--- a/crates/runtime-next/src/shard/derive/startup.rs
+++ b/crates/runtime-next/src/shard/derive/startup.rs
@@ -134,6 +134,7 @@ where
             shard_producer,
             &labeling.stats_journal,
             &[&spec],
+            &[0], // The derived collection is the shard's single binding.
         )
         .context("opening publisher")?;
 

--- a/crates/runtime-next/src/shard/derive/task.rs
+++ b/crates/runtime-next/src/shard/derive/task.rs
@@ -175,7 +175,7 @@ impl Task {
             .context("could not build a derived collection schema validator")?;
         let mut write_shape = doc::Shape::infer(validator.schema(), validator.schema_index());
         // Stamp the generation id so inferred-schema updates carry it (mirrors
-        // capture `Task::binding_shapes_by_index`).
+        // capture `Task::shapes_by_target`).
         write_shape.annotations.insert(
             crate::X_GENERATION_ID.to_string(),
             serde_json::Value::String(collection_generation_id.to_string()),

--- a/crates/runtime-next/src/shard/derive/task.rs
+++ b/crates/runtime-next/src/shard/derive/task.rs
@@ -16,9 +16,10 @@ pub(super) struct Task {
     pub key_extractors: Vec<doc::Extractor>,
     /// Salt used for redacting sensitive fields when combining.
     pub redact_salt: bytes::Bytes,
-    /// Source metadata of each transform (input binding), indexed by transform
-    /// index. Used to bound `C:Read` indices and to re-validate source documents.
+    /// Transforms of the derivation.
     pub transforms: Vec<Transform>,
+    /// Source collections read by the task's transforms.
+    pub sources: Vec<Source>,
     /// Stable RocksDB `state_key` of each transform, indexed by binding index.
     /// Used to map the leader's frontier binding indices to the `FC:`/`FH:`
     /// key layout.
@@ -33,33 +34,35 @@ pub(super) struct Task {
 pub(super) struct Transform {
     /// Name of this transform.
     pub transform: String,
-    /// Source collection name.
-    pub collection: String,
-    /// Schema the shuffle read pipeline validates source documents against:
-    /// the source collection's read schema, or its write schema when no read
-    /// schema is defined (mirroring `shuffle::binding::build_schema`).
-    pub schema_json: bytes::Bytes,
+    /// Index of this transform's source collection within [`Task::sources`].
+    pub source: u32,
     /// Extractors of this transform's shuffle key, applied to source documents
     /// to populate `Read.shuffle.key_json` for JSON connectors. Empty for a
     /// lambda-computed key.
     pub shuffle_key_extractors: Vec<doc::Extractor>,
 }
 
+/// A source collection, read by one or more transforms of the derivation.
+///
+/// Sources follow the spec's declared indirection: transforms sharing a
+/// `collection_index` share one Source, while a transform of an inline-form
+/// spec carries no index and is its own Source.
+pub(super) struct Source {
+    /// Source collection name.
+    pub collection_name: String,
+    /// Schema the shuffle read pipeline validates source documents against:
+    /// the source collection's read schema, or its write schema when no read
+    /// schema is defined (mirroring `shuffle::Source::new`).
+    pub read_schema_json: bytes::Bytes,
+}
+
 /// Build the runtime [`Transform`] for a single derivation transform (input binding).
 fn build_transform(
     t: &flow::collection_spec::derivation::Transform,
     collection: &flow::CollectionSpec,
+    source: u32,
     ser_policy: &doc::SerPolicy,
 ) -> anyhow::Result<Transform> {
-    // Prefer the read schema, falling back to the write schema, so
-    // re-validation uses the same schema the shuffle read pipeline
-    // validated against when it set `FLAGS_SCHEMA_VALID`.
-    let schema_json = if collection.read_schema_json.is_empty() {
-        collection.write_schema_json.clone()
-    } else {
-        collection.read_schema_json.clone()
-    };
-
     // Resolve the extractors of a transform's shuffle key, applied to source
     // documents to populate `Read.shuffle.key_json` for JSON connectors.
     //
@@ -76,10 +79,26 @@ fn build_transform(
 
     Ok(Transform {
         transform: t.name.clone(),
-        collection: collection.name.clone(),
-        schema_json,
+        source,
         shuffle_key_extractors,
     })
+}
+
+/// Build the runtime [`Source`] for a source collection.
+fn build_source(collection: &flow::CollectionSpec) -> Source {
+    // Prefer the read schema, falling back to the write schema, so
+    // re-validation uses the same schema the shuffle read pipeline
+    // validated against when it set `FLAGS_SCHEMA_VALID`.
+    let read_schema_json = if collection.read_schema_json.is_empty() {
+        collection.write_schema_json.clone()
+    } else {
+        collection.read_schema_json.clone()
+    };
+
+    Source {
+        collection_name: collection.name.clone(),
+        read_schema_json,
+    }
 }
 
 impl Task {
@@ -119,14 +138,27 @@ impl Task {
 
         let ser_policy = doc::SerPolicy::noop();
 
-        let sources = derivation
-            .resolved_transforms()
-            .map(|(t, resolved)| {
-                let (collection, _identity) =
-                    resolved.context("transform missing source collection")?;
-                build_transform(t, collection, &ser_policy)
-            })
-            .collect::<anyhow::Result<Vec<Transform>>>()?;
+        let mut transforms = Vec::new();
+        let mut sources = Vec::<Source>::new();
+        let mut sources_by_identity = std::collections::BTreeMap::<u32, u32>::new();
+
+        for (t, resolved) in derivation.resolved_transforms() {
+            let (collection, identity) = resolved.context("transform missing source collection")?;
+
+            let source = match identity.and_then(|i| sources_by_identity.get(&i)) {
+                Some(&source) => source,
+                None => {
+                    let source = sources.len() as u32;
+                    sources.push(build_source(collection));
+
+                    if let Some(identity) = identity {
+                        sources_by_identity.insert(identity, source);
+                    }
+                    source
+                }
+            };
+            transforms.push(build_transform(t, collection, source, &ser_policy)?);
+        }
 
         let partition_template = partition_template
             .as_ref()
@@ -154,33 +186,33 @@ impl Task {
             document_uuid_ptr,
             key_extractors,
             redact_salt: redact_salt.clone(),
-            transforms: sources,
+            transforms,
+            sources,
             binding_state_keys,
             write_schema_json: write_schema_json.clone(),
             write_shape,
         })
     }
 
-    /// Build a source-document validator per transform.
+    /// Build a source-document validator per Source.
     pub fn source_validators(&self) -> anyhow::Result<Vec<doc::Validator>> {
-        self.transforms
+        self.sources
             .iter()
             .map(
-                |Transform {
-                     collection: collection_name,
-                     transform: transform_name,
-                     schema_json,
-                     shuffle_key_extractors: _,
+                |Source {
+                     collection_name,
+                     read_schema_json,
+                     ..
                  }| {
-                    let built_schema =
-                        doc::validation::build_bundle(schema_json).with_context(|| {
+                    let built_schema = doc::validation::build_bundle(read_schema_json)
+                        .with_context(|| {
                             format!(
                                 "source collection {collection_name} schema is not a JSON schema",
                             )
                         })?;
                     doc::Validator::new(built_schema).with_context(|| {
                         format!(
-                            "could not build a schema validator for transform {transform_name}",
+                            "could not build a schema validator for collection {collection_name}",
                         )
                     })
                 },

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -1,10 +1,11 @@
-use super::{Binding, LoadKeys, boundaries::Boundaries, drain, scan};
+use super::{LoadKeys, Task, boundaries::Boundaries, drain, scan};
 use crate::{patches, proto};
 use anyhow::Context;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt, future, future::BoxFuture};
 use proto_flow::materialize;
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::proto::materialize::flushed::Binding as FlushedBinding;
@@ -22,8 +23,6 @@ pub(super) enum Phase {
 
 /// Shard-side materialization reactor for one joined leader session.
 pub(super) struct Actor {
-    // Task binding specifications.
-    bindings: Vec<Binding>,
     // Per-binding backfill-truncation boundaries. Both the scanner and
     // asynchronous Loaded handling classify ingress documents against them,
     // and an advancing boundary truncates the accumulator at L:Load receipt.
@@ -33,17 +32,13 @@ pub(super) struct Actor {
     connector_pending: Vec<materialize::Request>,
     // Bounded channel out to the connector subprocess.
     connector_tx: mpsc::Sender<materialize::Request>,
-    // RocksDB and binding state keys, when a Persist is not in flight.
-    db: Option<(crate::shard::RocksDB, Vec<String>)>,
+    // RocksDB, when a Persist is not in flight.
+    db: Option<crate::shard::RocksDB>,
     // RocksDB future when a Persist is in flight. Resolves to the reply the
     // leader awaits: a `Persisted` echo, or (when `rescan`) a fresh
     // `Recover` reflecting the just-written on-disk state.
-    db_persist_fut: Option<
-        BoxFuture<
-            'static,
-            anyhow::Result<((crate::shard::RocksDB, Vec<String>), proto::Materialize)>,
-        >,
-    >,
+    db_persist_fut:
+        Option<BoxFuture<'static, anyhow::Result<(crate::shard::RocksDB, proto::Materialize)>>>,
     // When true, don't suppress C:Load for keys less-than `max_keys`.
     disable_load_optimization: bool,
     // Wire codec negotiated with the connector.
@@ -61,6 +56,8 @@ pub(super) struct Actor {
     max_keys: Vec<(Bytes, Bytes)>,
     // Per-session metrics counters.
     metrics: super::Metrics,
+    // Task being executed.
+    task: Arc<Task>,
     // When Some, a deadline at which we ask the leader for a graceful session
     // stop, ahead of the expiry of IAM credentials injected into the connector
     // config. The session's restart re-runs the connector with fresh tokens.
@@ -70,15 +67,14 @@ pub(super) struct Actor {
 
 impl Actor {
     pub fn new(
-        bindings: Vec<Binding>,
-        binding_state_keys: Vec<String>,
+        codec: connector_init::Codec,
         connector_tx: mpsc::Sender<materialize::Request>,
         db: crate::shard::RocksDB,
         disable_load_optimization: bool,
-        codec: connector_init::Codec,
         leader_tx: mpsc::UnboundedSender<proto::Materialize>,
         max_keys: Vec<(Bytes, Bytes)>,
         metrics: super::Metrics,
+        task: Arc<Task>,
         token_restart_at: Option<std::time::SystemTime>,
     ) -> Self {
         // Map the wall-clock deadline onto the monotonic clock driving `serve`.
@@ -89,13 +85,11 @@ impl Actor {
             tokio::time::Instant::now() + delay
         });
 
-        let l = bindings.len();
         Self {
-            bindings,
-            boundaries: Boundaries::new(l),
+            boundaries: Boundaries::new(task.bindings.len()),
             connector_pending: Vec::new(),
             connector_tx,
-            db: Some((db, binding_state_keys)),
+            db: Some(db),
             db_persist_fut: None,
             disable_load_optimization,
             codec,
@@ -104,6 +98,7 @@ impl Actor {
             load_keys: Default::default(),
             max_keys,
             metrics,
+            task,
             token_restart_at,
         }
     }
@@ -166,7 +161,7 @@ impl Actor {
                 // Channel is stuffed -- don't allow further requests to queue.
             } else if let Phase::Scanning(mut scanner) = phase {
                 if scanner.step(
-                    &self.bindings,
+                    &self.task.bindings,
                     &self.boundaries,
                     &mut self.load_keys,
                     &mut self.max_keys,
@@ -204,7 +199,7 @@ impl Actor {
                 }
                 continue;
             } else if let Phase::Draining(mut drainer) = phase {
-                if let Some(request) = drainer.step(&self.bindings, self.codec)? {
+                if let Some(request) = drainer.step(&self.task.bindings, self.codec)? {
                     self.connector_pending.push(request);
                     phase = Phase::Draining(drainer);
                 } else {
@@ -316,7 +311,7 @@ impl Actor {
         // Leader-protocol invariant: the leader does not send L:Stopped while a
         // Persist is outstanding — every L:Persist is acknowledged with
         // L:Persisted before L:Stopped.
-        let Some((db, _)) = self.db.take() else {
+        let Some(db) = self.db.take() else {
             anyhow::bail!("leader Stopped while a Persist is in flight");
         };
 
@@ -466,35 +461,36 @@ impl Actor {
             let seq_no = persist.seq_no;
             let rescan = persist.rescan;
 
-            let (db, binding_state_keys) = self
+            let db = self
                 .db
                 .take()
                 .context("received L:Persist while a Persist is already in flight")?;
+            let task = Arc::clone(&self.task);
 
             self.db_persist_fut = Some(
                 async move {
-                    let db = db.persist(&persist, &binding_state_keys).await?;
+                    let db = db.persist(&persist, &task.binding_state_keys).await?;
 
                     if !rescan {
                         let response = proto::Materialize {
                             persisted: Some(proto::Persisted { seq_no }),
                             ..Default::default()
                         };
-                        return Ok(((db, binding_state_keys), response));
+                        return Ok((db, response));
                     }
 
                     // Rescan Persist (leader startup reconciliation): re-scan the
                     // freshly-written DB and reply Recover so the leader observes
                     // the reconciled on-disk state.
                     let (db, recover) = db
-                        .scan(binding_state_keys.iter())
+                        .scan(task.binding_state_keys.iter())
                         .await
                         .context("re-scanning RocksDB after rescan Persist")?;
                     let response = proto::Materialize {
                         recover: Some(recover),
                         ..Default::default()
                     };
-                    Ok(((db, binding_state_keys), response))
+                    Ok((db, response))
                 }
                 .boxed(),
             );
@@ -576,15 +572,15 @@ impl Actor {
                 }
             };
             let binding_index = binding as usize;
-            let binding_spec = self
-                .bindings
-                .get(binding_index)
-                .ok_or_else(|| anyhow::anyhow!("Loaded binding {binding_index} out of range"))?;
-
-            let (memtable, _alloc, doc) =
-                accumulator.parse_json_doc(&doc_json).with_context(|| {
-                    format!("parsing loaded doc for {}", binding_spec.collection_name)
+            let binding_spec =
+                self.task.bindings.get(binding_index).ok_or_else(|| {
+                    anyhow::anyhow!("Loaded binding {binding_index} out of range")
                 })?;
+            let source = &self.task.sources[binding_spec.source as usize];
+
+            let (memtable, _alloc, doc) = accumulator
+                .parse_json_doc(&doc_json)
+                .with_context(|| format!("parsing loaded doc for {}", source.collection_name))?;
 
             // Classify by the row's embedded document-UUID clock, not message
             // timing: staleness reflects when the row was last STORED, and a row
@@ -592,13 +588,11 @@ impl Actor {
             // A never-truncated binding needs no classification (nor a UUID).
             let stale = if !self.boundaries.has_boundary(binding_index) {
                 false
-            } else if let Some(doc::HeapNode::String(uuid)) =
-                binding_spec.document_uuid_ptr.query(&doc)
-            {
+            } else if let Some(doc::HeapNode::String(uuid)) = source.document_uuid_ptr.query(&doc) {
                 let (_, clock, _) = proto_gazette::uuid::parse_str(uuid).with_context(|| {
                     format!(
                         "loaded doc for {} has an unparseable document UUID {uuid:?}",
-                        binding_spec.collection_name,
+                        source.collection_name,
                     )
                 })?;
                 self.boundaries.is_stale(binding_index, clock)
@@ -607,8 +601,8 @@ impl Actor {
                     "loaded doc for {} is being backfill-truncated but has no document UUID \
                      at {}; the materialization must store the root document \
                      (flow_document) or reconstruct its UUID",
-                    binding_spec.collection_name,
-                    binding_spec.document_uuid_ptr,
+                    source.collection_name,
+                    source.document_uuid_ptr,
                 );
             };
             if stale {
@@ -684,13 +678,22 @@ async fn maybe_fut<T>(opt: &mut Option<BoxFuture<'static, T>>) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shard::materialize::task::{Binding, Source};
     use proto_flow::flow;
     use proto_flow::materialize::response;
     use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 
+    /// An empty Task: no bindings, no sources, no persisted state keys.
+    fn empty_task() -> Arc<Task> {
+        Arc::new(Task {
+            bindings: Vec::new(),
+            sources: Vec::new(),
+            binding_state_keys: Vec::new(),
+        })
+    }
+
     fn make_idle_phase() -> Phase {
-        let accumulator =
-            crate::Accumulator::new(super::super::task::combine_spec(&[]).unwrap()).unwrap();
+        let accumulator = crate::Accumulator::new(empty_task().combine_spec().unwrap()).unwrap();
         let shuffle_reader = shuffle::log::Reader::new(std::path::Path::new("/dev/null"), 0);
         Phase::Idle {
             accumulator,
@@ -709,7 +712,6 @@ mod tests {
 
         (
             Actor {
-                bindings: Vec::new(),
                 boundaries: Boundaries::new(0),
                 connector_pending: Vec::new(),
                 connector_tx,
@@ -722,6 +724,7 @@ mod tests {
                 flushed: HashMap::new(),
                 max_keys: Vec::new(),
                 metrics: super::super::Metrics::new("test/shard"),
+                task: empty_task(),
                 token_restart_at: None,
             },
             leader_rx,
@@ -808,11 +811,10 @@ mod tests {
         let db = crate::shard::RocksDB::open(None).await.unwrap();
 
         let actor = Actor {
-            bindings: Vec::new(),
             boundaries: Boundaries::new(0),
             connector_pending: Vec::new(),
             connector_tx: actor_to_conn_tx,
-            db: Some((db, Vec::new())),
+            db: Some(db),
             db_persist_fut: None,
             disable_load_optimization: false,
             codec: connector_init::Codec::Proto,
@@ -821,11 +823,11 @@ mod tests {
             flushed: HashMap::new(),
             max_keys: Vec::new(),
             metrics: super::super::Metrics::new("test/shard"),
+            task: empty_task(),
             token_restart_at: None,
         };
 
-        let accumulator =
-            crate::Accumulator::new(super::super::task::combine_spec(&[]).unwrap()).unwrap();
+        let accumulator = crate::Accumulator::new(empty_task().combine_spec().unwrap()).unwrap();
         let shuffle_dir = tempfile::tempdir().unwrap();
         let shuffle_reader = shuffle::log::Reader::new(shuffle_dir.path(), 0);
 
@@ -1005,34 +1007,40 @@ mod tests {
         assert_eq!(recover.last_applied.as_ref(), b"persisted-spec-bytes");
     }
 
-    // A full-reduction binding storing the root document, keyed on /key, whose
-    // `v` array reduces by append. `document_uuid_ptr` lets the shard read each
-    // loaded row's UUID to classify it against the backfill boundary.
-    fn backfill_binding() -> Binding {
-        Binding {
-            collection_name: "test/collection".to_string(),
-            delta_updates: false,
-            document_uuid_ptr: json::Pointer::from("/_meta/uuid"),
-            key_extractors: vec![doc::Extractor::with_default(
-                "/key",
-                &doc::SerPolicy::noop(),
-                serde_json::json!(""),
-            )],
-            read_schema_json: bytes::Bytes::from_static(
-                br#"{
-                    "type": "object",
-                    "properties": {
-                        "key": { "type": "string" },
-                        "v": { "type": "array", "reduce": { "strategy": "append" } }
-                    },
-                    "reduce": { "strategy": "merge" }
-                }"#,
-            ),
-            ser_policy: doc::SerPolicy::noop(),
-            state_key: "test/collection".to_string(),
-            store_document: true,
-            value_plan: doc::ExtractorPlan::new(&[]),
-        }
+    // A Task of one full-reduction binding storing the root document, keyed on
+    // /key, whose source's `v` array reduces by append. The source's
+    // `document_uuid_ptr` lets the shard read each loaded row's UUID to
+    // classify it against the backfill boundary.
+    fn backfill_task() -> Arc<Task> {
+        Arc::new(Task {
+            bindings: vec![Binding {
+                source: 0,
+                delta_updates: false,
+                key_extractors: vec![doc::Extractor::with_default(
+                    "/key",
+                    &doc::SerPolicy::noop(),
+                    serde_json::json!(""),
+                )],
+                ser_policy: doc::SerPolicy::noop(),
+                store_document: true,
+                value_plan: doc::ExtractorPlan::new(&[]),
+            }],
+            sources: vec![Source {
+                collection_name: "test/collection".to_string(),
+                document_uuid_ptr: json::Pointer::from("/_meta/uuid"),
+                read_schema_json: bytes::Bytes::from_static(
+                    br#"{
+                        "type": "object",
+                        "properties": {
+                            "key": { "type": "string" },
+                            "v": { "type": "array", "reduce": { "strategy": "append" } }
+                        },
+                        "reduce": { "strategy": "merge" }
+                    }"#,
+                ),
+            }],
+            binding_state_keys: vec!["test/collection".to_string()],
+        })
     }
 
     // Build an L:Load message whose Frontier carries `truncated_at` as binding
@@ -1059,16 +1067,13 @@ mod tests {
         let fresh = mk_uuid(proto_gazette::uuid::Clock::from_unix(1_700_000_001, 0));
 
         let (mut actor, _leader_rx, _connector_rx) = make_actor();
-        actor.bindings = vec![backfill_binding()];
+        actor.task = backfill_task();
         actor.boundaries = Boundaries::new(1);
 
         // Seed the accumulator with a pre-boundary source document BEFORE the
         // truncating L:Load. The truncate() at L:Load receipt must purge it (a
         // pre-boundary source carries no existence), so it never drains.
-        let mut accumulator = crate::Accumulator::new(
-            super::super::task::combine_spec(&[backfill_binding()]).unwrap(),
-        )
-        .unwrap();
+        let mut accumulator = crate::Accumulator::new(actor.task.combine_spec().unwrap()).unwrap();
         {
             let mt = accumulator.memtable().unwrap();
             let node = doc::HeapNode::from_node(
@@ -1146,7 +1151,7 @@ mod tests {
 
         let mut stores = Vec::new();
         while let Some(req) = drainer
-            .step(&actor.bindings, connector_init::Codec::Json)
+            .step(&actor.task.bindings, connector_init::Codec::Json)
             .unwrap()
         {
             let store = req.store.expect("drained request is a Store");
@@ -1181,14 +1186,11 @@ mod tests {
         // A begin that doesn't advance the boundary must not truncate again, or
         // it would purge freshly-accumulated post-boundary sources.
         let (mut actor, _leader_rx, _connector_rx) = make_actor();
-        actor.bindings = vec![backfill_binding()];
+        actor.task = backfill_task();
         actor.boundaries = Boundaries::new(1);
         let truncated_at = proto_gazette::uuid::Clock::from_unix(1_700_000_000, 0);
 
-        let accumulator = crate::Accumulator::new(
-            super::super::task::combine_spec(&[backfill_binding()]).unwrap(),
-        )
-        .unwrap();
+        let accumulator = crate::Accumulator::new(actor.task.combine_spec().unwrap()).unwrap();
         let shuffle_dir = tempfile::tempdir().unwrap();
         let idle = Phase::Idle {
             accumulator,
@@ -1234,7 +1236,7 @@ mod tests {
 
         let mut keys = Vec::new();
         while let Some(req) = drainer
-            .step(&actor.bindings, connector_init::Codec::Json)
+            .step(&actor.task.bindings, connector_init::Codec::Json)
             .unwrap()
         {
             let doc: serde_json::Value =
@@ -1251,7 +1253,7 @@ mod tests {
     #[tokio::test]
     async fn loaded_doc_with_corrupt_uuid_errors() {
         let (mut actor, _leader_rx, _connector_rx) = make_actor();
-        actor.bindings = vec![backfill_binding()];
+        actor.task = backfill_task();
         actor.boundaries = Boundaries::new(1);
         // The binding is truncating, so a loaded row's clock is required.
         actor

--- a/crates/runtime-next/src/shard/materialize/handler.rs
+++ b/crates/runtime-next/src/shard/materialize/handler.rs
@@ -263,8 +263,6 @@ where
 
     let startup::Startup {
         accumulator,
-        bindings,
-        binding_state_keys,
         mut connector_rx,
         connector_tx,
         db,
@@ -274,6 +272,7 @@ where
         leader_tx,
         max_keys,
         shuffle_reader,
+        task,
         token_restart_at,
     } = startup::run(
         controller_rx,
@@ -294,15 +293,14 @@ where
     handler.set_phase("running");
 
     let result = super::actor::Actor::new(
-        bindings,
-        binding_state_keys,
+        codec,
         connector_tx,
         db,
         disable_load_optimization,
-        codec,
         leader_tx,
         max_keys,
         metrics,
+        std::sync::Arc::new(task),
         token_restart_at,
     )
     .serve(

--- a/crates/runtime-next/src/shard/materialize/mod.rs
+++ b/crates/runtime-next/src/shard/materialize/mod.rs
@@ -8,6 +8,7 @@ mod startup;
 mod task;
 
 pub(crate) use handler::serve;
+use task::{Binding, Task};
 
 #[derive(Clone)]
 pub(crate) struct Metrics {
@@ -78,19 +79,6 @@ impl Metrics {
             ),
         }
     }
-}
-
-#[derive(Debug)]
-struct Binding {
-    collection_name: String,             // Source collection.
-    delta_updates: bool,                 // Delta updates, or standard?
-    document_uuid_ptr: json::Pointer,    // Document UUID pointer (often /_meta/uuid).
-    key_extractors: Vec<doc::Extractor>, // Key extractors for this collection.
-    read_schema_json: bytes::Bytes,      // Read JSON-Schema of collection documents.
-    ser_policy: doc::SerPolicy,          // Serialization policy for this source.
-    state_key: String,                   // State key for this binding.
-    store_document: bool, // Are we storing the root document (often `flow_document`)?
-    value_plan: doc::ExtractorPlan,
 }
 
 // Set of observed keys, used to de-duplicate sent C:Load requests.

--- a/crates/runtime-next/src/shard/materialize/startup.rs
+++ b/crates/runtime-next/src/shard/materialize/startup.rs
@@ -1,4 +1,4 @@
-use super::Binding;
+use super::Task;
 use crate::proto;
 use anyhow::Context;
 use futures::StreamExt;
@@ -65,8 +65,6 @@ pub async fn dial_and_join(
 
 pub(super) struct Startup {
     pub accumulator: crate::Accumulator,
-    pub bindings: Vec<Binding>,
-    pub binding_state_keys: Vec<String>,
     pub connector_rx: futures::stream::BoxStream<'static, tonic::Result<materialize::Response>>,
     pub connector_tx: mpsc::Sender<materialize::Request>,
     pub db: crate::shard::RocksDB,
@@ -76,6 +74,7 @@ pub(super) struct Startup {
     pub leader_tx: mpsc::UnboundedSender<proto::Materialize>,
     pub max_keys: Vec<(bytes::Bytes, bytes::Bytes)>,
     pub shuffle_reader: shuffle::log::Reader,
+    pub task: Task,
     pub token_restart_at: Option<std::time::SystemTime>,
 }
 
@@ -123,18 +122,14 @@ where
         publisher_id: _,
     } = l_task;
 
-    // Build task definition.
     let spec = flow::MaterializationSpec::decode(spec_bytes.as_ref())
         .context("invalid Task materialization")?;
-    let (bindings, shard_ref) =
-        super::task::build_bindings(&spec, &labeling).context("building task definition")?;
-    // Reserved for future logging; the actor and scan/drain activities
-    // don't presently need shard identity.
-    let _ = shard_ref;
+    let task = Task::new(&spec, &labeling).context("building task definition")?;
 
-    // Scan and send L:Recover state from RocksDB.
+    // Scan and send L:Recover state from RocksDB. Persisted state is
+    // per-binding, keyed by each binding's `state_key`.
     let (mut db, mut recover) = db
-        .scan(bindings.iter().map(|b| b.state_key.as_str()))
+        .scan(task.binding_state_keys.iter())
         .await
         .context("scanning RocksDB")?;
     if shard_index == 0 {
@@ -145,8 +140,6 @@ where
         recover: Some(recover),
         ..Default::default()
     });
-
-    let binding_state_keys: Vec<String> = bindings.iter().map(|b| b.state_key.clone()).collect();
 
     // Read and execute L:Apply and L:Persist from the leader until L:Open.
     let open = loop {
@@ -198,7 +191,7 @@ where
                 ..
             } => {
                 db = db
-                    .persist(&persist, &binding_state_keys)
+                    .persist(&persist, &task.binding_state_keys)
                     .await
                     .context("Persist failed")?;
 
@@ -277,11 +270,11 @@ where
     let shuffle_reader =
         shuffle::log::Reader::new(std::path::Path::new(&shuffle_directory), shard_index);
 
-    let accumulator = crate::Accumulator::new(super::task::combine_spec(&bindings)?)
-        .context("building materialize combiner")?;
+    let accumulator =
+        crate::Accumulator::new(task.combine_spec()?).context("building materialize combiner")?;
 
     // Densify the leader's sparse `max_keys` map into a per-binding Vec.
-    let max_keys: Vec<(bytes::Bytes, bytes::Bytes)> = (0..bindings.len() as u32)
+    let max_keys: Vec<(bytes::Bytes, bytes::Bytes)> = (0..task.bindings.len() as u32)
         .map(|i| {
             (
                 max_keys.get(&i).cloned().unwrap_or_default(), // Previous max.
@@ -292,8 +285,6 @@ where
 
     Ok(Startup {
         accumulator,
-        bindings,
-        binding_state_keys,
         connector_rx,
         connector_tx,
         db,
@@ -303,6 +294,7 @@ where
         leader_tx,
         max_keys,
         shuffle_reader,
+        task,
         token_restart_at,
     })
 }

--- a/crates/runtime-next/src/shard/materialize/task.rs
+++ b/crates/runtime-next/src/shard/materialize/task.rs
@@ -188,9 +188,17 @@ pub fn combine_spec(bindings: &[Binding]) -> anyhow::Result<doc::combine::Spec> 
         ));
     }
 
-    // Build combiner Spec with all bindings, plus one extra for state reductions.
+    let (spec_bindings, spec_validators): (Vec<_>, Vec<_>) = combiner_specs
+        .into_iter()
+        .enumerate()
+        .map(|(index, (is_full, key, name, validator))| {
+            ((is_full, key, index as u32), (name, validator))
+        })
+        .unzip();
+
     Ok(doc::combine::Spec::with_bindings(
-        combiner_specs,
+        spec_bindings,
+        spec_validators,
         Vec::new(),
     ))
 }

--- a/crates/runtime-next/src/shard/materialize/task.rs
+++ b/crates/runtime-next/src/shard/materialize/task.rs
@@ -1,75 +1,64 @@
-use super::Binding;
 use anyhow::Context;
 use proto_flow::flow;
 
-/// Build binding structures and shard_ref for a materialization task.
-pub fn build_bindings(
-    spec: &flow::MaterializationSpec,
-    shard: &ops::proto::ShardLabeling,
-) -> anyhow::Result<(Vec<Binding>, ops::ShardRef)> {
-    let flow::MaterializationSpec {
-        bindings: _,
-        config_json: _,
-        connector_type: _,
-        name,
-        network_ports: _,
-        recovery_log_template: _,
-        shard_template: _,
-        inactive_bindings: _,
-        triggers_json: _,
-        created_at: _,
-        sync_schedule_json: _,
-        linked_collections: _,
-    } = spec;
-
-    let ops::proto::ShardLabeling {
-        range,
-        build: version,
-        ..
-    } = shard;
-
-    let range = range.context("missing range")?;
-
-    if range.r_clock_begin != 0 || range.r_clock_end != u32::MAX {
-        anyhow::bail!("materialization cannot split on r-clock: {range:?}");
-    }
-
-    // `doc::combine` packs its binding index into a u16. This guards the
-    // *format* limit and deliberately shares no constant with
-    // `validation::MAX_BINDINGS`, which gates published tasks far below it:
-    // tripping this means an unvalidated spec reached the runtime.
-    if spec.bindings.len() > u16::MAX as usize {
-        anyhow::bail!(
-            "materialization has {} bindings, which exceeds the combiner limit of {}",
-            spec.bindings.len(),
-            u16::MAX,
-        );
-    }
-
-    let bindings = spec
-        .resolved_bindings()
-        .enumerate()
-        .map(|(index, (binding, resolved))| {
-            let (collection, _identity) = resolved.context("missing collection").context(index)?;
-            build_binding(binding, collection).context(index)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let shard_ref = ops::ShardRef {
-        kind: ops::TaskType::Materialization as i32,
-        name: name.clone(),
-        key_begin: format!("{:08x}", range.key_begin),
-        r_clock_begin: format!("{:08x}", range.r_clock_begin),
-        build: version.clone(),
-    };
-
-    Ok((bindings, shard_ref))
+/// Task configuration for a materialization shard.
+///
+/// A materialization is one-or-more bindings, each maintaining a view of a
+/// source collection within an endpoint resource. The shard combines source
+/// documents read from its bindings' collections with the `C:Loaded` documents
+/// of the endpoint, keyed by each binding's field selection, and drains the
+/// result to the connector as `C:Store`.
+pub(super) struct Task {
+    /// Bindings of the materialization.
+    pub bindings: Vec<Binding>,
+    /// Source collections read by the task's bindings.
+    pub sources: Vec<Source>,
+    /// Stable RocksDB `state_key` of each binding, indexed by binding index.
+    /// Used to map the leader's frontier binding indices to the `FC:`/`FH:`
+    /// key layout.
+    pub binding_state_keys: Vec<String>,
 }
 
-// Build the runtime structure for a single binding.
+/// Binding configuration for a materialization shard.
+pub(super) struct Binding {
+    /// Index of this binding's source collection within [`Task::sources`].
+    pub source: u32,
+    /// Delta updates, or standard?
+    pub delta_updates: bool,
+    /// Extractors of this binding's field-selected key, applied to source and
+    /// loaded documents to populate combiner keys and `Load.key_json`.
+    pub key_extractors: Vec<doc::Extractor>,
+    /// Serialization policy applied to this binding's field-selected values.
+    pub ser_policy: doc::SerPolicy,
+    /// Are we storing the root document (often `flow_document`)?
+    pub store_document: bool,
+    /// Extraction plan of this binding's field-selected values.
+    pub value_plan: doc::ExtractorPlan,
+}
+
+/// A source collection, read by one or more bindings of the materialization.
+///
+/// Sources follow the spec's declared indirection: bindings sharing a
+/// `collection_index` share one Source, while a binding of an inline-form
+/// spec carries no index and is its own Source.
+pub(super) struct Source {
+    /// Source collection name.
+    pub collection_name: String,
+    /// JSON pointer at which document UUIDs are found. A binding which is
+    /// backfill-truncating classifies each loaded document against its
+    /// boundary by the clock of the UUID at this pointer.
+    pub document_uuid_ptr: json::Pointer,
+    /// Schema the shuffle read pipeline validates source documents against:
+    /// the source collection's read schema, or its write schema when no read
+    /// schema is defined (mirroring `shuffle::Source::new`).
+    pub read_schema_json: bytes::Bytes,
+}
+
+/// Build the runtime [`Binding`] for a single materialization binding.
 fn build_binding(
-    spec: &flow::materialization_spec::Binding,
+    b: &flow::materialization_spec::Binding,
     collection: &flow::CollectionSpec,
+    source: u32,
 ) -> anyhow::Result<Binding> {
     let flow::materialization_spec::Binding {
         backfill: _,
@@ -85,9 +74,9 @@ fn build_binding(
         priority: _,
         resource_config_json: _,
         resource_path: _,
-        state_key,
+        state_key: _, // Hoisted into `Task::binding_state_keys`.
         ser_policy: binding_ser_policy,
-    } = spec;
+    } = b;
 
     let flow::FieldSelection {
         document: selected_root,
@@ -97,19 +86,6 @@ fn build_binding(
     } = field_selection
         .as_ref()
         .context("missing field selection")?;
-
-    let flow::CollectionSpec {
-        ack_template_json: _,
-        derivation: _,
-        key: _,
-        name: collection_name,
-        partition_fields: _,
-        partition_template: _,
-        projections,
-        read_schema_json,
-        uuid_ptr,
-        write_schema_json,
-    } = collection;
 
     // The policy is negotiated via the connector protocol: connectors return it
     // in their Validated response and it's baked into the built binding spec.
@@ -134,71 +110,273 @@ fn build_binding(
     // writer's no-op extraction lets the scan reuse the log's packed-key prefix
     // (and keeps Load, Store, and combiner keys byte-identical). Only values
     // carry the serialization policy.
-    let key_extractors =
-        extractors::for_fields(selected_key, projections, &doc::SerPolicy::noop())?;
+    let key_extractors = extractors::for_fields(
+        selected_key,
+        &collection.projections,
+        &doc::SerPolicy::noop(),
+    )?;
     let value_plan = doc::ExtractorPlan::new(&extractors::for_fields(
         selected_values,
-        projections,
+        &collection.projections,
         &ser_policy,
     )?);
 
-    let read_schema_json = if read_schema_json.is_empty() {
-        write_schema_json
-    } else {
-        read_schema_json
-    }
-    .clone();
-
     Ok(Binding {
-        collection_name: collection_name.clone(),
+        source,
         delta_updates: *delta_updates,
-        document_uuid_ptr: json::Pointer::from(uuid_ptr.as_str()),
         key_extractors,
-        read_schema_json,
         ser_policy,
-        state_key: state_key.clone(),
         store_document: !selected_root.is_empty(),
         value_plan,
     })
 }
 
-pub fn combine_spec(bindings: &[Binding]) -> anyhow::Result<doc::combine::Spec> {
-    let mut combiner_specs = Vec::with_capacity(bindings.len());
+/// Build the runtime [`Source`] for a source collection.
+fn build_source(collection: &flow::CollectionSpec) -> Source {
+    // Prefer the read schema, falling back to the write schema, so
+    // re-validation uses the same schema the shuffle read pipeline
+    // validated against when it set `FLAGS_SCHEMA_VALID`.
+    let read_schema_json = if collection.read_schema_json.is_empty() {
+        collection.write_schema_json.clone()
+    } else {
+        collection.read_schema_json.clone()
+    };
 
-    for Binding {
-        state_key,
+    Source {
+        collection_name: collection.name.clone(),
+        document_uuid_ptr: json::Pointer::from(collection.uuid_ptr.as_str()),
         read_schema_json,
-        delta_updates,
-        key_extractors,
-        collection_name,
-        ..
-    } in bindings
-    {
-        let built_schema = doc::validation::build_bundle(read_schema_json)
-            .context("collection read_schema_json is not a JSON schema")?;
-        let validator = doc::Validator::new(built_schema).with_context(|| {
-            format!("could not build a schema validator for binding {state_key}",)
-        })?;
+    }
+}
 
-        combiner_specs.push((
-            !delta_updates,
-            key_extractors.clone(),
-            format!("materialized collection {collection_name}"),
-            validator,
-        ));
+impl Task {
+    pub fn new(
+        spec: &flow::MaterializationSpec,
+        shard: &ops::proto::ShardLabeling,
+    ) -> anyhow::Result<Self> {
+        let flow::MaterializationSpec {
+            bindings: spec_bindings,
+            config_json: _,
+            connector_type: _,
+            name: _,
+            network_ports: _,
+            recovery_log_template: _,
+            shard_template: _,
+            inactive_bindings: _,
+            triggers_json: _,
+            created_at: _,
+            sync_schedule_json: _,
+            linked_collections: _,
+        } = spec;
+
+        let ops::proto::ShardLabeling { range, .. } = shard;
+        let range = range.context("missing range")?;
+
+        if range.r_clock_begin != 0 || range.r_clock_end != u32::MAX {
+            anyhow::bail!("materialization cannot split on r-clock: {range:?}");
+        }
+
+        // `doc::combine` packs its binding index into a u16. This guards the
+        // *format* limit and deliberately shares no constant with
+        // `validation::MAX_BINDINGS`, which gates published tasks far below it:
+        // tripping this means an unvalidated spec reached the runtime.
+        if spec_bindings.len() > u16::MAX as usize {
+            anyhow::bail!(
+                "materialization has {} bindings, which exceeds the combiner limit of {}",
+                spec_bindings.len(),
+                u16::MAX,
+            );
+        }
+
+        // Unlike a derivation's transforms, a materialization's built bindings
+        // carry a populated `state_key`, so it needs no recomputation here.
+        let binding_state_keys = spec_bindings
+            .iter()
+            .map(|b| b.state_key.clone())
+            .collect::<Vec<String>>();
+
+        let mut bindings = Vec::with_capacity(spec_bindings.len());
+        let mut sources = Vec::<Source>::new();
+        let mut sources_by_identity = std::collections::BTreeMap::<u32, u32>::new();
+
+        for (index, (b, resolved)) in spec.resolved_bindings().enumerate() {
+            let (collection, identity) = resolved.context("missing collection").context(index)?;
+
+            let source = match identity.and_then(|i| sources_by_identity.get(&i)) {
+                Some(&source) => source,
+                None => {
+                    let source = sources.len() as u32;
+                    sources.push(build_source(collection));
+
+                    if let Some(identity) = identity {
+                        sources_by_identity.insert(identity, source);
+                    }
+                    source
+                }
+            };
+            bindings.push(build_binding(b, collection, source).context(index)?);
+        }
+
+        Ok(Self {
+            bindings,
+            sources,
+            binding_state_keys,
+        })
     }
 
-    let (spec_bindings, spec_validators): (Vec<_>, Vec<_>) = combiner_specs
-        .into_iter()
-        .enumerate()
-        .map(|(index, (is_full, key, name, validator))| {
-            ((is_full, key, index as u32), (name, validator))
-        })
-        .unzip();
+    /// Build a source-document validator per Source.
+    fn source_validators(&self) -> anyhow::Result<Vec<doc::Validator>> {
+        self.sources
+            .iter()
+            .map(
+                |Source {
+                     collection_name,
+                     read_schema_json,
+                     ..
+                 }| {
+                    let built_schema = doc::validation::build_bundle(read_schema_json)
+                        .with_context(|| {
+                            format!(
+                                "source collection {collection_name} schema is not a JSON schema",
+                            )
+                        })?;
+                    doc::Validator::new(built_schema).with_context(|| {
+                        format!(
+                            "could not build a schema validator for collection {collection_name}",
+                        )
+                    })
+                },
+            )
+            .collect()
+    }
 
-    Ok(doc::combine::Spec::with_bindings(
-        spec_bindings,
-        spec_validators,
-        Vec::new(),
-    ))
+    /// Combiner over the task's bindings: one validator per Source, shared by
+    /// every binding which reads it.
+    ///
+    /// Keys and full-reduction flags stay per-binding: they follow the
+    /// binding's field selection and `delta_updates`, not its collection.
+    pub fn combine_spec(&self) -> anyhow::Result<doc::combine::Spec> {
+        let validators = self
+            .source_validators()?
+            .into_iter()
+            .zip(self.sources.iter())
+            .map(|(validator, source)| {
+                (
+                    format!("materialized collection {}", source.collection_name),
+                    validator,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let spec_bindings = self.bindings.iter().map(|binding| {
+            (
+                !binding.delta_updates,
+                binding.key_extractors.clone(),
+                binding.source,
+            )
+        });
+
+        Ok(doc::combine::Spec::with_bindings(
+            spec_bindings,
+            validators,
+            Vec::new(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bindings reading one collection share a combiner validator.
+    #[test]
+    fn combine_spec_groups_validators_by_source() {
+        let source = || Source {
+            collection_name: "acmeCo/collection".to_string(),
+            document_uuid_ptr: json::Pointer::from("/_meta/uuid"),
+            read_schema_json: bytes::Bytes::from_static(br#"{"type":"object"}"#),
+        };
+        let binding = |source| Binding {
+            source,
+            delta_updates: false,
+            key_extractors: Vec::new(),
+            ser_policy: doc::SerPolicy::noop(),
+            store_document: false,
+            value_plan: doc::ExtractorPlan::new(&[]),
+        };
+
+        // Five bindings over two sources.
+        let task = Task {
+            bindings: [0, 1, 0, 1, 0].into_iter().map(binding).collect(),
+            sources: vec![source(), source()],
+            binding_state_keys: Vec::new(),
+        };
+
+        let spec = task.combine_spec().unwrap();
+        assert_eq!(spec.binding_count(), 5);
+        assert_eq!(spec.validator_count(), 2);
+    }
+
+    /// An indirect-form spec groups bindings onto shared Sources; an inline-form
+    /// spec, which carries no identity, keeps one Source per binding.
+    #[test]
+    fn new_groups_sources_by_identity() {
+        let collection = |index: usize| flow::CollectionSpec {
+            name: format!("acmeCo/collection-{index}"),
+            uuid_ptr: "/_meta/uuid".to_string(),
+            write_schema_json: bytes::Bytes::from_static(br#"{"type":"object"}"#),
+            ..Default::default()
+        };
+        let binding = |collection_index: u32| flow::materialization_spec::Binding {
+            collection_index,
+            field_selection: Some(flow::FieldSelection::default()),
+            state_key: format!("state-{collection_index}"),
+            ..Default::default()
+        };
+        let shard = ops::proto::ShardLabeling {
+            range: Some(flow::RangeSpec {
+                key_begin: 0,
+                key_end: u32::MAX,
+                r_clock_begin: 0,
+                r_clock_end: u32::MAX,
+            }),
+            ..Default::default()
+        };
+
+        // Indirect form: five bindings over two linked collections.
+        let spec = flow::MaterializationSpec {
+            bindings: [0, 1, 0, 1, 0].into_iter().map(binding).collect(),
+            linked_collections: vec![collection(0), collection(1)],
+            ..Default::default()
+        };
+        let task = Task::new(&spec, &shard).unwrap();
+        assert_eq!(
+            task.bindings.iter().map(|b| b.source).collect::<Vec<_>>(),
+            [0, 1, 0, 1, 0],
+        );
+        assert_eq!(
+            task.sources
+                .iter()
+                .map(|s| s.collection_name.as_str())
+                .collect::<Vec<_>>(),
+            ["acmeCo/collection-0", "acmeCo/collection-1"],
+        );
+
+        // Inline form: each binding carries its own copy of one collection.
+        let spec = flow::MaterializationSpec {
+            bindings: (0..3)
+                .map(|_| flow::materialization_spec::Binding {
+                    collection: Some(collection(0)),
+                    ..binding(0)
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let task = Task::new(&spec, &shard).unwrap();
+        assert_eq!(
+            task.bindings.iter().map(|b| b.source).collect::<Vec<_>>(),
+            [0, 1, 2],
+        );
+        assert_eq!(task.sources.len(), 3);
+    }
 }

--- a/crates/runtime-next/src/shard/mod.rs
+++ b/crates/runtime-next/src/shard/mod.rs
@@ -304,7 +304,7 @@ mod tests {
     /// re-evaluated forever.
     #[test]
     fn start_due_split_terminally_ignores_unsplittable_journals() {
-        let publisher = crate::publish::NoopPublisher;
+        let publisher = crate::publish::RecordingPublisher::default();
         let (mut policy, now) = due_policy();
 
         assert!(start_due_split(&mut policy, &publisher, now).is_none());

--- a/crates/runtime-next/tests/split_e2e.rs
+++ b/crates/runtime-next/tests/split_e2e.rs
@@ -728,10 +728,10 @@ async fn journal_split_lost_cas_is_non_destructive() {
     // real journal client, and a stale fixed watch pinned to revision R. The
     // watched journal's full key range (width 2^32, well above 2W) clears the
     // floor check, so the split proceeds to its Apply.
-    let publisher::Binding::Mapped(binding) =
-        publisher::Binding::from_collection_spec(&spec).expect("binding builds")
+    let publisher::Target::Mapped(target) =
+        publisher::Target::from_collection_spec(&spec).expect("target builds")
     else {
-        unreachable!("from_collection_spec builds Mapped bindings");
+        unreachable!("from_collection_spec builds Mapped targets");
     };
     let stale_watch = tokens::fixed(Ok(vec![publisher::watch::PartitionSplit {
         name: parent.clone().into(),
@@ -742,7 +742,7 @@ async fn journal_split_lost_cas_is_non_destructive() {
     let client = data_plane.journal_client.clone();
 
     let outcome = publisher::mapping::split_partition(
-        &binding.partitions_template,
+        &target.partitions_template,
         &client,
         &stale_watch,
         &parent,

--- a/crates/runtime-next/tests/split_e2e.rs
+++ b/crates/runtime-next/tests/split_e2e.rs
@@ -113,6 +113,7 @@ fn open_publisher(
             runtime_next::new_producer(),
             "testing/ops/stats",
             &[spec],
+            &[0],
         )
         .expect("open JournalPublisher")
 }

--- a/crates/runtime/src/capture/task.rs
+++ b/crates/runtime/src/capture/task.rs
@@ -133,21 +133,27 @@ impl Task {
         let state_schema = doc::validation::build_bundle(state_schema.as_bytes()).unwrap();
         let state_validator = doc::Validator::new(state_schema).unwrap();
 
-        // Build combiner Spec with all bindings, plus one extra for state reductions.
-        let combiner_spec = doc::combine::Spec::with_bindings(
-            combiner_spec
-                .into_iter()
-                .map(|(is_full, key, name, validator)| (is_full, key, name, validator))
-                .chain(std::iter::once((
-                    false,
-                    Vec::new(),
-                    "connector state".to_string(),
-                    state_validator,
-                ))),
-            self.redact_salt.to_vec(),
-        );
+        // Build combiner Spec with all bindings, plus one extra for state
+        // reductions. Identity mapping: V1 builds one validator per binding.
+        let (bindings, validators): (Vec<_>, Vec<_>) = combiner_spec
+            .into_iter()
+            .chain(std::iter::once((
+                false,
+                Vec::new(),
+                "connector state".to_string(),
+                state_validator,
+            )))
+            .enumerate()
+            .map(|(index, (is_full, key, name, validator))| {
+                ((is_full, key, index as u32), (name, validator))
+            })
+            .unzip();
 
-        Ok(combiner_spec)
+        Ok(doc::combine::Spec::with_bindings(
+            bindings,
+            validators,
+            self.redact_salt.to_vec(),
+        ))
     }
 }
 

--- a/crates/runtime/src/combine/protocol.rs
+++ b/crates/runtime/src/combine/protocol.rs
@@ -48,9 +48,18 @@ pub fn recv_client_open(open: Request) -> anyhow::Result<(Accumulator, Vec<Bindi
         });
     }
 
+    let (spec_bindings, spec_validators): (Vec<_>, Vec<_>) = specs
+        .into_iter()
+        .enumerate()
+        .map(|(index, (is_full, key, name, validator))| {
+            ((is_full, key, index as u32), (name, validator))
+        })
+        .unzip();
+
     Ok((
         Accumulator::new(doc::combine::Spec::with_bindings(
-            specs.into_iter(),
+            spec_bindings,
+            spec_validators,
             Vec::new(),
         ))?,
         bindings,

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -25,7 +25,7 @@ const PORT_PROTO_LABEL_PREFIX: &str = "dev.estuary.port-proto.";
 // `flow-connector-init` is extracted from this image when a locally-built copy
 // isn't found by `locate_bin` (dev/CI builds place one alongside the executable).
 // TODO(johnny): Consider better packaging and versioning of `flow-connector-init`.
-const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.10-62-g8b6aeec1cd3";
+const CONNECTOR_INIT_IMAGE: &str = "ghcr.io/estuary/reactor:v0.6.12-69-gb7eb6426711";
 const CONNECTOR_INIT_IMAGE_PATH: &str = "/usr/local/bin/flow-connector-init";
 
 /// Determines the protocol of an image. If the image has a `FLOW_RUNTIME_PROTOCOL` label,

--- a/crates/runtime/src/materialize/task.rs
+++ b/crates/runtime/src/materialize/task.rs
@@ -109,15 +109,19 @@ impl Task {
             .map(|(index, binding)| binding.combiner_spec().context(index))
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Build combiner Spec with all bindings, plus one extra for state reductions.
-        let combiner_spec = doc::combine::Spec::with_bindings(
-            combiner_spec
-                .into_iter()
-                .map(|(is_full, key, name, validator)| (is_full, key, name, validator)),
-            Vec::new(),
-        );
+        let (bindings, validators): (Vec<_>, Vec<_>) = combiner_spec
+            .into_iter()
+            .enumerate()
+            .map(|(index, (is_full, key, name, validator))| {
+                ((is_full, key, index as u32), (name, validator))
+            })
+            .unzip();
 
-        Ok(combiner_spec)
+        Ok(doc::combine::Spec::with_bindings(
+            bindings,
+            validators,
+            Vec::new(),
+        ))
     }
 }
 

--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -245,8 +245,10 @@ materialization, or collection partitions), the shard topology, and a
 resume checkpoint frontier. The Session:
 
 1. Parses the task into `Binding` structs — one per transform/binding —
-   capturing the shuffle key, partition selector, priority, read delay,
-   UUID pointer, and schema validator.
+   capturing the shuffle key, partition selector, priority, and read delay,
+   plus `Source` structs — one per distinct source collection, following the
+   spec's declared indirection. Schema validators and journal clients are built
+   per Source, so bindings fanning in on one collection share them.
 2. Opens a Slice RPC to every shard (shard 0 is in-process; others are
    remote gRPC calls).
 3. Sends `Opened` to the coordinator, then reads the resume checkpoint
@@ -506,9 +508,10 @@ next one.
 
 ## Key Types
 
-- `Binding` (`binding.rs`): Per-binding shuffle configuration extracted
-  from the task spec. Captures key extractors, partition selectors,
-  priority, read delay, and schema.
+- `Binding` / `Source` (`binding.rs`): Shuffle configuration extracted from
+  the task spec. `Binding` captures per-binding key extractors, partition
+  selectors, priority, and read delay; `Source` captures the per-collection
+  schema, UUID pointer, and partition metadata.
 
 - `Frontier` / `JournalFrontier` / `ProducerFrontier` (`frontier.rs`):
   Sorted, reducible representation of per-journal, per-producer progress.
@@ -539,4 +542,4 @@ next one.
   - `log/block/`: Zero-copy types for working with segmented log blocks.
 - `frontier.rs`: Frontier types, reduction, causal hint resolution,
   chunked encode/decode, and drain.
-- `binding.rs`: Binding configuration, partition filtering.
+- `binding.rs`: Binding and Source configuration, partition filtering.

--- a/crates/shuffle/src/binding.rs
+++ b/crates/shuffle/src/binding.rs
@@ -11,8 +11,8 @@ use proto_gazette::{broker, uuid};
 pub struct Binding {
     /// Index of this Binding within the task.
     pub index: u16,
-    /// Source collection name (for logging/debugging).
-    pub collection: models::Collection,
+    /// Index of this Binding's source collection within the task's Sources.
+    pub source: u32,
     /// Should documents be filtered on their r-clocks?
     ///
     /// Intuitively, the purpose of r-clock filtering is to enable scale-out of
@@ -49,8 +49,6 @@ pub struct Binding {
     pub shuffle_key_partition_fields: Option<Vec<String>>,
     /// Partition selector for filtering source collection journals.
     pub partition_selector: broker::LabelSelector,
-    /// JSON pointer for extracting document UUIDs.
-    pub source_uuid_ptr: json::Pointer,
     /// True if shuffle key is dynamically computed via a lambda function.
     pub uses_lambda: bool,
     /// True if shuffle key equals the source collection key.
@@ -66,20 +64,108 @@ pub struct Binding {
     /// Assigned as ascending integers by walking bindings in index order
     /// and identifying unique (priority, read_delay) tuples.
     pub cohort: u32,
-    /// Sorted partition field names for this binding's source collection.
+}
+
+/// Source is a source collection read by one or more Bindings of a task.
+///
+/// Sources follow the spec's declared indirection: bindings sharing a
+/// `collection_index` share one Source, while a binding of an inline-form spec
+/// carries no index and is its own Source.
+#[derive(Debug)]
+pub struct Source {
+    /// Source collection name (for logging/debugging).
+    pub collection: models::Collection,
+    /// JSON pointer for extracting document UUIDs.
+    pub uuid_ptr: json::Pointer,
+    /// Sorted partition field names of the collection.
     /// Used to build partition filters for hint projection.
     pub partition_fields: Vec<String>,
-    /// Prefix of journal partition names for this binding's source collection,
-    /// including a trailing '/'. Used to build the hint index and gazette clients.
+    /// Prefix of journal partition names of the collection, including a
+    /// trailing '/'. Used to build the hint index and gazette clients.
     pub partition_prefix: Box<str>,
 }
 
+impl Source {
+    /// Build the Source for `collection`, returning it with the Validator and
+    /// inferred Shape of its schema.
+    fn new(
+        collection: &flow::CollectionSpec,
+    ) -> anyhow::Result<(Self, doc::Validator, doc::Shape)> {
+        let partition_template_name = collection
+            .partition_template
+            .as_ref()
+            .context("missing partition template")?
+            .name
+            .as_str();
+
+        // Read documents are validated against the read schema,
+        // or the write schema when no read schema is defined.
+        let bundle = if !collection.read_schema_json.is_empty() {
+            &collection.read_schema_json
+        } else {
+            &collection.write_schema_json
+        };
+        let schema = doc::validation::build_bundle(bundle)
+            .with_context(|| format!("parsing schema of collection {}", collection.name))?;
+        let validator = doc::validation::Validator::new(schema)
+            .with_context(|| format!("indexing schema of collection {}", collection.name))?;
+        let shape = doc::Shape::infer(validator.schema(), validator.schema_index());
+
+        Ok((
+            Self {
+                collection: models::Collection::new(&collection.name),
+                uuid_ptr: json::Pointer::from_str(&collection.uuid_ptr),
+                partition_fields: collection.partition_fields.clone(),
+                partition_prefix: format!("{partition_template_name}/").into(),
+            },
+            validator,
+            shape,
+        ))
+    }
+}
+
+/// Resolve `collection` to its Source, building one when it's first referenced.
+/// `validators` and `shapes` parallel `sources`, holding each schema's
+/// Validator and inferred Shape.
+fn resolve_source(
+    sources: &mut Vec<Source>,
+    validators: &mut Vec<doc::Validator>,
+    shapes: &mut Vec<doc::Shape>,
+    by_identity: &mut std::collections::BTreeMap<u32, u32>,
+    collection: &flow::CollectionSpec,
+    identity: Option<u32>,
+) -> anyhow::Result<u32> {
+    if let Some(&source) = identity.and_then(|i| by_identity.get(&i)) {
+        return Ok(source);
+    }
+    let (source, validator, shape) = Source::new(collection)?;
+    sources.push(source);
+    validators.push(validator);
+    shapes.push(shape);
+
+    let index = sources.len() as u32 - 1;
+    if let Some(identity) = identity {
+        by_identity.insert(identity, index);
+    }
+    Ok(index)
+}
+
 impl Binding {
-    /// Extract the bindings and per-binding validators of a shuffle::Task.
-    /// Validators are returned separately so that callers can store them independently
-    /// (e.g. on SliceActor) or discard them (e.g. SessionActor).
-    pub fn from_task(task: &shuffle::Task) -> anyhow::Result<(Vec<Self>, Vec<doc::Validator>)> {
-        let pairs = match &task.task {
+    /// Extract the Bindings, Sources, and per-Source document Validators of a
+    /// shuffle::Task. Validators parallel `sources` and are indexed by
+    /// `Binding::source`. Callers which don't validate read documents (the
+    /// Session handler) simply drop them: building a Validator is not extra
+    /// work, because inferring each source's Shape requires one regardless.
+    pub fn from_task(
+        task: &shuffle::Task,
+    ) -> anyhow::Result<(Vec<Self>, Vec<Source>, Vec<doc::Validator>)> {
+        let mut bindings = Vec::new();
+        let mut sources = Vec::<Source>::new();
+        let mut validators = Vec::<doc::Validator>::new();
+        let mut shapes = Vec::<doc::Shape>::new();
+        let mut by_identity = std::collections::BTreeMap::<u32, u32>::new();
+
+        match &task.task {
             Some(shuffle::task::Task::Derivation(collection_spec)) => {
                 let derivation = collection_spec
                     .derivation
@@ -88,32 +174,47 @@ impl Binding {
 
                 guard_index_width("derivation", derivation.transforms.len())?;
 
-                let pairs = derivation
-                    .resolved_transforms()
-                    .enumerate()
-                    .map(|(index, (transform, resolved))| {
-                        let (collection, _identity) =
-                            resolved.context("missing source collection")?;
-                        Self::from_derivation_transform(index as u16, transform, collection)
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()?;
-
-                pairs
+                for (index, (transform, resolved)) in derivation.resolved_transforms().enumerate() {
+                    let (collection, identity) = resolved.context("missing source collection")?;
+                    let source = resolve_source(
+                        &mut sources,
+                        &mut validators,
+                        &mut shapes,
+                        &mut by_identity,
+                        collection,
+                        identity,
+                    )?;
+                    bindings.push(Self::from_derivation_transform(
+                        index as u16,
+                        transform,
+                        collection,
+                        source,
+                        &shapes[source as usize],
+                    )?);
+                }
             }
             Some(shuffle::task::Task::Materialization(materialization)) => {
                 guard_index_width("materialization", materialization.bindings.len())?;
 
-                let pairs = materialization
-                    .resolved_bindings()
-                    .enumerate()
-                    .map(|(index, (binding, resolved))| {
-                        let (collection, _identity) =
-                            resolved.context("missing source collection")?;
-                        Self::from_materialization_binding(index as u16, binding, collection)
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()?;
-
-                pairs
+                for (index, (binding, resolved)) in materialization.resolved_bindings().enumerate()
+                {
+                    let (collection, identity) = resolved.context("missing source collection")?;
+                    let source = resolve_source(
+                        &mut sources,
+                        &mut validators,
+                        &mut shapes,
+                        &mut by_identity,
+                        collection,
+                        identity,
+                    )?;
+                    bindings.push(Self::from_materialization_binding(
+                        index as u16,
+                        binding,
+                        collection,
+                        source,
+                        &shapes[source as usize],
+                    )?);
+                }
             }
             Some(shuffle::task::Task::CollectionPartitions(collection_partitions)) => {
                 let shuffle::CollectionPartitions {
@@ -131,31 +232,38 @@ impl Binding {
                     .as_ref()
                     .context("CollectionPartitions missing partition selector")?;
 
-                let pairs = vec![Self::from_collection_partitions(
+                let source = resolve_source(
+                    &mut sources,
+                    &mut validators,
+                    &mut shapes,
+                    &mut by_identity,
+                    collection_spec,
+                    None,
+                )?;
+                bindings.push(Self::from_collection_partitions(
                     collection_spec,
                     partition_selector,
                     not_before.as_ref(),
                     not_after.as_ref(),
-                )?];
-
-                pairs
+                    source,
+                    &shapes[source as usize],
+                )?);
             }
             None => anyhow::bail!("missing task variant"),
         };
 
-        let (mut bindings, validators): (Vec<Self>, Vec<doc::Validator>) =
-            pairs.into_iter().unzip();
-
         assign_cohorts(&mut bindings);
 
-        Ok((bindings, validators))
+        Ok((bindings, sources, validators))
     }
 
     fn from_derivation_transform(
         index: u16,
         spec: &flow::collection_spec::derivation::Transform,
         collection: &flow::CollectionSpec,
-    ) -> anyhow::Result<(Self, doc::Validator)> {
+        source: u32,
+        shape: &doc::Shape,
+    ) -> anyhow::Result<Self> {
         let flow::collection_spec::derivation::Transform {
             backfill: _,
             collection: _,
@@ -175,23 +283,8 @@ impl Binding {
         } = spec;
 
         let flow::CollectionSpec {
-            ack_template_json: _,
-            derivation: _,
-            key,
-            name: collection_name,
-            partition_fields,
-            partition_template,
-            projections,
-            read_schema_json,
-            uuid_ptr,
-            write_schema_json,
+            key, projections, ..
         } = collection;
-
-        let partition_template_name = partition_template
-            .as_ref()
-            .context("missing partition template")?
-            .name
-            .as_str();
 
         // read_delay is a duration, not an absolute timestamp.
         // Clock's internal representation is (100ns_ticks << 4 | sequence_counter),
@@ -203,8 +296,6 @@ impl Binding {
             .as_ref()
             .context("missing partition selector")?;
 
-        let (validator, shape) = build_schema(read_schema_json, write_schema_json)?;
-
         // Determine shuffle key configuration.
         let (key_extractors, uses_lambda, uses_source_key, shuffle_key_partition_fields) =
             if !shuffle_key.is_empty() {
@@ -212,7 +303,7 @@ impl Binding {
                 let uses_source_key = shuffle_key == key;
                 let partition_fields = compute_partition_fields(shuffle_key, projections);
                 (
-                    build_key_extractors(shuffle_key, &shape),
+                    build_key_extractors(shuffle_key, shape),
                     false,
                     uses_source_key,
                     partition_fields,
@@ -222,11 +313,12 @@ impl Binding {
                 (Vec::new(), true, false, None)
             } else {
                 // Default: use source collection key.
-                (build_key_extractors(key, &shape), false, true, None)
+                (build_key_extractors(key, shape), false, true, None)
             };
 
-        let binding = Self {
+        Ok(Self {
             index,
+            source,
             filter_r_clocks: *read_only,
             journal_read_suffix: journal_read_suffix.clone(),
             priority: *priority,
@@ -234,25 +326,21 @@ impl Binding {
             key_extractors,
             shuffle_key_partition_fields,
             partition_selector: partition_selector.clone(),
-            collection: models::Collection::new(collection_name),
-            source_uuid_ptr: json::Pointer::from_str(uuid_ptr),
             uses_lambda,
             uses_source_key,
             not_before,
             not_after,
             cohort: 0, // Assigned by assign_cohorts().
-            partition_fields: partition_fields.clone(),
-            partition_prefix: format!("{partition_template_name}/").into(),
-        };
-
-        Ok((binding, validator))
+        })
     }
 
     fn from_materialization_binding(
         index: u16,
         spec: &flow::materialization_spec::Binding,
         collection: &flow::CollectionSpec,
-    ) -> anyhow::Result<(Self, doc::Validator)> {
+        source: u32,
+        shape: &doc::Shape,
+    ) -> anyhow::Result<Self> {
         let flow::materialization_spec::Binding {
             backfill: _,
             collection: _,
@@ -271,54 +359,28 @@ impl Binding {
             state_key: _,
         } = spec;
 
-        let flow::CollectionSpec {
-            ack_template_json: _,
-            derivation: _,
-            key,
-            name: collection_name,
-            partition_fields,
-            partition_template,
-            projections: _,
-            read_schema_json,
-            uuid_ptr,
-            write_schema_json,
-        } = collection;
-
-        let partition_template_name = partition_template
-            .as_ref()
-            .context("missing partition template")?
-            .name
-            .as_str();
-
         let (not_before, not_after) = not_before_after(not_before.as_ref(), not_after.as_ref());
 
         let partition_selector = partition_selector
             .as_ref()
             .context("missing partition selector")?;
 
-        let (validator, shape) = build_schema(read_schema_json, write_schema_json)?;
-
-        let binding = Self {
+        Ok(Self {
             index,
+            source,
             filter_r_clocks: false, // Always false for materializations.
             journal_read_suffix: journal_read_suffix.clone(),
             priority: *priority,
             read_delay: uuid::Clock::from_u64(0), // Always zero for materializations.
-            key_extractors: build_key_extractors(key, &shape),
+            key_extractors: build_key_extractors(&collection.key, shape),
             shuffle_key_partition_fields: None, // Not computed for materializations.
             partition_selector: partition_selector.clone(),
-            collection: models::Collection::new(collection_name),
-            source_uuid_ptr: json::Pointer::from_str(uuid_ptr),
             uses_lambda: false,    // Always false for materializations.
             uses_source_key: true, // Always true for materializations.
             not_before,
             not_after,
             cohort: 0, // Assigned by assign_cohorts().
-            partition_fields: partition_fields.clone(),
-            partition_prefix: format!("{partition_template_name}/").into(),
-        };
-
-        Ok((binding, validator))
+        })
     }
 
     fn from_collection_partitions(
@@ -326,51 +388,27 @@ impl Binding {
         source_partitions: &broker::LabelSelector,
         not_before: Option<&pbjson_types::Timestamp>,
         not_after: Option<&pbjson_types::Timestamp>,
-    ) -> anyhow::Result<(Self, doc::Validator)> {
-        let flow::CollectionSpec {
-            ack_template_json: _,
-            derivation: _,
-            key,
-            name: collection_name,
-            partition_fields,
-            partition_template,
-            projections: _,
-            read_schema_json,
-            uuid_ptr,
-            write_schema_json,
-        } = spec;
-
-        let partition_template_name = partition_template
-            .as_ref()
-            .context("missing partition template")?
-            .name
-            .as_str();
-
-        let (validator, shape) = build_schema(read_schema_json, write_schema_json)?;
-
+        source: u32,
+        shape: &doc::Shape,
+    ) -> anyhow::Result<Self> {
         let (not_before, not_after) = not_before_after(not_before, not_after);
 
-        let binding = Self {
+        Ok(Self {
             index: 0,
+            source,
             filter_r_clocks: false,
             journal_read_suffix: "ad-hoc".to_string(),
             priority: 0,
             read_delay: uuid::Clock::from_u64(0),
-            key_extractors: build_key_extractors(key, &shape),
+            key_extractors: build_key_extractors(&spec.key, shape),
             shuffle_key_partition_fields: None,
             partition_selector: source_partitions.clone(),
-            collection: models::Collection::new(collection_name),
-            source_uuid_ptr: json::Pointer::from_str(uuid_ptr),
             uses_lambda: false,
             uses_source_key: true,
             not_before,
             not_after,
             cohort: 0, // Assigned by assign_cohorts().
-            partition_fields: partition_fields.clone(),
-            partition_prefix: format!("{partition_template_name}/").into(),
-        };
-
-        Ok((binding, validator))
+        })
     }
 
     pub fn state_key(&self) -> &str {
@@ -411,24 +449,6 @@ fn assign_cohorts(bindings: &mut [Binding]) {
         };
         binding.cohort = cohort as u32;
     }
-}
-
-/// Parse a collection schema bundle into a Validator and inferred Shape.
-/// Prefers the read schema; falls back to the write schema.
-pub fn build_schema(
-    read_schema_json: &bytes::Bytes,
-    write_schema_json: &bytes::Bytes,
-) -> anyhow::Result<(doc::validation::Validator, doc::Shape)> {
-    let bundle = if !read_schema_json.is_empty() {
-        read_schema_json
-    } else {
-        write_schema_json
-    };
-    let schema = doc::validation::build_bundle(bundle).context("failed to parse schema bundle")?;
-    let validator =
-        doc::validation::Validator::new(schema).context("failed to index schema bundle")?;
-    let shape = doc::Shape::infer(validator.schema(), validator.schema_index());
-    Ok((validator, shape))
 }
 
 /// Build key extractors from string-encoded JSON pointers,

--- a/crates/shuffle/src/lib.rs
+++ b/crates/shuffle/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod testing;
 /// round-trip (for example, in an actual document) is impossible.
 pub const FLAGS_SCHEMA_VALID: u16 = 0x8000;
 
-pub use binding::Binding;
+pub use binding::{Binding, Source};
 pub use client::SessionClient;
 pub use frontier::{Completed, Frontier, JournalFrontier, ProducerFrontier};
 pub use service::{DEFAULT_SHUFFLE_DISK_LIMIT_BYTES, Service};

--- a/crates/shuffle/src/session/handler.rs
+++ b/crates/shuffle/src/session/handler.rs
@@ -66,7 +66,7 @@ where
 
     let metrics = super::Metrics::new(shard_zero);
     let task = task.context("Open must include task")?;
-    let (bindings, _validators) = crate::Binding::from_task(&task)?;
+    let (bindings, _ /* sources */, _ /* validators */) = crate::Binding::from_task(&task)?;
 
     service_kit::event!(
         tracing::Level::INFO,

--- a/crates/shuffle/src/slice/actor.rs
+++ b/crates/shuffle/src/slice/actor.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 pub struct SliceActor {
     /// Immutable slice configuration: topology, bindings, journal clients.
     pub topology: Topology,
-    /// Per-binding schema validators, indexed by binding index.
+    /// Schema validators, indexed by Source.
     pub validators: Vec<doc::Validator>,
     /// Per-read producer tracking
     pub reads: Vec<ReadState>,
@@ -270,7 +270,8 @@ impl SliceActor {
             }
             let join_handle = super::listing::spawn_listing(
                 binding,
-                (*self.topology.journal_clients[binding.index as usize]).clone(),
+                &self.topology.sources[binding.source as usize],
+                (*self.topology.journal_clients[binding.source as usize]).clone(),
                 self.slice_response_tx.clone(),
                 cancel.clone(),
             );
@@ -343,7 +344,7 @@ impl SliceActor {
             .context("StartRead invalid binding")?;
 
         let binding_state_key = binding.state_key().to_string();
-        let client = (*self.topology.journal_clients[binding.index as usize]).clone();
+        let client = (*self.topology.journal_clients[binding.source as usize]).clone();
         let spec = spec.context("StartRead missing spec")?;
 
         let truncated_at = match spec
@@ -651,8 +652,9 @@ impl SliceActor {
 
         let ready_read = match parse_lines_batch(
             &mut self.parser,
-            &mut self.validators[read_state.binding_index as usize],
+            &mut self.validators[binding.source as usize],
             binding,
+            &self.topology.sources[binding.source as usize],
             &read_state.journal,
             read,
             lines_batch,

--- a/crates/shuffle/src/slice/handler.rs
+++ b/crates/shuffle/src/slice/handler.rs
@@ -70,7 +70,7 @@ where
 
     let metrics = super::Metrics::new(shard_id);
     let task = task.context("Open must include task")?;
-    let (bindings, validators) = crate::Binding::from_task(&task)?;
+    let (bindings, sources, validators) = crate::Binding::from_task(&task)?;
 
     service_kit::event!(
         tracing::Level::INFO,
@@ -119,12 +119,12 @@ where
         }),
     )?;
 
-    let journal_clients = bindings
+    let journal_clients = sources
         .iter()
-        .map(|binding| {
+        .map(|source| {
             let service = service.clone();
             let shard_id = shard_id.to_string();
-            let partition_prefix = binding.partition_prefix.clone().into();
+            let partition_prefix = source.partition_prefix.clone().into();
 
             LazyJournalClient::new(Box::new(move || {
                 (service.journal_client_factory)(shard_id, partition_prefix)
@@ -132,13 +132,14 @@ where
         })
         .collect();
 
-    let hint_index = state::HintIndex::from_bindings(&bindings);
+    let hint_index = state::HintIndex::from_bindings(&bindings, &sources);
 
     let topology = state::Topology {
         session_id,
         shards,
         slice_shard_index,
         bindings,
+        sources,
         journal_clients,
         hint_index,
     };

--- a/crates/shuffle/src/slice/listing.rs
+++ b/crates/shuffle/src/slice/listing.rs
@@ -65,6 +65,7 @@ impl gazette::journal::list::Subscriber for Subscriber {
 
 pub fn spawn_listing(
     binding: &crate::Binding,
+    source: &crate::Source,
     client: gazette::journal::Client,
     tx: mpsc::Sender<tonic::Result<shuffle::SliceResponse>>,
     cancel: tokens::CancellationToken,
@@ -83,7 +84,7 @@ pub fn spawn_listing(
         gazette::journal::list::SubscriberFold::new_filtering_suspended(subscriber),
     );
 
-    let collection = binding.collection.clone();
+    let collection = source.collection.clone();
     let binding = binding.index;
 
     let list_watch = async move {

--- a/crates/shuffle/src/slice/read.rs
+++ b/crates/shuffle/src/slice/read.rs
@@ -383,6 +383,7 @@ pub fn parse_lines_batch(
     parser: &mut simd_doc::SimdParser,
     validator: &mut doc::Validator,
     binding: &crate::Binding,
+    source: &crate::Source,
     journal: &str,
     mut read: super::ReadLines,
     mut lines_batch: gazette::journal::read::LinesBatch,
@@ -411,7 +412,7 @@ pub fn parse_lines_batch(
         read.as_mut().put_back(lines_batch.content.into());
     }
 
-    let metas = extract_metas(&transcoded, &binding.source_uuid_ptr, validator, journal)?;
+    let metas = extract_metas(&transcoded, &source.uuid_ptr, validator, journal)?;
 
     // Consume into owned documents and pair with pre-extracted metadata.
     let mut doc_tail = transcoded.into_iter();

--- a/crates/shuffle/src/slice/replay.rs
+++ b/crates/shuffle/src/slice/replay.rs
@@ -123,7 +123,7 @@ impl SliceActor {
             min_etcd_revision: 0,
             header: None,
         };
-        let client = (*self.topology.journal_clients[binding.index as usize]).clone();
+        let client = (*self.topology.journal_clients[binding.source as usize]).clone();
 
         let read: super::ReadLines = Box::pin(gazette::journal::read::ReadLines::new(
             client.read(request).boxed(),
@@ -380,8 +380,9 @@ impl SliceActor {
 
         let ready_read = match read::parse_lines_batch(
             &mut self.parser,
-            &mut self.validators[read_state.binding_index as usize],
+            &mut self.validators[binding.source as usize],
             binding,
+            &self.topology.sources[binding.source as usize],
             &read_state.journal,
             read,
             lines_batch,

--- a/crates/shuffle/src/slice/state.rs
+++ b/crates/shuffle/src/slice/state.rs
@@ -19,7 +19,9 @@ pub struct Topology {
     pub slice_shard_index: u32,
     /// Per-binding shuffle configuration extracted from the task spec.
     pub bindings: Vec<crate::Binding>,
-    /// Lazily-initialized Gazette clients for listing and reading journals, indexed by binding.
+    /// Source collections read by the task's bindings.
+    pub sources: Vec<crate::Source>,
+    /// Lazily-initialized Gazette clients for listing and reading journals, indexed by Source.
     pub journal_clients: Vec<super::LazyJournalClient>,
     /// Sorted index for projecting hinted journal names to bindings.
     pub hint_index: HintIndex,
@@ -531,13 +533,14 @@ impl HintIndex {
         }
     }
 
-    pub fn from_bindings(bindings: &[crate::Binding]) -> Self {
+    pub fn from_bindings(bindings: &[crate::Binding], sources: &[crate::Source]) -> Self {
         Self::new(bindings.iter().map(|b| {
+            let source = &sources[b.source as usize];
             (
-                b.partition_prefix.as_ref(),
+                source.partition_prefix.as_ref(),
                 b.index,
                 b.cohort,
-                PartitionFilter::new(&b.partition_fields, &b.partition_selector),
+                PartitionFilter::new(&source.partition_fields, &b.partition_selector),
             )
         }))
     }

--- a/crates/shuffle/src/testing.rs
+++ b/crates/shuffle/src/testing.rs
@@ -117,7 +117,7 @@ pub fn test_binding(
 ) -> crate::Binding {
     crate::Binding {
         index,
-        collection: models::Collection::new("test/collection"),
+        source: 0,
         filter_r_clocks: false,
         journal_read_suffix: journal_read_suffix.to_string(),
         priority: 0,
@@ -125,14 +125,11 @@ pub fn test_binding(
         key_extractors: Vec::new(),
         shuffle_key_partition_fields: partition_fields,
         partition_selector: broker::LabelSelector::default(),
-        source_uuid_ptr: json::Pointer::from_str("/_meta/uuid"),
         uses_lambda: false,
         uses_source_key,
         not_before: Clock::UNIX_EPOCH,
         not_after: Clock::from_u64(u64::MAX),
         cohort: 0,
-        partition_fields: Vec::new(),
-        partition_prefix: "test/collection/".into(),
     }
 }
 

--- a/crates/shuffle/tests/scenario_fixtures.rs
+++ b/crates/shuffle/tests/scenario_fixtures.rs
@@ -4,8 +4,7 @@
 /// The fixture defines three collections (apples, bananas, cherries) shared
 /// between a capture and a materialization. Tests build the shuffle task from
 /// the MaterializationSpec (exercising `Binding::from_materialization_binding`)
-/// and construct the publisher from the CaptureSpec (exercising
-/// `Binding::from_capture_spec`).
+/// and construct the publisher from the CaptureSpec.
 ///
 /// Each scenario verifies both the `Frontier` checkpoint metadata AND the
 /// actual documents read back by a `FrontierScan` from the on-disk log.
@@ -83,8 +82,7 @@ fn build_shards(
         .collect()
 }
 
-/// Build a Publisher from a CaptureSpec.
-/// Exercises `publisher::Binding::from_capture_spec()`.
+/// Build a Publisher from a CaptureSpec, with one Target per binding.
 fn make_publisher(
     spec: &flow::CaptureSpec,
     journal_client: &gazette::journal::Client,
@@ -95,12 +93,21 @@ fn make_publisher(
         move |_authz_sub, _authz_obj| journal_client.clone()
     });
 
-    let bindings = publisher::Binding::from_capture_spec(spec)
-        .expect("should build bindings from capture spec");
+    let targets = spec
+        .resolved_bindings()
+        .enumerate()
+        .map(|(index, (_binding, resolved))| {
+            let (collection_spec, _identity) =
+                resolved.unwrap_or_else(|| panic!("capture binding {index} missing collection"));
+
+            publisher::Target::from_collection_spec(collection_spec)
+                .expect("should build target from collection spec")
+        })
+        .collect();
 
     publisher::Publisher::new(
         String::new(), // Empty AuthZ subject.
-        bindings,
+        targets,
         factory,
         producer,
         // Deterministic base clock for reproducible snapshots. Must be >=

--- a/crates/shuffle/tests/scenario_fuzz.rs
+++ b/crates/shuffle/tests/scenario_fuzz.rs
@@ -372,12 +372,21 @@ fn make_publisher(
         move |_authz_sub, _authz_obj| journal_client.clone()
     });
 
-    let bindings = publisher::Binding::from_capture_spec(capture_spec)
-        .expect("build bindings from capture spec");
+    let targets = capture_spec
+        .resolved_bindings()
+        .enumerate()
+        .map(|(index, (_binding, resolved))| {
+            let (collection_spec, _identity) =
+                resolved.unwrap_or_else(|| panic!("capture binding {index} missing collection"));
+
+            publisher::Target::from_collection_spec(collection_spec)
+                .expect("build target from collection spec")
+        })
+        .collect();
 
     publisher::Publisher::new(
         String::new(), // Empty AuthZ subject.
-        bindings,
+        targets,
         factory,
         producer,
         // Deterministic base clock. Must be >= UNIX_EPOCH so document clocks

--- a/crates/validation/src/capture.rs
+++ b/crates/validation/src/capture.rs
@@ -231,12 +231,17 @@ async fn walk_capture<C: Connectors>(
 
     let scope_bindings = scope.push_prop("bindings");
 
-    // Map enumerated binding models into paired validation requests.
+    // Target collections of this capture, resolved once each.
+    let mut targets: BTreeMap<models::Collection, flow::CollectionSpec> = BTreeMap::new();
+
+    // Map enumerated binding models into their (possibly fixed) models, paired
+    // with the stripped resource config of each *active* binding: one which
+    // resolved its target collection and will be validated.
     let bindings_model_len = bindings_model.len();
     let bindings: Vec<(
         models::ResourcePath,
         models::CaptureBinding,
-        Option<capture::request::validate::Binding>,
+        Option<bytes::Bytes>,
     )> = bindings_model
         .into_iter()
         .enumerate()
@@ -249,11 +254,16 @@ async fn walk_capture<C: Connectors>(
                 shards.disable,
                 &live_bindings_model,
                 &live_bindings_spec,
+                &mut targets,
                 &mut model_fixes,
                 errors,
             )
         })
         .collect();
+
+    // Live binding models have served their purpose. The map is proportional
+    // to the binding count, so release it before building the Validate request.
+    std::mem::drop(live_bindings_model);
 
     // We've completed all cheap validation checks.
     // If we've already encountered errors then stop now.
@@ -266,14 +276,14 @@ async fn walk_capture<C: Connectors>(
     let mut interner = linked::Interner::default();
     let bindings_validate: Vec<capture::request::validate::Binding> = bindings
         .iter()
-        .filter_map(|(_path, _model, validate)| validate.clone())
-        .map(|mut binding| {
-            let target = binding
-                .collection
-                .take()
-                .expect("active binding resolved its target collection");
-            binding.collection_index = interner.intern(target);
-            binding
+        .filter_map(|(_path, model, resource_config)| {
+            let resource_config_json = resource_config.as_ref()?.clone();
+            Some(capture::request::validate::Binding {
+                resource_config_json,
+                collection: None,
+                backfill: model.backfill,
+                collection_index: interner.intern_ref(&targets[&model.target]),
+            })
         })
         .collect();
     let bindings_validate_len = bindings_validate.len();
@@ -297,7 +307,7 @@ async fn walk_capture<C: Connectors>(
     _ = request_tx
         .send(
             capture::Request {
-                validate: Some(validate_request.clone()),
+                validate: Some(validate_request),
                 ..Default::default()
             }
             .with_internal(|internal| {
@@ -337,11 +347,11 @@ async fn walk_capture<C: Connectors>(
     // Join binding models and their Validate requests with their Validated responses.
     let bindings = bindings.into_iter().scan(
         bindings_validated.into_iter(),
-        |validated, (path, model, validate)| {
-            if let Some(validate) = validate {
+        |validated, (path, model, resource_config)| {
+            if let Some(resource_config) = resource_config {
                 validated
                     .next()
-                    .map(|validated| (path, model, Some((validate, validated))))
+                    .map(|validated| (path, model, Some((resource_config, validated))))
             } else {
                 Some((path, model, None))
             }
@@ -357,20 +367,13 @@ async fn walk_capture<C: Connectors>(
     let mut interner = linked::Interner::default();
 
     // Map `bindings` into destructured binding models and built specs.
-    for (index, (mut path, mut model, validate_validated)) in bindings.into_iter().enumerate() {
-        let Some((validate, validated)) = validate_validated else {
+    for (index, (mut path, mut model, active_validated)) in bindings.into_iter().enumerate() {
+        let Some((resource_config_json, validated)) = active_validated else {
             bindings_path.push(path);
             bindings_model.push(model);
             continue;
         };
         let scope = scope_bindings.push_item(index);
-
-        let capture::request::validate::Binding {
-            resource_config_json,
-            collection,
-            backfill: _, // Same as `model.backfill`.
-            collection_index: _,
-        } = validate;
 
         let capture::response::validated::Binding {
             resource_path: validated_path,
@@ -405,8 +408,7 @@ async fn walk_capture<C: Connectors>(
             collection: None,
             backfill: model.backfill,
             state_key,
-            collection_index: interner
-                .intern(collection.expect("active binding resolved its target collection")),
+            collection_index: interner.intern_ref(&targets[&model.target]),
         };
 
         bindings_path.push(path);
@@ -551,12 +553,13 @@ fn walk_capture_binding<'a>(
     disable: bool,
     live_bindings_model: &BTreeMap<Vec<String>, &models::CaptureBinding>,
     live_bindings_spec: &LiveBindings,
+    targets: &mut BTreeMap<models::Collection, flow::CollectionSpec>,
     model_fixes: &mut Vec<String>,
     errors: &mut tables::Errors,
 ) -> (
     models::ResourcePath,
     models::CaptureBinding,
-    Option<capture::request::validate::Binding>,
+    Option<bytes::Bytes>,
 ) {
     let model_path = super::load_resource_meta_path(model.resource.get().as_bytes());
 
@@ -567,27 +570,34 @@ fn walk_capture_binding<'a>(
 
     let live_model = live_bindings_model.get(&model_path);
     let modified_target = Some(&model.target) != live_model.map(|l| &l.target);
-    let target = &model.target;
 
-    // We must resolve the target collection to continue.
-    let Some((target_spec, _built_collection)) = reference::walk_reference(
-        scope,
-        "capture binding",
-        || {
-            if !model_path.is_empty() {
-                model_path.join(".")
-            } else {
-                model.resource.get().to_string()
-            }
-        },
-        target,
-        built_collections,
-        modified_target.then_some(errors),
-    ) else {
-        model_fixes.push(format!("disabled binding of deleted collection {target}"));
-        model.disable = true;
-        return (model_path, model, None);
-    };
+    // We must resolve the target collection to continue. A collection already
+    // in `targets` resolved for an earlier binding, and that resolution is
+    // also this binding's.
+    if !targets.contains_key(&model.target) {
+        let Some((target_spec, _built_collection)) = reference::walk_reference(
+            scope,
+            "capture binding",
+            || {
+                if !model_path.is_empty() {
+                    model_path.join(".")
+                } else {
+                    model.resource.get().to_string()
+                }
+            },
+            &model.target,
+            built_collections,
+            modified_target.then_some(errors),
+        ) else {
+            model_fixes.push(format!(
+                "disabled binding of deleted collection {}",
+                model.target
+            ));
+            model.disable = true;
+            return (model_path, model, None);
+        };
+        targets.insert(model.target.clone(), target_spec);
+    }
 
     if disable {
         // Perform no further validations if the task is disabled.
@@ -598,22 +608,18 @@ fn walk_capture_binding<'a>(
     let live_binding = live_bindings_spec.get(model_path.as_slice());
     let was_reset = live_binding.is_some_and(|(live_binding, live_collection)| {
         live_binding.backfill == model.backfill
-            && super::collection_was_reset(&target_spec, *live_collection)
+            && super::collection_was_reset(&targets[&model.target], *live_collection)
     });
 
     if was_reset {
-        model_fixes.push(format!("backfilled binding of reset collection {target}"));
+        model_fixes.push(format!(
+            "backfilled binding of reset collection {}",
+            model.target
+        ));
         model.backfill += 1;
     }
 
-    // The binding inlines its collection while it's detached from a request:
-    // interning happens in `walk_capture`, which holds the shared table.
-    let validate = capture::request::validate::Binding {
-        resource_config_json: super::strip_resource_meta(&model.resource),
-        collection: Some(target_spec),
-        backfill: model.backfill,
-        collection_index: 0,
-    };
+    let resource_config_json = super::strip_resource_meta(&model.resource);
 
-    (model_path, model, Some(validate))
+    (model_path, model, Some(resource_config_json))
 }

--- a/crates/validation/src/derivation.rs
+++ b/crates/validation/src/derivation.rs
@@ -547,7 +547,7 @@ async fn walk_derivation<C: Connectors>(
     _ = request_tx
         .send(
             derive::Request {
-                validate: Some(validate_request.clone()),
+                validate: Some(validate_request),
                 ..Default::default()
             }
             .with_internal(|internal| {

--- a/crates/validation/src/lib.rs
+++ b/crates/validation/src/lib.rs
@@ -20,18 +20,19 @@ mod test_step;
 pub use errors::Error;
 pub use noop::NoOpConnectors;
 
-/// Combiner slots reserved for runtime-internal bindings (today: the capture
-/// connector-state pseudo-binding). Internal additions must not move the
-/// user-visible binding ceilings.
+/// Portion of the binding namespace reserved for runtime-internal bindings
+/// (today: the capture connector-state pseudo-binding). Internal additions must
+/// not move the user-visible binding ceilings.
 pub const RESERVED_BINDINGS: usize = 100;
 /// Maximum number of bindings allowed in a capture, derivation, or materialization.
 /// We have a hard upper limit of 65,535 because doc::combine uses u16 indices.
 pub const MAX_BINDINGS: usize = 10_000;
 /// Maximum number of bindings allowed in a task which sets the `indirect-specs`
-/// shard flag: the doc::combine u16 format limit of 65,536 slots, less the
-/// internal reserve. Indirect form interns each collection of a spec once, so its
-/// size grows with the number of bindings and not with their product with the
-/// size of an inlined collection, which is what holds MAX_BINDINGS down.
+/// shard flag: the 65,536 binding namespace of doc::combine's u16 binding
+/// index, less the internal reserve. Indirect form interns each collection of a
+/// spec once, so its size grows with the number of bindings and not with their
+/// product with the size of an inlined collection, which is what holds
+/// MAX_BINDINGS down.
 pub const MAX_BINDINGS_INDIRECT_SPECS: usize = 65_536 - RESERVED_BINDINGS;
 
 /// Binding ceiling of a task, which its `indirect-specs` shard flag raises.

--- a/crates/validation/src/materialization.rs
+++ b/crates/validation/src/materialization.rs
@@ -304,14 +304,19 @@ async fn walk_materialization<C: Connectors>(
     let mut interner = linked::Interner::default();
     let bindings_validate: Vec<materialize::request::validate::Binding> = bindings
         .iter()
-        .filter_map(|(_path, _model, _disable_task, validate)| validate.clone())
-        .map(|mut binding| {
-            let source = binding
-                .collection
-                .take()
-                .expect("active binding resolved its source collection");
-            binding.collection_index = interner.intern(source);
-            binding
+        .filter_map(|(_path, _model, _disable_task, validate)| validate.as_ref())
+        .map(|binding| materialize::request::validate::Binding {
+            resource_config_json: binding.resource_config_json.clone(),
+            collection: None,
+            field_config_json_map: binding.field_config_json_map.clone(),
+            backfill: binding.backfill,
+            group_by: binding.group_by.clone(),
+            collection_index: interner.intern_ref(
+                binding
+                    .collection
+                    .as_ref()
+                    .expect("active binding resolved its source collection"),
+            ),
         })
         .collect();
     let bindings_validate_len = bindings_validate.len();
@@ -335,7 +340,7 @@ async fn walk_materialization<C: Connectors>(
     _ = request_tx
         .send(
             materialize::Request {
-                validate: Some(validate_request.clone()),
+                validate: Some(validate_request),
                 ..Default::default()
             }
             .with_internal(|internal| {

--- a/crates/validation/tests/indirect_specs_tests.rs
+++ b/crates/validation/tests/indirect_specs_tests.rs
@@ -80,6 +80,58 @@ fn test_flagged_tasks_build_indirect_specs() {
     insta::assert_snapshot!(summarize_all(&outcome));
 }
 
+/// A capture binds its target unmodified, so bindings of one collection share
+/// a single resolution of it. They must nonetheless keep their own per-binding
+/// state: a shared resolution is a shared *collection*, not a shared binding.
+#[test]
+fn test_shared_targets_keep_per_binding_state() {
+    let outcome = common::run(
+        INDIRECT_SPECS_YAML,
+        r#"
+test://example/catalog.yaml:
+  captures:
+    acmeCo/capture:
+      bindings:
+        - target: acmeCo/one
+          resource: { _meta: { path: [one, a] }, source: one-a }
+          backfill: 7
+        - target: acmeCo/two
+          resource: { _meta: { path: [two, a] }, source: two-a }
+        - target: acmeCo/one
+          resource: { _meta: { path: [one, b] }, source: one-b }
+          backfill: 3
+        - target: acmeCo/one
+          resource: { _meta: { path: [one, c] }, source: one-c }
+"#,
+    );
+    assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+
+    let spec = outcome.built_captures[0].spec.as_ref().unwrap();
+
+    // Three bindings of `acmeCo/one` share one table entry: the shared
+    // resolution guarantees value-identical specs, which the interner's
+    // by-value de-duplication then collapses.
+    assert_eq!(spec.linked_collections.len(), 2);
+
+    let summary: Vec<String> = spec
+        .resolved_bindings()
+        .map(|(binding, resolved)| {
+            let (collection, index) = resolved.unwrap();
+            format!(
+                "{:?} backfill={} state_key={} resource={} => [{}] {}",
+                binding.resource_path,
+                binding.backfill,
+                binding.state_key,
+                std::str::from_utf8(&binding.resource_config_json).unwrap(),
+                index.unwrap(),
+                collection.name,
+            )
+        })
+        .collect();
+
+    insta::assert_debug_snapshot!(summary);
+}
+
 /// Clearing the flag re-inlines every collection, yielding the encoding which
 /// predates indirect specs. This is the round-trip of interning and inlining.
 #[test]

--- a/crates/validation/tests/snapshots/indirect_specs_tests__shared_targets_keep_per_binding_state.snap
+++ b/crates/validation/tests/snapshots/indirect_specs_tests__shared_targets_keep_per_binding_state.snap
@@ -1,0 +1,11 @@
+---
+source: crates/validation/tests/indirect_specs_tests.rs
+assertion_line: 131
+expression: summary
+---
+[
+    "[\"one\", \"a\"] backfill=7 state_key=one%2Fa.v7 resource={\"source\":\"one-a\"} => [0] acmeCo/one",
+    "[\"two\", \"a\"] backfill=0 state_key=two%2Fa resource={\"source\":\"two-a\"} => [1] acmeCo/two",
+    "[\"one\", \"b\"] backfill=3 state_key=one%2Fb.v3 resource={\"source\":\"one-b\"} => [0] acmeCo/one",
+    "[\"one\", \"c\"] backfill=0 state_key=one%2Fc resource={\"source\":\"one-c\"} => [0] acmeCo/one",
+]


### PR DESCRIPTION
Tasks routinely fan many bindings onto few collections: a capture of many database tables or topic streams writing one collection, or a materialization maintaining several views of one source. Everything the runtime derives from a collection — parsed and indexed schema validators, publisher targets (a journal client and partitions watch each), shuffle read state, inferred write-shapes — was built once *per binding*, so these tasks paid that cost many times over.

This stack makes bindings *reference* a per-collection struct which owns the derived state, built once:

- `doc::combine::Spec` gains a binding → validator indirection, so bindings of one collection share a validator while still combining per-binding.
- The publisher's `Binding` becomes `Target`, with an explicit task-binding → target mapping.
- Shuffle, derive, and materialize group bindings onto shared `Source`s; the capture leader groups them onto `Target`s.

Two semantic consequences ride along, both on the capture side: schema inference becomes per-collection (every binding widens its collection's one shape, instead of each inferring independently and blind to the others), and a `BackfillBegin` of a binding whose peers also write the same collection suppresses its truncation markers — a TRUNCATE of one source table among many must not truncate the shared collection.

The commit messages carry the fine-grain details of each layer.
