### PR TITLE
runtime-next: log when a task applies a changed spec

### DIFF
--- a/crates/runtime-next/README.md
+++ b/crates/runtime-next/README.md
@@ -66,9 +66,10 @@ src/
 │                       #   crate is preview-agnostic)
 ├── logger.rs          # Logger / LoggerFactory traits: the task's log + event stream
 │                       #   (connector log sink + structured Events — persist / applied /
-│                       #   inferred-schema / container lifecycle — which flatten to logs
-│                       #   via LogEvent::to_log). Production shards install FnLoggerFactory
-│                       #   (→ task-log file); leaders & tests install TracingLogger
+│                       #   spec-update / inferred-schema / container lifecycle — which
+│                       #   flatten to logs via LogEvent::to_log). Production shards install
+│                       #   FnLoggerFactory (→ task-log file); leaders & tests install
+│                       #   TracingLogger
 ├── patches.rs         # wire format for connector-state patch streams
 │
 ├── leader/            # sidecar Leader service

--- a/crates/runtime-next/src/logger.rs
+++ b/crates/runtime-next/src/logger.rs
@@ -96,6 +96,13 @@ pub enum LogEvent<'a> {
     #[non_exhaustive]
     Applied { action_description: &'a str },
 
+    /// This session's spec differs from the last applied.
+    #[non_exhaustive]
+    SpecUpdated {
+        last_version: &'a str,
+        next_version: &'a str,
+    },
+
     /// A collection's inferred write-schema widened this transaction.
     /// `binding` is the most-recently-updated binding index for captures
     /// (multiple bindings may target the same collection, and only the
@@ -133,7 +140,21 @@ pub enum LogEvent<'a> {
     },
 }
 
-impl LogEvent<'_> {
+impl<'a> LogEvent<'a> {
+    /// Build a [`LogEvent::SpecUpdated`] if this session's Apply is a genuine
+    /// spec update: a prior spec must have been applied (`last_version` is
+    /// empty on a task's first Apply, which is not an update), and its version
+    /// must differ.
+    pub fn spec_update(last_version: &'a str, next_version: &'a str) -> Option<Self> {
+        if last_version.is_empty() || last_version == next_version {
+            return None;
+        }
+        Some(LogEvent::SpecUpdated {
+            last_version,
+            next_version,
+        })
+    }
+
     /// Flatten this event into its canonical [`ops::Log`] — the single place
     /// events render as task-log lines.
     /// Returns `None` when the event surfaces nothing (a [`LogEvent::Persist`]
@@ -163,6 +184,20 @@ impl LogEvent<'_> {
                 };
                 fields.push(("actionDescription", json_field(&action)));
                 (ops::LogLevel::Info, "connector applied")
+            }
+            LogEvent::SpecUpdated {
+                last_version,
+                next_version,
+                ..
+            } => {
+                // These field names are snake_case, against this file's
+                // camelCase convention, and the message is verbatim: V1 logs
+                // this same line from `runtime::materialize::protocol`, and
+                // operator queries over the ops journal must keep working
+                // across the V1 -> V2 migration.
+                fields.push(("last_version", json_field(last_version)));
+                fields.push(("next_version", json_field(next_version)));
+                (ops::LogLevel::Info, "applying updated task specification")
             }
             LogEvent::InferredSchema {
                 collection_name,
@@ -397,6 +432,10 @@ mod test {
             LogEvent::Applied {
                 action_description: "create table \"foo\"",
             },
+            LogEvent::SpecUpdated {
+                last_version: "0000aaaa11112222",
+                next_version: "0000bbbb33334444",
+            },
             LogEvent::InferredSchema {
                 collection_name: "acmeCo/collection",
                 binding: Some(2),
@@ -448,6 +487,14 @@ mod test {
             },
             "level": "info",
             "message": "connector applied"
+          },
+          {
+            "fields": {
+              "last_version": "0000aaaa11112222",
+              "next_version": "0000bbbb33334444"
+            },
+            "level": "info",
+            "message": "applying updated task specification"
           },
           {
             "fields": {

--- a/crates/runtime-next/src/shard/capture/handler.rs
+++ b/crates/runtime-next/src/shard/capture/handler.rs
@@ -482,6 +482,10 @@ async fn apply_loop<P: crate::PublisherFactory, L: crate::LoggerFactory>(
     let next_spec = flow::CaptureSpec::decode(next_applied.as_ref())
         .context("invalid current CaptureSpec for Apply")?;
 
+    if let Some(event) = crate::LogEvent::spec_update(&last_version, next_version) {
+        logger.event(event);
+    }
+
     const MAX_APPLY_ITERATIONS: u64 = 3;
 
     for iteration in 1..=MAX_APPLY_ITERATIONS {

--- a/crates/runtime-next/src/shard/materialize/startup.rs
+++ b/crates/runtime-next/src/shard/materialize/startup.rs
@@ -1,4 +1,5 @@
 use super::Task;
+use crate::Logger as _;
 use crate::proto;
 use anyhow::Context;
 use futures::StreamExt;
@@ -142,6 +143,9 @@ where
     });
 
     // Read and execute L:Apply and L:Persist from the leader until L:Open.
+    // The leader re-sends L:Apply once per Apply iteration, so latch the
+    // spec-update event to report it at most once per session.
+    let mut reported_spec_update = false;
     let open = loop {
         let verify = crate::verify("Materialize", "Apply, Persist, or Open", "leader");
         match verify.not_eof(leader_rx.next().await)? {
@@ -156,6 +160,13 @@ where
                     }),
                 ..
             } => {
+                if !reported_spec_update
+                    && let Some(event) = crate::LogEvent::spec_update(&last_version, &version)
+                {
+                    reported_spec_update = true;
+                    logger.event(event);
+                }
+
                 let last_spec = if last_spec.is_empty() {
                     None
                 } else {


### PR DESCRIPTION
**Description:**

Add `LogEvent::SpecUpdate`. A capture emits it from the shard apply loop. A materialization emits it from shard zero. The event gives the last and next build versions, so you can see why a task restarted.

This is for parity with the legacy runtime, which logged these lines when a task restarted due to a spec change. Otherwise, it is not immediately obvious why a task restarted when scanning the task logs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

