### PR TITLE
mise: pin RocksDB's target ISA instead of inheriting the builder's

### DIFF
--- a/mise/tasks/build/rocksdb
+++ b/mise/tasks/build/rocksdb
@@ -31,11 +31,21 @@ export ROCKSDB_DISABLE_LZ4=1
 export ROCKSDB_DISABLE_ZLIB=1
 export ROCKSDB_DISABLE_ZSTD=1
 
+# PORTABLE=0 means `-march=native`, so librocksdb.a inherited the builder's ISA:
+# an AVX-512 runner once produced binaries that SIGILL everywhere else. haswell
+# pins the AVX2 level we had been shipping. Avoid x86-64-v3 -- RocksDB falls back
+# to a slower software checksum under it, since v3 lacks PCLMUL. aarch64 adds no
+# -march under either setting, so 1 leaves it unchanged.
+case "$(uname -m)" in
+  x86_64) PORTABLE_ARCH=haswell ;;
+  *)      PORTABLE_ARCH=1 ;;
+esac
+
 make static_lib -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4) \
   EXTRA_CXXFLAGS="-fPIC -frtti" \
   EXTRA_CFLAGS="-fPIC" \
   DEBUG_LEVEL=0 \
-  PORTABLE=0
+  PORTABLE="${PORTABLE_ARCH}"
 
 strip --strip-unneeded "${SOURCE_DIR}/librocksdb.a"
 


### PR DESCRIPTION
# **Description:**

## Problem

I noticed `estuary/connectors` CI jobs failing recently with errors like:
```
./tests/run.sh: line 102: 10587 Illegal instruction     (core dumped) flowctl raw spec --source "$TESTDIR/spec.yaml"
     10588 Done                    | jq -cM
failed to validate spec
./tests/run.sh: line 1: kill: (10280) - No such process
```
and
```
            +error: flowctl preview failed: signal: illegal instruction (core dumped)
```
See [this CI job](https://github.com/estuary/connectors/actions/runs/31547963635/job/93964507405?pr=5047) for an example of these errors. I _think_ that means `flowctl` is trying to perform some CPU instruction that the machine running those jobs didn't understand.

What I _think_ caused this is that `build:rocksdb` passes `PORTABLE=0`, which RocksDB reads as `-march=native` (`build_tools/build_detect_platform` L631/L657). So `librocksdb.a` — and every binary linking it — took its instruction floor from whichever runner drew the build.

The master build of 78493a15 drew an AVX-512 runner, and the resulting `flowctl` dies on any CPU without it (`vinserti64x2`, EVEX, in RocksDB cache init — SIGILL before any output). That killed most `flowctl`-invoking jobs in `estuary/connectors` CI, with pass/fail tracking runner hardware exactly. The same library goes into the reactor and control-plane images, three of which deploy automatically from Platform Build.

## Fix

`reactor:v0.6.13-11-gd9006db953c`, the last build before the break, has zero AVX-512 instructions under RocksDB symbols and is AVX2-class throughout — the same source line compiles to `vinserti128` there and `vinserti64x2` after. This PR pins `haswell` on x86_64 to hold that level deliberately.

Note that we are targeting `haswell` instead of `x86-64-v3` - the later lacks PCLMUL & would cause RocksDB to fall back to a slower checksum without PCLMUL present. `haswell` does have PCLMUL present, so RocksDB can use the faster checksum path.

`aarch64` gets `PORTABLE=1`, which adds no `-march` either way and leaves it unchanged.

No production change — same ISA level as the last known good build — and builds become reproducible across runners.

## After merge

I already dropped the cached bad artifact, but if some other PR gets merged before this one, the cached bad artifact must be dropped or this is inert (`build:rocksdb` early-exits when `librocksdb.a` exists):
```bash
  gh cache delete rocksdb-Linux-X64-9.10.0 -R estuary/flow
```
then re-run Platform Build on master.

## Reference

[Slack thread](https://estuaryworkspace.slack.com/archives/C03PF2FSM5H/p1786504271918089)