### PR TITLE
control-plane-api: no-amplification and compatibility suite

### DIFF
--- a/crates/control-plane-api/src/fixtures/jwt_sign_polyfill.sql
+++ b/crates/control-plane-api/src/fixtures/jwt_sign_polyfill.sql
@@ -1,0 +1,32 @@
+-- Enables the SQL access-token mint (`public.generate_access_token`) inside
+-- a `#[sqlx::test]` database, where the real signing dependencies don't
+-- exist: `internal.access_token_jwt_secret()` reads `vault.decrypted_secrets`
+-- and `sign()` comes from the pgjwt extension, and `00_polyfill.sql` stubs
+-- neither (see the coverage note in `graphql/refresh_tokens.rs`).
+--
+-- The secret must match the harness key `test_server::build_app` hands the
+-- App, so that SQL-minted tokens verify against real Envelope extraction.
+-- `sign()` is a minimal HS256 implementation over pgcrypto's `hmac()`
+-- (already installed into `public` by `00_polyfill.sql`); its correctness is
+-- proven by the tokens it signs passing that verification.
+create or replace function internal.access_token_jwt_secret() returns text
+language sql stable as $$
+  select 'test-jwt-secret-for-integration-tests';
+$$;
+
+-- `translate` both maps base64 to the url-safe alphabet and strips the
+-- padding and line breaks `encode(..., 'base64')` inserts.
+create function public.jwt_url_encode(data bytea) returns text
+language sql immutable as $$
+  select translate(encode(data, 'base64'), E'+/=\n', '-_');
+$$;
+
+create function public.sign(payload json, secret text) returns text
+language sql immutable as $$
+  with parts as (
+    select public.jwt_url_encode(convert_to('{"alg":"HS256","typ":"JWT"}', 'utf8'))
+      || '.' || public.jwt_url_encode(convert_to(payload::text, 'utf8')) as signable
+  )
+  select signable || '.' || public.jwt_url_encode(public.hmac(signable, secret, 'sha256'))
+  from parts;
+$$;

--- a/crates/control-plane-api/src/fixtures/masked_suite.sql
+++ b/crates/control-plane-api/src/fixtures/masked_suite.sql
@@ -1,0 +1,65 @@
+-- Grant graph purpose-built for the masked-token no-amplification suite
+-- (`server/masked_token_suite/`). Composes with the `data_planes` fixture;
+-- deliberately independent of `alice`, whose shape many unrelated snapshot
+-- tests pin.
+--
+-- Each edge exists to discriminate one walk behavior under a mask:
+--
+--   dana ──admin──▶ danaCo/ ──read──▶ sharedCo/data/
+--     A direct legacy-admin grant (whose bits include Delegate, not Assume),
+--     and a role edge reachable only while the mask leaves Delegate enabled.
+--
+--   dana ──{viewer,assume}──▶ assumeCo/ ──admin──▶ wideCo/
+--     An Assume-bearing bundles grant: unmasked, Assume passes the edge's
+--     full admin bits through to wideCo/; a mask must contain that widening
+--     while still permitting traversal.
+--
+--   erin ──read──▶ sharedCo/
+--     The lifecycle subject: her grant is upgraded and then deleted mid-test
+--     to observe the same minted token across snapshot refreshes.
+--
+--   otherCo/ has no path from either user: the sweep's never-authorized
+--   column.
+do $$
+declare
+  data_plane_one_id flowid := '111111111111';
+
+  dana_uid uuid := '44444444-4444-4444-4444-444444444444';
+  erin_uid uuid := '55555555-5555-5555-5555-555555555555';
+
+  dana_data_id flowid  := '000000000011';
+  shared_data_id flowid := '000000000012';
+  wide_data_id flowid  := '000000000013';
+  other_data_id flowid := '000000000014';
+  last_pub_id flowid := '000000000002';
+
+begin
+
+  insert into auth.users (id, email) values
+    (dana_uid, 'dana@example.test'),
+    (erin_uid, 'erin@example.test')
+  ;
+  insert into public.user_grants (user_id, object_role, capability, bundles) values
+    (dana_uid, 'danaCo/', 'admin', '{}'),
+    (dana_uid, 'assumeCo/', 'none', array['viewer', 'assume']::capability_bundle[]),
+    (erin_uid, 'sharedCo/', 'read', '{}')
+  ;
+  insert into public.role_grants (subject_role, object_role, capability) values
+    ('danaCo/', 'sharedCo/data/', 'read'),
+    ('assumeCo/', 'wideCo/', 'admin')
+  ;
+
+  perform internal.create_task(dana_data_id, 1::smallint, '000000000000'::flowid);
+  perform internal.create_task(shared_data_id, 1::smallint, '000000000000'::flowid);
+  perform internal.create_task(wide_data_id, 1::smallint, '000000000000'::flowid);
+  perform internal.create_task(other_data_id, 1::smallint, '000000000000'::flowid);
+
+  insert into public.live_specs (id, controller_task_id, catalog_name, last_pub_id, spec_type, spec, built_spec, data_plane_id) values
+    (dana_data_id, dana_data_id, 'danaCo/data/collection', last_pub_id, 'collection', '{}', '{"partitionTemplate":{"name":"danaCo/data/collection/gen1234"}}', data_plane_one_id),
+    (shared_data_id, shared_data_id, 'sharedCo/data/collection', last_pub_id, 'collection', '{}', '{"partitionTemplate":{"name":"sharedCo/data/collection/gen1234"}}', data_plane_one_id),
+    (wide_data_id, wide_data_id, 'wideCo/data/collection', last_pub_id, 'collection', '{}', '{"partitionTemplate":{"name":"wideCo/data/collection/gen1234"}}', data_plane_one_id),
+    (other_data_id, other_data_id, 'otherCo/data/collection', last_pub_id, 'collection', '{}', '{"partitionTemplate":{"name":"otherCo/data/collection/gen1234"}}', data_plane_one_id)
+  ;
+
+end
+$$;

