### PR TITLE
ci: label PRs that ship with the Deploy agent-api workflow

### DIFF
--- a/.github/scripts/deploy_scope.py
+++ b/.github/scripts/deploy_scope.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Decide whether a set of changed files reaches a deployable artifact.
+
+The `Deploy agent-api` workflow deploys a prebuilt `control-plane-agent` image
+to the `agent-api` Cloud Run service. That image contains the `agent` binary
+plus a few sidecar binaries, so a change is *in the release* exactly when it
+touches something the image is built from:
+
+  * a crate in the transitive path-dependency closure of `crates/agent`,
+  * a workspace-level file that affects how that binary is built,
+  * the Dockerfile, packaging task, or entrypoint script for the image.
+
+Anything else -- `site/`, other services' crates, other Dockerfiles' binaries --
+cannot be shipped by this workflow.
+
+Within the closure we additionally mark changes that are compiled but cannot
+alter behavior (tests, snapshots, benches, docs), so snapshot churn alone
+does not count as shipping.
+
+Usage:
+    deploy_scope.py --files changed.txt [--target agent]
+
+`changed.txt` is one repo-relative path per line. Exit code is 0 when the
+change ships, 1 when it does not, so the workflow can branch on it. Any other
+exit code is a real error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import tomllib
+from dataclasses import dataclass, field
+
+# Files outside any crate that still change how the binary is built.
+WORKSPACE_BUILD_FILES = {
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    "mise.toml",
+    ".cargo/config.toml",
+}
+
+# Prefixes outside `crates/` that are baked into the image itself.
+IMAGE_INPUT_PREFIXES = (
+    "docker/control-plane-agent.Dockerfile",
+    "mise/tasks/ci/package",
+    "mise/tasks/ci/docker-images",
+    "mise/tasks/build/",
+    "go/",  # flowctl-go and gazette are copied into the image
+)
+
+# Within a shipping crate, these paths are compiled but cannot change behavior.
+INERT_SUFFIXES = (".snap", ".md")
+INERT_PATH_PARTS = (
+    "/tests/",
+    "/benches/",
+    "/snapshots/",
+    "/integration_tests/",
+    "/testdata/",
+)
+
+
+@dataclass
+class Verdict:
+    ships: bool = False
+    payload: list[str] = field(default_factory=list)
+    inert: list[str] = field(default_factory=list)
+    excluded: list[str] = field(default_factory=list)
+    crates_touched: set[str] = field(default_factory=set)
+
+
+def crate_dir_by_name(repo: pathlib.Path) -> dict[str, str]:
+    """Map crate name -> directory name under `crates/`."""
+    out: dict[str, str] = {}
+    for manifest in sorted((repo / "crates").glob("*/Cargo.toml")):
+        data = tomllib.loads(manifest.read_text())
+        name = data.get("package", {}).get("name")
+        if name:
+            out[name] = manifest.parent.name
+    return out
+
+
+def path_deps(manifest: pathlib.Path) -> set[str]:
+    """Path dependencies of a manifest, excluding dev-dependencies.
+
+    dev-dependencies are deliberately excluded: they are linked only into test
+    binaries, never into the shipped one. build-dependencies and
+    target-conditional dependencies are included.
+    """
+    data = tomllib.loads(manifest.read_text())
+    tables: list[dict] = []
+    for key in ("dependencies", "build-dependencies"):
+        tables.append(data.get(key, {}))
+    for cfg in data.get("target", {}).values():
+        for key in ("dependencies", "build-dependencies"):
+            tables.append(cfg.get(key, {}))
+
+    deps: set[str] = set()
+    for table in tables:
+        for name, spec in table.items():
+            if isinstance(spec, dict) and "path" in spec:
+                deps.add(spec.get("package", name))
+    return deps
+
+
+def closure(repo: pathlib.Path, root_crate: str) -> set[str]:
+    """Directory names of every in-repo crate linked into `root_crate`."""
+    dirs = crate_dir_by_name(repo)
+    if root_crate not in dirs:
+        raise SystemExit(f"error: no crate named {root_crate!r} under crates/")
+
+    seen: set[str] = set()
+    queue = [root_crate]
+    while queue:
+        name = queue.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        crate_dir = dirs.get(name)
+        if crate_dir is None:
+            # A path dep outside `crates/` (e.g. a vendored fork). Record the
+            # name so it is not silently dropped, but there is no dir to match.
+            continue
+        for dep in path_deps(repo / "crates" / crate_dir / "Cargo.toml"):
+            if dep not in seen:
+                queue.append(dep)
+
+    return {dirs[n] for n in seen if n in dirs}
+
+
+def is_inert(path: str) -> bool:
+    return path.endswith(INERT_SUFFIXES) or any(
+        part in f"/{path}" for part in INERT_PATH_PARTS
+    )
+
+
+def classify(paths: list[str], shipping_dirs: set[str]) -> Verdict:
+    v = Verdict()
+
+    for path in paths:
+        in_artifact = False
+
+        if path in WORKSPACE_BUILD_FILES or path.startswith(IMAGE_INPUT_PREFIXES):
+            in_artifact = True
+        elif path.startswith("crates/"):
+            parts = path.split("/")
+            if len(parts) > 2 and parts[1] in shipping_dirs:
+                in_artifact = True
+                v.crates_touched.add(parts[1])
+
+        if not in_artifact:
+            v.excluded.append(path)
+        elif is_inert(path):
+            v.inert.append(path)
+        else:
+            v.payload.append(path)
+
+    v.ships = bool(v.payload)
+    return v
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--files", required=True, help="file with one changed path per line")
+    ap.add_argument("--target", default="agent", help="root crate of the artifact")
+    ap.add_argument("--repo", default=".", help="repository root")
+    args = ap.parse_args()
+
+    repo = pathlib.Path(args.repo).resolve()
+    paths = [
+        line.strip()
+        for line in pathlib.Path(args.files).read_text().splitlines()
+        if line.strip()
+    ]
+
+    verdict = classify(paths, closure(repo, args.target))
+
+    print(
+        f"{'ships' if verdict.ships else 'does not ship'}: "
+        f"{len(verdict.payload)} payload, {len(verdict.inert)} inert, "
+        f"{len(verdict.excluded)} excluded",
+        file=sys.stderr,
+    )
+    return 0 if verdict.ships else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/deploy_scope.py
+++ b/.github/scripts/deploy_scope.py
@@ -33,22 +33,32 @@ import sys
 import tomllib
 from dataclasses import dataclass, field
 
-# Files outside any crate that still change how the binary is built.
+# Files outside any crate that still change what is built into the image.
+# go.mod / go.sum pin the Go module graph for the flowctl-go and gazette
+# binaries the image carries.
 WORKSPACE_BUILD_FILES = {
     "Cargo.toml",
     "Cargo.lock",
     "rust-toolchain.toml",
     "mise.toml",
     ".cargo/config.toml",
+    "go.mod",
+    "go.sum",
 }
 
 # Prefixes outside `crates/` that are baked into the image itself.
