### PR TITLE
control-plane-api: live capability-ceiling threading (#3376 task 3c)

### DIFF
--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -180,6 +180,12 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
             row.user_id,
             &row.capture_name,
             models::authz::Capability::SpecEdit,
+            // Deliberately unmasked: this is an async executor, where the
+            // requesting JWT and its capability mask are gone and
+            // authorization is by user identity. Threading a persisted mask
+            // across the async boundary — and deciding whether it should
+            // propagate at all — is the dedicated discovers follow-up task
+            // of the #3376 plan.
             models::authz::CapabilityMask::ALL_CAPABILITIES,
         ) {
             // Request an early background refresh: the grant may have been
@@ -210,6 +216,7 @@ impl<C: DiscoverConnectors> DiscoverExecutor<C> {
             row.user_id,
             &row.data_plane_name,
             models::Capability::Read,
+            // Deliberately unmasked; see the SpecEdit check above.
             models::authz::CapabilityMask::ALL_CAPABILITIES,
         )
         .then(|| snapshot.data_plane_by_catalog_name(&row.data_plane_name))

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -65,6 +65,25 @@ impl Requirement for RequireUnmasked {
     const REQUIRE_UNMASKED: bool = true;
 }
 
+/// A [`Requirement`] of the Viewer-bundle capability bits — what a legacy
+/// `models::Capability::Read` walk requires.
+///
+/// Declared by routes whose entire authorization is a Read-capability walk
+/// (`/api/v1/catalog/status`, `/api/v1/metrics`), so a mask shortfall is
+/// rejected at extraction, before the handler runs. The set is spelled as a
+/// literal because `CapabilityBundle::capabilities` is not a `const fn`;
+/// a test pins it to `bits_for_legacy(Read)` so the two cannot drift.
+pub struct RequireViewer;
+
+impl Requirement for RequireViewer {
+    const REQUIRED: CapabilitySet = enumset::enum_set!(
+        models::authz::Capability::CatalogRead
+            | models::authz::Capability::JournalRead
+            | models::authz::Capability::ViewDataPlanePrivateNetworking
+    );
+    const REQUIRE_UNMASKED: bool = false;
+}
+
 /// Forbidden is the structured body of a capability-shortfall `403`.
 ///
 /// Its shape is stable and machine-readable across the REST and GraphQL
@@ -110,6 +129,32 @@ impl Forbidden {
 impl axum::response::IntoResponse for Forbidden {
     fn into_response(self) -> axum::response::Response {
         (axum::http::StatusCode::FORBIDDEN, axum::Json(self)).into_response()
+    }
+}
+
+/// AuthZError is a denial from an authorization policy evaluation, and the
+/// distinction between its variants is load-bearing for
+/// [`crate::Envelope::authorization_outcome`]: a `Retriable` denial may be
+/// provisional — the Snapshot may simply not yet reflect a recently-committed
+/// grant — and enters the refresh-and-retry machinery, while a `Definitive`
+/// denial is a pure function of the bearer's verified claims (its capability
+/// mask), which no future Snapshot can change, and fails immediately with the
+/// structured `403` body.
+#[derive(Debug)]
+pub enum AuthZError {
+    Retriable(tonic::Status),
+    Definitive(Forbidden),
+}
+
+impl From<tonic::Status> for AuthZError {
+    fn from(status: tonic::Status) -> Self {
+        Self::Retriable(status)
+    }
+}
+
+impl From<Forbidden> for AuthZError {
+    fn from(forbidden: Forbidden) -> Self {
+        Self::Definitive(forbidden)
     }
 }
 

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -122,7 +122,7 @@ impl Forbidden {
     /// claims — when `mask` doesn't cover `required`, evaluated before the
     /// grant walk so the structured 403 names the missing capabilities
     /// without consulting (or disclosing anything about) the user's grants.
-    pub fn require_mask_covers(
+    pub fn required_covered(
         mask: CapabilityMask,
         required: impl Into<CapabilitySet>,
     ) -> Result<(), Self> {

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -158,6 +158,21 @@ impl From<Forbidden> for AuthZError {
     }
 }
 
+#[cfg(test)]
+impl AuthZError {
+    /// Map to the (HTTP status, message) pair which handler test harnesses
+    /// snapshot as their `Outcome::Err` shape.
+    pub(crate) fn into_status_message(self) -> (u16, String) {
+        match self {
+            Self::Retriable(status) => (
+                tokens::rest::grpc_status_code_to_http(status.code()),
+                status.message().to_string(),
+            ),
+            Self::Definitive(forbidden) => (403, forbidden.message),
+        }
+    }
+}
+
 /// Rejection is an error of Authority extraction.
 #[derive(Debug, thiserror::Error)]
 pub enum Rejection {

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -117,6 +117,24 @@ impl Forbidden {
         }
     }
 
+    /// The mask-shortfall pre-check shared by every authorization policy
+    /// function: a definitive denial — a pure function of the bearer's
+    /// claims — when `mask` doesn't cover `required`, evaluated before the
+    /// grant walk so the structured 403 names the missing capabilities
+    /// without consulting (or disclosing anything about) the user's grants.
+    pub fn require_mask_covers(
+        mask: CapabilityMask,
+        required: impl Into<CapabilitySet>,
+    ) -> Result<(), Self> {
+        let required: CapabilitySet = required.into();
+        let missing = required - mask.apply(required);
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(Self::missing_capabilities(missing))
+        }
+    }
+
     pub fn unmasked_token_required() -> Self {
         Self {
             error: "unmasked_token_required",

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -70,17 +70,12 @@ impl Requirement for RequireUnmasked {
 ///
 /// Declared by routes whose entire authorization is a Read-capability walk
 /// (`/api/v1/catalog/status`, `/api/v1/metrics`), so a mask shortfall is
-/// rejected at extraction, before the handler runs. The set is spelled as a
-/// literal because `CapabilityBundle::capabilities` is not a `const fn`;
-/// a test pins it to `bits_for_legacy(Read)` so the two cannot drift.
+/// rejected at extraction, before the handler runs. A test pins the bundle
+/// to `bits_for_legacy(Read)` so the two cannot drift.
 pub struct RequireViewer;
 
 impl Requirement for RequireViewer {
-    const REQUIRED: CapabilitySet = enumset::enum_set!(
-        models::authz::Capability::CatalogRead
-            | models::authz::Capability::JournalRead
-            | models::authz::Capability::ViewDataPlanePrivateNetworking
-    );
+    const REQUIRED: &'static [CapabilityBundle] = &[CapabilityBundle::Viewer];
     const REQUIRE_UNMASKED: bool = false;
 }
 

--- a/crates/control-plane-api/src/envelope.rs
+++ b/crates/control-plane-api/src/envelope.rs
@@ -99,7 +99,9 @@ impl Envelope {
     ///
     /// This method handles the complexity of Snapshot refresh, retry logic,
     /// and cordoning. Call it with a AuthZResult from your authorization
-    /// evaluation policy function.
+    /// evaluation policy function. Only [`crate::AuthZError::Retriable`]
+    /// denials participate in refresh-and-retry; a definitive denial is
+    /// returned immediately as [`crate::ApiError::Forbidden`].
     pub async fn authorization_outcome<Ok>(
         &self,
         policy_result: crate::AuthZResult<Ok>,
@@ -368,9 +370,9 @@ mod test {
 
     #[tokio::test]
     async fn test_retriable_denial_with_stale_snapshot_awaits_refresh() {
-        // The pre-existing provisional path: a walk denial against a Snapshot
-        // older than the request is not yet definitive, and becomes a client
-        // retry. This pins that Definitive and Retriable actually diverge.
+        // A walk denial against a Snapshot older than the request is not yet
+        // definitive, and becomes a client retry. This pins that Retriable
+        // and Definitive actually diverge.
         let env = envelope(chrono::TimeDelta::minutes(1)).await;
 
         let status = tonic::Status::permission_denied("not authorized");

--- a/crates/control-plane-api/src/envelope.rs
+++ b/crates/control-plane-api/src/envelope.rs
@@ -123,9 +123,15 @@ impl Envelope {
             Ok((Some(cordon_at), ok)) if cordon_at > self.started => {
                 return Ok((std::cmp::min(exp, cordon_at), ok));
             }
+            // A definitive denial is a pure function of the bearer's verified
+            // claims: no future Snapshot can change it, so it fails
+            // immediately rather than entering the retry machinery below.
+            Err(crate::AuthZError::Definitive(forbidden)) => {
+                return Err(crate::ApiError::Forbidden(forbidden));
+            }
             // Authorization is invalid and the Snapshot was taken after the
             // start of the authorization request. Terminal failure.
-            Err(status) if snapshot.taken_after(self.started) => {
+            Err(crate::AuthZError::Retriable(status)) if snapshot.taken_after(self.started) => {
                 return Err(status.into());
             }
             // Authorization is valid but is currently cordoned, and we must
@@ -137,7 +143,7 @@ impl Envelope {
             // Authorization is invalid but the Snapshot is older than the start
             // of the authorization request. It's possible that the requestor has
             // more-recent knowledge that the authorization is valid.
-            Err(status) => status,
+            Err(crate::AuthZError::Retriable(status)) => status,
         };
 
         // We must await a future Snapshot to determine the definitive outcome.
@@ -299,3 +305,95 @@ impl axum::extract::FromRequestParts<Arc<crate::App>> for Envelope {
 // Empty impl allows aide to generate OpenAPI specs for handlers using this extractor.
 // The extractor is an internal detail and doesn't appear in the API documentation.
 impl aide::operation::OperationInput for Envelope {}
+
+#[cfg(test)]
+mod test {
+    use super::{Envelope, Locale, MaybeControlClaims};
+
+    /// Build an Envelope whose logical start is `started_delta` relative to
+    /// when its (empty) Snapshot was taken. A positive delta means the request
+    /// began after the Snapshot — the condition under which a walk denial is
+    /// provisional and held for refresh.
+    async fn envelope(started_delta: chrono::TimeDelta) -> Envelope {
+        let refresh = crate::test_server::empty_snapshot().await.token();
+        let taken = refresh.result().unwrap().taken;
+
+        Envelope {
+            original_uri: "/test".parse().unwrap(),
+            maybe_claims: MaybeControlClaims::with_unauthenticated(),
+            retry_after: tokens::DateTime::UNIX_EPOCH,
+            refresh,
+            started: taken + started_delta,
+            // Never dialed: authorization_outcome doesn't touch the database.
+            pg_pool: sqlx::PgPool::connect_lazy("postgres://unused").unwrap(),
+            locale: Locale::EnUS,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_definitive_denial_bypasses_snapshot_retry() {
+        // The request began after the Snapshot was taken: a retriable walk
+        // denial would be held in limbo awaiting a refresh. A definitive
+        // denial is a pure function of the bearer's claims which no future
+        // Snapshot can change, so it must fail immediately instead.
+        let env = envelope(chrono::TimeDelta::minutes(1)).await;
+
+        let forbidden =
+            crate::Forbidden::missing_capabilities(models::authz::Capability::SpecEdit.into());
+        let result: Result<_, crate::ApiError> =
+            env.authorization_outcome::<()>(Err(forbidden.into())).await;
+
+        let Err(crate::ApiError::Forbidden(forbidden)) = result else {
+            panic!("expected an immediate ApiError::Forbidden, got {result:?}");
+        };
+        assert_eq!(forbidden.missing_capabilities, vec!["SpecEdit"]);
+    }
+
+    #[tokio::test]
+    async fn test_definitive_denial_with_fresh_snapshot() {
+        // A fresh Snapshot changes nothing: definitive denials are Forbidden
+        // regardless of Snapshot ordering.
+        let env = envelope(-chrono::TimeDelta::minutes(1)).await;
+
+        let forbidden =
+            crate::Forbidden::missing_capabilities(models::authz::Capability::CatalogRead.into());
+        let result: Result<_, crate::ApiError> =
+            env.authorization_outcome::<()>(Err(forbidden.into())).await;
+
+        assert!(
+            matches!(result, Err(crate::ApiError::Forbidden(_))),
+            "expected ApiError::Forbidden, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retriable_denial_with_stale_snapshot_awaits_refresh() {
+        // The pre-existing provisional path: a walk denial against a Snapshot
+        // older than the request is not yet definitive, and becomes a client
+        // retry. This pins that Definitive and Retriable actually diverge.
+        let env = envelope(chrono::TimeDelta::minutes(1)).await;
+
+        let status = tonic::Status::permission_denied("not authorized");
+        let result: Result<(tokens::DateTime, ()), _> =
+            env.authorization_outcome(Err(status.into())).await;
+
+        let Err(crate::ApiError::AuthZRetry(retry)) = result else {
+            panic!("expected ApiError::AuthZRetry, got {result:?}");
+        };
+        assert_eq!(retry.status.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn test_retriable_denial_with_fresh_snapshot_is_terminal() {
+        let env = envelope(-chrono::TimeDelta::minutes(1)).await;
+
+        let status = tonic::Status::permission_denied("not authorized");
+        let result: Result<(tokens::DateTime, ()), _> =
+            env.authorization_outcome(Err(status.into())).await;
+
+        let Err(crate::ApiError::Status(status)) = result else {
+            panic!("expected terminal ApiError::Status, got {result:?}");
+        };
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    }
+}

--- a/crates/control-plane-api/src/lib.rs
+++ b/crates/control-plane-api/src/lib.rs
@@ -43,8 +43,10 @@ pub type DataClaims = proto_gazette::Claims;
 ///
 /// Its Ok variant contains an optional `cordon_at` DateTime which denotes when
 /// the authorization will become invalid due to cordoning, which (when present)
-/// upper-bounds the expiry of a derived authorization.
-pub type AuthZResult<Ok> = tonic::Result<(Option<tokens::DateTime>, Ok)>;
+/// upper-bounds the expiry of a derived authorization. Its Err variant
+/// distinguishes Snapshot-retriable denials from definitive ones; see
+/// [`AuthZError`].
+pub type AuthZResult<Ok> = Result<(Option<tokens::DateTime>, Ok), AuthZError>;
 
 /// Envelope is common fields and parameters of every API request.
 pub use envelope::{Envelope, Locale, MaybeControlClaims};
@@ -52,7 +54,9 @@ pub use envelope::{Envelope, Locale, MaybeControlClaims};
 /// Authority is the authenticated context of an API request: an Envelope
 /// plus the capability mask of the bearer's `capability_mask` claim, with
 /// the route's Requirement evaluated at extraction.
-pub use authority::{Authority, Forbidden, NoRequirement, RequireUnmasked, Requirement};
+pub use authority::{
+    AuthZError, Authority, Forbidden, NoRequirement, RequireUnmasked, RequireViewer, Requirement,
+};
 
 // TODO(johnny): These types are all fundamental to this crate, and should be
 // hoisted from the `server` module. For now, just re-export to minimize churn.

--- a/crates/control-plane-api/src/live_specs/mod.rs
+++ b/crates/control-plane-api/src/live_specs/mod.rs
@@ -28,6 +28,12 @@ fn partition_by_authorization<'n>(
                 user_id,
                 name,
                 capability,
+                // Deliberately unmasked: this filter serves only async
+                // executors (discovers, publication initialization), where
+                // the original JWT and its capability mask are gone and
+                // authorization is by user identity. Threading a persisted
+                // mask across that boundary is the dedicated follow-up task
+                // of the #3376 plan (mask evaporation at async boundaries).
                 models::authz::CapabilityMask::ALL_CAPABILITIES,
             )
         });

--- a/crates/control-plane-api/src/server/authorize_dekaf.rs
+++ b/crates/control-plane-api/src/server/authorize_dekaf.rs
@@ -67,7 +67,7 @@ pub async fn authorize_dekaf(
                 ..Default::default()
             }));
         }
-        Err(err @ crate::ApiError::Status(_)) => return Err(err),
+        Err(err) => return Err(err),
     };
 
     let (spec_type, built_spec) = sqlx::query!(
@@ -140,7 +140,8 @@ fn evaluate_authorization(
     else {
         return Err(tonic::Status::unauthenticated(
             "no data-plane keys validated against the token signature",
-        ));
+        )
+        .into());
     };
 
     // First, try to find task in the requesting dataplane by mapping
@@ -153,7 +154,8 @@ fn evaluate_authorization(
             return Err(tonic::Status::failed_precondition(format!(
                 "task {task_name} must be a materialization, but is {:?} instead",
                 task.spec_type
-            )));
+            ))
+            .into());
         }
 
         let (Some(ops_logs), Some(ops_stats)) = (
@@ -163,7 +165,8 @@ fn evaluate_authorization(
             return Err(tonic::Status::internal(format!(
                 "couldn't resolve data-plane {} ops collections",
                 task.data_plane_id
-            )));
+            ))
+            .into());
         };
 
         let ops_suffix = super::ops_suffix(task);
@@ -188,7 +191,8 @@ fn evaluate_authorization(
             return Err(tonic::Status::failed_precondition(format!(
                 "task {task_name} must be a materialization, but is {:?} instead",
                 task.spec_type
-            )));
+            ))
+            .into());
         }
 
         let Some(target_dataplane) = snapshot
@@ -198,7 +202,8 @@ fn evaluate_authorization(
         else {
             return Err(tonic::Status::internal(format!(
                 "target dataplane for task {task_name} not found"
-            )));
+            ))
+            .into());
         };
 
         return Ok((
@@ -213,9 +218,7 @@ fn evaluate_authorization(
         ));
     }
 
-    Err(tonic::Status::not_found(format!(
-        "task {task_name} not found"
-    )))
+    Err(tonic::Status::not_found(format!("task {task_name} not found")).into())
 }
 
 const DEKAF_ROLE: &str = "dekaf";
