### PR TITLE
ci,local: one package set for local-stack binaries, and warm CI caches

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,7 +11,7 @@ capped-shard-reconfiguration = { max-threads = 3 }
 [profile.default]
 slow-timeout = { period = "30s", terminate-after = 4 }
 # Exclude e2e tests from Dekaf by default because they require special setup.
-# See mise/tasks/ci/dekaf-e2e for details. The materialization consistency
+# See mise/tasks/ci/dekaf-e2e-run for details. The materialization consistency
 # scenarios are excluded for the same reason: each one publishes tasks to a
 # running local stack. See mise/tasks/ci/consistency.
 default-filter = 'not binary_id(/dekaf::e2e/) and not binary_id(/materialize-consistency::scenarios/)'

--- a/.github/workflows/dekaf-test.yaml
+++ b/.github/workflows/dekaf-test.yaml
@@ -3,6 +3,14 @@ permissions:
     contents: read
 
 on:
+    # GitHub scopes a cache to the ref that wrote it, readable by that ref, its
+    # descendants, and the default branch. This job runs on master so pull
+    # requests have a master-scoped entry to restore; without it they all start
+    # cold. rust-cache keys on ${GITHUB_JOB}, so no other workflow warms it.
+    push:
+        branches: [master]
+        paths-ignore:
+            - "site/**"
     pull_request:
         branches: [master]
         paths-ignore:
@@ -10,7 +18,8 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # A cancelled run saves no cache, and master runs exist to save one.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
     SCCACHE_VERSION: v0.12.0
@@ -35,6 +44,17 @@ jobs:
                   # CI's single checkout registers as index 0 / `flow`, so the
                   # per-stack target dir is ../../../cargo-target/flow.
                   workspaces: ". -> ../../../cargo-target/flow"
+                  # Restore on every run, save only from master. The key ends
+                  # in a hash of Cargo.lock and the Cargo.tomls, so a pull
+                  # request that leaves dependencies alone computes the key
+                  # master already holds; its save is a private copy whose only
+                  # effect is to evict the shared entry. One that does change
+                  # them restores master's through the restore-key prefix.
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+                  # rust-cache saves only on success by default, and master's
+                  # is now the only entry -- a failing master run would leave
+                  # pull requests cold.
+                  cache-on-failure: true
 
             - name: Cache RocksDB
               uses: actions/cache@v4
@@ -55,15 +75,23 @@ jobs:
                   version: ${{ env.SCCACHE_VERSION }}
             - run: echo 'SCCACHE_GHA_ENABLED=true' >> $GITHUB_ENV
             - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
+            # Supabase's container pull and start is slow. Start it now to
+            # overlap the builds below; `local:stack` blocks on it before the
+            # agent needs a database.
+            - run: mise run local:supabase --no-block
             - run: mise run build:rocksdb
             - run: mise run ci:musl-dev
-            - run: mise run ci:gnu-dev
+            # Supersedes `ci:gnu-dev` here: one package set for every Rust
+            # binary this job needs, so `local:stack` finds them already built
+            # rather than compiling them inside systemd (see local/README.md).
+            - run: mise run build:local-rust
             - run: mise run build:gazette
             - run: mise run build:flowctl-go
+            - run: mise run ci:dekaf-e2e-build
             - run: mise run local:stack --dekaf
-            - run: mise run ci:dekaf-e2e
+            - run: mise run ci:dekaf-e2e-run
 
-            # `ci:dekaf-e2e` dumps logs for the services a test failure implicates,
+            # `ci:dekaf-e2e-run` dumps logs for the services a test failure implicates,
             # but a failure while bringing the stack up leaves no diagnostics at
             # all. Dump every unit's state and journal so those are debuggable
             # from the run alone.

--- a/.github/workflows/platform-test.yaml
+++ b/.github/workflows/platform-test.yaml
@@ -3,6 +3,14 @@ permissions:
   contents: read
 
 on:
