### PR TITLE
docs: fix hubspot property name for /_meta/op field

### DIFF
--- a/site/docs/reference/Connectors/materialization-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/materialization-connectors/hubspot.md
@@ -46,6 +46,9 @@ lowercased, leading underscores are removed as well as other symbols
 characters, and if the field begins with a number it will be prefixed with
 `n`. Names are truncated to 100 characters.
 
+To view the property name for a field in the UI, refresh the field selection
+and hover over the Outcome column.
+
 ## Deletions
 
 Hard deletes are not supported. To track deletions, ensure your collection

--- a/site/docs/reference/Connectors/materialization-connectors/hubspot.md
+++ b/site/docs/reference/Connectors/materialization-connectors/hubspot.md
@@ -49,7 +49,7 @@ characters, and if the field begins with a number it will be prefixed with
 ## Deletions
 
 Hard deletes are not supported. To track deletions, ensure your collection
-documents include the `/_meta/op` field and create a corresponding `meta_op`
+documents include the `/_meta/op` field and create a corresponding `metaop`
 property in HubSpot.
 
 Backfills do not remove existing HubSpot records.


### PR DESCRIPTION
**Description:**

In HubSpot, fix the documented property name that corresponds to `/_meta/op`, and suggest using the UI to view the calculated property names.  There needs to be an existing property name or the field will be marked incompatible.

