### PR TITLE
docs: correct the default materialization maxTxnDuration

### DIFF
--- a/crates/models/src/shards.rs
+++ b/crates/models/src/shards.rs
@@ -32,7 +32,7 @@ pub struct ShardTemplate {
     /// may process documents before it must flush and commit.
     /// It may run for less time if there aren't additional ready documents for
     /// it to process.
-    /// If not set, the maximum duration defaults to five minutes for materializations,
+    /// If not set, the maximum duration defaults to twenty minutes for materializations,
     /// and one second for captures and derivations.
     /// EXPERIMENTAL: this field MAY be removed.
     #[serde(

--- a/flow.schema.json
+++ b/flow.schema.json
@@ -1281,7 +1281,7 @@
         },
         "maxTxnDuration": {
           "title": "Maximum duration of task transactions.",
-          "description": "This duration upper-bounds the amount of time during which a transaction\nmay process documents before it must flush and commit.\nIt may run for less time if there aren't additional ready documents for\nit to process.\nIf not set, the maximum duration defaults to five minutes for materializations,\nand one second for captures and derivations.\nEXPERIMENTAL: this field MAY be removed.",
+          "description": "This duration upper-bounds the amount of time during which a transaction\nmay process documents before it must flush and commit.\nIt may run for less time if there aren't additional ready documents for\nit to process.\nIf not set, the maximum duration defaults to twenty minutes for materializations,\nand one second for captures and derivations.\nEXPERIMENTAL: this field MAY be removed.",
           "type": [
             "string",
             "null"

--- a/site/docs/features/configuring-task-shards.md
+++ b/site/docs/features/configuring-task-shards.md
@@ -15,7 +15,7 @@ You do this by adding the `shards` configuration to the capture or materializati
 |---|---|---|---|
 | `/disable` | Disable | Disable processing of the task's shards. | Boolean |
 | `/logLevel` | Log level | Log levels may currently be \"error\", \"warn\", \"info\", \"debug\", or \"trace\". If not set, the effective log level is \"info\". | String |
-| `/maxTxnDuration` | Maximum transaction duration | This duration upper-bounds the amount of time during which a transaction may process documents before it must initiate a commit. Note that it may take some additional time for the commit to complete after it is initiated. The shard may run for less time if there aren't additional ready documents for it to process. If not set, the maximum duration defaults to one second for captures and derivations, and 5 minutes for materializations. | String |
+| `/maxTxnDuration` | Maximum transaction duration | This duration upper-bounds the amount of time during which a transaction may process documents before it must initiate a commit. Note that it may take some additional time for the commit to complete after it is initiated. The shard may run for less time if there aren't additional ready documents for it to process. If not set, the maximum duration defaults to one second for captures and derivations, and 20 minutes for materializations. | String |
 | `/minTxnDuration` | Minimum transaction duration | This duration lower-bounds the amount of time during which a transaction must process documents before it must flush and commit. It may run for more time if additional documents are available. The default value is zero seconds. | String |
 
 For more information about these controls and when you might need to use them, see:


### PR DESCRIPTION
**Description:**

Three places describe the default `maxTxnDuration` for materializations as five minutes. The actual default has been twenty minutes since d09cb56d034 (June 2025), which raised it deliberately. This corrects the text in all three; no behavior changes.

| File | Was | Now |
|---|---|---|
| `crates/models/src/shards.rs:35` | five minutes | twenty minutes |
| `flow.schema.json:1284` | five minutes | twenty minutes |
| `site/docs/features/configuring-task-shards.md:18` | 5 minutes | 20 minutes |

`crates/assemble/src/lib.rs:411` is the authority and is unchanged:

```rust
} else if task_type == labels::TASK_TYPE_MATERIALIZATION {
    Duration::from_secs(20 * 60)
```

**Workflow steps:**

No change to how the field is used. A reader of the docs page or the JSON schema now sees the default the runtime actually applies.

**Documentation links affected:**

- https://docs.estuary.dev/reference/Configuring-task-shards/ — the `maxTxnDuration` row of the properties table.

**Notes for reviewers:**

Two things worth a look.

1. `flow.schema.json` is edited in place rather than regenerated. The released `flowctl v0.6.12` predates the `syncSchedule` model, so `flowctl raw json-schema` with it drops 102 lines of valid schema. The string I edited is the verbatim serialization of the doc comment, so this is byte-identical to what an in-tree regeneration emits, and the CI check added in d4583de6f22 should confirm that.
2. The docs page is not generated from the schema, despite carrying nearly the same text. Its wording diverges (an extra sentence about commit completion time, and reversed clause order), so it is a third independent copy that nothing keeps in sync. That is why this drifted for 14 months and it will drift again. Out of scope here, but worth someone deciding whether that table should be generated.
