### PR TITLE
shuffle, runtime-next: send panic statuses to peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,6 +6497,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures",
  "labels",
  "proto-build",
  "proto-flow",

--- a/crates/proto-grpc/Cargo.toml
+++ b/crates/proto-grpc/Cargo.toml
@@ -16,6 +16,7 @@ tokens = { path = "../tokens" }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }
+futures = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }

--- a/crates/proto-grpc/src/lib.rs
+++ b/crates/proto-grpc/src/lib.rs
@@ -11,7 +11,9 @@ pub mod runtime;
 pub mod shuffle;
 
 mod status;
-pub use status::{MAX_STATUS_MESSAGE_LEN, anyhow_to_status, bound_status, bounded_unknown_status};
+pub use status::{
+    MAX_STATUS_MESSAGE_LEN, anyhow_to_status, bound_status, bounded_unknown_status, catch_panic,
+};
 
 // The `protocol` package is publicly exported as `broker`.
 #[cfg(any(feature = "broker_client", feature = "broker_server"))]

--- a/crates/proto-grpc/src/status.rs
+++ b/crates/proto-grpc/src/status.rs
@@ -67,3 +67,62 @@ pub fn anyhow_to_status(err: anyhow::Error) -> tonic::Status {
         Err(err) => bounded_unknown_status(format!("{err:?}")),
     }
 }
+
+/// Convert a handler's returned error or panic into a gRPC status.
+///
+/// Catching panics prevents a dropped response sender from looking like a
+/// successful end-of-stream to the peer. The status includes only the panic
+/// payload; the panic hook logs its location and any enabled backtrace locally.
+pub async fn catch_panic<F, T>(future: F) -> tonic::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    match futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(future)).await {
+        Ok(result) => result.map_err(anyhow_to_status),
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<&'static str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("<non-string panic payload>");
+
+            Err(bounded_unknown_status(format!(
+                "handler panicked: {message}"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn catch_panic_renders_every_outcome() {
+        assert_eq!(super::catch_panic(async { Ok(1) }).await.unwrap(), 1);
+
+        let returned =
+            super::catch_panic(async { Err::<(), _>(anyhow::format_err!("a returned error")) })
+                .await
+                .unwrap_err();
+        assert_eq!(returned.message(), "a returned error");
+
+        let panicked = super::catch_panic::<_, ()>(async { panic!("{} payload", "a formatted") })
+            .await
+            .unwrap_err();
+        assert_eq!(panicked.message(), "handler panicked: a formatted payload");
+
+        let non_string = super::catch_panic::<_, ()>(async { std::panic::panic_any(42u64) })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            non_string.message(),
+            "handler panicked: <non-string panic payload>"
+        );
+
+        // An oversized payload is bounded like any other status message.
+        let huge = super::catch_panic::<_, ()>(async { panic!("{}", "a".repeat(1 << 16)) })
+            .await
+            .unwrap_err();
+        assert!(huge.message().len() <= super::MAX_STATUS_MESSAGE_LEN);
+        assert!(huge.message().ends_with("… [truncated]"), "{huge}");
+    }
+}

--- a/crates/runtime-next/src/leader/service.rs
+++ b/crates/runtime-next/src/leader/service.rs
@@ -87,8 +87,9 @@ impl<S: crate::ShuffleSessionFactory, P: crate::PublisherFactory, L: crate::Logg
         let error_tx = response_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = super::derive::serve(service, authz, request_rx, response_tx).await {
-                let _ = error_tx.send(Err(crate::anyhow_to_status(e)));
+            let handler = super::derive::serve(service, authz, request_rx, response_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status));
             }
         });
         response_rx
@@ -108,9 +109,9 @@ impl<S: crate::ShuffleSessionFactory, P: crate::PublisherFactory, L: crate::Logg
         let error_tx = response_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = super::materialize::serve(service, authz, request_rx, response_tx).await
-            {
-                let _ = error_tx.send(Err(crate::anyhow_to_status(e)));
+            let handler = super::materialize::serve(service, authz, request_rx, response_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status));
             }
         });
         response_rx