--- a/crates/control-plane-api/src/server/masked_token_suite/guards_and_compat.rs
+++ b/crates/control-plane-api/src/server/masked_token_suite/guards_and_compat.rs
@@ -1,0 +1,131 @@
+//! The compatibility half of the suite: unmasked callers keep the full
+//! refresh-token loop — create, exchange, and full authority from the
+//! exchanged token — and an identity-only minted token still operates as
+//! its user. The masked *refusals* guarding this loop (`createRefreshToken`
+//! and the `/admin` surfaces) are pinned in those surfaces' own modules and
+//! deliberately not repeated here; see the module doc.
+//!
+//! The loop's exchange runs the real SQL `generate_access_token` under the
+//! `jwt_sign_polyfill` fixture, which supplies the HS256 `sign()` and
+//! secret the sqlx::test database otherwise lacks.
+
+use super::{DANA, authorize_collection, mint, post_token};
+use crate::test_server;
+
+fn create_refresh_token_query() -> serde_json::Value {
+    serde_json::json!({
+        "query": r#"mutation { createRefreshToken(validFor: "P30D", detail: "suite") { id secret } }"#,
+    })
+}
+
+/// The full-authority credential loop, end to end: an unmasked caller
+/// creates a refresh token, exchanges it at `POST /api/v1/auth/token`, and
+/// the exchanged access token — minted by the SQL path, carrying no
+/// `capability_mask` — exercises the caller's full authority. This is the
+/// deliberate design fact the `createRefreshToken` guard exists to protect:
+/// refresh tokens are full-authority credentials, so only unmasked bearers
+/// may create them, and revocation (which never widens) stays open to any
+/// bearer — including an identity-only empty-mask token.
+#[sqlx::test(
+    migrations = "../../supabase/migrations",
+    fixtures(
+        path = "../../fixtures",
+        scripts("data_planes", "masked_suite", "jwt_sign_polyfill")
+    )
+)]
+async fn test_credential_loop(pool: sqlx::PgPool) {
+    let _guard = test_server::init();
+    let server = test_server::TestServer::start(
+        pool.clone(),
+        test_server::snapshot(pool.clone(), false).await,
+    )
+    .await;
+    let dana = server.make_access_token(DANA, Some("dana@example.test"));
+
+    // === An unmasked bearer runs the full loop ===
+    // (That a masked bearer cannot create the credential is pinned by
+    // `graphql/refresh_tokens`' own guard test.)
+    let created: serde_json::Value = server
+        .graphql(&create_refresh_token_query(), Some(&dana))
+        .await;
+    assert!(created["errors"].is_null(), "{created}");
+    let id = created["data"]["createRefreshToken"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let secret = created["data"]["createRefreshToken"]["secret"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (status, body) = post_token(
+        &server,
+        &serde_json::json!({
+            "grant_type": "refresh_token",
+            "refresh_token_id": id,
+            "secret": secret,
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "exchange: {body}");
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let exchanged = body["access_token"].as_str().unwrap().to_string();
+
+    // The exchanged token is unmasked and exercises dana's full authority:
+    // Write under her direct admin grant, through real Envelope
+    // verification of the SQL-signed token.
+    let claims = tokens::jwt::parse_unverified::<models::authorizations::ControlClaims>(
+        exchanged.as_bytes(),
+    )
+    .unwrap();
+    assert_eq!(claims.claims().capability_mask, None);
+    assert_eq!(claims.claims().sub, DANA);
+
+    let outcome =
+        authorize_collection(&server, &exchanged, "danaCo/data/collection", "write").await;
+    assert!(outcome.starts_with("OK"), "{outcome}");
+
+    // The bearer-credential form — the dot-less base64 (id, secret) pair
+    // exchanged inside Envelope extraction — is the same full authority.
+    use base64::Engine;
+    let bearer_credential = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::json!({ "id": id, "secret": secret }).to_string());
+    let outcome = authorize_collection(
+        &server,
+        &bearer_credential,
+        "danaCo/data/collection",
+        "write",
+    )
+    .await;
+    assert!(outcome.starts_with("OK"), "{outcome}");
+
+    // === Revocation stays open to a masked bearer, and never widens ===
+    // An identity-only token revokes the credential: its identity operates
+    // (the half of "empty mask is identity-only" the walk tests can't pin),
+    // and afterward the credential is dead — the loop is closed.
+    let identity_only = mint(&server, &dana, &[]).await;
+    let revoked: serde_json::Value = server
+        .graphql(
+            &serde_json::json!({
+                "query": r#"mutation($id: Id!) { revokeRefreshToken(id: $id) }"#,
+                "variables": { "id": id },
+            }),
+            Some(&identity_only),
+        )
+        .await;
+    assert!(revoked["errors"].is_null(), "{revoked}");
+    assert_eq!(revoked["data"]["revokeRefreshToken"], true);
+
+    let (status, _body) = post_token(
+        &server,
+        &serde_json::json!({
+            "grant_type": "refresh_token",
+            "refresh_token_id": id,
+            "secret": secret,
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+}

--- a/crates/control-plane-api/src/server/masked_token_suite/lifecycle.rs
+++ b/crates/control-plane-api/src/server/masked_token_suite/lifecycle.rs
@@ -1,0 +1,71 @@
+//! One minted token observed across snapshot refreshes as its user's
+//! grants change underneath it.
+//!
+//! A minted token embeds identity and mask, never grants: every request is
+//! decided against the server's current Snapshot. "A grant change takes
+//! effect immediately" therefore means *at the next snapshot refresh* — the
+//! stages below pin the stale window on each side of a refresh as
+//! deliberately as the flip itself.
+
+use super::{ERIN, authorize_collection, mint};
+use crate::test_server;
+
+#[sqlx::test(
+    migrations = "../../supabase/migrations",
+    fixtures(path = "../../fixtures", scripts("data_planes", "masked_suite"))
+)]
+async fn test_grants_change_under_a_live_token(pool: sqlx::PgPool) {
+    let _guard = test_server::init();
+
+    let mut snapshot = test_server::RefreshableSnapshot::start(pool.clone()).await;
+    let server = test_server::TestServer::start(pool.clone(), snapshot.watch()).await;
+    let erin = server.make_access_token(ERIN, Some("erin@example.test"));
+
+    // Erin holds `read` on sharedCo/; her token is approved for Writer.
+    // The mask covers the Write requirement, so the refusal is the walk's:
+    // approved-but-unheld bits stay inert until a grant actually holds them.
+    let token = mint(&server, &erin, &["Writer"]).await;
+
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "write").await;
+    insta::assert_snapshot!(outcome, @"403 erin@example.test is not authorized to sharedCo/data/collection for Write");
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "read").await;
+    assert!(outcome.starts_with("OK"), "{outcome}");
+
+    // === A grant addition activates already-approved bits ===
+    sqlx::query("UPDATE public.user_grants SET capability = 'write' WHERE user_id = $1")
+        .bind(ERIN)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // The running server still holds the prior snapshot: the mutation is
+    // not yet visible, which is the deliberate meaning of "immediately".
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "write").await;
+    assert!(
+        outcome.starts_with("403"),
+        "stale snapshot still refuses: {outcome}"
+    );
+
+    // At the next refresh the same token — approved for Writer all along —
+    // exercises the new grant with no re-mint.
+    snapshot.refresh().await;
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "write").await;
+    assert!(outcome.starts_with("OK"), "{outcome}");
+
+    // === Revocation takes effect at the next refresh ===
+    sqlx::query("DELETE FROM public.user_grants WHERE user_id = $1")
+        .bind(ERIN)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "read").await;
+    assert!(
+        outcome.starts_with("OK"),
+        "stale snapshot still allows: {outcome}"
+    );
+
+    snapshot.refresh().await;
+    let outcome = authorize_collection(&server, &token, "sharedCo/data/collection", "read").await;
+    insta::assert_snapshot!(outcome, @"403 erin@example.test is not authorized to sharedCo/data/collection for Read");
+}

