### PR TITLE
runtime-next: tolerate connector exit during Acknowledge; preview sessions stop at capture EOF

### DIFF
--- a/crates/flowctl/src/raw/preview_next/mod.rs
+++ b/crates/flowctl/src/raw/preview_next/mod.rs
@@ -44,9 +44,9 @@ pub struct Preview {
     /// of transactions for each session?
     ///
     /// Sessions are specified as a comma-separated list of the number of
-    /// transactions for the ordered session. For a given session, a value less
-    /// than zero means "unlimited transactions", though the session will still
-    /// end upon a connector exit / EOF (when a capture) or timeout.
+    /// transactions for the ordered session. For a given session, a value of
+    /// zero or less means "unlimited transactions", though the session will
+    /// still end upon a connector exit / EOF (when a capture) or timeout.
     ///
     /// For example, to run three sessions consisting of two transactions,
     /// then one transaction, and then unlimited transactions,
@@ -55,7 +55,10 @@ pub struct Preview {
     /// A session is stopped and the next started upon reaching the target number
     /// of transactions, or upon a timeout, or if the connector exits.
     ///
-    /// The default is a single session with an unbounded number of transactions.
+    /// The default (no --sessions) is a single session with an unbounded number
+    /// of transactions which acts as production does: when a capture connector
+    /// exits, the session holds through the capture's poll interval before
+    /// stopping, rather than stopping at EOF.
     ///
     /// Materialization previews always append one final empty drain session:
     /// a session halts after its final commit without running the post-commit
@@ -199,8 +202,13 @@ impl Preview {
         let session_targets: Vec<u32> = if let Some(s) = sessions {
             s.iter()
                 .map(|i| {
-                    if *i < 0 {
-                        Ok(0)
+                    if *i <= 0 {
+                        // "Unlimited" transactions: a bound never reached in
+                        // practice, but non-zero so a capture session stops at
+                        // connector EOF. Zero selects production semantics,
+                        // which hold an EOF'd session through the capture's
+                        // poll interval -- reserved for an unset --sessions.
+                        Ok(u32::MAX)
                     } else {
                         u32::try_from(*i).context("--sessions values must fit in uint32")
                     }

--- a/crates/proto-flow/src/runtime.rs
+++ b/crates/proto-flow/src/runtime.rs
@@ -490,8 +490,11 @@ pub struct Task {
     /// Task specification (protobuf-encoded bytes).
     #[prost(bytes = "bytes", tag = "1")]
     pub spec: ::prost::bytes::Bytes,
-    /// Maximum number of transactions to run before exiting. Zero means unlimited.
-    /// Used by "preview" workflows.
+    /// Maximum number of transactions to run before exiting. Zero means unlimited
+    /// and selects production semantics: on connector exit, a capture session
+    /// holds until its poll interval elapses. A non-zero bound instead stops the
+    /// capture session at connector EOF. Set only by "preview" workflows and test
+    /// harnesses; production leaves it zero.
     #[prost(uint32, tag = "3")]
     pub max_transactions: u32,
     /// URL of a SQLite VFS the shard threads to a SQLite derive connector via

--- a/crates/runtime-next/src/leader/capture/fsm.rs
+++ b/crates/runtime-next/src/leader/capture/fsm.rs
@@ -313,8 +313,14 @@ impl HeadIdle {
             }
         }
         // Restart condition: once the Tail has drained, hold until `task.restart`
-        // and then Stop this session.
+        // and then Stop this session. Under a preview or test harness -- the
+        // only setters of `max_transactions` -- stop at EOF instead: the
+        // session is done when the connector is, rather than holding through
+        // the capture's poll interval.
         if matches!(ready, ConnectorRx::Eof) && !is_open && tail_done {
+            if task.max_transactions != 0 {
+                return (Action::PollAgain, Head::Stop);
+            }
             return match uuid::Clock::delta(task.restart, now) {
                 Duration::ZERO => (Action::PollAgain, Head::Stop),
                 wake_after => (Action::Sleep { wake_after }, Head::Idle(self)),
@@ -1490,6 +1496,51 @@ mod tests {
             matches!(head, Head::Stop),
             "Head must stop once the Tail is Done, got {head:?}",
         );
+        assert!(matches!(action, Action::PollAgain));
+    }
+
+    /// On connector EOF with the Tail drained, a production session (zero
+    /// `max_transactions`) holds through the poll interval: it sleeps until
+    /// `task.restart` and stops only once that clock elapses. A preview or
+    /// test-harness session (non-zero `max_transactions`) stops at EOF
+    /// immediately -- the session is done when the connector is.
+    #[test]
+    fn eof_sleeps_until_restart_in_production_and_stops_preview_immediately() {
+        let interval = Duration::from_secs(300);
+        let mk = |max_transactions: u32| {
+            let mut task = mk_task(true);
+            task.max_transactions = max_transactions;
+            // `restart` is one poll interval past the Ctx clock.
+            task.restart = uuid::Clock::from_unix(1_700_000_300, 0);
+            let mut ctx = mk_ctx(task);
+            ctx.ready = ConnectorRx::Eof;
+            ctx
+        };
+        let tail = Tail::Done(TailDone::default());
+
+        // Production: Head sleeps until `restart` ...
+        let mut ctx = mk(0);
+        let (action, head) = ctx.step_head(Head::Idle(HeadIdle::default()), &tail);
+        assert!(matches!(head, Head::Idle(_)));
+        let Action::Sleep { wake_after } = action else {
+            panic!("expected Sleep until restart, got {action:?}");
+        };
+        assert!(
+            wake_after <= interval && wake_after > interval - Duration::from_secs(1),
+            "wake_after {wake_after:?} is not about one interval {interval:?}",
+        );
+
+        // ... and stops once it has elapsed.
+        ctx.now = ctx.task.restart;
+        let (action, head) = ctx.step_head(head, &tail);
+        assert!(matches!(head, Head::Stop));
+        assert!(matches!(action, Action::PollAgain));
+
+        // Preview / test harness: stops at EOF immediately, `restart`
+        // notwithstanding.
+        let mut ctx = mk(u32::MAX);
+        let (action, head) = ctx.step_head(Head::Idle(HeadIdle::default()), &tail);
+        assert!(matches!(head, Head::Stop));
         assert!(matches!(action, Action::PollAgain));
     }
 

--- a/crates/runtime-next/src/leader/capture/task.rs
+++ b/crates/runtime-next/src/leader/capture/task.rs
@@ -17,6 +17,8 @@ pub struct Task {
     pub explicit_acknowledgements: bool,
     /// Transactions to complete before stopping, or zero for unbounded.
     /// Set only by the preview / test harness; production leaves it zero.
+    /// A non-zero bound also stops the session at connector EOF, where
+    /// production holds it through the poll interval (`restart`).
     pub max_transactions: u32,
     /// Salt used for redacting sensitive fields.
     pub redact_salt: bytes::Bytes,

--- a/crates/runtime-next/src/shard/capture/actor.rs
+++ b/crates/runtime-next/src/shard/capture/actor.rs
@@ -71,7 +71,7 @@ pub(super) struct Actor<P: crate::Publisher, L: crate::Logger> {
     drain_input: Option<DrainInput>,
 
     // --- In-flight IO futures; `None` when idle. ---
-    acknowledge_fut: Option<BoxFuture<'static, anyhow::Result<()>>>,
+    acknowledge_fut: Option<BoxFuture<'static, ()>>,
     drain_fut: Option<BoxFuture<'static, anyhow::Result<drain::Output<P>>>>,
     intents_write_fut: Option<BoxFuture<'static, tonic::Result<P>>>,
     labels_apply_fut: Option<LabelsApplyFut<P>>,
@@ -336,8 +336,7 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                         None => {}
                     }
                 }
-                Some(result) = maybe_fut(&mut self.acknowledge_fut) => {
-                    result?;
+                Some(()) = maybe_fut(&mut self.acknowledge_fut) => {
                     self.acknowledge_fut = None;
                 }
                 Some(result) = maybe_fut(&mut self.intents_write_fut) => {
@@ -574,13 +573,18 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
                 let connector_tx = self.connector_tx.clone();
                 self.acknowledge_fut = Some(
                     async move {
-                        connector_tx
+                        // Sends to the connector are best-effort: a connector
+                        // which exited has closed its channel, and the
+                        // acknowledgement is moot once it has -- the commit is
+                        // durable, and it recovers from persisted state on its
+                        // next session. Connector failures surface on the
+                        // receive side, never here.
+                        _ = connector_tx
                             .send(Request {
                                 acknowledge: Some(request::Acknowledge { checkpoints }),
                                 ..Default::default()
                             })
-                            .await
-                            .context("sending connector Acknowledge")
+                            .await;
                     }
                     .boxed(),
                 );
@@ -1218,6 +1222,64 @@ mod tests {
 
         // The committing Persist durably recorded the connector state.
         let (_db, recover) = session.recover().await;
+        assert_eq!(
+            recover.connector_state_json.as_ref(),
+            br#"{"cursor":"lsn-9"}"#
+        );
+    }
+
+    /// A connector which exits before its committed transaction is acknowledged
+    /// must not fail the session: sends to the connector are best-effort, and
+    /// the acknowledgement is moot once it has exited -- the commit is durable,
+    /// and the connector recovers from persisted state on its next session.
+    /// This is routine for polling captures, which emit a final Checkpoint and
+    /// exit without awaiting its Acknowledge.
+    #[tokio::test]
+    async fn connector_exit_before_acknowledge_is_benign() {
+        let (conn_resp_tx, conn_resp_rx) =
+            mpsc::channel::<tonic::Result<Response>>(crate::CHANNEL_BUFFER);
+        let (_controller_tx, controller_rx) =
+            mpsc::unbounded_channel::<tonic::Result<proto::Capture>>();
+
+        let task = std::sync::Arc::new(mk_task(true));
+        let (actor, actor_to_conn_rx) = mk_actor(
+            &task,
+            BTreeMap::new(),
+            crate::shard::RocksDB::open(None).await.unwrap(),
+            true, // is_shard_zero
+            crate::TracingLogger,
+            RecordingPublisher::default(),
+        );
+        // The connector has exited: its request channel is closed before the
+        // actor can send the post-commit Acknowledge.
+        std::mem::drop(actor_to_conn_rx);
+
+        for response in [
+            captured(0, br#"{"id":"a0"}"#),
+            checkpoint(br#"{"cursor":"lsn-9"}"#),
+        ] {
+            conn_resp_tx.send(response).await.unwrap();
+        }
+        // Response stream EOF. Once the Tail drains, the Head steps to Stop on
+        // its own (the fixture's `restart` Clock is zero, and thus elapsed).
+        std::mem::drop(conn_resp_tx);
+
+        let mut controller_rx = UnboundedReceiverStream::new(controller_rx);
+        let (db, _shapes) = actor
+            .serve(
+                ReceiverStream::new(conn_resp_rx),
+                &mut controller_rx,
+                fsm::Head::Idle(fsm::HeadIdle::default()),
+                fsm::Tail::Recover(fsm::TailRecover {
+                    checkpoints: 0,
+                    ack_intents: BTreeMap::new(),
+                }),
+            )
+            .await
+            .expect("session must stop cleanly despite the closed connector channel");
+
+        // The transaction nonetheless committed durably.
+        let (_db, recover) = db.scan(state_keys(&task)).await.unwrap();
         assert_eq!(
             recover.connector_state_json.as_ref(),
             br#"{"cursor":"lsn-9"}"#

--- a/crates/runtime-next/src/shard/derive/actor.rs
+++ b/crates/runtime-next/src/shard/derive/actor.rs
@@ -327,13 +327,24 @@ impl<P: crate::Publisher, L: crate::Logger> Actor<P, L> {
             .connector_tx
             .capacity()
             .min(self.connector_pending.len());
-        let permits = self
-            .connector_tx
-            .try_reserve_many(n)
-            .expect("capacity was just observed and we are the sole sender");
 
-        for (request, permit) in self.connector_pending.drain(..n).zip(permits) {
-            permit.send(request);
+        match self.connector_tx.try_reserve_many(n) {
+            Ok(permits) => {
+                for (request, permit) in self.connector_pending.drain(..n).zip(permits) {
+                    permit.send(request);
+                }
+            }
+            // Sends to the connector are best-effort: a Closed channel means the
+            // connector exited, which surfaces on the receive side rather than
+            // here. `capacity()` is blind to closure, so Closed is reachable
+            // despite the capacity just observed. Drop what's pending.
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                self.connector_pending.clear();
+                return idle;
+            }
+            Err(mpsc::error::TrySendError::Full(())) => {
+                unreachable!("capacity was just observed and we are the sole sender")
+            }
         }
         // Wake when more capacity becomes available.
         future::Either::Left(self.connector_tx.clone().reserve_owned().map(ok))

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -343,13 +343,24 @@ impl Actor {
             .connector_tx
             .capacity()
             .min(self.connector_pending.len());
-        let permits = self
-            .connector_tx
-            .try_reserve_many(n)
-            .expect("capacity was just observed and we are the sole sender");
 
-        for (request, permit) in self.connector_pending.drain(..n).zip(permits) {
-            permit.send(request);
+        match self.connector_tx.try_reserve_many(n) {
+            Ok(permits) => {
+                for (request, permit) in self.connector_pending.drain(..n).zip(permits) {
+                    permit.send(request);
+                }
+            }
+            // Sends to the connector are best-effort: a Closed channel means the
+            // connector exited, which surfaces on the receive side rather than
+            // here. `capacity()` is blind to closure, so Closed is reachable
+            // despite the capacity just observed. Drop what's pending.
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                self.connector_pending.clear();
+                return idle;
+            }
+            Err(mpsc::error::TrySendError::Full(())) => {
+                unreachable!("capacity was just observed and we are the sole sender")
+            }
         }
         // Wake when more capacity becomes available.
         future::Either::Left(self.connector_tx.clone().reserve_owned().map(ok))

--- a/go/protocols/runtime/runtime.pb.go
+++ b/go/protocols/runtime/runtime.pb.go
@@ -1515,8 +1515,11 @@ var xxx_messageInfo_Joined proto.InternalMessageInfo
 type Task struct {
 	// Task specification (protobuf-encoded bytes).
 	Spec []byte `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
-	// Maximum number of transactions to run before exiting. Zero means unlimited.
-	// Used by "preview" workflows.
+	// Maximum number of transactions to run before exiting. Zero means unlimited
+	// and selects production semantics: on connector exit, a capture session
+	// holds until its poll interval elapses. A non-zero bound instead stops the
+	// capture session at connector EOF. Set only by "preview" workflows and test
+	// harnesses; production leaves it zero.
 	MaxTransactions uint32 `protobuf:"varint,3,opt,name=max_transactions,json=maxTransactions,proto3" json:"max_transactions,omitempty"`
 	// URL of a SQLite VFS the shard threads to a SQLite derive connector via
 	// `DeriveRequestExt.open.sqlite_vfs_uri` on C:Open. Set by the controller

--- a/go/protocols/runtime/runtime.proto
+++ b/go/protocols/runtime/runtime.proto
@@ -474,8 +474,11 @@ message Task {
 
   // Task specification (protobuf-encoded bytes).
   bytes spec = 1;
-  // Maximum number of transactions to run before exiting. Zero means unlimited.
-  // Used by "preview" workflows.
+  // Maximum number of transactions to run before exiting. Zero means unlimited
+  // and selects production semantics: on connector exit, a capture session
+  // holds until its poll interval elapses. A non-zero bound instead stops the
+  // capture session at connector EOF. Set only by "preview" workflows and test
+  // harnesses; production leaves it zero.
   uint32 max_transactions = 3;
   // URL of a SQLite VFS the shard threads to a SQLite derive connector via
   // `DeriveRequestExt.open.sqlite_vfs_uri` on C:Open. Set by the controller


### PR DESCRIPTION
Two related fixes surfaced by migrating the Go capture snapshot tests in estuary/connectors from `flowctl preview` (V1) to `flowctl raw preview-next` (V2).

## Sends to connectors are best-effort, never fatal

A capture connector which exits cleanly closes its request channel, and may do so while the leader still owes an `Acknowledge` for a committed transaction — routine for polling captures, which emit a final Checkpoint and exit without awaiting its acknowledgement. The actor treated the failed send as a fatal shard error (`sending connector Acknowledge: channel closed`), a race observed at ~3% of runs across `sqlcapture`-based connector snapshot suites (which enable explicit acknowledgements).

Sends to connectors are now best-effort: the acknowledgement is moot once the connector has exited — the commit is durable, and it recovers from persisted state on its next session. Connector failures surface on the receive side, never on sends. The same policy is applied to the one other violating site: the materialize and derive `try_connector_tx` drains panicked on a `Closed` channel (`capacity()` is blind to closure, so the partial-capacity `expect` was reachable when a connector crashed with requests still queued); they now drop pending requests instead.

New actor-level test: a connector whose channel is closed before the post-commit `Acknowledge` no longer fails the session, and the transaction still commits durably.

## Preview capture sessions stop at connector EOF

V2 preview modeled production on capture connector EOF: the FSM held the session open, sleeping until the poll interval elapsed, so `preview-next` ran until `--timeout` rather than until the connector was done — contradicting its own `--help` text ("the session will still end upon a connector exit / EOF").

The capture FSM now stops the session at connector EOF when `max_transactions != 0` — set only by preview and test harnesses; production leaves it zero and keeps the interval hold. flowctl maps explicit `--sessions` values ≤ 0 to `u32::MAX` (practically unlimited, but non-zero so the gate fires), while an *unset* `--sessions` remains the one spelling of "act as production does", poll-interval hold included. `--help` and the `runtime.proto` comment are updated to match (comment-only codegen churn).

New FSM test covers both arms: production sleeps until `task.restart` then stops; a harness session stops at EOF immediately.

## Follow-up in estuary/connectors

With this change the blackbox harness can drop its `interval: 0s` workaround (it passes `--sessions=-1`), and the Go capture snapshots need regeneration for benign V2 differences (transaction granularity, per-transaction document ordering, `preview-next` error strings).