### PR TITLE
demo: exercise the deploy-scope labeler with a trivial GraphQL change

### DIFF
--- a/.github/scripts/test_deploy_scope.py
+++ b/.github/scripts/test_deploy_scope.py
@@ -1,0 +1,103 @@
+"""Tests for deploy_scope.py, run against the real workspace manifests.
+
+Run from the repository root or from this directory:
+
+    python3 .github/scripts/test_deploy_scope.py
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from deploy_scope import classify, closure
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+# Computed once: the closure walks every crate manifest under crates/.
+CLOSURE = closure(REPO, "agent")
+
+
+class TestClosure(unittest.TestCase):
+    def test_expected_members(self):
+        # Crates the verdicts below depend on. `connector-init` is the
+        # counterintuitive member: it is a path dependency of v1 `runtime`,
+        # so its code links into the `agent` binary even though its behavior
+        # executes in the connector sidecar.
+        for crate in (
+            "agent",
+            "connector-init",
+            "control-plane-api",
+            "models",
+            "notifications",
+            "proto-flow",
+            "runtime",
+            "sources",
+            "validation",
+        ):
+            self.assertIn(crate, CLOSURE)
+
+    def test_expected_non_members(self):
+        # `runtime-next` and `shuffle` are not linked into `agent` at all;
+        # only v1 `runtime` is. A regression here would silently mislabel
+        # every runtime-next PR as shipping.
+        for crate in ("runtime-next", "shuffle", "data-plane-controller"):
+            self.assertNotIn(crate, CLOSURE)
+
+    def test_membership_not_count(self):
+        # 39 in-repo crates at 5221eb6. Assert a floor, not equality, so the
+        # test does not break each time a crate is added to the workspace.
+        self.assertGreaterEqual(len(CLOSURE), 30)
+
+
+class TestClassify(unittest.TestCase):
+    def verdict(self, *paths):
+        return classify(list(paths), CLOSURE)
+
+    def test_control_plane_api_ships(self):
+        v = self.verdict("crates/control-plane-api/src/graphql/storage_mappings.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"control-plane-api"})
+
+    def test_notifications_ships(self):
+        v = self.verdict("crates/notifications/src/shard_failed.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"notifications"})
+
+    def test_runtime_next_does_not_ship(self):
+        v = self.verdict("crates/runtime-next/src/leader/capture/fsm.rs")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_data_plane_controller_does_not_ship(self):
+        v = self.verdict("crates/data-plane-controller/src/stack.rs")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_connector_init_ships(self):
+        v = self.verdict("crates/connector-init/src/codec.rs")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.crates_touched, {"connector-init"})
+
+    def test_snapshot_is_inert(self):
+        v = self.verdict(
+            "crates/sources/tests/snapshots/"
+            "schema_generation__catalog_schema_snapshot.snap"
+        )
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.inert), 1)
+
+    def test_docs_do_not_ship(self):
+        v = self.verdict("site/docs/reference/materialization.md")
+        self.assertFalse(v.ships)
+        self.assertEqual(len(v.excluded), 1)
+
+    def test_mise_toml_ships(self):
+        v = self.verdict("mise.toml")
+        self.assertTrue(v.ships)
+        self.assertEqual(v.payload, ["mise.toml"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/dekaf-test.yaml
+++ b/.github/workflows/dekaf-test.yaml
@@ -2,9 +2,14 @@ name: Dekaf Test
 permissions:
     contents: read
 
+# DEMO ONLY (this PR is not for merge): `label-deploy-scope` is added to the
+# branch filter and a labeler job is piggybacked below, because a
+# `pull_request_target` workflow cannot trigger until its file reaches the
+# default branch. The `pull_request` event runs this PR's own version of the
+# workflow, which is what lets the demo fire pre-merge.
 on:
     pull_request:
-        branches: [master]
+        branches: [master, label-deploy-scope]
         paths-ignore:
             - "site/**"
 
@@ -16,8 +21,54 @@ env:
     SCCACHE_VERSION: v0.12.0
 
 jobs:
+    label-deploy-scope-demo:
+        name: agent-api label (demo)
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            pull-requests: write
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            LABEL: "deploy:agent-api"
+            PR: ${{ github.event.pull_request.number }}
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                  persist-credentials: false
+            - name: Collect changed files
+              run: |
+                  gh api --paginate \
+                    "repos/${{ github.repository }}/pulls/${PR}/files" \
+                    --jq '.[].filename' > changed.txt
+                  wc -l < changed.txt
+            - name: Classify
+              id: classify
+              run: |
+                  set +e
+                  python3 .github/scripts/deploy_scope.py --files changed.txt --target agent
+                  status=$?
+                  set -e
+                  if [ "$status" -gt 1 ]; then exit "$status"; fi
+                  echo "ships=$([ "$status" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            - name: Ensure label exists
+              run: |
+                  gh label create "$LABEL" \
+                    --repo "${{ github.repository }}" \
+                    --color 1D76DB \
+                    --description "Reaches production via the Deploy agent-api workflow" \
+                    || true
+            - name: Apply or remove label
+              run: |
+                  if [ "${{ steps.classify.outputs.ships }}" = "true" ]; then
+                    gh pr edit "$PR" --repo "${{ github.repository }}" --add-label "$LABEL"
+                  else
+                    gh pr edit "$PR" --repo "${{ github.repository }}" --remove-label "$LABEL" || true
+                  fi
+
     dekaf-test:
         name: Dekaf Test
+        # DEMO ONLY: skip the heavy e2e job for the demo PR's non-master base.
+        if: github.base_ref == 'master'
         runs-on: ubuntu-2404-large
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -1,0 +1,57 @@
+name: Label deploy scope
+# `pull_request_target` runs the workflow definition from the base branch with a
+# write-scoped token, which is what lets us label PRs from forks. It is only safe
+# because we never check out or execute PR head code: the base ref supplies the
+# Cargo manifests, and the changed-file list comes from the API as data.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  agent-api:
+    name: agent-api
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LABEL: "deploy:agent-api"
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout base ref
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - name: Collect changed files
+        run: |
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${PR}/files" \
+            --jq '.[].filename' > changed.txt
+          wc -l < changed.txt
+      - name: Classify
+        id: classify
+        run: |
+          set +e
+          python3 .github/scripts/deploy_scope.py --files changed.txt --target agent
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then exit "$status"; fi
+          echo "ships=$([ "$status" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+      - name: Ensure label exists
+        run: |
+          gh label create "$LABEL" \
+            --repo "${{ github.repository }}" \
+            --color 1D76DB \
+            --description "Reaches production via the Deploy agent-api workflow" \
+            || true
+      - name: Apply or remove label
+        run: |
+          if [ "${{ steps.classify.outputs.ships }}" = "true" ]; then
+            gh pr edit "$PR" --repo "${{ github.repository }}" --add-label "$LABEL"
+          else
+            gh pr edit "$PR" --repo "${{ github.repository }}" --remove-label "$LABEL" || true
+          fi

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -1,6 +1,7 @@
 //! GraphQL API
 //!
-//! The `QueryRoot`
+//! `QueryRoot` and `MutationRoot` merge each domain module's queries and
+//! mutations into the public schema.
 use async_graphql::{EmptySubscription, Schema, types::connection};
 use axum::response::IntoResponse;
 use chrono::{DateTime, Utc};


### PR DESCRIPTION
Demonstrates the labeler from #3374: a `pull_request_target` workflow cannot trigger until its file is on the default branch, so this PR piggybacks the same steps as a demo job on the `Dekaf Test` workflow, which runs this PR's own version of its file under `pull_request`. The one-line GraphQL doc change is payload in `control-plane-api`, and the `deploy:agent-api` label was applied automatically by the run. Not for merge.
