### PR TITLE
control-plane-api: Add tenant filter to dataPlanes query

### DIFF
--- a/crates/control-plane-api/src/fixtures/bob_co.sql
+++ b/crates/control-plane-api/src/fixtures/bob_co.sql
@@ -1,0 +1,92 @@
+-- The `bobCo/` tenant: two users and three private data planes.
+--
+-- It exists so tests can exercise queries that must distinguish one
+-- tenant's data planes from another's.
+--
+--   * alice and bob both read every plane bobCo/ can reach. Their tenant-level
+--     `admin` grant carries `Delegate`, so authorization chains through the
+--     `role_grants` edges below and out to each plane.
+--   * only bob manages bobCo's private planes. The `manage_data_plane` bundle
+--     rides on a `user_grants` row addressed to bob, rather than on the
+--     tenant-wide role edge, precisely so it does not reach alice.
+do $$
+declare
+  alice_uid uuid := '11111111-1111-1111-1111-111111111111';
+  bob_uid uuid := '22222222-2222-2222-2222-222222222222';
+begin
+
+  insert into public.tenants (id, tenant) values
+    (internal.id_generator(), 'bobCo/')
+  ;
+
+  -- `hmac_keys` is populated directly (rather than via `encrypted_hmac_keys`)
+  -- so the snapshot loader takes these rows as live without exercising the
+  -- SOPS decrypt path, which `data_planes.sql` already covers. Every column
+  -- that isn't a plane's identity is derived from its slug: fixtures assert
+  -- over names and capabilities, and uniform addresses keep the per-plane
+  -- rows to a line each.
+  insert into public.data_planes (
+    id,
+    data_plane_name,
+    data_plane_fqdn,
+    hmac_keys,
+    broker_address,
+    reactor_address,
+    ops_logs_name,
+    ops_stats_name,
+    ops_l1_events_name,
+    ops_l1_inferred_name,
+    ops_l1_stats_name,
+    ops_l2_events_transform,
+    ops_l2_inferred_transform,
+    ops_l2_stats_transform,
+    enable_l2,
+    cidr_blocks
+  )
+  select
+    dp.id::flowid,
+    dp.name::catalog_name,
+    'dp.' || dp.slug,
+    '{c2VjcmV0,b3RoZXI=}'::text[],
+    'broker.dp.' || dp.slug,
+    'reactor.dp.' || dp.slug,
+    ('ops/tasks/' || dp.slug || '/logs')::catalog_name,
+    ('ops/tasks/' || dp.slug || '/stats')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/events')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/inferred')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/stats')::catalog_name,
+    'from.dp.' || dp.slug,
+    'from.dp.' || dp.slug,
+    'from.dp.' || dp.slug,
+    false,
+    '{10.20.0.0/16}'::cidr[]
+  from (values
+    ('663333333333', 'ops/dp/private/bobCo/aws-us-east-1-c1',    'private/bobCo-one'),
+    ('664444444444', 'ops/dp/private/bobCo/gcp-us-central1-c1',  'private/bobCo-two'),
+    ('665555555555', 'ops/dp/private/bobCo/az-eastus-c1',        'private/bobCo-three')
+  ) as dp(id, name, slug)
+  ;
+
+  insert into public.user_grants (user_id, object_role, capability) values
+    (alice_uid, 'bobCo/', 'admin'),
+    (bob_uid, 'bobCo/', 'admin')
+  ;
+
+  -- The tenant reads its own private planes and the shared public ones. `read`
+  -- conveys the `Viewer` bundle, which includes `ViewDataPlanePrivateNetworking`
+  -- but stops short of modifying it.
+  insert into public.role_grants (subject_role, object_role, capability) values
+    ('bobCo/', 'ops/dp/public/', 'read'),
+    ('bobCo/', 'ops/dp/private/bobCo/', 'read')
+  ;
+
+  -- Bob alone manages the private planes. Mirrors what `create_data_plane.rs`
+  -- installs at provisioning time (legacy `read` for RLS/`user_roles()`, plus
+  -- the `ManageDataPlane` bundle for the capability bits), but addressed to a
+  -- user rather than the tenant role.
+  insert into public.user_grants (user_id, object_role, capability, bundles) values
+    (bob_uid, 'ops/dp/private/bobCo/', 'read', '{manage_data_plane}')
+  ;
+
+end
+$$;

