### PR TITLE
runtime: captures use the V2 runtime by default

### DIFF
--- a/go/runtime/capture.go
+++ b/go/runtime/capture.go
@@ -75,14 +75,15 @@ func (c *captureApp) RestoreCheckpoint(shard consumer.Shard) (_ pf.Checkpoint, _
 		return pf.Checkpoint{}, err
 	}
 
-	// Fail the shard if its runtime-v2 flag has been turned on. NewStore is
-	// invoked only on the initial PRIMARY transition, so a publish that
-	// flips the flag on a running shard cannot otherwise reroute it. We
-	// surface a functional error so the controller restarts the shard,
-	// at which point NewStore re-evaluates the flag and selects V2.
+	// Fail the shard if it no longer selects V1 -- because its explicit
+	// `enable-runtime-v2: false` was raised or removed. NewStore is invoked
+	// only on the initial PRIMARY transition, so a publish that flips the
+	// flag on a running shard cannot otherwise reroute it. We surface a
+	// functional error so the controller restarts the shard, at which point
+	// NewStore re-evaluates the flag and selects V2.
 	if useRuntimeV2(shard.Spec().LabelSet) {
 		return pf.Checkpoint{}, fmt.Errorf(
-			"runtime-v2 feature flag is set but this shard is running the V1 capture runtime; failing to force a restart")
+			"this shard now selects the V2 runtime but is running the V1 capture runtime; failing to force a restart")
 	}
 
 	var watchCtx context.Context

--- a/go/runtime/capture_v2.go
+++ b/go/runtime/capture_v2.go
@@ -105,7 +105,7 @@ func (c *captureAppV2) RestoreCheckpoint(shard consumer.Shard) (pf.Checkpoint, e
 	if !useRuntimeV2(shard.Spec().LabelSet) {
 		c.term.cancel()
 		return pf.Checkpoint{}, fmt.Errorf(
-			"runtime-v2 feature flag is unset but this shard is running the V2 capture runtime; failing to force a restart")
+			"this shard now pins the V1 runtime (enable-runtime-v2: false) but is running the V2 capture runtime; failing to force a restart")
 	}
 	return pf.Checkpoint{}, nil
 }

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -204,8 +204,17 @@ func (f *FlowConsumer) NewStore(shard consumer.Shard, rec *recoverylog.Recorder)
 const runtimeV2Flag = labels.FlagPrefix + "enable-runtime-v2"
 
 // useRuntimeV2 reports whether the shard's labels select the runtime-next path.
+//
+// Captures have ratcheted past opt-in: they run V2 unless the flag is
+// explicitly "false", which is now the only way to hold a capture on V1.
+// Derivations and materializations remain opt-in, requiring an explicit "true".
 func useRuntimeV2(set pf.LabelSet) bool {
-	return set.ValueOf(runtimeV2Flag) == "true"
+	var flag = set.ValueOf(runtimeV2Flag)
+
+	if set.ValueOf(labels.TaskType) == ops.TaskType_capture.String() {
+		return flag != "false"
+	}
+	return flag == "true"
 }
 
 // NewMessage panics if called.

--- a/go/runtime/flow_consumer_test.go
+++ b/go/runtime/flow_consumer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/estuary/flow/go/labels"
-	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/estuary/flow/go/protocols/ops"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	pb "go.gazette.dev/core/broker/protocol"
 	"github.com/stretchr/testify/require"
@@ -57,36 +57,76 @@ func TestFlowConsumerConfig_Plane(t *testing.T) {
 }
 
 func TestUseRuntimeV2(t *testing.T) {
+	var capture = pb.Label{Name: labels.TaskType, Value: ops.TaskType_capture.String()}
+	var derivation = pb.Label{Name: labels.TaskType, Value: ops.TaskType_derivation.String()}
+	var materialization = pb.Label{Name: labels.TaskType, Value: ops.TaskType_materialization.String()}
+
 	tests := []struct {
 		name   string
 		labels []pb.Label
 		want   bool
 	}{
+		// Captures default to V2: only an explicit `false` holds them on V1.
 		{
-			name:   "no flag",
-			labels: []pb.Label{{Name: labels.TaskName, Value: "task"}},
-			want:   false,
-		},
-		{
-			name:   "enable-runtime-v2=true",
-			labels: []pb.Label{{Name: labels.FlagPrefix + "enable-runtime-v2", Value: "true"}},
+			name:   "capture with no flag",
+			labels: []pb.Label{capture},
 			want:   true,
 		},
 		{
-			name:   "enable-runtime-v2=false",
-			labels: []pb.Label{{Name: labels.FlagPrefix + "enable-runtime-v2", Value: "false"}},
+			name:   "capture with enable-runtime-v2=true",
+			labels: []pb.Label{capture, {Name: runtimeV2Flag, Value: "true"}},
+			want:   true,
+		},
+		{
+			name:   "capture with enable-runtime-v2=false",
+			labels: []pb.Label{capture, {Name: runtimeV2Flag, Value: "false"}},
 			want:   false,
 		},
 		{
-			name:   "unrelated flag",
-			labels: []pb.Label{{Name: labels.FlagPrefix + "some-other-flag", Value: "true"}},
+			name:   "capture with an unrelated flag",
+			labels: []pb.Label{capture, {Name: labels.FlagPrefix + "some-other-flag", Value: "true"}},
+			want:   true,
+		},
+		// Derivations and materializations remain opt-in.
+		{
+			name:   "derivation with no flag",
+			labels: []pb.Label{derivation},
+			want:   false,
+		},
+		{
+			name:   "derivation with enable-runtime-v2=true",
+			labels: []pb.Label{derivation, {Name: runtimeV2Flag, Value: "true"}},
+			want:   true,
+		},
+		{
+			name:   "materialization with no flag",
+			labels: []pb.Label{materialization},
+			want:   false,
+		},
+		{
+			name:   "materialization with enable-runtime-v2=true",
+			labels: []pb.Label{materialization, {Name: runtimeV2Flag, Value: "true"}},
+			want:   true,
+		},
+		{
+			name:   "materialization with enable-runtime-v2=false",
+			labels: []pb.Label{materialization, {Name: runtimeV2Flag, Value: "false"}},
+			want:   false,
+		},
+		{
+			name:   "missing task type falls back to opt-in",
+			labels: []pb.Label{{Name: labels.TaskName, Value: "task"}},
 			want:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var set = pf.LabelSet{Labels: tt.labels}
+			// AddValue inserts in sorted position, which ValueOf's binary search requires.
+			var set pb.LabelSet
+			for _, label := range tt.labels {
+				set.AddValue(label.Name, label.Value)
+			}
 			require.Equal(t, tt.want, useRuntimeV2(set))
 		})
 	}


### PR DESCRIPTION
**Description:**

A capture shard now selects V2 unless its labels set `enable-runtime-v2` to "false". That flag is the only way to keep a capture on V1. Derivations and materializations do not change. They still need an explicit "true".

The restart errors no longer say the flag is "set" or "unset", because those words no longer describe the check. Each error now names the runtime the shard selects, and the runtime it runs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Agentic Q/A completed on a local stack

