### PR TITLE
control-plane-api: require_unmasked guards credential and admin surfaces

### DIFF
--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -58,6 +58,29 @@ impl Requirement for NoRequirement {
 /// `internal.user_roles` rather than the snapshot walk — and for operations
 /// which would let a masked bearer escape its mask, such as minting a
 /// full-authority refresh credential.
+///
+/// The audited inventory of unmasked-only surfaces (#3376):
+/// - The `capability_token` grant of `POST /api/v1/auth/token`: a reduced
+///   token must not widen or re-mint itself.
+/// - GraphQL `createRefreshToken`: a refresh token exchanges for a
+///   full-authority access token, so a masked bearer minting one escapes
+///   its mask. The resolver enforces this through
+///   [`Forbidden::require_unmasked`], since an axum extractor cannot reach
+///   a resolver.
+/// - `/admin/create-data-plane` and `/admin/update-l2-reporting`: their
+///   SQL authorization cannot bind the mask, so they fail closed instead.
+///
+/// Every other identity-gated operation deliberately stays open to masked
+/// bearers: revocations (`revokeRefreshToken`, `revokeApiKey`, and kin)
+/// never widen the bearer's authority; credential-adjacent operations like
+/// `createApiKey` and `createServiceAccount` authorize through the grant
+/// walk, which the mask already filters; and invite redemption widens the
+/// *user's* grants while the bearer still exercises them only through its
+/// mask. SQL functions reachable through PostgREST
+/// (`public.create_refresh_token`, `public.gateway_auth_token`) are outside
+/// this crate's enforcement entirely — they are part of the documented
+/// PostgREST mask bypass whose resolution is the #2877 migration, tracked
+/// under #3376.
 pub struct RequireUnmasked;
 
 impl Requirement for RequireUnmasked {
@@ -131,6 +154,20 @@ impl Forbidden {
         } else {
             Err(Self::missing_capabilities(missing))
         }
+    }
+
+    /// The masked-bearer refusal shared by every surface which demands a
+    /// full-authority credential: a definitive denial keyed on the
+    /// *presence* of the `capability_mask` claim, never its value — a mask
+    /// which happens to enable everything is still a deliberately-reduced
+    /// credential. Requirement evaluation consumes this during extraction;
+    /// GraphQL resolvers consume it directly, where an axum extractor
+    /// cannot reach.
+    pub fn require_unmasked(claims: &crate::ControlClaims) -> Result<(), Self> {
+        if claims.capability_mask.is_some() {
+            return Err(Self::unmasked_token_required());
+        }
+        Ok(())
     }
 
     pub fn unmasked_token_required() -> Self {
@@ -304,8 +341,8 @@ fn evaluate_requirement<R: Requirement>(
     };
     let mask = CapabilityMask::from_claim(claims.capability_mask.as_deref());
 
-    if R::REQUIRE_UNMASKED && claims.capability_mask.is_some() {
-        return Err(Rejection::Forbidden(Forbidden::unmasked_token_required()));
+    if R::REQUIRE_UNMASKED {
+        Forbidden::require_unmasked(claims).map_err(Rejection::Forbidden)?;
     }
 
     let required = R::required();

--- a/crates/control-plane-api/src/authority.rs
+++ b/crates/control-plane-api/src/authority.rs
@@ -70,17 +70,17 @@ impl Requirement for NoRequirement {
 /// - `/admin/create-data-plane` and `/admin/update-l2-reporting`: their
 ///   SQL authorization cannot bind the mask, so they fail closed instead.
 ///
-/// Every other identity-gated operation deliberately stays open to masked
-/// bearers: revocations (`revokeRefreshToken`, `revokeApiKey`, and kin)
-/// never widen the bearer's authority; credential-adjacent operations like
-/// `createApiKey` and `createServiceAccount` authorize through the grant
-/// walk, which the mask already filters; and invite redemption widens the
-/// *user's* grants while the bearer still exercises them only through its
-/// mask. SQL functions reachable through PostgREST
-/// (`public.create_refresh_token`, `public.gateway_auth_token`) are outside
-/// this crate's enforcement entirely — they are part of the documented
-/// PostgREST mask bypass whose resolution is the #2877 migration, tracked
-/// under #3376.
+/// Everything else needs no unmasked guard. Identity-gated revocation
+/// (`revokeRefreshToken`) deliberately stays open to masked bearers,
+/// because revocation never widens the bearer's authority.
+/// Capability-gated operations — `createApiKey`, `createServiceAccount`,
+/// `revokeApiKey`, and kin — authorize through the grant walk, which the
+/// mask already filters. Invite redemption widens the *user's* grants
+/// while the bearer still exercises them only through its mask. SQL
+/// functions reachable through PostgREST (`public.create_refresh_token`,
+/// `public.gateway_auth_token`) are outside this crate's enforcement
+/// entirely — they are part of the documented PostgREST mask bypass whose
+/// resolution is the #2877 migration, tracked under #3376.
 pub struct RequireUnmasked;
 
 impl Requirement for RequireUnmasked {

--- a/crates/control-plane-api/src/server/create_data_plane.rs
+++ b/crates/control-plane-api/src/server/create_data_plane.rs
@@ -53,14 +53,14 @@ pub struct Request {
 pub struct Response {}
 
 /// Authorization is SQL `internal.user_roles` rather than the snapshot walk,
-/// so the bearer's capability mask has no effect — a masked bearer is
-/// treated as unmasked — until this endpoint's authorization is refactored
-/// onto the snapshot. See #3376.
+/// so the capability ceiling cannot bind here; `RequireUnmasked` fail-closes
+/// masked bearers instead, until the wider refactor retires this endpoint's
+/// SQL authorization (#3376, decision 12).
 #[axum::debug_handler(state=std::sync::Arc<crate::App>)]
 #[tracing::instrument(skip(app, env), ret, err(Debug, level = tracing::Level::WARN))]
 pub async fn create_data_plane(
     axum::extract::State(app): axum::extract::State<std::sync::Arc<crate::App>>,
-    crate::Authority { envelope: env, .. }: crate::Authority,
+    crate::Authority { envelope: env, .. }: crate::Authority<crate::RequireUnmasked>,
     super::Request(Request {
         name,
         private,
@@ -328,5 +328,64 @@ impl Validate for Category {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_server;
+
+    const ALICE: uuid::Uuid = uuid::Uuid::from_bytes([0x11; 16]);
+
+    /// A masked bearer is refused at extraction with the structured `403`,
+    /// while an unmasked bearer reaches the handler's own `ops/` admin gate
+    /// unchanged.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_create_data_plane_requires_unmasked(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+
+        let body = serde_json::json!({"name": "test-plane", "category": "managed"});
+
+        // The mask enables Admin, and is still refused: masked-ness is the
+        // claim's presence, never its value.
+        let masked_token =
+            server.make_masked_access_token(ALICE, Some("alice@example.com"), Some(vec!["Admin"]));
+        let response = server
+            .rest_client()
+            .post("/admin/create-data-plane", &body, Some(&masked_token))
+            .send()
+            .await
+            .unwrap();
+        let (status, text) = (response.status(), response.text().await.unwrap());
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "{text}");
+        insta::assert_snapshot!(
+            text,
+            @r###"{"error":"unmasked_token_required","message":"this operation requires a full-authority token, but the bearer token carries a capability mask","missing_capabilities":[]}"###
+        );
+
+        // An unmasked bearer passes extraction and lands on the handler's
+        // SQL authorization, which refuses alice: she is no `ops/` admin.
+        let unmasked_token = server.make_access_token(ALICE, Some("alice@example.com"));
+        let response = server
+            .rest_client()
+            .post("/admin/create-data-plane", &body, Some(&unmasked_token))
+            .send()
+            .await
+            .unwrap();
+        let (status, text) = (response.status(), response.text().await.unwrap());
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "{text}");
+        assert!(
+            text.contains("not an admin of the 'ops/' tenant"),
+            "the unmasked refusal is the handler's own gate: {text}"
+        );
     }
 }

--- a/crates/control-plane-api/src/server/public/graphql/refresh_tokens.rs
+++ b/crates/control-plane-api/src/server/public/graphql/refresh_tokens.rs
@@ -117,6 +117,8 @@ pub struct RefreshTokensMutation;
 impl RefreshTokensMutation {
     /// Create a refresh token for the authenticated user.
     ///
+    /// Capability-masked callers are rejected: a refresh token exchanges for
+    /// a full-authority access token, which would escape the bearer's mask.
     /// Service-account callers are rejected: their API keys are administered
     /// via createApiKey and revokeApiKey.
     async fn create_refresh_token(
@@ -133,6 +135,11 @@ impl RefreshTokensMutation {
         let env = ctx.data::<crate::Envelope>()?;
         let claims = env.claims()?;
 
+        // The mask refusal precedes the service-account lookup: it's a pure
+        // function of the verified claims, so a masked caller is refused
+        // without a database round-trip, in the same order as the
+        // capability_token mint.
+        crate::Forbidden::require_unmasked(claims).map_err(crate::ApiError::Forbidden)?;
         super::service_accounts::verify_not_service_account(&env.pg_pool, claims.sub).await?;
 
         // ISO 8601 durations begin with 'P'; considering this cheap and good enough validation for now.
@@ -482,5 +489,82 @@ mod test {
             )
             .await;
         assert!(revoke_again["errors"].is_array());
+    }
+
+    /// A masked bearer cannot mint a refresh credential: a refresh token
+    /// exchanges for a full-authority access token, which would escape the
+    /// mask. Revocation never widens authority, so it deliberately stays
+    /// open to masked bearers.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../../../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_create_refresh_token_requires_unmasked(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+
+        let alice = uuid::Uuid::from_bytes([0x11; 16]);
+        let unmasked_token = server.make_access_token(alice, Some("alice@example.com"));
+        // The mask enables Admin, and is still refused: masked-ness is the
+        // claim's presence, never its value.
+        let masked_token =
+            server.make_masked_access_token(alice, Some("alice@example.com"), Some(vec!["Admin"]));
+
+        let refused: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"mutation { createRefreshToken(validFor: "P30D") { id } }"#
+                }),
+                Some(&masked_token),
+            )
+            .await;
+        assert_eq!(
+            refused["errors"][0]["extensions"]["error"], "unmasked_token_required",
+            "a masked caller is refused with the structured code: {refused}"
+        );
+        assert_eq!(
+            refused["errors"][0]["extensions"]["missing_capabilities"],
+            serde_json::json!([]),
+            "no re-mint can remedy this refusal: {refused}"
+        );
+
+        // An unmasked caller mints one...
+        let create: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"mutation { createRefreshToken(validFor: "P30D") { id } }"#
+                }),
+                Some(&unmasked_token),
+            )
+            .await;
+        assert!(
+            create["errors"].is_null(),
+            "create should succeed: {create}"
+        );
+        let token_id = create["data"]["createRefreshToken"]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // ...and a masked bearer may revoke it.
+        let revoke: serde_json::Value = server
+            .graphql(
+                &serde_json::json!({
+                    "query": r#"mutation($id: Id!) { revokeRefreshToken(id: $id) }"#,
+                    "variables": { "id": token_id }
+                }),
+                Some(&masked_token),
+            )
+            .await;
+        assert!(
+            revoke["errors"].is_null(),
+            "masked revocation should succeed: {revoke}"
+        );
+        assert_eq!(revoke["data"]["revokeRefreshToken"], true);
     }
 }

