### PR TITLE
flowctl: preview-next no longer hangs when its fixture feeder dies

### DIFF
--- a/crates/flowctl/src/raw/preview_next/fixture.rs
+++ b/crates/flowctl/src/raw/preview_next/fixture.rs
@@ -1125,6 +1125,88 @@ mod test {
         feeder.await.unwrap().unwrap();
     }
 
+    /// A feeder that dies before EOF must fail the run, not stall it.
+    ///
+    /// A panic inside the feeder unwinds only its tokio worker. It sends no
+    /// `Boundary`, never cancels `eof_stop`, and never releases `hold` — while
+    /// `services::Run` still retains a `frontier_tx` clone, so the channel stays
+    /// open. The consumer therefore cannot distinguish a dead feeder from a slow
+    /// producer, and parks on `recv_checkpoint` until something external reaps
+    /// the process. Aborting the task reproduces exactly that state.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_streaming_feeder_death_is_not_a_hang() {
+        use tokio::io::AsyncWriteExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fifo");
+        assert!(
+            std::process::Command::new("mkfifo")
+                .arg(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let (opener, frontier_tx) = fixture_opener();
+        // `services::Run` holds a sender for the life of the run, so a dead
+        // feeder does not close the channel.
+        let _run_tx = frontier_tx.clone();
+
+        let eof_stop = tokio_util::sync::CancellationToken::new();
+        let hold = tokio_util::sync::CancellationToken::new();
+
+        let (_dir, feeder) = start_streaming(
+            &empty_task(),
+            Some(path.clone()),
+            tmp.path(),
+            1,
+            frontier_tx,
+            eof_stop.clone(),
+            hold.clone(),
+        )
+        .unwrap();
+
+        // The producer holds the pipe open for the whole test, as a benchmark
+        // generator does: the feeder's death is the only thing that changes.
+        let mut pipe = tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .await
+            .unwrap();
+        pipe.write_all(b"[\"a/coll\", {\"k\": 1}]\n{\"commit\": true}\n")
+            .await
+            .unwrap();
+        pipe.flush().await.unwrap();
+
+        let mut src = opener
+            .open(Default::default(), Vec::new(), shuffle::Frontier::default())
+            .await
+            .unwrap();
+        src.request_checkpoint();
+        src.recv_checkpoint().await.unwrap();
+
+        feeder.abort();
+        let _ = feeder.await;
+
+        // The next checkpoint can never be served. It must resolve — as an
+        // error, or by the run being stopped — rather than await forever.
+        src.request_checkpoint();
+        let recv = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::select! {
+                r = src.recv_checkpoint() => Some(r),
+                () = eof_stop.cancelled() => None, // The run was stopped instead.
+            }
+        })
+        .await;
+
+        match recv {
+            Err(_elapsed) => panic!("a dead fixture feeder hung the run"),
+            Ok(Some(Ok(_))) => panic!("a dead feeder must not yield a further checkpoint"),
+            Ok(_) => (),
+        }
+    }
+
     #[test]
     fn test_is_commit_line() {
         assert!(is_commit_line(r#"{"commit": true}"#));

--- a/crates/flowctl/src/raw/preview_next/fixture.rs
+++ b/crates/flowctl/src/raw/preview_next/fixture.rs
@@ -388,6 +388,14 @@ async fn feed_stream(
     eof_stop: tokio_util::sync::CancellationToken,
     hold: tokio_util::sync::CancellationToken,
 ) -> anyhow::Result<()> {
+    // A panic unwinds this task without running the graceful stop below, so the
+    // consumer would park on a checkpoint that can never arrive: `Run` retains a
+    // `frontier_tx` clone, so a dead feeder doesn't even close the channel. The
+    // guard cancels on unwind, ending the run; `finish_fixtures` then joins this
+    // handle and reports the panic. Redundant on the graceful path, which
+    // cancels first.
+    let _stop_on_panic = eof_stop.clone().drop_guard();
+
     let mut sealed = Vec::new();
     let result = feed_lines(
         &bindings,

--- a/crates/flowctl/src/raw/preview_next/fixture.rs
+++ b/crates/flowctl/src/raw/preview_next/fixture.rs
@@ -388,14 +388,6 @@ async fn feed_stream(
     eof_stop: tokio_util::sync::CancellationToken,
     hold: tokio_util::sync::CancellationToken,
 ) -> anyhow::Result<()> {
-    // A panic unwinds this task without running the graceful stop below, so the
-    // consumer would park on a checkpoint that can never arrive: `Run` retains a
-    // `frontier_tx` clone, so a dead feeder doesn't even close the channel. The
-    // guard cancels on unwind, ending the run; `finish_fixtures` then joins this
-    // handle and reports the panic. Redundant on the graceful path, which
-    // cancels first.
-    let _stop_on_panic = eof_stop.clone().drop_guard();
-
     let mut sealed = Vec::new();
     let result = feed_lines(
         &bindings,
@@ -1131,88 +1123,6 @@ mod test {
 
         hold.cancel();
         feeder.await.unwrap().unwrap();
-    }
-
-    /// A feeder that dies before EOF must fail the run, not stall it.
-    ///
-    /// A panic inside the feeder unwinds only its tokio worker. It sends no
-    /// `Boundary`, never cancels `eof_stop`, and never releases `hold` — while
-    /// `services::Run` still retains a `frontier_tx` clone, so the channel stays
-    /// open. The consumer therefore cannot distinguish a dead feeder from a slow
-    /// producer, and parks on `recv_checkpoint` until something external reaps
-    /// the process. Aborting the task reproduces exactly that state.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn test_streaming_feeder_death_is_not_a_hang() {
-        use tokio::io::AsyncWriteExt;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("fifo");
-        assert!(
-            std::process::Command::new("mkfifo")
-                .arg(&path)
-                .status()
-                .unwrap()
-                .success()
-        );
-
-        let (opener, frontier_tx) = fixture_opener();
-        // `services::Run` holds a sender for the life of the run, so a dead
-        // feeder does not close the channel.
-        let _run_tx = frontier_tx.clone();
-
-        let eof_stop = tokio_util::sync::CancellationToken::new();
-        let hold = tokio_util::sync::CancellationToken::new();
-
-        let (_dir, feeder) = start_streaming(
-            &empty_task(),
-            Some(path.clone()),
-            tmp.path(),
-            1,
-            frontier_tx,
-            eof_stop.clone(),
-            hold.clone(),
-        )
-        .unwrap();
-
-        // The producer holds the pipe open for the whole test, as a benchmark
-        // generator does: the feeder's death is the only thing that changes.
-        let mut pipe = tokio::fs::OpenOptions::new()
-            .write(true)
-            .open(&path)
-            .await
-            .unwrap();
-        pipe.write_all(b"[\"a/coll\", {\"k\": 1}]\n{\"commit\": true}\n")
-            .await
-            .unwrap();
-        pipe.flush().await.unwrap();
-
-        let mut src = opener
-            .open(Default::default(), Vec::new(), shuffle::Frontier::default())
-            .await
-            .unwrap();
-        src.request_checkpoint();
-        src.recv_checkpoint().await.unwrap();
-
-        feeder.abort();
-        let _ = feeder.await;
-
-        // The next checkpoint can never be served. It must resolve — as an
-        // error, or by the run being stopped — rather than await forever.
-        src.request_checkpoint();
-        let recv = tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            tokio::select! {
-                r = src.recv_checkpoint() => Some(r),
-                () = eof_stop.cancelled() => None, // The run was stopped instead.
-            }
-        })
-        .await;
-
-        match recv {
-            Err(_elapsed) => panic!("a dead fixture feeder hung the run"),
-            Ok(Some(Ok(_))) => panic!("a dead feeder must not yield a further checkpoint"),
-            Ok(_) => (),
-        }
     }
 
     #[test]

--- a/crates/flowctl/src/raw/preview_next/mod.rs
+++ b/crates/flowctl/src/raw/preview_next/mod.rs
@@ -282,11 +282,12 @@ impl Preview {
                     session_targets,
                     fixture_dirs,
                     controls.clone(),
-                    session_stop,
+                    session_stop.clone(),
                 );
+                let session_loop =
+                    with_fixture_feeder(session_loop, fixture_keepalive, &session_stop);
                 tokio::pin!(session_loop);
                 let result = run_with_timeout(session_loop, timeout, &stop_token).await;
-                let result = finish_fixtures(result, fixture_keepalive).await;
                 finish_output_state(&run, *output_state, result).await
             }
             TaskSpec::Derivation(mut spec) => {
@@ -326,11 +327,12 @@ impl Preview {
                     session_targets,
                     fixture_dirs,
                     controls.clone(),
-                    session_stop,
+                    session_stop.clone(),
                 );
+                let session_loop =
+                    with_fixture_feeder(session_loop, fixture_keepalive, &session_stop);
                 tokio::pin!(session_loop);
                 let result = run_with_timeout(session_loop, timeout, &stop_token).await;
-                let result = finish_fixtures(result, fixture_keepalive).await;
                 finish_output_state(&run, *output_state, result).await
             }
         };
@@ -456,22 +458,53 @@ fn is_streaming_fixture(path: &str) -> anyhow::Result<bool> {
     }
 }
 
-/// Conclude fixture feeding once the session loop has ended: release the
-/// streaming feeder's segment keepalive and join it, surfacing a stream error
-/// (e.g. a malformed fixture line) that otherwise manifests only as a
-/// gracefully-stopped run.
-async fn finish_fixtures(
-    result: anyhow::Result<()>,
+/// Run the session loop alongside a streaming fixture's feeder, concluding both.
+///
+/// The feeder holds its shuffle-log writers until the run ends, so it outlives
+/// the session loop on every ordinary path — a malformed fixture line included,
+/// since that still hands over a Boundary before waiting. Its completing early
+/// therefore means it died: a panic unwinds its worker, stopping nothing. The
+/// consumer would then wait on transactions that can never arrive, so stop the
+/// session and report the feeder's cause.
+///
+/// On the ordinary path the session loop ends first: release the segment
+/// keepalive and join the feeder, surfacing a stream error that otherwise
+/// manifests only as a gracefully-stopped run.
+async fn with_fixture_feeder<F>(
+    session_loop: F,
     keepalive: Option<FixtureKeepalive>,
-) -> anyhow::Result<()> {
-    let Some(FixtureKeepalive::Streaming { _hold, feeder }) = keepalive else {
-        return result;
+    session_stop: &tokio_util::sync::CancellationToken,
+) -> anyhow::Result<()>
+where
+    F: std::future::Future<Output = anyhow::Result<()>>,
+{
+    // An eager fixture (or no fixture) has no feeder; `keepalive` still holds
+    // its segments for the loop's lifetime.
+    let Some(FixtureKeepalive::Streaming { _hold, mut feeder }) = keepalive else {
+        return session_loop.await;
     };
-    drop(_hold); // Cancels the feeder's hold token.
-    let feeder_result = feeder
-        .await
-        .unwrap_or_else(|panic| Err(anyhow::anyhow!("fixture feeder panic: {panic}")));
-    result.and(feeder_result)
+    tokio::pin!(session_loop);
+
+    tokio::select! {
+        result = &mut session_loop => {
+            drop(_hold); // Cancels the feeder's hold token.
+            result.and(feeder_result((&mut feeder).await))
+        }
+        joined = &mut feeder => {
+            tracing::error!("fixture feeder ended before end-of-stream; stopping active session");
+            session_stop.cancel();
+            let _ = session_loop.await;
+            // A panic or stream error is the more useful cause to report.
+            feeder_result(joined).and(Err(anyhow::anyhow!(
+                "fixture feeder ended before end-of-stream"
+            )))
+        }
+    }
+}
+
+/// The feeder's own result, with a panic mapped into an error.
+fn feeder_result(joined: Result<anyhow::Result<()>, tokio::task::JoinError>) -> anyhow::Result<()> {
+    joined.unwrap_or_else(|panic| Err(anyhow::anyhow!("fixture feeder panic: {panic}")))
 }
 
 /// On a successful `--output-state` run, emit the final reduced connector state.
@@ -730,6 +763,41 @@ fn resolve_task(validations: &tables::Validations, name: Option<&str>) -> anyhow
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// A feeder that dies before end-of-stream must fail the run, not stall it.
+    ///
+    /// The feeder holds its writers until the run ends, so its completion means
+    /// death. A panic unwinds only its worker, leaving the session loop parked
+    /// on a checkpoint that can never arrive.
+    #[tokio::test]
+    async fn test_feeder_death_fails_the_run() {
+        let session_stop = tokio_util::sync::CancellationToken::new();
+        let hold = tokio_util::sync::CancellationToken::new();
+
+        let keepalive = Some(FixtureKeepalive::Streaming {
+            _hold: hold.drop_guard(),
+            feeder: tokio::spawn(async { panic!("feeder died") }),
+        });
+
+        // A session loop parked until something stops it, as one awaiting a
+        // checkpoint is.
+        let stop = session_stop.clone();
+        let session_loop = async move {
+            stop.cancelled().await;
+            Ok(())
+        };
+
+        let run = with_fixture_feeder(session_loop, keepalive, &session_stop);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), run).await;
+
+        let Ok(Err(err)) = result else {
+            panic!("a dead fixture feeder must fail the run, got {result:?}");
+        };
+        assert!(
+            format!("{err:#}").contains("fixture feeder panic"),
+            "the error must name the panic: {err:#}",
+        );
+    }
 
     #[test]
     fn test_is_streaming_fixture() {


### PR DESCRIPTION
**Description:**

Fixes #3409.

`flowctl raw preview-next --fixture` can read its fixture from a FIFO or stdin. A background task — the "feeder" — reads lines off the pipe and hands each committed transaction to the consumer. If that feeder panics, the run used to hang forever instead of failing.

Two things combined to hide the death:

1. A panic in a tokio task unwinds only that task. The process keeps running, and the feeder's cleanup code — the part that signals "no more transactions" — is skipped.
2. The consumer waits on a channel for the next transaction. `services::Run` holds its own copy of the sending end, so the channel never closes. Waiting on a dead feeder looks exactly like waiting on a slow one.

So the run sat at ~1% CPU with no timeout and no exit. It cost 2h12m on one benchmark, and the same hang has now happened from two unrelated panics.

The fix supervises the feeder instead of inferring that it is alive. The feeder holds its log writers open until the run ends, so it outlives the session loop on every ordinary path — including a bad fixture line, which still hands over a transaction boundary first. So if the feeder finishes early, it died.

We now run the session loop and the feeder's task handle side by side. Whichever ends first decides what happens. Feeder first: stop the session, let it drain, and fail the run naming the panic. Session loop first: release the writers and join the feeder, which surfaces a stream error that would otherwise look like a clean stop.

**Workflow steps:**

No user-facing change when things go well. When a fixture feeder panics, `preview-next` now exits non-zero with `fixture feeder panic: ...` instead of hanging.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Three commits. The first adds the test and is **red**; the second makes it green; the third reworks the fix after review (see the comment below). Check out the first commit alone if you want to watch it hang.
- No fixture input can make the feeder panic today, so the test spawns a panicking task in its place and checks that the supervisor fails the run.