--- a/crates/control-plane-api/src/server/masked_token_suite/mod.rs
+++ b/crates/control-plane-api/src/server/masked_token_suite/mod.rs
@@ -1,0 +1,110 @@
+//! The no-amplification and compatibility suite for capability-masked
+//! tokens (#3376, task 7).
+//!
+//! Every assertion here drives a token *minted by the real
+//! `capability_token` grant* through real routes, over a real snapshot of a
+//! real database — the composed pipeline no single enforcement or mint test
+//! exercises. What this suite holds is the security claim of the whole
+//! stack: a token the mint produces can never exercise more authority than
+//! its user's live grants, under any mask.
+//!
+//! Assertions already pinned elsewhere are deliberately not repeated:
+//! per-surface enforcement plumbing with hand-signed masked tokens lives in
+//! each surface's own module, and several of the task's named properties
+//! are already minted compositions there — a minted token cannot re-mint
+//! and the mint refuses service accounts (`token_exchange`), a masked
+//! bearer cannot `createRefreshToken` while masked revocation stays open
+//! (`graphql/refresh_tokens`), and the `/admin` endpoints fail closed at
+//! extraction (`create_data_plane`, `update_l2_reporting`, with the mint's
+//! verbatim claim stamping pinned by `token_exchange`).
+//!
+//! The suite reads against the `masked_suite` fixture, whose grant graph is
+//! documented (with the per-edge rationale) at the top of
+//! `fixtures/masked_suite.sql`.
+//!
+//! Organization:
+//! - [`walk`]: the subset property as an exhaustive mask-family sweep, plus
+//!   the named traversal semantics (`Delegate` confinement, `Assume`
+//!   containment, the empty mask) and the legacy-metadata probe.
+//! - [`lifecycle`]: one minted token observed across snapshot refreshes as
+//!   its user's grants change. "Immediately" means the next snapshot
+//!   refresh — the running server flips with no restart and no token
+//!   invalidation, which these tests pin in both directions.
+//! - [`guards_and_compat`]: the credential loop — refresh tokens remain
+//!   full-authority credentials for unmasked callers, and an identity-only
+//!   minted token still operates as its user.
+
+mod guards_and_compat;
+mod lifecycle;
+mod walk;
+
+use crate::test_server::TestServer;
+
+pub(crate) const DANA: uuid::Uuid = uuid::Uuid::from_bytes([0x44; 16]);
+pub(crate) const ERIN: uuid::Uuid = uuid::Uuid::from_bytes([0x55; 16]);
+
+/// Mint a capability token through the real endpoint, using `bearer` as the
+/// full-authority broker, and return the minted access token.
+pub(crate) async fn mint(server: &TestServer, bearer: &str, mask: &[&str]) -> String {
+    let (status, body) = post_token(
+        server,
+        &serde_json::json!({
+            "grant_type": "capability_token",
+            "capability_mask": mask,
+        }),
+        Some(bearer),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "mint of {mask:?}: {body}");
+
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+    body["access_token"].as_str().unwrap().to_string()
+}
+
+pub(crate) async fn post_token(
+    server: &TestServer,
+    body: &serde_json::Value,
+    bearer: Option<&str>,
+) -> (reqwest::StatusCode, String) {
+    let response = server
+        .rest_client()
+        .post("/api/v1/auth/token", body, bearer)
+        .send()
+        .await
+        .unwrap();
+    (response.status(), response.text().await.unwrap())
+}
+
+/// Present `bearer` to the canonical walk surface, `POST
+/// /authorize/user/collection`, and reduce the response to a compact
+/// outcome: the authorized journal prefix on success, the status and body
+/// on refusal. Refusal bodies carry the caller's email, so outcome strings
+/// double as the identity-copy-through probe for minted bearers.
+pub(crate) async fn authorize_collection(
+    server: &TestServer,
+    bearer: &str,
+    collection: &str,
+    capability: &str,
+) -> String {
+    let response = server
+        .rest_client()
+        .post(
+            "/authorize/user/collection",
+            &serde_json::json!({
+                "collection": collection,
+                "capability": capability,
+            }),
+            Some(bearer),
+        )
+        .send()
+        .await
+        .unwrap();
+    let (status, body) = (response.status(), response.text().await.unwrap());
+
+    if status == reqwest::StatusCode::OK {
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        format!("OK {}", body["journalNamePrefix"].as_str().unwrap())
+    } else {
+        format!("{} {body}", status.as_u16())
+    }
+}

