### PR TITLE
runtime: remove shard recovery directory on Destroy

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -406,6 +406,7 @@ func (c *captureApp) Destroy() {
 		_ = c.client.CloseSend()
 	}
 	c.taskBase.drop()
+	c.taskBase.removeRecoveryDir()
 	c.taskBase.opsCancel()
 }
 

--- a/go/runtime/capture_v2.go
+++ b/go/runtime/capture_v2.go
@@ -203,6 +203,7 @@ func (c *captureAppV2) Destroy() {
 		c.client = nil
 	}
 	c.taskBase.drop()
+	c.taskBase.removeRecoveryDir()
 	c.taskBase.opsCancel()
 }
 

--- a/go/runtime/derive.go
+++ b/go/runtime/derive.go
@@ -244,6 +244,7 @@ func (d *deriveApp) Destroy() {
 	if d.sqlite != nil {
 		d.sqlite.Destroy()
 	}
+	d.taskBase.removeRecoveryDir()
 	d.taskBase.opsCancel()
 }
 

--- a/go/runtime/derive_v2.go
+++ b/go/runtime/derive_v2.go
@@ -327,6 +327,7 @@ func (m *deriveAppV2) Destroy() {
 	if m.sqlite != nil {
 		m.sqlite.Destroy()
 	}
+	m.taskBase.removeRecoveryDir()
 	m.taskBase.opsCancel()
 	_ = os.RemoveAll(m.shuffleDir)
 }

--- a/go/runtime/materialize.go
+++ b/go/runtime/materialize.go
@@ -224,6 +224,7 @@ func (m *materializeApp) Destroy() {
 		_ = m.client.CloseSend()
 	}
 	m.taskReader.drop()
+	m.taskBase.removeRecoveryDir()
 	m.taskBase.opsCancel()
 }
 

--- a/go/runtime/materialize_v2.go
+++ b/go/runtime/materialize_v2.go
@@ -284,6 +284,7 @@ func (m *materializeAppV2) Destroy() {
 		m.client = nil
 	}
 	m.taskBase.drop()
+	m.taskBase.removeRecoveryDir()
 	m.taskBase.opsCancel()
 	_ = os.RemoveAll(m.shuffleDir)
 }

--- a/go/runtime/task.go
+++ b/go/runtime/task.go
@@ -10,6 +10,7 @@ import (
 	"hash/fnv"
 	"io"
 	"math"
+	"os"
 	"path"
 	"runtime/pprof"
 	"sync/atomic"
@@ -206,6 +207,21 @@ func (t *taskBase[TaskSpec]) ProxyHook() (*pr.Container, ops.Publisher) {
 
 func (t *taskBase[TaskSpec]) drop() {
 	t.svc.Drop()
+}
+
+// removeRecoveryDir reclaims the shard's recovery-log playback directory.
+// Call only after drop(): the Rust runtime holds RocksDB open until its task
+// service is dropped.
+func (t *taskBase[TaskSpec]) removeRecoveryDir() {
+	if t.recorder == nil {
+		return // Shards may run without a recovery log.
+	}
+	if err := os.RemoveAll(t.recorder.Dir()); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"dir": t.recorder.Dir(),
+			"err": err,
+		}).Error("failed to remove shard recovery directory")
+	}
 }
 
 func newTaskTerm[TaskSpec pf.Task](


### PR DESCRIPTION
**Description:**

Gazette frees a shard's local state only through Store.Destroy. Flow's Stores did not remove the recovery-log playback directory. Thus each shard teardown left a directory on disk. Captures and materializations never removed it. Derivations removed it only for the SQLITE connector type.

Add taskBase.removeRecoveryDir. Call it from all six Destroy implementations, after the task service drops.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

