### PR TITLE
go.mod: bump gazette to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
-	go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64
+	go.gazette.dev/core v0.103.1-0.20260824180052-f481dfcaf314
 	golang.org/x/net v0.55.0
 	google.golang.org/api v0.251.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64 h1:YX2MhHISLxvz1xoS+YQntf4FMZ24Q02+97nmTHImrYI=
-go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
+go.gazette.dev/core v0.103.1-0.20260824180052-f481dfcaf314 h1:OHazhjp7twgrRyPysyPlgUfGENwqALGqYIiqm/TOkm0=
+go.gazette.dev/core v0.103.1-0.20260824180052-f481dfcaf314/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=


### PR DESCRIPTION
**Description:**

Brings in the following gazette changes:
- f481dfc: gazctl shards prune: retry transient fragment removal errors

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