+# The two ops-catalog bundles are include_str!'d by control-plane-api, which
+# links into the agent binary. ops-task-template.bundle.json is deliberately
+# absent: flowctl embeds it, and the Rust flowctl binary is not in this image.
 IMAGE_INPUT_PREFIXES = (
     "docker/control-plane-agent.Dockerfile",
     "mise/tasks/ci/package",
     "mise/tasks/ci/docker-images",
+    "mise/tasks/ci/gnu-opt",  # the `cargo build --release` that produces `agent`
     "mise/tasks/build/",
     "go/",  # flowctl-go and gazette are copied into the image
+    "ops-catalog/data-plane-template.bundle.json",
+    "ops-catalog/reporting-L2-template.bundle.json",
 )
 
 # Within a shipping crate, these paths are compiled but cannot change behavior.

--- a/.github/scripts/deploy_scope.py
+++ b/.github/scripts/deploy_scope.py
@@ -33,33 +33,56 @@ import sys
 import tomllib
 from dataclasses import dataclass, field
 
-# Files outside any crate that still change what is built into the image.
-# go.mod / go.sum pin the Go module graph for the flowctl-go and gazette
-# binaries the image carries.
-WORKSPACE_BUILD_FILES = {
-    "Cargo.toml",
-    "Cargo.lock",
-    "rust-toolchain.toml",
-    "mise.toml",
-    ".cargo/config.toml",
-    "go.mod",
-    "go.sum",
+# Per-artifact build inputs. Each target names a root crate, plus the files
+# outside any crate that still change what is built into that artifact:
+#
+#   workspace_files    exact paths (lockfiles, toolchain pins).
+#   input_prefixes     path prefixes baked into the artifact itself.
+#
+# agent: the control-plane-agent image. go.mod / go.sum pin the Go module
+# graph for the flowctl-go and gazette binaries the image carries; the two
+# ops-catalog bundles are include_str!'d by control-plane-api, which links
+# into the agent binary.
+#
+# flowctl: the released CLI binary, built by flowctl-release.yaml with plain
+# cargo (no mise, no Go, no Dockerfile). It include_str!'s the ops-task
+# bundle, which is deliberately absent from the agent target: the Rust
+# flowctl binary is not in the agent image.
+TARGETS = {
+    "agent": {
+        "workspace_files": {
+            "Cargo.toml",
+            "Cargo.lock",
+            "rust-toolchain.toml",
+            "mise.toml",
+            ".cargo/config.toml",
+            "go.mod",
+            "go.sum",
+        },
+        "input_prefixes": (
+            "docker/control-plane-agent.Dockerfile",
+            "mise/tasks/ci/package",
+            "mise/tasks/ci/docker-images",
+            "mise/tasks/ci/gnu-opt",  # the `cargo build --release` that produces `agent`
+            "mise/tasks/build/",
+            "go/",  # flowctl-go and gazette are copied into the image
+            "ops-catalog/data-plane-template.bundle.json",
+            "ops-catalog/reporting-L2-template.bundle.json",
+        ),
+    },
+    "flowctl": {
+        "workspace_files": {
+            "Cargo.toml",
+            "Cargo.lock",
+            "rust-toolchain.toml",
+            ".cargo/config.toml",
+        },
+        "input_prefixes": (
+            ".github/workflows/flowctl-release.yaml",
+            "ops-catalog/ops-task-template.bundle.json",
+        ),
+    },
 }
-
-# Prefixes outside `crates/` that are baked into the image itself.
-# The two ops-catalog bundles are include_str!'d by control-plane-api, which
-# links into the agent binary. ops-task-template.bundle.json is deliberately
-# absent: flowctl embeds it, and the Rust flowctl binary is not in this image.
-IMAGE_INPUT_PREFIXES = (
-    "docker/control-plane-agent.Dockerfile",
-    "mise/tasks/ci/package",
-    "mise/tasks/ci/docker-images",
-    "mise/tasks/ci/gnu-opt",  # the `cargo build --release` that produces `agent`
-    "mise/tasks/build/",
-    "go/",  # flowctl-go and gazette are copied into the image
-    "ops-catalog/data-plane-template.bundle.json",
-    "ops-catalog/reporting-L2-template.bundle.json",
-)
 
 # Within a shipping crate, these paths are compiled but cannot change behavior.
 # _test.go files are excluded from production Go binaries by the toolchain.
@@ -147,13 +170,14 @@ def is_inert(path: str) -> bool:
     )
 
 
-def classify(paths: list[str], shipping_dirs: set[str]) -> Verdict:
+def classify(paths: list[str], shipping_dirs: set[str], target: str = "agent") -> Verdict:
+    spec = TARGETS[target]
     v = Verdict()
 
     for path in paths:
         in_artifact = False
 
-        if path in WORKSPACE_BUILD_FILES or path.startswith(IMAGE_INPUT_PREFIXES):
+        if path in spec["workspace_files"] or path.startswith(spec["input_prefixes"]):
             in_artifact = True
         elif path.startswith("crates/"):
             parts = path.split("/")
@@ -175,7 +199,10 @@ def classify(paths: list[str], shipping_dirs: set[str]) -> Verdict:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--files", required=True, help="file with one changed path per line")
-    ap.add_argument("--target", default="agent", help="root crate of the artifact")
+    ap.add_argument(
+        "--target", default="agent", choices=sorted(TARGETS),
+        help="artifact to classify against; also names the root crate",
+    )
     ap.add_argument("--repo", default=".", help="repository root")
     args = ap.parse_args()
 
@@ -186,7 +213,7 @@ def main() -> int:
         if line.strip()
     ]
 
