### PR TITLE
runtime-next: make per-shard tokio worker threads configurable

### DIFF
--- a/crates/runtime-next/README.md
+++ b/crates/runtime-next/README.md
@@ -142,7 +142,9 @@ types.
 - **`TaskService::new`** (`task_service.rs`) — CGO constructor invoked by Go
   on shard assignment. Wires the data-plane environment (FQDN, control API,
   signing key), constructs a `shard::Service`, and serves it over a per-shard
-  Unix domain socket.
+  Unix domain socket. Each shard gets its own tokio runtime of
+  `FLOW_RUNTIME_WORKER_THREADS` workers (default one), so raising it multiplies
+  by the reactor's shard count.
 - **`leader::Service::new`** (`leader/service.rs`) — sidecar process builds
   one of these and registers it on the sidecar port alongside `shuffle::Service`.
 - **`shard::Service`** (`shard/service.rs`) — implements the controller-facing

--- a/crates/runtime-next/src/task_service.rs
+++ b/crates/runtime-next/src/task_service.rs
@@ -42,7 +42,7 @@ impl TaskService {
             ops::LogLevel::Warn,
             log_handler.clone(),
             task_name.clone(),
-            1,
+            worker_threads(),
         );
 
         let control_api_endpoint: url::Url =
@@ -128,6 +128,15 @@ impl TaskService {
         };
         let () = tokio_context.block_on(tokio_context.spawn(log)).unwrap();
     }
+}
+
+// This count is per-shard, and multiplies by the reactor's shard count.
+fn worker_threads() -> usize {
+    std::env::var("FLOW_RUNTIME_WORKER_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n != 0)
+        .unwrap_or(1)
 }
 
 // Decode the first key from `CONSUMER_AUTH_KEYS`, matching Gazette's


### PR DESCRIPTION
Each assigned shard builds its own `TaskService` and tokio runtime, which until now was pinned to a single worker thread. This reads the count from an optional `FLOW_RUNTIME_WORKER_THREADS` instead, so a shard that turns out to be async-executor bound can be given more workers without a rebuild.

The default stays at one: the count multiplies by a reactor's shard count, so a densely packed reactor would otherwise spawn thousands of mostly-idle workers. Malformed and zero values fall back to that default silently.

V2 only — `crates/runtime/src/task_service.rs` and the sidecar's runtime are untouched.