### PR TITLE
Docs: Point OpenMetrics API endpoint at api.estuary.dev

### DIFF
--- a/site/docs/features/openmetrics-api.md
+++ b/site/docs/features/openmetrics-api.md
@@ -12,7 +12,7 @@ Integrating the API with monitoring platforms like Prometheus or Datadog also al
 
 The OpenMetrics API consists of one main endpoint:
 
-```https://agent-api-1084703453822.us-central1.run.app/api/v1/metrics/{prefix}/```
+```https://api.estuary.dev/api/v1/metrics/{prefix}/```
 
 The prefix may be for your entire tenant (such as `acmeCo/`) or a subset (such as `acmeCo/sub/path/`).
 
@@ -43,7 +43,7 @@ scrape_configs:
     bearer_token: REFRESH_TOKEN
     metrics_path: /api/v1/metrics/PREFIX/
     static_configs:
-      - targets: [agent-api-1084703453822.us-central1.run.app]
+      - targets: [api.estuary.dev]
 ```
 
 Make sure to replace `REFRESH_TOKEN` and `PREFIX` with your generated refresh token and desired prefix.
@@ -68,7 +68,7 @@ To use the OpenMetrics API with Datadog, add the API endpoint to your `datadog.y
 init_config: {}
 
 instances:
-  - openmetrics_endpoint: https://agent-api-1084703453822.us-central1.run.app/api/v1/metrics/PREFIX/
+  - openmetrics_endpoint: https://api.estuary.dev/api/v1/metrics/PREFIX/
     namespace: estuary
     min_collection_interval: 60
     headers:
@@ -106,7 +106,7 @@ You can also access the OpenMetrics API directly or as part of a custom integrat
 For example, using `curl` this would look like:
 
 ```bash
-curl --location 'https://agent-api-1084703453822.us-central1.run.app/api/v1/metrics/PREFIX/' \
+curl --location 'https://api.estuary.dev/api/v1/metrics/PREFIX/' \
 --header 'Authorization: Bearer REFRESH_TOKEN'
 ```
 


### PR DESCRIPTION
The OpenMetrics page gave customers the bare Cloud Run hostname
(`agent-api-1084703453822.us-central1.run.app`) as their scrape endpoint. Traffic to
that hostname bypasses the Cloud Armor WAF, which only inspects requests arriving
through the load balancer at `api.estuary.dev`.

Swaps all four occurrences to `api.estuary.dev`: the stated endpoint (line 15),
the Prometheus `static_configs.targets` (46), the Datadog `openmetrics_endpoint` (71),
and the `curl` example (109). No other `run.app` references remain under `site/`.

Both hostnames return `401` unauthenticated on `/api/v1/metrics/acmeCo/`, so
`api.estuary.dev` routes to the same service on the same path.

This is the `site/` twin of estuary/docs#49, which made the identical change to
`content/features/openmetrics-api.md`. The two files were byte-identical beforehand.

Refs estuary/security#776