-    verdict = classify(paths, closure(repo, args.target))
+    verdict = classify(paths, closure(repo, args.target), args.target)
 
     print(
         f"{'ships' if verdict.ships else 'does not ship'}: "

--- a/.github/scripts/deploy_scope.py
+++ b/.github/scripts/deploy_scope.py
@@ -60,6 +60,8 @@ TARGETS = {
             "go.sum",
         },
         "input_prefixes": (
+            ".github/workflows/platform-build.yaml",  # builds and packages the image
+            ".sqlx/",  # offline query metadata; gnu-opt builds with SQLX_OFFLINE=true
             "docker/control-plane-agent.Dockerfile",
             "mise/tasks/ci/package",
             "mise/tasks/ci/docker-images",
@@ -79,6 +81,7 @@ TARGETS = {
         },
         "input_prefixes": (
             ".github/workflows/flowctl-release.yaml",
+            ".sqlx/",  # offline query metadata; the release builds with SQLX_OFFLINE=1
             "ops-catalog/ops-task-template.bundle.json",
         ),
     },

--- a/.github/scripts/deploy_scope.py
+++ b/.github/scripts/deploy_scope.py
@@ -62,7 +62,8 @@ IMAGE_INPUT_PREFIXES = (
 )
 
 # Within a shipping crate, these paths are compiled but cannot change behavior.
-INERT_SUFFIXES = (".snap", ".md")
+# _test.go files are excluded from production Go binaries by the toolchain.
+INERT_SUFFIXES = (".snap", ".md", "_test.go")
 INERT_PATH_PARTS = (
     "/tests/",
     "/benches/",

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Reconcile `pending:agent-api` labels against what is actually deployed.
+
+Desired state: a merged PR carries the label exactly when its changes are
+compiled into the deployed image (see deploy_scope.py) and the most recently
+deployed image does not include its merge commit. This script recomputes that
+full set and applies the difference — adding and removing labels — so missed
+events, rollbacks, and manual label edits all converge on the next run.
+
+The deployed commit is read from the logs of a successful `Deploy agent-api`
+run: the image tag ends in the git-describe suffix g<short-sha> of the commit
+the image was built from (bare, e.g. g71fbcda6, or a full describe string,
+e.g. v0.6.12-24-gc8fbf5ce5ce).
+
+Requires: a full-history checkout (git log <deployed>..HEAD), the `gh` CLI
+with a token holding actions:read and pull-requests:write, and Python 3.11+.
+
+Usage:
+    reconcile_deploy_labels.py [--deploy-run ID] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from deploy_scope import classify, closure
+
+LABEL = "pending:agent-api"
+LABEL_COLOR = "1D76DB"
+LABEL_DESCRIPTION = "Merged, ships via Deploy agent-api, and not yet deployed"
+DEPLOY_WORKFLOW = "deploy-agent-api.yaml"
+IMAGE_NAME = "control-plane-agent"
+
+
+def run(*argv: str) -> str:
+    return subprocess.run(argv, check=True, capture_output=True, text=True).stdout
+
+
+def deployed_commit(repo: str, run_id: str | None) -> str:
+    """Full sha of the commit the deployed image was built from."""
+    if not run_id:
+        # `gh run list` does not return a guaranteed order, so sort here.
+        runs = json.loads(run(
+            "gh", "run", "list", "--repo", repo,
+            "--workflow", DEPLOY_WORKFLOW, "--status", "success", "--limit", "50",
+            "--json", "databaseId,createdAt",
+        ))
+        if not runs:
+            raise SystemExit(f"error: no successful {DEPLOY_WORKFLOW} run found")
+        run_id = str(max(runs, key=lambda r: r["createdAt"])["databaseId"])
+
+    log = run("gh", "run", "view", run_id, "--repo", repo, "--log")
+    m = re.search(rf"{IMAGE_NAME}:([A-Za-z0-9._-]+)", log)
+    if not m:
+        raise SystemExit(f"error: no {IMAGE_NAME} image tag in logs of run {run_id}")
+    tag = m.group(1)
+
+    suffix = re.search(r"(?:^|-)g([0-9a-f]{7,40})$", tag)
+    ref = suffix.group(1) if suffix else tag
+    return run("gh", "api", f"repos/{repo}/commits/{ref}", "--jq", ".sha").strip()
+
+
+def merged_prs_since(repo: str, repo_dir: str, deployed: str) -> dict[int, list[str]]:
+    """PR number -> changed files, for merged PRs not included in the deploy.
+
+    Commits are resolved to PRs via associatedPullRequests: the repository
+    mixes squash and non-squash merges, so subject parsing undercounts.
+    """
+    shas = run("git", "-C", repo_dir, "log", "--format=%H", f"{deployed}..HEAD").split()
+
+    prs: dict[int, dict] = {}
+    for start in range(0, len(shas), 25):
+        chunk = shas[start : start + 25]
+        aliases = [
+            f'c{i}: object(oid: "{sha}") {{ ... on Commit {{'
+            " associatedPullRequests(first: 1) { nodes {"
+            " number merged files(first: 100) { totalCount nodes { path } }"
+            " } } } }"
+            for i, sha in enumerate(chunk)
+        ]
+        owner, name = repo.split("/")
+        query = (
+            f'query {{ repository(owner: "{owner}", name: "{name}") {{ '
+            + " ".join(aliases)
+            + " } }"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".graphql", delete=False) as f:
+            f.write(query)
+        data = json.loads(run("gh", "api", "graphql", "-F", f"query=@{f.name}"))
+        os.unlink(f.name)
+
+        for obj in data["data"]["repository"].values():
+            if obj is None:
+                continue
+            for pr in obj["associatedPullRequests"]["nodes"]:
+                if pr["merged"]:
+                    prs[pr["number"]] = pr["files"]
+
+    out: dict[int, list[str]] = {}
+    for number, files in prs.items():
+        if files["totalCount"] > 100:
+            out[number] = run(
+                "gh", "api", "--paginate",
+                f"repos/{repo}/pulls/{number}/files", "--jq", ".[].filename",
+            ).split()
+        else:
+            out[number] = [f["path"] for f in files["nodes"]]
+    return out
+
+
+def currently_labeled(repo: str) -> set[int]:
+    out = run(
+        "gh", "pr", "list", "--repo", repo,
+        "--state", "merged", "--label", LABEL, "--limit", "100",
+        "--json", "number", "--jq", ".[].number",
+    )
+    return {int(n) for n in out.split()}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "estuary/flow"))
+    ap.add_argument("--repo-dir", default=".", help="full-history checkout")
+    ap.add_argument("--deploy-run", help="deploy run id; defaults to the latest successful run")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    deployed = deployed_commit(args.repo, args.deploy_run)
+    print(f"deployed commit: {deployed}")
+
+    shipping_dirs = closure(pathlib.Path(args.repo_dir).resolve(), "agent")
+    desired = {
+        number
+        for number, files in merged_prs_since(args.repo, args.repo_dir, deployed).items()
+        if classify(files, shipping_dirs).ships
+    }
+    current = currently_labeled(args.repo)
+
+    to_add = sorted(desired - current)
+    to_remove = sorted(current - desired)
+    print(f"desired {sorted(desired)}; add {to_add}; remove {to_remove}")
+
+    if args.dry_run:
+        return
+
+    if to_add:
+        subprocess.run(
+            ["gh", "label", "create", LABEL, "--repo", args.repo,
+             "--color", LABEL_COLOR, "--description", LABEL_DESCRIPTION],
+            check=False, capture_output=True,
+        )
+    for number in to_add:
+        run("gh", "pr", "edit", str(number), "--repo", args.repo, "--add-label", LABEL)
+    for number in to_remove:
+        run("gh", "pr", "edit", str(number), "--repo", args.repo, "--remove-label", LABEL)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
-"""Reconcile `pending:agent-api` labels against what is actually deployed.
+"""Reconcile pending-deploy labels against what is actually deployed.
 
-Desired state: a merged PR carries the label exactly when its changes are
-compiled into the deployed image (see deploy_scope.py) and the most recently
-deployed image does not include its merge commit. This script recomputes that
-full set and applies the difference — adding and removing labels — so missed
-events, rollbacks, and manual label edits all converge on the next run.
+Desired state, per label: a merged PR carries the label exactly when its
+changes are compiled into the control-plane-agent image (see deploy_scope.py)
+and the named deployment does not include its merge commit yet.
 