@@ -354,9 +357,13 @@ mod tests {
                     Outcome::Ok(authz_result)
                 }
             }
-            Err(status) => Outcome::Err {
+            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
                 status: tokens::rest::grpc_status_code_to_http(status.code()),
                 error: status.message().to_string(),
+            },
+            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
+                status: 403,
+                error: forbidden.message,
             },
         }
     }

--- a/crates/control-plane-api/src/server/authorize_dekaf.rs
+++ b/crates/control-plane-api/src/server/authorize_dekaf.rs
@@ -357,14 +357,10 @@ mod tests {
                     Outcome::Ok(authz_result)
                 }
             }
-            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
-                status: tokens::rest::grpc_status_code_to_http(status.code()),
-                error: status.message().to_string(),
-            },
-            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
-                status: 403,
-                error: forbidden.message,
-            },
+            Err(err) => {
+                let (status, error) = err.into_status_message();
+                Outcome::Err { status, error }
+            }
         }
     }
 

--- a/crates/control-plane-api/src/server/authorize_task.rs
+++ b/crates/control-plane-api/src/server/authorize_task.rs
@@ -79,7 +79,7 @@ pub async fn authorize_task(
                     ..Default::default()
                 }));
             }
-            Err(err @ crate::ApiError::Status(_)) => return Err(err),
+            Err(err) => return Err(err),
         };
 
     // Build and sign response claims.
@@ -136,7 +136,8 @@ fn evaluate_authorization(
     else {
         return Err(tonic::Status::unauthenticated(
             "no data-plane keys validated against the token signature",
-        ));
+        )
+        .into());
     };
 
     // Map `claims.sub`, a Shard ID, into a task running in `task_data_plane`.
@@ -146,7 +147,8 @@ fn evaluate_authorization(
     else {
         return Err(tonic::Status::failed_precondition(format!(
             "task shard {shard_id} within data-plane {shard_data_plane_fqdn} is not known"
-        )));
+        ))
+        .into());
     };
 
     // Map a required `name` journal label selector into its collection.
@@ -159,7 +161,8 @@ fn evaluate_authorization(
             return Err(tonic::Status::internal(format!(
                 "collection {} data-plane {} not found",
                 collection.collection_name, collection.data_plane_id,
-            )));
+            ))
+            .into());
         };
 
         // As a special case outside of the RBAC system, allow a task to write
@@ -195,14 +198,15 @@ fn evaluate_authorization(
         );
         return Err(tonic::Status::permission_denied(format!(
             "task shard {shard_id} is not authorized to {journal_name_or_prefix} for {required_role:?}"
-        )));
+        )).into());
     }
 
     let Some(encoding_key) = collection_data_plane.hmac_keys.first() else {
         return Err(tonic::Status::internal(format!(
             "collection data-plane {} has no configured HMAC keys",
             collection_data_plane.data_plane_name
-        )));
+        ))
+        .into());
     };
     let encoding_key =
         tokens::jwt::EncodingKey::from_secret(&tokens::jwt::parse_base64(encoding_key)?);
@@ -231,7 +235,8 @@ fn evaluate_authorization(
     if !found && !snapshot.taken_after(started) {
         return Err(tonic::Status::unavailable(format!(
             "{journal_name_or_prefix} does not map to a known collection"
-        )));
+        ))
+        .into());
     }
 
     Ok((
@@ -470,9 +475,13 @@ mod tests {
                     Outcome::Ok(output)
                 }
             }
-            Err(status) => Outcome::Err {
+            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
                 status: tokens::rest::grpc_status_code_to_http(status.code()),
                 error: status.message().to_string(),
+            },
+            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
+                status: 403,
+                error: forbidden.message,
             },
         }
     }

--- a/crates/control-plane-api/src/server/authorize_task.rs
+++ b/crates/control-plane-api/src/server/authorize_task.rs
@@ -475,14 +475,10 @@ mod tests {
                     Outcome::Ok(output)
                 }
             }
-            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
-                status: tokens::rest::grpc_status_code_to_http(status.code()),
-                error: status.message().to_string(),
-            },
-            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
-                status: 403,
-                error: forbidden.message,
-            },
+            Err(err) => {
+                let (status, error) = err.into_status_message();
+                Outcome::Err { status, error }
+            }
         }
     }
 

--- a/crates/control-plane-api/src/server/authorize_user_collection.rs
+++ b/crates/control-plane-api/src/server/authorize_user_collection.rs
@@ -70,15 +70,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    // A mask which doesn't cover `capability` is a definitive denial — a pure
-    // function of the bearer's claims — evaluated before any walk so that the
-    // structured 403 names the missing capabilities without consulting (or
-    // disclosing anything about) the user's grants.
-    let required: models::authz::CapabilitySet = capability.into();
-    let missing = required - mask.apply(required);
-    if !missing.is_empty() {
-        return Err(crate::Forbidden::missing_capabilities(missing).into());
-    }
+    crate::Forbidden::require_mask_covers(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_collection.rs
+++ b/crates/control-plane-api/src/server/authorize_user_collection.rs
@@ -5,7 +5,9 @@ type Response = models::authorizations::UserCollectionAuthorization;
 #[tracing::instrument(skip(env), err(Debug, level = tracing::Level::WARN))]
 pub async fn authorize_user_collection(
     crate::Authority {
-        envelope: mut env, ..
+        envelope: mut env,
+        mask,
+        ..
     }: crate::Authority,
     super::Request(Request {
         collection,
@@ -21,7 +23,7 @@ pub async fn authorize_user_collection(
     }
 
     let policy_result =
-        evaluate_authorization(env.snapshot(), env.claims()?, &collection, capability);
+        evaluate_authorization(env.snapshot(), env.claims()?, mask, &collection, capability);
 
     // Legacy: if `started_unix` was set then use a custom 200 response for client-side retries.
     let (expiry, (encoding_key, mut claims, broker_address, journal_name_prefix)) =
@@ -52,6 +54,7 @@ pub async fn authorize_user_collection(
 fn evaluate_authorization(
     snapshot: &crate::Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     collection_name: &models::Collection,
     capability: models::Capability,
 ) -> crate::AuthZResult<(
@@ -67,17 +70,28 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
+    // A mask which doesn't cover `capability` is a definitive denial — a pure
+    // function of the bearer's claims — evaluated before any walk so that the
+    // structured 403 names the missing capabilities without consulting (or
+    // disclosing anything about) the user's grants.
+    let required: models::authz::CapabilitySet = capability.into();
+    let missing = required - mask.apply(required);
+    if !missing.is_empty() {
+        return Err(crate::Forbidden::missing_capabilities(missing).into());
+    }
+
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,
         &snapshot.user_grants,
         *user_id,
         collection_name,
         capability,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ) {
         return Err(tonic::Status::permission_denied(format!(
             "{user_email} is not authorized to {collection_name} for {capability:?}",
-        )));
+        ))
+        .into());
     }
 
     // For admin capability, require that the user has a transitive role grant to estuary_support/
@@ -88,32 +102,34 @@ fn evaluate_authorization(
             *user_id,
             "estuary_support/",
             models::Capability::Admin,
-            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            mask,
         );
 
         if !has_support_access {
             return Err(tonic::Status::permission_denied(format!(
                 "{user_email} is not authorized to {collection_name} for Admin capability (requires estuary_support/ grant)",
-            )));
+            )).into());
         }
     }
 
     let Some(collection) = snapshot.collection_by_catalog_name(collection_name) else {
-        return Err(tonic::Status::not_found(format!(
-            "collection {collection_name} is not known"
-        )));
+        return Err(
+            tonic::Status::not_found(format!("collection {collection_name} is not known")).into(),
+        );
     };
     let Some(data_plane) = snapshot.data_planes.get_by_key(&collection.data_plane_id) else {
         return Err(tonic::Status::internal(format!(
             "collection data-plane {} not found",
             collection.data_plane_id
-        )));
+        ))
+        .into());
     };
     let Some(encoding_key) = data_plane.hmac_keys.first() else {
         return Err(tonic::Status::internal(format!(
             "collection data-plane {} has no configured HMAC keys",
             data_plane.data_plane_name
-        )));
+        ))
+        .into());
     };
     let encoding_key =
         tokens::jwt::EncodingKey::from_secret(&tokens::jwt::parse_base64(encoding_key)?);
@@ -349,6 +365,109 @@ mod tests {
         "###);
     }
 
+    #[test]
+    fn test_mask_shortfall_is_definitive() {
+        // Bob holds write on bobCo/, but the bearer's mask doesn't cover
+        // what a Write walk requires: a definitive 403 naming the missing
+        // capabilities, computed before (and disclosing nothing about) the
+        // grant walk.
+        let outcome = run_masked(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Collection::new("bobCo/anvils/peaches"),
+            models::Capability::Write,
+            Some(vec!["CatalogRead", "JournalRead"]),
+        );
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 403,
+            "error": "the bearer token's capability mask does not enable required capabilities: JournalAppend, ViewDataPlanePrivateNetworking"
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_empty_mask_denies_all_authorization() {
+        // An empty mask is a valid identity-only token: identity verifies,
+        // but every capability is missing.
+        let outcome = run_masked(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Collection::new("bobCo/anvils/peaches"),
+            models::Capability::Read,
+            Some(vec![]),
+        );
+
+        insta::assert_json_snapshot!(outcome, @r###"
+        {
+          "Err": {
+            "status": 403,
+            "error": "the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking"
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_covering_mask_matches_unmasked_outcome() {
+        // A mask which enables everything the operation requires yields the
+        // exact unmasked outcome (compare test_success).
+        let unmasked = run(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Collection::new("bobCo/anvils/peaches"),
+            models::Capability::Write,
+        );
+        let masked = run_masked(
+            uuid::Uuid::from_bytes([32; 16]),
+            Some("bob@bob".to_string()),
+            models::Collection::new("bobCo/anvils/peaches"),
+            models::Capability::Write,
+            Some(vec![
+                "CatalogRead",
+                "JournalRead",
+                "JournalAppend",
+                "ViewDataPlanePrivateNetworking",
+            ]),
+        );
+        assert_eq!(
+            serde_json::to_value(&unmasked).unwrap(),
+            serde_json::to_value(&masked).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_masked_admin_support_walk() {
+        // The estuary_support/ secondary walk runs under the same mask as
+        // every other walk of the request: alice passes with a mask covering
+        // the Admin requirement, identically to her unmasked outcome.
+        let all_names: Vec<&str> = models::authz::CapabilitySet::all()
+            .iter()
+            .map(|c| c.name())
+            .collect();
+
+        let unmasked = run(
+            uuid::Uuid::from_bytes([64; 16]),
+            Some("alice@alice".to_string()),
+            models::Collection::new("aliceCo/wonderland/data"),
+            models::Capability::Admin,
+        );
+        let masked = run_masked(
+            uuid::Uuid::from_bytes([64; 16]),
+            Some("alice@alice".to_string()),
+            models::Collection::new("aliceCo/wonderland/data"),
+            models::Capability::Admin,
+            Some(all_names),
+        );
+        assert_eq!(
+            serde_json::to_value(&unmasked).unwrap(),
+            serde_json::to_value(&masked).unwrap(),
+        );
+    }
+
     // Serialization wrapper that distinguishes cordoned vs non-cordoned success.
     #[derive(serde::Serialize)]
     enum Outcome {
@@ -367,6 +486,16 @@ mod tests {
         collection: models::Collection,
         capability: models::Capability,
     ) -> Outcome {
+        run_masked(user_id, email, collection, capability, None)
+    }
+
+    fn run_masked(
+        user_id: uuid::Uuid,
+        email: Option<String>,
+        collection: models::Collection,
+        capability: models::Capability,
+        capability_mask: Option<Vec<&str>>,
+    ) -> Outcome {
         let snapshot = crate::Snapshot::build_fixture(None);
         let claims = models::authorizations::ControlClaims {
             aud: "authenticated".to_string(),
@@ -375,10 +504,14 @@ mod tests {
             sub: user_id,
             role: "authenticated".to_string(),
             email,
-            capability_mask: None,
+            capability_mask: capability_mask
+                .map(|names| names.into_iter().map(String::from).collect()),
         };
+        // As the handler does: the mask is computed from the verified claim
+        // at extraction and passed alongside it.
+        let mask = models::authz::CapabilityMask::from_claim(claims.capability_mask.as_deref());
 
-        match evaluate_authorization(&snapshot, &claims, &collection, capability) {
+        match evaluate_authorization(&snapshot, &claims, mask, &collection, capability) {
             Ok((cordon_at, (_key, mut data_claims, broker_address, journal_name_prefix))) => {
                 // Zero out timestamps for stable snapshots.
                 data_claims.iat = 0;
@@ -390,9 +523,13 @@ mod tests {
                     Outcome::Ok((broker_address, journal_name_prefix, data_claims))
                 }
             }
-            Err(status) => Outcome::Err {
+            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
                 status: tokens::rest::grpc_status_code_to_http(status.code()),
                 error: status.message().to_string(),
+            },
+            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
+                status: 403,
+                error: forbidden.message,
             },
         }
     }

--- a/crates/control-plane-api/src/server/authorize_user_collection.rs
+++ b/crates/control-plane-api/src/server/authorize_user_collection.rs
@@ -523,14 +523,10 @@ mod tests {
                     Outcome::Ok((broker_address, journal_name_prefix, data_claims))
                 }
             }
-            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
-                status: tokens::rest::grpc_status_code_to_http(status.code()),
-                error: status.message().to_string(),
-            },
-            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
-                status: 403,
-                error: forbidden.message,
-            },
+            Err(err) => {
+                let (status, error) = err.into_status_message();
+                Outcome::Err { status, error }
+            }
         }
     }
 

--- a/crates/control-plane-api/src/server/authorize_user_collection.rs
+++ b/crates/control-plane-api/src/server/authorize_user_collection.rs
@@ -70,7 +70,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    crate::Forbidden::require_mask_covers(mask, capability)?;
+    crate::Forbidden::required_covered(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_prefix.rs
+++ b/crates/control-plane-api/src/server/authorize_user_prefix.rs
@@ -85,7 +85,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    crate::Forbidden::require_mask_covers(mask, capability)?;
+    crate::Forbidden::required_covered(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_prefix.rs
+++ b/crates/control-plane-api/src/server/authorize_user_prefix.rs
@@ -85,15 +85,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    // A mask which doesn't cover `capability` is a definitive denial — a pure
-    // function of the bearer's claims — evaluated before any walk so that the
-    // structured 403 names the missing capabilities without consulting (or
-    // disclosing anything about) the user's grants.
-    let required: models::authz::CapabilitySet = capability.into();
-    let missing = required - mask.apply(required);
-    if !missing.is_empty() {
-        return Err(crate::Forbidden::missing_capabilities(missing).into());
-    }
+    crate::Forbidden::require_mask_covers(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_prefix.rs
+++ b/crates/control-plane-api/src/server/authorize_user_prefix.rs
@@ -598,14 +598,10 @@ mod tests {
                     reactor_claims,
                 ))
             }
-            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
-                status: tokens::rest::grpc_status_code_to_http(status.code()),
-                error: status.message().to_string(),
-            },
-            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
-                status: 403,
-                error: forbidden.message,
-            },
+            Err(err) => {
+                let (status, error) = err.into_status_message();
+                Outcome::Err { status, error }
+            }
         }
     }
 

--- a/crates/control-plane-api/src/server/authorize_user_prefix.rs
+++ b/crates/control-plane-api/src/server/authorize_user_prefix.rs
@@ -5,7 +5,9 @@ type Response = models::authorizations::UserPrefixAuthorization;
 #[tracing::instrument(skip(env), err(Debug, level = tracing::Level::WARN))]
 pub async fn authorize_user_prefix(
     crate::Authority {
-        envelope: mut env, ..
+        envelope: mut env,
+        mask,
+        ..
     }: crate::Authority,
     super::Request(Request {
         prefix,
@@ -24,6 +26,7 @@ pub async fn authorize_user_prefix(
     let policy_result = evaluate_authorization(
         env.snapshot(),
         env.claims()?,
+        mask,
         &prefix,
         &data_plane,
         capability,
@@ -64,18 +67,16 @@ pub async fn authorize_user_prefix(
 fn evaluate_authorization(
     snapshot: &crate::Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     prefix: &models::Prefix,
     data_plane_name: &models::Name,
     capability: models::Capability,
-) -> tonic::Result<(
-    Option<chrono::DateTime<chrono::Utc>>,
-    (
-        tokens::jwt::EncodingKey,
-        proto_gazette::Claims, // Broker claims.
-        String,                // Broker address.
-        proto_gazette::Claims, // Reactor claims.
-        String,                // Reactor address.
-    ),
+) -> crate::AuthZResult<(
+    tokens::jwt::EncodingKey,
+    proto_gazette::Claims, // Broker claims.
+    String,                // Broker address.
+    proto_gazette::Claims, // Reactor claims.
+    String,                // Reactor address.
 )> {
     let models::authorizations::ControlClaims {
         sub: user_id,
@@ -84,17 +85,28 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
+    // A mask which doesn't cover `capability` is a definitive denial — a pure
+    // function of the bearer's claims — evaluated before any walk so that the
+    // structured 403 names the missing capabilities without consulting (or
+    // disclosing anything about) the user's grants.
+    let required: models::authz::CapabilitySet = capability.into();
+    let missing = required - mask.apply(required);
+    if !missing.is_empty() {
+        return Err(crate::Forbidden::missing_capabilities(missing).into());
+    }
+
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,
         &snapshot.user_grants,
         *user_id,
         prefix,
         capability,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ) {
         return Err(tonic::Status::permission_denied(format!(
             "{user_email} is not authorized to {prefix} for {capability:?}",
-        )));
+        ))
+        .into());
     }
 
     // For admin capability, require that the user has a transitive role grant to estuary_support/
@@ -105,13 +117,13 @@ fn evaluate_authorization(
             *user_id,
             "estuary_support/",
             models::Capability::Admin,
-            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            mask,
         );
 
         if !has_support_access {
             return Err(tonic::Status::permission_denied(format!(
                 "{user_email} is not authorized to {prefix} for Admin capability (requires estuary_support/ grant)",
-            )));
+            )).into());
         }
     }
 
@@ -121,22 +133,24 @@ fn evaluate_authorization(
         *user_id,
         data_plane_name,
         models::Capability::Read,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ) {
         return Err(tonic::Status::permission_denied(format!(
             "{user_email} is not authorized to {data_plane_name}",
-        )));
+        ))
+        .into());
     }
 
     let Some(data_plane) = snapshot.data_plane_by_catalog_name(data_plane_name) else {
-        return Err(tonic::Status::not_found(format!(
-            "data-plane {data_plane_name} not found"
-        )));
+        return Err(
+            tonic::Status::not_found(format!("data-plane {data_plane_name} not found")).into(),
+        );
     };
     let Some(encoding_key) = data_plane.hmac_keys.first() else {
         return Err(tonic::Status::internal(format!(
             "data-plane {data_plane_name} has no configured HMAC keys"
-        )));
+        ))
+        .into());
     };
     let encoding_key =
         tokens::jwt::EncodingKey::from_secret(&tokens::jwt::parse_base64(encoding_key)?);
