### PR TITLE
runtime-next: log an auto-split only when one is started

### DIFF
--- a/crates/publisher/src/mapping.rs
+++ b/crates/publisher/src/mapping.rs
@@ -363,6 +363,7 @@ pub async fn split_partition(
     if key_range_width(split.key_begin, split.key_end) < 2 * MIN_PARTITION_WIDTH {
         return Ok(SplitOutcome::AtFloor);
     }
+    tracing::info!(journal, "starting automatic journal split");
 
     // Read the parent's current spec: the watch tracks only its name, key
     // range, and revision, while the split derives the LHS / RHS specs from

--- a/crates/runtime-next/src/shard/mod.rs
+++ b/crates/runtime-next/src/shard/mod.rs
@@ -59,7 +59,6 @@ pub fn start_due_split<P: crate::Publisher>(
             policy.ignore(&journal);
             continue;
         };
-        tracing::info!(journal, "starting automatic journal split");
         return Some(async move { (journal, split.await) }.boxed());
     }
     None
@@ -92,7 +91,7 @@ pub fn finish_split(
         // Too narrow to split, and a journal's width never grows: terminally
         // stop observing it.
         Ok(publisher::SplitOutcome::AtFloor) => {
-            tracing::debug!(
+            tracing::info!(
                 journal,
                 "journal is at the minimum split width; will not auto-split"
             );


### PR DESCRIPTION
start_due_split logged "starting automatic journal split" as soon as a
due journal resolved to a splittable target, before split_partition
checked the journal's width against the MIN_PARTITION_WIDTH floor. A
journal already at the floor is due until its first outcome lands, so
that path emitted a start message for a split which never happened.

Move the message into split_partition, past the width check and just
ahead of the List / Apply RPCs which do the work.

Raise the matching at-floor message from debug to info. It fires at
most once per journal per assignment (finish_split then ignores the
journal terminally), and it is the only record of why a hot journal
stopped being considered for splits.