--- a/crates/control-plane-api/src/server/public/token_exchange.rs
+++ b/crates/control-plane-api/src/server/public/token_exchange.rs
@@ -82,11 +82,7 @@ async fn mint_capability_token(
 ) -> Result<TokenResponse, crate::ApiError> {
     let claims = envelope.claims()?;
 
-    if claims.capability_mask.is_some() {
-        return Err(crate::ApiError::Forbidden(
-            crate::Forbidden::unmasked_token_required(),
-        ));
-    }
+    crate::Forbidden::require_unmasked(claims).map_err(crate::ApiError::Forbidden)?;
     if crate::grants::is_service_account(&envelope.pg_pool, claims.sub).await? {
         return Err(crate::ApiError::Forbidden(
             crate::Forbidden::service_account_forbidden(),

--- a/crates/control-plane-api/src/server/update_l2_reporting.rs
+++ b/crates/control-plane-api/src/server/update_l2_reporting.rs
@@ -20,9 +20,9 @@ pub struct Response {
 }
 
 /// Authorization is SQL `internal.user_roles` rather than the snapshot walk,
-/// so the bearer's capability mask has no effect — a masked bearer is
-/// treated as unmasked — until this endpoint's authorization is refactored
-/// onto the snapshot. See #3376.
+/// so the capability ceiling cannot bind here; `RequireUnmasked` fail-closes
+/// masked bearers instead, until the wider refactor retires this endpoint's
+/// SQL authorization (#3376, decision 12).
 #[axum::debug_handler]
 #[tracing::instrument(
     skip(app),
@@ -30,7 +30,7 @@ pub struct Response {
 )]
 pub async fn update_l2_reporting(
     axum::extract::State(app): axum::extract::State<Arc<crate::App>>,
-    crate::Authority { envelope: env, .. }: crate::Authority,
+    crate::Authority { envelope: env, .. }: crate::Authority<crate::RequireUnmasked>,
     super::Request(Request {
         default_data_plane,
         dry_run,
@@ -365,4 +365,63 @@ fn camel_case(name: &str, mut upper: bool) -> String {
         }
     }
     w
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_server;
+
+    const ALICE: uuid::Uuid = uuid::Uuid::from_bytes([0x11; 16]);
+
+    /// A masked bearer is refused at extraction with the structured `403`,
+    /// while an unmasked bearer reaches the handler's own `ops/` admin gate
+    /// unchanged.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_update_l2_reporting_requires_unmasked(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        let server = test_server::TestServer::start(
+            pool.clone(),
+            test_server::snapshot(pool.clone(), true).await,
+        )
+        .await;
+
+        let body = serde_json::json!({"dryRun": true});
+
+        // The mask enables Admin, and is still refused: masked-ness is the
+        // claim's presence, never its value.
+        let masked_token =
+            server.make_masked_access_token(ALICE, Some("alice@example.com"), Some(vec!["Admin"]));
+        let response = server
+            .rest_client()
+            .post("/admin/update-l2-reporting", &body, Some(&masked_token))
+            .send()
+            .await
+            .unwrap();
+        let (status, text) = (response.status(), response.text().await.unwrap());
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "{text}");
+        insta::assert_snapshot!(
+            text,
+            @r###"{"error":"unmasked_token_required","message":"this operation requires a full-authority token, but the bearer token carries a capability mask","missing_capabilities":[]}"###
+        );
+
+        // An unmasked bearer passes extraction and lands on the handler's
+        // SQL authorization, which refuses alice: she is no `ops/` admin.
+        let unmasked_token = server.make_access_token(ALICE, Some("alice@example.com"));
+        let response = server
+            .rest_client()
+            .post("/admin/update-l2-reporting", &body, Some(&unmasked_token))
+            .send()
+            .await
+            .unwrap();
+        let (status, text) = (response.status(), response.text().await.unwrap());
+        assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "{text}");
+        assert!(
+            text.contains("not an admin of the 'ops/' tenant"),
+            "the unmasked refusal is the handler's own gate: {text}"
+        );
+    }
 }

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -1379,6 +1379,8 @@ type MutationRoot {
 	"""
 	Create a refresh token for the authenticated user.
 	
+	Capability-masked callers are rejected: a refresh token exchanges for
+	a full-authority access token, which would escape the bearer's mask.
 	Service-account callers are rejected: their API keys are administered
 	via createApiKey and revokeApiKey.
 	"""


### PR DESCRIPTION
Task 6 of #3376 (stacked on #3424): the `require_unmasked` guards. Masked bearers are refused on every surface where holding one must not mint a wider credential or slip past mask enforcement entirely.

## What this does

**`Forbidden::require_unmasked(&ControlClaims)`** is the single definition of the masked-bearer refusal — keyed on the `capability_mask` claim's *presence*, never its value, because a mask which happens to enable everything is still a deliberately-reduced credential. Requirement evaluation consumes it at extraction, the `capability_token` mint consumes it in place of its inline check, and GraphQL resolvers consume it directly, where an axum extractor cannot reach.

**GraphQL `createRefreshToken`** refuses masked bearers with the structured `unmasked_token_required` body (carried in error extensions, identical to the REST shape). A refresh token exchanges for a full-authority access token, so a masked bearer minting one would escape its mask. The refusal precedes the service-account lookup: it's a pure function of the verified claims, so a masked caller costs no DB round-trip — the same ordering as the mint. `revokeRefreshToken` deliberately stays open to masked bearers: revocation never widens authority. A test pins both sides.

**`/admin/create-data-plane` and `/admin/update-l2-reporting`** take `Authority<RequireUnmasked>`. Their authorization is SQL `internal.user_roles` rather than the snapshot walk, so the capability ceiling structurally cannot bind there; fail-closed is the safe posture until the wider refactor retires their SQL checks (decision 12 on the ticket). Unmasked callers are byte-identical.

**The identity-gated mutation audit** (decision 8) is re-verified against the current mutation surface and documented as the `RequireUnmasked` doc comment, where the next person adding a credential mutation will find it: the unmasked-only inventory (the mint, `createRefreshToken`, both `/admin` routes), and why everything else deliberately stays open — revocations never widen, credential-adjacent operations (`createApiKey`, `createServiceAccount`) authorize through the mask-filtered grant walk, and invite redemption widens the *user's* grants while the bearer still exercises them only through its mask.

## What this does not close

The SQL twins reachable through PostgREST — `public.create_refresh_token` and `public.gateway_auth_token` — remain an open bypass for a masked token presented directly to Supabase, part of the documented PostgREST mask-evaporation boundary whose resolution is the #2877 migration (task 8 on the ticket). This PR closes the control-plane-API escapes only.

## Plan as executed

- Shared guard: a pure helper on `Forbidden` beside the `required_covered` precedent, so "masked = claim presence" has exactly one definition; the mint and requirement evaluation are refactored onto it.
- Guard ordering in `createRefreshToken`: mask check first — pure claims check before any I/O, matching the mint.
- `/admin` comments rewritten in the present tense: what binds, what cannot, and where the refactor is tracked.
- Audit documentation lives with the mechanism (`RequireUnmasked` doc) rather than only in ticket/PR prose.
- Tests: denial paths plus a SQL-gate probe. Each `/admin` route gets its first tests — a masked bearer draws the structured 403 at extraction, and an unmasked non-`ops/`-admin draws the handler's own `permission_denied`, proving unmasked callers still reach the unchanged handler logic. Full success-path provisioning fixtures are deliberately out of scope.
- The GraphQL schema regen also picks up the `userCapability` description text from #3422, which had not been regenerated there — doc-only drift, caught up here rather than churning the stack.

## Tests

- `authority::test::*` — `require_unmasked` behavior unchanged under the refactor (presence-keyed refusal, HTTP-level 403 bodies).
- `refresh_tokens::test::test_create_refresh_token_requires_unmasked` — masked create refused with `unmasked_token_required` and empty `missing_capabilities` in extensions; unmasked create succeeds; masked revocation succeeds.
- `create_data_plane::test::test_create_data_plane_requires_unmasked`, `update_l2_reporting::test::test_update_l2_reporting_requires_unmasked` — an Admin-enabling mask is still refused (presence, not value) with the structured body; an unmasked non-admin reaches the handler's own `ops/` gate.
- `token_exchange::test::test_capability_token_mint` — the mint's refusals, now through the shared helper.