@@ -559,7 +573,14 @@ mod tests {
             capability_mask: None,
         };
 
-        match evaluate_authorization(&snapshot, &claims, &prefix, &data_plane, capability) {
+        match evaluate_authorization(
+            &snapshot,
+            &claims,
+            models::authz::CapabilityMask::from_claim(claims.capability_mask.as_deref()),
+            &prefix,
+            &data_plane,
+            capability,
+        ) {
             Ok((
                 _cordon_at,
                 (_key, mut broker_claims, broker_address, mut reactor_claims, reactor_address),
@@ -577,9 +598,13 @@ mod tests {
                     reactor_claims,
                 ))
             }
-            Err(status) => Outcome::Err {
+            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
                 status: tokens::rest::grpc_status_code_to_http(status.code()),
                 error: status.message().to_string(),
+            },
+            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
+                status: 403,
+                error: forbidden.message,
             },
         }
     }

--- a/crates/control-plane-api/src/server/authorize_user_task.rs
+++ b/crates/control-plane-api/src/server/authorize_user_task.rs
@@ -92,15 +92,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    // A mask which doesn't cover `capability` is a definitive denial — a pure
-    // function of the bearer's claims — evaluated before any walk so that the
-    // structured 403 names the missing capabilities without consulting (or
-    // disclosing anything about) the user's grants.
-    let required: models::authz::CapabilitySet = capability.into();
-    let missing = required - mask.apply(required);
-    if !missing.is_empty() {
-        return Err(crate::Forbidden::missing_capabilities(missing).into());
-    }
+    crate::Forbidden::require_mask_covers(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_task.rs
+++ b/crates/control-plane-api/src/server/authorize_user_task.rs
@@ -560,14 +560,10 @@ mod tests {
                     Outcome::Ok(output)
                 }
             }
-            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
-                status: tokens::rest::grpc_status_code_to_http(status.code()),
-                error: status.message().to_string(),
-            },
-            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
-                status: 403,
-                error: forbidden.message,
-            },
+            Err(err) => {
+                let (status, error) = err.into_status_message();
+                Outcome::Err { status, error }
+            }
         }
     }
 

--- a/crates/control-plane-api/src/server/authorize_user_task.rs
+++ b/crates/control-plane-api/src/server/authorize_user_task.rs
@@ -92,7 +92,7 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    crate::Forbidden::require_mask_covers(mask, capability)?;
+    crate::Forbidden::required_covered(mask, capability)?;
 
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,

--- a/crates/control-plane-api/src/server/authorize_user_task.rs
+++ b/crates/control-plane-api/src/server/authorize_user_task.rs
@@ -5,7 +5,9 @@ type Response = models::authorizations::UserTaskAuthorization;
 #[tracing::instrument(skip(env), err(Debug, level = tracing::Level::WARN))]
 pub async fn authorize_user_task(
     crate::Authority {
-        envelope: mut env, ..
+        envelope: mut env,
+        mask,
+        ..
     }: crate::Authority,
     super::Request(Request {
         task,
@@ -20,7 +22,8 @@ pub async fn authorize_user_task(
             tokens::DateTime::from_timestamp_secs(1 + started_unix as i64).unwrap_or_default();
     }
 
-    let policy_result = evaluate_authorization(env.snapshot(), env.claims()?, &task, capability);
+    let policy_result =
+        evaluate_authorization(env.snapshot(), env.claims()?, mask, &task, capability);
 
     // Legacy: if `started_unix` was set then use a custom 200 response for client-side retries.
     let (
@@ -69,20 +72,18 @@ pub async fn authorize_user_task(
 fn evaluate_authorization(
     snapshot: &crate::Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     task_name: &models::Name,
     capability: models::Capability,
-) -> tonic::Result<(
-    Option<chrono::DateTime<chrono::Utc>>,
-    (
-        tokens::jwt::EncodingKey,
-        proto_gazette::Claims, // Broker claims.
-        String,                // Broker address.
-        String,                // ops logs journal
-        String,                // opts stats journal
-        proto_gazette::Claims, // Reactor claims.
-        String,                // Reactor address.
-        String,                // Shard ID prefix.
-    ),
+) -> crate::AuthZResult<(
+    tokens::jwt::EncodingKey,
+    proto_gazette::Claims, // Broker claims.
+    String,                // Broker address.
+    String,                // ops logs journal
+    String,                // opts stats journal
+    proto_gazette::Claims, // Reactor claims.
+    String,                // Reactor address.
+    String,                // Shard ID prefix.
 )> {
     let models::authorizations::ControlClaims {
         sub: user_id,
@@ -91,17 +92,28 @@ fn evaluate_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
+    // A mask which doesn't cover `capability` is a definitive denial — a pure
+    // function of the bearer's claims — evaluated before any walk so that the
+    // structured 403 names the missing capabilities without consulting (or
+    // disclosing anything about) the user's grants.
+    let required: models::authz::CapabilitySet = capability.into();
+    let missing = required - mask.apply(required);
+    if !missing.is_empty() {
+        return Err(crate::Forbidden::missing_capabilities(missing).into());
+    }
+
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,
         &snapshot.user_grants,
         *user_id,
         task_name,
         capability,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ) {
         return Err(tonic::Status::permission_denied(format!(
             "{user_email} is not authorized to {task_name} for {capability:?}",
-        )));
+        ))
+        .into());
     }
 
     // For admin capability, require that the user has a transitive role grant to estuary_support/
@@ -112,32 +124,32 @@ fn evaluate_authorization(
             *user_id,
             "estuary_support/",
             models::Capability::Admin,
-            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            mask,
         );
 
         if !has_support_access {
             return Err(tonic::Status::permission_denied(format!(
                 "{user_email} is not authorized to {task_name} for Admin capability (requires estuary_support/ grant)",
-            )));
+            )).into());
         }
     }
 
     let Some(task) = snapshot.task_by_catalog_name(task_name) else {
-        return Err(tonic::Status::not_found(format!(
-            "task {task_name} is not known"
-        )));
+        return Err(tonic::Status::not_found(format!("task {task_name} is not known")).into());
     };
     let Some(data_plane) = snapshot.data_planes.get_by_key(&task.data_plane_id) else {
         return Err(tonic::Status::internal(format!(
             "task data-plane {} not found",
             task.data_plane_id
-        )));
+        ))
+        .into());
     };
     let Some(encoding_key) = data_plane.hmac_keys.first() else {
         return Err(tonic::Status::internal(format!(
             "task data-plane {} has no configured HMAC keys",
             data_plane.data_plane_name
-        )));
+        ))
+        .into());
     };
     let encoding_key =
         tokens::jwt::EncodingKey::from_secret(&tokens::jwt::parse_base64(encoding_key)?);
@@ -149,7 +161,8 @@ fn evaluate_authorization(
         return Err(tonic::Status::internal(format!(
             "couldn't resolve data-plane {} ops collections",
             task.data_plane_id
-        )));
+        ))
+        .into());
     };
 
     let ops_suffix = super::ops_suffix(task);
@@ -505,7 +518,13 @@ mod tests {
             capability_mask: None,
         };
 
