### PR TITLE
shuffle: refresh the disk-backlog gauge on the LogActor tick

### DIFF
--- a/crates/shuffle/src/log/actor.rs
+++ b/crates/shuffle/src/log/actor.rs
@@ -204,7 +204,12 @@ impl LogActor {
                 // Periodic tick ensures tracing fires even when idle.
                 // Guarded like sealed_segments to allow the `else` arm to fire
                 // when all slices have disconnected.
-                _ = ticker.tick(), if connected != 0 => {}
+                _ = ticker.tick(), if connected != 0 => {
+                    // The exporter evicts metrics idle for 10m, and a Log wedged
+                    // by back-pressure neither seals nor reclaims, so without
+                    // this the series vanishes on a stalled task.
+                    self.metrics.disk_backlog_bytes.set(disk_backlog_bytes as f64);
+                }
 
                 // All slices EOF'd, heap drained, IO complete, and flushes sent.
                 // No pending flushes can remain: they imply a non-empty block,


### PR DESCRIPTION
**Description:**

`shuffle_log_disk_backlog_bytes` was written only on segment seal and on reclaim. service-kit configures the Prometheus exporter with a 600s idle timeout across all metric kinds, which deletes a metric from the registry once its generation stops advancing -- the series ends, rather than holding a stale value.

A Log wedged by disk back-pressure seals nothing (`may_buffer` gates on it) and reclaims nothing (sealed segments compress within seconds, then only poll for an unlink that never comes). It stops writing the gauge entirely, so the series disappears about ten minutes in.

Re-set the gauge on the actor's existing 60s tick, tying the metric's lifetime to the actor's rather than to its rate of change. Eviction still bounds `shard_id` cardinality once the actor exits, which keeps series presence a usable liveness signal.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