+  # GitHub scopes a cache to the ref that wrote it, readable by that ref, its
+  # descendants, and the default branch. These jobs run on master so pull
+  # requests have a master-scoped entry to restore; without it they all start
+  # cold. rust-cache keys on ${GITHUB_JOB}, so no other workflow warms them.
+  push:
+    branches: [master]
+    paths-ignore:
+      - "site/**"
   pull_request:
     branches: [master]
     paths-ignore:
@@ -10,7 +18,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A cancelled run saves no cache, and master runs exist to save one.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   SCCACHE_VERSION: v0.12.0
@@ -44,6 +53,16 @@ jobs:
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           workspaces: ". -> ../../../cargo-target/flow"
+          # Restore on every run, save only from master. The key ends in a hash
+          # of Cargo.lock and the Cargo.tomls, so a pull request that leaves
+          # dependencies alone computes the key master already holds; its save is
+          # a private copy whose only effect is to evict the shared entry. One
+          # that does change them restores master's through the restore-key
+          # prefix and rebuilds just what changed.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          # rust-cache saves only on success by default, and master's is now the
+          # only entry -- a failing master run would leave pull requests cold.
+          cache-on-failure: true
 
       - name: Cache RocksDB
         uses: actions/cache@v4
@@ -95,6 +114,9 @@ jobs:
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           workspaces: ". -> ../../../cargo-target/flow"
+          # See the note on the job above.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-on-failure: true
 
       - name: Cache RocksDB
         uses: actions/cache@v4

