### PR TITLE
connector-init: demote broken-pipe stdin writes to debug

### DIFF
--- a/crates/connector-init/src/rpc.rs
+++ b/crates/connector-init/src/rpc.rs
@@ -153,18 +153,14 @@ where
 
             // No message is ready. Should we flush?
             _ = async {}, if !buffer.is_empty() => {
-                if let Err(error) = stdin.write_all(&buffer).await {
-                    tracing::warn!(%error, "i/o error writing to connector stdin");
-                }
+                write_stdin(&mut stdin, &buffer).await;
                 buffer.clear();
                 continue;
             }
         };
 
         let Some(Ok(message)) = message else {
-            if let Err(error) = stdin.write_all(&buffer).await {
-                tracing::warn!(%error, "i/o error writing to connector stdin");
-            }
+            write_stdin(&mut stdin, &buffer).await;
             if let Some(Err(error)) = message {
                 tracing::error!(%error, "failed to read next runtime request");
             }
@@ -173,6 +169,24 @@ where
         };
 
         codec.encode(&message, &mut buffer);
+    }
+}
+
+/// Write `buffer` to the connector's stdin, logging but not returning an I/O error.
+///
+/// A broken pipe means the connector has exited or is not reading its stdin, which the
+/// protocol allows and which is routine when a connector fails: the write fails *because*
+/// the connector is already gone. Logging it at `warn` puts pure downstream noise beside
+/// the causal error, so it's logged at `debug`. Any other error is unexpected and remains
+/// a `warn`.
+async fn write_stdin(stdin: &mut async_process::ChildStdio, buffer: &[u8]) {
+    let Err(error) = stdin.write_all(buffer).await else {
+        return;
+    };
+    if error.kind() == std::io::ErrorKind::BrokenPipe {
+        tracing::debug!(%error, "connector is not reading its stdin");
+    } else {
+        tracing::warn!(%error, "i/o error writing to connector stdin");
     }
 }
 


### PR DESCRIPTION
**Description:**

`flow-connector-init` pipes runtime requests into the connector's stdin. When a connector dies, the next write fails with a broken pipe — there's no reader left — and we logged that at `warn`. It's noise: the write failed *because* the connector was already gone, and it sat in the task's ops logs beside the connector's real error at the same level.

Broken pipes now log at `debug`. Other i/o errors keep their `warn` and original wording. A connector is allowed to not read its stdin at all, so this was never treated as an error — the function's comment already said so; now the level agrees. The sibling message was demoted the same way in a1bb93bff8.

Closes #3354.

**Workflow steps:**

No user-facing change. One fewer misleading `warn` when reading ops logs for a failed task.

**Documentation links affected:**

None.

**Notes for reviewers:**

The issue asked to key on "the connector has already exited", but that isn't known at the write site — the exit future hasn't resolved, which is why we're still in the loop. `BrokenPipe` means the reader is gone either way.
