### PR TITLE
data-plane-controller: new task type for testing separate builds

### DIFF
--- a/.github/workflows/deploy-data-plane-controller-dev.yaml
+++ b/.github/workflows/deploy-data-plane-controller-dev.yaml
@@ -1,10 +1,23 @@
-name: Deploy data-plane-controller
+name: Deploy data-plane-controller (dev)
 
-# Deployed manually rather than on every master build, so a candidate image can
-# be validated by the dev deployment (deploy-data-plane-controller-dev.yaml)
-# against test data-planes before it reaches the rest of the fleet. Both
-# deployments take the same tag, so what gets promoted is the same artifact that
-# was tested. Mirrors deploy-agent-api.yaml.
+# The dev deployment of the data-plane-controller. It is identical to the
+# primary deployment except that it passes DPC_DEV=true, which makes it serve
+# the DATA_PLANE_CONTROLLER_DEV task type instead of DATA_PLANE_CONTROLLER.
+# Only data-planes whose controller task has been explicitly moved to that type
+# are operated on here, so this deployment can run a candidate build against
+# test planes without touching the rest of the fleet. Move a plane with:
+#
+#   UPDATE internal.tasks SET task_type = 13
+#   WHERE task_id = (SELECT controller_task_id FROM data_planes
+#                    WHERE data_plane_name = '<name>');
+#
+# Both Cloud Run resources are created on first run: `gcloud run deploy` and
+# `gcloud run jobs deploy`, which this action wraps, each create or update.
+#
+# Deploy here first, then promote the same tag with
+# deploy-data-plane-controller.yaml once it looks good on the test planes.
+# Neither workflow builds anything: the tag must already have been pushed by a
+# Platform Build run.
 on:
   workflow_dispatch:
     inputs:
@@ -39,16 +52,18 @@ jobs:
           service_account: cd-github-actions@estuary-control.iam.gserviceaccount.com
           workload_identity_provider: projects/1084703453822/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
 
-      - name: Deploy Cloud Run service `data-plane-controller-service`
+      - name: Deploy Cloud Run service `data-plane-controller-service-dev`
         id: deploy-service
         uses: google-github-actions/deploy-cloudrun@v2
         with:
-          service: data-plane-controller-service
+          service: data-plane-controller-service-dev
           project_id: estuary-control
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
           timeout: 3600s
-          # Declare the VPC egress (previously set out-of-band) in code so it survives a full replace.
+          # Same network as the primary deployment, so this service egresses via the
+          # NAT IP that every data-plane's `ssh_subnets` already allows. Without that
+          # the Ansible step could not reach instances.
           flags: '--args=service --no-allow-unauthenticated --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com --network=data-plane-controller --subnet=data-plane-controller-sn1 --vpc-egress=all-traffic'
 
           # NOTE: env_vars and secrets are literal block scalars (|-); every
@@ -56,6 +71,8 @@ jobs:
           # KEY=SECRET:version. Do NOT put `#` comments inside them.
           # DPC_GIT_AUTH_MODE selects git auth (ssh | github-app); see
           # crates/data-plane-controller/entrypoint.sh.
+          # The service takes no DPC_DEV: it executes whatever the job dispatches
+          # to it and never dequeues, so it has no task type of its own.
           env_vars: |-
             DPC_DATABASE_CA=/etc/db-ca.crt
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
@@ -79,6 +96,25 @@ jobs:
 
           env_vars_update_strategy: overwrite
           secrets_update_strategy: overwrite
+
+      # The service has no application-level auth: nothing in src/service/ checks
+      # Authorization, so this binding is the only thing stopping anyone who can
+      # reach the URL from driving Pulumi and Ansible. The job authenticates with a
+      # GCP ID token minted from the metadata server, and on failure to mint one it
+      # logs a warning and proceeds tokenless, so a missing binding shows up as a
+      # 403 on /execute rather than as an auth error. Adding a binding that already
+      # exists is a no-op, so this is safe to re-run.
+      #
+      # This needs run.services.setIamPolicy on the deploying identity. If
+      # cd-github-actions lacks it this step fails, and the binding can be applied
+      # once by hand with the same command.
+      - name: Grant the controller service account invoker on the dev service
+        run: |
+          gcloud run services add-iam-policy-binding data-plane-controller-service-dev \
+            --project=estuary-control \
+            --region=us-central1 \
+            --member=serviceAccount:data-plane-controller@estuary-control.iam.gserviceaccount.com \
+            --role=roles/run.invoker
 
   deploy-job:
     runs-on: ubuntu-24.04
@@ -104,10 +140,10 @@ jobs:
           service_account: cd-github-actions@estuary-control.iam.gserviceaccount.com
           workload_identity_provider: projects/1084703453822/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
 