-The deployed commit is read from the logs of a successful `Deploy agent-api`
-run: the image tag ends in the git-describe suffix g<short-sha> of the commit
-the image was built from (bare, e.g. g71fbcda6, or a full describe string,
-e.g. v0.6.12-24-gc8fbf5ce5ce).
+  pending:agent-api  the `agent-api` Cloud Run service. Its baseline is read
+                     from the logs of the newest successful `Deploy agent-api`
+                     run: the deployed image tag ends in the git-describe
+                     suffix g<short-sha> of the commit it was built from.
+  pending:agent      the `flow-agent` Kubernetes Deployment (the worker tier).
+                     Its baseline is the image tag pinned in estuary/ops
+                     env/estuary/combustable-cronut/main.jsonnet. Reading that
+                     private repo from CI requires a token with contents:read
+                     on estuary/ops in the GH_TOKEN_OPS environment variable.
+
+The script recomputes each full label set and applies the difference — adding
+and removing labels — so missed events, rollbacks, and manual label edits all
+converge on the next run.
 
 Requires: a full-history checkout (git log <deployed>..HEAD), the `gh` CLI
 with a token holding actions:read and pull-requests:write, and Python 3.11+.
@@ -22,6 +29,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import pathlib
@@ -34,39 +42,72 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 from deploy_scope import classify, closure
 
-LABEL = "pending:agent-api"
 LABEL_COLOR = "1D76DB"
-LABEL_DESCRIPTION = "Merged, ships via Deploy agent-api, and not yet deployed"
 DEPLOY_WORKFLOW = "deploy-agent-api.yaml"
 IMAGE_NAME = "control-plane-agent"
+OPS_REPO = "estuary/ops"
+OPS_PIN_PATH = "env/estuary/combustable-cronut/main.jsonnet"
 
 
-def run(*argv: str) -> str:
-    return subprocess.run(argv, check=True, capture_output=True, text=True).stdout
+def run(*argv: str, env: dict | None = None) -> str:
+    merged_env = {**os.environ, **env} if env else None
+    return subprocess.run(
+        argv, check=True, capture_output=True, text=True, env=merged_env
+    ).stdout
 
 
-def deployed_commit(repo: str, run_id: str | None) -> str:
-    """Full sha of the commit the deployed image was built from."""
+def tag_to_commit(repo: str, tag: str) -> str:
+    """Full sha of the commit an image tag was built from."""
+    suffix = re.search(r"(?:^|-)g([0-9a-f]{7,40})$", tag)
+    ref = suffix.group(1) if suffix else tag
+    return run("gh", "api", f"repos/{repo}/commits/{ref}", "--jq", ".sha").strip()
+
+
+def agent_api_commit(repo: str, run_id: str | None) -> str:
+    """Baseline of the agent-api Cloud Run service, from deploy run logs."""
     if not run_id:
-        # `gh run list` does not return a guaranteed order, so sort here.
-        runs = json.loads(run(
-            "gh", "run", "list", "--repo", repo,
-            "--workflow", DEPLOY_WORKFLOW, "--status", "success", "--limit", "50",
-            "--json", "databaseId,createdAt",
-        ))
-        if not runs:
+        # The runs listing does not reliably return newest-first (observed
+        # windows anchored months back), so page through every successful run
+        # and select the newest ourselves. This is a low-volume, manually
+        # dispatched workflow; the full listing is a few pages.
+        lines = run(
+            "gh", "api", "--paginate",
+            f"repos/{repo}/actions/workflows/{DEPLOY_WORKFLOW}/runs"
+            "?status=success&per_page=100",
+            "--jq", r'.workflow_runs[] | "\(.created_at) \(.id)"',
+        ).splitlines()
+        if not lines:
             raise SystemExit(f"error: no successful {DEPLOY_WORKFLOW} run found")
-        run_id = str(max(runs, key=lambda r: r["createdAt"])["databaseId"])
+        run_id = max(lines).split()[1]
 
     log = run("gh", "run", "view", run_id, "--repo", repo, "--log")
     m = re.search(rf"{IMAGE_NAME}:([A-Za-z0-9._-]+)", log)
     if not m:
         raise SystemExit(f"error: no {IMAGE_NAME} image tag in logs of run {run_id}")
-    tag = m.group(1)
+    return tag_to_commit(repo, m.group(1))
 
-    suffix = re.search(r"(?:^|-)g([0-9a-f]{7,40})$", tag)
-    ref = suffix.group(1) if suffix else tag
-    return run("gh", "api", f"repos/{repo}/commits/{ref}", "--jq", ".sha").strip()
+
+def worker_commit(repo: str) -> str:
+    """Baseline of the flow-agent k8s Deployment, from the estuary/ops pin."""
+    env = None
+    if token := os.environ.get("GH_TOKEN_OPS"):
+        env = {"GH_TOKEN": token}
+    try:
+        content = run(
+            "gh", "api", f"repos/{OPS_REPO}/contents/{OPS_PIN_PATH}",
+            "--jq", ".content", env=env,
+        )
+    except subprocess.CalledProcessError as err:
+        raise SystemExit(
+            f"error: cannot read {OPS_REPO}/{OPS_PIN_PATH}: {err.stderr.strip()}\n"
+            "In CI this needs GH_TOKEN_OPS, a token with contents:read on "
+            f"{OPS_REPO}."
+        )
+    jsonnet = base64.b64decode(content).decode()
+    m = re.search(rf"{IMAGE_NAME}:([A-Za-z0-9._-]+)'", jsonnet)
+    if not m:
+        raise SystemExit(f"error: no {IMAGE_NAME} image pin in {OPS_PIN_PATH}")
+    return tag_to_commit(repo, m.group(1))
 
 
 def merged_prs_since(repo: str, repo_dir: str, deployed: str) -> dict[int, list[str]]:
@@ -117,13 +158,44 @@ def merged_prs_since(repo: str, repo_dir: str, deployed: str) -> dict[int, list[
     return out
 
 
-def currently_labeled(repo: str) -> set[int]:
+def currently_labeled(repo: str, label: str) -> set[int]:
     out = run(
         "gh", "pr", "list", "--repo", repo,
-        "--state", "merged", "--label", LABEL, "--limit", "100",
+        "--state", "merged", "--label", label, "--limit", "100",
         "--json", "number", "--jq", ".[].number",
     )
     return {int(n) for n in out.split()}
+
+
+def reconcile(
+    repo: str, repo_dir: str, shipping_dirs: set[str],
+    label: str, description: str, deployed: str, apply: bool,
+) -> None:
+    print(f"{label}: deployed commit {deployed}")
+    desired = {
+        number
+        for number, files in merged_prs_since(repo, repo_dir, deployed).items()
+        if classify(files, shipping_dirs).ships
+    }
+    current = currently_labeled(repo, label)
+
+    to_add = sorted(desired - current)
+    to_remove = sorted(current - desired)
+    print(f"{label}: desired {sorted(desired)}; add {to_add}; remove {to_remove}")
+
+    if not apply:
+        return
+
+    if to_add:
+        subprocess.run(
+            ["gh", "label", "create", label, "--repo", repo,
+             "--color", LABEL_COLOR, "--description", description],
+            check=False, capture_output=True,
+        )
+    for number in to_add:
+        run("gh", "pr", "edit", str(number), "--repo", repo, "--add-label", label)
+    for number in to_remove:
+        run("gh", "pr", "edit", str(number), "--repo", repo, "--remove-label", label)
 
 
 def main() -> None:
@@ -134,34 +206,22 @@ def main() -> None:
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
-    deployed = deployed_commit(args.repo, args.deploy_run)
-    print(f"deployed commit: {deployed}")
-
     shipping_dirs = closure(pathlib.Path(args.repo_dir).resolve(), "agent")
-    desired = {
-        number
-        for number, files in merged_prs_since(args.repo, args.repo_dir, deployed).items()
-        if classify(files, shipping_dirs).ships
-    }
-    current = currently_labeled(args.repo)
 
-    to_add = sorted(desired - current)
-    to_remove = sorted(current - desired)
-    print(f"desired {sorted(desired)}; add {to_add}; remove {to_remove}")
-
-    if args.dry_run:
-        return
-
-    if to_add:
-        subprocess.run(
-            ["gh", "label", "create", LABEL, "--repo", args.repo,
-             "--color", LABEL_COLOR, "--description", LABEL_DESCRIPTION],
-            check=False, capture_output=True,
-        )
-    for number in to_add:
-        run("gh", "pr", "edit", str(number), "--repo", args.repo, "--add-label", LABEL)
-    for number in to_remove:
-        run("gh", "pr", "edit", str(number), "--repo", args.repo, "--remove-label", LABEL)
+    reconcile(
+        args.repo, args.repo_dir, shipping_dirs,
+        "pending:agent-api",
+        "Merged, ships via Deploy agent-api, and not yet deployed",
+        agent_api_commit(args.repo, args.deploy_run),
+        apply=not args.dry_run,
+    )
+    reconcile(
+        args.repo, args.repo_dir, shipping_dirs,
+        "pending:agent",
+        "Merged, in the control-plane-agent image, and not yet rolled to flow-agent",
+        worker_commit(args.repo),
+        apply=not args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -14,6 +14,8 @@ and the named deployment does not include its merge commit yet.
                      env/estuary/combustable-cronut/main.jsonnet. Reading that
                      private repo from CI requires a token with contents:read
                      on estuary/ops in the GH_TOKEN_OPS environment variable.
+  pending:flowctl    the released flowctl CLI. Its baseline is the tag of the
+                     latest published (non-prerelease) GitHub release.
 
 The script recomputes each full label set and applies the difference — adding
 and removing labels — so missed events, rollbacks, and manual label edits all
@@ -85,6 +87,16 @@ def agent_api_commit(repo: str, run_id: str | None) -> str:
     if not m:
         raise SystemExit(f"error: no {IMAGE_NAME} image tag in logs of run {run_id}")
     return tag_to_commit(repo, m.group(1))
+
+
+def flowctl_release_commit(repo: str) -> str:
+    """Baseline of the released flowctl CLI: the latest published release.
+
+    /releases/latest excludes prereleases, so the continuously-updated
+    dev-next prerelease does not move this baseline.
+    """
+    tag = run("gh", "api", f"repos/{repo}/releases/latest", "--jq", ".tag_name").strip()
+    return run("gh", "api", f"repos/{repo}/commits/{tag}", "--jq", ".sha").strip()
 
 
 def worker_commit(repo: str) -> str:
@@ -172,14 +184,14 @@ def currently_labeled(repo: str, label: str) -> set[int]:
 
 
 def reconcile(
-    repo: str, repo_dir: str, shipping_dirs: set[str],
+    repo: str, repo_dir: str, target: str, shipping_dirs: set[str],
     label: str, description: str, deployed: str, end_ref: str, apply: bool,
 ) -> None:
     print(f"{label}: deployed commit {deployed}")
     desired = {
         number
         for number, files in merged_prs_since(repo, repo_dir, deployed, end_ref).items()
-        if classify(files, shipping_dirs).ships
+        if classify(files, shipping_dirs, target).ships
     }
     current = currently_labeled(repo, label)
 
@@ -214,10 +226,12 @@ def main() -> None:
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
-    shipping_dirs = closure(pathlib.Path(args.repo_dir).resolve(), "agent")
+    repo_root = pathlib.Path(args.repo_dir).resolve()
+    agent_dirs = closure(repo_root, "agent")
+    flowctl_dirs = closure(repo_root, "flowctl")
 
     reconcile(
-        args.repo, args.repo_dir, shipping_dirs,
+        args.repo, args.repo_dir, "agent", agent_dirs,
         "pending:agent-api",
         "Merged, ships via Deploy agent-api, and not yet deployed",
         agent_api_commit(args.repo, args.deploy_run),
@@ -225,10 +239,18 @@ def main() -> None:
         apply=not args.dry_run,
     )
     reconcile(
-        args.repo, args.repo_dir, shipping_dirs,
+        args.repo, args.repo_dir, "agent", agent_dirs,
         "pending:agent",
         "Merged, in the control-plane-agent image, and not yet rolled to flow-agent",
         worker_commit(args.repo),
+        args.end_ref,
+        apply=not args.dry_run,
+    )
+    reconcile(
+        args.repo, args.repo_dir, "flowctl", flowctl_dirs,
+        "pending:flowctl",
+        "Merged, changes the flowctl binary, and not in a published release",
+        flowctl_release_commit(args.repo),
         args.end_ref,
         apply=not args.dry_run,
     )

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -110,13 +110,17 @@ def worker_commit(repo: str) -> str:
     return tag_to_commit(repo, m.group(1))
 
 
-def merged_prs_since(repo: str, repo_dir: str, deployed: str) -> dict[int, list[str]]:
+def merged_prs_since(
+    repo: str, repo_dir: str, deployed: str, end_ref: str
+) -> dict[int, list[str]]:
     """PR number -> changed files, for merged PRs not included in the deploy.
 
     Commits are resolved to PRs via associatedPullRequests: the repository
     mixes squash and non-squash merges, so subject parsing undercounts.
     """
-    shas = run("git", "-C", repo_dir, "log", "--format=%H", f"{deployed}..HEAD").split()
+    shas = run(
+        "git", "-C", repo_dir, "log", "--format=%H", f"{deployed}..{end_ref}"
+    ).split()
 
     prs: dict[int, dict] = {}
     for start in range(0, len(shas), 25):
@@ -169,12 +173,12 @@ def currently_labeled(repo: str, label: str) -> set[int]:
 
 def reconcile(
     repo: str, repo_dir: str, shipping_dirs: set[str],
-    label: str, description: str, deployed: str, apply: bool,
+    label: str, description: str, deployed: str, end_ref: str, apply: bool,
 ) -> None:
     print(f"{label}: deployed commit {deployed}")
     desired = {
         number
-        for number, files in merged_prs_since(repo, repo_dir, deployed).items()
+        for number, files in merged_prs_since(repo, repo_dir, deployed, end_ref).items()
         if classify(files, shipping_dirs).ships
     }
     current = currently_labeled(repo, label)
@@ -203,6 +207,10 @@ def main() -> None:
     ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "estuary/flow"))
     ap.add_argument("--repo-dir", default=".", help="full-history checkout")
     ap.add_argument("--deploy-run", help="deploy run id; defaults to the latest successful run")
+    ap.add_argument(
+        "--end-ref", default="HEAD",
+        help="merged-through ref; pass origin/master when running from a branch checkout",
+    )
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
@@ -213,6 +221,7 @@ def main() -> None:
         "pending:agent-api",
         "Merged, ships via Deploy agent-api, and not yet deployed",
         agent_api_commit(args.repo, args.deploy_run),
+        args.end_ref,
         apply=not args.dry_run,
     )
     reconcile(
@@ -220,6 +229,7 @@ def main() -> None:
         "pending:agent",
         "Merged, in the control-plane-agent image, and not yet rolled to flow-agent",
         worker_commit(args.repo),
+        args.end_ref,
         apply=not args.dry_run,
     )
 

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -14,8 +14,10 @@ and the named deployment does not include its merge commit yet.
                      env/estuary/combustable-cronut/main.jsonnet. Reading that
                      private repo from CI requires a token with contents:read
                      on estuary/ops in the GH_TOKEN_OPS environment variable.
