### PR TITLE
go/flow/keyhash: split the packed-key hash into its own package

### DIFF
--- a/crates/doc/src/extractor.rs
+++ b/crates/doc/src/extractor.rs
@@ -197,7 +197,8 @@ impl Extractor {
     /// The hash is the top 32 bits of a HighwayHash over the tuple's bytes
     /// using a fixed public (non-cryptographic) key.
     ///
-    /// This routine's results are identical to Go's flow.PackedKeyHash_HH64.
+    /// This routine's results are identical to Go's keyhash.PackedKeyHash_HH64
+    /// (`go/flow/keyhash/keyhash.go`).
     pub fn packed_hash(packed_key: &[u8]) -> u32 {
         use highway::HighwayHash;
 
@@ -490,7 +491,7 @@ pub(crate) fn finalize_json_truncation_indicator(
 }
 
 /// Fixed 32-byte key used with HighwayHash to derive a canonical hash from
-/// a packed tuple encoding. Matches the Go implementation in go/flow/mapping.go.
+/// a packed tuple encoding. Matches the Go implementation in go/flow/keyhash/keyhash.go.
 pub const HIGHWAY_KEY: highway::Key = highway::Key([
     u64::from_le_bytes([0xba, 0x73, 0x7e, 0x89, 0x15, 0x52, 0x38, 0xd4]),
     u64::from_le_bytes([0x7d, 0x80, 0x67, 0xc3, 0x5a, 0xad, 0x4d, 0x25]),

--- a/go/flow/keyhash/README.md
+++ b/go/flow/keyhash/README.md
@@ -1,0 +1,27 @@
+# keyhash
+
+Flow's canonical packed-key hash: the top 32 bits of a HighwayHash-64 over a
+packed key tuple, using a fixed public key.
+
+## Purpose
+
+The runtime routes a document by hashing its packed key and comparing that hash
+against the `KeyBegin` / `KeyEnd` range labels of a shard or physical partition.
+Every implementation of that routing must produce bit-identical hashes.
+
+This package holds the hash on its own so that other projects — notably
+connectors which reproduce shard routing in a keyed sink — can import it without
+`go/flow`, which pulls in the gazette consumer stack.
+
+## Entry points
+
+- `PackedKeyHash_HH64(packedKey []byte) uint32` — the hash. Feed it a packed
+  tuple, such as `tuple.Tuple{...}.Pack()`.
+
+## Non-obvious details
+
+- The Rust implementation is `doc::Extractor::packed_hash` in
+  `crates/doc/src/extractor.rs`.
+- `keyhash_test.go` and Rust's `test_packed_hash_regression` pin the same 14
+  golden vectors. Both must be updated together, and neither should ever change:
+  a new hash would re-route every existing collection and task.

--- a/go/flow/keyhash/keyhash.go
+++ b/go/flow/keyhash/keyhash.go
@@ -1,0 +1,20 @@
+// Package keyhash computes Flow's canonical packed-key hash.
+//
+// Neither the algorithm nor its key may ever change. Rust reimplements the same
+// hash as doc::Extractor::packed_hash, and golden vectors pin both.
+package keyhash
+
+import (
+	"encoding/hex"
+
+	"github.com/minio/highwayhash"
+)
+
+// PackedKeyHash_HH64 builds a packed key hash from the top 32-bits of a
+// HighwayHash 64-bit checksum computed using a fixed key.
+func PackedKeyHash_HH64(packedKey []byte) uint32 {
+	return uint32(highwayhash.Sum64(packedKey, highwayHashKey) >> 32)
+}
+
+// highwayHashKey is a fixed 32 bytes (as required by HighwayHash) read from /dev/random.
+var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c3488227e011ffa480c022bd3ba")

--- a/go/flow/keyhash/keyhash_test.go
+++ b/go/flow/keyhash/keyhash_test.go
@@ -1,0 +1,36 @@
+package keyhash
+
+import (
+	"testing"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/stretchr/testify/require"
+)
+
+// These vectors are also pinned by Rust's test_packed_hash_regression.
+// The two implementations must never diverge.
+func TestHighwayHashRegression(t *testing.T) {
+	var cases = []struct {
+		expect uint32
+		given  tuple.Tuple
+	}{
+		// Expect that small (e.x. single bit) changes to the input wildly change the output.
+		{0xb9f08d38, tuple.Tuple{true}},
+		{0x1505e3cb, tuple.Tuple{false}},
+		{0x6ae719f3, tuple.Tuple{"foo", "bar"}},
+		{0x8adddd61, tuple.Tuple{"foobar"}},
+		{0x7273e587, tuple.Tuple{"foobas"}},
+		{0xf4ec4d33, tuple.Tuple{"1"}},
+		{0x1e023d95, tuple.Tuple{"2"}},
+		{0x38a34efe, tuple.Tuple{"3"}},
+		{0x17751bae, tuple.Tuple{"10"}},
+		{0x87d93806, tuple.Tuple{"11"}},
+		{0x3c90c1d9, tuple.Tuple{1}},
+		{0x97901bac, tuple.Tuple{2}},
+		{0xcbc7f1e2, tuple.Tuple{3}},
+		{0xd1d3f3eb, tuple.Tuple{10}},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.expect, PackedKeyHash_HH64(tc.given.Pack()))
+	}
+}

--- a/go/flow/mapping.go
+++ b/go/flow/mapping.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/bits"
@@ -12,10 +11,10 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/estuary/flow/go/flow/keyhash"
 	"github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	"github.com/minio/highwayhash"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
@@ -151,7 +150,7 @@ func logicalPrefixAndHexKey(b []byte, msg Mappable) (logicalPrefix []byte, hexKe
 	}
 	var pivot = len(b)
 
-	b = appendHex32(b, PackedKeyHash_HH64(msg.PackedKey))
+	b = appendHex32(b, keyhash.PackedKeyHash_HH64(msg.PackedKey))
 
 	return b[:pivot], b[pivot:], b
 }
@@ -246,12 +245,3 @@ func (m Mappable) MarshalJSONTo(bw *bufio.Writer) (int, error) {
 	var n, _ = bw.Write(m.Doc)
 	return n + 1, bw.WriteByte('\n')
 }
-
-// PackedKeyHash_HH64 builds a packed key hash from the top 32-bits of a
-// HighwayHash 64-bit checksum computed using a fixed key.
-func PackedKeyHash_HH64(packedKey []byte) uint32 {
-	return uint32(highwayhash.Sum64(packedKey, highwayHashKey) >> 32)
-}
-
-// highwayHashKey is a fixed 32 bytes (as required by HighwayHash) read from /dev/random.
-var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c3488227e011ffa480c022bd3ba")

--- a/go/flow/mapping_test.go
+++ b/go/flow/mapping_test.go
@@ -228,30 +228,4 @@ func buildCombineFixtures(t *testing.T) []Mappable {
 	}
 }
 
-func TestHighwayHashRegression(t *testing.T) {
-	var cases = []struct {
-		expect uint32
-		given  tuple.Tuple
-	}{
-		// Expect that small (e.x. single bit) changes to the input wildly change the output.
-		{0xb9f08d38, tuple.Tuple{true}},
-		{0x1505e3cb, tuple.Tuple{false}},
-		{0x6ae719f3, tuple.Tuple{"foo", "bar"}},
-		{0x8adddd61, tuple.Tuple{"foobar"}},
-		{0x7273e587, tuple.Tuple{"foobas"}},
-		{0xf4ec4d33, tuple.Tuple{"1"}},
-		{0x1e023d95, tuple.Tuple{"2"}},
-		{0x38a34efe, tuple.Tuple{"3"}},
-		{0x17751bae, tuple.Tuple{"10"}},
-		{0x87d93806, tuple.Tuple{"11"}},
-		{0x3c90c1d9, tuple.Tuple{1}},
-		{0x97901bac, tuple.Tuple{2}},
-		{0xcbc7f1e2, tuple.Tuple{3}},
-		{0xd1d3f3eb, tuple.Tuple{10}},
-	}
-	for _, tc := range cases {
-		require.Equal(t, tc.expect, PackedKeyHash_HH64(tc.given.Pack()))
-	}
-}
-
 func TestMain(m *testing.M) { etcdtest.TestMainWithEtcd(m) }

--- a/go/shuffle/api_test.go
+++ b/go/shuffle/api_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/estuary/flow/go/bindings"
-	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/keyhash"
 	"github.com/estuary/flow/go/labels"
 	"github.com/estuary/flow/go/protocols/catalog"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
@@ -81,8 +81,8 @@ func TestAPIIntegrationWithFixtures(t *testing.T) {
 	// Observe only messages having {"a": 1, "aa": "1"}, and not 0 or 2.
 	var expectKey = tuple.Tuple{1, "1"}.Pack()
 	var range_ = pf.RangeSpec{
-		KeyBegin: flow.PackedKeyHash_HH64(expectKey),
-		KeyEnd:   flow.PackedKeyHash_HH64(expectKey) + 1,
+		KeyBegin: keyhash.PackedKeyHash_HH64(expectKey),
+		KeyEnd:   keyhash.PackedKeyHash_HH64(expectKey) + 1,
 		// Observe only even Clock values.
 		RClockBegin: 0,
 		RClockEnd:   1 << 31,

--- a/go/shuffle/read.go
+++ b/go/shuffle/read.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/keyhash"
 	"github.com/estuary/flow/go/labels"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/estuary/flow/go/protocols/ops"
@@ -622,7 +623,7 @@ func walkReads(id pc.ShardID, shardSpecs []*pc.ShardSpec, shuffles []shuffle,
 					return fmt.Errorf("parsing shuffle key from partition fields: %w", err)
 				}
 				// Identify shards that cover the key's shuffle hash.
-				var keyHash = flow.PackedKeyHash_HH64(key.Pack())
+				var keyHash = keyhash.PackedKeyHash_HH64(key.Pack())
 				start, stop = rangeSpan(members, keyHash, keyHash)
 
 				if index < start || index >= stop {
@@ -728,7 +729,7 @@ func rangeSpan(s []shuffleMember, begin, end uint32) (start, stop int) {
 func hrwHash(s string) uint32 {
 	// We use HH64 for convenience. This could be any reasonable hash function
 	// and is unrelated to the hash applied to shuffle keys.
-	return flow.PackedKeyHash_HH64([]byte(s))
+	return keyhash.PackedKeyHash_HH64([]byte(s))
 }
 
 func pickHRW(h uint32, from []shuffleMember, start, stop int) int {

--- a/go/shuffle/subscriber.go
+++ b/go/shuffle/subscriber.go
@@ -7,7 +7,7 @@ import (
 	"math/bits"
 	"sort"
 
-	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/keyhash"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	pb "go.gazette.dev/core/broker/protocol"
@@ -131,7 +131,7 @@ func (s subscribers) stageResponses(from *pr.ShuffleResponse) {
 			continue
 		}
 
-		var keyHash = flow.PackedKeyHash_HH64(from.Arena.Bytes(from.PackedKey[doc]))
+		var keyHash = keyhash.PackedKeyHash_HH64(from.Arena.Bytes(from.PackedKey[doc]))
 		var start, stop = s.keySpan(keyHash)
 		var rClock = rotateClock(uuid.Clock)
 

--- a/go/shuffle/subscriber_test.go
+++ b/go/shuffle/subscriber_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
-	"github.com/estuary/flow/go/flow"
+	"github.com/estuary/flow/go/flow/keyhash"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pr "github.com/estuary/flow/go/protocols/runtime"
 	"github.com/gogo/protobuf/proto"
@@ -261,7 +261,7 @@ func TestSubscriberResponseStaging(t *testing.T) {
 		{0xa08b7e30, "fub"}, // High (out of fixture range).
 	}
 	for _, tc := range tokenHashRegresionCheck {
-		require.Equal(t, tc.hash, flow.PackedKeyHash_HH64([]byte(tc.token)))
+		require.Equal(t, tc.hash, keyhash.PackedKeyHash_HH64([]byte(tc.token)))
 	}
 
 	var tokens = bytes.Split([]byte("foo bar qib ACK foo fub foo"), []byte{' '})


### PR DESCRIPTION
**Description:**

Some connectors recompute Flow's packed-key hash to match shard routing. They can't import `go/flow` for it — that pulls in the gazette consumer stack — so they kept copies. estuary/connectors#5149 consolidated those copies.

This moves `PackedKeyHash_HH64` and its key into `go/flow/keyhash`, so there's one canonical home to point at. The golden-vector test comes along; it no longer needs etcd and cgo to run. Callers in `go/flow` and `go/shuffle` updated. No behavior change.

**Workflow steps:**

No user-facing change.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Kept the stuttery `PackedKeyHash_HH64` name so it matches the connectors package.
- Follow-up: connectors could import this and delete its copy.
