### PR TITLE
shuffle: remap materialization key routing to couple shard read rates

### DIFF
--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -345,6 +345,18 @@ computes its hash, and routes to target Log shard(s) using
 `filter_r_clocks` additionally filters by the rotated clock value,
 distributing reads across shards in the r_clock dimension.
 
+Key routing is deliberately "mostly solid": within `route_to_shards()`, a
+small fixed fraction of keys (`routing::REMAP_THRESHOLD / REMAP_BUCKETS`,
+selected by the key hash's low bits) route by a remapped hash — the hash's
+16-bit halves swapped — landing them across the key space rather than in
+their own range. This puts a
+trickle of every Slice's documents into every Log, so a lagging Log's
+clock-ordered merge (§8) back-pressures a Slice that has raced ahead,
+bounding how far shards' wall-clocks can diverge within a transaction. The
+remap is a pure function of the key hash, so every Slice agrees on it, and
+it is internal to routing: the key hash that connectors and log entries
+observe is always the true hash of the packed key.
+
 The document, its packed key, metadata, and journal context are sent
 as an `Append` message to each target Log. Journal names are
 delta-encoded across consecutive sends to minimize wire overhead.

--- a/crates/shuffle/README.md
+++ b/crates/shuffle/README.md
@@ -319,6 +319,14 @@ Before processing the heap top, the Slice gates on wall-clock time: if
 sleeps until the clock catches up. This is how read delays impose
 cross-transform ordering guarantees.
 
+Each dequeue also records the document's clock on the
+`shuffle_slice_last_source_published_at_time_seconds` gauge, labeled by
+cohort: how far this shard's shuffled read has progressed in source
+published-at time. `time() - gauge` is the shard's read lag, and max - min
+across sibling shards is their skew — the measure of how tightly remapped
+routing (§7) actually couples shards. Clocks are only comparable within a
+cohort: bindings of differing priority or read delay legitimately diverge.
+
 ### 6. Document Sequencing
 
 The top document is sequenced against per-producer state using

--- a/crates/shuffle/src/slice/actor.rs
+++ b/crates/shuffle/src/slice/actor.rs
@@ -849,6 +849,10 @@ impl SliceActor {
             // Copy so the `binding` borrow can end below, freeing &mut self for re-borrow.
             let (cohort, read_delay) = (binding.cohort, binding.read_delay);
 
+            let (clock_seconds, clock_nanos) = clock.to_unix();
+            self.metrics.last_source_published_at[cohort as usize]
+                .set(clock_seconds as f64 + clock_nanos as f64 / 1_000_000_000.0);
+
             if sequenced.is_commit {
                 if flags.is_ack() {
                     // This ACK is (binding, journal)-scoped: it commits only

--- a/crates/shuffle/src/slice/handler.rs
+++ b/crates/shuffle/src/slice/handler.rs
@@ -68,9 +68,15 @@ where
     handler.set_field("token", serde_json::to_string(&authz.claims()).unwrap());
     handler.set_phase("opening");
 
-    let metrics = super::Metrics::new(shard_id);
     let task = task.context("Open must include task")?;
     let (bindings, sources, validators) = crate::Binding::from_task(&task)?;
+
+    let num_cohorts = bindings
+        .iter()
+        .map(|b| b.cohort as usize + 1)
+        .max()
+        .unwrap_or(0);
+    let metrics = super::Metrics::new(shard_id, num_cohorts);
 
     service_kit::event!(
         tracing::Level::INFO,

--- a/crates/shuffle/src/slice/mod.rs
+++ b/crates/shuffle/src/slice/mod.rs
@@ -60,10 +60,17 @@ pub(crate) struct Metrics {
     replays_started: metrics::Counter,
     /// Replays that have either completed or failed.
     replays_stopped: metrics::Counter,
+    /// Unix time (seconds) of the last document dequeued from the ready-read
+    /// heap, indexed by cohort: how far this shard's shuffled read has
+    /// progressed in source published-at time. `time() - gauge` in PromQL is
+    /// the shard's read lag, and max - min across sibling shards' series is
+    /// their skew. Clocks are only comparable within a cohort (bindings of
+    /// differing priority or read delay legitimately diverge), hence the label.
+    last_source_published_at: Vec<metrics::Gauge>,
 }
 
 impl Metrics {
-    fn new(shard_id: &str) -> Self {
+    fn new(shard_id: &str, num_cohorts: usize) -> Self {
         static DESCRIBE: std::sync::Once = std::sync::Once::new();
         DESCRIBE.call_once(|| {
             metrics::describe_counter!(
@@ -106,6 +113,11 @@ impl Metrics {
                 metrics::Unit::Count,
                 "replays that stopped running (historical read completed, benign journal removal, or session teardown)",
             );
+            metrics::describe_gauge!(
+                "shuffle_slice_last_source_published_at_time_seconds",
+                metrics::Unit::Seconds,
+                "unix time of the last document dequeued from the ready-read heap, by cohort",
+            );
         });
 
         Self {
@@ -117,6 +129,15 @@ impl Metrics {
             stalled_reads: metrics::gauge!("shuffle_slice_stalled_reads", "shard_id" => shard_id.to_string()),
             replays_started: metrics::counter!("shuffle_slice_replays_started", "shard_id" => shard_id.to_string()),
             replays_stopped: metrics::counter!("shuffle_slice_replays_stopped", "shard_id" => shard_id.to_string()),
+            last_source_published_at: (0..num_cohorts)
+                .map(|cohort| {
+                    metrics::gauge!(
+                        "shuffle_slice_last_source_published_at_time_seconds",
+                        "shard_id" => shard_id.to_string(),
+                        "cohort" => cohort.to_string(),
+                    )
+                })
+                .collect(),
         }
     }
 }

--- a/crates/shuffle/src/slice/routing.rs
+++ b/crates/shuffle/src/slice/routing.rs
@@ -13,13 +13,50 @@ pub fn rotate_clock(clock: proto_gazette::uuid::Clock) -> u32 {
     (((raw >> 4) ^ (raw & 0xf)) as u32).reverse_bits()
 }
 
+/// A fraction of keys have their routing "remapped" away from the shard
+/// owning their key-hash range to one spread uniformly over the key space.
+/// Shards otherwise own solid key ranges, so a Slice reading journals
+/// aligned with its shard's range appends only to its own Log and nothing
+/// couples its read rate to other shards'. Journals on a busy machine are then
+/// read slower than the rest, that shard's log falls behind in wall-clock, and
+/// each transaction mixes documents of widely differing age. Remapping a
+/// trickle of every Slice's documents into every Log lets a lagging Log's
+/// clock-ordered merge hold back the Appends of a Slice which has raced ahead,
+/// back-pressuring it towards the slowest shard.
+///
+/// A key is remapped when its hash's low REMAP_BITS, read as a bucket in
+/// [0, REMAP_BUCKETS), fall below REMAP_THRESHOLD: the remapped fraction is
+/// REMAP_THRESHOLD / REMAP_BUCKETS.
+const REMAP_BITS: u32 = 8;
+const REMAP_BUCKETS: u32 = 1 << REMAP_BITS;
+const REMAP_BUCKET_MASK: u32 = REMAP_BUCKETS - 1;
+const REMAP_THRESHOLD: u32 = 4; // 4 / 256 = 1.56%
+
+/// Remap the routing of the fraction of keys selected above by swapping the
+/// hash's 16-bit halves. Every Slice must route a key identically, so this is
+/// a pure function of the hash.
+///
+/// The remap exists solely within `route_to_shards`: the key hash a connector
+/// or log entry observes is always the true hash of the packed key.
+fn remap_key_hash(key_hash: u32) -> u32 {
+    if (key_hash & REMAP_BUCKET_MASK) < REMAP_THRESHOLD {
+        key_hash.rotate_left(16)
+    } else {
+        key_hash
+    }
+}
+
 /// Find which shard(s) should receive a document based on its key hash and r-clock.
+/// Remapped keys (see REMAP_BITS et al) route by a remapped hash in the key
+/// dimension; the r_clock dimension is unaffected.
 pub fn route_to_shards(
     key_hash: u32,
     r_clock: u32,
     filter_r_clocks: bool,
     shards: &[shuffle::Shard],
 ) -> impl Iterator<Item = usize> + '_ {
+    let key_hash = remap_key_hash(key_hash);
+
     shards.iter().enumerate().filter_map(move |(i, shard)| {
         let range = shard.range.as_ref()?;
 
@@ -77,12 +114,13 @@ mod test {
             },
         ];
 
-        // Low key hash routes to shard 0.
-        let out: Vec<_> = route_to_shards(0x10000000, 0, false, &shards).collect();
+        // Low key hash routes to shard 0. Low bytes are >= REMAP_THRESHOLD
+        // throughout, so no fixture here is remapped.
+        let out: Vec<_> = route_to_shards(0x10000010, 0, false, &shards).collect();
         assert_eq!(out.as_slice(), &[0]);
 
         // High key hash routes to shard 1.
-        let out: Vec<_> = route_to_shards(0x90000000, 0, false, &shards).collect();
+        let out: Vec<_> = route_to_shards(0x90000010, 0, false, &shards).collect();
         assert_eq!(out.as_slice(), &[1]);
 
         // r-clock filtering: only shard 0 has matching r-clock range.
@@ -107,14 +145,89 @@ mod test {
             },
         ];
 
-        let out: Vec<_> = route_to_shards(0x50000000, 0x10000000, true, &shards_rclock).collect();
+        let out: Vec<_> = route_to_shards(0x50000010, 0x10000000, true, &shards_rclock).collect();
         assert_eq!(out.as_slice(), &[0]);
 
-        let out: Vec<_> = route_to_shards(0x50000000, 0x90000000, true, &shards_rclock).collect();
+        let out: Vec<_> = route_to_shards(0x50000010, 0x90000000, true, &shards_rclock).collect();
         assert_eq!(out.as_slice(), &[1]);
 
         // Without r-clock filtering, both match.
-        let out: Vec<_> = route_to_shards(0x50000000, 0x90000000, false, &shards_rclock).collect();
+        let out: Vec<_> = route_to_shards(0x50000010, 0x90000000, false, &shards_rclock).collect();
         assert_eq!(out.as_slice(), &[0, 1]);
+    }
+
+    fn key_shards(n: u32) -> Vec<shuffle::Shard> {
+        // Tile the key space evenly across `n` shards, full r_clock range.
+        (0..n)
+            .map(|i| {
+                let step = (u32::MAX as u64 + 1) / n as u64;
+                shuffle::Shard {
+                    range: Some(flow::RangeSpec {
+                        key_begin: (i as u64 * step) as u32,
+                        key_end: (((i as u64 + 1) * step) - 1) as u32,
+                        r_clock_begin: 0,
+                        r_clock_end: u32::MAX,
+                    }),
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_route_to_shards_remaps_keys() {
+        let shards = key_shards(4);
+        let key_hash = 0x1000C302; // Low byte < REMAP_THRESHOLD.
+        let remapped = remap_key_hash(key_hash);
+        let home_of = |h: u32| (h >> 30) as usize; // 4 equal ranges tile on the top two bits.
+        assert_ne!(home_of(remapped), home_of(key_hash));
+
+        // A remapped key routes by its remapped hash, not its own range home.
+        let out: Vec<_> = route_to_shards(key_hash, 0, false, &shards).collect();
+        assert_eq!(out.as_slice(), &[home_of(remapped)]);
+
+        // The adjacent non-remapped key routes home.
+        let out: Vec<_> = route_to_shards(key_hash + 2, 0, false, &shards).collect();
+        assert_eq!(out.as_slice(), &[home_of(key_hash)]);
+    }
+
+    #[test]
+    fn test_route_to_shards_remap_composes_with_r_clocks() {
+        // Shards tile r_clock with full key ranges: a remapped key still
+        // broadcasts to all shards when unfiltered, and routes by its r_clock
+        // when filtered.
+        let shards: Vec<_> = [(0, 0x7FFFFFFF), (0x80000000, u32::MAX)]
+            .into_iter()
+            .map(|(r_clock_begin, r_clock_end)| shuffle::Shard {
+                range: Some(flow::RangeSpec {
+                    key_begin: 0,
+                    key_end: u32::MAX,
+                    r_clock_begin,
+                    r_clock_end,
+                }),
+                ..Default::default()
+            })
+            .collect();
+
+        let out: Vec<_> = route_to_shards(0x10000302, 0x10000000, false, &shards).collect();
+        assert_eq!(out.as_slice(), &[0, 1]);
+
+        let out: Vec<_> = route_to_shards(0x10000302, 0x90000000, true, &shards).collect();
+        assert_eq!(out.as_slice(), &[1]);
+    }
+
+    #[test]
+    fn test_remap_key_hash_is_identity_outside_threshold() {
+        assert_eq!(remap_key_hash(0x10000004), 0x10000004);
+        assert_eq!(remap_key_hash(0x900000FF), 0x900000FF);
+    }
+
+    #[test]
+    fn test_remap_key_hash_remaps_selected_keys() {
+        // A remapped key swaps its 16-bit halves. The routed hash's top byte
+        // is the true hash's second byte, so the (biased) selecting byte
+        // doesn't bias which range a remapped key lands in.
+        assert_eq!(remap_key_hash(0x1000C302), 0xC3021000);
+        assert_eq!(remap_key_hash(0x1000C302) >> 24, (0x1000C302 >> 8) & 0xFF);
     }
 }


### PR DESCRIPTION
Fixes #3421.

## Problem

Shards own solid key-hash ranges. A Slice reading journals aligned with its
shard's range appends only to its own Log, so nothing ties its read rate to
the other shards'. When one shard of a multi-shard task lands on a busy
machine, it reads slower than the rest, its log falls behind in wall-clock,
and each transaction mixes documents of widely differing age. We saw a ~2x
rate divergence between two materialization shards, with transaction size
spiking as a result. Correctness was fine; the transactions were just
inconsistent in what "now" meant.

## Change

Key routing becomes "mostly solid". Within route_to_shards, a small fixed
fraction of keys (4/256 = 1.56%, selected by the key hash's low byte) route
by a remapped hash (its 16-bit halves swapped) which lands them uniformly
across the key space rather than in their own range. Every Slice then
appends a trickle of documents into every Log. Because a Log drains its
merge heap in (priority, clock) order, a lagging Log holds a fast Slice's
remapped Append behind its own older documents, and the Slice is
head-of-line blocked on that send, which back-pressures its journal reads
toward the slowest shard.

Notes on the mechanics:

- The remap is entirely internal to route_to_shards. The key hash that
  connectors and log entries observe is always the true hash of the packed
  key.
- It is a pure function of the key hash, so every Slice agrees on where a
  key lands, across sessions and topologies.
- It composes with the existing 2D routing rather than replacing it:
  r_clock filtering and the keyed broadcast across r_clock splits still
  apply to remapped keys.
- Swapping the halves puts the true hash's second byte at the top of the
  routed hash, so the (biased) selecting low byte doesn't bias which range
  a remapped key lands in.
- The math is built up in a block of REMAP_* consts; changing the fraction
  is a one-const edit.

This applies to all shuffled reads: materializations, derivations, and
ad-hoc collection reads. Materializations hold no shard-local per-key state
(the destination is the state, and transactions Load it), and there are no
scaled stateful derivations, so re-homing a key is safe everywhere. Splits
are safe for the same reason a split is safe today: a remapped key's routed
hash is fixed, so a split moves it exactly as it would any key whose hash
falls in the split range.

## Observability

A second commit makes the effect measurable in prod:
shuffle_slice_last_source_published_at_time_seconds{shard_id, cohort} is
the unix time of the last document a Slice dequeued from its ready-read
heap, set at the point of dequeue. `time() - gauge` is a shard's read lag,
and max - min across sibling shards is their skew, which is also the
measure of how tightly the remapped routing actually couples shards. It is
labeled by cohort because clocks are only comparable within one: bindings
of differing priority or read delay legitimately diverge. The gauge holds
absolute time per Prometheus practice, so it never goes stale and needs no
periodic refresh, and the per-document cost is one atomic store against a
pre-created per-cohort gauge handle.

## Testing

- agent assisted verification that keys are landing in correct places
- route_to_shards tests: a remapped key routes by its remapped hash while
  its non-remapped neighbor routes home; the remap composes with r_clock
  topologies (keyed broadcast and filtered routing).
- remap_key_hash tests: identity outside the threshold; the swap keeps the
  biased selecting byte out of the routed hash's top byte.
- cargo test -p shuffle (unit, scenarios), -p runtime-next, and -p flowctl
  preview_next all pass with no snapshot churn.
