### PR TITLE
doc: bound allocator growth when draining a key across many segments

### DIFF
--- a/crates/doc/src/combine/spill.rs
+++ b/crates/doc/src/combine/spill.rs
@@ -423,65 +423,69 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
         let key = self.spec.keys[binding].as_ref();
         let validator = &mut self.spec.validators[validator_index];
 
-        // `reduced` root which is updated as reductions occur.
-        let mut reduced: Option<HeapNode<'_>> = None;
+        let reduced: Option<HeapNode<'_>> = loop {
+            // `reduced` root which is updated as reductions occur.
+            let mut reduced: Option<HeapNode<'_>> = None;
 
-        // Attempt to reduce additional entries.
-        while let Some(cmp::Reverse(next)) = self.heap.peek() {
-            if meta.0 != next.head.meta.0
-                || !Extractor::compare_key(key, root.get(), next.head.root.get()).is_eq()
-            {
-                self.in_group = false;
-                break;
-            } else if !is_full && (!self.in_group || meta.not_associative()) {
-                // We're performing associative reductions and:
-                // * This is the first document of a group, which we cannot reduce into, or
-                // * We've already attempted this associative reduction.
-                self.in_group = true;
-                break;
-            }
-
-            let rhs_outcomes = validator
-                .validate(next.head.root.get(), validation::reduce_filter)
-                .map_err(|invalid| {
-                    let rhs_binding = next.head.meta.binding();
-                    let rhs_index = self.spec.validator_index[rhs_binding] as usize;
-
-                    Error::FailedValidation(
-                        super::memtable::failed_name(&self.spec.names[rhs_index], rhs_binding),
-                        invalid,
-                    )
-                })?;
-
-            match reduce::reduce::<crate::ArchivedNode>(
-                match &reduced {
-                    Some(root) => LazyNode::Heap(root),
-                    None => LazyNode::Node(root.get()),
-                },
-                LazyNode::Node(next.head.root.get()),
-                &rhs_outcomes,
-                &self.alloc,
-                is_full,
-            ) {
-                Ok((node, deleted)) => {
-                    meta.set_deleted(deleted);
-                    meta.set_known_valid(false); // Must re-validate.
-                    reduced = Some(node);
-
-                    // Discard the peeked entry, which was reduced into `reduced_root`.
-                    let segment = self.heap.pop().unwrap().0;
-                    let (_discard, segment) = segment.pop_head(&mut self.spill)?;
-                    if let Some(segment) = segment {
-                        self.heap.push(cmp::Reverse(segment));
-                    }
-                }
-                Err(reduce::Error::NotAssociative) => {
-                    meta.set_not_associative();
+            // Attempt to reduce additional entries.
+            while let Some(cmp::Reverse(next)) = self.heap.peek() {
+                if meta.0 != next.head.meta.0
+                    || !Extractor::compare_key(key, root.get(), next.head.root.get()).is_eq()
+                {
+                    self.in_group = false;
+                    break;
+                } else if !is_full && (!self.in_group || meta.not_associative()) {
+                    // We're performing associative reductions and:
+                    // * This is the first document of a group, which we cannot reduce into, or
+                    // * We've already attempted this associative reduction.
+                    self.in_group = true;
                     break;
                 }
-                Err(err) => return Err(Error::Reduce(err)),
+
+                let rhs_outcomes = validator
+                    .validate(next.head.root.get(), validation::reduce_filter)
+                    .map_err(|invalid| {
+                        let rhs_binding = next.head.meta.binding();
+                        let rhs_index = self.spec.validator_index[rhs_binding] as usize;
+
+                        Error::FailedValidation(
+                            super::memtable::failed_name(&self.spec.names[rhs_index], rhs_binding),
+                            invalid,
+                        )
+                    })?;
+
+                match reduce::reduce::<crate::ArchivedNode>(
+                    match &reduced {
+                        Some(root) => LazyNode::Heap(root),
+                        None => LazyNode::Node(root.get()),
+                    },
+                    LazyNode::Node(next.head.root.get()),
+                    &rhs_outcomes,
+                    &self.alloc,
+                    is_full,
+                ) {
+                    Ok((node, deleted)) => {
+                        meta.set_deleted(deleted);
+                        meta.set_known_valid(false); // Must re-validate.
+                        reduced = Some(node);
+
+                        // Discard the peeked entry, which was reduced into `reduced`.
+                        let segment = self.heap.pop().unwrap().0;
+                        let (_discard, segment) = segment.pop_head(&mut self.spill)?;
+                        if let Some(segment) = segment {
+                            self.heap.push(cmp::Reverse(segment));
+                        }
+                    }
+                    Err(reduce::Error::NotAssociative) => {
+                        meta.set_not_associative();
+                        break;
+                    }
+                    Err(err) => return Err(Error::Reduce(err)),
+                }
             }
-        }
+
+            break reduced;
+        };
 
         let outcomes = if meta.known_valid() {
             Vec::new() // Skip validation.

--- a/crates/doc/src/combine/spill.rs
+++ b/crates/doc/src/combine/spill.rs
@@ -423,7 +423,12 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
         let key = self.spec.keys[binding].as_ref();
         let validator = &mut self.spec.validators[validator_index];
 
-        let reduced: Option<HeapNode<'_>> = loop {
+        // Reduce further entries of this key into `root`. Each reduction allocates
+        // its output from `alloc`, and a bump allocator can't reclaim the prior
+        // output, so a key reduced across many segments could grow `alloc` without
+        // bound. Once it's past threshold, the intermediate reduction is archived
+        // back into `root`, `alloc` is replaced, and reduction resumes from there.
+        let reduced: Option<HeapNode<'_>> = 'outer: loop {
             // `reduced` root which is updated as reductions occur.
             let mut reduced: Option<HeapNode<'_>> = None;
 
@@ -440,6 +445,23 @@ impl<F: io::Read + io::Seek> SpillDrainer<F> {
                     // * We've already attempted this associative reduction.
                     self.in_group = true;
                     break;
+                } else if let Some(node) = &reduced
+                    && bump_mem_used(&self.alloc) > BUMP_THRESHOLD
+                {
+                    // Safety: `to_archive` produces a valid ArchivedNode, and Bytes adopts
+                    // the AlignedVec's 16-byte aligned allocation without copying.
+                    root = unsafe {
+                        OwnedArchivedNode::new(bytes::Bytes::from_owner(node.to_archive()))
+                    };
+                    tracing::debug!(
+                        alloc_bytes = bump_mem_used(&self.alloc),
+                        archived_bytes = root.bytes().len(),
+                        "archived an intermediate reduction to bound allocator memory"
+                    );
+                    self.alloc = Arc::new(Bump::new());
+                    // Re-enter with a fresh `reduced`: its lifetime is bound to the
+                    // allocator we just replaced.
+                    continue 'outer;
                 }
 
                 let rhs_outcomes = validator
@@ -1165,6 +1187,213 @@ mod test {
           ]
         ]
         "###);
+    }
+
+    /// Push `drainer`'s allocator past BUMP_THRESHOLD, so that its next reduction
+    /// archives the intermediate result and replaces it. The reservation is never
+    /// written, so it costs address space rather than resident memory.
+    fn exhaust_alloc<F: io::Read + io::Seek>(drainer: &SpillDrainer<F>) {
+        let layout = std::alloc::Layout::from_size_align(BUMP_THRESHOLD + 1, 8).unwrap();
+        drainer.alloc.alloc_layout(layout);
+        assert!(bump_mem_used(&drainer.alloc) > BUMP_THRESHOLD);
+    }
+
+    #[test]
+    fn test_drain_archives_intermediate_reductions() {
+        // A key reduced across many segments has its intermediate reduction
+        // archived, and its allocator replaced, whenever `alloc` is past
+        // threshold. Exhausting the allocator before each drain does so at the
+        // first reduction of every key, which must not change the drained result
+        // under either full or associative reduction.
+        for full in [true, false] {
+            let schema = json::schema::build(
+                &url::Url::parse("http://example/schema").unwrap(),
+                &json!({
+                    "properties": {
+                        "key": { "type": "string" },
+                        "v": { "type": "array", "reduce": { "strategy": "append" } }
+                    },
+                    "reduce": { "strategy": "merge" }
+                }),
+            )
+            .unwrap();
+            let spec = Spec::with_one_binding(
+                full,
+                vec![Extractor::new("/key", &SerPolicy::noop())],
+                "source",
+                Vec::new(),
+                Validator::new(schema).unwrap(),
+            );
+
+            // Every segment holds the hot key and one unique key.
+            let alloc = Bump::new();
+            let mut spill = SpillWriter::new(io::Cursor::new(Vec::new())).unwrap();
+            for i in 0..12 {
+                let segment = segment_fixture(
+                    &[
+                        (0, json!({"key": "hot", "v": [i]}), false),
+                        (0, json!({"key": format!("k{i:02}"), "v": [i]}), false),
+                    ],
+                    &alloc,
+                );
+                spill.write_segment(&segment, CHUNK_TARGET_SIZE).unwrap();
+            }
+            let (spill, ranges) = spill.into_parts();
+
+            let to_json = |doc: DrainedDoc| {
+                serde_json::to_value(SerPolicy::noop().on_owned(&doc.root)).unwrap()
+            };
+            let mut drainer = SpillDrainer::new(spec, spill, &ranges, Vec::new().into()).unwrap();
+            let expected = (&mut drainer)
+                .map_ok(to_json)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+
+            let (spec, spill) = drainer.into_parts();
+            let mut drainer = SpillDrainer::new(spec, spill, &ranges, Vec::new().into()).unwrap();
+            let mut actual = Vec::new();
+            loop {
+                exhaust_alloc(&drainer);
+                match drainer.drain_next().unwrap() {
+                    Some(doc) => actual.push(to_json(doc)),
+                    None => break,
+                }
+            }
+            assert_eq!(expected, actual);
+
+            // Full reduction drains the hot key as one document; associative
+            // reduction holds back its first entry and reduces the rest.
+            let hot: Vec<_> = expected.iter().filter(|d| d["key"] == "hot").collect();
+            assert_eq!(hot.len(), if full { 1 } else { 2 });
+            let reduced = hot.last().unwrap()["v"].as_array().unwrap().len();
+            assert_eq!(reduced, if full { 12 } else { 11 });
+        }
+    }
+
+    /// Random RFC-7396 merge patches: nested objects over a few keys, with
+    /// `null` (a deletion under full reduction), scalars, and arrays.
+    #[derive(Clone, Debug)]
+    struct MergePatchOps(Vec<Value>);
+
+    impl quickcheck::Arbitrary for MergePatchOps {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            fn value(g: &mut quickcheck::Gen, depth: usize) -> Value {
+                let scalar = |g: &mut quickcheck::Gen| match g.choose(&[0, 0, 1, 2, 3]).unwrap() {
+                    0 => Value::Null,
+                    1 => json!(u8::arbitrary(g) % 4),
+                    2 => json!(g.choose(&["x", "y"]).unwrap()),
+                    _ => json!([u8::arbitrary(g) % 4]),
+                };
+                if depth == 0 || bool::arbitrary(g) {
+                    return scalar(g);
+                }
+                let n = usize::arbitrary(g) % 4 + 1;
+                (0..n)
+                    .map(|_| {
+                        (
+                            g.choose(&["a", "b", "c", "d"]).unwrap().to_string(),
+                            value(g, depth - 1),
+                        )
+                    })
+                    .collect::<serde_json::Map<_, _>>()
+                    .into()
+            }
+            let n = usize::arbitrary(g) % 11 + 2; // 2..=12 operands.
+            Self((0..n).map(|_| value(g, 2)).collect())
+        }
+
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            if self.0.len() <= 2 {
+                return quickcheck::empty_shrinker();
+            }
+            let ops = self.0.clone();
+            Box::new((0..ops.len()).map(move |i| {
+                let mut ops = ops.clone();
+                ops.remove(i);
+                Self(ops)
+            }))
+        }
+    }
+
+    #[test]
+    fn test_drain_archive_merge_patch_fuzz() {
+        // Archiving within a key's reduction must be invisible: a drain that
+        // archives at the first reduction of every key must match a plain drain
+        // in both documents and Meta, and full reductions must match RFC-7396
+        // merge-patch.
+        fn prop(MergePatchOps(ops): MergePatchOps) -> bool {
+            let spec = |full| {
+                let curi = url::Url::parse("schema://").unwrap();
+                let schema = json::schema::build(&curi, &reduce::merge_patch_schema()).unwrap();
+                Spec::with_one_binding(
+                    full,
+                    [],
+                    "source",
+                    Vec::new(),
+                    Validator::new(schema).unwrap(),
+                )
+            };
+            let to_json = |doc: &DrainedDoc| {
+                serde_json::to_value(SerPolicy::noop().on_owned(&doc.root)).unwrap()
+            };
+
+            // One operand per segment, all under the empty key.
+            let alloc = Bump::new();
+            let mut spill = SpillWriter::new(io::Cursor::new(Vec::new())).unwrap();
+            for op in &ops {
+                let segment = segment_fixture(&[(0, op.clone(), false)], &alloc);
+                spill.write_segment(&segment, CHUNK_TARGET_SIZE).unwrap();
+            }
+            let (spill, ranges) = spill.into_parts();
+
+            let mut expect = ops[0].clone();
+            for op in &ops[1..] {
+                json_patch::merge(&mut expect, op);
+            }
+
+            for full in [true, false] {
+                let drainer =
+                    SpillDrainer::new(spec(full), spill.clone(), &ranges, Vec::new().into())
+                        .unwrap();
+                let plain: Vec<(Meta, Value)> = drainer
+                    .map(|doc| doc.map(|doc| (doc.meta, to_json(&doc))))
+                    .collect::<Result<_, _>>()
+                    .unwrap();
+
+                let mut drainer =
+                    SpillDrainer::new(spec(full), spill.clone(), &ranges, Vec::new().into())
+                        .unwrap();
+                let mut archived = Vec::new();
+                loop {
+                    exhaust_alloc(&drainer);
+                    match drainer.drain_next().unwrap() {
+                        Some(doc) => archived.push((doc.meta, to_json(&doc))),
+                        None => break,
+                    }
+                }
+                if archived != plain {
+                    return false;
+                }
+
+                // Full reduction yields one document, with `null` as a tombstone.
+                // Associative reduction yields documents which merge-patch to it.
+                let mut actual = archived[0].1.clone();
+                for (_, doc) in &archived[1..] {
+                    json_patch::merge(&mut actual, doc);
+                }
+                if actual != expect {
+                    return false;
+                }
+                if full && (archived.len() != 1 || archived[0].0.deleted() != expect.is_null()) {
+                    return false;
+                }
+            }
+            true
+        }
+
+        quickcheck::QuickCheck::new()
+            .tests(500)
+            .quickcheck(prop as fn(MergePatchOps) -> bool);
     }
 
     #[test]


### PR DESCRIPTION
**Description:**

Each reduction allocates its output from the drainer's bump allocator, which cannot reclaim the previous output, and the allocator was replaced only after a key was yielded. A key repeated across many spill segments grew it without bound within one drain step.

Once the allocator passes `BUMP_THRESHOLD` mid-key, archive the intermediate reduction into an owned buffer, replace the allocator, and continue reducing from the archived document.

Split up into 2 commits, with the first being refactoring to support the second, which contains the new logic.

Q/A testing on a local stack. The expected peak memory reduction during drain was observed, reading from a collection of huge documents with hot keys.

Closes https://github.com/estuary/flow/issues/3413

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

