### PR TITLE
runtime-next: yield from the materialize actor's scan loop

### DIFF
--- a/crates/runtime-next/src/container.rs
+++ b/crates/runtime-next/src/container.rs
@@ -278,6 +278,10 @@ pub async fn start<L: crate::Logger>(
         .expect("formatting endpoint address")
         .connect_timeout(std::time::Duration::from_secs(5))
         .http2_keep_alive_interval(std::time::Duration::from_secs(5))
+        // Default is 20s. The task runtime is single-threaded and hyper checks
+        // this timer before reading the pending PONG, so a long synchronous
+        // stretch of shard work would otherwise be misread as a dead peer.
+        .keep_alive_timeout(std::time::Duration::from_secs(60))
         .connect()
         .await
         .with_context(|| {

--- a/crates/runtime-next/src/shard/materialize/actor.rs
+++ b/crates/runtime-next/src/shard/materialize/actor.rs
@@ -151,6 +151,14 @@ impl Actor {
                 "shard materialize Actor::serve iteration"
             );
 
+            // Scanning and Draining `continue` below without awaiting, and a
+            // scan of an append-only binding emits no C:Load at all, so a large
+            // transaction would otherwise monopolize the single-threaded runtime
+            // and starve the connector's h2 keep-alive, killing the connection.
+            if loop_count % 64 == 0 {
+                tokio::task::yield_now().await;
+            }
+
             // Perform non-blocking sends of pending connector requests.
             let wake_connector_tx = self.try_connector_tx();
 


### PR DESCRIPTION
The shard's Actor::serve drives Scanning and Draining with a `continue` that never awaits, and a frontier scan of an append-only binding emits no C:Load at all (load optimization skips every new key), so a large transaction ran the entire scan as one synchronous loop on the task's single-worker tokio runtime.

The hyper h2 connection to connector-init lives on that same runtime with a 5s keep-alive ping and hyper's default 20s timeout. hyper checks the ping timer before reading pending frames, so once the scan outlasted 20s the connection was torn down on the actor's next yield and every open stream failed with "h2 protocol error: error reading a body from connection", surfaced as "Materialize error (expected connector response) from connector" roughly 30s into the transaction.

Yield every 64 loop iterations (one shuffle-log block each), as the capture and derive drain loops already do, and set an explicit 60s keep-alive timeout on the connector-init channel so a shorter stall is not misread as a dead peer.


