### PR TITLE
docs: document materialize-s3-iceberg variant_columns option

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/site/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -67,6 +67,7 @@ Estuary collections to your tables.
 | **`/namespace`**                  | Namespace             | Namespace for bound collection tables (unless overridden within the binding resource configuration).                                                | string | Required         |
 | `/upload_interval`                | Upload Interval       | Frequency at which files will be uploaded. Must be a valid ISO8601 duration string no greater than 4 hours.                                         | string | PT5M             |
 | `/advanced/nanosecond_timestamps` | Nanosecond Timestamps | Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2).                                    | bool   | false            |
+| `/advanced/variant_columns`       | Variant Columns       | Use the Iceberg variant column type (format v3) for object/array/multi-type fields and the root document instead of JSON strings.                   | bool   | false            |
 | **`/catalog/catalog_type`**       | Catalog Type          | Either "Iceberg REST Server" or "AWS Glue".                                                                                                         | string | Required         |
 | `/catalog/glue_id`                | Glue Catalog ID       | Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials. This enables cross-account Glue catalog access. | string |                  |
 | **`/catalog/uri`**                | URI                   | URI identifying the REST catalog, in the format of 'https://yourserver.com/catalog'.                                                                | string | Required         |
@@ -143,6 +144,28 @@ Enabling the option on an existing format v2 table also upgrades the table to fo
 Prior values remain
 readable in the table's earlier snapshots via time travel. To repopulate history under the new
 type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
+
+With the advanced option `variant_columns` enabled, fields that would otherwise be materialized as
+JSON strings — objects, arrays, multi-type fields, and the root document — are instead materialized
+as **[variant](https://iceberg.apache.org/spec/#semi-structured-types)** columns, and tables are
+created using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
+Variant preserves the semi-structured shape of the data natively, so query engines can extract
+nested paths without parsing JSON text. Collection key fields keep their string mapping, and the
+per-field `castToString` option still forces a JSON string column. String-encoded numbers — a
+field typed as both `string` and `integer` or `number` with a matching `format` annotation — also
+keep their numeric column, since their values are already pinned to a single type.
+
+Within a variant column, a string is stored using the type implied by its format annotation,
+matching how the same value is typed as a column of its own: `{format: date-time}` becomes a
+variant timestamp (nanosecond precision when `nanosecond_timestamps` is also enabled),
+`{format: date}` a variant date, and a base64-encoded string variant binary. Formats with no
+variant equivalent — `uuid`, `time`, and `duration` — are stored as strings, as they are in a
+column of their own, and a value that fails to parse as its annotated type is stored as a string.
+Only top-level fields carry format annotations, so values nested inside an object, an array, or the
+root document are stored as strings.
+
+Make sure your query engine supports reading format v3 variant columns (for example Spark 4.0,
+Snowflake, or DuckDB 1.5.3 and later) before enabling this option.
 
 ## Table Maintenance
 


### PR DESCRIPTION
**Description:**

`materialize-s3-iceberg` gained an advanced option called `variant_columns`. With it on, fields that would otherwise land in the table as JSON text — objects, arrays, multi-type fields, and the root document — become Iceberg `variant` columns instead. A variant keeps the shape of the data, so a query engine can pull out a nested path without parsing JSON.

The docs page for that connector never mentioned the option. This adds it: a row in the endpoint configuration table, plus a short section explaining what the option does and how values inside a variant column are typed.

Docs only — no code changes.

**Workflow steps:**

Nothing to do; this is a page that was missing content. Readers of the connector docs will now see the option and learn that:

- `{format: date-time}` is stored as a variant timestamp (nanoseconds if `nanosecond_timestamps` is also on), `{format: date}` as a variant date, and a base64 string as variant binary
- `uuid`, `time`, and `duration` stay strings, since a variant has no matching type
- a value that doesn't parse is stored as a string rather than failing the materialization
- only top-level fields carry format annotations, so anything nested inside an object, an array, or the root document stays a string

**Documentation links affected:**

`reference/Connectors/materialization-connectors/amazon-s3-iceberg` — added the `/advanced/variant_columns` row and a new section covering the option.

**Notes for reviewers:**

- The text is copied verbatim from the same page in `estuary/connectors` (`docs/reference/Connectors/...`), where it landed with the feature. After this change the two copies are byte-identical.
- Worth knowing: `docs.estuary.dev` is currently served from this repo's `gh-pages`, while the newer `estuary/docs` site builds the connectors repo copy and isn't on the live domain yet. So connector docs need landing in both places until that cutover happens — this PR is the live-site half.
