### PR TITLE
go/runtime-v2: log on spec change restarts

### DIFF
--- a/go/runtime/capture_v2.go
+++ b/go/runtime/capture_v2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/estuary/flow/go/protocols/ops"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
 	"github.com/sirupsen/logrus"
@@ -169,6 +170,10 @@ func (c *captureAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.En
 		case <-termDone:
 			// Spec update: initiate graceful drain. The leader replies with
 			// Stopped, read from `respCh` below.
+			if shard.Context().Err() == nil {
+				ops.PublishLog(c.opsPublisher, ops.Log_info,
+					"task specification changed; draining to restart")
+			}
 			_ = c.client.Send(&pr.Capture{Stop: &pr.Stop{}})
 			termDone = nil
 

--- a/go/runtime/derive_v2.go
+++ b/go/runtime/derive_v2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/estuary/flow/go/bindings"
 	"github.com/estuary/flow/go/flow"
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/estuary/flow/go/protocols/ops"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
 	"github.com/sirupsen/logrus"
@@ -292,6 +293,10 @@ func (m *deriveAppV2) runOneSession(shard consumer.Shard, ch chan<- consumer.Env
 		case <-termDone:
 			// Spec update: initiate graceful drain. The leader replies with
 			// Stopped, read from `respCh` below.
+			if shard.Context().Err() == nil {
+				ops.PublishLog(m.opsPublisher, ops.Log_info,
+					"task specification changed; draining to restart")
+			}
 			_ = m.client.Send(&pr.Derive{Stop: &pr.Stop{}})
 			termDone = nil
 

--- a/go/runtime/materialize_v2.go
+++ b/go/runtime/materialize_v2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/estuary/flow/go/flow"
 	"github.com/estuary/flow/go/labels"
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/estuary/flow/go/protocols/ops"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/estuary/flow/go/shuffle"
 	"github.com/sirupsen/logrus"
@@ -254,6 +255,10 @@ func (m *materializeAppV2) runOneSession(shard consumer.Shard, ch chan<- consume
 		case <-termDone:
 			// Spec update: initiate graceful drain. The leader replies with
 			// Stopped, read from `respCh` below.
+			if shard.Context().Err() == nil {
+				ops.PublishLog(m.opsPublisher, ops.Log_info,
+					"task specification changed; draining to restart")
+			}
 			_ = m.client.Send(&pr.Materialize{Stop: &pr.Stop{}})
 			termDone = nil
 


### PR DESCRIPTION
**Description:**

Adds a log on task restarts caused by spec changes, which are otherwise not obviously differentiated from other restart causes.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

