### PR TITLE
control-plane-api: run publication tests on catalog-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "billing-types",
  "build",
  "bytes",
+ "catalog-tests",
  "chrono",
  "clap",
  "colored_json",

--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -252,7 +252,6 @@ impl HarnessBuilder {
 
         let builder = control_plane_api::publications::builds::new_builder(mock_connectors);
         let publisher = Publisher::new(
-            "/not/a/real/flowctl-go".into(),
             &url::Url::from_directory_path(builds_root.path()).unwrap(),
             "some-connector-network",
             &logs_tx,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -226,8 +226,6 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 async fn async_main(args: Args) -> Result<(), anyhow::Error> {
-    let flowctl_go = locate_bin::locate("flowctl-go")?;
-
     // The HOSTNAME variable will be set to the name of the pod in k8s
     let application_name = std::env::var("HOSTNAME").unwrap_or_else(|_| "agent".to_string());
     let pg_options = args
@@ -323,7 +321,6 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
 
     let builder = control_plane_api::publications::builds::new_builder(connectors);
     let mut publisher = Publisher::new(
-        flowctl_go,
         &args.builds_root,
         &args.connector_network,
         &logs_tx,

--- a/crates/catalog-tests/src/run.rs
+++ b/crates/catalog-tests/src/run.rs
@@ -189,7 +189,7 @@ async fn run_cases(
         let case_failed = result.is_err();
 
         outcomes.push(match result {
-            Ok(_) => TestOutcome {
+            Ok(()) => TestOutcome {
                 name: test.name.clone(),
                 scope: step_scope(test).to_string(),
                 status: TestStatus::Passed,

--- a/crates/catalog-tests/src/scheduler.rs
+++ b/crates/catalog-tests/src/scheduler.rs
@@ -40,8 +40,7 @@ pub trait Driver {
     async fn advance(&mut self, delta: TestTime) -> anyhow::Result<()>;
 }
 
-/// Run one test case using the given `graph` and `driver`. Returns the scope of
-/// the last step reached (used for error reporting), on success.
+/// Run one test case using the given `graph` and `driver`.
 ///
 /// On failure the graph is still quiesced before returning: a case which fails
 /// partway leaves reads pending (and possibly delayed into the future), and
@@ -52,7 +51,7 @@ pub async fn run_test_case<D: Driver>(
     graph: &mut Graph,
     driver: &mut D,
     test: &TestSpec,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<()> {
     let result = run_steps(graph, driver, test).await;
     let Err(err) = &result else {
         return result;
@@ -94,10 +93,9 @@ async fn run_steps<D: Driver>(
     graph: &mut Graph,
     driver: &mut D,
     test: &TestSpec,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<()> {
     let initial = graph.write_clock().clone();
     let mut test_step = 0usize;
-    let mut scope = String::new();
 
     loop {
         let (ready, next_ready, next_name) = graph.pop_ready_reads();
@@ -115,9 +113,6 @@ async fn run_steps<D: Driver>(
         }
 
         let step = test.steps.get(test_step);
-        if let Some(step) = step {
-            scope = step.step_scope.clone();
-        }
 
         // Ingest steps always run immediately.
         if let Some(step) = step
@@ -157,7 +152,7 @@ async fn run_steps<D: Driver>(
         }
 
         assert_eq!(test_step, test.steps.len(), "unexpected test steps remain",);
-        return Ok(scope);
+        return Ok(());
     }
 }
 

--- a/crates/control-plane-api/Cargo.toml
+++ b/crates/control-plane-api/Cargo.toml
@@ -15,6 +15,7 @@ async-process = { path = "../async-process" }
 async-stripe = { workspace = true }
 billing-types = { path = "../billing-types", features = ["async-graphql"] }
 build = { path = "../build" }
+catalog-tests = { path = "../catalog-tests" }
 coroutines = { path = "../coroutines" }
 doc = { path = "../doc" }
 gazette = { path = "../gazette" }

--- a/crates/control-plane-api/src/publications/builds.rs
+++ b/crates/control-plane-api/src/publications/builds.rs
@@ -4,7 +4,6 @@ use models::Id;
 use rand::RngCore;
 use sqlx::types::Uuid;
 use std::path;
-use tables::BuiltRow;
 use validation::Connectors;
 
 #[async_trait::async_trait]
@@ -82,10 +81,8 @@ async fn build_catalog<Conn: Connectors>(
     connectors: &Conn,
     explicit_plane_name: Option<&str>,
 ) -> anyhow::Result<build::Output> {
-    // We perform the build under a ./builds/ subdirectory, which is a
-    // specific sub-path expected by temp-data-plane underneath its
-    // working temporary directory. This lets temp-data-plane use the
-    // build database in-place.
+    // Stage the build database under a ./builds/ subdirectory of the working
+    // temporary directory; it is uploaded to `builds_root` further below.
     let builds_dir = tmpdir.join("builds");
     std::fs::create_dir(&builds_dir).context("creating builds directory")?;
     tracing::debug!(?builds_dir, "using build directory");
@@ -160,192 +157,61 @@ async fn build_catalog<Conn: Connectors>(
     Ok(output)
 }
 
-pub async fn data_plane(
-    connector_network: &str,
-    flowctl_go: &std::path::Path,
-    logs_token: Uuid,
-    logs_tx: &logs::Tx,
-    tmpdir: &path::Path,
-) -> anyhow::Result<()> {
-    // Start a data-plane. It will use ${tmp_dir}/builds as its builds-root,
-    // which we also used as the build directory, meaning the build database
-    // is already in-place.
-    let data_plane_job = jobs::run(
-        "temp-data-plane",
-        logs_tx,
-        logs_token,
-        async_process::Command::new(flowctl_go)
-            .arg("temp-data-plane")
-            .arg("--network")
-            .arg(connector_network)
-            .arg("--tempdir")
-            .arg(tmpdir)
-            .arg("--unix-sockets")
-            .arg("--log.level=warn")
-            .arg("--log.format=color")
-            .current_dir(tmpdir),
-    )
-    .await
-    .with_context(|| format!("starting data-plane in {tmpdir:?}"))?;
-
-    if !data_plane_job.success() {
-        anyhow::bail!("data-plane in {tmpdir:?} exited with an unexpected error");
-    }
-
-    Ok(())
-}
-
+/// Run a built catalog's tests locally, returning a `tables::Error` per test
+/// case that failed — or that never ran because an earlier failure ended the run.
+///
+/// Derivations execute as resident runtime-next sessions, split across two
+/// shards to exercise multi-shard key routing. Connector and runtime logs stream
+/// to the publication's job logs, gated by each task's own `shards: {logLevel}`.
+/// A user who wants a derivation's debug output in their publication logs raises
+/// that task's level.
 pub async fn test_catalog(
-    flowctl_go: &std::path::Path,
     logs_token: Uuid,
     logs_tx: &logs::Tx,
-    build_id: Id,
-    tmpdir: &path::Path,
+    connector_network: &str,
     catalog: &build::Output,
 ) -> anyhow::Result<tables::Errors> {
     let mut errors = tables::Errors::default();
 
-    // The tmpdir path will always begin with a /, so we don't need to add one
-    let broker_socket_path = tmpdir.join("gazette.sock");
-    let broker_sock = format!("unix://localhost{}", broker_socket_path.display());
-    let consumer_socket_path = tmpdir.join("consumer.sock");
-    let consumer_sock = format!("unix://localhost{}", consumer_socket_path.display());
+    if catalog.built.built_tests.is_empty() {
+        return Ok(errors);
+    }
 
-    // The temp-data-plane is started concurrently and the unix sockets do not
-    // exist until gazette and the consumer have begun listening. Waiting for
-    // the socket files prevents an immediate ENOENT on the first gRPC dial.
-    wait_for_sockets(&[&broker_socket_path, &consumer_socket_path]).await?;
+    // Stream ops logs to the publication's job logs under the "test" stream
+    // name that existing log consumers already select on.
+    let ops_handler = logs::ops_handler(logs_tx.clone(), "test".to_string(), logs_token);
+    let options = catalog_tests::Options {
+        network: connector_network.to_string(),
+        splits: 2, // Exercise multi-shard key routing.
+        log_handler: std::sync::Arc::new(move |log: &ops::Log| {
+            runtime::LogHandler::log(&ops_handler, log)
+        }),
+    };
 
-    let build_id = format!("{build_id}");
-
-    // Activate all derivations.
-    let journal_client = gazette::journal::Client::new(
-        broker_sock.clone(),
-        gazette::journal::Client::new_fragment_client(),
-        proto_grpc::Metadata::default(),
-        gazette::Router::new("local"),
-    );
-    let shard_client = gazette::shard::Client::new(
-        consumer_sock.clone(),
-        proto_grpc::Metadata::default(),
-        gazette::Router::new("local"),
-    );
-
-    for built in catalog
-        .built
-        .built_collections
-        .iter()
-        .filter(|c| c.model().is_some_and(|m| m.derive.is_some()))
-    {
-        let mut spec = built.spec().cloned().unwrap();
-        let shards = spec
-            .derivation
-            .as_mut()
-            .unwrap()
-            .shard_template
-            .as_mut()
-            .unwrap();
-        let build_label = shards
-            .labels
-            .as_mut()
-            .unwrap()
-            .labels
-            .iter_mut()
-            .find(|l| l.name == labels::BUILD)
-            .unwrap();
-        build_label.value = build_id.clone();
-
-        if let Err(err) = activate::activate_collection(
-            &journal_client,
-            &shard_client,
-            &built.collection,
-            Some(&spec),
-            None, // Use "local" logging.
-            None,
-            3, // use 3 splits to try to catch shuffle errors
-        )
+    let results = catalog_tests::run_tests(&catalog.built, options)
         .await
-        .context("activating derivation for test")
-        {
-            tracing::error!(error = ?err, derivation = %built.catalog_name(), "failed to activate derivation in temp-data-plane");
-            errors.insert(tables::Error {
-                error: anyhow::anyhow!(
-                    "Test setup failed. View logs for details and reach out to support@estuary.dev"
-                ),
-                scope: url::Url::parse("flow://publication/test/activate").unwrap(),
-            });
-            // Fail fast on first activation error
-            return Ok(errors);
+        .context("running catalog tests")?;
+
+    for outcome in &results.outcomes {
+        let error = match &outcome.status {
+            catalog_tests::TestStatus::Passed => continue,
+            catalog_tests::TestStatus::Failed { error } => {
+                anyhow::anyhow!("test {} failed:\n{error}", outcome.name)
+            }
+            // A case a preceding failure prevented from running is reported
+            // too, so the publication never silently understates coverage.
+            catalog_tests::TestStatus::NotRun { reason } => {
+                anyhow::anyhow!("test {} was not run: {reason}", outcome.name)
+            }
         };
-    }
-
-    // Run test cases.
-    let job = jobs::run(
-        "test",
-        &logs_tx,
-        logs_token,
-        async_process::Command::new(flowctl_go)
-            .arg("api")
-            .arg("test")
-            .arg("--build-id")
-            .arg(&build_id)
-            .arg("--broker.address")
-            .arg(&broker_sock)
-            .arg("--consumer.address")
-            .arg(&consumer_sock)
-            .arg("--log.level=warn")
-            .arg("--log.format=color"),
-    )
-    .await
-    .context("starting test runner")?;
-
-    if !job.success() {
-        errors.insert(tables::Error {
-            error: anyhow::anyhow!("One or more test cases failed. View logs for details."),
-            scope: url::Url::parse("flow://publication/test/api/test").unwrap(),
-        });
-    }
-
-    // Clean up derivations.
-    for built in catalog
-        .built
-        .built_collections
-        .iter()
-        .filter(|c| c.model().is_some_and(|m| m.derive.is_some()))
-    {
-        if let Err(error) = activate::activate_collection(
-            &journal_client,
-            &shard_client,
-            &built.collection,
-            None,
-            None,
-            None,
-            1,
-        )
-        .await
-        .context("cleaning up derivation after test")
-        {
-            tracing::error!(?error, derivation = %built.catalog_name(), "failed to delete derivation from temp-data-plane");
-            errors.insert(tables::Error {
-                error: anyhow::anyhow!(
-                    "Test cleanup failed. View logs for details and reach out to support@estuary.dev"
-                ),
-                scope: url::Url::parse("flow://publication/test/api/delete").unwrap(),
-            });
-        }
+        // The scope is the failing step's source URL with a JSON-pointer
+        // fragment, so a failure anchors to the exact test step.
+        let scope = url::Url::parse(&outcome.scope)
+            .unwrap_or_else(|_| url::Url::parse("flow://publication/test").unwrap());
+        errors.insert(tables::Error { error, scope });
     }
 
     Ok(errors)
-}
-
-async fn wait_for_sockets(paths: &[&path::Path]) -> anyhow::Result<()> {
-    tokio::time::timeout(std::time::Duration::from_secs(30), async {
-        while !paths.iter().all(|p| p.exists()) {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    .with_context(|| format!("timed out waiting for temp-data-plane sockets {paths:?}"))
 }
 
 /*

--- a/crates/control-plane-api/src/publications/mod.rs
+++ b/crates/control-plane-api/src/publications/mod.rs
@@ -143,7 +143,6 @@ impl PublicationResult {
 /// A PublishHandler is a Handler which publishes catalog specifications.
 #[derive(Debug, Clone)]
 pub struct Publisher {
-    flowctl_go: std::path::PathBuf,
     builds_root: url::Url,
     connector_network: String,
     logs_tx: logs::Tx,
@@ -222,7 +221,6 @@ impl Into<build::Output> for UncommittedBuild {
 
 impl Publisher {
     pub fn new(
-        flowctl_go: std::path::PathBuf,
         builds_root: &url::Url,
         connector_network: &str,
         logs_tx: &logs::Tx,
@@ -231,7 +229,6 @@ impl Publisher {
         builder: Box<dyn builds::Builder>,
     ) -> Self {
         Self {
-            flowctl_go,
             builds_root: builds_root.clone(),
             connector_network: connector_network.to_string(),
             logs_tx: logs_tx.clone(),
@@ -456,34 +453,14 @@ impl Publisher {
             && !self.skip_tests
             && built.errors().next().is_none()
         {
-            tracing::info!(%build_id, %publication_id, tmpdir = %tmpdir.display(), "running tests");
-            let data_plane_job = builds::data_plane(
-                &self.connector_network,
-                &self.flowctl_go,
-                logs_token,
-                &self.logs_tx,
-                tmpdir,
-            );
-            let test_jobs = builds::test_catalog(
-                &self.flowctl_go,
-                logs_token,
-                &self.logs_tx,
-                build_id,
-                tmpdir,
-                &built,
-            );
+            tracing::info!(%build_id, %publication_id, "running tests");
 
-            // Drive the data-plane and test jobs, until test jobs complete.
-            tokio::pin!(test_jobs);
-            let errors: tables::Errors = tokio::select! {
-                r = data_plane_job => {
-                    tracing::error!(?r, "test data-plane exited unexpectedly");
-                    test_jobs.await // Wait for test jobs to finish.
-                }
-                r = &mut test_jobs => r,
-            }?;
+            // Tests run in-process; there is no data plane to race against.
+            let errors =
+                builds::test_catalog(logs_token, &self.logs_tx, &self.connector_network, &built)
+                    .await?;
 
-            tracing::debug!(test_count = %built.live.tests.len(), test_errors = %errors.len(), "finished running tests");
+            tracing::debug!(test_count = %built.built.built_tests.len(), test_errors = %errors.len(), "finished running tests");
             errors
         } else {
             tables::Errors::default()

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -110,7 +110,6 @@ impl TestServer {
 
         // Build an invalid Publisher that will blow up if used.
         let publisher = crate::publications::Publisher::new(
-            std::path::PathBuf::from("/invalid"),
             &url::Url::parse("file:///invalid").unwrap(),
             &"invalid",
             &logs_tx,

--- a/crates/control-plane-api/tests/catalog_tests.rs
+++ b/crates/control-plane-api/tests/catalog_tests.rs
@@ -1,0 +1,152 @@
+//! Verifies the control-plane's `test_catalog` linkage to `catalog-tests`:
+//! publication tests run on the Rust-only runtime-next stack (no temp data-plane,
+//! no `flowctl-go`), and a failing test surfaces a `tables::Error` to the
+//! publication.
+//!
+//! Uses derive-sqlite, so no connector containers are needed, and `test_catalog`
+//! never touches Postgres, so these run without a database.
+
+use control_plane_api::logs;
+use control_plane_api::publications::builds;
+
+/// Build a derive-sqlite catalog (with tests) to a `build::Output`, validating
+/// in-process with no control-plane round-trip.
+async fn build_catalog(yaml: &str) -> build::Output {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("catalog.flow.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    let url = build::arg_source_to_url(path.to_str().unwrap(), false).unwrap();
+
+    let output = build::for_catalog_test(&url, "", ::ops::tracing_log_handler).await;
+    assert!(
+        output.errors().next().is_none(),
+        "catalog should build cleanly: {:?}",
+        output.errors().collect::<Vec<_>>()
+    );
+    output
+}
+
+/// A drained log sink standing in for a publication's `logs_tx`.
+fn logs_sink() -> logs::Tx {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1024);
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    tx
+}
+
+const PASSING: &str = r#"
+collections:
+  acmeCo/ints:
+    schema:
+      type: object
+      properties:
+        Key: { type: string }
+        Int: { type: integer }
+      required: [Key, Int]
+    key: [/Key]
+  acmeCo/doubled:
+    schema:
+      type: object
+      properties:
+        Key: { type: string }
+        Doubled: { type: integer }
+      required: [Key, Doubled]
+    key: [/Key]
+    derive:
+      using:
+        sqlite: {}
+      transforms:
+        - name: fromInts
+          source: { name: acmeCo/ints }
+          shuffle: { key: [/Key] }
+          lambda: SELECT JSON_OBJECT('Key', $Key, 'Doubled', $Int * 2);
+tests:
+  acmeCo/test/doubles:
+    - ingest:
+        collection: acmeCo/ints
+        documents:
+          - { Key: a, Int: 3 }
+    - verify:
+        collection: acmeCo/doubled
+        documents:
+          - { Key: a, Doubled: 6 }
+"#;
+
+/// A catalog whose expectation is deliberately wrong.
+const FAILING: &str = r#"
+collections:
+  acmeCo/ints:
+    schema:
+      type: object
+      properties:
+        Key: { type: string }
+        Int: { type: integer }
+      required: [Key, Int]
+    key: [/Key]
+  acmeCo/doubled:
+    schema:
+      type: object
+      properties:
+        Key: { type: string }
+        Doubled: { type: integer }
+      required: [Key, Doubled]
+    key: [/Key]
+    derive:
+      using:
+        sqlite: {}
+      transforms:
+        - name: fromInts
+          source: { name: acmeCo/ints }
+          shuffle: { key: [/Key] }
+          lambda: SELECT JSON_OBJECT('Key', $Key, 'Doubled', $Int * 2);
+tests:
+  acmeCo/test/wrong:
+    - ingest:
+        collection: acmeCo/ints
+        documents:
+          - { Key: a, Int: 3 }
+    - verify:
+        collection: acmeCo/doubled
+        documents:
+          - { Key: a, Doubled: 999 }
+"#;
+
+#[tokio::test]
+async fn passing_catalog_test_reports_no_errors() {
+    let output = build_catalog(PASSING).await;
+    let logs_token = uuid::Uuid::nil();
+
+    let errors = builds::test_catalog(logs_token, &logs_sink(), "", &output)
+        .await
+        .expect("test_catalog runs");
+
+    assert!(
+        errors.is_empty(),
+        "a passing catalog test should surface no errors, got: {:?}",
+        errors
+            .iter()
+            .map(|e| e.error.to_string())
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[tokio::test]
+async fn failing_catalog_test_surfaces_error() {
+    let output = build_catalog(FAILING).await;
+    let logs_token = uuid::Uuid::nil();
+
+    let errors = builds::test_catalog(logs_token, &logs_sink(), "", &output)
+        .await
+        .expect("test_catalog runs");
+
+    assert_eq!(
+        errors.len(),
+        1,
+        "the wrong expectation must surface one error"
+    );
+    let rendered = errors.iter().next().unwrap().error.to_string();
+    assert!(
+        rendered.contains("acmeCo/test/wrong") && rendered.contains("999"),
+        "error should name the failing test and render the diff, got:\n{rendered}",
+    );
+}


### PR DESCRIPTION
**Description:**

Stack 4 of 5, one commit. Publication tests now call `catalog_tests::run_tests` in-process, against the `build::Output` the publication already produced.

**Workflow steps:**

No change to how a user runs tests — they still publish a draft and see test results in publication logs. What changes is where those results come from and how precisely failures are reported.

**Documentation links affected:**

None.

**Notes for reviewers:**

Most of the surface is deletion. One behavior changes:

* **Failures anchor precisely.** Each failing case becomes a `tables::Error` scoped to the failing *step's* source URL and JSON pointer, where before a whole run collapsed into one error at `flow://publication/test/api/test` with "View logs for details". A case the run never reached is reported as an error too, so a publication never silently understates its test coverage.

---

**Stack** — each PR is based on the one above it, so review only the top commits of each.

1. #3415 — Housekeeping and prep *(merged)*
2. #3416 — runtime-local: extract the local task-drive layer
3. #3417 — catalog-tests: the harness, and `flowctl raw test`
4. #3418 — control-plane-api: run publication tests on catalog-tests ← **you are here**
5. #3419 — Remove the V1 catalog-test machinery
