### PR TITLE
docs: Shopify REST API tense, drop "Estuary Flow" from Smartsheet

### DIFF
--- a/site/docs/reference/Connectors/capture-connectors/shopify.md
+++ b/site/docs/reference/Connectors/capture-connectors/shopify.md
@@ -2,7 +2,7 @@
 # Shopify
 
 :::deprecated
-This connector is deprecated and no longer receives updates, as Shopify is deprecating their REST API
+This connector is deprecated and no longer receives updates, as Shopify has deprecated their REST API
 in favor of their GraphQL API. We recommend using our [Shopify GraphQL connector](./shopify-native.md)
 instead.
 :::

--- a/site/docs/reference/Connectors/capture-connectors/smartsheet.md
+++ b/site/docs/reference/Connectors/capture-connectors/smartsheet.md
@@ -1,10 +1,10 @@
 ---
-description: Use the Smartsheet connector to capture sheets, reports, and their rows into Estuary Flow. Authenticates with a Smartsheet API access token and captures sheets incrementally and reports as full-refresh snapshots.
+description: Use the Smartsheet connector to capture sheets, reports, and their rows into Estuary. Authenticates with a Smartsheet API access token and captures sheets incrementally and reports as full-refresh snapshots.
 ---
 
 # Smartsheet
 
-This connector captures data from [Smartsheet](https://www.smartsheet.com/) sheets and reports into Estuary Flow collections.
+This connector captures data from [Smartsheet](https://www.smartsheet.com/) sheets and reports into Estuary collections.
 It authenticates with a Smartsheet [API access token](https://smartsheet.redoc.ly/#section/API-Basics/Authentication) and reads data through the [Smartsheet API 2.0](https://smartsheet.redoc.ly/).
 
 ## Supported data resources


### PR DESCRIPTION
Picks up the two non-blocking wording notes Emily left on #3362 and estuary/connectors#5070. Both of those were approved and merged without them.

## Changes

**`shopify.md`** — Emily on #3362: "At this point, it would technically be Shopify *has deprecated* their REST API."

She's right. Shopify's REST Admin API became a legacy API on 2024-10-01 and is now in maintenance mode receiving only critical updates, so the present-tense "is deprecating" understates where things actually stand.

**`smartsheet.md`** — the product is Estuary, not "Estuary Flow". Two spots: the frontmatter `description` and the opening line. Applies Emily's suggestions from the connectors#5070 review verbatim.

## Scope

Both files are byte-identical in `flow/site/docs` and `connectors/docs`, so the same change goes to estuary/connectors in a companion PR. #5070 and estuary/docs#31 just brought those trees to zero drift, and fixing only one side would reintroduce drift right before the cutover. This repo is still what production builds from, so this is the copy that changes what readers see today.

One deliberate non-change: `transformations/dbt-integration.md` also matches "Estuary Flow", but there it documents the literal default value the connector sends to dbt Cloud as the job cause message. Changing the doc without changing the connector would make it wrong.