--- a/crates/runtime-next/src/shard/service.rs
+++ b/crates/runtime-next/src/shard/service.rs
@@ -99,9 +99,9 @@ impl<P: crate::PublisherFactory, L: crate::LoggerFactory> Service<P, L> {
         let error_tx = controller_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(err) = super::materialize::serve(service, controller_rx, controller_tx).await
-            {
-                let _ = error_tx.send(Err(crate::anyhow_to_status(err))); // The ONLY send of Err.
+            let handler = super::materialize::serve(service, controller_rx, controller_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status)); // The ONLY send of Err.
             }
         });
         response_rx
@@ -120,8 +120,9 @@ impl<P: crate::PublisherFactory, L: crate::LoggerFactory> Service<P, L> {
         let error_tx = controller_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(err) = super::capture::serve(service, controller_rx, controller_tx).await {
-                let _ = error_tx.send(Err(crate::anyhow_to_status(err))); // The ONLY send of Err.
+            let handler = super::capture::serve(service, controller_rx, controller_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status)); // The ONLY send of Err.
             }
         });
         response_rx
@@ -140,8 +141,9 @@ impl<P: crate::PublisherFactory, L: crate::LoggerFactory> Service<P, L> {
         let error_tx = controller_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(err) = super::derive::serve(service, controller_rx, controller_tx).await {
-                let _ = error_tx.send(Err(crate::anyhow_to_status(err))); // The ONLY send of Err.
+            let handler = super::derive::serve(service, controller_rx, controller_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status)); // The ONLY send of Err.
             }
         });
         response_rx

--- a/crates/shuffle/src/lib.rs
+++ b/crates/shuffle/src/lib.rs
@@ -167,11 +167,6 @@ fn opening_aborted<T>(source: &str, peer: &str, msg: Option<tonic::Result<T>>) -
     }
 }
 
-// Map an anyhow::Error into a tonic::Status, bounding its message so that an
-// oversized status isn't replaced in transit by an opaque transport error.
-// See `proto_grpc::MAX_STATUS_MESSAGE_LEN`.
-use proto_grpc::anyhow_to_status;
-
 // Map a tonic::Status into an anyhow::Error.
 #[inline]
 fn status_to_anyhow(status: tonic::Status) -> anyhow::Error {

--- a/crates/shuffle/src/service.rs
+++ b/crates/shuffle/src/service.rs
@@ -1,4 +1,4 @@
-use crate::{anyhow_to_status, log, new_channel, session, slice};
+use crate::{log, new_channel, session, slice};
 use proto_flow::shuffle;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -107,8 +107,9 @@ impl Service {
         let error_tx = response_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = session::serve_session(service, authz, request_rx, response_tx).await {
-                let _ = error_tx.send(Err(anyhow_to_status(e)));
+            let handler = session::serve_session(service, authz, request_rx, response_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status));
             }
         });
         response_rx
@@ -127,8 +128,9 @@ impl Service {
         let error_tx = response_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = slice::serve_slice(service, authz, request_rx, response_tx).await {
-                let _ = error_tx.send(Err(anyhow_to_status(e))).await;
+            let handler = slice::serve_slice(service, authz, request_rx, response_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status)).await;
             }
         });
         response_rx
@@ -147,8 +149,9 @@ impl Service {
         let error_tx = response_tx.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = log::serve_log(service, authz, request_rx, response_tx).await {
-                let _ = error_tx.send(Err(anyhow_to_status(e))).await;
+            let handler = log::serve_log(service, authz, request_rx, response_tx);
+            if let Err(status) = proto_grpc::catch_panic(handler).await {
+                let _ = error_tx.send(Err(status)).await;
             }
         });
         response_rx


### PR DESCRIPTION
**Description:**

Panics in spawned shuffle and runtime-next handlers currently drop the response sender, causing peers to see a successful end-of-stream instead of an error. This adds `proto_grpc::catch_panic` to return bounded gRPC statuses for handler errors and panics, and applies it to all spawned shuffle, leader, and shard handlers. Panic locations and enabled backtraces remain in the local process logs.

Closes https://github.com/estuary/flow/issues/3461

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

