### PR TITLE
update_l2_reporting: run the old L2 stats rollup on runtime-v2

### DIFF
--- a/crates/control-plane-api/src/server/update_l2_reporting.rs
+++ b/crates/control-plane-api/src/server/update_l2_reporting.rs
@@ -99,6 +99,7 @@ pub async fn update_l2_reporting(
     let models::Derivation {
         transforms: l2_stats_transforms,
         using: l2_stats_using,
+        shards: l2_stats_shards,
         ..
     } = &mut l2_stats.model.as_mut().unwrap().derive.as_mut().unwrap();
 
@@ -277,10 +278,12 @@ export class Derivation extends Types.IDerivation {"#
     *l2_stats_new_module_raw =
         models::RawValue::from_value(&serde_json::json!(l2_stats_new_module));
 
-    l2_stats_new_shards.flags.insert(
-        models::Token::new(models::ENABLE_RUNTIME_V2),
-        models::Token::new("true"),
-    );
+    for shards in [l2_stats_shards, l2_stats_new_shards] {
+        shards.flags.insert(
+            models::Token::new(models::ENABLE_RUNTIME_V2),
+            models::Token::new("true"),
+        );
+    }
 
     let draft = tables::DraftCatalog {
         collections: tables::DraftCollections::from_iter([


### PR DESCRIPTION
**Description:**

Apply the `enable-runtime-v2` shard flag to `ops.us-central1.v1/catalog-stats-L2`, the same way it is already applied to `ops/rollups/L2/catalog-stats`. Both L2 stats rollups now run the V2 task runtime.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