-  pending:flowctl    the released flowctl CLI. Its baseline is the tag of the
-                     latest published (non-prerelease) GitHub release.
+  pending:flowctl    the released flowctl CLI. Its baseline is the head commit
+                     of the newest successful `Flowctl release` run — not the
+                     release itself, whose publication merely starts the
+                     binary build.
 
 The script recomputes each full label set and applies the difference — adding
 and removing labels — so missed events, rollbacks, and manual label edits all
@@ -39,6 +41,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
@@ -46,6 +49,7 @@ from deploy_scope import classify, closure
 
 LABEL_COLOR = "1D76DB"
 DEPLOY_WORKFLOW = "deploy-agent-api.yaml"
+FLOWCTL_WORKFLOW = "flowctl-release.yaml"
 IMAGE_NAME = "control-plane-agent"
 OPS_REPO = "estuary/ops"
 OPS_PIN_PATH = "env/estuary/combustable-cronut/main.jsonnet"
@@ -58,6 +62,30 @@ def run(*argv: str, env: dict | None = None) -> str:
     ).stdout
 
 
+def newest_successful_run(repo: str, workflow: str, field: str) -> str:
+    """`field` of the newest successful run of `workflow`.
+
+    The runs listing intermittently serves stale snapshots that omit recent
+    runs entirely (observed windows anchored months back, even paginated), so
+    take the newest across several spaced attempts: a wrong answer then needs
+    every attempt to hit a stale snapshot.
+    """
+    best = ""
+    for attempt in range(3):
+        if attempt:
+            time.sleep(2)
+        lines = run(
+            "gh", "api", "--paginate",
+            f"repos/{repo}/actions/workflows/{workflow}/runs"
+            "?status=success&per_page=100",
+            "--jq", rf'.workflow_runs[] | "\(.created_at) \({field})"',
+        ).splitlines()
+        best = max([best, *lines])
+    if not best:
+        raise SystemExit(f"error: no successful {workflow} run found")
+    return best.split()[1]
+
+
 def tag_to_commit(repo: str, tag: str) -> str:
     """Full sha of the commit an image tag was built from."""
     suffix = re.search(r"(?:^|-)g([0-9a-f]{7,40})$", tag)
@@ -68,19 +96,7 @@ def tag_to_commit(repo: str, tag: str) -> str:
 def agent_api_commit(repo: str, run_id: str | None) -> str:
     """Baseline of the agent-api Cloud Run service, from deploy run logs."""
     if not run_id:
-        # The runs listing does not reliably return newest-first (observed
-        # windows anchored months back), so page through every successful run
-        # and select the newest ourselves. This is a low-volume, manually
-        # dispatched workflow; the full listing is a few pages.
-        lines = run(
-            "gh", "api", "--paginate",
-            f"repos/{repo}/actions/workflows/{DEPLOY_WORKFLOW}/runs"
-            "?status=success&per_page=100",
-            "--jq", r'.workflow_runs[] | "\(.created_at) \(.id)"',
-        ).splitlines()
-        if not lines:
-            raise SystemExit(f"error: no successful {DEPLOY_WORKFLOW} run found")
-        run_id = max(lines).split()[1]
+        run_id = newest_successful_run(repo, DEPLOY_WORKFLOW, ".id")
 
     log = run("gh", "run", "view", run_id, "--repo", repo, "--log")
     m = re.search(rf"{IMAGE_NAME}:([A-Za-z0-9._-]+)", log)
@@ -90,13 +106,14 @@ def agent_api_commit(repo: str, run_id: str | None) -> str:
 
 
 def flowctl_release_commit(repo: str) -> str:
-    """Baseline of the released flowctl CLI: the latest published release.
+    """Baseline of the released flowctl CLI.
 
