### PR TITLE
control-plane-api: create_data_plane gates ops admin via Snapshot

### DIFF
--- a/crates/control-plane-api/src/server/create_data_plane.rs
+++ b/crates/control-plane-api/src/server/create_data_plane.rs
@@ -63,20 +63,11 @@ pub async fn create_data_plane(
         category,
     }): super::Request<Request>,
 ) -> Result<axum::Json<Response>, crate::server::error::ApiError> {
-    let models::authorizations::ControlClaims { sub: user_id, .. } = env.claims()?;
+    let claims = env.claims()?;
+    let user_id = claims.sub;
 
-    if let None = sqlx::query!(
-        "select role_prefix from internal.user_roles($1, 'admin') where role_prefix = 'ops/'",
-        user_id,
-    )
-    .fetch_optional(&env.pg_pool)
-    .await?
-    {
-        return Err(tonic::Status::permission_denied(
-            "authenticated user is not an admin of the 'ops/' tenant",
-        )
-        .into());
-    }
+    let policy_result = super::evaluate_ops_admin(env.snapshot(), claims);
+    let (_expiry, ()) = env.authorization_outcome(policy_result).await?;
 
     let (data_plane_fqdn, base_name, pulumi_stack) = match &private {
         None => (
@@ -233,7 +224,7 @@ pub async fn create_data_plane(
         .into();
 
     let publication = DraftPublication {
-        user_id: *user_id,
+        user_id,
         logs_token: insert.logs_token,
         draft,
         dry_run: false,
@@ -325,5 +316,56 @@ impl Validate for Category {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_server;
+
+    /// Denial-path coverage of the `ops/` admin gate. Only denials are
+    /// exercised end-to-end: an authorized request proceeds into data-plane
+    /// provisioning, which is out of scope for authorization tests (and would
+    /// panic in the test server's NoopBuilder). The allowed cases — including
+    /// the ancestor-subject admin chain — are pinned by the unit tests of
+    /// `evaluate_ops_admin`.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(path = "../fixtures", scripts("data_planes", "alice"))
+    )]
+    async fn test_ops_admin_gate_denials(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+        let snapshot = test_server::snapshot(pool.clone(), false).await;
+        let server = test_server::TestServer::start(pool, snapshot).await;
+
+        let body = serde_json::json!({"name": "test-plane", "category": "managed"});
+
+        // A request without a bearer token is unauthenticated.
+        let response = server
+            .rest_client()
+            .post("/admin/create-data-plane", &body, None)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+        // Alice admins aliceCo/ but holds nothing on ops/. The test Snapshot
+        // post-dates the request, so the denial is terminal rather than a
+        // 307 authorization retry.
+        let alice = uuid::Uuid::from_bytes([0x11; 16]);
+        let token = server.make_access_token(alice, Some("alice@example.com"));
+        let response = server
+            .rest_client()
+            .post("/admin/create-data-plane", &body, Some(&token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+
+        let text = response.text().await.unwrap();
+        assert!(
+            text.contains("is not an admin of the 'ops/' tenant"),
+            "unexpected denial body: {text}"
+        );
     }
 }

--- a/crates/control-plane-api/src/server/create_data_plane.rs
+++ b/crates/control-plane-api/src/server/create_data_plane.rs
@@ -66,7 +66,12 @@ pub async fn create_data_plane(
     let claims = env.claims()?;
     let user_id = claims.sub;
 
-    let policy_result = super::evaluate_ops_admin(env.snapshot(), claims);
+    let policy_result = super::evaluate_names_authorization(
+        env.snapshot(),
+        claims,
+        models::Capability::Admin,
+        ["ops/"],
+    );
     let (_expiry, ()) = env.authorization_outcome(policy_result).await?;
 
     let (data_plane_fqdn, base_name, pulumi_stack) = match &private {
@@ -327,8 +332,8 @@ mod test {
     /// exercised end-to-end: an authorized request proceeds into data-plane
     /// provisioning, which is out of scope for authorization tests (and would
     /// panic in the test server's NoopBuilder). The allowed cases — including
-    /// the ancestor-subject admin chain — are pinned by the unit tests of
-    /// `evaluate_ops_admin`.
+    /// the ancestor-subject admin chain — are pinned by the gate's unit
+    /// tests in the parent module.
     #[sqlx::test(
         migrations = "../../supabase/migrations",
         fixtures(path = "../fixtures", scripts("data_planes", "alice"))
@@ -364,7 +369,10 @@ mod test {
 
         let text = response.text().await.unwrap();
         assert!(
-            text.contains("is not an admin of the 'ops/' tenant"),
+            text.contains(
+                "alice@example.com is not authorized to access prefix or name 'ops/' \
+                 with required capability admin"
+            ),
             "unexpected denial body: {text}"
         );
     }

--- a/crates/control-plane-api/src/server/create_data_plane.rs
+++ b/crates/control-plane-api/src/server/create_data_plane.rs
@@ -331,9 +331,9 @@ mod test {
     /// Denial-path coverage of the `ops/` admin gate. Only denials are
     /// exercised end-to-end: an authorized request proceeds into data-plane
     /// provisioning, which is out of scope for authorization tests (and would
-    /// panic in the test server's NoopBuilder). The allowed cases — including
-    /// the ancestor-subject admin chain — are pinned by the gate's unit
-    /// tests in the parent module.
+    /// panic in the test server's NoopBuilder). The allowed case is pinned by
+    /// the gate's unit test in the parent module, and the grant walk it
+    /// composes is covered by the `tables` crate.
     #[sqlx::test(
         migrations = "../../supabase/migrations",
         fixtures(path = "../fixtures", scripts("data_planes", "alice"))

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -502,12 +502,19 @@ mod tests {
         // A read grant to `ops/` is not admin.
         let snapshot = snapshot_of_grants(&[(user, "ops/", Read)], &[]);
         assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_err());
+    }
 
-        // An admin chain reached through an *ancestor* subject role:
-        // the user admins `estuary/support/`, and `estuary/` (its ancestor)
-        // is granted admin of `ops/`. The replaced `internal.user_roles()`
-        // gate walked only downward and wrongly denied this; the Snapshot
-        // walk authorizes it. This pins the deliberate semantic change.
+    /// Pins the deliberate semantic change from the replaced
+    /// `internal.user_roles()` gate: an admin chain reached through an
+    /// *ancestor* subject role. The user admins `estuary/support/`, and
+    /// `estuary/` (its ancestor) is granted admin of `ops/`. The SQL gate
+    /// walked only downward from held roles and wrongly denied this; the
+    /// Snapshot walk authorizes it.
+    #[test]
+    fn test_evaluate_ops_admin_ancestor_subject_chain() {
+        use models::Capability::{Admin, Read};
+        let user = uuid::Uuid::from_bytes([0x11; 16]);
+
         let snapshot = snapshot_of_grants(
             &[(user, "estuary/support/", Admin)],
             &[("estuary/", "ops/", Admin)],

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -136,6 +136,31 @@ where
     Ok((None, ()))
 }
 
+/// Evaluate whether the user identified by `claims` is an admin of the
+/// `ops/` role, which gates the `/admin/*` endpoints.
+/// Return a policy_result shape which fits Envelope::authorization_outcome.
+///
+/// This replaces a SQL gate over `internal.user_roles()`, whose grant walk
+/// is downward-only from the roles a user holds. The Snapshot walk also
+/// reaches grants held by *ancestors* of those roles, so an admin chain
+/// into `ops/` through an ancestor subject — which the SQL gate wrongly
+/// rejected — is authorized here.
+pub fn evaluate_ops_admin(snapshot: &Snapshot, claims: &crate::ControlClaims) -> AuthZResult<()> {
+    let models::authorizations::ControlClaims {
+        sub: user_id,
+        email: user_email,
+        ..
+    } = claims;
+    let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
+
+    if !snapshot.is_user_authorized(*user_id, "ops/", models::Capability::Admin) {
+        return Err(tonic::Status::permission_denied(format!(
+            "{user_email} is not an admin of the 'ops/' tenant",
+        )));
+    }
+    Ok((None, ()))
+}
+
 /// Looks up the user's authorization grants for each item in
 /// `prefixes_or_names`, and calls the provided `attach` function with each
 /// item and its capability. The `Some` results are returned in a vec.
@@ -405,5 +430,95 @@ const fn map_capability_to_gazette(capability: models::Capability) -> u32 {
                 | proto_gazette::capability::APPEND
                 | proto_gazette::capability::APPLY
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claims(user_id: uuid::Uuid) -> crate::ControlClaims {
+        models::authorizations::ControlClaims {
+            iat: 0,
+            exp: u64::MAX,
+            sub: user_id,
+            role: "authenticated".to_string(),
+            aud: "authenticated".to_string(),
+            email: Some("user@example.test".to_string()),
+        }
+    }
+
+    fn snapshot_of_grants(
+        user_grants: &[(uuid::Uuid, &str, models::Capability)],
+        role_grants: &[(&str, &str, models::Capability)],
+    ) -> Snapshot {
+        Snapshot::new(
+            Default::default(),
+            snapshot::SnapshotData {
+                collections: Vec::new(),
+                data_planes: Vec::new(),
+                migrations: Vec::new(),
+                role_grants: role_grants
+                    .iter()
+                    .map(|(sub, obj, cap)| tables::RoleGrant {
+                        subject_role: models::Prefix::new(*sub),
+                        object_role: models::Prefix::new(*obj),
+                        capability: *cap,
+                        bundles: Vec::new(),
+                    })
+                    .collect(),
+                user_grants: user_grants
+                    .iter()
+                    .map(|(id, obj, cap)| tables::UserGrant {
+                        user_id: *id,
+                        object_role: models::Prefix::new(*obj),
+                        capability: *cap,
+                        bundles: Vec::new(),
+                    })
+                    .collect(),
+                tasks: Vec::new(),
+            },
+        )
+    }
+
+    #[test]
+    fn test_evaluate_ops_admin() {
+        use models::Capability::{Admin, Read};
+        let user = uuid::Uuid::from_bytes([0x11; 16]);
+
+        // A direct admin grant to `ops/` is authorized.
+        let snapshot = snapshot_of_grants(&[(user, "ops/", Admin)], &[]);
+        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_ok());
+
+        // Admin of an unrelated tenant is denied.
+        let snapshot = snapshot_of_grants(&[(user, "acmeCo/", Admin)], &[]);
+        let status = evaluate_ops_admin(&snapshot, &claims(user)).unwrap_err();
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert_eq!(
+            status.message(),
+            "user@example.test is not an admin of the 'ops/' tenant"
+        );
+
+        // A read grant to `ops/` is not admin.
+        let snapshot = snapshot_of_grants(&[(user, "ops/", Read)], &[]);
+        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_err());
+
+        // An admin chain reached through an *ancestor* subject role:
+        // the user admins `estuary/support/`, and `estuary/` (its ancestor)
+        // is granted admin of `ops/`. The replaced `internal.user_roles()`
+        // gate walked only downward and wrongly denied this; the Snapshot
+        // walk authorizes it. This pins the deliberate semantic change.
+        let snapshot = snapshot_of_grants(
+            &[(user, "estuary/support/", Admin)],
+            &[("estuary/", "ops/", Admin)],
+        );
+        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_ok());
+
+        // The same chain with a non-admin object grant is denied.
+        let snapshot = snapshot_of_grants(
+            &[(user, "estuary/support/", Admin)],
+            &[("estuary/", "ops/", Read)],
+        );
+        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_err());
     }
 }

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -136,31 +136,6 @@ where
     Ok((None, ()))
 }
 
-/// Evaluate whether the user identified by `claims` is an admin of the
-/// `ops/` role, which gates the `/admin/*` endpoints.
-/// Return a policy_result shape which fits Envelope::authorization_outcome.
-///
-/// This replaces a SQL gate over `internal.user_roles()`, whose grant walk
-/// is downward-only from the roles a user holds. The Snapshot walk also
-/// reaches grants held by *ancestors* of those roles, so an admin chain
-/// into `ops/` through an ancestor subject — which the SQL gate wrongly
-/// rejected — is authorized here.
-pub fn evaluate_ops_admin(snapshot: &Snapshot, claims: &crate::ControlClaims) -> AuthZResult<()> {
-    let models::authorizations::ControlClaims {
-        sub: user_id,
-        email: user_email,
-        ..
-    } = claims;
-    let user_email = user_email.as_ref().map(String::as_str).unwrap_or("user");
-
-    if !snapshot.is_user_authorized(*user_id, "ops/", models::Capability::Admin) {
-        return Err(tonic::Status::permission_denied(format!(
-            "{user_email} is not an admin of the 'ops/' tenant",
-        )));
-    }
-    Ok((None, ()))
-}
-
 /// Looks up the user's authorization grants for each item in
 /// `prefixes_or_names`, and calls the provided `attach` function with each
 /// item and its capability. The `Some` results are returned in a vec.
@@ -436,6 +411,7 @@ const fn map_capability_to_gazette(capability: models::Capability) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_server::snapshot_of_grants;
 
     fn claims(user_id: uuid::Uuid) -> crate::ControlClaims {
         models::authorizations::ControlClaims {
@@ -448,64 +424,36 @@ mod tests {
         }
     }
 
-    fn snapshot_of_grants(
-        user_grants: &[(uuid::Uuid, &str, models::Capability)],
-        role_grants: &[(&str, &str, models::Capability)],
-    ) -> Snapshot {
-        Snapshot::new(
-            Default::default(),
-            snapshot::SnapshotData {
-                collections: Vec::new(),
-                data_planes: Vec::new(),
-                migrations: Vec::new(),
-                role_grants: role_grants
-                    .iter()
-                    .map(|(sub, obj, cap)| tables::RoleGrant {
-                        subject_role: models::Prefix::new(*sub),
-                        object_role: models::Prefix::new(*obj),
-                        capability: *cap,
-                        bundles: Vec::new(),
-                    })
-                    .collect(),
-                user_grants: user_grants
-                    .iter()
-                    .map(|(id, obj, cap)| tables::UserGrant {
-                        user_id: *id,
-                        object_role: models::Prefix::new(*obj),
-                        capability: *cap,
-                        bundles: Vec::new(),
-                    })
-                    .collect(),
-                tasks: Vec::new(),
-            },
-        )
-    }
-
+    /// The `ops/` admin gate of the /admin/* endpoints, expressed as
+    /// evaluate_names_authorization over the Snapshot's grant walk.
     #[test]
-    fn test_evaluate_ops_admin() {
+    fn test_evaluate_ops_admin_gate() {
         use models::Capability::{Admin, Read};
         let user = uuid::Uuid::from_bytes([0x11; 16]);
+        let evaluate = |snapshot: &Snapshot| {
+            evaluate_names_authorization(snapshot, &claims(user), Admin, ["ops/"])
+        };
 
         // A direct admin grant to `ops/` is authorized.
         let snapshot = snapshot_of_grants(&[(user, "ops/", Admin)], &[]);
-        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_ok());
+        assert!(evaluate(&snapshot).is_ok());
 
         // Admin of an unrelated tenant is denied.
         let snapshot = snapshot_of_grants(&[(user, "acmeCo/", Admin)], &[]);
-        let status = evaluate_ops_admin(&snapshot, &claims(user)).unwrap_err();
+        let status = evaluate(&snapshot).unwrap_err();
         assert_eq!(status.code(), tonic::Code::PermissionDenied);
         assert_eq!(
             status.message(),
-            "user@example.test is not an admin of the 'ops/' tenant"
+            "user@example.test is not authorized to access prefix or name 'ops/' with required capability admin"
         );
 
         // A read grant to `ops/` is not admin.
         let snapshot = snapshot_of_grants(&[(user, "ops/", Read)], &[]);
-        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_err());
+        assert!(evaluate(&snapshot).is_err());
     }
 
-    /// Pins the deliberate semantic change from the replaced
-    /// `internal.user_roles()` gate: an admin chain reached through an
+    /// Pins the deliberate semantic change from the `internal.user_roles()`
+    /// SQL gate this check replaced: an admin chain reached through an
     /// *ancestor* subject role. The user admins `estuary/support/`, and
     /// `estuary/` (its ancestor) is granted admin of `ops/`. The SQL gate
     /// walked only downward from held roles and wrongly denied this; the
@@ -519,13 +467,29 @@ mod tests {
             &[(user, "estuary/support/", Admin)],
             &[("estuary/", "ops/", Admin)],
         );
-        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_ok());
+        assert!(
+            evaluate_names_authorization(
+                &snapshot,
+                &claims(user),
+                models::Capability::Admin,
+                ["ops/"]
+            )
+            .is_ok()
+        );
 
         // The same chain with a non-admin object grant is denied.
         let snapshot = snapshot_of_grants(
             &[(user, "estuary/support/", Admin)],
             &[("estuary/", "ops/", Read)],
         );
-        assert!(evaluate_ops_admin(&snapshot, &claims(user)).is_err());
+        assert!(
+            evaluate_names_authorization(
+                &snapshot,
+                &claims(user),
+                models::Capability::Admin,
+                ["ops/"]
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/control-plane-api/src/server/mod.rs
+++ b/crates/control-plane-api/src/server/mod.rs
@@ -451,45 +451,4 @@ mod tests {
         let snapshot = snapshot_of_grants(&[(user, "ops/", Read)], &[]);
         assert!(evaluate(&snapshot).is_err());
     }
-
-    /// Pins the deliberate semantic change from the `internal.user_roles()`
-    /// SQL gate this check replaced: an admin chain reached through an
-    /// *ancestor* subject role. The user admins `estuary/support/`, and
-    /// `estuary/` (its ancestor) is granted admin of `ops/`. The SQL gate
-    /// walked only downward from held roles and wrongly denied this; the
-    /// Snapshot walk authorizes it.
-    #[test]
-    fn test_evaluate_ops_admin_ancestor_subject_chain() {
-        use models::Capability::{Admin, Read};
-        let user = uuid::Uuid::from_bytes([0x11; 16]);
-
-        let snapshot = snapshot_of_grants(
-            &[(user, "estuary/support/", Admin)],
-            &[("estuary/", "ops/", Admin)],
-        );
-        assert!(
-            evaluate_names_authorization(
-                &snapshot,
-                &claims(user),
-                models::Capability::Admin,
-                ["ops/"]
-            )
-            .is_ok()
-        );
-
-        // The same chain with a non-admin object grant is denied.
-        let snapshot = snapshot_of_grants(
-            &[(user, "estuary/support/", Admin)],
-            &[("estuary/", "ops/", Read)],
-        );
-        assert!(
-            evaluate_names_authorization(
-                &snapshot,
-                &claims(user),
-                models::Capability::Admin,
-                ["ops/"]
-            )
-            .is_err()
-        );
-    }
 }

--- a/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/authorized_prefixes.rs
@@ -78,30 +78,8 @@ pub(super) fn filtered_authorized_prefixes(
 mod tests {
     use super::super::filters::PrefixFilter;
     use super::{authorized_prefixes, filtered_authorized_prefixes};
+    use crate::test_server::make_grants;
     use models::Capability::{Admin, Read, Write};
-
-    fn make_grants(
-        user_grants: &[(uuid::Uuid, &str, models::Capability)],
-        role_grants: &[(&str, &str, models::Capability)],
-    ) -> (tables::UserGrants, tables::RoleGrants) {
-        let ug = tables::UserGrants::from_iter(user_grants.iter().map(|(id, obj, cap)| {
-            tables::UserGrant {
-                user_id: *id,
-                object_role: models::Prefix::new(*obj),
-                capability: *cap,
-                bundles: vec![],
-            }
-        }));
-        let rg = tables::RoleGrants::from_iter(role_grants.iter().map(|(sub, obj, cap)| {
-            tables::RoleGrant {
-                subject_role: models::Prefix::new(*sub),
-                object_role: models::Prefix::new(*obj),
-                capability: *cap,
-                bundles: vec![],
-            }
-        }));
-        (ug, rg)
-    }
 
     const ALICE: uuid::Uuid = uuid::Uuid::from_bytes([0x11; 16]);
 

--- a/crates/control-plane-api/src/test_server.rs
+++ b/crates/control-plane-api/src/test_server.rs
@@ -245,3 +245,39 @@ impl crate::publications::builds::Builder for NoopBuilder {
         panic!("NoopBuilder::build called in test - this should not happen for authorization tests")
     }
 }
+
+/// Build grant tables from compact (subject, object, capability) tuples,
+/// shared by tests which pin grant-walk authorization semantics.
+pub fn make_grants(
+    user_grants: &[(uuid::Uuid, &str, models::Capability)],
+    role_grants: &[(&str, &str, models::Capability)],
+) -> (tables::UserGrants, tables::RoleGrants) {
+    let user_grants =
+        tables::UserGrants::from_iter(user_grants.iter().map(|(id, obj, cap)| tables::UserGrant {
+            user_id: *id,
+            object_role: models::Prefix::new(*obj),
+            capability: *cap,
+            bundles: Vec::new(),
+        }));
+    let role_grants = tables::RoleGrants::from_iter(role_grants.iter().map(|(sub, obj, cap)| {
+        tables::RoleGrant {
+            subject_role: models::Prefix::new(*sub),
+            object_role: models::Prefix::new(*obj),
+            capability: *cap,
+            bundles: Vec::new(),
+        }
+    }));
+    (user_grants, role_grants)
+}
+
+/// Build a Snapshot holding only the given user and role grants.
+pub fn snapshot_of_grants(
+    user_grants: &[(uuid::Uuid, &str, models::Capability)],
+    role_grants: &[(&str, &str, models::Capability)],
+) -> Snapshot {
+    let (user_grants, role_grants) = make_grants(user_grants, role_grants);
+    let mut snapshot = Snapshot::empty();
+    snapshot.user_grants = user_grants;
+    snapshot.role_grants = role_grants;
+    snapshot
+}


### PR DESCRIPTION
Part 1 of a 3-PR stack strangling the last reachable Rust call sites of `internal.user_roles()`, continuing the Snapshot-authorization work of #2781. Stacked on the publications-spec-authz branch.

## Plan

After the publications migration, exactly three reachable Rust paths still authorize via `internal.user_roles()` SQL:

1. **`/admin/create-data-plane`** — this PR.
2. **`/admin/update-l2-reporting`** — next PR, an identical swap.
3. **The storage-mappings directive** (`user_has_admin_capability`) — final PR, which must thread the agent's `snapshot_watch` into `DirectiveHandler`.

Everything else that references `user_roles`/`auth_roles` is SQL-land reachable only via PostgREST/RLS (`live_specs_ext`, `combined_grants_ext`, `gateway_auth_token`, …) and is out of scope for this stack. In particular, the #2848 workaround `ensure_private_data_plane_grants` stays: its removal is gated on the RLS-side migration, not on these three.

## This change

- Swaps `create_data_plane`'s SQL gate for `evaluate_names_authorization(snapshot, claims, Admin, ["ops/"])`, evaluated through `Envelope::authorization_outcome`. Denials now follow the standard authorization-retry protocol (early Snapshot refresh + 307 retry when the Snapshot may be stale) instead of failing terminally, matching the `authorize_*` endpoints. This is an HTTP-envelope mechanism; GraphQL resolvers and the (upcoming) directive handler instead take one-shot pinned-Snapshot checks.
- The denial message becomes the crate-standard "…is not authorized to access prefix or name 'ops/' with required capability admin". (An earlier revision introduced a dedicated `evaluate_ops_admin` helper with a bespoke message; review flagged it as a Middle Man over `evaluate_names_authorization` and it was folded away.)
- Adds shared test fixtures `make_grants` / `snapshot_of_grants` to `test_server`, deduplicating the grant-table construction previously repeated in the `authorized_prefixes` tests.

### Deliberate semantic change

`internal.user_roles()` walks the grant graph only *downward* from roles the user holds. The Snapshot walk (`tables::UserGrant::is_authorized`) also reaches grants held by *ancestor* subject roles — the same gap tracked by #2848. An admin chain into `ops/` through an ancestor subject (e.g. admin of `estuary/support/` with a `(estuary/ → ops/, admin)` grant) was wrongly denied by the SQL gate and is authorized here. The named test `test_evaluate_ops_admin_ancestor_subject_chain` pins this.

## Tests

- Unit tests in `server::tests` pin the ops-gate semantics: direct `ops/` admin, unrelated-tenant admin denied (with the exact denial message), `read` ≠ admin, the ancestor-subject chain allowed, and the same chain denied without admin capability.
- Endpoint tests cover the denial paths only (no bearer → 401, non-ops-admin → terminal 403 with the expected message). An authorized request proceeds into data-plane provisioning, which authorization tests have no business exercising — so allowed cases live in the unit tests.

## Review

An `xhigh` two-axis review (standards + spec) ran against this PR; its findings — a named-test granularity nit, the Middle Man helper, and the duplicated test fixture — are addressed in the two follow-up commits.