--- a/crates/control-plane-api/src/fixtures/bob_co2.sql
+++ b/crates/control-plane-api/src/fixtures/bob_co2.sql
@@ -1,0 +1,90 @@
+-- The `bobCo2/` tenant: two users and one private data plane.
+--
+-- Its name deliberately shares a prefix with `bobCo/`, so tests that filter or
+-- authorize by tenant have a neighbour to be wrong about: a check that matches
+-- on `bobCo` rather than the full `bobCo/` path segment sees this tenant's
+-- plane too. Load it alongside `bob_co.sql` for that pairing.
+--
+--   * bob holds the same permissions here as in `bobCo/`: he reads every plane
+--     the tenant can reach, and manages its private one.
+--   * carol reads only public data planes. Her tenant grant is `read`, which
+--     conveys the `Viewer` bundle without `Delegate`, so authorization stops at
+--     `bobCo2/` and never chains through the `role_grants` edges out to the
+--     private plane. Public planes come from a `user_grants` row addressed
+--     directly at `ops/dp/public/`, which needs no chaining to apply.
+do $$
+declare
+  bob_uid uuid := '22222222-2222-2222-2222-222222222222';
+  carol_uid uuid := '33333333-3333-3333-3333-333333333333';
+begin
+
+  insert into public.tenants (id, tenant) values
+    (internal.id_generator(), 'bobCo2/')
+  ;
+
+  -- Mirrors the single-plane shape of `bob_co.sql`, down to the region and
+  -- cluster tag, so the tenant path is the only thing that distinguishes this
+  -- plane's name from `ops/dp/private/bobCo/aws-us-east-1-c1`.
+  insert into public.data_planes (
+    id,
+    data_plane_name,
+    data_plane_fqdn,
+    hmac_keys,
+    broker_address,
+    reactor_address,
+    ops_logs_name,
+    ops_stats_name,
+    ops_l1_events_name,
+    ops_l1_inferred_name,
+    ops_l1_stats_name,
+    ops_l2_events_transform,
+    ops_l2_inferred_transform,
+    ops_l2_stats_transform,
+    enable_l2,
+    cidr_blocks
+  )
+  select
+    dp.id::flowid,
+    dp.name::catalog_name,
+    'dp.' || dp.slug,
+    '{c2VjcmV0,b3RoZXI=}'::text[],
+    'broker.dp.' || dp.slug,
+    'reactor.dp.' || dp.slug,
+    ('ops/tasks/' || dp.slug || '/logs')::catalog_name,
+    ('ops/tasks/' || dp.slug || '/stats')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/events')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/inferred')::catalog_name,
+    ('ops/rollups/L1/' || dp.slug || '/stats')::catalog_name,
+    'from.dp.' || dp.slug,
+    'from.dp.' || dp.slug,
+    'from.dp.' || dp.slug,
+    false,
+    '{10.30.0.0/16}'::cidr[]
+  from (values
+    ('667777777777', 'ops/dp/private/bobCo2/aws-us-east-1-c1',   'private/bobCo2-one')
+  ) as dp(id, name, slug)
+  ;
+
+  insert into public.user_grants (user_id, object_role, capability) values
+    (bob_uid, 'bobCo2/', 'admin'),
+    (carol_uid, 'bobCo2/', 'read'),
+    -- Carol's only data-plane visibility. Granted at the public prefix itself
+    -- because her tenant grant, lacking `Delegate`, reaches no plane at all.
+    (carol_uid, 'ops/dp/public/', 'read')
+  ;
+
+  -- The tenant reads its own private plane and the shared public ones. `read`
+  -- conveys the `Viewer` bundle, which includes `ViewDataPlanePrivateNetworking`
+  -- but stops short of modifying it.
+  insert into public.role_grants (subject_role, object_role, capability) values
+    ('bobCo2/', 'ops/dp/public/', 'read'),
+    ('bobCo2/', 'ops/dp/private/bobCo2/', 'read')
+  ;
+
+  -- Bob alone manages the private plane, exactly as in `bob_co.sql`.
+  insert into public.user_grants (user_id, object_role, capability, bundles) values
+    (bob_uid, 'ops/dp/private/bobCo2/', 'read', '{manage_data_plane}')
+  ;
+
+end
+$$;

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -14,6 +14,10 @@ pub struct DataPlanesFilter {
     /// Match data planes by id, such as a `LiveSpec`'s `dataPlaneId`.
     /// Unknown or unauthorized ids are silently dropped.
     pub id: Option<filters::IdFilter>,
+    /// Match data planes by tenant. Only data planes whose name prefix matches the tenant are returned.
+    /// All public data planes are considered to match all tenants. Unknown tenants are ignored and only
+    /// public data planes are returned.
+    pub tenant: Option<String>,
     /// Filter on the `closed` flag.
     pub closed: Option<filters::BoolFilter>,
     /// Filter on the `public` flag, which is derived from the data plane's
@@ -487,10 +491,25 @@ impl DataPlanesQuery {
         let claims = env.claims()?;
         let snapshot = env.snapshot();
 
-        let DataPlanesFilter { id, closed, public } = filter.unwrap_or_default();
+        let DataPlanesFilter {
+            id,
+            closed,
+            public,
+            tenant,
+        } = filter.unwrap_or_default();
+
         let id_in = id.and_then(|f| f.r#in);
         let closed_eq = closed.and_then(|f| f.eq);
         let public_eq = public.and_then(|f| f.eq);
+
+        // Tenant filter must end with a slash so that it captures the full tenant path segment in the
+        // private data plane names. This prevents the tenant filter from matching two tenants with the same
+        // starting characters (e.g. keeps "foo" from matching both "foo-bar" and "foo-baz").
+        if tenant.as_ref().is_some_and(|t| !t.ends_with("/")) {
+            return Err(async_graphql::Error::new(format!(
+                "tenant filter must end with a slash"
+            )));
+        }
 
         // Keep data planes that match the filter, that the user can read, and
         // that have valid names. Sort by name for stable pagination.
@@ -504,6 +523,7 @@ impl DataPlanesQuery {
                     tracing::warn!(data_plane_name = %dp.data_plane_name, "skipping data plane with unparseable name");
                     return false;
                 };
+                // Filter to public/private planes, if requested.
                 if public_eq.is_some_and(|want| want != public) {
                     return false;
                 }
@@ -528,6 +548,18 @@ impl DataPlanesQuery {
         // snapshot, so this needs no database round-trip.
         if let Some(want_closed) = closed_eq {
             accessible_data_planes.retain(|dp| dp.closed == want_closed);
+        }
+
+        // Narrow the results based on the provided `tenant` filter. Public data planes are always included,
+        // and private data planes are included only if they match the tenant prefix. Do this here to ensure
+        // the grant check is done and user capabilities are attached to the correct data planes.
+        if let Some(tenant_str) = tenant.as_ref() {
+            let public_prefix = "ops/dp/public/".to_string();
+            let private_tenant_prefix = "ops/dp/private/".to_string() + tenant_str.as_str();
+            accessible_data_planes.retain(|dp| {
+                dp.data_plane_name.starts_with(&public_prefix)
+                    || dp.data_plane_name.starts_with(&private_tenant_prefix)
+            });
         }
 
         // Apply cursor-based pagination.

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -1,3 +1,5 @@
+use crate::server::public::graphql::tenant::validate_tenant_name;
+
 use super::filters;
 use async_graphql::{
     ComplexObject, Context, SimpleObject,
@@ -17,7 +19,7 @@ pub struct DataPlanesFilter {
     /// Match data planes by tenant. Only data planes whose name prefix matches the tenant are returned.
     /// All public data planes are considered to match all tenants. Unknown tenants are ignored and only
     /// public data planes are returned.
-    pub tenant: Option<String>,
+    pub tenant: Option<filters::StringFilter>,
     /// Filter on the `closed` flag.
     pub closed: Option<filters::BoolFilter>,
     /// Filter on the `public` flag, which is derived from the data plane's
@@ -495,12 +497,15 @@ impl DataPlanesQuery {
         let id_in = id.and_then(|f| f.r#in);
         let closed_eq = closed.and_then(|f| f.eq);
         let public_eq = public.and_then(|f| f.eq);
+        let tenant_eq = tenant.and_then(|f| f.eq);
 
-        // The tenant must match a whole path segment of a private plane's name,
-        // so append the trailing slash when the caller omits it: a bare "foo"
-        // would otherwise match both "foo-bar/" and "foo-baz/".
-        let tenant_prefix = tenant.map(|t| if t.ends_with('/') { t } else { t + "/" });
-        let private_tenant_prefix = tenant_prefix.map(|t| format!("ops/dp/private/{t}"));
+        // The tenant must be a valid tenant prefix. Tenant filtering only applies
+        // to private data planes, so prepend the private scope prefix before filtering.
+        let tenant_prefix = tenant_eq
+            .as_deref()
+            .map(|s| validate_tenant_name(s))
+            .transpose()?
+            .map(|s| format!("ops/dp/private/{s}"));
 
         // Keep data planes that match the filter, that the user can read, and
         // that have valid names. Sort by name for stable pagination.
@@ -520,7 +525,7 @@ impl DataPlanesQuery {
                 }
                 // Narrow private data planes to the specified tenant, if requested. Public planes are shared
                 // with every tenant, so are not impacted by this filter.
-                if !public && let Some(prefix) = private_tenant_prefix.as_ref() {
+                if !public && let Some(prefix) = tenant_prefix.as_ref() {
                     if !dp.data_plane_name.starts_with(prefix.as_str()) {
                         return false;
                     }
@@ -1441,12 +1446,11 @@ mod tests {
             want
         }
 
-        // A tenant missing its trailing slash is normalized, not rejected, and
-        // still doesn't reach the prefix-sharing `bobCo2/`.
-        let filter = serde_json::json!({ "tenant": "bobCo" });
-        let actual = names(&server, &token, filter.clone()).await;
-        let expected = flatten(&[&public_dps, &bob_co_dps]);
-        assert_eq!(actual, expected);
+        // Error case: invalid tenant name passed in as the filter.
+        let filter = serde_json::json!({ "tenant": { "eq": "bobCo"}});
+        let response = query(&server, &token, filter).await;
+        let error = response["errors"][0]["message"].as_str();
+        assert!(error.unwrap_or_default().contains("invalid tenant name"));
 
         // No filter: every readable plane, of both tenants.
         let filter = serde_json::Value::Null;
@@ -1457,24 +1461,24 @@ mod tests {
         // A tenant keeps its own private planes and all public planes.
         // Neither `bobCo/` nor `bobCo2/` picks up the other's, despite
         // starting with the same prefix.
-        let filter = serde_json::json!({ "tenant": "bobCo/" });
+        let filter = serde_json::json!({ "tenant": { "eq": "bobCo/" }});
         let actual = names(&server, &token, filter.clone()).await;
         let expected = flatten(&[&public_dps, &bob_co_dps]);
         assert_eq!(actual, expected);
-        let filter = serde_json::json!({ "tenant": "bobCo2/" });
+        let filter = serde_json::json!({ "tenant": { "eq": "bobCo2/" }});
         let actual = names(&server, &token, filter.clone()).await;
         let expected = flatten(&[&public_dps, &bob_co2_dps]);
         assert_eq!(actual, expected);
 
         // A tenant with no private planes isn't an error: public planes are
         // still shared with it.
-        let filter = serde_json::json!({ "tenant": "acmeCo/" });
+        let filter = serde_json::json!({ "tenant": { "eq": "acmeCo/" }});
         let actual = names(&server, &token, filter.clone()).await;
         let expected = public_dps.clone();
         assert_eq!(actual, expected);
 
         // Composing with `public` just returns public planes.
-        let filter = serde_json::json!({ "tenant": "bobCo/", "public": { "eq": true } });
+        let filter = serde_json::json!({ "tenant": { "eq": "bobCo/"}, "public": { "eq": true } });
         let actual = names(&server, &token, filter.clone()).await;
         let expected = public_dps.clone();
         assert_eq!(actual, expected);

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -496,14 +496,10 @@ impl DataPlanesQuery {
         let closed_eq = closed.and_then(|f| f.eq);
         let public_eq = public.and_then(|f| f.eq);
 
-        // Tenant filter must end with a slash so that it captures the full tenant path segment in the
-        // private data plane names. This prevents the tenant filter from matching two tenants with the same
-        // starting characters (e.g. keeps "foo" from matching both "foo-bar" and "foo-baz").
-        if tenant.as_ref().is_some_and(|t| !t.ends_with("/")) {
-            return Err(async_graphql::Error::new(format!(
-                "tenant filter must end with a slash"
-            )));
-        }
+        // The tenant must match a whole path segment of a private plane's name,
+        // so append the trailing slash when the caller omits it: a bare "foo"
+        // would otherwise match both "foo-bar/" and "foo-baz/".
+        let tenant = tenant.map(|t| if t.ends_with('/') { t } else { t + "/" });
 
         // Keep data planes that match the filter, that the user can read, and
         // that have valid names. Sort by name for stable pagination.
@@ -1448,13 +1444,12 @@ mod tests {
             want
         }
 
-        // Error case: a tenant filter must end with a slash
-        let response = query(&server, &token, serde_json::json!({ "tenant": "bobCo" })).await;
-        let error = response["errors"][0]["message"].as_str();
-        assert_eq!(
-            error.unwrap_or_default(),
-            "tenant filter must end with a slash"
-        );
+        // A tenant missing its trailing slash is normalized, not rejected, and
+        // still doesn't reach the prefix-sharing `bobCo2/`.
+        let filter = serde_json::json!({ "tenant": "bobCo" });
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = flatten(&[&public_dps, &bob_co_dps]);
+        assert_eq!(actual, expected);
 
         // No filter: every readable plane, of both tenants.
         let filter = serde_json::Value::Null;

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -499,7 +499,8 @@ impl DataPlanesQuery {
         // The tenant must match a whole path segment of a private plane's name,
         // so append the trailing slash when the caller omits it: a bare "foo"
         // would otherwise match both "foo-bar/" and "foo-baz/".
-        let tenant = tenant.map(|t| if t.ends_with('/') { t } else { t + "/" });
+        let tenant_prefix = tenant.map(|t| if t.ends_with('/') { t } else { t + "/" });
+        let private_tenant_prefix = tenant_prefix.map(|t| format!("ops/dp/private/{t}"));
 
         // Keep data planes that match the filter, that the user can read, and
         // that have valid names. Sort by name for stable pagination.
@@ -517,6 +518,14 @@ impl DataPlanesQuery {
                 if public_eq.is_some_and(|want| want != public) {
                     return false;
                 }
+                // Narrow private data planes to the specified tenant, if requested. Public planes are shared
+                // with every tenant, so are not impacted by this filter.
+                if !public && let Some(prefix) = private_tenant_prefix.as_ref() {
+                    if !dp.data_plane_name.starts_with(prefix.as_str()) {
+                        return false;
+                    }
+                }
+
                 if let Some(ids) = id_in.as_ref() {
                     if !ids.contains(&dp.control_id) {
                         return false;
@@ -538,18 +547,6 @@ impl DataPlanesQuery {
         // snapshot, so this needs no database round-trip.
         if let Some(want_closed) = closed_eq {
             accessible_data_planes.retain(|dp| dp.closed == want_closed);
-        }
-
-        // Narrow the results based on the provided `tenant` filter. Public data planes are always included,
-        // and private data planes are included only if they match the tenant prefix. Do this here to ensure
-        // the grant check is done and user capabilities are attached to the correct data planes.
-        if let Some(tenant_str) = tenant.as_ref() {
-            let public_prefix = "ops/dp/public/".to_string();
-            let private_tenant_prefix = "ops/dp/private/".to_string() + tenant_str.as_str();
-            accessible_data_planes.retain(|dp| {
-                dp.data_plane_name.starts_with(&public_prefix)
-                    || dp.data_plane_name.starts_with(&private_tenant_prefix)
-            });
         }
 
         // Apply cursor-based pagination.
@@ -1476,7 +1473,7 @@ mod tests {
         let expected = public_dps.clone();
         assert_eq!(actual, expected);
 
-        // Composing with `public` narrows to just the tenant's own planes.
+        // Composing with `public` just returns public planes.
         let filter = serde_json::json!({ "tenant": "bobCo/", "public": { "eq": true } });
         let actual = names(&server, &token, filter.clone()).await;
         let expected = public_dps.clone();

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -435,32 +435,26 @@ fn paginate_by_name<T>(
         return (Vec::new(), false, false);
     }
 
+    let total = sorted.len();
+
     if before.is_some() || last.is_some() {
-        // Backward pagination
-        let filtered: Vec<T> = sorted
-            .into_iter()
-            .filter(|t| {
-                before
-                    .as_ref()
-                    .map(|b| name(t) < b.as_str())
-                    .unwrap_or(true)
-            })
-            .collect();
-
-        let total = filtered.len();
-        let skip = total.saturating_sub(limit);
-        let rows: Vec<T> = filtered.into_iter().skip(skip).collect();
-        (rows, skip > 0, before.is_some())
+        // Backward: the window ends at the first row not before the cursor.
+        let end = match before.as_ref() {
+            Some(b) => sorted.partition_point(|t| name(t) < b.as_str()),
+            None => total,
+        };
+        let skip = end.saturating_sub(limit);
+        let rows: Vec<T> = sorted.into_iter().take(end).skip(skip).collect();
+        (rows, skip > 0, end < total)
     } else {
-        // Forward pagination
-        let rows: Vec<T> = sorted
-            .into_iter()
-            .filter(|t| after.as_ref().map(|a| name(t) > a.as_str()).unwrap_or(true))
-            .take(limit)
-            .collect();
-
+        // Forward: the window starts just past the cursor.
+        let start = match after.as_ref() {
+            Some(a) => sorted.partition_point(|t| name(t) <= a.as_str()),
+            None => 0,
+        };
+        let rows: Vec<T> = sorted.into_iter().skip(start).take(limit).collect();
         let has_next = rows.len() == limit;
-        (rows, after.is_some(), has_next)
+        (rows, start > 0, has_next)
     }
 }
 
@@ -2050,6 +2044,24 @@ mod tests {
             page(None, None, None, None),
             (vec!["a", "b", "c", "d"], false, false)
         );
+
+        // empty `after` cursor should return the first page
+        assert_eq!(
+            page(Some(""), None, Some(10), None),
+            (vec!["a", "b", "c", "d"], false, false)
+        );
+        // `after` cursor that is before the first element should return the first page
+        assert_eq!(
+            page(Some("0"), None, Some(2), None),
+            (vec!["a", "b"], false, true)
+        );
+        // a `before` cursor past the last row excludes nothing
+        assert_eq!(
+            page(None, Some("z"), None, Some(2)),
+            (vec!["c", "d"], true, false)
+        );
+        // empty `before` cursor should exclude all results
+        assert_eq!(page(None, Some(""), None, Some(2)), (vec![], false, true));
     }
 
     #[test]

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -1367,6 +1367,133 @@ mod tests {
         );
     }
 
+    // Tests the `filter.tenant` filter on the `dataPlanes` query. Expected behavior is to filter
+    // private planes to only the ones the given tenant owns, while public planes are also returned
+    // since they are shared across tenants. If no tenant filter is provided, the expectation is that
+    // all private planes the user has access to are returned along with public planes.
+    //
+    // The `sso_tenant` fixture is loaded only for the user records needed by the `bob_co` and `bob_co2`
+    // tenants. The `data_planes` fixture creates the needed public data planes.
+    //
+    // Bob belongs to `bobCo/` and `bobCo2/` and has access to their private planes. The two tenant names
+    // start with the same characters, so can be used to ensure that the tenant filter does not inadvertantly
+    // match other tenants, since under-the-hood it relies on a string prefix match.
+    #[sqlx::test(
+        migrations = "../../supabase/migrations",
+        fixtures(
+            path = "../../../fixtures",
+            scripts("sso_tenant", "data_planes", "bob_co", "bob_co2",)
+        )
+    )]
+    async fn test_graphql_data_planes_tenant_filter(pool: sqlx::PgPool) {
+        let _guard = test_server::init();
+
+        // Bob reads every plane below, so the tenant filter is the only thing
+        // that can narrow the listing.
+        let public_dps = vec![
+            "ops/dp/public/aws-us-west-2-c1".to_string(),
+            "ops/dp/public/gcp-us-central1-c2".to_string(),
+        ];
+        let bob_co_dps = vec![
+            "ops/dp/private/bobCo/aws-us-east-1-c1".to_string(),
+            "ops/dp/private/bobCo/az-eastus-c1".to_string(),
+            "ops/dp/private/bobCo/gcp-us-central1-c1".to_string(),
+        ];
+        let bob_co2_dps = vec!["ops/dp/private/bobCo2/aws-us-east-1-c1".to_string()];
+
+        let server =
+            test_server::TestServer::start(pool.clone(), test_server::snapshot(pool, false).await)
+                .await;
+        let token = server.make_access_token(uuid::Uuid::from_bytes([0x22; 16]), None);
+
+        // Runs the `dataPlanes` query with the given `filter` argument.
+        async fn query(
+            server: &test_server::TestServer,
+            token: &str,
+            filter: serde_json::Value,
+        ) -> serde_json::Value {
+            server
+                .graphql(
+                    &serde_json::json!({
+                        "query": r#"
+                        query($filter: DataPlanesFilter) {
+                            dataPlanes(filter: $filter) {
+                                edges { node { name isPublic } }
+                            }
+                        }
+                        "#,
+                        "variables": { "filter": filter },
+                    }),
+                    Some(token),
+                )
+                .await
+        }
+
+        // Collects the sorted set of returned data-plane names.
+        async fn names(
+            server: &test_server::TestServer,
+            token: &str,
+            filter: serde_json::Value,
+        ) -> Vec<String> {
+            let response = query(server, token, filter).await;
+            let mut names: Vec<String> = response["data"]["dataPlanes"]["edges"]
+                .as_array()
+                .unwrap_or_else(|| panic!("expected edges, got: {response}"))
+                .iter()
+                .map(|e| e["node"]["name"].as_str().unwrap().to_string())
+                .collect();
+            names.sort();
+            names
+        }
+
+        // Sorted union of `public_dps` and the given private planes, which is
+        // the order the listing returns and `names` re-establishes.
+        fn flatten(expected_dps: &[&Vec<String>]) -> Vec<String> {
+            let mut want: Vec<String> = expected_dps.iter().copied().flatten().cloned().collect();
+            want.sort();
+            want
+        }
+
+        // Error case: a tenant filter must end with a slash
+        let response = query(&server, &token, serde_json::json!({ "tenant": "bobCo" })).await;
+        let error = response["errors"][0]["message"].as_str();
+        assert_eq!(
+            error.unwrap_or_default(),
+            "tenant filter must end with a slash"
+        );
+
+        // No filter: every readable plane, of both tenants.
+        let filter = serde_json::Value::Null;
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = flatten(&[&public_dps, &bob_co_dps, &bob_co2_dps]);
+        assert_eq!(actual, expected);
+
+        // A tenant keeps its own private planes and all public planes.
+        // Neither `bobCo/` nor `bobCo2/` picks up the other's, despite
+        // starting with the same prefix.
+        let filter = serde_json::json!({ "tenant": "bobCo/" });
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = flatten(&[&public_dps, &bob_co_dps]);
+        assert_eq!(actual, expected);
+        let filter = serde_json::json!({ "tenant": "bobCo2/" });
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = flatten(&[&public_dps, &bob_co2_dps]);
+        assert_eq!(actual, expected);
+
+        // A tenant with no private planes isn't an error: public planes are
+        // still shared with it.
+        let filter = serde_json::json!({ "tenant": "acmeCo/" });
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = public_dps.clone();
+        assert_eq!(actual, expected);
+
+        // Composing with `public` narrows to just the tenant's own planes.
+        let filter = serde_json::json!({ "tenant": "bobCo/", "public": { "eq": true } });
+        let actual = names(&server, &token, filter.clone()).await;
+        let expected = public_dps.clone();
+        assert_eq!(actual, expected);
+    }
+
     #[sqlx::test(
         migrations = "../../supabase/migrations",
         fixtures(

--- a/crates/control-plane-api/src/server/public/graphql/data_planes.rs
+++ b/crates/control-plane-api/src/server/public/graphql/data_planes.rs
@@ -455,7 +455,7 @@ fn paginate_by_name<T>(
             None => 0,
         };
         let rows: Vec<T> = sorted.into_iter().skip(start).take(limit).collect();
-        let has_next = rows.len() == limit;
+        let has_next = (total - start) > limit;
         (rows, start > 0, has_next)
     }
 }
@@ -2012,7 +2012,7 @@ mod tests {
         );
         assert_eq!(
             page(Some("b"), None, Some(2), None),
-            (vec!["c", "d"], true, true)
+            (vec!["c", "d"], true, false)
         );
         assert_eq!(
             page(Some("b"), None, Some(10), None),

--- a/crates/control-plane-api/src/server/public/graphql/filters.rs
+++ b/crates/control-plane-api/src/server/public/graphql/filters.rs
@@ -6,6 +6,11 @@ pub struct BoolFilter {
 }
 
 #[derive(Debug, Clone, Default, async_graphql::InputObject)]
+pub struct StringFilter {
+    pub eq: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, async_graphql::InputObject)]
 pub struct DateFilter {
     pub gt: Option<NaiveDate>,
     pub lt: Option<NaiveDate>,

--- a/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__data_planes__tests__public_data_planes_page_two.snap
+++ b/crates/control-plane-api/src/server/public/graphql/snapshots/control_plane_api__server__public__graphql__data_planes__tests__public_data_planes_page_two.snap
@@ -14,7 +14,7 @@ expression: page_two
       ],
       "pageInfo": {
         "endCursor": "ops/dp/public/gcp-us-central1-c2",
-        "hasNextPage": true
+        "hasNextPage": false
       }
     }
   }

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -839,7 +839,7 @@ input DataPlanesFilter {
 	All public data planes are considered to match all tenants. Unknown tenants are ignored and only
 	public data planes are returned.
 	"""
-	tenant: String
+	tenant: StringFilter
 	"""
 	Filter on the `closed` flag.
 	"""
@@ -2444,6 +2444,10 @@ input StorageMappingsFilter {
 	the caller's authorized read prefixes.
 	"""
 	catalogPrefix: PrefixFilter
+}
+
+input StringFilter {
+	eq: String
 }
 
 type Tenant {

--- a/crates/flow-client/control-plane-api.graphql
+++ b/crates/flow-client/control-plane-api.graphql
@@ -835,6 +835,12 @@ input DataPlanesFilter {
 	"""
 	id: IdFilter
 	"""
+	Match data planes by tenant. Only data planes whose name prefix matches the tenant are returned.
+	All public data planes are considered to match all tenants. Unknown tenants are ignored and only
+	public data planes are returned.
+	"""
+	tenant: String
+	"""
 	Filter on the `closed` flag.
 	"""
 	closed: BoolFilter


### PR DESCRIPTION
**Description:**

Related to https://github.com/estuary/ui/issues/2065

Adding a new `tenant` string filter to allow filtering the DataPlanesQuery results to just data planes owned by that tenant. This is required to migrate the DataPlanesTable to GQL, since the current supabase query does this filtering.

**Filter by tenant `acmeCo/`**
<img width="1045" height="653" alt="Screenshot 2026-08-28 at 11 13 39 AM" src="https://github.com/user-attachments/assets/deb2419c-6a33-46bc-8e7f-d5d6a8dce046" />

**Filter by tenant `umbrellaCo/`**
<img width="958" height="575" alt="Screenshot 2026-08-28 at 11 14 47 AM" src="https://github.com/user-attachments/assets/f6ca2d1c-c010-4a79-b636-4e12865816ca" />

**Includes public data planes by default**
<img width="953" height="572" alt="Screenshot 2026-08-28 at 11 17 49 AM" src="https://github.com/user-attachments/assets/950ef78f-cb47-42d3-916a-0a7d6606c195" />


**Workflow steps:**

The filter will be used by the data planes table in the admin UI to filter planes to the selected tenant.

**Documentation links affected:**

No documentation changed.

**Notes for reviewers:**