### PR TITLE
control-plane-api: capability_token grant mints masked access tokens

### DIFF
--- a/crates/agent/src/integration_tests/harness.rs
+++ b/crates/agent/src/integration_tests/harness.rs
@@ -1790,6 +1790,7 @@ impl TestHarness {
             self.publisher.clone(),
             snapshot_watch.clone(),
             None,
+            control_plane_api::DEFAULT_CAPABILITY_TOKEN_VALIDITY,
         ));
 
         self.control_plane_app = Some(app);

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -13,6 +13,12 @@ use futures::FutureExt;
 use sqlx::{ConnectOptions, Connection};
 use std::sync::Arc;
 
+/// The `--capability-token-validity` default, as the humantime string clap
+/// requires. A test welds it to the `Duration` the rest of the platform
+/// uses, `control_plane_api::DEFAULT_CAPABILITY_TOKEN_VALIDITY`, so the two
+/// spellings of the default cannot drift.
+const CAPABILITY_TOKEN_VALIDITY_DEFAULT: &str = "1h";
+
 /// Agent is a daemon which runs server-side tasks of the Flow control-plane.
 #[derive(Derivative, Parser)]
 #[derivative(Debug)]
@@ -95,6 +101,18 @@ struct Args {
     )]
     #[arg(value_parser = humantime::parse_duration)]
     heartbeat_timeout: std::time::Duration,
+    /// Validity window of access tokens minted by the `capability_token`
+    /// grant. The default matches the one-hour access tokens of the SQL
+    /// `generate_access_token` mint; raising it widens the exposure of a
+    /// leaked masked token and diverges from the SQL mint's fixed hour, so
+    /// overrides warrant care.
+    #[clap(
+        long = "capability-token-validity",
+        env = "CAPABILITY_TOKEN_VALIDITY",
+        default_value = CAPABILITY_TOKEN_VALIDITY_DEFAULT
+    )]
+    #[arg(value_parser = humantime::parse_duration)]
+    capability_token_validity: std::time::Duration,
 
     #[clap(long = "log-format", env = "LOG_FORMAT", default_value = "json")]
     log_format: LogFormat,
