### PR TITLE
runtime-next: absorb a shard Stop which outruns the session it addressed

### DIFF
--- a/crates/runtime-next/README.md
+++ b/crates/runtime-next/README.md
@@ -181,6 +181,17 @@ documented inline in the proto.
 - **`shard/rocksdb.rs` is the single Persist application path.** Capture
   reuses it by synthesizing `Persist` messages locally rather than receiving
   them from a leader.
+- **A `Stop` may outrun the session it addresses.** The controller sends
+  `Stop` when it observes its task term cancelled, and it selects over that
+  cancellation and our `Stopped` concurrently — so the two cross on the wire
+  whenever a session ends at the same moment the term does. A publish does
+  exactly that to every shard at once, and an idempotent-replay session that
+  stops itself can coincide with one. Each session loop therefore absorbs a
+  `Stop` received while awaiting a `Join`: the session it addressed is over,
+  and its `Stopped` is already on its way to the controller.
+  Failing the stream instead strands the shard, since the stream is created
+  once per replica (`NewStore`) and reused by every later session — each of
+  which would then fail its `Join`, recoverable only by unassigning.
 
 ## Coexistence with `runtime`
 

--- a/crates/runtime-next/src/publish.rs
+++ b/crates/runtime-next/src/publish.rs
@@ -429,6 +429,30 @@ pub(crate) struct RecordingPublisher {
     pub stats: std::sync::Arc<std::sync::Mutex<Vec<ops::proto::Stats>>>,
 }
 
+/// Test [`PublisherFactory`] opening [`RecordingPublisher`]s, for tests which
+/// need to stand up a whole `Service` rather than an actor. Each `open` yields
+/// a fresh publisher, so this is for tests that never inspect what was
+/// published — those build a `RecordingPublisher` directly.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct RecordingPublisherFactory;
+
+#[cfg(test)]
+impl PublisherFactory for RecordingPublisherFactory {
+    type Publisher = RecordingPublisher;
+
+    fn open(
+        &self,
+        _authz_subject: String,
+        _producer: uuid::Producer,
+        _stats_journal: &str,
+        _collection_specs: &[&proto_flow::flow::CollectionSpec],
+        _binding_targets: &[u32],
+    ) -> anyhow::Result<RecordingPublisher> {
+        Ok(RecordingPublisher::default())
+    }
+}
+
 #[cfg(test)]
 impl RecordingPublisher {
     pub fn take_docs(&self) -> Vec<(usize, String)> {

--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -169,6 +169,12 @@ where
             proto::Capture {
                 join: Some(join), ..
             } => join,
+
+            // A Stop addressed to a session which has already returned here;
+            // see the materialize session loop for how the controller comes to
+            // send one, and why failing the stream over it strands the shard.
+            proto::Capture { stop: Some(_), .. } => continue,
+
             request => return Err(verify.fail_msg(request)),
         };
 
@@ -580,4 +586,53 @@ fn labels_build_for(spec: &flow::CaptureSpec) -> String {
     labels::expect_one(set, labels::BUILD)
         .unwrap_or_default()
         .to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn stop_awaiting_join_leaves_the_session_loop_serving() {
+        let service = crate::shard::Service::new(
+            crate::Plane::Local,
+            String::new(),
+            None,
+            "test/task".to_string(),
+            crate::publish::RecordingPublisherFactory,
+            crate::TracingLoggerFactory,
+            service_kit::Registry::new(),
+            None,
+        );
+
+        let (controller_tx, controller_rx) = mpsc::unbounded_channel();
+        let mut responses = service.spawn_capture(
+            tokio_stream::wrappers::UnboundedReceiverStream::new(controller_rx),
+        );
+
+        controller_tx
+            .send(Ok(proto::Capture {
+                session_loop: Some(proto::SessionLoop {
+                    rocksdb_descriptor: None,
+                }),
+                ..Default::default()
+            }))
+            .unwrap();
+        controller_tx
+            .send(Ok(proto::Capture {
+                stop: Some(proto::Stop {}),
+                ..Default::default()
+            }))
+            .unwrap();
+        std::mem::drop(controller_tx);
+
+        let mut collected = Vec::new();
+        while let Some(response) = responses.recv().await {
+            collected.push(response);
+        }
+        assert!(
+            collected.is_empty(),
+            "session loop must absorb the Stop and close cleanly, got {collected:?}",
+        );
+    }
 }

--- a/crates/runtime-next/src/shard/derive/handler.rs
+++ b/crates/runtime-next/src/shard/derive/handler.rs
@@ -148,6 +148,12 @@ where
                 )
                 .await?;
             }
+
+            // A Stop addressed to a session which has already returned here;
+            // see the materialize session loop for how the controller comes to
+            // send one, and why failing the stream over it strands the shard.
+            proto::Derive { stop: Some(_), .. } => continue,
+
             request => return Err(verify.fail_msg(request)),
         };
     }