-      - name: Update Cloud Run job `data-plane-controller`
+      - name: Update Cloud Run job `data-plane-controller-dev`
         uses: google-github-actions/deploy-cloudrun@v2
         with:
-          job: data-plane-controller
+          job: data-plane-controller-dev
           project_id: estuary-control
           region: us-central1
           image: ${{ steps.image-tag.outputs.image }}
@@ -117,11 +153,21 @@ jobs:
           # provisioning SSH, so it does not need the data-plane-controller egress IP.
           flags: '--args=job --service-account=data-plane-controller@estuary-control.iam.gserviceaccount.com --network=data-plane-controller --subnet=control-plane-api-sn1 --vpc-egress=all-traffic'
 
+          # NOTE: literal block scalars, as above. No `#` comments inside them.
+          # DPC_DEV selects the DATA_PLANE_CONTROLLER_DEV task type and must be
+          # exactly `true` or `false`; the flag rejects anything else at startup
+          # rather than defaulting to false.
+          # DPC_SERVICE_URL must be this deployment's own service, because the job
+          # uses it verbatim as the ID-token audience. Pointing it at the primary
+          # service's URL yields a 403 from Cloud Run.
+          # DPC_CONCURRENCY is lower than the primary deployment's: this one serves
+          # a handful of test planes, not the fleet.
           env_vars: |-
             DPC_DATABASE_CA=/etc/db-ca.crt
             DPC_DATABASE_URL=postgresql://postgres@db.eyrcnmuzzyriypdajwdk.supabase.co:5432/postgres
             DPC_SERVICE_URL=${{ needs.deploy-service.outputs.service-url }}
-            DPC_CONCURRENCY=10
+            DPC_CONCURRENCY=2
+            DPC_DEV=true
             NO_COLOR=1
 
           secrets: |-

--- a/crates/automations/README.md
+++ b/crates/automations/README.md
@@ -59,6 +59,20 @@ Registered task types in `task_types` module:
 - `EVOLUTIONS` - Handles schema evolution tasks
 - `APPLIED_DIRECTIVES` - Processes applied directives
 - `CONNECTOR_TAGS` - Manages connector tag updates
+- `DATA_PLANE_MIGRATION` - Migrates tasks between data planes
+- `ALERT_NOTIFICATIONS` - Sends notifications as alerts fire and resolve
+- `TENANT_ALERT_EVALS` - Evaluates tenant-related alerts
+- `DATA_MOVEMENT_ALERT_EVALS` - Evaluates `data_movement_stalled` alerts
+- `TENANT_CONTROLLER` - Reconciles a tenant's billing contact with Stripe
+- `DATA_PLANE_CONTROLLER_DEV` - Second data-plane-controller deployment
+
+Task types are the only axis on which the dequeue partitions work, so they
+double as the mechanism for splitting one executor across two deployments:
+register the same executor under a second type, have each deployment register
+just one of them, and move a task between deployments by updating its
+`task_type`. `DATA_PLANE_CONTROLLER_DEV` exists for exactly this. Do not
+confuse it with the hazard the `task_types` doc comment warns about, which is
+two *different* executors sharing a single type.
 
 ## Server and Runtime
 

--- a/crates/automations/src/lib.rs
+++ b/crates/automations/src/lib.rs
@@ -47,6 +47,13 @@ pub mod task_types {
     pub const DATA_MOVEMENT_ALERT_EVALS: TaskType = TaskType(11);
     /// Per-tenant controller that reconciles billing contact with Stripe
     pub const TENANT_CONTROLLER: TaskType = TaskType(12);
+    /// Second deployment of the data-plane-controller, which serves only the
+    /// data-planes explicitly assigned to it. This is the *same* executor as
+    /// DATA_PLANE_CONTROLLER registered under a second type: each deployment
+    /// registers one of the two, and the dequeue predicate divides the
+    /// data-planes between them. Note this is the inverse of the hazard called
+    /// out above, which is two *different* executors sharing one task type.
+    pub const DATA_PLANE_CONTROLLER_DEV: TaskType = TaskType(13);
 }
 
 /// Outcome of an `Executor::poll()` for a given task, which encloses

--- a/crates/data-plane-controller/src/job/executor.rs
+++ b/crates/data-plane-controller/src/job/executor.rs
@@ -175,6 +175,33 @@ impl automations::Executor for Executor {
     }
 }
 