--- a/crates/dekaf/tests/e2e/harness.rs
+++ b/crates/dekaf/tests/e2e/harness.rs
@@ -12,14 +12,14 @@ fn test_namespace_prefix() -> String {
 
 /// The running stack's default data-plane name (FLOW_CLUSTER, set by
 /// mise/tasks/local/stack-env). Local-stack identity is dynamic per checkout,
-/// so these tests must be run via `mise run ci:dekaf-e2e`.
+/// so these tests must be run via `mise run ci:dekaf-e2e-run`.
 pub fn cluster_name() -> String {
     std::env::var("FLOW_CLUSTER")
-        .expect("FLOW_CLUSTER must be set — run via 'mise run ci:dekaf-e2e'")
+        .expect("FLOW_CLUSTER must be set — run via 'mise run ci:dekaf-e2e-run'")
 }
 
 /// The second data-plane used by migration tests (`${FLOW_CLUSTER}-2`, matching
-/// the ci:dekaf-e2e task's `local:data-plane "${FLOW_CLUSTER}-2"`).
+/// the ci:dekaf-e2e-run task's `local:data-plane "${FLOW_CLUSTER}-2"`).
 pub fn cluster_name_2() -> String {
     format!("{}-2", cluster_name())
 }
@@ -59,7 +59,7 @@ fn flowctl_command() -> anyhow::Result<async_process::Command> {
     // ambient under mise, but pass it explicitly so the command doesn't depend
     // on env inheritance.
     let profile = std::env::var("FLOW_STACK_NAME")
-        .expect("FLOW_STACK_NAME must be set — run via 'mise run ci:dekaf-e2e'");
+        .expect("FLOW_STACK_NAME must be set — run via 'mise run ci:dekaf-e2e-run'");
 
     let mut cmd = async_process::Command::new(flowctl);
     cmd.env("FLOW_AUTH_TOKEN", auth_token);
@@ -616,7 +616,7 @@ pub async fn db_pool() -> anyhow::Result<&'static sqlx::PgPool> {
 
     // Stack Postgres port is dynamic; FLOW_PG_URL is set by stack-env.
     let pg_url = std::env::var("FLOW_PG_URL")
-        .expect("FLOW_PG_URL must be set — run via 'mise run ci:dekaf-e2e'");
+        .expect("FLOW_PG_URL must be set — run via 'mise run ci:dekaf-e2e-run'");
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(5)
         .connect(&pg_url)

--- a/local/README.md
+++ b/local/README.md
@@ -170,6 +170,21 @@ at `FLOW_PLANE_BASE` with 4 brokers, 1 reactor, and link, then publishes
 `ops-catalog/local-view.bundle.json`, waits for the stack to actually serve
 (next section), and prints the stack card. Add `--dekaf` for the Kafka shim.
 
+### One package set builds every Rust binary
+
+`build:local-rust` builds agent, bindings, config-encryption,
+data-plane-controller, dekaf, flowctl, and runtime-sidecar in a single `cargo
+build`. Every `cargo build` for a local stack goes through it: the
+`ExecStartPre` of each `flow-*@.service`, and the Dekaf CI job. Cargo resolves
+features over the set of packages you name, and that resolution reaches every
+dependency's `-C metadata` hash, so builds naming different sets share no
+artifacts. It is a dependency of `local:control-plane`, `local:data-plane`, and
+`local:data-plane-controller`, so on a cold checkout it runs once, concurrently
+with Supabase's and BigTable's Docker startup, before anything is asked to serve.
+
+Test binaries cannot share the set and are built by `ci:dekaf-e2e-build`. See
+`mise/tasks/build/local-rust`, which is where you add a binary.
+
 ### Unit state is NOT a readiness signal
 
 Every `flow-*@.service` is `Type=simple` and builds in `ExecStartPre` (cargo/go).
@@ -179,7 +194,8 @@ Two consequences that will mislead you if you script against systemd state:
   port. `active` means "launched", not "serving".
 - `flow-plane@<dp>.target` aggregates its members with `Wants=`, so the target
   reports `active` even while a member is still in `activating (start-pre)`
-  compiling. On a cold checkout that takes *minutes*.
+  compiling. Through `local:stack` that is brief, since `build:local-rust` ran
+  first; starting a unit directly on a cold checkout takes *minutes*.
 
 `local:stack-wait` is a readiness check - it enumerates this stack's
 loaded units, maps each to its port, and blocks until all accept connections:

--- a/local/systemd/flow-config-encryption@.service
+++ b/local/systemd/flow-config-encryption@.service
@@ -8,7 +8,7 @@ TimeoutStartSec=300
 
 EnvironmentFile=%h/flow-local/env/config-encryption-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p config-encryption'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/flow-config-encryption'
 
 Restart=on-failure

--- a/local/systemd/flow-control-agent@.service
+++ b/local/systemd/flow-control-agent@.service
@@ -13,7 +13,7 @@ TimeoutStartSec=600
 
 EnvironmentFile=%h/flow-local/env/agent-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p agent'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 # Two CORS allow-origins: the global external UI (FLOW_DASHBOARD_ORIGIN,
 # http://localhost:3000), plus the optional per-stack UI at base+5. Both vars
 # come from the EnvironmentFile above.

--- a/local/systemd/flow-data-plane-controller-job@.service
+++ b/local/systemd/flow-data-plane-controller-job@.service
@@ -11,7 +11,7 @@ TimeoutStartSec=600
 
 EnvironmentFile=%h/flow-local/env/data-plane-controller-job-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p data-plane-controller'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/data-plane-controller job --dry-run --database ${DPC_DATABASE_URL} --concurrency ${DPC_CONCURRENCY} --dequeue-interval ${DPC_DEQUEUE_INTERVAL} --heartbeat-timeout ${DPC_HEARTBEAT_TIMEOUT} --git-repo ${DPC_GIT_REPO} --ops-git-repo ${DPC_OPS_GIT_REPO} --service-url ${DPC_SERVICE_URL}'
 
 Restart=on-failure

--- a/local/systemd/flow-data-plane-controller-service@.service
+++ b/local/systemd/flow-data-plane-controller-service@.service
@@ -11,7 +11,7 @@ TimeoutStartSec=600
 
 EnvironmentFile=%h/flow-local/env/data-plane-controller-service-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p data-plane-controller'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/data-plane-controller service --database ${DPC_DATABASE_URL} --port ${DPC_PORT}'
 
 Restart=on-failure

--- a/local/systemd/flow-dekaf@.service
+++ b/local/systemd/flow-dekaf@.service
@@ -11,6 +11,7 @@ TimeoutStartSec=600
 
 EnvironmentFile=%h/flow-local/env/dekaf-%i.env
 
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/dekaf \
     --local \
     --advertise-host 127.0.0.1 \

--- a/local/systemd/flow-reactor@.service
+++ b/local/systemd/flow-reactor@.service
@@ -13,7 +13,7 @@ TimeoutStartSec=600
 # Instance format: <cluster>-<port> (e.g., foobar-9000)
 EnvironmentFile=%h/flow-local/env/reactor-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p bindings'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/flowctl-go'
 # Two CORS allow-origins (CONSUMER_ALLOW_ORIGIN env var takes only one): the
 # global external UI, plus the optional per-stack UI at base+5. Both vars come

--- a/local/systemd/flow-runtime-sidecar@.service
+++ b/local/systemd/flow-runtime-sidecar@.service
@@ -8,7 +8,7 @@ TimeoutStartSec=600
 
 EnvironmentFile=%h/flow-local/env/runtime-sidecar-%i.env
 
-ExecStartPre=sh -c 'cd ${FLOW_ROOT} && cargo build -p runtime-sidecar'
+ExecStartPre=sh -c 'cd ${FLOW_ROOT} && ./mise/tasks/build/local-rust'
 ExecStart=sh -c 'exec ${CARGO_TARGET_DIR}/debug/runtime-sidecar'
 
 Restart=on-failure

--- a/local/systemd/flow-supabase@.service
+++ b/local/systemd/flow-supabase@.service
@@ -4,7 +4,12 @@ Documentation=https://github.com/estuary/flow
 
 [Service]
 Type=simple
-TimeoutStartSec=300
+# This budget covers `supabase start`'s cold pull of ~8 container images in
+# ExecStartPre, not the edge-function server in ExecStart, which Type=simple
+# considers started as soon as it forks. CI has failed the unit at 300s with the
+# machine idle, and callers now start it with --no-block so the pull overlaps a
+# full `cargo build`.
+TimeoutStartSec=900
 
 # One consolidated env file per stack. Its FLOW_* vars are what config.toml's
 # env() references resolve against (project id, ports, site url), and PATH lets

--- a/mise/README.md
+++ b/mise/README.md
@@ -314,6 +314,7 @@ mise tasks
 | `build:rust-protobufs` | Generate Rust protobuf bindings            |
 | `build:gazette`        | Build gazette binaries                     |
 | `build:flowctl-go`     | Build flowctl-go binary                    |
+| `build:local-rust`     | Build Rust binaries for local-stack units  |
 
 ### Local Stack Tasks
 
@@ -334,14 +335,16 @@ mise tasks
 
 ### CI Tasks
 
-| Task                | Description                       |
-| ------------------- | --------------------------------- |
-| `ci:platform-test`  | Run full test suite (mirrors CI)  |
-| `ci:platform-build` | Run full build suite (mirrors CI) |
-| `ci:sql-tap`        | Run pgTAP SQL tests               |
-| `ci:nextest-run`    | Run Rust tests via nextest        |
-| `ci:gotest`         | Run Go tests                      |
-| `ci:dekaf-e2e`      | Run Dekaf E2E tests               |
+| Task                 | Description                       |
+| -------------------- | --------------------------------- |
+| `ci:platform-test`   | Run full test suite (mirrors CI)  |
+| `ci:platform-build`  | Run full build suite (mirrors CI) |
+| `ci:sql-tap`         | Run pgTAP SQL tests               |
+| `ci:nextest-build`   | Build Rust test binaries          |
+| `ci:nextest-run`     | Run Rust tests via nextest        |
+| `ci:gotest`          | Run Go tests                      |
+| `ci:dekaf-e2e-build` | Build the Dekaf E2E test binary   |
+| `ci:dekaf-e2e-run`   | Run Dekaf E2E tests               |
 
 ### VM Tasks
 

--- a/mise/tasks/build/local-rust
+++ b/mise/tasks/build/local-rust
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#MISE description="Build the Rust binaries that a local stack's systemd units run"
+#MISE depends=["build:rocksdb"]
+
+# `bindings` links librocksdb, so units that never needed it (config-encryption,
+# dekaf, runtime-sidecar) do now. systemd runs this script directly and so does
+# not honor the `#MISE depends` above; every `mise run` path here already does.
+if [ ! -f "${ROCKSDB_LIB_DIR:-}/librocksdb.a" ]; then
+    echo "Error: librocksdb.a not found under ROCKSDB_LIB_DIR=${ROCKSDB_LIB_DIR:-<unset>}." >&2
+    echo "       Run \`mise run build:rocksdb\` first; local:stack and friends do." >&2
+    exit 1
+fi
+
+# One package set, built by one invocation, shared by every `cargo build` for a
+# local stack: the ExecStartPre of each local/systemd/flow-*@.service, and the
+# Dekaf CI job. Add a binary here rather than building it on its own.
+#
+# Cargo resolves features over the set of packages named on the command line, so
+# `-p agent -p dekaf` and `-p dekaf` resolve differently, and that difference
+# lands in each dependency's `-C metadata` hash. Builds naming different sets
+# share no artifacts and recompile each other's dependencies.
+#
+# Test builds cannot join: `cargo test` unifies dev-dependency features and
+# `cargo build` does not, so ci:dekaf-e2e-build resolves its own way whatever
+# packages it names.
+#
+# `--locked` holds every consumer to the checked-in Cargo.lock. Editing a
+# Cargo.toml dependency fails here until the lock is updated too.
+#
+# SQLX_OFFLINE lets this run before Supabase is up: `agent` and its dependents
+# verify queries at compile time against the checked-in `.sqlx`. Add or change a
+# query and run `mise run build:sqlx-prepare`, which `ci:sqlx-check` enforces.
+SQLX_OFFLINE=true \
+cargo build \
+    --locked \
+    -p agent \
+    -p bindings \
+    -p config-encryption \
+    -p data-plane-controller \
+    -p dekaf \
+    -p flowctl \
+    -p runtime-sidecar

--- a/mise/tasks/ci/dekaf-e2e-build
+++ b/mise/tasks/ci/dekaf-e2e-build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#MISE description="Build the Dekaf E2E test binary"
+
+# The --no-run half of ci:dekaf-e2e-run's test command; profile and package must
+# match it, or that run compiles the binary itself against an idle stack. It
+# resolves its own feature set rather than build:local-rust's, so a cold target
+# directory pays for both.
+cargo nextest run --locked --profile dekaf-e2e -p dekaf --no-run

--- a/mise/tasks/ci/dekaf-e2e-run
+++ b/mise/tasks/ci/dekaf-e2e-run
@@ -24,8 +24,11 @@ DP2_BASE=$((FLOW_PLANE_BASE + 200))
 DEKAF1_KAFKA_PORT=$((FLOW_PLANE_BASE + 50))
 DEKAF2_KAFKA_PORT=$((DP2_BASE + 50))
 
-echo "Building flowctl..."
-cargo build -p flowctl --quiet
+# The shared package set (see mise/tasks/build/local-rust), for when this task
+# is run by hand; a running stack has already built it. It does not cover the
+# test binary below -- ci:dekaf-e2e-build does.
+echo "Building Rust binaries..."
+mise run build:local-rust
 
 # ${FLOW_CLUSTER} with Dekaf is expected to already be running from
 # local:stack --dekaf. Bring up a second plane BEFORE provisioning the tenant so

--- a/mise/tasks/local/control-plane
+++ b/mise/tasks/local/control-plane
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 #MISE description="Start control plane agent via systemd (for this stack)"
-#MISE depends=["local:tls-cert", "local:supabase", "local:bigtable"]
+#MISE depends=["build:local-rust", "local:tls-cert", "local:supabase", "local:bigtable"]
 
 source "$(dirname "$0")/lib.sh"
 ensure_stack_env

--- a/mise/tasks/local/data-plane
+++ b/mise/tasks/local/data-plane
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 #MISE description="Start data plane with gazette brokers and reactors (for this stack)"
-#MISE depends=["build:connector-init", "build:rocksdb", "local:tls-cert", "local:etcd"]
+#MISE depends=["build:connector-init", "build:local-rust", "build:rocksdb", "local:tls-cert", "local:etcd"]
 #USAGE arg "<data_plane>" help="Name of the data plane"
 #USAGE arg "<base_port>" help="Base port block for data plane services (multiple of 100, within this stack's decade)"
 #USAGE flag "--num-brokers <num_brokers>" help="Number of broker instances"
@@ -72,8 +72,6 @@ fi
 if [ "${DEKAF}" = "true" ]; then
     # Dekaf requires upstream Kafka for consumer group management (per-stack).
     mise run local:dekaf-kafka
-
-    cargo build -p dekaf --quiet
 
     DATA_PLANE_FQDN="${DATA_PLANE}.dp.estuary-data.com"
 

--- a/mise/tasks/local/data-plane-controller
+++ b/mise/tasks/local/data-plane-controller
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 #MISE description="Start data-plane-controller (service + job) in dry-run mode via systemd (for this stack)"
-#MISE depends=["local:supabase"]
+#MISE depends=["build:local-rust", "local:supabase"]
 
 source "$(dirname "$0")/lib.sh"
 ensure_stack_env

--- a/mise/tasks/local/dekaf-kafka
+++ b/mise/tasks/local/dekaf-kafka
@@ -21,17 +21,23 @@ link_unit flow-dekaf-kafka@.service
 systemctl --user daemon-reload
 systemctl --user start "flow-dekaf-kafka@${NAME}"
 
-# Wait for Kafka to be ready
+# The budget covers a cold `docker pull` of confluentinc/cp-kafka -- several
+# hundred MB, pulled implicitly by `docker run` on a fresh CI runner -- and not
+# just broker startup, which takes seconds. Observed cold waits are 1m40s to
+# 4m32s. It is measured against the clock: each pass also costs however long the
+# probe takes to fail, so counting passes would denominate the budget in
+# something that varies with why we are waiting.
 echo "Waiting for Kafka to be ready on :${FLOW_PORT_KAFKA}..."
-TIMEOUT=60
-ELAPSED=0
+TIMEOUT=300
+DEADLINE=$(( SECONDS + TIMEOUT ))
 until docker exec "dekaf-kafka-${NAME}" kafka-broker-api-versions \
     --bootstrap-server "localhost:${FLOW_PORT_KAFKA}" > /dev/null 2>&1; do
-    sleep 1
-    ELAPSED=$((ELAPSED + 1))
-    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
-        echo "Error: Kafka failed to start within ${TIMEOUT} seconds"
+    if [ "${SECONDS}" -ge "${DEADLINE}" ]; then
+        echo "Error: Kafka not ready on :${FLOW_PORT_KAFKA} within ${TIMEOUT}s."
+        echo "       If the log below is still pulling layers, the image download"
+        echo "       -- not the broker -- exceeded the budget."
         journalctl --user -u "flow-dekaf-kafka@${NAME}" --no-pager -n 50
         exit 1
     fi
+    sleep 1
 done


### PR DESCRIPTION
The commit message carries the full reasoning and measurements. Notes for
review, and for after merge:

- **The cache benefit does not appear on this PR.** No master-scoped entry
  exists for `dekaf-test`, `platform-test` or `generated-artifacts-check`
  today. The first master run after merge writes them; pull requests opened
  after that are the ones that restore.

- **The first build on any checkout is a full rebuild.** Naming a different
  package set changes every dependency's `-C metadata` hash, so folding
  `data-plane-controller` into the shared set invalidates what a warm target
  directory already holds. One time, locally and in CI.

- **`local:supabase --no-block` and the `save-if`/`push` pairing** each have a
  matched half elsewhere in the file. Removing the `push` trigger without
  removing `save-if` writes no cache at all.

Validated on a local stack: 13/13 services accepting connections after 52s,
26/26 Dekaf e2e tests passing in 124s. CI on this PR exercises the reordered
Dekaf job, still on a cold cache.
