### PR TITLE
data-plane-controller: pass through aws_resource_tags stack config field

### DIFF
--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -152,6 +152,13 @@ pub struct DataPlane {
     // IP at S3 changes from the NAT EIP to the private-subnet IP.
     #[serde(default, skip_serializing_if = "is_false")]
     pub s3_endpoint_on_private_subnet: bool,
+    // Extra tags applied to every AWS resource of the data-plane, through the
+    // Pulumi AWS provider's `default_tags`. Used for customer cost-allocation
+    // schemes which require a tag on resources we create and replace over
+    // time, such as the `map-migrated` tag of the AWS Migration Acceleration
+    // Program. AWS only; Azure and GCP deployments ignore it.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub aws_resource_tags: std::collections::BTreeMap<String, String>,
     pub deployments: Vec<Deployment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connector_limits: Option<ConnectorLimits>,
@@ -726,6 +733,40 @@ mod test {
             Some(GCPBYOC {
                 project_id: "12345678".to_string(),
             }),
+        );
+    }
+
+    // We deserialize `data_planes.config` and re-serialize it into the Pulumi
+    // stack config, so `aws_resource_tags` reaches est-dry-dock only if it
+    // survives that round trip. An absent map must stay absent, so that
+    // data-planes which set no tags see no change to their stack config.
+    #[test]
+    fn aws_resource_tags_round_trip() {
+        let State { stack, .. } = serde_json::from_str(include_str!("state_fixture.json")).unwrap();
+
+        assert!(stack.config.model.aws_resource_tags.is_empty());
+        assert_eq!(
+            serde_json::to_value(&stack.config.model)
+                .unwrap()
+                .get("aws_resource_tags"),
+            None,
+        );
+
+        let tagged = serde_json::to_value(DataPlane {
+            aws_resource_tags: [("map-migrated".to_string(), "migAQWO5XH8V0".to_string())].into(),
+            ..stack.config.model.clone()
+        })
+        .unwrap();
+
+        assert_eq!(
+            tagged.get("aws_resource_tags").unwrap(),
+            &serde_json::json!({"map-migrated": "migAQWO5XH8V0"}),
+        );
+        assert_eq!(
+            serde_json::from_value::<DataPlane>(tagged)
+                .unwrap()
+                .aws_resource_tags,
+            [("map-migrated".to_string(), "migAQWO5XH8V0".to_string())].into(),
         );
     }
 


### PR DESCRIPTION
**Description:**

BYOC customers enrolled in AWS's Migration Acceleration Program (MAP) need a cost-allocation tag — `map-migrated = mig<id>` in Vivek's/YouLend's case — applied to every AWS resource of their data-plane, including the EC2 hosts (reactor, gazette, etcd) and their EBS volumes. Manual tagging doesn't stick, since est-dry-dock's automation replaces these hosts over time.

This adds `aws_resource_tags: BTreeMap<String, String>` to `stack::DataPlane` in `crates/data-plane-controller/src/shared/stack.rs`. It's needed because the controller deserializes `data_planes.config` and re-serializes it into the Pulumi stack config, and `DataPlane` has no serde catch-all — a field added only on the est-dry-dock/Pydantic side would be silently stripped before Pulumi ever sees it.

This is plumbing only, at the same tier as the file's other plain stack-config flags (`disable_ipv6`, `enable_dns_hostnames`, `s3_endpoint_on_private_subnet`): no `crates/models` or GraphQL surface, since there's no per-entry provisioning result or id correlation to track, unlike `private_links`.

**Workflow steps:**

Nothing changes for existing data-planes: the field is `#[serde(default, skip_serializing_if = "...is_empty")]`, so an absent field deserializes to an empty map and an empty map is omitted on serialize — no stack config changes for any plane that doesn't set it.

Once deployed, an operator sets `aws_resource_tags` on a `data_planes.config` row (direct edit, same as the other plain flags above) to apply a tag map to every AWS resource of that one data-plane. This needs the companion est-dry-dock change (estuary/est-dry-dock#350) to actually reach Pulumi/AWS — that PR is gated on this one shipping and deploying first.

**Documentation links affected:**

None.

**Notes for reviewers:**

- New `aws_resource_tags_round_trip` test covers: absent (empty map, omitted on serialize), and a populated map round-tripping out and back in.
- `cargo check -p data-plane-controller` and `cargo fmt -p data-plane-controller -- --check` are clean. `cargo test -p data-plane-controller --lib` doesn't compile here without a live control-plane database — confirmed this is pre-existing and not introduced by this change (same failure on a clean `origin/master`); CI will be the first real run of the new test.
- AWS only. GCP (`default_labels`) and Azure (no provider-level equivalent) were investigated and explicitly descoped by the requester for this change.