@@ -392,6 +410,7 @@ async fn async_main(args: Args) -> Result<(), anyhow::Error> {
         publisher.clone(),
         snapshot_watch.clone(),
         args.stripe_webhook_secret,
+        args.capability_token_validity,
     ));
     let api_router = control_plane_api::build_router(
         api_app.clone(),
@@ -512,4 +531,19 @@ fn new_http_client() -> anyhow::Result<reqwest::Client> {
 
     let c = reqwest::Client::builder().default_headers(map).build()?;
     Ok(c)
+}
+
+#[cfg(test)]
+mod test {
+    /// The clap default string and the platform's `Duration` constant are two
+    /// spellings of one value; this pins them together — and pins that the
+    /// default parses at all, which clap otherwise validates only at the
+    /// first agent startup.
+    #[test]
+    fn test_capability_token_validity_default_welds() {
+        assert_eq!(
+            humantime::parse_duration(super::CAPABILITY_TOKEN_VALIDITY_DEFAULT).unwrap(),
+            control_plane_api::DEFAULT_CAPABILITY_TOKEN_VALIDITY,
+        );
+    }
 }

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -88,14 +88,17 @@ impl Requirement for RequireViewer {
 #[derive(Debug, serde::Serialize)]
 pub struct Forbidden {
     /// Stable machine-readable code: `missing_capabilities` when the
-    /// bearer's mask does not enable required capabilities, or
+    /// bearer's mask does not enable required capabilities,
     /// `unmasked_token_required` when the operation refuses masked bearers
-    /// outright (which no re-mint can remedy).
+    /// outright (which no re-mint can remedy), or
+    /// `service_account_forbidden` when the operation is restricted to
+    /// human users and the bearer is a service-account identity.
     pub error: &'static str,
     /// Human-readable description of the refusal.
     pub message: String,
     /// PascalCase names of capabilities which are required but not enabled
-    /// by the bearer's mask. Empty for `unmasked_token_required`.
+    /// by the bearer's mask. Empty for `unmasked_token_required` and
+    /// `service_account_forbidden`.
     pub missing_capabilities: Vec<&'static str>,
 }
 
@@ -134,6 +137,14 @@ impl Forbidden {
         Self {
             error: "unmasked_token_required",
             message: "this operation requires a full-authority token, but the bearer token carries a capability mask".to_string(),
+            missing_capabilities: Vec::new(),
+        }
+    }
+
+    pub fn service_account_forbidden() -> Self {
+        Self {
+            error: "service_account_forbidden",
+            message: "this operation is restricted to human users, but the bearer token belongs to a service account".to_string(),
             missing_capabilities: Vec::new(),
         }
     }

--- a/crates/control-plane-api/src/grants.rs
+++ b/crates/control-plane-api/src/grants.rs
@@ -55,3 +55,26 @@ pub async fn overwrite_user_grant(
 
     Ok(())
 }
+
+/// Whether `user_id` is a service-account identity.
+///
+/// Claims alone cannot answer this — a service-account access token is
+/// shaped identically to a human one — so callers which restrict an
+/// operation to human users pay this lookup at that operation, never
+/// per-request. Consumers: the refresh-token GraphQL mutations (via
+/// `verify_not_service_account`) and the REST `capability_token` mint.
+pub(crate) async fn is_service_account(
+    pg_pool: &sqlx::PgPool,
+    user_id: Uuid,
+) -> sqlx::Result<bool> {
+    sqlx::query_scalar!(
+        r#"
+        SELECT EXISTS(
+            SELECT 1 FROM internal.service_accounts WHERE user_id = $1
+        ) AS "is_service_account!"
+        "#,
+        user_id,
+    )
+    .fetch_one(pg_pool)
+    .await
+}

--- a/crates/control-plane-api/src/lib.rs
+++ b/crates/control-plane-api/src/lib.rs
@@ -62,7 +62,7 @@ pub use authority::{
 // hoisted from the `server` module. For now, just re-export to minimize churn.
 pub(crate) use server::evaluate_names_authorization;
 pub use server::{
-    ApiError, App, AuthZRetry, build_router,
+    ApiError, App, AuthZRetry, DEFAULT_CAPABILITY_TOKEN_VALIDITY, build_router,
     snapshot::{self, Snapshot},
 };
 

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -32,9 +32,20 @@ pub enum Rejection {
 }
 
 /// App is the wired application state of the control-plane API.
+/// Default validity of access tokens minted by the `capability_token`
+/// grant, matching the one-hour access tokens of the SQL
+/// `generate_access_token` mint. The agent's `--capability-token-validity`
+/// setting defaults to this value; a test there welds its default string to
+/// this constant.
+pub const DEFAULT_CAPABILITY_TOKEN_VALIDITY: std::time::Duration =
+    std::time::Duration::from_secs(3600);
+
 pub struct App {
     pub _id_generator: std::sync::Mutex<models::IdGenerator>,
     pub billing_provider: Option<Arc<dyn crate::billing::BillingProvider>>,
+    /// Validity window of access tokens minted by the `capability_token`
+    /// grant. See [`DEFAULT_CAPABILITY_TOKEN_VALIDITY`].
+    pub capability_token_validity: std::time::Duration,
     pub control_plane_jwt_decode_keys: Vec<tokens::jwt::DecodingKey>,
     pub control_plane_jwt_encode_key: tokens::jwt::EncodingKey,
     pub pg_pool: sqlx::PgPool,
@@ -55,10 +66,12 @@ impl App {
         publisher: crate::publications::Publisher,
         snapshot: Arc<dyn tokens::Watch<Snapshot>>,
         stripe_webhook_secret: Option<String>,
+        capability_token_validity: std::time::Duration,
     ) -> Self {
         Self {
             _id_generator: std::sync::Mutex::new(id_generator),
             billing_provider,
+            capability_token_validity,
             control_plane_jwt_decode_keys: vec![tokens::jwt::DecodingKey::from_secret(jwt_secret)],
             control_plane_jwt_encode_key: tokens::jwt::EncodingKey::from_secret(jwt_secret),
             pg_pool,

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -40,6 +40,7 @@ mod publication_history;
 mod refresh_tokens;
 mod scalars;
 mod service_accounts;
+pub(crate) use service_accounts::is_service_account;
 pub mod status;
 mod storage_mappings;
 mod tenant;

--- a/crates/control-plane-api/src/server/public/graphql/mod.rs
+++ b/crates/control-plane-api/src/server/public/graphql/mod.rs
@@ -40,7 +40,6 @@ mod publication_history;
 mod refresh_tokens;
 mod scalars;
 mod service_accounts;
-pub(crate) use service_accounts::is_service_account;
 pub mod status;
 mod storage_mappings;
 mod tenant;

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -748,29 +748,6 @@ impl ServiceAccountsMutation {
     }
 }
 
-/// Whether `user_id` is a service-account identity.
-///
-/// Claims alone cannot answer this — a service-account access token is
-/// shaped identically to a human one — so callers which restrict an
-/// operation to human users pay this lookup at that operation, never
-/// per-request. Consumers: the refresh-token mutations (via
-/// [`verify_not_service_account`]) and the `capability_token` mint.
-pub(crate) async fn is_service_account(
-    pg_pool: &sqlx::PgPool,
-    user_id: uuid::Uuid,
-) -> sqlx::Result<bool> {
-    sqlx::query_scalar!(
-        r#"
-        SELECT EXISTS(
-            SELECT 1 FROM internal.service_accounts WHERE user_id = $1
-        ) AS "is_service_account!"
-        "#,
-        user_id,
-    )
-    .fetch_one(pg_pool)
-    .await
-}
-
 /// Verify that `user_id` is not a service-account identity, erroring if it is.
 ///
 /// Service-account credentials are administered through createApiKey /
@@ -782,7 +759,7 @@ pub(super) async fn verify_not_service_account(
     pg_pool: &sqlx::PgPool,
     user_id: uuid::Uuid,
 ) -> async_graphql::Result<()> {
-    if is_service_account(pg_pool, user_id).await? {
+    if crate::grants::is_service_account(pg_pool, user_id).await? {
         return Err(async_graphql::Error::new(
             "service accounts cannot manage refresh tokens: their API keys are \
              administered via createApiKey and revokeApiKey",

--- a/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
+++ b/crates/control-plane-api/src/server/public/graphql/service_accounts.rs
@@ -748,6 +748,29 @@ impl ServiceAccountsMutation {
     }
 }
 
+/// Whether `user_id` is a service-account identity.
+///
+/// Claims alone cannot answer this — a service-account access token is
+/// shaped identically to a human one — so callers which restrict an
+/// operation to human users pay this lookup at that operation, never
+/// per-request. Consumers: the refresh-token mutations (via
+/// [`verify_not_service_account`]) and the `capability_token` mint.
+pub(crate) async fn is_service_account(
+    pg_pool: &sqlx::PgPool,
+    user_id: uuid::Uuid,
+) -> sqlx::Result<bool> {
+    sqlx::query_scalar!(
+        r#"
+        SELECT EXISTS(
+            SELECT 1 FROM internal.service_accounts WHERE user_id = $1
+        ) AS "is_service_account!"
+        "#,
+        user_id,
+    )
+    .fetch_one(pg_pool)
+    .await
+}
+
 /// Verify that `user_id` is not a service-account identity, erroring if it is.
 ///
 /// Service-account credentials are administered through createApiKey /
@@ -759,18 +782,7 @@ pub(super) async fn verify_not_service_account(
     pg_pool: &sqlx::PgPool,
     user_id: uuid::Uuid,
 ) -> async_graphql::Result<()> {
-    let is_service_account = sqlx::query_scalar!(
-        r#"
-        SELECT EXISTS(
-            SELECT 1 FROM internal.service_accounts WHERE user_id = $1
-        ) AS "is_service_account!"
-        "#,
-        user_id,
-    )
-    .fetch_one(pg_pool)
-    .await?;
-
-    if is_service_account {
+    if is_service_account(pg_pool, user_id).await? {
         return Err(async_graphql::Error::new(
             "service accounts cannot manage refresh tokens: their API keys are \
              administered via createApiKey and revokeApiKey",

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -247,11 +247,15 @@ mod test {
     }
 
     /// Covers the capability_token grant end-to-end: the copy-through claim
-    /// set of a successful mint, verbatim mask stamping, the identity-only
-    /// empty mask, and every refusal — missing bearer, masked caller,
-    /// service-account caller — plus the bearer handling of the endpoint as
-    /// a whole (an invalid bearer is rejected regardless of grant) and the
-    /// typed extractor's rejection of an unknown grant.
+    /// set of a successful mint (with a scoped-role, email-less bearer
+    /// distinguishing copy-through from hardcoded values), verbatim mask
+    /// stamping, the identity-only empty mask, and minted names driving real
+    /// enforcement at a RequireViewer route; every refusal — missing bearer,
+    /// masked caller, service-account caller, and the mask refusal preceding
+    /// the service-account lookup when a bearer is both — plus the bearer
+    /// handling of the endpoint as a whole (an invalid bearer is rejected
+    /// regardless of grant) and the typed extractor's rejection of
+    /// structurally invalid requests.
     #[sqlx::test(
         migrations = "../../supabase/migrations",
         fixtures(path = "../../fixtures", scripts("data_planes", "alice"))
@@ -340,16 +344,86 @@ mod test {
         .await;
         assert_eq!(status, reqwest::StatusCode::FORBIDDEN);
 
-        // === A caller without an email claim mints a token without one ===
-        let no_email_token = server.make_access_token(ALICE, None);
+        // === Minted names are enforcement's vocabulary ===
+        // The mask is opaque at mint, so nothing above proves that a name the
+        // mint stamps is a name enforcement recognizes — a token whose names
+        // enforcement couldn't parse would round-trip every claim assertion
+        // and still be functionally identity-only. Driving a
+        // RequireViewer route with minted tokens closes that seam through
+        // real extraction: the Viewer-bearing mask passes the requirement
+        // gate (the 307 is the walk's provisional denial under the test's
+        // empty first Snapshot — extraction is already behind it), while the
+        // identity-only mask is the structured shortfall 403.
+        let no_redirect = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let probe_status = |bearer: String| {
+            let url = server.base_url().join("/api/v1/catalog/status").unwrap();
+            let no_redirect = no_redirect.clone();
+            async move {
+                let response = no_redirect
+                    .get(url)
+                    .query(&[("name", "aliceCo/thing")])
+                    .bearer_auth(bearer)
+                    .send()
+                    .await
+                    .unwrap();
+                (response.status(), response.text().await.unwrap())
+            }
+        };
+
+        let (status, body) = probe_status(minted_token.clone()).await;
+        assert_eq!(
+            status,
+            reqwest::StatusCode::TEMPORARY_REDIRECT,
+            "a minted Viewer mask clears the requirement gate: {body}"
+        );
+
+        let (status, body) = probe_status(identity_token.clone()).await;
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "{body}");
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["error"], "missing_capabilities");
+        assert!(
+            !body["missing_capabilities"].as_array().unwrap().is_empty(),
+            "the shortfall names the Viewer capabilities: {body}"
+        );
+
+        // === Identity claims are copied, not assumed ===
+        // Every other bearer in this test carries role "authenticated" and an
+        // email, which a hardcoded role literal and an invented email would
+        // satisfy equally well. A scoped role — the shape of a pg_role CI
+        // credential — distinguishes copy-through (role fidelity is what
+        // keeps a minted token authorizing as its caller does against
+        // Supabase/PostgREST's SET ROLE), and the same bearer's absent email
+        // pins that the mint carries `None` rather than inventing a value.
+        let scoped_role_token = {
+            let now = tokens::now();
+            let claims = models::authorizations::ControlClaims {
+                iat: now.timestamp() as u64,
+                exp: (now + chrono::Duration::hours(1)).timestamp() as u64,
+                sub: ALICE,
+                role: "github_action_connector_refresh".to_string(),
+                aud: "authenticated".to_string(),
+                email: None,
+                capability_mask: None,
+            };
+            jsonwebtoken::encode(
+                &jsonwebtoken::Header::default(),
+                &claims,
+                &server.encoding_key,
+            )
+            .unwrap()
+        };
         let (status, body) = post_token(
             &server,
             &capability_request(serde_json::json!(["CatalogRead"])),
-            Some(&no_email_token),
+            Some(&scoped_role_token),
         )
         .await;
-        assert_eq!(status, reqwest::StatusCode::OK, "email-less mint: {body}");
+        assert_eq!(status, reqwest::StatusCode::OK, "scoped-role mint: {body}");
         let (claims, _token) = claims_of(&body);
+        assert_eq!(claims.role, "github_action_connector_refresh");
         assert_eq!(claims.email, None);
 
         // === The grant requires an authenticated caller ===
@@ -393,6 +467,24 @@ mod test {
             @r###"403 Forbidden: {"error":"service_account_forbidden","message":"this operation is restricted to human users, but the bearer token belongs to a service account","missing_capabilities":[]}"###
         );
 
+        // A bearer which is both masked and a service account gets the mask
+        // refusal: the pure-claims check runs before the database lookup, so
+        // the cheaper check decides and the response discloses nothing the
+        // claims don't already say.
+        let masked_svc_token =
+            server.make_masked_access_token(svc_user, None, Some(vec!["CatalogRead"]));
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!(["CatalogRead"])),
+            Some(&masked_svc_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN);
+        assert!(
+            body.contains("unmasked_token_required"),
+            "the mask refusal precedes the service-account lookup: {body}"
+        );
+
         // === An invalid bearer is rejected regardless of grant ===
         // The endpoint verifies any Authorization header it is given, so a
         // broken bearer fails even the otherwise-unauthenticated
@@ -410,13 +502,21 @@ mod test {
         .await;
         assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
 
-        // === An unknown grant is rejected by the typed extractor ===
-        let (status, _body) = post_token(
-            &server,
-            &serde_json::json!({ "grant_type": "not_a_grant" }),
-            Some(&alice_token),
-        )
-        .await;
-        assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+        // === Structurally invalid requests are rejected by the typed extractor ===
+        // `capability_mask` is a required array, so the grant structurally
+        // cannot be spoken without one — there is no request shape which
+        // mints an unmasked token — and null is not the empty mask.
+        for invalid in [
+            serde_json::json!({ "grant_type": "not_a_grant" }),
+            serde_json::json!({ "grant_type": "capability_token" }),
+            serde_json::json!({ "grant_type": "capability_token", "capability_mask": null }),
+        ] {
+            let (status, body) = post_token(&server, &invalid, Some(&alice_token)).await;
+            assert_eq!(
+                status,
+                reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+                "{invalid}: {body}"
+            );
+        }
     }
 }

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -1,5 +1,9 @@
 use std::sync::Arc;
 
+/// Validity of a minted capability token, matching the one-hour access
+/// tokens of the SQL `generate_access_token` mint.
+const CAPABILITY_TOKEN_VALIDITY_SECONDS: u64 = 3600;
+
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(tag = "grant_type")]
 pub enum TokenRequest {
@@ -7,6 +11,19 @@ pub enum TokenRequest {
     RefreshToken {
         refresh_token_id: models::Id,
         secret: String,
+    },
+    /// Mint an access token whose authority is limited to a selected set of
+    /// capabilities. The caller authenticates with a normal full-authority
+    /// bearer token; the minted token identifies the same user and carries
+    /// `capability_mask` as a claim, which authorization intersects with the
+    /// user's live grants at use time.
+    #[serde(rename = "capability_token")]
+    CapabilityToken {
+        /// Capability-bundle names to mask the minted token's authority to.
+        /// Names are opaque here: unrecognized names are carried through and
+        /// are inert at use, and an empty list is valid — it mints an
+        /// identity-only token.
+        capability_mask: Vec<String>,
     },
 }
 
@@ -27,9 +44,15 @@ pub struct RefreshTokenResponse {
 
 pub async fn handle_post_token(
     axum::extract::State(app): axum::extract::State<Arc<crate::App>>,
+    crate::Authority { envelope, .. }: crate::Authority,
     axum::Json(req): axum::Json<TokenRequest>,
 ) -> Result<axum::Json<TokenResponse>, crate::ApiError> {
     match req {
+        // The refresh_token grant is unauthenticated: the credential is the
+        // (id, secret) pair in the body, and `envelope` goes unused. A request
+        // which nonetheless presents an Authorization bearer has it verified
+        // by extraction above, so a broken bearer is rejected regardless of
+        // grant.
         TokenRequest::RefreshToken {
             refresh_token_id,
             secret,
@@ -37,7 +60,90 @@ pub async fn handle_post_token(
             let response = generate_access_token(&app.pg_pool, refresh_token_id, &secret).await?;
             Ok(axum::Json(response))
         }
+        TokenRequest::CapabilityToken { capability_mask } => {
+            let response = mint_capability_token(
+                &envelope,
+                capability_mask,
+                &app.control_plane_jwt_encode_key,
+            )
+            .await?;
+            Ok(axum::Json(response))
+        }
     }
+}
+
+/// Mint a capability-masked access token for the authenticated caller.
+///
+/// The `capability_token` grant requires an unmasked, human caller:
+/// - A missing or invalid bearer is `401 Unauthorized`.
+/// - A masked bearer is `403 unmasked_token_required`: the mint is brokered
+///   by a holder of the user's full-authority token, and a reduced token
+///   must not be able to widen or re-mint itself by calling this exchange.
+/// - A service-account bearer is `403 service_account_forbidden`: masked
+///   tokens are a human-delegation mechanism, and service accounts hold
+///   admin-issued API keys instead. The lookup cost lives here at the mint
+///   only — enforcement needs no such check, because a mask only ever
+///   narrows authority.
+async fn mint_capability_token(
+    envelope: &crate::Envelope,
+    capability_mask: Vec<String>,
+    encoding_key: &tokens::jwt::EncodingKey,
+) -> Result<TokenResponse, crate::ApiError> {
+    let claims = envelope.claims()?;
+
+    if claims.capability_mask.is_some() {
+        return Err(crate::ApiError::Forbidden(
+            crate::Forbidden::unmasked_token_required(),
+        ));
+    }
+    if super::graphql::is_service_account(&envelope.pg_pool, claims.sub).await? {
+        return Err(crate::ApiError::Forbidden(
+            crate::Forbidden::service_account_forbidden(),
+        ));
+    }
+
+    let access_token = sign_capability_token(claims, capability_mask, encoding_key)?;
+    Ok(TokenResponse {
+        access_token,
+        refresh_token: None,
+    })
+}
+
+/// Sign a one-hour access token which copies the caller's verified identity
+/// claims and carries `capability_mask` verbatim.
+///
+/// The identity claims (`sub`, `role`, `aud`, and `email` when the caller's
+/// token has it) are a pure copy-through, so the minted token remains a
+/// fully functional access token everywhere its bearer's identity is what
+/// matters — including Supabase/PostgREST, which reads `sub` and `role` and
+/// ignores claims it doesn't know. Aside from `email` and `capability_mask`,
+/// this is the claim set of the SQL `generate_access_token` mint, whose
+/// shape is pinned by the pgTAP tests in
+/// `supabase/tests/scoped_ci_tokens.test.sql`; the two mint paths must not
+/// drift.
+///
+/// The mask is deliberately not validated: enforcement recognizes the
+/// bundle names it knows and ignores the rest, which is what makes unknown
+/// names inert and mixed-version fleets safe. See
+/// `models::authorizations::ControlClaims::capability_mask`.
+fn sign_capability_token(
+    caller: &models::authorizations::ControlClaims,
+    capability_mask: Vec<String>,
+    encoding_key: &tokens::jwt::EncodingKey,
+) -> tonic::Result<String> {
+    let iat = tokens::now().timestamp() as u64;
+
+    let claims = models::authorizations::ControlClaims {
+        aud: caller.aud.clone(),
+        iat,
+        exp: iat + CAPABILITY_TOKEN_VALIDITY_SECONDS,
+        sub: caller.sub,
+        role: caller.role.clone(),
+        email: caller.email.clone(),
+        capability_mask: Some(capability_mask),
+    };
+
+    tokens::jwt::sign(&claims, encoding_key)
 }
 
 // Exchange a refresh token for an access token by calling the SQL
@@ -90,4 +196,227 @@ pub(crate) async fn generate_access_token(
         );
         tonic::Status::internal("invalid token response")
     })
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_server;
+
+    const ALICE: uuid::Uuid = uuid::Uuid::from_bytes([0x11; 16]);
+
+    async fn post_token(
+        server: &test_server::TestServer,
+        body: &serde_json::Value,
+        bearer: Option<&str>,
+    ) -> (reqwest::StatusCode, String) {
+        let response = server
+            .rest_client()
+            .post("/api/v1/auth/token", body, bearer)
+            .send()
+            .await
+            .unwrap();
+        (response.status(), response.text().await.unwrap())
+    }
+
+    fn capability_request(mask: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "grant_type": "capability_token",
+            "capability_mask": mask,
+        })
+    }
+
+    /// Decode a minted token's claims without signature verification. The
+    /// signature itself is proven by presenting the token back to the server
+    /// as a bearer, which routes it through real Envelope verification.
+    fn claims_of(body: &str) -> (models::authorizations::ControlClaims, String) {
+        let body: serde_json::Value = serde_json::from_str(body).unwrap();
+        let access_token = body["access_token"].as_str().unwrap().to_string();
+
+        // The capability_token grant mints no refresh credential, so the
+        // response carries exactly the access_token.
+        assert_eq!(
+            body.as_object().unwrap().keys().collect::<Vec<_>>(),
+            vec!["access_token"],
+        );
+
+        let unverified = tokens::jwt::parse_unverified::<models::authorizations::ControlClaims>(
+            access_token.as_bytes(),
+        )
+        .unwrap();
+        (unverified.claims().clone(), access_token)
+    }
+
+    /// Covers the capability_token grant end-to-end: the copy-through claim
+    /// set of a successful mint, verbatim mask stamping, the identity-only
+    /// empty mask, and every refusal — missing bearer, masked caller,
+    /// service-account caller — plus the bearer handling of the endpoint as
+    /// a whole (an invalid bearer is rejected regardless of grant) and the
+    /// typed extractor's rejection of an unknown grant.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_capability_token_mint(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+        let alice_token = server.make_access_token(ALICE, Some("alice@example.com"));
+
+        // === A full-authority caller mints a masked token ===
+        // The mask is stamped verbatim: unrecognized names and duplicates
+        // carry through, because enforcement (not the mint) decides what a
+        // name enables.
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!([
+                "CatalogRead",
+                "Viewer",
+                "NotARealBundle",
+                "CatalogRead"
+            ])),
+            Some(&alice_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::OK, "mint failed: {body}");
+        let (claims, minted_token) = claims_of(&body);
+
+        // Identity claims are a pure copy-through of the caller's, and the
+        // fresh validity window matches the SQL mint's one hour.
+        assert_eq!(claims.sub, ALICE);
+        assert_eq!(claims.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(claims.role, "authenticated");
+        assert_eq!(claims.aud, "authenticated");
+        assert_eq!(claims.exp, claims.iat + 3600);
+        let now = tokens::now().timestamp() as u64;
+        assert!(now - claims.iat < 60, "iat {} is fresh", claims.iat);
+        assert_eq!(
+            claims.capability_mask,
+            Some(vec![
+                "CatalogRead".to_string(),
+                "Viewer".to_string(),
+                "NotARealBundle".to_string(),
+                "CatalogRead".to_string(),
+            ]),
+        );
+
+        // === A masked caller cannot mint (and so cannot widen itself) ===
+        // Presenting the minted token as the bearer also proves its
+        // signature: the refusal below requires Envelope verification of the
+        // token to have succeeded.
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!(["Admin"])),
+            Some(&minted_token),
+        )
+        .await;
+        insta::assert_snapshot!(
+            format!("{status}: {body}"),
+            @r###"403 Forbidden: {"error":"unmasked_token_required","message":"this operation requires a full-authority token, but the bearer token carries a capability mask","missing_capabilities":[]}"###
+        );
+
+        // === An empty mask mints a valid identity-only token ===
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!([])),
+            Some(&alice_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::OK, "empty-mask mint: {body}");
+        let (claims, identity_token) = claims_of(&body);
+        assert_eq!(claims.capability_mask, Some(vec![]));
+
+        // "Masked" is the claim's presence, never its value: the
+        // identity-only token is refused as a mint caller like any other
+        // masked bearer.
+        let (status, _body) = post_token(
+            &server,
+            &capability_request(serde_json::json!([])),
+            Some(&identity_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN);
+
+        // === A caller without an email claim mints a token without one ===
+        let no_email_token = server.make_access_token(ALICE, None);
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!(["CatalogRead"])),
+            Some(&no_email_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::OK, "email-less mint: {body}");
+        let (claims, _token) = claims_of(&body);
+        assert_eq!(claims.email, None);
+
+        // === The grant requires an authenticated caller ===
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!(["CatalogRead"])),
+            None,
+        )
+        .await;
+        insta::assert_snapshot!(
+            format!("{status}: {body}"),
+            @"401 Unauthorized: This is an authenticated API but the request is missing a required Authorization: Bearer token"
+        );
+
+        // === A service-account caller is refused ===
+        let svc_user = uuid::Uuid::from_bytes([0x77; 16]);
+        sqlx::query("INSERT INTO auth.users (id, email) VALUES ($1, 'svc@example.com')")
+            .bind(svc_user)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO internal.service_accounts (user_id, catalog_name, created_by) \
+             VALUES ($1, 'aliceCo/service-account', $2)",
+        )
+        .bind(svc_user)
+        .bind(ALICE)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let svc_token = server.make_access_token(svc_user, Some("svc@example.com"));
+        let (status, body) = post_token(
+            &server,
+            &capability_request(serde_json::json!(["CatalogRead"])),
+            Some(&svc_token),
+        )
+        .await;
+        insta::assert_snapshot!(
+            format!("{status}: {body}"),
+            @r###"403 Forbidden: {"error":"service_account_forbidden","message":"this operation is restricted to human users, but the bearer token belongs to a service account","missing_capabilities":[]}"###
+        );
+
+        // === An invalid bearer is rejected regardless of grant ===
+        // The endpoint verifies any Authorization header it is given, so a
+        // broken bearer fails even the otherwise-unauthenticated
+        // refresh_token grant. (A bearer-less refresh_token request remains
+        // covered by the refresh-token management test.)
+        let (status, _body) = post_token(
+            &server,
+            &serde_json::json!({
+                "grant_type": "refresh_token",
+                "refresh_token_id": "00:00:00:00:00:00:00:00",
+                "secret": "irrelevant",
+            }),
+            Some("not-a-valid.jwt.token"),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+
+        // === An unknown grant is rejected by the typed extractor ===
+        let (status, _body) = post_token(
+            &server,
+            &serde_json::json!({ "grant_type": "not_a_grant" }),
+            Some(&alice_token),
+        )
+        .await;
+        assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    }
 }

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -96,7 +96,7 @@ async fn mint_capability_token(
             crate::Forbidden::unmasked_token_required(),
         ));
     }