-    /releases/latest excludes prereleases, so the continuously-updated
-    dev-next prerelease does not move this baseline.
+    The newest successful `Flowctl release` run, which checks out the release
+    tag; its head commit is the released code. Publishing a release only
+    *starts* that build, and binaries land tens of minutes later (or never,
+    on failure), so the release itself is not the baseline.
     """
-    tag = run("gh", "api", f"repos/{repo}/releases/latest", "--jq", ".tag_name").strip()
-    return run("gh", "api", f"repos/{repo}/commits/{tag}", "--jq", ".sha").strip()
+    return newest_successful_run(repo, FLOWCTL_WORKFLOW, ".head_sha")
 
 
 def worker_commit(repo: str) -> str:

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -98,6 +98,17 @@ class TestClassify(unittest.TestCase):
         self.assertTrue(v.ships)
         self.assertEqual(v.payload, ["mise.toml"])
 
+    def test_go_test_files_are_inert(self):
+        # The Go toolchain excludes _test.go files from production binaries,
+        # so a test-only Go PR does not ship.
+        v = self.verdict("go/flow/converge_test.go")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.inert), 1)
+
+    def test_non_test_go_files_ship(self):
+        v = self.verdict("go/flow/converge.go")
+        self.assertTrue(v.ships)
+
     def test_go_module_files_ship(self):
         # go.mod / go.sum pin the module graph of the flowctl-go and gazette
         # binaries copied into the image.

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -121,6 +121,17 @@ class TestClassify(unittest.TestCase):
         # `agent` binary; its flags and env are build inputs.
         self.assertTrue(self.verdict("mise/tasks/ci/gnu-opt").ships)
 
+    def test_build_workflow_and_sqlx_ship(self):
+        # platform-build.yaml drives the image build, and .sqlx/ holds the
+        # offline query metadata compiled in under SQLX_OFFLINE=true.
+        self.assertTrue(self.verdict(".github/workflows/platform-build.yaml").ships)
+        self.assertTrue(self.verdict(".sqlx/query-0000.json").ships)
+
+    def test_deploy_workflow_does_not_ship(self):
+        # Deploying moves an existing image; it cannot change the artifact.
+        v = self.verdict(".github/workflows/deploy-agent-api.yaml")
+        self.assertFalse(v.ships)
+
     def test_embedded_ops_catalog_bundles_ship(self):
         # Both are include_str!'d by control-plane-api, in the closure.
         for path in (
@@ -182,6 +193,10 @@ class TestFlowctlTarget(unittest.TestCase):
 
     def test_release_workflow_ships(self):
         self.assertTrue(self.verdict(".github/workflows/flowctl-release.yaml").ships)
+
+    def test_sqlx_ships_for_flowctl(self):
+        # flowctl-release also builds with SQLX_OFFLINE.
+        self.assertTrue(self.verdict(".sqlx/query-0000.json").ships)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -98,6 +98,37 @@ class TestClassify(unittest.TestCase):
         self.assertTrue(v.ships)
         self.assertEqual(v.payload, ["mise.toml"])
 
+    def test_go_module_files_ship(self):
+        # go.mod / go.sum pin the module graph of the flowctl-go and gazette
+        # binaries copied into the image.
+        for path in ("go.mod", "go.sum"):
+            self.assertTrue(self.verdict(path).ships)
+
+    def test_release_build_task_ships(self):
+        # mise/tasks/ci/gnu-opt is the cargo invocation that produces the
+        # `agent` binary; its flags and env are build inputs.
+        self.assertTrue(self.verdict("mise/tasks/ci/gnu-opt").ships)
+
+    def test_embedded_ops_catalog_bundles_ship(self):
+        # Both are include_str!'d by control-plane-api, in the closure.
+        for path in (
+            "ops-catalog/data-plane-template.bundle.json",
+            "ops-catalog/reporting-L2-template.bundle.json",
+        ):
+            self.assertTrue(self.verdict(path).ships)
+
+    def test_flowctl_ops_bundle_does_not_ship(self):
+        # flowctl embeds this bundle, and the Rust flowctl binary is not in
+        # the image. Other ops-catalog sources do not ship either.
+        for path in (
+            "ops-catalog/ops-task-template.bundle.json",
+            "ops-catalog/catalog-stats.ts",
+            "ops-catalog/data-plane-template.flow.yaml",
+        ):
+            v = self.verdict(path)
+            self.assertFalse(v.ships)
+            self.assertEqual(len(v.excluded), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -17,6 +17,7 @@ REPO = pathlib.Path(__file__).resolve().parents[2]
 
 # Computed once: the closure walks every crate manifest under crates/.
 CLOSURE = closure(REPO, "agent")
+FLOWCTL_CLOSURE = closure(REPO, "flowctl")
 
 
 class TestClosure(unittest.TestCase):
@@ -139,6 +140,46 @@ class TestClassify(unittest.TestCase):
             v = self.verdict(path)
             self.assertFalse(v.ships)
             self.assertEqual(len(v.excluded), 1)
+
+
+class TestFlowctlTarget(unittest.TestCase):
+    def verdict(self, *paths):
+        return classify(list(paths), FLOWCTL_CLOSURE, "flowctl")
+
+    def test_flowctl_sources_ship(self):
+        self.assertTrue(self.verdict("crates/flowctl/src/ops.rs").ships)
+        # flow-client-next is the CLI's client of the control-plane API;
+        # flow-client (no -next) is dekaf's and is NOT in this closure.
+        self.assertTrue(self.verdict("crates/flow-client-next/src/lib.rs").ships)
+        self.assertFalse(self.verdict("crates/flow-client/src/lib.rs").ships)
+
+    def test_runtime_next_ships_for_flowctl(self):
+        # The inverse of the agent target: flowctl links runtime-next and
+        # shuffle (for preview-next), so those PRs ship via flowctl releases.
+        self.assertTrue(self.verdict("crates/runtime-next/src/logger.rs").ships)
+        self.assertTrue(self.verdict("crates/shuffle/src/lib.rs").ships)
+
+    def test_ops_task_bundle_ships_for_flowctl(self):
+        # The inverse of the agent target: flowctl include_str!'s this bundle,
+        # and the two bundles embedded by control-plane-api do not apply.
+        self.assertTrue(self.verdict("ops-catalog/ops-task-template.bundle.json").ships)
+        self.assertFalse(
+            self.verdict("ops-catalog/data-plane-template.bundle.json").ships
+        )
+
+    def test_agent_image_inputs_do_not_apply(self):
+        # flowctl-release builds with plain cargo: no mise, no Go, no image.
+        for path in (
+            "mise.toml",
+            "go.mod",
+            "go/flow/converge.go",
+            "docker/control-plane-agent.Dockerfile",
+            "crates/agent/src/main.rs",
+        ):
+            self.assertFalse(self.verdict(path).ships)
+
+    def test_release_workflow_ships(self):
+        self.assertTrue(self.verdict(".github/workflows/flowctl-release.yaml").ships)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -1,0 +1,103 @@
+"""Tests for deploy_scope.py, run against the real workspace manifests.
+
+Run from the repository root or from this directory:
+
+    python3 .github/scripts/test_deploy_scope.py
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from deploy_scope import classify, closure
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+# Computed once: the closure walks every crate manifest under crates/.
+CLOSURE = closure(REPO, "agent")
+
+
+class TestClosure(unittest.TestCase):
+    def test_expected_members(self):
+        # Crates the verdicts below depend on. `connector-init` is the
+        # counterintuitive member: it is a path dependency of v1 `runtime`,
+        # so its code links into the `agent` binary even though its behavior
+        # executes in the connector sidecar.
+        for crate in (
+            "agent",
+            "connector-init",
+            "control-plane-api",
+            "models",
+            "notifications",
+            "proto-flow",
+            "runtime",
+            "sources",
+            "validation",
+        ):
+            self.assertIn(crate, CLOSURE)
+
+    def test_expected_non_members(self):
+        # `runtime-next` and `shuffle` are not linked into `agent` at all;
+        # only v1 `runtime` is. A regression here would silently mislabel
+        # every runtime-next PR as shipping.
+        for crate in ("runtime-next", "shuffle", "data-plane-controller"):
+            self.assertNotIn(crate, CLOSURE)
+
+    def test_membership_not_count(self):
+        # 39 in-repo crates at 5221eb6. Assert a floor, not equality, so the
+        # test does not break each time a crate is added to the workspace.
+        self.assertGreaterEqual(len(CLOSURE), 30)
+
+
+class TestClassify(unittest.TestCase):
+    def verdict(self, *paths):
+        return classify(list(paths), CLOSURE)
+
+    def test_control_plane_api_ships(self):
+        v = self.verdict("crates/control-plane-api/src/graphql/storage_mappings.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"control-plane-api"})
+
+    def test_notifications_ships(self):
+        v = self.verdict("crates/notifications/src/shard_failed.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"notifications"})
+
+    def test_runtime_next_does_not_ship(self):
+        v = self.verdict("crates/runtime-next/src/leader/capture/fsm.rs")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_data_plane_controller_does_not_ship(self):
+        v = self.verdict("crates/data-plane-controller/src/stack.rs")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_connector_init_ships(self):
+        v = self.verdict("crates/connector-init/src/codec.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"connector-init"})
+
+    def test_snapshot_is_inert(self):
+        v = self.verdict(
+            "crates/sources/tests/snapshots/"
+            "schema_generation__catalog_schema_snapshot.snap"
+        )
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.inert), 1)
+
+    def test_docs_do_not_ship(self):
+        v = self.verdict("site/docs/reference/materialization.md")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_mise_toml_ships(self):
+        v = self.verdict("mise.toml")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.payload, ["mise.toml"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -148,8 +148,10 @@ class TestFlowctlTarget(unittest.TestCase):
 
     def test_flowctl_sources_ship(self):
         self.assertTrue(self.verdict("crates/flowctl/src/ops.rs").ships)
-        # flow-client-next is the CLI's client of the control-plane API;
-        # flow-client (no -next) is dekaf's and is NOT in this closure.
+        # flowctl has moved to flow-client-next; its predecessor flow-client
+        # is still used by dekaf (only), so it is not in flowctl's closure.
+        # When dekaf adopts flow-client-next, closures follow the manifests
+        # automatically and only this pin needs a fresh look.
         self.assertTrue(self.verdict("crates/flow-client-next/src/lib.rs").ships)
         self.assertFalse(self.verdict("crates/flow-client/src/lib.rs").ships)
 

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -15,10 +15,11 @@ on:
   push:
     branches: [master]
   workflow_run:
-    workflows: ["Deploy agent-api"]
+    # Flowctl release, not `release: published`: publication merely starts the
+    # binary build, so reconciling then would clear pending:flowctl before
+    # binaries exist (or despite a failed build).
+    workflows: ["Deploy agent-api", "Flowctl release"]
     types: [completed]
-  release:
-    types: [published]
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}
@@ -35,7 +36,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_TOKEN_OPS: ${{ secrets.OPS_READ_TOKEN }}
-      DEPLOY_RUN_ID: ${{ github.event.workflow_run.id }}
+      # Only a Deploy agent-api run is a usable agent-api baseline; for any
+      # other trigger the script finds the newest successful deploy itself.
+      DEPLOY_RUN_ID: ${{ github.event.workflow_run.name == 'Deploy agent-api' && github.event.workflow_run.id || '' }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -1,8 +1,8 @@
 name: Label deploy scope
-# A merged PR carries `pending:agent-api` / `pending:agent` exactly when its
-# changes are compiled into the control-plane-agent image and that deployment
-# does not include them yet, so filtering merged PRs by a label yields that
-# deployment's queue. The reconciler recomputes the full label sets on every
+# A merged PR carries `pending:agent-api` / `pending:agent` / `pending:flowctl`
+# exactly when its changes are compiled into that target's artifact and the
+# deployed (or released) artifact does not include them yet, so filtering
+# merged PRs by a label yields that target's queue. The reconciler recomputes the full label sets on every
 # master push and after every successful deploy: missed events, rollbacks, and
 # manual label edits all converge on the next run. It never executes PR code —
 # deployed commits come from the deploy run's logs and the estuary/ops image
@@ -17,6 +17,8 @@ on:
   workflow_run:
     workflows: ["Deploy agent-api"]
     types: [completed]
+  release:
+    types: [published]
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -1,12 +1,16 @@
 name: Label deploy scope
-# A merged PR carries `pending:agent-api` exactly when its changes are compiled
-# into the deployed image and the deployed image does not include them yet, so
-# filtering merged PRs by the label yields the deploy queue. The reconciler
-# recomputes the full label set on every master push and after every
-# successful deploy: missed events, rollbacks, and manual label edits all
-# converge on the next run. It never executes PR code — the deployed commit
-# comes from the deploy run's logs, changed files from the API, and manifests
-# from the master checkout.
+# A merged PR carries `pending:agent-api` / `pending:agent` exactly when its
+# changes are compiled into the control-plane-agent image and that deployment
+# does not include them yet, so filtering merged PRs by a label yields that
+# deployment's queue. The reconciler recomputes the full label sets on every
+# master push and after every successful deploy: missed events, rollbacks, and
+# manual label edits all converge on the next run. It never executes PR code —
+# deployed commits come from the deploy run's logs and the estuary/ops image
+# pin, changed files from the API, and manifests from the master checkout.
+#
+# OPS_READ_TOKEN must hold contents:read on estuary/ops: the `pending:agent`
+# baseline is that repo's pinned flow-agent image, and GITHUB_TOKEN cannot
+# read across repositories.
 on:
   push:
     branches: [master]
@@ -28,6 +32,7 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN_OPS: ${{ secrets.OPS_READ_TOKEN }}
       DEPLOY_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -1,0 +1,40 @@
+name: Label deploy scope
+# A merged PR carries `pending:agent-api` exactly when its changes are compiled
+# into the deployed image and the deployed image does not include them yet, so
+# filtering merged PRs by the label yields the deploy queue. The reconciler
+# recomputes the full label set on every master push and after every
+# successful deploy: missed events, rollbacks, and manual label edits all
+# converge on the next run. It never executes PR code — the deployed commit
+# comes from the deploy run's logs, changed files from the API, and manifests
+# from the master checkout.
+on:
+  push:
+    branches: [master]
+  workflow_run:
+    workflows: ["Deploy agent-api"]
+    types: [completed]
+  workflow_dispatch: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  reconcile:
+    name: reconcile agent-api labels
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DEPLOY_RUN_ID: ${{ github.event.workflow_run.id }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Reconcile labels
+        run: |
+          python3 .github/scripts/reconcile_deploy_labels.py \
+            ${DEPLOY_RUN_ID:+--deploy-run "$DEPLOY_RUN_ID"}


### PR DESCRIPTION
Labels a merged PR `pending:agent-api`, `pending:agent`, or `pending:flowctl`, and then remove the label on deploy.

This actually is just a label-reconciler script that runs on PR merge into master, when the deploy agent-api workflow is run, or it can be dispatched manually. A merged PR gets a deployment's `pending:xyz` label when it changed any file that gets built into that deployment's binary, and the version now running doesn't include that change yet.