-        match evaluate_authorization(&snapshot, &claims, &task, capability) {
+        match evaluate_authorization(
+            &snapshot,
+            &claims,
+            models::authz::CapabilityMask::from_claim(claims.capability_mask.as_deref()),
+            &task,
+            capability,
+        ) {
             Ok((
                 cordon_at,
                 (
@@ -541,9 +560,13 @@ mod tests {
                     Outcome::Ok(output)
                 }
             }
-            Err(status) => Outcome::Err {
+            Err(crate::AuthZError::Retriable(status)) => Outcome::Err {
                 status: tokens::rest::grpc_status_code_to_http(status.code()),
                 error: status.message().to_string(),
+            },
+            Err(crate::AuthZError::Definitive(forbidden)) => Outcome::Err {
+                status: 403,
+                error: forbidden.message,
             },
         }
     }

--- a/crates/control-plane-api/src/server/error.rs
+++ b/crates/control-plane-api/src/server/error.rs
@@ -90,6 +90,11 @@ impl AuthZRetry {
 pub enum ApiError {
     Status(tonic::Status),
     AuthZRetry(AuthZRetry),
+    /// A definitive capability-mask denial, carrying the structured `403`
+    /// body. Unlike Status denials it is never provisional: it's a pure
+    /// function of the bearer's verified claims, so no Snapshot refresh or
+    /// client retry can change the outcome.
+    Forbidden(crate::Forbidden),
 }
 
 impl From<sqlx::Error> for ApiError {
@@ -130,19 +135,38 @@ impl axum::response::IntoResponse for ApiError {
         match self {
             Self::Status(status) => crate::status_into_response(status),
             Self::AuthZRetry(retry) => retry.to_response(),
+            Self::Forbidden(forbidden) => forbidden.into_response(),
         }
     }
 }
 
 impl From<ApiError> for async_graphql::Error {
     fn from(api_error: ApiError) -> Self {
-        let status = match &api_error {
-            ApiError::Status(status) => status,
-            ApiError::AuthZRetry(retry) => &retry.status,
+        let mut err = match &api_error {
+            ApiError::Status(status) => {
+                Self::new(format!("{:?}: {}", status.code(), status.message()))
+            }
+            ApiError::AuthZRetry(retry) => Self::new(format!(
+                "{:?}: {}",
+                retry.status.code(),
+                retry.status.message()
+            )),
+            // Carry the structured 403 body in error extensions, so that
+            // "you need capability X" is machine-readable identically on the
+            // REST and GraphQL surfaces: a client parses the missing names
+            // and re-mints a capability token which enables them.
+            ApiError::Forbidden(forbidden) => {
+                let mut err = Self::new(forbidden.message.clone());
+                let mut extensions = async_graphql::ErrorExtensionValues::default();
+                extensions.set("error", forbidden.error);
+                extensions.set(
+                    "missing_capabilities",
+                    forbidden.missing_capabilities.clone(),
+                );
+                err.extensions = Some(extensions);
+                err
+            }
         };
-        let message = format!("{:?}: {}", status.code(), status.message());
-
-        let mut err = Self::new(message);
         err.source = Some(std::sync::Arc::new(api_error));
 
         err

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -386,7 +386,7 @@ const fn map_capability_to_gazette(capability: models::Capability) -> u32 {
 
 #[cfg(test)]
 mod test {
-    use models::authz::{Capability, CapabilityMask, CapabilitySet};
+    use models::authz;
 
     fn claims(user_id: uuid::Uuid) -> crate::ControlClaims {
         models::authorizations::ControlClaims {
@@ -407,14 +407,14 @@ mod test {
         let claims = claims(bob);
 
         // Legacy Read requires the full Viewer bundle of capability bits.
-        let viewer: CapabilitySet = models::Capability::Read.into();
+        let viewer: authz::CapabilitySet = models::Capability::Read.into();
 
         // An unmasked bearer is authorized through Bob's grant.
         assert!(
             super::evaluate_names_authorization(
                 &snapshot,
                 &claims,
-                CapabilityMask::ALL_CAPABILITIES,
+                authz::CapabilityMask::ALL_CAPABILITIES,
                 models::Capability::Read,
                 ["bobCo/tires/"],
             )
@@ -426,7 +426,7 @@ mod test {
             super::evaluate_names_authorization(
                 &snapshot,
                 &claims,
-                CapabilityMask::bounded(viewer),
+                authz::CapabilityMask::bounded(viewer),
                 models::Capability::Read,
                 ["bobCo/tires/"],
             )
@@ -439,7 +439,7 @@ mod test {
         let result = super::evaluate_names_authorization(
             &snapshot,
             &claims,
-            CapabilityMask::bounded(Capability::CatalogRead.into()),
+            authz::CapabilityMask::bounded(authz::Capability::CatalogRead.into()),
             models::Capability::Read,
             ["bobCo/tires/"],
         );
@@ -457,7 +457,7 @@ mod test {
         let result = super::evaluate_names_authorization(
             &snapshot,
             &claims,
-            CapabilityMask::bounded(CapabilitySet::empty()),
+            authz::CapabilityMask::bounded(authz::CapabilitySet::empty()),
             models::Capability::Read,
             ["acmeCo/nothing/"],
         );
@@ -471,7 +471,7 @@ mod test {
         let result = super::evaluate_names_authorization(
             &snapshot,
             &claims,
-            CapabilityMask::bounded(viewer),
+            authz::CapabilityMask::bounded(viewer),
             models::Capability::Read,
             ["acmeCo/nothing/"],
         );

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -119,7 +119,7 @@ where
     S: AsRef<str> + std::fmt::Display,
     C: Into<models::authz::CapabilitySet> + std::fmt::Display + Copy,
 {
-    crate::Forbidden::require_mask_covers(mask, min_capability)?;
+    crate::Forbidden::required_covered(mask, min_capability)?;
 
     let models::authorizations::ControlClaims {
         sub: user_id,

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -94,8 +94,15 @@ pub(crate) async fn wake_tenant_controller(
 }
 
 /// Evaluate whether the user identified by `claims` is authorized to access all
-/// of the enumerated `prefixes_or_names` with at least `min_capability`.
+/// of the enumerated `prefixes_or_names` with at least `min_capability`,
+/// under the bearer's capability `mask`.
 /// Return a policy_result shape which fits Envelope::authorization_outcome.
+///
+/// A mask which doesn't cover `min_capability` is a definitive denial — a
+/// pure function of the bearer's claims which no Snapshot refresh can change —
+/// evaluated before the walk so that its structured `403` names the missing
+/// capabilities without consulting (or disclosing anything about) the user's
+/// actual grants.
 ///
 /// `min_capability` accepts any value that converts into a `CapabilitySet`:
 /// legacy `models::Capability` (mapped via `bits_for_legacy`), a single
@@ -103,6 +110,7 @@ pub(crate) async fn wake_tenant_controller(
 pub fn evaluate_names_authorization<'r, Iter, S, C>(
     snapshot: &Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     min_capability: C,
     prefixes_or_names: Iter,
 ) -> AuthZResult<()>
@@ -111,6 +119,12 @@ where
     S: AsRef<str> + std::fmt::Display,
     C: Into<models::authz::CapabilitySet> + std::fmt::Display + Copy,
 {
+    let min_bits: models::authz::CapabilitySet = min_capability.into();
+    let missing = min_bits - mask.apply(min_bits);
+    if !missing.is_empty() {
+        return Err(crate::Forbidden::missing_capabilities(missing).into());
+    }
+
     let models::authorizations::ControlClaims {
         sub: user_id,
         email: user_email,
@@ -125,11 +139,11 @@ where
             *user_id,
             prefix_or_name.as_ref(),
             min_capability,
-            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            mask,
         ) {
             return Err(tonic::Status::permission_denied(format!(
                 "{user_email} is not authorized to access prefix or name '{prefix_or_name}' with required capability {min_capability}",
-            )));
+            )).into());
         }
     }
     Ok((None, ()))
@@ -141,6 +155,7 @@ where
 pub fn attach_user_capabilities<I, F, T>(
     snapshot: &Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     prefixes_or_names: I,
     mut attach: F,
 ) -> Vec<T>
@@ -156,7 +171,7 @@ where
                 &snapshot.user_grants,
                 claims.sub,
                 &prefix,
-                models::authz::CapabilityMask::ALL_CAPABILITIES,
+                mask,
             );
             attach(prefix, capability)
         })
@@ -362,5 +377,103 @@ const fn map_capability_to_gazette(capability: models::Capability) -> u32 {
                 | proto_gazette::capability::APPEND
                 | proto_gazette::capability::APPLY
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use models::authz::{Capability, CapabilityMask, CapabilitySet};
+
+    fn claims(user_id: uuid::Uuid) -> crate::ControlClaims {
+        models::authorizations::ControlClaims {
+            aud: "authenticated".to_string(),
+            iat: 0,
+            exp: 0,
+            sub: user_id,
+            role: "authenticated".to_string(),
+            email: None,
+            capability_mask: None,
+        }
+    }
+
+    #[test]
+    fn test_names_authorization_applies_the_mask() {
+        let snapshot = crate::Snapshot::build_fixture(None);
+        let bob = uuid::Uuid::from_bytes([32; 16]); // Holds `write` on bobCo/.
+        let claims = claims(bob);
+
+        // Legacy Read requires the full Viewer bundle of capability bits.
+        let viewer: CapabilitySet = models::Capability::Read.into();
+
+        // An unmasked bearer is authorized through Bob's grant.
+        assert!(
+            super::evaluate_names_authorization(
+                &snapshot,
+                &claims,
+                CapabilityMask::ALL_CAPABILITIES,
+                models::Capability::Read,
+                ["bobCo/tires/"],
+            )
+            .is_ok()
+        );
+
+        // A mask which enables everything the operation requires changes nothing.
+        assert!(
+            super::evaluate_names_authorization(
+                &snapshot,
+                &claims,
+                CapabilityMask::bounded(viewer),
+                models::Capability::Read,
+                ["bobCo/tires/"],
+            )
+            .is_ok()
+        );
+
+        // A mask which does not cover the required capabilities is a
+        // definitive denial naming exactly the missing bits — even though
+        // Bob holds the underlying grant.
+        let result = super::evaluate_names_authorization(
+            &snapshot,
+            &claims,
+            CapabilityMask::bounded(Capability::CatalogRead.into()),
+            models::Capability::Read,
+            ["bobCo/tires/"],
+        );
+        let Err(crate::AuthZError::Definitive(forbidden)) = result else {
+            panic!("expected a definitive denial, got {result:?}");
+        };
+        assert_eq!(
+            forbidden.missing_capabilities,
+            vec!["JournalRead", "ViewDataPlanePrivateNetworking"],
+        );
+
+        // The mask shortfall is evaluated before the walk, so it wins even
+        // for a name the user holds no grant on: no existence or grant
+        // oracle leaks through the error distinction.
+        let result = super::evaluate_names_authorization(
+            &snapshot,
+            &claims,
+            CapabilityMask::bounded(CapabilitySet::empty()),
+            models::Capability::Read,
+            ["acmeCo/nothing/"],
+        );
+        assert!(
+            matches!(result, Err(crate::AuthZError::Definitive(_))),
+            "expected a definitive denial, got {result:?}"
+        );
+
+        // A mask which covers the requirement, over a grant the user lacks:
+        // an ordinary retriable denial, exactly as an unmasked bearer sees.
+        let result = super::evaluate_names_authorization(
+            &snapshot,
+            &claims,
+            CapabilityMask::bounded(viewer),
+            models::Capability::Read,
+            ["acmeCo/nothing/"],
+        );
+        assert!(
+            matches!(result, Err(crate::AuthZError::Retriable(_))),
+            "expected a retriable denial, got {result:?}"
+        );
     }
 }

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -152,6 +152,10 @@ where
 /// Looks up the user's authorization grants for each item in
 /// `prefixes_or_names`, and calls the provided `attach` function with each
 /// item and its capability. The `Some` results are returned in a vec.
+///
+/// Grant reachability is evaluated under the bearer's capability `mask`;
+/// the legacy capability of a reached grant passes through un-attenuated
+/// (see `tables::UserGrant::get_user_capability`).
 pub fn attach_user_capabilities<I, F, T>(
     snapshot: &Snapshot,
     claims: &crate::ControlClaims,

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -119,11 +119,7 @@ where
     S: AsRef<str> + std::fmt::Display,
     C: Into<models::authz::CapabilitySet> + std::fmt::Display + Copy,
 {
-    let min_bits: models::authz::CapabilitySet = min_capability.into();
-    let missing = min_bits - mask.apply(min_bits);
-    if !missing.is_empty() {
-        return Err(crate::Forbidden::missing_capabilities(missing).into());
-    }
+    crate::Forbidden::require_mask_covers(mask, min_capability)?;
 
     let models::authorizations::ControlClaims {
         sub: user_id,

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -129,7 +129,7 @@ impl AlertConfigsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 claims.sub,
-                *ctx.data()?,
+                *ctx.data::<models::authz::CapabilityMask>()?,
                 models::Capability::Read,
                 filter.and_then(|f| f.catalog_prefix_or_name),
                 "filter.catalogPrefixOrName",
@@ -227,7 +227,7 @@ impl AlertConfigsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             models::authz::Capability::CatalogRead,
             [catalog_prefix_or_name.as_str()],
         );
@@ -272,7 +272,7 @@ impl AlertConfigsMutation {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             models::Capability::Admin,
             [gov.as_str()],
         );

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -129,7 +129,7 @@ impl AlertConfigsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 claims.sub,
-                *ctx.data::<models::authz::CapabilityMask>()?,
+                super::bearer_mask(ctx)?,
                 models::Capability::Read,
                 filter.and_then(|f| f.catalog_prefix_or_name),
                 "filter.catalogPrefixOrName",
@@ -227,7 +227,7 @@ impl AlertConfigsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             models::authz::Capability::CatalogRead,
             [catalog_prefix_or_name.as_str()],
         );
@@ -272,7 +272,7 @@ impl AlertConfigsMutation {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             models::Capability::Admin,
             [gov.as_str()],
         );

--- a/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_configs.rs
@@ -129,6 +129,7 @@ impl AlertConfigsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 claims.sub,
+                *ctx.data()?,
                 models::Capability::Read,
                 filter.and_then(|f| f.catalog_prefix_or_name),
                 "filter.catalogPrefixOrName",
@@ -226,6 +227,7 @@ impl AlertConfigsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
+            *ctx.data()?,
             models::authz::Capability::CatalogRead,
             [catalog_prefix_or_name.as_str()],
         );
@@ -270,6 +272,7 @@ impl AlertConfigsMutation {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             claims,
+            *ctx.data()?,
             models::Capability::Admin,
             [gov.as_str()],
         );

--- a/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
@@ -30,7 +30,9 @@ impl AlertSubscriptionsQuery {
     ) -> async_graphql::Result<Vec<AlertSubscription>> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, &by.prefix, models::Capability::Admin).await?;
+        let _ =
+            super::verify_authorization(env, *ctx.data()?, &by.prefix, models::Capability::Admin)
+                .await?;
 
         let mut conn = env.pg_pool.acquire().await?;
         let alerts = fetch_alert_subscriptions_prefixed_by(&by.prefix, &mut conn).await?;
@@ -55,7 +57,8 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, &prefix, models::Capability::Admin).await?;
+        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
+            .await?;
 
         // Validate the email address. Note that we _don't_ support mailbox
         // address syntax like `Foo <foo@bar.test>`. We just want the plain
@@ -112,7 +115,8 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, &prefix, models::Capability::Admin).await?;
+        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
+            .await?;
         if alert_types.is_none() && detail.is_none() {
             return Err(async_graphql::Error::new(
                 "must provide at least one of: alertTypes, detail",
@@ -161,7 +165,8 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, &prefix, models::Capability::Admin).await?;
+        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
+            .await?;
 
         let Some(existing) =
             delete_alert_subscription(prefix.as_str(), email.as_str(), &env.pg_pool).await?

--- a/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
@@ -30,9 +30,13 @@ impl AlertSubscriptionsQuery {
     ) -> async_graphql::Result<Vec<AlertSubscription>> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ =
-            super::verify_authorization(env, *ctx.data()?, &by.prefix, models::Capability::Admin)
-                .await?;
+        let _ = super::verify_authorization(
+            env,
+            *ctx.data::<models::authz::CapabilityMask>()?,
+            &by.prefix,
+            models::Capability::Admin,
+        )
+        .await?;
 
         let mut conn = env.pg_pool.acquire().await?;
         let alerts = fetch_alert_subscriptions_prefixed_by(&by.prefix, &mut conn).await?;
@@ -57,8 +61,13 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
-            .await?;
+        let _ = super::verify_authorization(
+            env,
+            *ctx.data::<models::authz::CapabilityMask>()?,
+            &prefix,
+            models::Capability::Admin,
+        )
+        .await?;
 
         // Validate the email address. Note that we _don't_ support mailbox
         // address syntax like `Foo <foo@bar.test>`. We just want the plain
@@ -115,8 +124,13 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
-            .await?;
+        let _ = super::verify_authorization(
+            env,
+            *ctx.data::<models::authz::CapabilityMask>()?,
+            &prefix,
+            models::Capability::Admin,
+        )
+        .await?;
         if alert_types.is_none() && detail.is_none() {
             return Err(async_graphql::Error::new(
                 "must provide at least one of: alertTypes, detail",
@@ -165,8 +179,13 @@ impl AlertSubscriptionsMutation {
     ) -> async_graphql::Result<AlertSubscription> {
         let env = ctx.data::<crate::Envelope>()?;
 
-        let _ = super::verify_authorization(env, *ctx.data()?, &prefix, models::Capability::Admin)
-            .await?;
+        let _ = super::verify_authorization(
+            env,
+            *ctx.data::<models::authz::CapabilityMask>()?,
+            &prefix,
+            models::Capability::Admin,
+        )
+        .await?;
 
         let Some(existing) =
             delete_alert_subscription(prefix.as_str(), email.as_str(), &env.pg_pool).await?

--- a/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alert_subscriptions.rs
@@ -32,7 +32,7 @@ impl AlertSubscriptionsQuery {
 
         let _ = super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &by.prefix,
             models::Capability::Admin,
         )
@@ -63,7 +63,7 @@ impl AlertSubscriptionsMutation {
 
         let _ = super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &prefix,
             models::Capability::Admin,
         )
@@ -126,7 +126,7 @@ impl AlertSubscriptionsMutation {
 
         let _ = super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &prefix,
             models::Capability::Admin,
         )
@@ -181,7 +181,7 @@ impl AlertSubscriptionsMutation {
 
         let _ = super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &prefix,
             models::Capability::Admin,
         )

--- a/crates/control-plane-api/src/server/public/graphql/alerts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alerts.rs
@@ -142,7 +142,7 @@ async fn fetch_alert_history_by_prefix(
     let policy_result = crate::server::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
-        *ctx.data()?,
+        *ctx.data::<models::authz::CapabilityMask>()?,
         models::Capability::Read,
         [&by.prefix],
     );

--- a/crates/control-plane-api/src/server/public/graphql/alerts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alerts.rs
@@ -142,7 +142,7 @@ async fn fetch_alert_history_by_prefix(
     let policy_result = crate::server::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
-        *ctx.data::<models::authz::CapabilityMask>()?,
+        super::bearer_mask(ctx)?,
         models::Capability::Read,
         [&by.prefix],
     );

--- a/crates/control-plane-api/src/server/public/graphql/alerts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/alerts.rs
@@ -142,6 +142,7 @@ async fn fetch_alert_history_by_prefix(
     let policy_result = crate::server::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
+        *ctx.data()?,
         models::Capability::Read,
         [&by.prefix],
     );

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -1,5 +1,8 @@
 /// Returns catalog prefixes where the authenticated user has at least
-/// `min_capability`, optionally narrowed to those overlapping `prefix_filter`.
+/// `min_capability` under the bearer's capability `mask`, optionally narrowed
+/// to those overlapping `prefix_filter`. The mask gates the walk itself, so a
+/// masked listing narrows (a mask without `Delegate` stops at direct grants)
+/// rather than erroring.
 ///
 /// Intended for use by GraphQL queries that list resources scoped to the
 /// caller's authorized prefixes, with an optional prefix filter.

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -12,6 +12,7 @@ pub(super) fn authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
     user_id: uuid::Uuid,
+    mask: models::authz::CapabilityMask,
     min_capability: impl Into<models::authz::CapabilitySet>,
     prefix_filter: Option<&str>,
 ) -> Vec<String> {
@@ -19,18 +20,13 @@ pub(super) fn authorized_prefixes(
 
     // BTreeMap iteration from reachable_prefixes is already prefix-sorted,
     // so the parent-prune step below can run directly on it.
-    let prefixes = tables::UserGrant::reachable_prefixes(
-        role_grants,
-        user_grants,
-        user_id,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
-    )
-    .into_iter()
-    .filter(|(prefix, _)| {
-        prefix_filter.is_none_or(|pf| prefix.starts_with(pf) || pf.starts_with(*prefix))
-    })
-    .filter(|(_, (bits, _))| bits.is_superset(min_bits))
-    .map(|(prefix, _)| prefix.to_string());
+    let prefixes = tables::UserGrant::reachable_prefixes(role_grants, user_grants, user_id, mask)
+        .into_iter()
+        .filter(|(prefix, _)| {
+            prefix_filter.is_none_or(|pf| prefix.starts_with(pf) || pf.starts_with(*prefix))
+        })
+        .filter(|(_, (bits, _))| bits.is_superset(min_bits))
+        .map(|(prefix, _)| prefix.to_string());
 
     let mut pruned: Vec<String> = Vec::new();
     for p in prefixes {
@@ -58,6 +54,7 @@ pub(super) fn filtered_authorized_prefixes(
     role_grants: &tables::RoleGrants,
     user_grants: &tables::UserGrants,
     user_id: uuid::Uuid,
+    mask: models::authz::CapabilityMask,
     min_capability: impl Into<models::authz::CapabilitySet>,
     filter: Option<super::filters::PrefixFilter>,
     field: &str,
@@ -70,6 +67,7 @@ pub(super) fn filtered_authorized_prefixes(
         role_grants,
         user_grants,
         user_id,
+        mask,
         min_capability,
         starts_with.as_deref(),
     );
@@ -121,13 +119,34 @@ mod tests {
             &[],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Write,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/", "widgets/"]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Read, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Read,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/", "readonly/", "widgets/"]);
     }
 
@@ -137,7 +156,14 @@ mod tests {
         // the filter, so "acmeCo/" is included.
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin)], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/data/"));
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            Some("acmeCo/data/"),
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -147,7 +173,14 @@ mod tests {
         // with the filter, so "acmeCo/data/" is included.
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/data/", Admin)], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/"));
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            Some("acmeCo/"),
+        );
         assert_eq!(result, vec!["acmeCo/data/"]);
     }
 
@@ -155,7 +188,14 @@ mod tests {
     fn filter_excludes_non_overlapping() {
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "other/", Admin)], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, Some("acmeCo/"));
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            Some("acmeCo/"),
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -163,7 +203,14 @@ mod tests {
     fn no_grants_returns_empty() {
         let (ug, rg) = make_grants(&[], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+        );
         assert!(result.is_empty());
     }
 
@@ -175,11 +222,25 @@ mod tests {
             &[("acmeCo/", "shared/", Write)],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Write,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/", "shared/"]);
 
         // Admin threshold excludes the transitive Write grant.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -192,7 +253,14 @@ mod tests {
             &[],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -205,7 +273,14 @@ mod tests {
             &[("acmeCo/", "acmeCo/team/", Write)],
         );
 
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Write,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -214,7 +289,14 @@ mod tests {
         let bob = uuid::Uuid::from_bytes([0x22; 16]);
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin)], &[]);
 
-        let result = authorized_prefixes(&rg, &ug, bob, Read, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            bob,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Read,
+            None,
+        );
         assert!(result.is_empty());
     }
 
@@ -323,11 +405,25 @@ mod tests {
         // child of the qualifying parent. If the union were across
         // ancestors, acmeCo/data/ would qualify on its own (Writer +
         // inherited Admin bits) — it does not.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Admin, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
 
         // min=Write: both qualify on their own bits; parent prunes child.
-        let result = authorized_prefixes(&rg, &ug, ALICE, Write, None);
+        let result = authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Write,
+            None,
+        );
         assert_eq!(result, vec!["acmeCo/"]);
     }
 
@@ -335,9 +431,16 @@ mod tests {
     fn filtered_no_filter_returns_all_prefixes_and_no_parts() {
         let (ug, rg) = make_grants(&[(ALICE, "acmeCo/", Admin), (ALICE, "beta/", Admin)], &[]);
 
-        let (prefixes, starts_with, r#in) =
-            filtered_authorized_prefixes(&rg, &ug, ALICE, Admin, None, "filter.catalogPrefix")
-                .unwrap();
+        let (prefixes, starts_with, r#in) = filtered_authorized_prefixes(
+            &rg,
+            &ug,
+            ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            Admin,
+            None,
+            "filter.catalogPrefix",
+        )
+        .unwrap();
         assert_eq!(prefixes, vec!["acmeCo/", "beta/"]);
         assert_eq!(starts_with, None);
         assert_eq!(r#in, None);
@@ -355,6 +458,7 @@ mod tests {
             &rg,
             &ug,
             ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
             Admin,
             Some(filter),
             "filter.catalogPrefix",
@@ -380,6 +484,7 @@ mod tests {
             &rg,
             &ug,
             ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
             Admin,
             Some(filter),
             "filter.catalogPrefix",
@@ -402,6 +507,7 @@ mod tests {
             &rg,
             &ug,
             ALICE,
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
             Admin,
             Some(filter),
             "filter.catalogPrefix",

--- a/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
@@ -39,7 +39,13 @@ impl BillingMutation {
     ) -> Result<CreateBillingSetupIntentPayload> {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&tenant)?;
-        verify_authorization(env, tenant.as_str(), models::authz::Capability::EditBilling).await?;
+        verify_authorization(
+            env,
+            *ctx.data()?,
+            tenant.as_str(),
+            models::authz::Capability::EditBilling,
+        )
+        .await?;
 
         let claims = env.claims()?;
         let user_email = claims
@@ -95,7 +101,13 @@ impl BillingMutation {
     ) -> Result<BillingPaymentMethodPayload> {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&tenant)?;
-        verify_authorization(env, tenant.as_str(), models::authz::Capability::EditBilling).await?;
+        verify_authorization(
+            env,
+            *ctx.data()?,
+            tenant.as_str(),
+            models::authz::Capability::EditBilling,
+        )
+        .await?;
 
         let provider = billing_provider(ctx)?;
         let customer = provider
@@ -131,7 +143,13 @@ impl BillingMutation {
     ) -> Result<SetBillingContactPayload> {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&tenant)?;
-        verify_authorization(env, tenant.as_str(), models::authz::Capability::EditBilling).await?;
+        verify_authorization(
+            env,
+            *ctx.data()?,
+            tenant.as_str(),
+            models::authz::Capability::EditBilling,
+        )
+        .await?;
 
         if !email.contains('@') || email.len() > 512 {
             return Err(async_graphql::Error::new(
@@ -167,7 +185,13 @@ impl BillingMutation {
     ) -> Result<BillingPaymentMethodPayload> {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&tenant)?;
-        verify_authorization(env, tenant.as_str(), models::authz::Capability::EditBilling).await?;
+        verify_authorization(
+            env,
+            *ctx.data()?,
+            tenant.as_str(),
+            models::authz::Capability::EditBilling,
+        )
+        .await?;
 
         let provider = billing_provider(ctx)?;
         let customer = provider

--- a/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
@@ -41,7 +41,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::super::bearer_mask(ctx)?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -103,7 +103,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::super::bearer_mask(ctx)?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -145,7 +145,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::super::bearer_mask(ctx)?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -187,7 +187,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::super::bearer_mask(ctx)?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )

--- a/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/mutations.rs
@@ -41,7 +41,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -103,7 +103,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -145,7 +145,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )
@@ -187,7 +187,7 @@ impl BillingMutation {
         let tenant = validate_tenant_name(&tenant)?;
         verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             tenant.as_str(),
             models::authz::Capability::EditBilling,
         )

--- a/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
@@ -20,7 +20,7 @@ impl Tenant {
         let env = ctx.data::<crate::Envelope>()?;
         verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::super::bearer_mask(ctx)?,
             &self.name,
             models::authz::Capability::ViewBilling,
         )

--- a/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
@@ -18,7 +18,13 @@ use async_graphql::{
 impl Tenant {
     async fn billing(&self, ctx: &Context<'_>) -> Result<TenantBilling> {
         let env = ctx.data::<crate::Envelope>()?;
-        verify_authorization(env, &self.name, models::authz::Capability::ViewBilling).await?;
+        verify_authorization(
+            env,
+            *ctx.data()?,
+            &self.name,
+            models::authz::Capability::ViewBilling,
+        )
+        .await?;
         let provider = billing_provider(ctx)?;
         Ok(TenantBilling::new(self.name.clone(), provider))
     }

--- a/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/billing/tenant.rs
@@ -20,7 +20,7 @@ impl Tenant {
         let env = ctx.data::<crate::Envelope>()?;
         verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &self.name,
             models::authz::Capability::ViewBilling,
         )

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -485,7 +485,7 @@ impl DataPlanesQuery {
     ) -> async_graphql::Result<PaginatedDataPlanes> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
-        let mask: models::authz::CapabilityMask = *ctx.data()?;
+        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
         let snapshot = env.snapshot();
 
         let DataPlanesFilter { id, closed, public } = filter.unwrap_or_default();
@@ -567,7 +567,7 @@ impl DataPlanesQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             names.into_iter(),
             |data_plane_name, user_capability| {
                 let dp = row_data.get(&data_plane_name)?;
@@ -761,7 +761,7 @@ impl DataPlanesMutation {
         require_private_dp_name(&data_plane_name)?;
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &data_plane_name,
             models::authz::Capability::ModifyDataPlanePrivateNetworking,
         )

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -485,7 +485,7 @@ impl DataPlanesQuery {
     ) -> async_graphql::Result<PaginatedDataPlanes> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
-        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
+        let mask = super::bearer_mask(ctx)?;
         let snapshot = env.snapshot();
 
         let DataPlanesFilter { id, closed, public } = filter.unwrap_or_default();
@@ -567,7 +567,7 @@ impl DataPlanesQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             names.into_iter(),
             |data_plane_name, user_capability| {
                 let dp = row_data.get(&data_plane_name)?;
@@ -761,7 +761,7 @@ impl DataPlanesMutation {
         require_private_dp_name(&data_plane_name)?;
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &data_plane_name,
             models::authz::Capability::ModifyDataPlanePrivateNetworking,
         )

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -485,6 +485,7 @@ impl DataPlanesQuery {
     ) -> async_graphql::Result<PaginatedDataPlanes> {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
+        let mask: models::authz::CapabilityMask = *ctx.data()?;
         let snapshot = env.snapshot();
 
         let DataPlanesFilter { id, closed, public } = filter.unwrap_or_default();
@@ -518,7 +519,7 @@ impl DataPlanesQuery {
                         claims.sub,
                         &dp.data_plane_name,
                         models::Capability::Read,
-                        models::authz::CapabilityMask::ALL_CAPABILITIES,
+                        mask,
                     )
             })
             .collect();
@@ -566,6 +567,7 @@ impl DataPlanesQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
+            *ctx.data()?,
             names.into_iter(),
             |data_plane_name, user_capability| {
                 let dp = row_data.get(&data_plane_name)?;
@@ -759,6 +761,7 @@ impl DataPlanesMutation {
         require_private_dp_name(&data_plane_name)?;
         super::verify_authorization(
             env,
+            *ctx.data()?,
             &data_plane_name,
             models::authz::Capability::ModifyDataPlanePrivateNetworking,
         )

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -82,7 +82,7 @@ impl InviteLinksQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
-                *ctx.data()?,
+                *ctx.data::<models::authz::CapabilityMask>()?,
                 models::Capability::Admin,
                 filter.and_then(|f| f.catalog_prefix),
                 "filter.catalogPrefix",
@@ -200,7 +200,7 @@ impl InviteLinksMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &catalog_prefix,
             models::Capability::Admin,
         )
@@ -395,7 +395,7 @@ impl InviteLinksMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &invite.catalog_prefix,
             models::Capability::Admin,
         )

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -82,6 +82,7 @@ impl InviteLinksQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
+                *ctx.data()?,
                 models::Capability::Admin,
                 filter.and_then(|f| f.catalog_prefix),
                 "filter.catalogPrefix",
@@ -197,7 +198,13 @@ impl InviteLinksMutation {
             )));
         }
 
-        super::verify_authorization(env, &catalog_prefix, models::Capability::Admin).await?;
+        super::verify_authorization(
+            env,
+            *ctx.data()?,
+            &catalog_prefix,
+            models::Capability::Admin,
+        )
+        .await?;
 
         let row = sqlx::query!(
             r#"
@@ -386,7 +393,13 @@ impl InviteLinksMutation {
             None => return Err(async_graphql::Error::new("Invalid invite link")),
         };
 
-        super::verify_authorization(env, &invite.catalog_prefix, models::Capability::Admin).await?;
+        super::verify_authorization(
+            env,
+            *ctx.data()?,
+            &invite.catalog_prefix,
+            models::Capability::Admin,
+        )
+        .await?;
 
         sqlx::query!("DELETE FROM internal.invite_links WHERE token = $1", token,)
             .execute(&mut *txn)

--- a/crates/control-plane-api/src/server/public/graphql/invite_links.rs
+++ b/crates/control-plane-api/src/server/public/graphql/invite_links.rs
@@ -82,7 +82,7 @@ impl InviteLinksQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
-                *ctx.data::<models::authz::CapabilityMask>()?,
+                super::bearer_mask(ctx)?,
                 models::Capability::Admin,
                 filter.and_then(|f| f.catalog_prefix),
                 "filter.catalogPrefix",
@@ -200,7 +200,7 @@ impl InviteLinksMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &catalog_prefix,
             models::Capability::Admin,
         )
@@ -395,7 +395,7 @@ impl InviteLinksMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &invite.catalog_prefix,
             models::Capability::Admin,
         )

--- a/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
@@ -186,7 +186,7 @@ pub async fn paginate_live_specs_refs(
     let all_refs = crate::server::attach_user_capabilities(
         env.snapshot(),
         env.claims()?,
-        *ctx.data()?,
+        *ctx.data::<models::authz::CapabilityMask>()?,
         all_names,
         |name, maybe_capability| {
             if require_min_capability.is_some_and(|min_cap| maybe_capability < Some(min_cap)) {
@@ -292,7 +292,7 @@ impl LiveSpecsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             env.claims()?,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             models::Capability::Read,
             names
                 .iter()
@@ -363,7 +363,7 @@ impl LiveSpecsQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             names,
             |name, user_capability| {
                 Some(connection::Edge::new(

--- a/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
@@ -186,7 +186,7 @@ pub async fn paginate_live_specs_refs(
     let all_refs = crate::server::attach_user_capabilities(
         env.snapshot(),
         env.claims()?,
-        *ctx.data::<models::authz::CapabilityMask>()?,
+        super::bearer_mask(ctx)?,
         all_names,
         |name, maybe_capability| {
             if require_min_capability.is_some_and(|min_cap| maybe_capability < Some(min_cap)) {
@@ -292,7 +292,7 @@ impl LiveSpecsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             env.claims()?,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             models::Capability::Read,
             names
                 .iter()
@@ -363,7 +363,7 @@ impl LiveSpecsQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             names,
             |name, user_capability| {
                 Some(connection::Edge::new(

--- a/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_spec_refs.rs
@@ -186,6 +186,7 @@ pub async fn paginate_live_specs_refs(
     let all_refs = crate::server::attach_user_capabilities(
         env.snapshot(),
         env.claims()?,
+        *ctx.data()?,
         all_names,
         |name, maybe_capability| {
             if require_min_capability.is_some_and(|min_cap| maybe_capability < Some(min_cap)) {
@@ -291,6 +292,7 @@ impl LiveSpecsQuery {
         let policy_result = crate::server::evaluate_names_authorization(
             env.snapshot(),
             env.claims()?,
+            *ctx.data()?,
             models::Capability::Read,
             names
                 .iter()
@@ -361,6 +363,7 @@ impl LiveSpecsQuery {
         let edges = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
+            *ctx.data()?,
             names,
             |name, user_capability| {
                 Some(connection::Edge::new(

--- a/crates/control-plane-api/src/server/public/graphql/live_specs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_specs.rs
@@ -99,7 +99,7 @@ impl LiveSpec {
         let attached = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             [source_capture_name.clone()],
             |name, user_capability| {
                 Some(LiveSpecRef {

--- a/crates/control-plane-api/src/server/public/graphql/live_specs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_specs.rs
@@ -99,6 +99,7 @@ impl LiveSpec {
         let attached = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
+            *ctx.data()?,
             [source_capture_name.clone()],
             |name, user_capability| {
                 Some(LiveSpecRef {

--- a/crates/control-plane-api/src/server/public/graphql/live_specs.rs
+++ b/crates/control-plane-api/src/server/public/graphql/live_specs.rs
@@ -99,7 +99,7 @@ impl LiveSpec {
         let attached = crate::server::attach_user_capabilities(
             env.snapshot(),
             env.claims()?,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             [source_capture_name.clone()],
             |name, user_capability| {
                 Some(LiveSpecRef {

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -46,6 +46,15 @@ mod tenant;
 
 pub(crate) use scalars::Sensitive;
 
+/// The bearer's capability mask, as injected into the GraphQL context by
+/// `graphql_handler`. One named accessor keeps the ~40 resolver pulls
+/// explicit about what they read without each repeating the type.
+pub(crate) fn bearer_mask(
+    ctx: &async_graphql::Context<'_>,
+) -> async_graphql::Result<models::authz::CapabilityMask> {
+    Ok(*ctx.data::<models::authz::CapabilityMask>()?)
+}
+
 /// Whether the current user holds `capability` on `name`, as a pure check
 /// against the request's authorization Snapshot under the bearer's capability
 /// mask: a capability the mask doesn't enable is absent here exactly as a
@@ -65,7 +74,7 @@ fn may_access(
     capability: impl Into<models::authz::CapabilitySet>,
 ) -> async_graphql::Result<bool> {
     let env = ctx.data::<crate::Envelope>()?;
-    let mask = *ctx.data::<models::authz::CapabilityMask>()?;
+    let mask = bearer_mask(ctx)?;
     let snapshot = env.snapshot();
     Ok(tables::UserGrant::is_authorized(
         &snapshot.role_grants,
@@ -78,7 +87,7 @@ fn may_access(
 }
 
 /// Errors unless the current user holds `capability` on `prefix`, under the
-/// bearer's capability `mask` (read from the GraphQL context as `*ctx.data::<models::authz::CapabilityMask>()?`).
+/// bearer's capability `mask` (read from the GraphQL context as `bearer_mask(ctx)?`).
 ///
 /// This is the hard gate for mutations and access-controlled queries: a denial
 /// becomes `permission_denied`, and a provisional denial against a stale

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -47,7 +47,9 @@ mod tenant;
 pub(crate) use scalars::Sensitive;
 
 /// Whether the current user holds `capability` on `name`, as a pure check
-/// against the request's authorization Snapshot.
+/// against the request's authorization Snapshot under the bearer's capability
+/// mask: a capability the mask doesn't enable is absent here exactly as a
+/// grant the user doesn't hold.
 ///
 /// This is the visibility gate: use it to hide a field or filter a list,
 /// failing closed to an empty or default value when it returns `false`. Unlike

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -63,6 +63,7 @@ fn may_access(
     capability: impl Into<models::authz::CapabilitySet>,
 ) -> async_graphql::Result<bool> {
     let env = ctx.data::<crate::Envelope>()?;
+    let mask: models::authz::CapabilityMask = *ctx.data()?;
     let snapshot = env.snapshot();
     Ok(tables::UserGrant::is_authorized(
         &snapshot.role_grants,
@@ -70,27 +71,32 @@ fn may_access(
         env.claims()?.sub,
         name,
         capability,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ))
 }
 
-/// Errors unless the current user holds `capability` on `prefix`.
+/// Errors unless the current user holds `capability` on `prefix`, under the
+/// bearer's capability `mask` (read from the GraphQL context as `*ctx.data()?`).
 ///
 /// This is the hard gate for mutations and access-controlled queries: a denial
 /// becomes `permission_denied`, and a provisional denial against a stale
-/// Snapshot follows the standard refresh-and-retry path. See [`may_access`] for
+/// Snapshot follows the standard refresh-and-retry path — except a mask
+/// shortfall, which is definitive and carries the same structured
+/// missing-capabilities shape as the REST 403 body. See [`may_access`] for
 /// the visibility-gate counterpart that fails closed instead of erroring.
 ///
 /// `capability` accepts a legacy `models::Capability`, an orthogonal
 /// `models::authz::Capability` bit, or a `models::authz::CapabilitySet`.
 async fn verify_authorization(
     env: &crate::Envelope,
+    mask: models::authz::CapabilityMask,
     prefix: &str,
     capability: impl Into<models::authz::CapabilitySet> + std::fmt::Display + Copy,
 ) -> async_graphql::Result<()> {
     let policy_result = crate::server::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
+        mask,
         capability,
         [prefix],
     );
@@ -346,4 +352,114 @@ fn graphql_json_values_preserves_field_order() {
     let parsed: async_graphql::Value = serde_json::from_str(json_str).unwrap();
     let round_tripped = serde_json::to_string(&parsed).unwrap();
     assert_eq!(json_str.replace(' ', ""), round_tripped);
+}
+
+#[cfg(test)]
+mod authz_test {
+    use crate::test_server;
+
+    const LIST_QUERY: &str = r#"query {
+        alertSubscriptions(by: {prefix: "aliceCo/"}) { catalogPrefix email }
+    }"#;
+
+    /// A masked bearer's GraphQL denials carry the same structured,
+    /// machine-readable shape as the REST 403 body — `verify_authorization`
+    /// is the shared hard gate — while a mask covering the operation's
+    /// requirement behaves identically to an unmasked bearer.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_graphql_gate_applies_the_mask(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+        let alice = uuid::Uuid::from_bytes([0x11; 16]);
+
+        // Alice is admin of aliceCo/, but her token's mask doesn't cover the
+        // Admin requirement of this query: a definitive denial naming the
+        // missing capabilities in extensions, for a client to re-mint from.
+        let masked = server.make_masked_access_token(
+            alice,
+            Some("alice@example.test"),
+            Some(vec!["CatalogRead", "JournalRead"]),
+        );
+        let response: serde_json::Value = server
+            .graphql(&serde_json::json!({"query": LIST_QUERY}), Some(&masked))
+            .await;
+
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "extensions": {
+                "error": "missing_capabilities",
+                "missing_capabilities": [
+                  "JournalAppend",
+                  "SpecEdit",
+                  "CreateGrant",
+                  "DeleteGrant",
+                  "CreateInviteLink",
+                  "ViewDataPlanePrivateNetworking",
+                  "ModifyDataPlanePrivateNetworking",
+                  "ViewBilling",
+                  "EditBilling",
+                  "QueryServiceAccounts",
+                  "CreateServiceAccount",
+                  "CreateApiKey",
+                  "RevokeApiKey",
+                  "Delegate"
+                ]
+              },
+              "locations": [
+                {
+                  "column": 9,
+                  "line": 2
+                }
+              ],
+              "message": "the bearer token's capability mask does not enable required capabilities: JournalAppend, SpecEdit, CreateGrant, DeleteGrant, CreateInviteLink, ViewDataPlanePrivateNetworking, ModifyDataPlanePrivateNetworking, ViewBilling, EditBilling, QueryServiceAccounts, CreateServiceAccount, CreateApiKey, RevokeApiKey, Delegate",
+              "path": [
+                "alertSubscriptions"
+              ]
+            }
+          ]
+        }
+        "#);
+
+        // An empty mask is identity-only: still a definitive denial.
+        let identity_only =
+            server.make_masked_access_token(alice, Some("alice@example.test"), Some(vec![]));
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({"query": LIST_QUERY}),
+                Some(&identity_only),
+            )
+            .await;
+        assert_eq!(
+            response["errors"][0]["extensions"]["error"], "missing_capabilities",
+            "{response}",
+        );
+
+        // A mask covering the requirement is indistinguishable from unmasked.
+        let all_names: Vec<&str> = models::authz::CapabilitySet::all()
+            .iter()
+            .map(|c| c.name())
+            .collect();
+        let covering =
+            server.make_masked_access_token(alice, Some("alice@example.test"), Some(all_names));
+        let unmasked = server.make_access_token(alice, Some("alice@example.test"));
+
+        let covered: serde_json::Value = server
+            .graphql(&serde_json::json!({"query": LIST_QUERY}), Some(&covering))
+            .await;
+        let baseline: serde_json::Value = server
+            .graphql(&serde_json::json!({"query": LIST_QUERY}), Some(&unmasked))
+            .await;
+        assert_eq!(covered, baseline);
+        assert_eq!(baseline["errors"], serde_json::Value::Null, "{baseline}");
+    }
 }

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -63,7 +63,7 @@ fn may_access(
     capability: impl Into<models::authz::CapabilitySet>,
 ) -> async_graphql::Result<bool> {
     let env = ctx.data::<crate::Envelope>()?;
-    let mask: models::authz::CapabilityMask = *ctx.data()?;
+    let mask = *ctx.data::<models::authz::CapabilityMask>()?;
     let snapshot = env.snapshot();
     Ok(tables::UserGrant::is_authorized(
         &snapshot.role_grants,
@@ -76,7 +76,7 @@ fn may_access(
 }
 
 /// Errors unless the current user holds `capability` on `prefix`, under the
-/// bearer's capability `mask` (read from the GraphQL context as `*ctx.data()?`).
+/// bearer's capability `mask` (read from the GraphQL context as `*ctx.data::<models::authz::CapabilityMask>()?`).
 ///
 /// This is the hard gate for mutations and access-controlled queries: a denial
 /// becomes `permission_denied`, and a provisional denial against a stale

--- a/crates/control-plane-api/src/server/public/graphql/prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/prefixes.rs
@@ -48,7 +48,7 @@ impl PrefixesQuery {
         first: Option<i32>,
     ) -> async_graphql::Result<PaginatedPrefixes> {
         let env = ctx.data::<crate::Envelope>()?;
-        let mask: models::authz::CapabilityMask = *ctx.data()?;
+        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
 
         connection::query(after, None, first, None, |after, _, first, _| async move {
             let snapshot = env.snapshot();

--- a/crates/control-plane-api/src/server/public/graphql/prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/prefixes.rs
@@ -48,7 +48,7 @@ impl PrefixesQuery {
         first: Option<i32>,
     ) -> async_graphql::Result<PaginatedPrefixes> {
         let env = ctx.data::<crate::Envelope>()?;
-        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
+        let mask = super::bearer_mask(ctx)?;
 
         connection::query(after, None, first, None, |after, _, first, _| async move {
             let snapshot = env.snapshot();

--- a/crates/control-plane-api/src/server/public/graphql/prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/prefixes.rs
@@ -48,6 +48,7 @@ impl PrefixesQuery {
         first: Option<i32>,
     ) -> async_graphql::Result<PaginatedPrefixes> {
         let env = ctx.data::<crate::Envelope>()?;
+        let mask: models::authz::CapabilityMask = *ctx.data()?;
 
         connection::query(after, None, first, None, |after, _, first, _| async move {
             let snapshot = env.snapshot();
@@ -59,7 +60,7 @@ impl PrefixesQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 user_id,
-                models::authz::CapabilityMask::ALL_CAPABILITIES,
+                mask,
             );
             // Cursor pagination: BTreeMap::range jumps directly to the
             // first key strictly greater than the previous page's last
@@ -163,6 +164,132 @@ mod tests {
                   }
                 }
               ]
+            }
+          }
+        }
+        "#);
+
+        // A masked bearer's listing narrows to what the mask can reach —
+        // it never errors. Without `Delegate` the walk is confined to
+        // alice's direct grant; the role-edge-derived prefixes disappear.
+        let masked = server.make_masked_access_token(
+            uuid::Uuid::from_bytes([0x11; 16]),
+            None,
+            Some(vec![
+                "CatalogRead",
+                "JournalRead",
+                "ViewDataPlanePrivateNetworking",
+            ]),
+        );
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        prefixes(by: { minCapability: read }) {
+                            edges { node { prefix userCapability } }
+                        }
+                    }
+                "#
+                }),
+                Some(&masked),
+            )
+            .await;
+        insta::assert_json_snapshot!(response,
+          @r#"
+        {
+          "data": {
+            "prefixes": {
+              "edges": [
+                {
+                  "node": {
+                    "prefix": "aliceCo/",
+                    "userCapability": "admin"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        // Adding `Delegate` re-enables role-graph traversal: the listing is
+        // the full unmasked set, because every reached node still clears the
+        // Viewer bits under this mask.
+        let masked = server.make_masked_access_token(
+            uuid::Uuid::from_bytes([0x11; 16]),
+            None,
+            Some(vec![
+                "CatalogRead",
+                "JournalRead",
+                "ViewDataPlanePrivateNetworking",
+                "Delegate",
+            ]),
+        );
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        prefixes(by: { minCapability: read }) {
+                            edges { node { prefix } }
+                        }
+                    }
+                "#
+                }),
+                Some(&masked),
+            )
+            .await;
+        insta::assert_json_snapshot!(response,
+          @r#"
+        {
+          "data": {
+            "prefixes": {
+              "edges": [
+                {
+                  "node": {
+                    "prefix": "aliceCo/"
+                  }
+                },
+                {
+                  "node": {
+                    "prefix": "aliceCo/data/"
+                  }
+                },
+                {
+                  "node": {
+                    "prefix": "ops/dp/public/"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        // An identity-only (empty-mask) token lists nothing, and does not error.
+        let identity_only =
+            server.make_masked_access_token(uuid::Uuid::from_bytes([0x11; 16]), None, Some(vec![]));
+        let response: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"
+                    query {
+                        prefixes(by: { minCapability: read }) {
+                            edges { node { prefix } }
+                        }
+                    }
+                "#
+                }),
+                Some(&identity_only),
+            )
+            .await;
+        insta::assert_json_snapshot!(response,
+          @r#"
+        {
+          "data": {
+            "prefixes": {
+              "edges": []
             }
           }
         }

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -91,7 +91,7 @@ impl ServiceAccountsQuery {
             &snapshot.role_grants,
             &snapshot.user_grants,
             env.claims()?.sub,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             models::authz::Capability::QueryServiceAccounts,
             None,
         );
@@ -219,7 +219,7 @@ impl ServiceAccountsMutation {
         // narrower than full Admin.
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -250,7 +250,7 @@ impl ServiceAccountsMutation {
         for grant in &grants {
             super::verify_authorization(
                 env,
-                *ctx.data()?,
+                *ctx.data::<models::authz::CapabilityMask>()?,
                 grant.prefix.as_str(),
                 models::authz::Capability::CreateGrant,
             )
@@ -354,7 +354,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateGrant,
         )
@@ -376,7 +376,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             prefix.as_str(),
             models::authz::Capability::CreateGrant,
         )
@@ -432,7 +432,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -478,7 +478,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -524,7 +524,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateApiKey,
         )
@@ -676,7 +676,7 @@ impl ServiceAccountsMutation {
         // and denial are indistinguishable.
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &owner.catalog_name,
             models::authz::Capability::RevokeApiKey,
         )
@@ -720,7 +720,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             catalog_name.as_str(),
             models::authz::Capability::RevokeApiKey,
         )

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -91,6 +91,7 @@ impl ServiceAccountsQuery {
             &snapshot.role_grants,
             &snapshot.user_grants,
             env.claims()?.sub,
+            *ctx.data()?,
             models::authz::Capability::QueryServiceAccounts,
             None,
         );
@@ -218,6 +219,7 @@ impl ServiceAccountsMutation {
         // narrower than full Admin.
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -248,6 +250,7 @@ impl ServiceAccountsMutation {
         for grant in &grants {
             super::verify_authorization(
                 env,
+                *ctx.data()?,
                 grant.prefix.as_str(),
                 models::authz::Capability::CreateGrant,
             )
@@ -351,6 +354,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateGrant,
         )
@@ -370,8 +374,13 @@ impl ServiceAccountsMutation {
             ));
         }
 
-        super::verify_authorization(env, prefix.as_str(), models::authz::Capability::CreateGrant)
-            .await?;
+        super::verify_authorization(
+            env,
+            *ctx.data()?,
+            prefix.as_str(),
+            models::authz::Capability::CreateGrant,
+        )
+        .await?;
 
         let user_id = resolve_service_account(&env.pg_pool, catalog_name.as_str()).await?;
 
@@ -423,6 +432,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -468,6 +478,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -513,6 +524,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::CreateApiKey,
         )
@@ -664,6 +676,7 @@ impl ServiceAccountsMutation {
         // and denial are indistinguishable.
         super::verify_authorization(
             env,
+            *ctx.data()?,
             &owner.catalog_name,
             models::authz::Capability::RevokeApiKey,
         )
@@ -707,6 +720,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
+            *ctx.data()?,
             catalog_name.as_str(),
             models::authz::Capability::RevokeApiKey,
         )

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -91,7 +91,7 @@ impl ServiceAccountsQuery {
             &snapshot.role_grants,
             &snapshot.user_grants,
             env.claims()?.sub,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             models::authz::Capability::QueryServiceAccounts,
             None,
         );
@@ -219,7 +219,7 @@ impl ServiceAccountsMutation {
         // narrower than full Admin.
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -250,7 +250,7 @@ impl ServiceAccountsMutation {
         for grant in &grants {
             super::verify_authorization(
                 env,
-                *ctx.data::<models::authz::CapabilityMask>()?,
+                super::bearer_mask(ctx)?,
                 grant.prefix.as_str(),
                 models::authz::Capability::CreateGrant,
             )
@@ -354,7 +354,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::CreateGrant,
         )
@@ -376,7 +376,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             prefix.as_str(),
             models::authz::Capability::CreateGrant,
         )
@@ -432,7 +432,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -478,7 +478,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::CreateServiceAccount,
         )
@@ -524,7 +524,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::CreateApiKey,
         )
@@ -676,7 +676,7 @@ impl ServiceAccountsMutation {
         // and denial are indistinguishable.
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &owner.catalog_name,
             models::authz::Capability::RevokeApiKey,
         )
@@ -720,7 +720,7 @@ impl ServiceAccountsMutation {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             catalog_name.as_str(),
             models::authz::Capability::RevokeApiKey,
         )

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -1101,8 +1101,9 @@ mod test {
         });
 
         // The row filter and the attached userCapability metadata are
-        // computed under the same mask, so a masked listing narrows
-        // coherently — it never errors on a row it chose to show.
+        // computed under the same mask, so masking narrows the listing
+        // coherently: it cannot show a row whose capability lookup then
+        // comes up empty, because both are the same masked reachability.
         let masked = server.make_masked_access_token(alice, None, Some(vec!["CatalogRead"]));
         let response: serde_json::Value = server.graphql(&query, Some(&masked)).await;
         insta::assert_json_snapshot!(response, @r#"

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -214,7 +214,14 @@ impl StorageMappingsMutation {
         validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
+        evaluate_authorization(
+            env,
+            claims,
+            *ctx.data()?,
+            &catalog_prefix,
+            &spec.data_planes,
+        )
+        .await?;
 
         let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
@@ -346,7 +353,14 @@ impl StorageMappingsMutation {
         validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
+        evaluate_authorization(
+            env,
+            claims,
+            *ctx.data()?,
+            &catalog_prefix,
+            &spec.data_planes,
+        )
+        .await?;
 
         let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
@@ -491,7 +505,14 @@ impl StorageMappingsMutation {
         validate_inputs(&catalog_prefix, &spec)?;
 
         // Verify user has admin capability to the catalog prefix and read capability to named data planes.
-        evaluate_authorization(env, claims, &catalog_prefix, &spec.data_planes).await?;
+        evaluate_authorization(
+            env,
+            claims,
+            *ctx.data()?,
+            &catalog_prefix,
+            &spec.data_planes,
+        )
+        .await?;
 
         let data_planes = resolve_data_planes(&snapshot, &spec.data_planes)?;
 
@@ -508,11 +529,17 @@ impl StorageMappingsMutation {
 async fn evaluate_authorization(
     env: &crate::Envelope,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     catalog_prefix: &models::Prefix,
     data_plane_names: &[String],
 ) -> Result<(), crate::ApiError> {
-    let policy_result =
-        check_authorization(&env.snapshot(), claims, catalog_prefix, data_plane_names);
+    let policy_result = check_authorization(
+        &env.snapshot(),
+        claims,
+        mask,
+        catalog_prefix,
+        data_plane_names,
+    );
     env.authorization_outcome(policy_result).await?;
     Ok(())
 }
@@ -520,6 +547,7 @@ async fn evaluate_authorization(
 fn check_authorization(
     snapshot: &crate::Snapshot,
     claims: &crate::ControlClaims,
+    mask: models::authz::CapabilityMask,
     catalog_prefix: &models::Prefix,
     data_plane_names: &[String],
 ) -> crate::AuthZResult<()> {
@@ -530,6 +558,15 @@ fn check_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
+    // A mask which doesn't cover the Admin requirement is a definitive
+    // denial, evaluated before the walk so the structured 403 names the
+    // missing capabilities without consulting the user's grants.
+    let required: models::authz::CapabilitySet = models::Capability::Admin.into();
+    let missing = required - mask.apply(required);
+    if !missing.is_empty() {
+        return Err(crate::Forbidden::missing_capabilities(missing).into());
+    }
+
     // Verify the User admins `catalog_prefix`.
     if !tables::UserGrant::is_authorized(
         &snapshot.role_grants,
@@ -537,11 +574,12 @@ fn check_authorization(
         *user_id,
         catalog_prefix,
         models::Capability::Admin,
-        models::authz::CapabilityMask::ALL_CAPABILITIES,
+        mask,
     ) {
         return Err(tonic::Status::permission_denied(format!(
             "{user_email} is not an authorized as an Admin of catalog prefix '{catalog_prefix}'",
-        )));
+        ))
+        .into());
     }
 
     for data_plane_name in data_plane_names {
@@ -554,7 +592,8 @@ fn check_authorization(
         ) {
             return Err(tonic::Status::permission_denied(format!(
                 "'{catalog_prefix}' is not authorized to data plane '{data_plane_name}' for Read",
-            )));
+            ))
+            .into());
         }
     }
 
@@ -708,6 +747,7 @@ impl StorageMappingsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
+                *ctx.data()?,
                 models::authz::Capability::CatalogRead,
                 prefix_filter,
                 "filter.catalogPrefix",
@@ -772,6 +812,7 @@ impl StorageMappingsQuery {
 
         let snapshot = env.snapshot();
         let claims = env.claims()?;
+        let mask: models::authz::CapabilityMask = *ctx.data()?;
         let edges = rows
             .into_iter()
             .map(|row| {
@@ -780,7 +821,7 @@ impl StorageMappingsQuery {
                     &snapshot.user_grants,
                     claims.sub,
                     &row.catalog_prefix,
-                    models::authz::CapabilityMask::ALL_CAPABILITIES,
+                    mask,
                 )
                 .ok_or_else(|| {
                     async_graphql::Error::new(format!(
@@ -978,6 +1019,127 @@ mod test {
             err.message,
             "provide exactly one of `exactPrefixes` or `underPrefix`, or omit `by` entirely"
         );
+    }
+
+    #[test]
+    fn test_check_authorization_applies_the_mask() {
+        let snapshot = crate::Snapshot::build_fixture(None);
+        let claims = models::authorizations::ControlClaims {
+            aud: "authenticated".to_string(),
+            iat: 0,
+            exp: 0,
+            sub: uuid::Uuid::from_bytes([32; 16]), // bob: admin of bobCo/tires/.
+            role: "authenticated".to_string(),
+            email: Some("bob@bob".to_string()),
+            capability_mask: None,
+        };
+        let prefix = models::Prefix::new("bobCo/tires/");
+
+        // Unmasked, and a mask covering the Admin requirement: authorized.
+        for mask in [
+            models::authz::CapabilityMask::ALL_CAPABILITIES,
+            models::authz::CapabilityMask::bounded(models::Capability::Admin.into()),
+        ] {
+            assert!(
+                super::check_authorization(&snapshot, &claims, mask, &prefix, &[]).is_ok(),
+                "{mask:?}",
+            );
+        }
+
+        // A mask which doesn't cover Admin is a definitive denial naming the
+        // missing capabilities, though bob holds the underlying grant.
+        let mask =
+            models::authz::CapabilityMask::bounded(models::authz::Capability::CatalogRead.into());
+        let result = super::check_authorization(&snapshot, &claims, mask, &prefix, &[]);
+        let Err(crate::AuthZError::Definitive(forbidden)) = result else {
+            panic!("expected a definitive denial, got {result:?}");
+        };
+        assert!(
+            !forbidden.missing_capabilities.contains(&"CatalogRead"),
+            "{forbidden:?}",
+        );
+        assert!(
+            forbidden.missing_capabilities.contains(&"SpecEdit"),
+            "{forbidden:?}",
+        );
+    }
+
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn storage_mappings_list_is_coherent_under_a_mask(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let mut store = models::Store::example();
+        *store.prefix_mut() = models::Prefix::new("tenant/collection-data/");
+        let spec = crate::TextJson(models::StorageDef {
+            data_planes: Vec::new(),
+            stores: vec![store],
+        });
+        for prefix in ["aliceCo/", "aliceCo/team/", "otherCo/"] {
+            sqlx::query("INSERT INTO storage_mappings (catalog_prefix, spec) VALUES ($1, $2)")
+                .bind(prefix)
+                .bind(&spec)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let snapshot = test_server::snapshot(pool.clone(), false).await;
+        let server = test_server::TestServer::start(pool.clone(), snapshot).await;
+        let alice = uuid::Uuid::from_bytes([0x11; 16]);
+
+        let query = serde_json::json!({
+            "query": r#"
+                query {
+                    storageMappings {
+                        edges { node { catalogPrefix userCapability } }
+                    }
+                }
+            "#,
+        });
+
+        // The row filter and the attached userCapability metadata are
+        // computed under the same mask, so a masked listing narrows
+        // coherently — it never errors on a row it chose to show.
+        let masked = server.make_masked_access_token(alice, None, Some(vec!["CatalogRead"]));
+        let response: serde_json::Value = server.graphql(&query, Some(&masked)).await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "storageMappings": {
+              "edges": [
+                {
+                  "node": {
+                    "catalogPrefix": "aliceCo/",
+                    "userCapability": "admin"
+                  }
+                },
+                {
+                  "node": {
+                    "catalogPrefix": "aliceCo/team/",
+                    "userCapability": "admin"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        // An identity-only token lists nothing, and does not error.
+        let identity_only = server.make_masked_access_token(alice, None, Some(vec![]));
+        let response: serde_json::Value = server.graphql(&query, Some(&identity_only)).await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "storageMappings": {
+              "edges": []
+            }
+          }
+        }
+        "#);
     }
 
     #[sqlx::test(

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -217,7 +217,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -356,7 +356,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -508,7 +508,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -747,7 +747,7 @@ impl StorageMappingsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
-                *ctx.data::<models::authz::CapabilityMask>()?,
+                super::bearer_mask(ctx)?,
                 models::authz::Capability::CatalogRead,
                 prefix_filter,
                 "filter.catalogPrefix",
@@ -812,7 +812,7 @@ impl StorageMappingsQuery {
 
         let snapshot = env.snapshot();
         let claims = env.claims()?;
-        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
+        let mask = super::bearer_mask(ctx)?;
         let edges = rows
             .into_iter()
             .map(|row| {
@@ -1054,14 +1054,25 @@ mod test {
         let Err(crate::AuthZError::Definitive(forbidden)) = result else {
             panic!("expected a definitive denial, got {result:?}");
         };
-        assert!(
-            !forbidden.missing_capabilities.contains(&"CatalogRead"),
-            "{forbidden:?}",
-        );
-        assert!(
-            forbidden.missing_capabilities.contains(&"SpecEdit"),
-            "{forbidden:?}",
-        );
+        insta::assert_debug_snapshot!(forbidden.missing_capabilities, @r#"
+        [
+            "JournalRead",
+            "JournalAppend",
+            "SpecEdit",
+            "CreateGrant",
+            "DeleteGrant",
+            "CreateInviteLink",
+            "ViewDataPlanePrivateNetworking",
+            "ModifyDataPlanePrivateNetworking",
+            "ViewBilling",
+            "EditBilling",
+            "QueryServiceAccounts",
+            "CreateServiceAccount",
+            "CreateApiKey",
+            "RevokeApiKey",
+            "Delegate",
+        ]
+        "#);
     }
 
     #[sqlx::test(

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -217,7 +217,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -356,7 +356,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -508,7 +508,7 @@ impl StorageMappingsMutation {
         evaluate_authorization(
             env,
             claims,
-            *ctx.data()?,
+            *ctx.data::<models::authz::CapabilityMask>()?,
             &catalog_prefix,
             &spec.data_planes,
         )
@@ -747,7 +747,7 @@ impl StorageMappingsQuery {
                 &snapshot.role_grants,
                 &snapshot.user_grants,
                 env.claims()?.sub,
-                *ctx.data()?,
+                *ctx.data::<models::authz::CapabilityMask>()?,
                 models::authz::Capability::CatalogRead,
                 prefix_filter,
                 "filter.catalogPrefix",
@@ -812,7 +812,7 @@ impl StorageMappingsQuery {
 
         let snapshot = env.snapshot();
         let claims = env.claims()?;
-        let mask: models::authz::CapabilityMask = *ctx.data()?;
+        let mask = *ctx.data::<models::authz::CapabilityMask>()?;
         let edges = rows
             .into_iter()
             .map(|row| {

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -558,7 +558,7 @@ fn check_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    crate::Forbidden::require_mask_covers(mask, models::Capability::Admin)?;
+    crate::Forbidden::required_covered(mask, models::Capability::Admin)?;
 
     // Verify the User admins `catalog_prefix`.
     if !tables::UserGrant::is_authorized(

--- a/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
+++ b/crates/control-plane-api/src/server/public/graphql/storage_mappings.rs
@@ -558,14 +558,7 @@ fn check_authorization(
     } = claims;
     let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
 
-    // A mask which doesn't cover the Admin requirement is a definitive
-    // denial, evaluated before the walk so the structured 403 names the
-    // missing capabilities without consulting the user's grants.
-    let required: models::authz::CapabilitySet = models::Capability::Admin.into();
-    let missing = required - mask.apply(required);
-    if !missing.is_empty() {
-        return Err(crate::Forbidden::missing_capabilities(missing).into());
-    }
+    crate::Forbidden::require_mask_covers(mask, models::Capability::Admin)?;
 
     // Verify the User admins `catalog_prefix`.
     if !tables::UserGrant::is_authorized(

--- a/crates/control-plane-api/src/server/public/graphql/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/tenant.rs
@@ -10,8 +10,13 @@ impl TenantQuery {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&name)?;
 
-        super::verify_authorization(env, *ctx.data()?, tenant.as_str(), models::Capability::Read)
-            .await?;
+        super::verify_authorization(
+            env,
+            *ctx.data::<models::authz::CapabilityMask>()?,
+            tenant.as_str(),
+            models::Capability::Read,
+        )
+        .await?;
 
         let exists: bool = sqlx::query_scalar!(
             r#"SELECT EXISTS(SELECT 1 FROM tenants WHERE tenant = $1) AS "exists!""#,

--- a/crates/control-plane-api/src/server/public/graphql/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/tenant.rs
@@ -12,7 +12,7 @@ impl TenantQuery {
 
         super::verify_authorization(
             env,
-            *ctx.data::<models::authz::CapabilityMask>()?,
+            super::bearer_mask(ctx)?,
             tenant.as_str(),
             models::Capability::Read,
         )

--- a/crates/control-plane-api/src/server/public/graphql/tenant.rs
+++ b/crates/control-plane-api/src/server/public/graphql/tenant.rs
@@ -10,7 +10,8 @@ impl TenantQuery {
         let env = ctx.data::<crate::Envelope>()?;
         let tenant = validate_tenant_name(&name)?;
 
-        super::verify_authorization(env, tenant.as_str(), models::Capability::Read).await?;
+        super::verify_authorization(env, *ctx.data()?, tenant.as_str(), models::Capability::Read)
+            .await?;
 
         let exists: bool = sqlx::query_scalar!(
             r#"SELECT EXISTS(SELECT 1 FROM tenants WHERE tenant = $1) AS "exists!""#,

--- a/crates/control-plane-api/src/server/public/mod.rs
+++ b/crates/control-plane-api/src/server/public/mod.rs
@@ -151,3 +151,118 @@ fn api_docs(api: aide::transform::TransformOpenApi) -> aide::transform::Transfor
         )
         .security_requirement("ApiKey")
 }
+
+#[cfg(test)]
+mod test {
+    /// The real public v1 router over an empty Snapshot and a pool which is
+    /// never dialed: these tests exercise extraction-time capability
+    /// requirements, which reject before any handler body runs.
+    async fn router() -> (axum::Router, tokens::jwt::EncodingKey) {
+        let snapshot = crate::test_server::empty_snapshot().await;
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://unused-by-extraction").unwrap();
+        let app = crate::test_server::build_app(pg_pool, snapshot, None);
+        let encoding_key = app.control_plane_jwt_encode_key.clone();
+
+        let router =
+            super::api_v1_router(app.clone(), models::AlertConfig::default()).with_state(app);
+
+        (router, encoding_key)
+    }
+
+    fn sign_token(
+        encoding_key: &tokens::jwt::EncodingKey,
+        capability_mask: Option<Vec<&str>>,
+    ) -> String {
+        let now = tokens::now();
+        let claims = models::authorizations::ControlClaims {
+            iat: now.timestamp() as u64,
+            exp: (now + chrono::Duration::hours(1)).timestamp() as u64,
+            sub: uuid::Uuid::nil(),
+            role: "authenticated".to_string(),
+            aud: "authenticated".to_string(),
+            email: None,
+            capability_mask: capability_mask
+                .map(|names| names.into_iter().map(String::from).collect()),
+        };
+        jsonwebtoken::encode(&jsonwebtoken::Header::default(), &claims, encoding_key).unwrap()
+    }
+
+    async fn fetch(router: &axum::Router, path: &str, bearer: &str) -> (u16, String) {
+        use tower::ServiceExt;
+
+        let request = axum::http::Request::builder()
+            .uri(path)
+            .header("authorization", format!("Bearer {bearer}"))
+            .header("accept", "application/json")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let (parts, body) = router.clone().oneshot(request).await.unwrap().into_parts();
+        let body = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        (parts.status.as_u16(), String::from_utf8_lossy(&body).into())
+    }
+
+    #[test]
+    fn test_viewer_requirement_matches_legacy_read() {
+        // The route consts on /catalog/status and /metrics and their
+        // handlers' walk requirement (legacy Read) are two statements of one
+        // fact; this pins them together so they cannot drift.
+        assert_eq!(
+            <crate::RequireViewer as crate::Requirement>::REQUIRED,
+            models::authz::bits_for_legacy(models::Capability::Read),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_status_and_metrics_reject_mask_shortfall_at_extraction() {
+        let (router, key) = router().await;
+
+        // A mask which doesn't cover the Viewer bits is rejected with the
+        // structured 403 before the handler (or any database access) runs.
+        let masked = sign_token(&key, Some(vec!["SpecEdit"]));
+        for path in [
+            "/api/v1/catalog/status?name=acmeCo/thing",
+            "/api/v1/metrics/acmeCo/",
+        ] {
+            let (status, body) = fetch(&router, path, &masked).await;
+            assert_eq!(status, 403, "{path}: {body}");
+
+            let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(body["error"], "missing_capabilities", "{path}");
+            assert_eq!(
+                body["missing_capabilities"],
+                serde_json::json!([
+                    "CatalogRead",
+                    "JournalRead",
+                    "ViewDataPlanePrivateNetworking"
+                ]),
+                "{path}",
+            );
+        }
+
+        // A mask which covers the requirement passes extraction: with no
+        // grants in the (empty) Snapshot the walk then provisionally denies,
+        // which surfaces as the 307 retry — proof the const is a necessary
+        // condition on the mask only, never a grant decision.
+        let covering = sign_token(
+            &key,
+            Some(vec![
+                "CatalogRead",
+                "JournalRead",
+                "ViewDataPlanePrivateNetworking",
+            ]),
+        );
+        // An unmasked bearer behaves identically.
+        let unmasked = sign_token(&key, None);
+
+        for bearer in [&covering, &unmasked] {
+            for path in [
+                "/api/v1/catalog/status?name=acmeCo/thing",
+                "/api/v1/metrics/acmeCo/",
+            ] {
+                let (status, body) = fetch(&router, path, bearer).await;
+                assert_eq!(status, 307, "{path}: {body}");
+            }
+        }
+    }
+}

--- a/crates/control-plane-api/src/server/public/mod.rs
+++ b/crates/control-plane-api/src/server/public/mod.rs
@@ -208,7 +208,7 @@ mod test {
         // handlers' walk requirement (legacy Read) are two statements of one
         // fact; this pins them together so they cannot drift.
         assert_eq!(
-            <crate::RequireViewer as crate::Requirement>::REQUIRED,
+            <crate::RequireViewer as crate::Requirement>::required(),
             models::authz::bits_for_legacy(models::Capability::Read),
         );
     }

--- a/crates/control-plane-api/src/server/public/open_metrics.rs
+++ b/crates/control-plane-api/src/server/public/open_metrics.rs
@@ -6,7 +6,13 @@ use std::fmt::Write;
 
 #[axum::debug_handler(state=std::sync::Arc<crate::App>)]
 pub async fn handle_get_metrics(
-    crate::Authority { envelope: env, .. }: crate::Authority,
+    // RequireViewer fast-fails a mask which can't satisfy the Read walk
+    // below; a test pins the two together.
+    crate::Authority {
+        envelope: env,
+        mask,
+        ..
+    }: crate::Authority<crate::RequireViewer>,
     axum::extract::Path(prefix): axum::extract::Path<String>,
 ) -> Result<axum::response::Response, crate::ApiError> {
     if !prefix.ends_with('/') {
@@ -19,6 +25,7 @@ pub async fn handle_get_metrics(
     let policy_result = crate::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
+        mask,
         models::Capability::Read,
         [&prefix],
     );

--- a/crates/control-plane-api/src/server/public/status.rs
+++ b/crates/control-plane-api/src/server/public/status.rs
@@ -19,7 +19,13 @@ pub struct StatusQuery {
 
 #[axum::debug_handler(state=std::sync::Arc<crate::App>)]
 pub(crate) async fn handle_get_status(
-    crate::Authority { envelope: env, .. }: crate::Authority,
+    // RequireViewer fast-fails a mask which can't satisfy the Read walk
+    // below; a test pins the two together.
+    crate::Authority {
+        envelope: env,
+        mask,
+        ..
+    }: crate::Authority<crate::RequireViewer>,
     axum_extra::extract::Query(StatusQuery {
         name, // axum_extra handles multiple `name` params.
         short,
@@ -29,6 +35,7 @@ pub(crate) async fn handle_get_status(
     let policy_result = crate::evaluate_names_authorization(
         env.snapshot(),
         env.claims()?,
+        mask,
         models::Capability::Read,
         &name,
     );
@@ -53,7 +60,7 @@ pub(crate) async fn handle_get_status(
                     claims.sub,
                     name,
                     models::Capability::Read,
-                    models::authz::CapabilityMask::ALL_CAPABILITIES,
+                    mask,
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -185,6 +185,17 @@ impl TestServer {
     /// Create a valid access token for a test user.
     /// The token includes all required claims for the server's JWT validation.
     pub fn make_access_token(&self, user_id: uuid::Uuid, email: Option<&str>) -> String {
+        self.make_masked_access_token(user_id, email, None)
+    }
+
+    /// Sign an access token carrying a `capability_mask` claim.
+    /// `Some(vec![])` mints a valid identity-only token; `None` is unmasked.
+    pub fn make_masked_access_token(
+        &self,
+        user_id: uuid::Uuid,
+        email: Option<&str>,
+        capability_mask: Option<Vec<&str>>,
+    ) -> String {
         let now = tokens::now();
         let claims = models::authorizations::ControlClaims {
             iat: now.timestamp() as u64,
@@ -193,7 +204,8 @@ impl TestServer {
             role: "authenticated".to_string(),
             aud: "authenticated".to_string(),
             email: email.map(String::from),
-            capability_mask: None,
+            capability_mask: capability_mask
+                .map(|names| names.into_iter().map(String::from).collect()),
         };
 
         jsonwebtoken::encode(


### PR DESCRIPTION
Task 3c of the #3376 capability-mask plan ([implementation plan](https://github.com/estuary/flow/issues/3376#issuecomment-5342195183)), stacked on #3405: live ceiling threading. The `Authority` extractor's capability mask now reaches every request-path authorization walk, so enforcement of masked tokens goes live — while no production path mints masked tokens yet.

## What changed

**Definitive vs. retriable denials become a typed distinction.** `AuthZResult`'s error side is now `AuthZError { Retriable(tonic::Status), Definitive(Forbidden) }`. A walk denial stays retriable — a fresh Snapshot may reveal a just-committed grant, so `authorization_outcome` holds it for refresh as before. A mask shortfall is a pure function of the bearer's verified claims which no Snapshot can change: `authorization_outcome` returns it immediately as the new `ApiError::Forbidden`, which renders the structured 403 body (`error: "missing_capabilities"`, `missing_capabilities: [...]`) on REST and a GraphQL error carrying the same fields in `extensions`. An MCP client parses the missing names identically on both surfaces and drives the `upgrade_token` re-mint.

**The mask-shortfall pre-check lives inside the shared policy functions** — `evaluate_names_authorization`, the three `authorize_user_*` `evaluate_authorization` helpers, and storage-mappings' `check_authorization` — computed as `required − mask.apply(required)` *before* the walk, so no call site can forget it and the error discloses nothing about the user's actual grants (no existence or grant oracle in the definitive/retriable distinction).

**Route-level `REQUIRED` declarations are used where the capability is statically known.** `/api/v1/catalog/status` and `/api/v1/metrics/{*prefix}` take `Authority<RequireViewer>`, which declares `CapabilityBundle::Viewer` — the bits legacy `Read` requires — in the same bundle vocabulary the `capability_mask` claim speaks, rejecting mask shortfalls at extraction before the handler or any DB access runs. A parity test pins the bundle's bits to `bits_for_legacy(Read)` so the declaration and the handler's walk requirement cannot drift. Everywhere a const structurally can't reach — GraphQL's single route, the body-dependent `/authorize/user/*` endpoints — the identical runtime pre-check applies.

**Every request-path walk runs under the bearer's mask** (~17 sites task 2 pinned to `ALL_CAPABILITIES`):
- REST: `/authorize/user/{collection,task,prefix}` (including the `estuary_support/` secondary Admin walks — the mask applies uniformly to every walk a request performs), `/api/v1/catalog/status` (both the gate and the `connected` filter), `/api/v1/metrics`.
- GraphQL hard gates: `verify_authorization` (22 call sites), storage-mappings' `check_authorization`, and the direct `evaluate_names_authorization` callers (alerts, alert_configs, live_spec_refs).
- GraphQL filters and metadata: `may_access`, `authorized_prefixes` / `filtered_authorized_prefixes` and their consumers (prefixes, invite_links, alert_configs, storage_mappings, service_accounts), `attach_user_capabilities` (live_spec_refs, live_specs, data_planes), the data-planes list filter, and storage-mappings' attached `user_capability` — filter and metadata are computed under the same mask, so masked listings narrow coherently rather than erroring.

**Plumbing** follows the agreed split: ctx-taking GraphQL helpers (`may_access`) read the mask from context internally; `&Envelope`/claims-taking helpers take an explicit `mask: CapabilityMask` parameter, threaded from a resolver's single `*ctx.data::<models::authz::CapabilityMask>()?` pull or a REST handler's `Authority { envelope, mask, .. }` binding. No new context objects.

**Deliberately not threaded (mask-evaporation class):** the two `agent/src/discovers.rs` walks and `live_specs::partition_by_authorization` (consumed only by the discovers/publications executors) stay explicitly unmasked with comments — they run after the requesting JWT and its mask are gone, authorizing by user identity. Whether and how the mask should propagate across the async discover boundary is a new dedicated task on the #3376 plan (spike + implementation).

## Decisions made in review of this task

1. **No blanket route consts.** `REQUIRED` consts only where the required capability is a static fact of the route (status, metrics); runtime pre-checks with the identical error shape everywhere else. Considered and rejected: dropping the const mechanism entirely (loses free extraction-time fail-fast), and consts-only (structurally impossible for GraphQL and body-dependent routes).
2. **`AuthZError` enum over alternatives** (option A): pre-check helpers at every call site risk omission; smuggling the structured body through `tonic::Status` would send definitive denials through the snapshot-retry limbo and force clients to parse JSON out of a message string.
3. **The `estuary_support/` secondary check is masked like every other walk** — the invariant is that a masked token's authority is a subset of the same bearer's unmasked authority, with no special-cased walks.
4. **Legacy `user_capability` metadata under a mask** keeps task 2's semantics: the mask gates node *reachability*; a reached node's legacy value passes through un-attenuated as informational compatibility metadata.
5. **Discovers mask propagation split out** as its own task: a spike first — what could a mask-limited discovery expose or wrongly withhold, and should the mask propagate across the async boundary at all — then implementation only if the spike says yes.

## Tests (written first, TDD)

- `envelope.rs`: definitive denials bypass snapshot-retry (stale and fresh snapshots); retriable denials keep their existing provisional/terminal behavior.
- `server/mod.rs`: the chokepoint pre-check — mask shortfall is definitive and names exactly the missing bits, evaluated before the walk; covering-mask and unmasked walks are ordinary.
- `public/mod.rs`: oneshot-router tests of the two `RequireViewer` routes — structured 403 at extraction with no DB touched; covering and unmasked bearers pass extraction identically; plus the const↔`bits_for_legacy(Read)` parity pin.
- `authorize_user_collection.rs` (class representative for `/authorize/user/*`): masked shortfall, empty-mask identity-only denial, covering-mask parity with the unmasked outcome, and the masked `estuary_support/` Admin walk.
- `graphql/mod.rs` (DB-backed, class representative for GraphQL hard gates): masked denial with the full extensions shape pinned, empty-mask denial, covering-mask/unmasked parity.
- `prefixes.rs` (class representative for GraphQL filters): a mask without `Delegate` confines the listing to direct grants; adding `Delegate` restores role-graph traversal; an empty mask lists nothing — never an error.
- `storage_mappings.rs`: unit coverage of `check_authorization` under masks, plus the list-coherence case — row filter and attached `user_capability` computed under one mask.
- Every pre-existing test passes unchanged (all fixtures mint unmasked tokens), which is the unmasked-parity assertion for the whole surface.