-    if super::graphql::is_service_account(&envelope.pg_pool, claims.sub).await? {
+    if crate::grants::is_service_account(&envelope.pg_pool, claims.sub).await? {
         return Err(crate::ApiError::Forbidden(
             crate::Forbidden::service_account_forbidden(),
         ));
@@ -288,24 +288,37 @@ mod test {
         assert_eq!(status, reqwest::StatusCode::OK, "mint failed: {body}");
         let (claims, minted_token) = claims_of(&body);
 
-        // Identity claims are a pure copy-through of the caller's, and the
-        // fresh validity window matches the SQL mint's one hour.
-        assert_eq!(claims.sub, ALICE);
-        assert_eq!(claims.email.as_deref(), Some("alice@example.com"));
-        assert_eq!(claims.role, "authenticated");
-        assert_eq!(claims.aud, "authenticated");
+        // The validity window matches the SQL mint's one hour and `iat` is
+        // fresh; both are volatile, so the snapshot below redacts them.
         assert_eq!(claims.exp, claims.iat + 3600);
         let now = tokens::now().timestamp() as u64;
         assert!(now - claims.iat < 60, "iat {} is fresh", claims.iat);
-        assert_eq!(
-            claims.capability_mask,
-            Some(vec![
-                "CatalogRead".to_string(),
-                "Viewer".to_string(),
-                "NotARealBundle".to_string(),
-                "CatalogRead".to_string(),
-            ]),
-        );
+
+        // The full serialized claim set: identity claims are a pure
+        // copy-through of the caller's, the mask is stamped verbatim
+        // (unrecognized names and duplicates included), and the key set is
+        // exactly the SQL `generate_access_token` mint's plus `email` and
+        // `capability_mask`. This is the Rust half of the two-snapshot claim
+        // parity; pgTAP pins the SQL half in `supabase/tests/`.
+        let mut redacted = serde_json::to_value(&claims).unwrap();
+        redacted["iat"] = serde_json::json!("[iat]");
+        redacted["exp"] = serde_json::json!("[iat+3600]");
+        insta::assert_json_snapshot!(redacted, @r###"
+        {
+          "aud": "authenticated",
+          "capability_mask": [
+            "CatalogRead",
+            "Viewer",
+            "NotARealBundle",
+            "CatalogRead"
+          ],
+          "email": "alice@example.com",
+          "exp": "[iat+3600]",
+          "iat": "[iat]",
+          "role": "authenticated",
+          "sub": "11111111-1111-1111-1111-111111111111"
+        }
+        "###);
 
         // === A masked caller cannot mint (and so cannot widen itself) ===
         // Presenting the minted token as the bearer also proves its

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -1,9 +1,5 @@
 use std::sync::Arc;
 
-/// Validity of a minted capability token, matching the one-hour access
-/// tokens of the SQL `generate_access_token` mint.
-const CAPABILITY_TOKEN_VALIDITY_SECONDS: u64 = 3600;
-
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(tag = "grant_type")]
 pub enum TokenRequest {
@@ -61,12 +57,7 @@ pub async fn handle_post_token(
             Ok(axum::Json(response))
         }
         TokenRequest::CapabilityToken { capability_mask } => {
-            let response = mint_capability_token(
-                &envelope,
-                capability_mask,
-                &app.control_plane_jwt_encode_key,
-            )
-            .await?;
+            let response = mint_capability_token(&envelope, capability_mask, &app).await?;
             Ok(axum::Json(response))
         }
     }
@@ -87,7 +78,7 @@ pub async fn handle_post_token(
 async fn mint_capability_token(
     envelope: &crate::Envelope,
     capability_mask: Vec<String>,
-    encoding_key: &tokens::jwt::EncodingKey,
+    app: &crate::App,
 ) -> Result<TokenResponse, crate::ApiError> {
     let claims = envelope.claims()?;
 
@@ -102,15 +93,20 @@ async fn mint_capability_token(
         ));
     }
 
-    let access_token = sign_capability_token(claims, capability_mask, encoding_key)?;
+    let access_token = sign_capability_token(
+        claims,
+        capability_mask,
+        app.capability_token_validity,
+        &app.control_plane_jwt_encode_key,
+    )?;
     Ok(TokenResponse {
         access_token,
         refresh_token: None,
     })
 }
 
-/// Sign a one-hour access token which copies the caller's verified identity
-/// claims and carries `capability_mask` verbatim.
+/// Sign an access token, valid for `validity`, which copies the caller's
+/// verified identity claims and carries `capability_mask` verbatim.
 ///
 /// The identity claims (`sub`, `role`, `aud`, and `email` when the caller's
 /// token has it) are a pure copy-through, so the minted token is a fully
@@ -129,6 +125,7 @@ async fn mint_capability_token(
 fn sign_capability_token(
     caller: &models::authorizations::ControlClaims,
     capability_mask: Vec<String>,
+    validity: std::time::Duration,
     encoding_key: &tokens::jwt::EncodingKey,
 ) -> tonic::Result<String> {
     let iat = tokens::now().timestamp() as u64;
@@ -136,7 +133,7 @@ fn sign_capability_token(
     let claims = models::authorizations::ControlClaims {
         aud: caller.aud.clone(),
         iat,
-        exp: iat + CAPABILITY_TOKEN_VALIDITY_SECONDS,
+        exp: iat + validity.as_secs(),
         sub: caller.sub,
         role: caller.role.clone(),
         email: caller.email.clone(),
@@ -246,6 +243,37 @@ mod test {
         (unverified.claims().clone(), access_token)
     }
 
+    /// The configured validity drives the minted expiry: `exp` sits exactly
+    /// `--capability-token-validity` past `iat`, whatever that setting is.
+    /// The HTTP test below exercises only the harness-configured one-hour
+    /// default, so a non-default window is pinned here at the signing seam.
+    #[test]
+    fn test_validity_is_configurable() {
+        let caller = models::authorizations::ControlClaims {
+            aud: "authenticated".to_string(),
+            iat: 0,
+            exp: 0,
+            sub: ALICE,
+            role: "authenticated".to_string(),
+            email: None,
+            capability_mask: None,
+        };
+        let token = super::sign_capability_token(
+            &caller,
+            vec!["CatalogRead".to_string()],
+            std::time::Duration::from_secs(90),
+            &tokens::jwt::EncodingKey::from_secret(b"unit-test-secret"),
+        )
+        .unwrap();
+
+        let unverified = tokens::jwt::parse_unverified::<models::authorizations::ControlClaims>(
+            token.as_bytes(),
+        )
+        .unwrap();
+        let claims = unverified.claims();
+        assert_eq!(claims.exp, claims.iat + 90);
+    }
+
     /// Covers the capability_token grant end-to-end: the copy-through claim
     /// set of a successful mint (with a scoped-role, email-less bearer
     /// distinguishing copy-through from hardcoded values), verbatim mask
@@ -288,9 +316,13 @@ mod test {
         assert_eq!(status, reqwest::StatusCode::OK, "mint failed: {body}");
         let (claims, minted_token) = claims_of(&body);
 
-        // The validity window matches the SQL mint's one hour and `iat` is
-        // fresh; both are volatile, so the snapshot below redacts them.
-        assert_eq!(claims.exp, claims.iat + 3600);
+        // The validity window is the harness-configured default — the SQL
+        // mint's hour — and `iat` is fresh; both are volatile, so the
+        // snapshot below redacts them.
+        assert_eq!(
+            claims.exp,
+            claims.iat + crate::DEFAULT_CAPABILITY_TOKEN_VALIDITY.as_secs()
+        );
         let now = tokens::now().timestamp() as u64;
         assert!(now - claims.iat < 60, "iat {} is fresh", claims.iat);
 

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -113,8 +113,8 @@ async fn mint_capability_token(
 /// claims and carries `capability_mask` verbatim.
 ///
 /// The identity claims (`sub`, `role`, `aud`, and `email` when the caller's
-/// token has it) are a pure copy-through, so the minted token remains a
-/// fully functional access token everywhere its bearer's identity is what
+/// token has it) are a pure copy-through, so the minted token is a fully
+/// functional access token everywhere its bearer's identity is what
 /// matters — including Supabase/PostgREST, which reads `sub` and `role` and
 /// ignores claims it doesn't know. Aside from `email` and `capability_mask`,
 /// this is the claim set of the SQL `generate_access_token` mint, whose
@@ -396,7 +396,7 @@ mod test {
         // === An invalid bearer is rejected regardless of grant ===
         // The endpoint verifies any Authorization header it is given, so a
         // broken bearer fails even the otherwise-unauthenticated
-        // refresh_token grant. (A bearer-less refresh_token request remains
+        // refresh_token grant. (Bearer-less refresh_token requests are
         // covered by the refresh-token management test.)
         let (status, _body) = post_token(
             &server,

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -108,6 +108,7 @@ pub fn build_app(
         publisher,
         snapshot,
         Some(crate::server::public::stripe_webhooks::tests::DEV_WEBHOOK_SECRET.to_string()),
+        crate::DEFAULT_CAPABILITY_TOKEN_VALIDITY,
     ))
 }
 


### PR DESCRIPTION
Task 5 of #3376 (stacked on #3422): `POST /api/v1/auth/token` gains the `capability_token` grant, the first production path that mints masked tokens.

## What this does

```json
{"grant_type": "capability_token", "capability_mask": ["CatalogRead", "Viewer"]}
```

An unmasked, human bearer mints a one-hour access token that copies the caller's verified identity claims and carries `capability_mask` as a claim. Enforcement (landed in #3406) intersects the mask with the user's live grants at use time.

Per Gregor's revision on the issue, there is **no `upgrade_token` parameter**: a client wanting more capabilities requests the full list in a fresh mint. This removes the planned signature-only verify variant in the `tokens` crate, the mask-union semantics, and the expired-token re-mint rules from the original decision 4.

## Decisions implemented

- **Copy-through claim set.** `sub`, `role`, `aud`, and `email` (when present) are copied verbatim from the caller's claims; fresh `iat`; `exp = iat + 1h`. Aside from `email` and `capability_mask` this is exactly the SQL `generate_access_token` claim set (pinned by pgTAP in `supabase/tests/`), so the two mint paths cannot drift, and a masked token remains a fully functional Supabase/PostgREST token during the GraphQL migration: PostgREST reads `sub` (RLS via `auth.uid()`) and `role` (SET ROLE) and carries unknown claims inertly in `request.jwt.claims`.
- **The mask is stamped verbatim** — bundle-name vocabulary, unknown names and duplicates included, empty list valid (identity-only token). Enforcement, not the mint, decides what a name enables; unrecognized names can never widen.
- **Rust-side signing** with the control plane's existing HMAC encoding key, following the `authorize_dekaf` precedent. The SQL function is untouched and keeps serving the `refresh_token` grant and PostgREST clients.
- **Masked callers are refused** with the structured `unmasked_token_required` 403 — a reduced token cannot widen or re-mint itself (the issue's open question).
- **Service-account callers are refused** with a new structured `service_account_forbidden` 403 (decision 11). The `internal.service_accounts` lookup is shared with the refresh-token mutations via a new `is_service_account` predicate and is paid only at the mint, never per-request.
- **The handler extracts `Authority<NoRequirement>`**, so a presented bearer is verified regardless of grant: a broken bearer now 401s even for the `refresh_token` grant, which previously ignored the Authorization header entirely. Bearer-less `refresh_token` requests are byte-identical. No known client sends a bearer to this endpoint (flowctl authenticates via PostgREST; the dashboard via the Supabase library).

## Tests

`test_capability_token_mint` drives the real router end-to-end: the copy-through claim set and 1-hour expiry of a successful mint (presenting the minted token back as a bearer proves the signature through production Envelope verification); verbatim mask stamping including unknown names and duplicates; the identity-only empty mask, which is still refused as a mint caller ("masked" is claim presence, not value); an email-less caller minting an email-less token; missing-bearer 401; masked-caller and service-account-caller 403 bodies (insta-pinned); invalid-bearer 401 on the `refresh_token` grant; and the typed extractor's 422 for an unknown grant. Note the last: axum's `Json` rejects a well-formed body with an unknown `grant_type` as 422, not the 400 named in plan decision 6 — the tests pin actual behavior.

Closes nothing on its own; tasks 6 (guards) and 7 (no-amplification suite) follow.


## Revision (2026-08-28): configurable validity window

The mint's validity window is deploy-configurable (initially opened as #3433 and folded into this PR): a new agent setting `--capability-token-validity` / `CAPABILITY_TOKEN_VALIDITY` (humantime syntax, following the controller duration settings' pattern) feeds an `App` field into the signer, which stays pure. The default is the shared `DEFAULT_CAPABILITY_TOKEN_VALIDITY` constant — one hour, matching the SQL mint — consumed by the test builders and the mint test, with a weld test in `agent` pinning the clap default string to the constant (which also proves the default parses before the first production boot). An override deliberately diverges from the SQL mint's fixed hour (claim-set parity is unaffected), and a longer window widens leaked-masked-token exposure — the flag docs carry both warnings. A unit test pins a non-default window at the signing seam.