@@ -319,4 +325,53 @@ where
     }));
 
     Ok(db)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn stop_awaiting_join_leaves_the_session_loop_serving() {
+        let service = crate::shard::Service::new(
+            crate::Plane::Local,
+            String::new(),
+            None,
+            "test/task".to_string(),
+            crate::publish::RecordingPublisherFactory,
+            crate::TracingLoggerFactory,
+            service_kit::Registry::new(),
+            None,
+        );
+
+        let (controller_tx, controller_rx) = mpsc::unbounded_channel();
+        let mut responses = service.spawn_derive(
+            tokio_stream::wrappers::UnboundedReceiverStream::new(controller_rx),
+        );
+
+        controller_tx
+            .send(Ok(proto::Derive {
+                session_loop: Some(proto::SessionLoop {
+                    rocksdb_descriptor: None,
+                }),
+                ..Default::default()
+            }))
+            .unwrap();
+        controller_tx
+            .send(Ok(proto::Derive {
+                stop: Some(proto::Stop {}),
+                ..Default::default()
+            }))
+            .unwrap();
+        std::mem::drop(controller_tx);
+
+        let mut collected = Vec::new();
+        while let Some(response) = responses.recv().await {
+            collected.push(response);
+        }
+        assert!(
+            collected.is_empty(),
+            "session loop must absorb the Stop and close cleanly, got {collected:?}",
+        );
+    }
 }

--- a/crates/runtime-next/src/shard/materialize/handler.rs
+++ b/crates/runtime-next/src/shard/materialize/handler.rs
@@ -330,3 +330,58 @@ where
 
     Ok(db)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn stop_awaiting_join_leaves_the_session_loop_serving() {
+        let service = crate::shard::Service::new(
+            crate::Plane::Local,
+            String::new(),
+            None,
+            "test/task".to_string(),
+            crate::publish::RecordingPublisherFactory,
+            crate::TracingLoggerFactory,
+            service_kit::Registry::new(),
+            None,
+        );
+
+        let (controller_tx, controller_rx) = mpsc::unbounded_channel();
+        let mut responses = service.spawn_materialize(
+            tokio_stream::wrappers::UnboundedReceiverStream::new(controller_rx),
+        );
+
+        controller_tx
+            .send(Ok(proto::Materialize {
+                session_loop: Some(proto::SessionLoop {
+                    rocksdb_descriptor: None,
+                }),
+                ..Default::default()
+            }))
+            .unwrap();
+
+        // A Stop can reach the session loop after the session it addressed has
+        // already ended: the controller's teardown select observes its term
+        // cancellation and our Stopped concurrently, and a publish makes both
+        // happen at once, so either can win. The session is over either way,
+        // and the Stop is satisfied by that.
+        controller_tx
+            .send(Ok(proto::Materialize {
+                stop: Some(proto::Stop {}),
+                ..Default::default()
+            }))
+            .unwrap();
+        std::mem::drop(controller_tx);
+
+        let mut collected = Vec::new();
+        while let Some(response) = responses.recv().await {
+            collected.push(response);
+        }
+        assert!(
+            collected.is_empty(),
+            "session loop must absorb the Stop and close cleanly, got {collected:?}",
+        );
+    }
+}

--- a/crates/runtime-next/src/shard/materialize/handler.rs
+++ b/crates/runtime-next/src/shard/materialize/handler.rs
@@ -158,6 +158,17 @@ where
                 )
                 .await?;
             }
+
+            // A Stop addressed to a session which has already returned here.
+            // The controller's teardown select observes its term cancellation
+            // and our Stopped concurrently — a publish cancels every shard's
+            // term at once, and also ends every session, so both are ready
+            // together and either can win. The session it asked us to stop is
+            // over, so the Stop is already satisfied; failing the stream over
+            // it instead strands the shard, because every later session on
+            // this stream then fails its Join.
+            proto::Materialize { stop: Some(_), .. } => continue,
+
             request => return Err(verify.fail_msg(request)),
         };
     }


### PR DESCRIPTION
Fixes #3289.

**Description:**

A publish to any runtime-v2 task with more than one shard can strand a shard's
controller stream, leaving it FAILED — and its Apply unrun — until an operator
unassigns it.

The controller and the Rust runtime share one long-lived gRPC stream, created
once per replica in `NewStore`. A publish ends the Rust session and cancels the
controller's task term at the same instant, so `Stopped` (ours) and `Stop`
(theirs) cross in flight: the session loop, which will only accept a `Join`,
fails the whole stream over the `Stop`. The controller reads the queued `Stopped`
and returns a *clean* shutdown, so nothing is logged — and every later session on
that replica then fails its `Join`. Which message wins is Go's random `select`
over two ready cases, so it's a coin flip per shard per publish.

Fix: absorb a `Stop` received while awaiting a `Join`. The session it addressed is
already over, so the `Stop` is satisfied and its `Stopped` is already on the way.
One match arm in each of the three session loops (materialize, derive, capture).
The controller can't fix this itself — whether the Rust session has ended isn't
knowable at the instant it decides to send.

**Workflow steps:**

None. Publishing a runtime-v2 task stops requiring a `shards unassign` to take
effect.

**Documentation links affected:**

None user-facing. `crates/runtime-next/README.md` gains the invariant.

**Notes for reviewers:**

- First commit is red, second green: the test drives `Service::spawn_materialize`
  and reproduces the production error string byte-for-byte
  (`Materialize protocol error (expected Join) from controller: {"stop":{}}`).
- The three loops are fixed identically; the rationale comment lives on the
  materialize arm, the other two point at it.
- `f4009a5ac3` (two-session idempotent recovery) widened this: a shard parked
  awaiting a `Join` is now routine, so the crossing no longer needs a publish to
  coincide with a session end.
- `runtime-next` lib suite: 199/199. `tests/split_e2e.rs` needs a built gazette
  binary and wasn't run locally.