+/// Serves the same controller logic as `Executor`, registered under the dev
+/// task type so a second deployment can operate on a disjoint set of
+/// data-planes. Which data-planes those are is decided entirely by the
+/// automations dequeue predicate: nothing below this point behaves
+/// differently, because a task is joined to its data-plane row by
+/// `controller_task_id` and never by task type.
+pub struct DevExecutor(pub Executor);
+
+impl automations::Executor for DevExecutor {
+    const TASK_TYPE: automations::TaskType = automations::task_types::DATA_PLANE_CONTROLLER_DEV;
+
+    type Receive = Message;
+    type State = Option<State>;
+    type Outcome = Outcome;
+
+    fn poll<'s>(
+        &'s self,
+        pool: &'s sqlx::PgPool,
+        task_id: models::Id,
+        parent_id: Option<models::Id>,
+        state: &'s mut Self::State,
+        inbox: &'s mut VecDeque<(models::Id, Option<Message>)>,
+    ) -> impl std::future::Future<Output = anyhow::Result<Self::Outcome>> + Send + 's {
+        <Executor as automations::Executor>::poll(&self.0, pool, task_id, parent_id, state, inbox)
+    }
+}
+
 impl Executor {
     pub async fn on_poll(
         &self,

--- a/crates/data-plane-controller/src/job/mod.rs
+++ b/crates/data-plane-controller/src/job/mod.rs
@@ -71,6 +71,12 @@ pub struct JobArgs {
     /// It's not required that the Pulumi stacks of data planes actually exist.
     #[clap(long = "dry-run")]
     dry_run: bool,
+    /// Serve the dev task type rather than the primary one, so this deployment
+    /// operates only on the data-planes explicitly assigned to it.
+    /// `DPC_DEV` must be exactly `true` or `false`; anything else (`1`, `yes`)
+    /// is rejected at startup rather than silently treated as false.
+    #[clap(long = "dev", env = "DPC_DEV")]
+    dev: bool,
     /// URL of the data-plane-controller service (worker).
     #[clap(
         long = "service-url",
@@ -145,8 +151,16 @@ pub async fn run_job(args: JobArgs) -> anyhow::Result<()> {
 
     let executor = executor::Executor::new(controller_config, args.service_url);
 
-    let server = automations::Server::new()
-        .register(executor)
+    // Registering under exactly one task type is what divides the data-planes
+    // between this deployment and the other one.
+    let server = automations::Server::new();
+    let server = if args.dev {
+        server.register(executor::DevExecutor(executor))
+    } else {
+        server.register(executor)
+    };
+
+    let server = server
         .serve(
             args.concurrency,
             pg_pool,

--- a/crates/data-plane-controller/src/shared/stack.rs
+++ b/crates/data-plane-controller/src/shared/stack.rs
@@ -1,5 +1,12 @@
 use itertools::{EitherOrBoth, Itertools};
 
+/// Status is persisted inside `internal.tasks.inner_state`, which makes it a
+/// wire format between the two data-plane-controller deployments: a plane moved
+/// from the dev deployment back to the primary one is resumed from state the
+/// dev build wrote. A deployment which cannot deserialize a status errors every
+/// poll and the task makes no further progress, so a plane should only be moved
+/// between deployments while `Idle`, and a newly-added variant needs to reach
+/// the primary deployment before any plane using it moves back to it.
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 pub enum Status {
     Idle,

--- a/crates/data-plane-controller/tests/test_task_types.rs
+++ b/crates/data-plane-controller/tests/test_task_types.rs
@@ -1,0 +1,20 @@
+use automations::Executor as _;
+use data_plane_controller::job::executor::{DevExecutor, Executor};
+
+/// `DevExecutor` exists only to register the same controller logic under a
+/// second task type, so the two types differing is the entire feature. If a
+/// refactor left `DevExecutor::TASK_TYPE` pointing at the primary type, both
+/// deployments would serve every data-plane and nothing would fail loudly:
+/// they would simply contend for the same tasks through the heartbeat lease.
+#[test]
+fn dev_executor_serves_a_distinct_task_type() {
+    assert_eq!(
+        Executor::TASK_TYPE,
+        automations::task_types::DATA_PLANE_CONTROLLER,
+    );
+    assert_eq!(
+        DevExecutor::TASK_TYPE,
+        automations::task_types::DATA_PLANE_CONTROLLER_DEV,
+    );
+    assert_ne!(Executor::TASK_TYPE, DevExecutor::TASK_TYPE);
+}


### PR DESCRIPTION
**Description:**

Adds a new task type to the executor in automations, adds a configurable option on the DPC to make use of it. 

This allows us to run a separate deployment of the data-plane-controller against the task types that have been assigned to this type manually.

Changes the deployment behavior of DPC, no longer deploys either deployment automatically, now requires a manual fire of the workflow.

**Workflow steps:**

In our internal.tasks table, you can now set something that was previously of `task_type` 1 to `task_type` 13 and it will run under the other DPC deployment.

**Documentation links affected:**

N/A

**Notes for reviewers:**

Verified this locally by running 2 copies of DPC against local supabase, one with the dev arg and one without. Confirmed they only operated on their respective task types.

