### PR TITLE
product name: use "Estuary" instead of "Estuary Flow"

### DIFF
--- a/crates/dekaf/src/main.rs
+++ b/crates/dekaf/src/main.rs
@@ -24,7 +24,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use url::Url;
 
-/// A Kafka-compatible proxy for reading Estuary Flow collections.
+/// A Kafka-compatible proxy for reading Estuary collections.
 #[derive(Debug, Parser, serde::Serialize)]
 #[command(about, version)]
 pub struct Cli {

--- a/crates/flow-client-next/README.md
+++ b/crates/flow-client-next/README.md
@@ -1,6 +1,6 @@
 # flow-client-next
 
-Client library for Estuary Flow control-plane APIs with auto-refreshing authentication.
+Client library for Estuary control-plane APIs with auto-refreshing authentication.
 
 This crate is a replacement for `flow-client`. Dependent crates should use
 `use flow_client_next as flow_client;` to ease the transition.

--- a/crates/flowctl/README.md
+++ b/crates/flowctl/README.md
@@ -1,6 +1,6 @@
 # Flowctl
 
-**The command line interface for Estuary Flow**
+**The command line interface for Estuary**
 
 ### Installing `flowctl`
 
@@ -24,7 +24,7 @@ Verify that it's working by running `flowctl --version`.
 
 ### Use the `flowctl` CLI:
 
-**Authentication to Estuary Flow**
+**Authentication to Estuary**
 
 1. Visit (https://dashboard.estuary.dev/admin) and login.
 2. Find the "Access Token" at the bottom of the page, and copy it.

--- a/crates/flowctl/src/lib.rs
+++ b/crates/flowctl/src/lib.rs
@@ -23,7 +23,7 @@ use models::authorizations::ControlClaims;
 use output::{Output, OutputType};
 use poll::poll_while_queued;
 
-/// A command-line tool for working with Estuary Flow.
+/// A command-line tool for working with Estuary.
 #[derive(Debug, Parser)]
 #[command(author, about, version, next_display_order = None)]
 pub struct Cli {

--- a/go/runtime/flow_consumer.go
+++ b/go/runtime/flow_consumer.go
@@ -92,7 +92,7 @@ func (c *FlowConsumerConfig) Plane() pr.Plane {
 	return pr.Plane_PUBLIC
 }
 
-// FlowConsumer implements the Estuary Flow Consumer.
+// FlowConsumer implements the Estuary Consumer.
 type FlowConsumer struct {
 	// Configuration of this FlowConsumer.
 	config *FlowConsumerConfig

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
-# Mise configuration for Estuary Flow development tasks
+# Mise configuration for Estuary development tasks
 # See https://mise.jdx.dev for documentation
 
 # Tool versions


### PR DESCRIPTION
The product is "Estuary", not "Estuary Flow" ([context](https://estuaryworkspace.slack.com/archives/C012S5U0WP2/p1788452319856409)).

Two of these print in `--help`, via clap's `#[command(about, ...)]` on the `flowctl` and `dekaf` `Cli` structs. The rest are READMEs and comments, which agents read and imitate when drafting documentation.

Left alone as identifiers, not the product name: `LICENSE-BSL`, `pyproject.toml`, the `estuary-flow-poc` bucket in fixtures and `seed.sql`, and the `estuary-flow-web` tarball in CI.

Nothing under `site/` is touched, since that tree is deprecated and `estuary/docs` is the live source. #2964 edits `site/docs/getting-started/getting-started.md` for the same rename and may want redirecting there.

Companion PR: estuary/connectors#5191
