### PR TITLE
flowctl: don't underflow the fixture disk backlog when compression grows a segment

### DIFF
--- a/crates/flowctl/src/raw/preview_next/fixture.rs
+++ b/crates/flowctl/src/raw/preview_next/fixture.rs
@@ -675,9 +675,7 @@ fn on_reclaimed(
     disk_backlog_bytes: &mut u64,
     disk_back_pressure: &mut bool,
 ) {
-    *disk_backlog_bytes = disk_backlog_bytes
-        .checked_sub(reclaimed)
-        .expect("disk_backlog_bytes underflow");
+    *disk_backlog_bytes = disk_backlog_bytes.saturating_sub(reclaimed);
 
     if *disk_back_pressure && *disk_backlog_bytes < disk_limit_bytes / 2 {
         *disk_back_pressure = false;


### PR DESCRIPTION
**Description:**

`flowctl raw preview-next --fixture` panicked with `disk_backlog_bytes underflow` once a connector took longer than `COMPRESS_AFTER` per transaction. Blocks above the writer's compress threshold are already LZ4-compressed, so compressing a sealed segment can grow it; the reclaim stream then credits the larger size on unlink, more than was charged when the segment rolled. The subtraction now saturates.

Closes #3443.

**Workflow steps:**

None.

**Documentation links affected:**

None.

**Notes for reviewers:**

`LogActor::on_reclaimed` in `crates/shuffle/src/log/actor.rs` has the same `checked_sub`; left alone here since I have not reproduced it on that path.
