### PR TITLE
docs: use :::deprecated on four deprecated connector pages

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/amazon-sqs.md
+++ b/site/docs/reference/Connectors/capture-connectors/amazon-sqs.md
@@ -6,7 +6,7 @@ description: Capture Amazon SQS messages into Estuary, using AWS IAM secret and 
 
 This connector captures data from Amazon Simple Queue Service (SQS) into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Amazon SQS connector](./amazon-sqs-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/mailchimp.md
+++ b/site/docs/reference/Connectors/capture-connectors/mailchimp.md
@@ -6,7 +6,7 @@ description: Sync Mailchimp data with Estuary's connector, including lists, camp
 
 This connector captures data from a Mailchimp account.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Mailchimp connector](./mailchimp-native.md) instead.
 :::
 

--- a/site/docs/reference/Connectors/capture-connectors/shopify.md
+++ b/site/docs/reference/Connectors/capture-connectors/shopify.md
@@ -1,8 +1,10 @@
 
 # Shopify
 
-:::warning
-Shopify is deprecating their REST API in favor of their GraphQL API. We recommend using our [Shopify GraphQL connector](./shopify-native.md) whenever possible.
+:::deprecated
+This connector is deprecated and no longer receives updates, as Shopify is deprecating their REST API
+in favor of their GraphQL API. We recommend using our [Shopify GraphQL connector](./shopify-native.md)
+instead.
 :::
 
 This connector captures data from [Shopify's REST Admin API](https://shopify.dev/docs/api/admin-rest).

--- a/site/docs/reference/Connectors/capture-connectors/zendesk-support.md
+++ b/site/docs/reference/Connectors/capture-connectors/zendesk-support.md
@@ -2,6 +2,10 @@
 
 This connector captures data from Zendesk into Estuary collections.
 
+:::deprecated
+This connector is deprecated. For the best experience, we recommend using our native [Zendesk Support connector](./zendesk-support-native.md) instead.
+:::
+
 ## Supported data resources
 
 The following data resources are supported through the Zendesk API:


### PR DESCRIPTION
Four connector pages document deprecated connectors but did not carry the `:::deprecated` admonition. This finishes the batch started in #3321.

| Page | Before | After |
|---|---|---|
| `amazon-sqs.md` | `:::warning` | `:::deprecated` |
| `mailchimp.md` | `:::warning` | `:::deprecated` |
| `zendesk-support.md` | no admonition at all | `:::deprecated` added |
| `shopify.md` | `:::warning`, vendor-focused text | `:::deprecated`, connector-focused text |

## Why

`theme-admonition-deprecated` is the CSS class the Kapa exclusion rule matches on. That rule is live and verified, so pages using the wrong admonition type stayed in the search index and kept surfacing in results. These four were the stragglers the original 16-page batch missed.

## The shopify wording is not a pure marker swap

The old text said Shopify is deprecating their REST API, which describes the vendor rather than our connector. This adopts the wording already merged in estuary/connectors:

> This connector is deprecated and no longer receives updates, as Shopify is deprecating their REST API in favor of their GraphQL API.

That is accurate: `source-shopify` was removed from estuary/connectors outright in `679891c5e`. The connector does not exist any more.

## Not swapped, deliberately

`concepts/materialization/materialization.md` has a `:::warning` about the `source/targetNaming` property being deprecated. That is property-level deprecation on a current, heavily used page. Swapping it would drop a core concept page from search. Same reasoning for the Salesforce, Apache Kafka, Google Search Console and Snowflake pages, which mention the word but describe supported connectors.

## Verification

- `npm run build` in `site/`: server and client both compiled with no broken-link errors, under `onBrokenLinks: 'throw'`. This matters for `zendesk-support.md`, which gains a link to `zendesk-support-native.md` that did not previously exist on the page.
- Rendered HTML for all four pages contains `theme-admonition-deprecated`.
- Pages carrying `:::deprecated` in `site/docs` goes from 16 to 20.

The build does fail afterwards in the redirect plugin's `postBuild` step on `hubspot-real-time`, which is pre-existing on master and unrelated to these pages.

## Companion

estuary/connectors gets the same treatment for `amazon-sqs.md` and `zendesk-support.md`. `mailchimp.md` is already covered there by estuary/connectors#5070, and `shopify.md` was already correct.
