### PR TITLE
one reconciler job per target

### DIFF
--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -13,7 +13,7 @@ and the named deployment does not include its merge commit yet.
                      Its baseline is the image tag pinned in estuary/ops
                      env/estuary/combustable-cronut/main.jsonnet. Reading that
                      private repo from CI requires a token with contents:read
-                     on estuary/ops in the GH_TOKEN_OPS environment variable.
+                     on estuary/ops in the OPS_READ_TOKEN environment variable.
   pending:flowctl    the released flowctl CLI. Its baseline is the head commit
                      of the newest successful `Flowctl release` run — not the
                      release itself, whose publication merely starts the
@@ -119,7 +119,7 @@ def flowctl_release_commit(repo: str) -> str:
 def worker_commit(repo: str) -> str:
     """Baseline of the flow-agent k8s Deployment, from the estuary/ops pin."""
     env = None
-    if token := os.environ.get("GH_TOKEN_OPS"):
+    if token := os.environ.get("OPS_READ_TOKEN"):
         env = {"GH_TOKEN": token}
     try:
         content = run(
@@ -129,7 +129,7 @@ def worker_commit(repo: str) -> str:
     except subprocess.CalledProcessError as err:
         raise SystemExit(
             f"error: cannot read {OPS_REPO}/{OPS_PIN_PATH}: {err.stderr.strip()}\n"
-            "In CI this needs GH_TOKEN_OPS, a token with contents:read on "
+            "In CI this needs OPS_READ_TOKEN, a token with contents:read on "
             f"{OPS_REPO}."
         )
     jsonnet = base64.b64decode(content).decode()
@@ -253,7 +253,7 @@ def main() -> None:
 
     # key -> (target, closure, label, description, baseline). Baselines are
     # resolved lazily and each label reconciles independently: one target's
-    # failure — e.g. a missing GH_TOKEN_OPS — must not skip the others.
+    # failure — e.g. a missing OPS_READ_TOKEN — must not skip the others.
     targets = {
         "agent-api": (
             "agent", agent_dirs, "pending:agent-api",

--- a/.github/scripts/reconcile_deploy_labels.py
+++ b/.github/scripts/reconcile_deploy_labels.py
@@ -240,6 +240,10 @@ def main() -> None:
         "--end-ref", default="HEAD",
         help="merged-through ref; pass origin/master when running from a branch checkout",
     )
+    ap.add_argument(
+        "--only", choices=["agent-api", "agent", "flowctl"],
+        help="reconcile a single target; CI runs one matrix job per target",
+    )
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
@@ -247,29 +251,31 @@ def main() -> None:
     agent_dirs = closure(repo_root, "agent")
     flowctl_dirs = closure(repo_root, "flowctl")
 
-    # (target, closure, label, description, baseline). Baselines are resolved
-    # lazily and each label reconciles independently: one target's failure —
-    # e.g. a missing GH_TOKEN_OPS — must not skip the others.
-    targets = [
-        (
+    # key -> (target, closure, label, description, baseline). Baselines are
+    # resolved lazily and each label reconciles independently: one target's
+    # failure — e.g. a missing GH_TOKEN_OPS — must not skip the others.
+    targets = {
+        "agent-api": (
             "agent", agent_dirs, "pending:agent-api",
             "Merged, ships via Deploy agent-api, and not yet deployed",
             lambda: agent_api_commit(args.repo, args.deploy_run),
         ),
-        (
+        "agent": (
             "agent", agent_dirs, "pending:agent",
             "Merged, in the control-plane-agent image, and not yet rolled to flow-agent",
             lambda: worker_commit(args.repo),
         ),
-        (
+        "flowctl": (
             "flowctl", flowctl_dirs, "pending:flowctl",
             "Merged, changes the flowctl binary, and not in a published release",
             lambda: flowctl_release_commit(args.repo),
         ),
-    ]
+    }
+    if args.only:
+        targets = {args.only: targets[args.only]}
 
     failed = []
-    for target, dirs, label, description, baseline in targets:
+    for target, dirs, label, description, baseline in targets.values():
         try:
             reconcile(
                 args.repo, args.repo_dir, target, dirs,

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_TOKEN_OPS: ${{ secrets.OPS_READ_TOKEN }}
+      OPS_READ_TOKEN: ${{ secrets.OPS_READ_TOKEN }}
       # Only a Deploy agent-api run is a usable agent-api baseline; for any
       # other trigger the script finds the newest successful deploy itself.
       DEPLOY_RUN_ID: ${{ github.event.workflow_run.name == 'Deploy agent-api' && github.event.workflow_run.id || '' }}

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -8,9 +8,11 @@ name: Label deploy scope
 # deployed commits come from the deploy run's logs and the estuary/ops image
 # pin, changed files from the API, and manifests from the master checkout.
 #
-# OPS_READ_TOKEN must hold contents:read on estuary/ops: the `pending:agent`
-# baseline is that repo's pinned flow-agent image, and GITHUB_TOKEN cannot
-# read across repositories.
+# The `pending:agent` baseline is the flow-agent image pinned in estuary/ops,
+# and GITHUB_TOKEN cannot read across repositories. The OPS_READ_TOKEN secret
+# holds the private key of a GitHub App installed on estuary/ops (contents:
+# read); the OPS_APP_ID repository variable identifies that app, and a
+# short-lived installation token is minted from the two each run.
 on:
   push:
     branches: [master]
@@ -41,7 +43,6 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OPS_READ_TOKEN: ${{ secrets.OPS_READ_TOKEN }}
       # Only a Deploy agent-api run is a usable agent-api baseline; for any
       # other trigger the script finds the newest successful deploy itself.
       DEPLOY_RUN_ID: ${{ github.event.workflow_run.name == 'Deploy agent-api' && github.event.workflow_run.id || '' }}
@@ -55,7 +56,18 @@ jobs:
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
+      - name: Mint ops read token
+        id: ops-token
+        if: matrix.target == 'agent'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.OPS_APP_ID }}
+          private-key: ${{ secrets.OPS_READ_TOKEN }}
+          owner: estuary
+          repositories: ops
       - name: Reconcile labels
+        env:
+          OPS_READ_TOKEN: ${{ steps.ops-token.outputs.token }}
         run: |
           python3 .github/scripts/reconcile_deploy_labels.py \
             --only "${{ matrix.target }}" \

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -50,12 +50,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           # Blobless partial clone: the reconciler needs the full commit graph
-          # (git log <deployed>..HEAD) and the manifests at HEAD, but none of
-          # the historical file contents — a plain fetch-depth: 0 downloads
-          # multiple GB of blobs and dominates the run.
+          # and the manifests at HEAD, but none of the historical file
+          # contents — a plain fetch-depth: 0 downloads multiple GB of blobs
+          # and dominates the run. Credentials stay persisted so the reconcile
+          # step can fetch origin/master below.
           fetch-depth: 0
           filter: blob:none
-          persist-credentials: false
       - name: Mint ops read token
         id: ops-token
         if: matrix.target == 'agent'
@@ -69,6 +69,12 @@ jobs:
         env:
           OPS_READ_TOKEN: ${{ steps.ops-token.outputs.token }}
         run: |
+          # Enumerate merged PRs against real master, not the checked-out ref:
+          # a workflow_dispatch preview from a branch would otherwise treat
+          # every PR merged after the branch point as not-pending and strip
+          # its labels.
+          git fetch origin master
           python3 .github/scripts/reconcile_deploy_labels.py \
             --only "${{ matrix.target }}" \
+            --end-ref origin/master \
             ${DEPLOY_RUN_ID:+--deploy-run "$DEPLOY_RUN_ID"}

--- a/.github/workflows/label-deploy-scope.yaml
+++ b/.github/workflows/label-deploy-scope.yaml
@@ -26,8 +26,14 @@ concurrency:
   cancel-in-progress: true
 jobs:
   reconcile:
-    name: reconcile agent-api labels
+    name: ${{ matrix.target }}
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    strategy:
+      # One job per target so a failing target is visible by name, and one
+      # target's failure does not cancel the others.
+      fail-fast: false
+      matrix:
+        target: [agent-api, agent, flowctl]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -52,4 +58,5 @@ jobs:
       - name: Reconcile labels
         run: |
           python3 .github/scripts/reconcile_deploy_labels.py \
+            --only "${{ matrix.target }}" \
             ${DEPLOY_RUN_ID:+--deploy-run "$DEPLOY_RUN_ID"}


### PR DESCRIPTION
Runs the label reconciler as one matrix job per target (`agent-api` / `agent` / `flowctl`, `fail-fast: false`) so a failing target is visible by job name and doesn't affect the others.