### PR TITLE
agent: discovers require SpecEdit to the capture

### DIFF
--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -193,7 +193,7 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
                 ),
                 catalog_name: row.capture_name.clone(),
                 detail: format!(
-                    "user is not authorized to edit specs under '{}'; if this access was granted recently, retry the discover in a moment",
+                    "user is not authorized to edit specs under '{}'; if this access was granted recently, please retry in a moment",
                     row.capture_name
                 ),
             }];

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -27,6 +27,7 @@ pub enum JobStatus {
     },
     DeprecatedBackground,
     NoDataPlane,
+    NotAuthorized,
 }
 
 impl JobStatus {
@@ -380,6 +381,16 @@ mod test {
 
     use models::Id;
     use uuid::Uuid;
+
+    // `discovers.job_status` is a UI-facing contract: pin the wire tag.
+    #[test]
+    fn test_job_status_not_authorized_serde() {
+        let status = serde_json::to_value(super::JobStatus::NotAuthorized).unwrap();
+        assert_eq!(serde_json::json!({"type": "notAuthorized"}), status);
+
+        let round: super::JobStatus = serde_json::from_value(status).unwrap();
+        assert!(matches!(round, super::JobStatus::NotAuthorized));
+    }
 
     #[tokio::test]
     async fn test_prepare_discover() {

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -98,9 +98,6 @@ impl<C: DiscoverConnectors> automations::Executor for DiscoverExecutor<C> {
 
     type Receive = serde_json::Value;
 
-    /// Polls are stateless and persist the JSON `null` that `None`
-    /// round-trips, keeping in-flight task state readable across a deploy
-    /// in either direction.
     type State = Option<DiscoverState>;
 
     type Outcome = DiscoverOutcome;
@@ -308,19 +305,18 @@ async fn prepare_discover<'a>(
     // embedded in its control-plane Id — is carried on the Discover request,
     // so that re-discovers resolve connector feature-flag defaults as the
     // running task does. It's empty for a task which doesn't exist yet.
-    // The executor has already required the user hold SpecEdit to the
-    // capture, but this fetch also *discloses* the live model into the
-    // user's draft, and disclosure is CatalogRead's axis. Bundles which
-    // convey SpecEdit convey CatalogRead too, so this is a no-op for
-    // real grants — but requiring both here keeps the fetch's read
-    // semantics locally correct rather than leaning on that bundling
-    // convention: a SpecEdit-only grant may discover, with the live
-    // capture treated as absent.
+    //
+    // process() already required the user hold SpecEdit to the capture, but
+    // this fetch *discloses* the live model into the user's draft, and
+    // disclosure is CatalogRead's axis — so the fetch filters on CatalogRead
+    // in its own right rather than leaning on the convention that bundles
+    // conveying SpecEdit convey CatalogRead too. Under a SpecEdit-only
+    // grant the discover proceeds with the live capture treated as absent.
     let name = &[capture_name.to_string()];
     let live = live_specs::get_live_specs_filtered(
         user_id,
         name,
-        models::authz::Capability::SpecEdit | models::authz::Capability::CatalogRead,
+        models::authz::Capability::CatalogRead,
         snapshot,
         pool,
     )

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -98,9 +98,9 @@ impl<C: DiscoverConnectors> automations::Executor for DiscoverExecutor<C> {
 
     type Receive = serde_json::Value;
 
-    /// `None` round-trips as the JSON `null` that stateless polls have always
-    /// persisted, keeping in-flight tasks readable across a deploy in either
-    /// direction.
+    /// Polls are stateless and persist the JSON `null` that `None`
+    /// round-trips, keeping in-flight task state readable across a deploy
+    /// in either direction.
     type State = Option<DiscoverState>;
 
     type Outcome = DiscoverOutcome;
@@ -203,9 +203,9 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
             return Ok((JobStatus::NotAuthorized, Err(errors)));
         }
 
-        // Data-plane authorization is evaluated against the pinned Snapshot,
-        // like the live-spec authorization below. An unauthorized plane and a
-        // missing one are deliberately indistinguishable.
+        // Data-plane authorization: unlike the capture check above, resolving
+        // the plane consults what exists in the Snapshot, so an unauthorized
+        // plane and a missing one are deliberately indistinguishable.
         let Some(data_plane) = tables::UserGrant::is_authorized(
             &snapshot.role_grants,
             &snapshot.user_grants,

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -42,21 +42,8 @@ impl JobStatus {
 
 type ProcessResult = Result<tables::DraftCatalog, Vec<models::draft_error::Error>>;
 
-/// Poll state persisted to `internal.tasks` between polls, and therefore
-/// shared with whichever agent instance dequeues the next poll.
-///
-/// This deploy doesn't yet read or write this state: it's carried so that
-/// state persisted by the upcoming stale-snapshot deferral changes remains
-/// decodable by this version during a deploy or rollback.
-#[allow(dead_code)]
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
-pub struct DiscoverState {
-    /// The instant a Snapshot must postdate (per `Snapshot::taken_after`)
-    /// before this discover is retried: the queued time its prior attempt
-    /// anchored authorization staleness on.
-    #[serde(default)]
-    pub awaiting_snapshot_after: Option<tokens::DateTime>,
-}
+pub struct DiscoverState {}
 
 pub struct DiscoverOutcome {
     id: Id,
@@ -111,9 +98,9 @@ impl<C: DiscoverConnectors> automations::Executor for DiscoverExecutor<C> {
 
     type Receive = serde_json::Value;
 
-    /// `None` — the common, never-deferred case — round-trips as the JSON
-    /// `null` that stateless polls have always persisted, keeping in-flight
-    /// tasks readable across a deploy in either direction.
+    /// `None` round-trips as the JSON `null` that stateless polls have always
+    /// persisted, keeping in-flight tasks readable across a deploy in either
+    /// direction.
     type State = Option<DiscoverState>;
 
     type Outcome = DiscoverOutcome;
@@ -184,6 +171,38 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
         } else if !connector_tags::does_connector_exist(&row.image_name, pool).await? {
             return Ok(precheck_failed(JobStatus::ImageForbidden));
         }
+        // A discover validates and edits the capture's spec, so the user must
+        // hold SpecEdit to the capture's name -- without it they could never
+        // publish the result. The check is deliberately unconditional: a pure
+        // function of the grant graph and the requested name, never of whether
+        // a spec exists at that name, so its outcome discloses nothing about
+        // other tenants' catalogs.
+        if !tables::UserGrant::is_authorized(
+            &snapshot.role_grants,
+            &snapshot.user_grants,
+            row.user_id,
+            &row.capture_name,
+            models::authz::Capability::SpecEdit,
+        ) {
+            // Request an early background refresh: the grant may have been
+            // committed after this Snapshot was taken, and cancelling narrows
+            // the staleness window for a manual retry.
+            snapshot.revoke.cancel();
+            tracing::warn!(capture_name = %row.capture_name, "user is not authorized to edit the capture spec");
+            let errors = vec![models::draft_error::Error {
+                scope: Some(
+                    tables::synthetic_scope(models::CatalogType::Capture, &row.capture_name)
+                        .to_string(),
+                ),
+                catalog_name: row.capture_name.clone(),
+                detail: format!(
+                    "user is not authorized to edit specs under '{}'; if this access was granted recently, retry the discover in a moment",
+                    row.capture_name
+                ),
+            }];
+            return Ok((JobStatus::NotAuthorized, Err(errors)));
+        }
+
         // Data-plane authorization is evaluated against the pinned Snapshot,
         // like the live-spec authorization below. An unauthorized plane and a
         // missing one are deliberately indistinguishable.
@@ -289,14 +308,19 @@ async fn prepare_discover<'a>(
     // embedded in its control-plane Id — is carried on the Discover request,
     // so that re-discovers resolve connector feature-flag defaults as the
     // running task does. It's empty for a task which doesn't exist yet.
-    // Filter to only specs the user holds CatalogRead to: a capture they
-    // can't read is treated as absent, and any error surfaces when they
-    // try to publish.
+    // The executor has already required the user hold SpecEdit to the
+    // capture, but this fetch also *discloses* the live model into the
+    // user's draft, and disclosure is CatalogRead's axis. Bundles which
+    // convey SpecEdit convey CatalogRead too, so this is a no-op for
+    // real grants — but requiring both here keeps the fetch's read
+    // semantics locally correct rather than leaning on that bundling
+    // convention: a SpecEdit-only grant may discover, with the live
+    // capture treated as absent.
     let name = &[capture_name.to_string()];
     let live = live_specs::get_live_specs_filtered(
         user_id,
         name,
-        models::authz::Capability::CatalogRead.into(),
+        models::authz::Capability::SpecEdit | models::authz::Capability::CatalogRead,
         snapshot,
         pool,
     )

--- a/crates/agent/src/integration_tests/user_discovers.rs
+++ b/crates/agent/src/integration_tests/user_discovers.rs
@@ -412,7 +412,7 @@ async fn test_discover_not_authorized_capture() {
         let expect_errors = vec![(
             format!("flow://capture/{capture_name}"),
             format!(
-                "user is not authorized to edit specs under '{capture_name}'; if this access was granted recently, retry the discover in a moment"
+                "user is not authorized to edit specs under '{capture_name}'; if this access was granted recently, please retry in a moment"
             ),
         )];
         assert_eq!(expect_errors, result.errors, "{case}");

--- a/crates/agent/src/integration_tests/user_discovers.rs
+++ b/crates/agent/src/integration_tests/user_discovers.rs
@@ -347,25 +347,173 @@ fn document_schema(version: usize) -> bytes::Bytes {
 }
 
 #[tokio::test]
-async fn test_discover_filters_unauthorized_capture() {
-    let mut harness = TestHarness::init("test_discover_filters_unauthorized_capture").await;
+async fn test_discover_not_authorized_capture() {
+    let mut harness = TestHarness::init("test_discover_not_authorized_capture").await;
 
     let user_id = harness.setup_tenant("squirrels").await;
 
-    // The user holds no grant to chipmunks/: the live-capture precheck fetch
-    // silently filters the name, and the discover proceeds treating the
-    // capture as new rather than failing. Any authorization error surfaces
-    // when the user tries to publish.
+    // A live capture exists at one of the unauthorized names, and not at the
+    // other. The SpecEdit precheck is a pure function of the grant graph and
+    // the requested name, so both cases must produce identical outcomes:
+    // a discover's failure may never disclose whether a spec exists in
+    // another tenant's catalog.
+    sqlx::query(
+        r#"
+        with p1 as (
+            insert into live_specs (id, catalog_name, spec_type, controller_task_id, spec, built_spec) values
+            ('1111000011110000'::flowid, 'chipmunks/capture-existing', 'capture', '2222000022220000'::flowid, '{
+                "bindings": [ ],
+                "endpoint": { "connector": { "config": {}, "image": "source/test:test" } }
+            }', '{}')
+        )
+        insert into internal.tasks (task_id, task_type) values ('2222000022220000'::flowid, 2)
+        on conflict do nothing;
+        "#,
+    )
+    .execute(&harness.pool)
+    .await
+    .unwrap();
+
+    for (case, capture_name) in [
+        ("missing live spec", "chipmunks/capture-missing"),
+        ("existing live spec", "chipmunks/capture-existing"),
+    ] {
+        let draft_id = harness
+            .create_draft(user_id, case, Default::default())
+            .await;
+        let discover_id = harness
+            .queue_user_discover(
+                "source/test",
+                ":test",
+                capture_name,
+                draft_id,
+                r#"{"filtered": 1}"#,
+                false,
+                Ok((
+                    spec_fixture(),
+                    Discovered {
+                        bindings: Vec::new(),
+                    },
+                )),
+            )
+            .await;
+        let result = harness.run_queued_discover(discover_id).await;
+
+        assert!(
+            matches!(
+                result.job_status,
+                crate::discovers::JobStatus::NotAuthorized
+            ),
+            "{case}: expected NotAuthorized, got: {:?}",
+            result.job_status
+        );
+        // A single, grant-based draft error: it speaks only to the user's
+        // grants, never to whether a spec exists at the name.
+        let expect_errors = vec![(
+            format!("flow://capture/{capture_name}"),
+            format!(
+                "user is not authorized to edit specs under '{capture_name}'; if this access was granted recently, retry the discover in a moment"
+            ),
+        )];
+        assert_eq!(expect_errors, result.errors, "{case}");
+        assert_eq!(0, result.draft.spec_count(), "{case}");
+
+        // A NotAuthorized outcome requests an early background Snapshot
+        // refresh, so a grant committed after the Snapshot was taken is
+        // visible to a manual retry. Each poll pins a freshly taken Snapshot,
+        // so cancellation is attributable to this case alone.
+        let snapshot = harness.snapshot_watch.token();
+        assert!(
+            snapshot.result().unwrap().revoke.is_cancelled(),
+            "{case}: expected the NotAuthorized outcome to cancel the Snapshot's revoke token"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_discover_capture_requires_spec_edit() {
+    let mut harness = TestHarness::init("test_discover_capture_requires_spec_edit").await;
+
+    // Provision the tenant (and its data-plane read grant), then a separate
+    // user whose only authorization is a direct grant to `squirrels/`.
+    let _admin_user = harness.setup_tenant("squirrels").await;
+    let limited_user = uuid::Uuid::new_v4();
+    sqlx::query(r#"insert into auth.users (id, email) values ($1, 'limited@squirrels.test')"#)
+        .bind(limited_user)
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+    // Only grants conveying SpecEdit may discover: legacy `read` (Viewer) and
+    // `write` (Writer) hold CatalogRead but not SpecEdit, while `admin` does.
+    for (capability, expect_authorized) in [
+        (models::Capability::Read, false),
+        (models::Capability::Write, false),
+        (models::Capability::Admin, true),
+    ] {
+        harness
+            .add_user_grant(limited_user, "squirrels/", capability)
+            .await;
+        let draft_id = harness
+            .create_draft(limited_user, format!("{capability:?}"), Default::default())
+            .await;
+        let discover_id = harness
+            .queue_user_discover(
+                "source/test",
+                ":test",
+                "squirrels/capture-1",
+                draft_id,
+                r#"{}"#,
+                false,
+                Ok((
+                    spec_fixture(),
+                    Discovered {
+                        bindings: Vec::new(),
+                    },
+                )),
+            )
+            .await;
+        let result = harness.run_queued_discover(discover_id).await;
+
+        if expect_authorized {
+            assert!(
+                result.job_status.is_success(),
+                "{capability:?}: expected success, got: {:?}",
+                result.job_status
+            );
+        } else {
+            assert!(
+                matches!(
+                    result.job_status,
+                    crate::discovers::JobStatus::NotAuthorized
+                ),
+                "{capability:?}: expected NotAuthorized, got: {:?}",
+                result.job_status
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_discover_not_authorized_wins_over_missing_plane() {
+    let mut harness =
+        TestHarness::init("test_discover_not_authorized_wins_over_missing_plane").await;
+
+    let user_id = harness.setup_tenant("squirrels").await;
+
+    // The user is unauthorized to the capture AND names a nonexistent data
+    // plane: the SpecEdit precheck runs first, so NotAuthorized wins.
     let draft_id = harness
-        .create_draft(user_id, "filtered discover", Default::default())
+        .create_draft(user_id, "ordering", Default::default())
         .await;
     let discover_id = harness
-        .queue_user_discover(
+        .queue_user_discover_in_plane(
             "source/test",
             ":test",
             "chipmunks/capture",
+            "ops/dp/public/missing",
             draft_id,
-            r#"{"filtered": 1}"#,
+            r#"{}"#,
             false,
             Ok((
                 spec_fixture(),
@@ -378,18 +526,13 @@ async fn test_discover_filters_unauthorized_capture() {
     let result = harness.run_queued_discover(discover_id).await;
 
     assert!(
-        result.job_status.is_success(),
-        "expected success, got: {:?}",
+        matches!(
+            result.job_status,
+            crate::discovers::JobStatus::NotAuthorized
+        ),
+        "expected NotAuthorized, got: {:?}",
         result.job_status
     );
-    assert!(result.errors.is_empty());
-    // The capture is drafted as a brand-new spec.
-    let drafted = result
-        .draft
-        .captures
-        .get_by_key(&models::Capture::new("chipmunks/capture"))
-        .expect("expected chipmunks/capture to be drafted");
-    assert_eq!(Some(models::Id::zero()), drafted.expect_pub_id);
 }
 
 #[tokio::test]

--- a/crates/agent/src/integration_tests/user_discovers.rs
+++ b/crates/agent/src/integration_tests/user_discovers.rs
@@ -612,7 +612,7 @@ async fn test_discover_merge_filters_unauthorized_collection() {
 
     let user_id = harness.setup_tenant("squirrels").await;
 
-    // The drafted capture is readable by the user, but an existing binding
+    // The user holds SpecEdit to the drafted capture, but an existing binding
     // targets a collection outside their grants. The binding is retained by
     // the discover merge; its target is silently filtered from the
     // merge-phase fetch, so the collection is drafted fresh rather than

--- a/crates/control-plane-api/src/discovers/mod.rs
+++ b/crates/control-plane-api/src/discovers/mod.rs
@@ -319,7 +319,7 @@ impl<C: DiscoverConnectors> DiscoverHandler<C> {
             crate::live_specs::get_live_specs_filtered(
                 user_id,
                 &collection_names,
-                models::authz::Capability::CatalogRead.into(),
+                models::authz::Capability::CatalogRead,
                 snapshot,
                 db,
             )

--- a/crates/control-plane-api/src/live_specs/mod.rs
+++ b/crates/control-plane-api/src/live_specs/mod.rs
@@ -49,11 +49,12 @@ fn partition_by_authorization<'n>(
 pub async fn get_live_specs_filtered(
     user_id: Uuid,
     names: &[String],
-    capability: models::authz::CapabilitySet,
+    capability: impl Into<models::authz::CapabilitySet>,
     snapshot: &crate::Snapshot,
     db: &sqlx::PgPool,
 ) -> anyhow::Result<tables::LiveCatalog> {
-    let (authorized, denied) = partition_by_authorization(user_id, names, capability, snapshot);
+    let (authorized, denied) =
+        partition_by_authorization(user_id, names, capability.into(), snapshot);
 
     if !denied.is_empty() {
         tracing::debug!(?denied, %user_id, "filtered unauthorized specs from fetch");


### PR DESCRIPTION
## What

Next slice of the #2781 strangler series (following #3373 and #3386): the discovers executor now **proves** the user's authorization over the specs a discover touches, rather than only filtering. All decisions evaluate against the Snapshot pinned for the operation.

- **SpecEdit on the capture, hard-fail**: an unconditional precheck on `capture_name` runs ahead of data-plane resolution. A user without SpecEdit gets the new terminal `JobStatus::NotAuthorized` plus a single grant-based draft error, and the Snapshot's `revoke` token is cancelled to request an early background refresh (the `NoDataPlane` precedent).
- **Live-capture merge-base fetch filters at `SpecEdit | CatalogRead`**: the fetch also *discloses* the live model into the user's draft, and disclosure is CatalogRead's axis. Every real bundle conveying SpecEdit conveys CatalogRead too, so this is a no-op in practice — it keeps the fetch's read semantics locally correct rather than leaning on that bundling convention.
- **Collections keep the silent CatalogRead filter, verbatim**: an unauthorized binding-target collection remains indistinguishable from a nonexistent one (#3373's doctrine).
- The auto-discover path (`filter_user_authz: false`, system user) is untouched.

## Reviewer callout: behavior change for CatalogRead-only users

Previously a user lacking edit authority on the capture had it silently drafted as **brand-new** (filtered-as-absent), with the authorization error surfacing only at publish. Now the discover **fails up-front** with `NotAuthorized`. This is a deliberate security-posture change: a user who cannot SpecEdit the capture can never publish the result, so silent success was a UX trap, and the up-front check is cheaper than a doomed connector RPC.

This does **not** create an existence oracle: the check is a pure function of the grant graph and the requested name — its outcome is identical whether or not a spec exists at that name, which `test_discover_not_authorized_capture` pins by asserting byte-identical outcomes for an existing and a nonexistent unauthorized name. (The data-plane check, by contrast, must conflate unauthorized-with-missing because it is existence-conditional; this check never looks anything up.)

Also note the legacy-capability fallout, pinned by test: legacy `read` (Viewer) and `write` (Writer) grants convey CatalogRead but not SpecEdit and are now refused; `admin` conveys SpecEdit and succeeds. Nothing usable is lost — publications already require admin.

## Scope note: secrets in specs

CatalogRead remains the platform's spec-read boundary. A discover merge copies CatalogRead-visible live collection models (including any `derive` section) into the user's draft — the identical surface `flowctl catalog pull-specs` already grants, so this PR neither widens nor narrows it. Secret-in-spec exposure (unencrypted configs, plaintext `redactSalt`) is explicitly out of scope here and is owned by #3366 (first-class secrets) and #2963 (redactSalt encryption).

## No retry mechanism, by design

There is deliberately no stale-snapshot deferral or retry machinery, now or planned: an authorization failure is terminal, the `revoke` cancellation narrows the staleness window to roughly `MIN_REFRESH_INTERVAL`, and the error text asks the user to retry in a moment. `DiscoverState`, which was carried as dead state for a planned deferral mechanism (#3279), is accordingly emptied.

## UI

The dashboard will render `job_status.type == "notAuthorized"` as an unknown status until it learns the new variant; the draft error text is the user-facing message in the interim. The wire tag is pinned by a serde test.

## Tests

Written first, red-green (each phase is its own commit):

- `test_discover_not_authorized_capture`: terminal `NotAuthorized`, grant-based draft error, cancelled revoke token — asserted identically for existing and nonexistent unauthorized names (the no-oracle guard).
- `test_discover_capture_requires_spec_edit`: `read` → refused, `write` → refused, `admin` → success, via a bare user holding a single direct grant.
- `test_discover_not_authorized_wins_over_missing_plane`: the SpecEdit check precedes data-plane resolution.
- `test_job_status_not_authorized_serde`: pins the UI-facing wire tag.
- Removed `test_discover_filters_unauthorized_capture`, which pinned the prior filter semantics.
- Unchanged and still green: `test_discover_merge_filters_unauthorized_collection` (the collections filter), `test_user_discovers`, `test_discover_no_data_plane`, `created_at`, and the `auto_discovers` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
