### PR TITLE
DO NOT MERGE: verify the site/ deprecation notice

### DIFF
--- a/site/docs/getting-started/support.md
+++ b/site/docs/getting-started/support.md
@@ -45,3 +45,5 @@ You should then see `estuary_support/` in the list of entities that you're shari
 When your issue is resolved, you can revoke access again by selecting the `estuary_support/` row and clicking **Remove**.
 
 Learn more about [access grants](/guides/dashboard/admin/#account-access).
+
+<!-- Throwaway edit verifying the site/ deprecation notice in docs-ci-previews.yaml. Not for merge. -->


### PR DESCRIPTION
Throwaway PR verifying the changes in #3384. Based on that branch, not master, so both the new workflow and the new CODEOWNERS file are in play.

Checking three things:

1. The rewritten sticky comment posts and reads correctly to a contributor.
2. No new `pr-preview/` directory appears on `gh-pages`.
3. CODEOWNERS auto-requests review for a `site/` change.

Closing as soon as those are confirmed.