--- a/crates/control-plane-api/src/server/masked_token_suite/walk.rs
+++ b/crates/control-plane-api/src/server/masked_token_suite/walk.rs
@@ -1,0 +1,320 @@
+//! The subset property, the traversal semantics under a mask, and the
+//! legacy-metadata probe — all with tokens produced by the real mint.
+
+use super::{DANA, authorize_collection, mint};
+use crate::test_server;
+
+/// The collections of the `masked_suite` fixture, one per grant-graph path
+/// class: direct grant, Delegate role-edge hop, Assume role-edge hop, and
+/// no path at all.
+const COLLECTIONS: [&str; 4] = [
+    "danaCo/data/collection",
+    "sharedCo/data/collection",
+    "wideCo/data/collection",
+    "otherCo/data/collection",
+];
+
+/// The headline no-amplification property, as an implication sweep: for
+/// every mask in a family crossing the fixture's path classes, a minted
+/// token's authorized set is a subset of its user's unmasked authorized
+/// set, and a mask naming every bundle behaves exactly as no mask at all.
+///
+/// The grid itself is snapshotted so a legitimate behavior change reads as
+/// a reviewable diff. Beyond the subset relation it exhibits the traversal
+/// semantics: a mask without `Delegate` walk-denies the role-edge hop with
+/// the requirement pre-check satisfied, a mask without `Assume` walk-denies
+/// the Assume hop, and a mask below the Viewer threshold is the structured
+/// pre-check refusal that discloses nothing about grants — the `empty` row
+/// is the identity-only token, which authenticates everywhere and
+/// authorizes nothing (that its identity still *operates* is pinned by the
+/// revocation step in `guards_and_compat`). Denial messages carry the
+/// caller's email — identity claims flowed from the mint through
+/// enforcement.
+#[sqlx::test(
+    migrations = "../../supabase/migrations",
+    fixtures(path = "../../fixtures", scripts("data_planes", "masked_suite"))
+)]
+async fn test_no_amplification_sweep(pool: sqlx::PgPool) {
+    let _guard = test_server::init();
+    let server = test_server::TestServer::start(
+        pool.clone(),
+        test_server::snapshot(pool.clone(), false).await,
+    )
+    .await;
+    let dana = server.make_access_token(DANA, Some("dana@example.test"));
+
+    let all_bundles: Vec<&str> = models::authz::CapabilityBundle::ALL
+        .iter()
+        .map(|b| b.name())
+        .collect();
+
+    let masks: Vec<(&str, Option<Vec<&str>>)> = vec![
+        ("unmasked", None),
+        ("empty", Some(vec![])),
+        ("unknown-only", Some(vec!["NotARealBundle"])),
+        ("CatalogRead", Some(vec!["CatalogRead"])),
+        ("Delegate", Some(vec!["Delegate"])),
+        ("Viewer", Some(vec!["Viewer"])),
+        ("Viewer+unknown", Some(vec!["Viewer", "FutureCapability"])),
+        ("Viewer+Delegate", Some(vec!["Viewer", "Delegate"])),
+        ("Viewer+Assume", Some(vec!["Viewer", "Assume"])),
+        ("Admin", Some(vec!["Admin"])),
+        ("all-bundles", Some(all_bundles)),
+    ];
+
+    let mut grid = String::new();
+    let mut outcomes: Vec<(&str, Vec<String>)> = Vec::new();
+
+    for (label, mask) in &masks {
+        let token = match mask {
+            None => dana.clone(),
+            Some(mask) => mint(&server, &dana, mask).await,
+        };
+
+        let mut row = Vec::new();
+        grid.push_str(&format!("{label}:\n"));
+        for collection in COLLECTIONS {
+            let outcome = authorize_collection(&server, &token, collection, "read").await;
+            grid.push_str(&format!("  {collection} => {outcome}\n"));
+            row.push(outcome);
+        }
+        outcomes.push((label, row));
+    }
+
+    // Masked-allowed implies unmasked-allowed: no mask amplifies.
+    let allowed = |row: &[String]| -> Vec<usize> {
+        (0..row.len())
+            .filter(|i| row[*i].starts_with("OK"))
+            .collect()
+    };
+    let unmasked = &outcomes[0].1;
+    for (label, row) in &outcomes[1..] {
+        for i in allowed(row) {
+            assert!(
+                unmasked[i].starts_with("OK"),
+                "mask {label} authorized {} which the unmasked walk denies",
+                COLLECTIONS[i],
+            );
+        }
+    }
+
+    // A mask naming every bundle is byte-identical to no mask: the masked-in
+    // positive counterpart, generalized.
+    let (label, row) = outcomes.last().unwrap();
+    assert_eq!(*label, "all-bundles");
+    assert_eq!(row, unmasked);
+
+    insta::assert_snapshot!(grid, @r#"
+    unmasked:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => OK sharedCo/data/collection/gen1234/
+      wideCo/data/collection => OK wideCo/data/collection/gen1234/
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    empty:
+      danaCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      sharedCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      wideCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      otherCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+    unknown-only:
+      danaCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      sharedCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      wideCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      otherCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+    CatalogRead:
+      danaCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["JournalRead","ViewDataPlanePrivateNetworking"]}
+      sharedCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["JournalRead","ViewDataPlanePrivateNetworking"]}
+      wideCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["JournalRead","ViewDataPlanePrivateNetworking"]}
+      otherCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["JournalRead","ViewDataPlanePrivateNetworking"]}
+    Delegate:
+      danaCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      sharedCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      wideCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+      otherCo/data/collection => 403 {"error":"missing_capabilities","message":"the bearer token's capability mask does not enable required capabilities: CatalogRead, JournalRead, ViewDataPlanePrivateNetworking","missing_capabilities":["CatalogRead","JournalRead","ViewDataPlanePrivateNetworking"]}
+    Viewer:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => 403 dana@example.test is not authorized to sharedCo/data/collection for Read
+      wideCo/data/collection => 403 dana@example.test is not authorized to wideCo/data/collection for Read
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    Viewer+unknown:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => 403 dana@example.test is not authorized to sharedCo/data/collection for Read
+      wideCo/data/collection => 403 dana@example.test is not authorized to wideCo/data/collection for Read
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    Viewer+Delegate:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => OK sharedCo/data/collection/gen1234/
+      wideCo/data/collection => 403 dana@example.test is not authorized to wideCo/data/collection for Read
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    Viewer+Assume:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => 403 dana@example.test is not authorized to sharedCo/data/collection for Read
+      wideCo/data/collection => OK wideCo/data/collection/gen1234/
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    Admin:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => OK sharedCo/data/collection/gen1234/
+      wideCo/data/collection => 403 dana@example.test is not authorized to wideCo/data/collection for Read
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    all-bundles:
+      danaCo/data/collection => OK danaCo/data/collection/gen1234/
+      sharedCo/data/collection => OK sharedCo/data/collection/gen1234/
+      wideCo/data/collection => OK wideCo/data/collection/gen1234/
+      otherCo/data/collection => 403 dana@example.test is not authorized to otherCo/data/collection for Read
+    "#);
+}
+
+/// Requested-but-unheld capabilities are inert: a mask may enable `Admin`,
+/// but dana's live grant at the role-edge hop is `read`, and the minted
+/// token gets exactly what the unmasked walk would grant there — no more.
+#[sqlx::test(
+    migrations = "../../supabase/migrations",
+    fixtures(path = "../../fixtures", scripts("data_planes", "masked_suite"))
+)]
+async fn test_unheld_bits_are_inert(pool: sqlx::PgPool) {
+    let _guard = test_server::init();
+    let server = test_server::TestServer::start(
+        pool.clone(),
+        test_server::snapshot(pool.clone(), false).await,
+    )
+    .await;
+    let dana = server.make_access_token(DANA, Some("dana@example.test"));
+
+    // The mask enables every Admin-bundle bit, and Write is still refused
+    // at sharedCo/: the mask is a ceiling, never a grant, and the walk
+    // decides from live grants. The same request under danaCo/'s direct
+    // admin grant succeeds, so the refusal is the grant's, not the mask's.
+    let masked_admin = mint(&server, &dana, &["Admin"]).await;
+    let outcome =
+        authorize_collection(&server, &masked_admin, "sharedCo/data/collection", "write").await;
+    insta::assert_snapshot!(outcome, @"403 dana@example.test is not authorized to sharedCo/data/collection for Write");
+
+    let outcome =
+        authorize_collection(&server, &masked_admin, "danaCo/data/collection", "write").await;
+    assert!(outcome.starts_with("OK"), "{outcome}");
+}
+
+/// Legacy response metadata attenuates to null under the mask rather than
+/// leaking, and never authorizes. Dana's unmasked twin sees the role-edge
+/// referent with its legacy `read` label and full gated fields; under a
+/// minted `["Viewer"]` mask (no `Delegate`, so the referent's effective
+/// bits are empty) the same ref presents as inaccessible — `userCapability`
+/// null and gated fields null together, exactly as an unmasked user sees a
+/// ref they can't access. The accessible danaCo ref still reports its
+/// literal legacy label: at or above the threshold the label is
+/// informational and may read broader than the mask, per decision 3.
+#[sqlx::test(
+    migrations = "../../supabase/migrations",
+    fixtures(path = "../../fixtures", scripts("data_planes", "masked_suite"))
+)]
+async fn test_legacy_metadata_cannot_authorize(pool: sqlx::PgPool) {
+    let _guard = test_server::init();
+
+    // danaCo's collection names the role-edge collection as a write target,
+    // giving the masked query an accessible ref which references one the
+    // mask denies.
+    sqlx::query(
+        "UPDATE public.live_specs
+         SET writes_to = ARRAY['sharedCo/data/collection']::catalog_name[]
+         WHERE catalog_name = 'danaCo/data/collection'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let server = test_server::TestServer::start(
+        pool.clone(),
+        test_server::snapshot(pool.clone(), false).await,
+    )
+    .await;
+    let dana = server.make_access_token(DANA, Some("dana@example.test"));
+
+    let query = serde_json::json!({
+        "query": r#"
+        query {
+            liveSpecs(by: { names: ["danaCo/data/collection"] }) {
+                edges {
+                    node {
+                        catalogName
+                        userCapability
+                        liveSpec {
+                            writesTo {
+                                edges {
+                                    node {
+                                        catalogName
+                                        userCapability
+                                        liveSpec { catalogType }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    "#});
+
+    let unmasked: serde_json::Value = server.graphql(&query, Some(&dana)).await;
+    insta::assert_json_snapshot!(unmasked, @r#"
+    {
+      "data": {
+        "liveSpecs": {
+          "edges": [
+            {
+              "node": {
+                "catalogName": "danaCo/data/collection",
+                "liveSpec": {
+                  "writesTo": {
+                    "edges": [
+                      {
+                        "node": {
+                          "catalogName": "sharedCo/data/collection",
+                          "liveSpec": {
+                            "catalogType": "collection"
+                          },
+                          "userCapability": "read"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "userCapability": "admin"
+              }
+            }
+          ]
+        }
+      }
+    }
+    "#);
+
+    let masked = mint(&server, &dana, &["Viewer"]).await;
+    let masked: serde_json::Value = server.graphql(&query, Some(&masked)).await;
+    insta::assert_json_snapshot!(masked, @r#"
+    {
+      "data": {
+        "liveSpecs": {
+          "edges": [
+            {
+              "node": {
+                "catalogName": "danaCo/data/collection",
+                "liveSpec": {
+                  "writesTo": {
+                    "edges": [
+                      {
+                        "node": {
+                          "catalogName": "sharedCo/data/collection",
+                          "liveSpec": null,
+                          "userCapability": null
+                        }
+                      }
+                    ]
+                  }
+                },
+                "userCapability": "admin"
+              }
+            }
+          ]
+        }
+      }
+    }
+    "#);
+}

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -10,6 +10,8 @@ mod authorize_user_prefix;
 mod authorize_user_task;
 mod create_data_plane;
 mod error;
+#[cfg(test)]
+mod masked_token_suite;
 pub mod public;
 pub mod snapshot;
 mod update_l2_reporting;

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -67,6 +67,55 @@ pub async fn snapshot(pg_pool: sqlx::PgPool, gate: bool) -> Arc<dyn tokens::Watc
     tokens::watch(source).ready_owned().await
 }
 
+/// A snapshot watch the test refreshes by hand: each `refresh` re-fetches
+/// the database's current state and swaps it into the live watch, so a
+/// single running server observes grant mutations the way production
+/// observes a periodic snapshot refresh — no restart, no token
+/// invalidation. This is the operational meaning of "a grant change takes
+/// effect immediately": at the next snapshot refresh.
+pub struct RefreshableSnapshot {
+    pg_pool: sqlx::PgPool,
+    decrypted_hmac_keys: std::collections::HashMap<String, (models::RawValue, Vec<String>)>,
+    replace: Box<dyn Fn(tonic::Result<Snapshot>) -> Option<tokens::WaitForCancellationFutureOwned>>,
+    watch: Arc<dyn tokens::Watch<Snapshot>>,
+}
+
+impl RefreshableSnapshot {
+    pub async fn start(pg_pool: sqlx::PgPool) -> Self {
+        let (pending, replace) = tokens::manual();
+        let (watch, _ready) = pending.into_parts();
+
+        let mut this = Self {
+            pg_pool,
+            decrypted_hmac_keys: Default::default(),
+            replace: Box::new(replace),
+            watch,
+        };
+        this.refresh().await;
+        this
+    }
+
+    pub fn watch(&self) -> Arc<dyn tokens::Watch<Snapshot>> {
+        Arc::clone(&self.watch)
+    }
+
+    /// Fetch the database's current state and swap it into the watch.
+    /// Fetches directly rather than through `PgSnapshotSource`, whose
+    /// MIN_REFRESH_INTERVAL cool-off would stall back-to-back test
+    /// refreshes.
+    pub async fn refresh(&mut self) {
+        let data = crate::server::snapshot::try_fetch(&self.pg_pool, &mut self.decrypted_hmac_keys)
+            .await
+            .expect("failed to fetch snapshot");
+        let mut snapshot = Snapshot::new(tokens::now(), data);
+
+        // Shift `taken` past the test's wall-clock runtime so that denials
+        // are terminal; see `snapshot` above.
+        snapshot.taken += chrono::TimeDelta::hours(1);
+        (self.replace)(Ok(snapshot));
+    }
+}
+
 /// A snapshot watch serving a single empty Snapshot. For tests which never
 /// evaluate authorization — such as extractor tests — and so never await a
 /// refresh (the gated source panics if refreshed again).


### PR DESCRIPTION
Task 7 of #3376 (PR 9 on the stack, stacked on #3427): end-to-end assertions
that a capability-masked token's authority is always a subset of its user's
live grants. Tests only — no production code changes.

## What the suite is

Every assertion drives a token **minted by the real `capability_token`
grant** through real routes, over a real snapshot of a real database — the
composed mint→use pipeline no single enforcement or mint test exercises.
Per-surface enforcement plumbing with hand-signed tokens is already pinned in
each surface's own module (3c/5/6) and is deliberately not re-proven here.

New module `src/server/masked_token_suite/` (`#[cfg(test)]`):

- **`walk`** — the headline property as an implication sweep: fixture
  collections × an 11-mask family, every masked row minted through the
  endpoint, asserting *masked-allowed ⟹ unmasked-allowed* and
  *all-bundles ≡ unmasked*, with the outcome grid insta-snapshotted so a
  legitimate behavior change reads as a grid diff. Plus targeted tests:
  empty mask is identity-only (structured `missing_capabilities` body),
  requested-but-unheld bits are inert, and the legacy-metadata GraphQL probe
  (under a mask, an unreachable referent presents `userCapability: null`
  with null gated fields — legacy attenuates to null rather than leaking,
  and never authorizes; an accessible ref keeps its literal informational
  label per decision 3).
- **`lifecycle`** — one minted token observed across snapshot refreshes as
  its user's grants change: a grant addition activates already-approved
  mask bits with no re-mint, and revocation takes effect at the next
  refresh. Both stale windows (before the refresh) are pinned deliberately:
  "immediately" *means* next-snapshot-refresh, no restart, no token
  invalidation.
- **`guards_and_compat`** — the full-authority credential loop
  (createRefreshToken → exchange → full authority, including the dot-less
  bearer-credential form) closed by the empty-mask identity probe: an
  identity-only minted token still revokes its user's refresh token
  (revocation never widens), and the revoked credential is dead.

Task-7 assertions already pinned elsewhere are deliberately not repeated,
and the suite's module doc points at each: a minted token cannot re-mint
and the mint refuses service accounts (`token_exchange`), masked
`createRefreshToken` refusal and masked-revocation openness
(`graphql/refresh_tokens`), and the `/admin` fail-closed guards
(`create_data_plane` / `update_l2_reporting`).

## Test infrastructure

- `test_server::RefreshableSnapshot` — a manual snapshot watch the test
  refreshes by hand (via `tokens::manual`), so a single running server
  observes DB grant mutations the way production observes a periodic
  snapshot refresh. Fetches via `try_fetch` directly to skip
  `PgSnapshotSource`'s MIN_REFRESH_INTERVAL cool-off.
- `fixtures/masked_suite.sql` — a purpose-built grant graph, one edge per
  walk behavior under a mask (direct grant / Delegate hop / Assume hop /
  no path), documented in-file. `alice.sql` is untouched.
- `fixtures/jwt_sign_polyfill.sql` — enables the SQL
  `generate_access_token` mint inside a sqlx::test database by overriding
  `internal.access_token_jwt_secret()` to the harness key and supplying a
  minimal HS256 `sign()` over pgcrypto's `hmac()`. This unlocks the
  credential loop's real exchange (previously impossible under sqlx::test —
  see the coverage note in `graphql/refresh_tokens.rs`); the polyfill's
  correctness is proven by SQL-signed tokens passing real Envelope
  verification.

## Decisions (grilled 2026-08-28)

1. **Charter:** strictly real-mint composition — every assertion exercises a
   genuinely minted token; unit-level duplication of 3c/5/6 coverage is out
   of scope. The suite is the regression net for mint/enforcement drift.
2. **Stale assertions dropped:** the task's "upgrade union never exceeds
   live grants" and "expired-upgrade re-mint" items predate the removal of
   `upgrade_token` (Gregor, 2026-08-27) and are not implemented. Their
   successor property — a minted token cannot re-mint itself — turned out
   to be already pinned inside task 5's `test_capability_token_mint`. The
   plan comment's task-7 text is amended accordingly.
3. **Lifecycle harness:** a refreshable snapshot source (one server, live
   refresh) over the two-servers-over-one-DB alternative, pinning
   "immediately = next snapshot refresh" as the documented semantics.
4. **Fixture:** a new companion fixture with a dedicated tenant graph
   designed per-assertion, rather than growing `alice.sql` (whose shape many
   existing snapshots pin) or inlining SQL per test.
5. **Layout:** a `#[cfg(test)]` directory module grouped by harness need
   (minting / walk / lifecycle / guards+compat).
6. **Surfaces:** `/authorize/user/collection` is the canonical walk surface
   (richest outcome shape; denial messages carry the caller's email, which
   doubles as the identity-copy-through probe). Surface-specific assertions
   keep their own endpoints. The full assertion×surface matrix was rejected
   as re-proving 3c's per-surface plumbing.
7. **Headline property as a sweep:** one snapshot-gridded implication sweep
   over a mask family, catching any future mask-widens-something regression
   nobody thought to enumerate, plus targeted example tests for the named
   semantics (Delegate confinement, Assume containment, empty mask).
8. **Legacy metadata probe:** the minted `["Viewer"]`-mask `writesTo`
   contrast — accessible ref keeps its informational literal label,
   mask-denied referent attenuates to null metadata and null fields
   together.
9. **Compat centerpiece:** the full credential loop (proving "unmasked
   still can" alongside the guards' "masked cannot"), with the
   `revokeRefreshToken` rider pinning that an identity-only token's
   identity operates. Discovered constraint: the SQL exchange needs
   vault/pgjwt, absent under sqlx::test — resolved with the
   `jwt_sign_polyfill` fixture rather than degrading the approved loop
   test.
10. **No explicit duplicates:** a post-implementation scan removed every
    test whose only delta from an existing pinned test was token
    provenance — the standalone re-mint probe, the empty-mask standalone
    (it was verbatim the sweep's `empty` row), the `/admin` refusal test,
    and the loop's masked-`createRefreshToken` step. The module doc carries
    coverage pointers instead.

Closes the task-7 item of #3376's implementation plan.
